### PR TITLE
support function_call api; streamline task code

### DIFF
--- a/llmagent/agent/base.py
+++ b/llmagent/agent/base.py
@@ -2,7 +2,6 @@ import json
 import logging
 from abc import ABC
 from contextlib import ExitStack
-from enum import Enum
 from typing import Dict, List, Optional, Set, Tuple, Type, no_type_check
 
 from pydantic import BaseSettings, ValidationError
@@ -10,13 +9,13 @@ from rich import print
 from rich.console import Console
 from rich.prompt import Prompt
 
+from llmagent.agent.chat_document import ChatDocMetaData, ChatDocument, Entity
 from llmagent.agent.message import INSTRUCTION, AgentMessage
 from llmagent.language_models.base import (
     LanguageModel,
     LLMConfig,
-    LLMFunctionCall,
 )
-from llmagent.mytypes import DocMetaData, Document
+from llmagent.mytypes import DocMetaData
 from llmagent.parsing.json import extract_top_level_json
 from llmagent.parsing.parser import Parser, ParsingConfig
 from llmagent.prompts.prompts_config import PromptsConfig
@@ -27,26 +26,6 @@ from llmagent.vector_store.base import VectorStore, VectorStoreConfig
 console = Console()
 
 logger = logging.getLogger(__name__)
-
-
-class Entity(str, Enum):
-    AGENT = "Agent"
-    LLM = "LLM"
-    USER = "User"
-
-
-class ChatDocMetaData(DocMetaData):
-    sender: Entity
-    sender_name: str = ""
-    recipient: str = ""
-    usage: int = 0
-    cached: bool = False
-    displayed: bool = False
-
-
-class ChatDocument(Document):
-    function_call: Optional[LLMFunctionCall] = None
-    metadata: ChatDocMetaData
 
 
 class AgentConfig(BaseSettings):
@@ -209,17 +188,27 @@ class Agent(ABC):
         """
         if msg is None:
             return None
+        if isinstance(msg, ChatDocument) and msg.metadata.sender == Entity.AGENT:
+            # Agent cannot respond to message emitted by itself
+            return None
+
         results = self.handle_message(msg)
         if results is None:
             return None
         console.print(f"[red]{self.indent}", end="")
         print(f"[red]Agent: {results}")
+        sender_name = self.config.name
+        if isinstance(msg, ChatDocument) and msg.function_call is not None:
+            # if result was from handling an LLM `function_call`,
+            # set sender_name to "request", i.e. name of the function_call
+            sender_name = msg.function_call.name
+
         return ChatDocument(
             content=results,
-            metadata=DocMetaData(
+            metadata=ChatDocMetaData(
                 source=Entity.AGENT,
                 sender=Entity.AGENT,
-                sender_name=self.config.name,
+                sender_name=sender_name,
             ),
         )
 
@@ -232,13 +221,16 @@ class Agent(ABC):
         with an actual answer, or quit using "q" or "x"
 
         Args:
-            msg (str|ChatDocument): the string to respond to. Ignored here, but kept
-                for signature uniformity with other *_response methods.
+            msg (str|ChatDocument): the string to respond to.
 
         Returns:
             (str) User response, packaged as a ChatDocument
 
         """
+        if isinstance(msg, ChatDocument) and msg.metadata.sender == Entity.USER:
+            # User cannot respond to message emitted by user
+            return None
+
         if self.default_human_response is not None:
             # useful for automated testing
             user_msg = self.default_human_response
@@ -264,6 +256,26 @@ class Agent(ABC):
             )
 
     @no_type_check
+    def llm_can_respond(self, message: Optional[str | ChatDocument] = None) -> bool:
+        """
+        Whether the LLM can respond to a message.
+        Args:
+            message (str|ChatDocument): message or ChatDocument object to respond to.
+
+        Returns:
+
+        """
+        if self.llm is None:
+            return False
+
+        if message is not None and len(self.get_tool_messages(message)) > 0:
+            # if there is a valid "tool" message (either JSON or via `function_call`)
+            # then LLM cannot respond to it
+            return False
+
+        return True
+
+    @no_type_check
     def llm_response(
         self,
         msg: Optional[str | ChatDocument] = None,
@@ -276,7 +288,7 @@ class Agent(ABC):
         Returns:
             Response from LLM, packaged as a ChatDocument
         """
-        if msg is None or self.llm is None:
+        if msg is None or not self.llm_can_respond(msg):
             return None
 
         if isinstance(msg, ChatDocument):
@@ -323,17 +335,7 @@ class Agent(ABC):
             print("[green]" + response.message)
             displayed = True
 
-        return ChatDocument(
-            content=response.message,
-            function_call=response.function_call,
-            metadata=DocMetaData(
-                source=Entity.LLM.value,
-                sender=Entity.LLM.value,
-                usage=response.usage,
-                displayed=displayed,
-                cached=response.cached,
-            ),
-        )
+        return ChatDocument.from_LLMResponse(response, displayed)
 
     def get_tool_messages(self, msg: str | ChatDocument) -> List[AgentMessage]:
         if isinstance(msg, str):
@@ -343,19 +345,9 @@ class Agent(ABC):
         if msg.content != "":
             return self.get_json_tool_messages(msg.content)
 
-        if msg.function_call is None:
-            return []
-        tool_name = msg.function_call.name
-        tool_msg = msg.function_call.arguments or {}
-        if tool_name not in self.llm_tools_handled:
-            return []
-        tool_class = self.llm_tools_map[tool_name]
-        tool_msg.update(dict(request=tool_name))
-        try:
-            tool = tool_class.parse_obj(tool_msg)
-        except ValidationError as ve:
-            raise ValueError("Error parsing tool_msg as message class") from ve
-        return [tool]
+        # otherwise, we check look for a `function_call`
+        fun_call_cls = self.get_function_call_class(msg)
+        return [fun_call_cls] if fun_call_cls is not None else []
 
     def get_json_tool_messages(self, input_str: str) -> List[AgentMessage]:
         """
@@ -372,6 +364,21 @@ class Agent(ABC):
             return []
         results = [self._get_one_tool_message(j) for j in json_substrings]
         return [r for r in results if r is not None]
+
+    def get_function_call_class(self, msg: ChatDocument) -> Optional[AgentMessage]:
+        if msg.function_call is None:
+            return None
+        tool_name = msg.function_call.name
+        tool_msg = msg.function_call.arguments or {}
+        if tool_name not in self.llm_tools_handled:
+            return None
+        tool_class = self.llm_tools_map[tool_name]
+        tool_msg.update(dict(request=tool_name))
+        try:
+            tool = tool_class.parse_obj(tool_msg)
+        except ValidationError as ve:
+            raise ValueError("Error parsing tool_msg as message class") from ve
+        return tool
 
     def handle_message(self, msg: str | ChatDocument) -> Optional[str]:
         """
@@ -435,6 +442,8 @@ class Agent(ABC):
         try:
             message = message_class.parse_obj(json_data)
         except ValidationError as ve:
+            # TODO use this as feedback to the LLM, directly
+            # or as part of a ToolValidatorAgent
             raise ValueError("Error parsing JSON as message class") from ve
         return message
 

--- a/llmagent/agent/task.py
+++ b/llmagent/agent/task.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
+import logging
 from typing import Callable, Dict, List, Optional, Set, Type, cast
 
 from rich import print
 
-from llmagent.agent.base import Agent, ChatDocMetaData, ChatDocument, Entity
+from llmagent.agent.base import Agent
 from llmagent.agent.chat_agent import ChatAgent
+from llmagent.agent.chat_document import (
+    ChatDocLoggerFields,
+    ChatDocMetaData,
+    ChatDocument,
+    Entity,
+)
 from llmagent.language_models.base import LLMMessage, Role
-from llmagent.mytypes import DocMetaData
-from llmagent.parsing.agent_chats import parse_message
 from llmagent.utils.configuration import settings
 from llmagent.utils.constants import DONE, NO_ANSWER, USER_QUIT
+from llmagent.utils.logging import setup_file_logger
 
 Responder = Entity | Type["Task"]
 
@@ -36,6 +42,7 @@ class Task:
         restart: bool = False,
         default_human_response: Optional[str] = None,
         only_user_quits_root: bool = True,
+        erase_substeps: bool = False,
     ):
         """
         A task to be performed by an agent.
@@ -56,6 +63,11 @@ class Task:
             default_human_response (str): default response from user; useful for
                 testing, to avoid interactive input from user.
             only_user_quits_root (bool): if true, only user can quit the root task.
+            erase_substeps (bool): if true, when task completes, erase intermediate
+                conversation with subtasks from this agent's `message_history`, and also
+                erase all subtask agents' `message_history`.
+                Note: erasing can reduce prompt sizes, but results in repetitive
+                sub-task delegation.
 
         """
         if isinstance(agent, ChatAgent) and len(agent.message_history) == 0 or restart:
@@ -72,13 +84,15 @@ class Task:
                         content=user_message,
                     )
                 )
-
+        self.logger: Optional[logging.Logger] = None
+        self.tsv_logger: Optional[logging.Logger] = None
         self.agent = agent
         self.name = name or agent.config.name
         self.default_human_response = default_human_response
         if default_human_response is not None:
             self.agent.default_human_response = default_human_response
         self.only_user_quits_root = only_user_quits_root
+        self.erase_substeps = erase_substeps
         self.allowed_responders: Set[Responder] = set()
         self.responders: List[Responder] = [
             Entity.AGENT,  # response to LLM wanting to use tool or function_call
@@ -145,17 +159,41 @@ class Task:
     def _leave(self) -> str:
         return self._indent + "<<<"
 
-    def add_sub_task(self, task: Task) -> None:
+    def add_sub_task(self, task: Task | List[Task]) -> None:
         """
-        Add a sub-task that this task can delegate to
+        Add a sub-task (or list of subtasks) that this task can delegate
+        (or fail-over) to. Note that the sequence of sub-tasks is important,
+        since these are tried in order, as the parent task searches for a valid
+        response.
 
         Args:
-            task (Task): sub-task to add
+            task (Task|List[Task]): sub-task(s) to add
         """
+
+        if isinstance(task, list):
+            for t in task:
+                self.add_sub_task(t)
+            return
         task.parent_task = self
         self.sub_tasks.append(task)
         self.responders.append(cast(Responder, task))
         self.name_sub_task_map[task.name] = task
+
+    def init_pending_message(self, msg: Optional[str | ChatDocument] = None) -> None:
+        self._allow_all_responders_except(Entity.USER)
+        if isinstance(msg, str):
+            self.pending_message = ChatDocument(
+                content=msg,
+                metadata=ChatDocMetaData(
+                    sender=Entity.USER,
+                ),
+            )
+        else:
+            self.pending_message = msg
+            if self.pending_message is not None and self.parent_task is not None:
+                # msg may have come from parent_task, so we pretend this is from
+                # the CURRENT task's USER entity
+                self.pending_message.metadata.sender = Entity.USER
 
     def run(
         self,
@@ -185,7 +223,28 @@ class Task:
         # message can be considered to be from the USER
         # (from the POV of this agent's LLM).
 
-        self.reset_pending_message(msg)
+        if (
+            isinstance(msg, ChatDocument)
+            and msg.metadata.recipient != ""
+            and msg.metadata.recipient != self.name
+        ):
+            # this task is not the intended recipient so return None
+            return None
+
+        if self.parent_task is not None and self.parent_task.logger is not None:
+            self.logger = self.parent_task.logger
+        else:
+            self.logger = setup_file_logger("task_logger", f"logs/{self.name}.log")
+
+        if self.parent_task is not None and self.parent_task.tsv_logger is not None:
+            self.tsv_logger = self.parent_task.tsv_logger
+        else:
+            self.tsv_logger = setup_file_logger("tsv_logger", f"logs/{self.name}.tsv")
+            header = ChatDocLoggerFields().tsv_header()
+            self.tsv_logger.info(f"Task\t{header}")
+
+        self.init_pending_message(msg)
+        self.log_message()
         # sets indentation to be printed prior to any output from agent
         self.agent.indent = self._indent
         if self.default_human_response is not None:
@@ -206,6 +265,7 @@ class Task:
         )
         while True:
             self.step()
+            self.log_message()
             if self.pending_message is not None:
                 if self.pending_message.metadata.sender == Entity.LLM:
                     self.last_llm_message = self.pending_message
@@ -223,17 +283,18 @@ class Task:
         # message, and BEFORE final result message
         n_messages = 0
         if isinstance(self.agent, ChatAgent):
-            len(self.agent.message_history)
-            del self.agent.message_history[message_history_idx + 2 : n_messages - 1]
+            if self.erase_substeps:
+                del self.agent.message_history[message_history_idx + 2 : n_messages - 1]
             n_messages = len(self.agent.message_history)
-        for t in self.sub_tasks:
-            # erase our conversation with agent of subtask t
+        if self.erase_substeps:
+            for t in self.sub_tasks:
+                # erase our conversation with agent of subtask t
 
-            # erase message_history of agent of subtask t
-            # TODO - here we assume that subtask-agents are
-            # ONLY talking to the current agent.
-            if isinstance(t.agent, ChatAgent):
-                t.agent.clear_history(0)
+                # erase message_history of agent of subtask t
+                # TODO - here we assume that subtask-agents are
+                # ONLY talking to the current agent.
+                if isinstance(t.agent, ChatAgent):
+                    t.agent.clear_history(0)
         print(
             f"[bold magenta]{self._leave} Finished Agent "
             f"{self.name} ({n_messages}) [/bold magenta]"
@@ -263,47 +324,29 @@ class Task:
             else self.pending_message.metadata.sender
         )
 
-        responder_name = ""
+        result = None
         for r in self.responders:
+            if not self._is_allowed_responder(r):
+                continue
             result = self.response(r, turns)
             if self.valid(result):
-                if isinstance(r, Task):
-                    responder_name = r.name
-                elif (
-                    self.pending_message is not None
-                    and self.pending_message.function_call is not None
-                ):
-                    # when the response was to a `function_call`, set the
-                    # `sender_name` to the name of the function that was called,
-                    # so that in the LLM message-list, the `name` field of the latest
-                    # message is set to the name of the function that was called.
-                    responder_name = self.pending_message.function_call.name
+                self._allow_all_responders_except(r)
+                assert result is not None
                 break
 
-        response: str | ChatDocument # to appease mypy
         if result is None:
-            response = NO_ANSWER
-            responder = Entity.USER if pending_sender == Entity.LLM else Entity.LLM
-        else:
-            if result.content != "":
-                response = result.content
-            elif result.function_call is not None:
-                response = result
-            else:
-                response = NO_ANSWER
-            responder = result.metadata.sender
-
-        self.reset_pending_message(
-            msg=response,
-            ent=responder,
-            sender_name=responder_name,
-        )
-        if settings.debug:
-            pending_message = (
-                "" if self.pending_message is None else self.pending_message.content
+            responder = Entity.LLM if pending_sender == Entity.USER else Entity.USER
+            self.pending_message = ChatDocument(
+                content=NO_ANSWER,
+                metadata=ChatDocMetaData(sender=responder),
             )
-            sender_name_str = f"({responder_name})" if responder_name != "" else ""
-            print(f"[red][{responder} {sender_name_str}]: {pending_message}")
+            self._allow_all_responders_except(responder)
+        else:
+            self.pending_message = result
+
+        if settings.debug:
+            msg_str = str(self.pending_message)
+            print(f"[red][{msg_str}")
 
     def response(self, e: Responder, turns: int = -1) -> Optional[ChatDocument]:
         """
@@ -318,80 +361,15 @@ class Task:
             Optional[ChatDocument]: response to `self.pending_message` from entity if
             valid, None otherwise
         """
-        if not self._is_allowed_responder(e):
-            return None
+        # TODO we many not need this - remove later
+        # if not self._is_allowed_responder(e):
+        #     return None
 
         if isinstance(e, Task):
             actual_turns = e.turns if e.turns > 0 else turns
             return e.run(self.pending_message, turns=actual_turns)
         else:
             return self._entity_responder_map[cast(Entity, e)](self.pending_message)
-
-    def reset_pending_message(
-        self,
-        msg: Optional[str | ChatDocument] = None,
-        ent: Entity = Entity.USER,
-        sender_name: str = "",
-    ) -> None:
-        """
-        Set up pending message (the "task")  before continuing processing loop.
-
-        Args:
-            msg (str|FunctionCall): latest message sent by an entity; optional,
-                default is None. Could either be a string, or a FunctionCall object
-                from the LLM (e.g. OpenAI `function_call` API response).
-            ent (Entity): sender of the pending msg; optional, default is Entity.USER
-            sender_name (str): name of sender; optional, default is ""
-                (Used to fill in "name" field in OpenAI message list)
-
-        """
-        self._allow_all_responders_except(ent)
-        fun_call = None
-        recipient_task_name = ""
-        if isinstance(msg, ChatDocument):
-            if msg.function_call is not None:
-                fun_call = msg.function_call
-                recipient_task_name = msg.function_call.to
-            else:
-                msg = msg.content
-
-        if fun_call is None:
-            recipient_task_name, text = (
-                parse_message(msg) if msg is not None else ("", "")
-            )
-
-        if recipient_task_name:
-            # When a recipient task is specified, we only allow that task to respond,
-            # so disable any sub-task that is NOT the recipient task
-            for task in self.sub_tasks:
-                if task.name != recipient_task_name:
-                    self._disallow_responder(
-                        cast(Type["Task"], self.name_sub_task_map[task.name])
-                    )
-        if (
-            msg is not None
-            and ent == Entity.USER
-            and len(self.agent.get_tool_messages(msg)) > 0
-        ):
-            # if there is a valid "tool" message (either JSON or via `function_call`)
-            # from the USER (typically comes from an outside entity),
-            # then LLM of THIS agent should NOT respond!
-            self._disallow_responder(Entity.LLM)
-
-        self.pending_message = (
-            None
-            if msg is None
-            else ChatDocument(
-                content=text,
-                function_call=fun_call,
-                metadata=ChatDocMetaData(
-                    source=ent,
-                    sender=ent,
-                    sender_name=sender_name,
-                    recipient=recipient_task_name,
-                ),
-            )
-        )
 
     def result(self) -> ChatDocument:
         """
@@ -417,7 +395,11 @@ class Task:
         # since to the "parent" task, this result is equivalent to a response from USER
         return ChatDocument(
             content=content,
-            metadata=DocMetaData(source=Entity.USER, sender=Entity.USER),
+            metadata=ChatDocMetaData(
+                source=Entity.USER,
+                sender=Entity.USER,
+                sender_name=self.name,
+            ),
         )
 
     def done(self) -> bool:
@@ -473,6 +455,24 @@ class Task:
             )
         )
 
+    def log_message(self) -> None:
+        """
+        Log current pending message, and related state, for lineage/debugging purposes.
+        """
+        default_values = ChatDocLoggerFields().dict().values()
+        msg_str_tsv = "\t".join(str(v) for v in default_values)
+        if self.pending_message is not None:
+            msg_str_tsv = self.pending_message.tsv_str()
+        msg_str = ""
+        if self.pending_message is not None:
+            msg_str = str(self.pending_message)
+        task_name = self.name if self.name != "" else "root"
+
+        if self.logger is not None:
+            self.logger.info(f"Task[{task_name}] {msg_str}")
+        if self.tsv_logger is not None:
+            self.tsv_logger.info(f"{task_name}\t{msg_str_tsv}")
+
     def _disallow_responder(self, e: Responder) -> None:
         """
         Disallow a responder from responding to current message.
@@ -513,3 +513,12 @@ class Task:
         """
         self._allow_all_responders()
         self._disallow_responder(e)
+
+    def _allow_only_responder(self, e: Responder) -> None:
+        """
+        Allow ONLY `e` to respond to current pending message.
+
+        Args:
+            e (Entity): only entity to allow
+        """
+        self.allowed_responders = {e}

--- a/llmagent/language_models/base.py
+++ b/llmagent/language_models/base.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, BaseSettings
 
 from llmagent.cachedb.redis_cachedb import RedisCacheConfig
 from llmagent.mytypes import Document
+from llmagent.parsing.agent_chats import parse_message
 from llmagent.prompts.dialog import collate_chat_history
 from llmagent.prompts.templates import (
     EXTRACTION_PROMPT_GPT4,
@@ -50,13 +51,6 @@ class LLMFunctionCall(BaseModel):
         return "FUNC: " + json.dumps(self.dict(), indent=2)
 
 
-class LLMResponse(BaseModel):
-    message: str
-    function_call: Optional[LLMFunctionCall] = None
-    usage: int
-    cached: bool = False
-
-
 class LLMFunctionSpec(BaseModel):
     """
     Description of a function available for the LLM to use.
@@ -78,11 +72,75 @@ class Role(str, Enum):
 
 class LLMMessage(BaseModel):
     role: Role
-    name: str = "xyz"
+    name: Optional[str] = None
     content: str
+    function_call: Optional[LLMFunctionCall] = None
+
+    def api_dict(self) -> Dict[str, Any]:
+        """
+        Convert to dictionary for API request.
+        Returns:
+            dict: dictionary representation of LLM message
+        """
+        d = self.dict()
+        # drop None values since API doesn't accept them
+        dict_no_none = {k: v for k, v in d.items() if v is not None}
+        if "name" in dict_no_none and dict_no_none["name"] == "":
+            # OpenAI API does not like empty name
+            del dict_no_none["name"]
+        return dict_no_none
 
     def __str__(self) -> str:
-        return f"{self.role} ({self.name}): {self.content}"
+        if self.function_call is not None:
+            content = "FUNC: " + json.dumps(self.function_call)
+        else:
+            content = self.content
+        name_str = f" ({self.name})" if self.name else ""
+        return f"{self.role} {name_str}: {content}"
+
+
+class LLMResponse(BaseModel):
+    message: str
+    function_call: Optional[LLMFunctionCall] = None
+    usage: int
+    cached: bool = False
+
+    def to_LLMMessage(self) -> LLMMessage:
+        content = self.message
+        role = Role.ASSISTANT if self.function_call is None else Role.FUNCTION
+        name = None if self.function_call is None else self.function_call.name
+        return LLMMessage(
+            role=role,
+            content=content,
+            name=name,
+            function_call=self.function_call,
+        )
+
+    def recipient_message(
+        self,
+    ) -> Tuple[str, str]:
+        """
+        If `message` or `function_call` of an LLM response contains an explicit
+        recipient name, return this recipient name and `message` stripped
+        of the recipient name if specified.
+
+        Two cases:
+        (a) `message` contains "TO: <name> <content>", or
+        (b) `message` is empty and `function_call` with `to: <name>`
+
+        Returns:
+            (str): name of recipient, which may be empty string if no recipient
+            (str): content of message
+
+        """
+
+        if self.function_call is not None:
+            return self.function_call.to, ""
+        else:
+            msg = self.message
+
+        recipient_name, content = parse_message(msg) if msg is not None else ("", "")
+        return recipient_name, content
 
 
 # Define an abstract base class for language models

--- a/llmagent/utils/configuration.py
+++ b/llmagent/utils/configuration.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     cache: bool = True  # use cache?
     interactive: bool = True  # interactive mode?
     gpt3_5: bool = True  # use GPT-3.5?
+    nofunc: bool = False  # use model without function_call? (i.e. gpt-4)
 
     class Config:
         extra = "forbid"

--- a/llmagent/utils/logging.py
+++ b/llmagent/utils/logging.py
@@ -1,4 +1,5 @@
 import logging
+import os.path
 
 import colorlog
 
@@ -28,7 +29,7 @@ def setup_colored_logging() -> None:
     # logger.setLevel(logging.DEBUG)
 
 
-def setup_logger(name: str, level: int) -> logging.Logger:
+def setup_logger(name: str, level: int = logging.INFO) -> logging.Logger:
     """
     Set up a logger of module `name` at a desired level.
     Args:
@@ -46,6 +47,45 @@ def setup_logger(name: str, level: int) -> logging.Logger:
         )
         handler.setFormatter(formatter)
         logger.addHandler(handler)
+    return logger
+
+
+def setup_console_logger(name: str) -> logging.Logger:
+    logger = setup_logger(name)
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    return logger
+
+
+def setup_file_logger(
+    name: str,
+    filename: str,
+    append: bool = False,
+    log_format: bool = False,
+    propagate: bool = False,
+) -> logging.Logger:
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    if not append:
+        if os.path.exists(filename):
+            os.remove(filename)
+
+    logger = setup_logger(name)
+    handler = logging.FileHandler(filename)
+    handler.setLevel(logging.INFO)
+    if log_format:
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+    else:
+        formatter = logging.Formatter("%(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.propagate = propagate
     return logger
 
 

--- a/llmagent/utils/output/printing.py
+++ b/llmagent/utils/output/printing.py
@@ -8,6 +8,11 @@ from llmagent.utils.configuration import settings
 from llmagent.utils.constants import Colors
 
 
+def shorten_text(text: str, chars: int = 40) -> str:
+    text = " ".join(text.split())
+    return text[:chars] + "..." + text[-chars:] if len(text) > 2 * chars else text
+
+
 def print_long_text(
     color: str, style: str, preamble: str, text: str, chars: Optional[int] = None
 ) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,12 @@ def pytest_addoption(parser) -> None:
     parser.addoption("--nc", action="store_true", default=False, help="don't use cache")
     parser.addoption("--3", action="store_true", default=False, help="use GPT-3.5")
     parser.addoption("--ns", action="store_true", default=False, help="no streaming")
+    parser.addoption(
+        "--nof",
+        action="store_true",
+        default=False,
+        help="use model with no function_call",
+    )
 
 
 @pytest.fixture
@@ -22,4 +28,5 @@ def test_settings(request) -> Settings:
         cache=not request.config.getoption("--nc"),
         gpt3_5=request.config.getoption("--3"),
         stream=not request.config.getoption("--ns"),
+        nofunc=request.config.getoption("--nof"),
     )

--- a/tests/examples/doc_chat/test_doc_chat_agent.py
+++ b/tests/examples/doc_chat/test_doc_chat_agent.py
@@ -127,7 +127,7 @@ def test_doc_chat_agent(test_settings: Settings, query: str, expected: str):
 def test_doc_chat_process(test_settings: Settings):
     set_global(test_settings)
     task = Task(agent, restart=True)
-    task.reset_pending_message()
+    task.init_pending_message()
     # LLM responds to Sys msg, initiates conv, says thank you, etc.
     task.step()
     for q, expected in QUERY_EXPECTED_PAIRS:

--- a/tests/examples/dockerchat/test_build_run.py
+++ b/tests/examples/dockerchat/test_build_run.py
@@ -19,7 +19,7 @@ cfg = ChatAgentConfig(
     vecdb=None,
     llm=OpenAIGPTConfig(
         type="openai",
-        chat_model=OpenAIChatModel.GPT3_5_TURBO,
+        chat_model=OpenAIChatModel.GPT4,
         cache_config=RedisCacheConfig(fake=True),
     ),
 )

--- a/tests/examples/dockerchat/test_dockerchat_agent_messages.py
+++ b/tests/examples/dockerchat/test_dockerchat_agent_messages.py
@@ -19,7 +19,7 @@ cfg = ChatAgentConfig(
     vecdb=None,
     llm=OpenAIGPTConfig(
         type="openai",
-        chat_model=OpenAIChatModel.GPT3_5_TURBO,
+        chat_model=OpenAIChatModel.GPT4,
         cache_config=RedisCacheConfig(fake=False),
     ),
 )

--- a/tests/examples/dockerchat/test_dockerfile_validation.py
+++ b/tests/examples/dockerchat/test_dockerfile_validation.py
@@ -74,7 +74,7 @@ cfg = ChatAgentConfig(
     vecdb=None,
     llm=OpenAIGPTConfig(
         type="openai",
-        chat_model=OpenAIChatModel.GPT3_5_TURBO,
+        chat_model=OpenAIChatModel.GPT4,
         cache_config=RedisCacheConfig(fake=False),
     ),
     parsing=ParsingConfig(),

--- a/tests/examples/dockerchat/test_python_dependency.py
+++ b/tests/examples/dockerchat/test_python_dependency.py
@@ -1,12 +1,10 @@
 import os
 import tempfile
 import pytest
-from llmagent.utils.configuration import Settings, set_global
 from llmagent.language_models.openai_gpt import OpenAIGPTConfig, OpenAIChatModel
 from llmagent.prompts.prompts_config import PromptsConfig
 from llmagent.parsing.parser import ParsingConfig
 from llmagent.agent.base import AgentMessage
-from llmagent.agent.task import Task
 from llmagent.agent.chat_agent import ChatAgent, ChatAgentConfig
 from llmagent.utils.system import rmdir
 from llmagent.cachedb.redis_cachedb import RedisCacheConfig
@@ -62,7 +60,7 @@ cfg = ChatAgentConfig(
     vecdb=None,
     llm=OpenAIGPTConfig(
         type="openai",
-        chat_model=OpenAIChatModel.GPT3_5_TURBO,
+        chat_model=OpenAIChatModel.GPT4,
         cache_config=RedisCacheConfig(fake=False),
     ),
     parsing=ParsingConfig(),
@@ -110,22 +108,6 @@ def test_agent_handle_message():
         agent.handle_message(PYTHON_DEPENDENCY_MSG)
         == "This repo uses requirements.txt for managing dependencies"
     )
-
-
-def test_llm_agent_message(test_settings: Settings):
-    """
-    Test whether LLM is able to generate message in required format, and the
-    agent handles the message correctly.
-    """
-    set_global(test_settings)
-    agent = MessageHandlingAgent(cfg)
-    agent.enable_message(PythonDependencyMessage)
-    task = Task(
-        agent,
-        default_human_response="I don't know, please ask your next question.",
-    )
-    task.run(turns=2)
-    # TODO need an assert here
 
 
 @pytest.mark.parametrize("depfile", DEPENDENCY_FILES)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -13,7 +13,7 @@ class CustomAgentConfig(AgentConfig):
     vecdb: VectorStoreConfig = None
     llm: OpenAIGPTConfig = OpenAIGPTConfig(
         type="openai",
-        chat_model=OpenAIChatModel.GPT3_5_TURBO,
+        chat_model=OpenAIChatModel.GPT4,
         use_chat_for_completion=True,
         cache_config=RedisCacheConfig(fake=False),
     )

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -1,5 +1,6 @@
-from llmagent.agent.base import NO_ANSWER, Entity
+from llmagent.agent.base import NO_ANSWER
 from llmagent.agent.chat_agent import ChatAgent, ChatAgentConfig
+from llmagent.agent.chat_document import Entity
 from llmagent.agent.task import Task
 from llmagent.cachedb.redis_cachedb import RedisCacheConfig
 from llmagent.language_models.openai_gpt import OpenAIChatModel, OpenAIGPTConfig
@@ -14,7 +15,7 @@ class _TestChatAgentConfig(ChatAgentConfig):
     vecdb: VectorStoreConfig = None
     llm: OpenAIGPTConfig = OpenAIGPTConfig(
         cache_config=RedisCacheConfig(fake=False),
-        chat_model=OpenAIChatModel.GPT3_5_TURBO,
+        chat_model=OpenAIChatModel.GPT4,
         use_chat_for_completion=True,
     )
     parsing: ParsingConfig = ParsingConfig()
@@ -63,7 +64,7 @@ def test_process_messages(test_settings: Settings):
         agent, llm_delegate=False, single_round=False, only_user_quits_root=False
     )
     msg = "What is the capital of France?"
-    task.reset_pending_message(msg)
+    task.init_pending_message(msg)
     assert task.pending_message.content == msg
 
     # LLM answers
@@ -108,7 +109,7 @@ def test_process_messages(test_settings: Settings):
         only_user_quits_root=False,
     )
     # LLM responds with NO_ANSWER
-    task.reset_pending_message()
+    task.init_pending_message()
     task.step()
     assert NO_ANSWER in task.pending_message.content
     assert task.pending_message.metadata.sender == Entity.LLM

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -71,7 +71,7 @@ def test_inter_agent_chat(test_settings: Settings, helper_human_response: str):
     Your job is to ask me questions. 
     Start by asking me what the capital of France is.
     """
-    task.reset_pending_message(msg)
+    task.init_pending_message(msg)
 
     task.step()
     assert "What" in task.pending_message.content


### PR DESCRIPTION
- cli options to disable streaming
- task responses ChatDocument -> ChatDocument
- * task.py - eliminate reset_pending_message,             streamline task loop,             constructor has erase_substeps=False option,             add logging of messages to .log, .tsv * tests can be run with --ns option (disable streaming)
