### PR TITLE
Fix #161 - summarize_docs context len

### DIFF
--- a/langroid/agent/special/doc_chat_agent.py
+++ b/langroid/agent/special/doc_chat_agent.py
@@ -380,8 +380,13 @@ class DocChatAgent(ChatAgent):
         if self.parser is None:
             raise ValueError("No parser defined")
         tot_tokens = self.parser.num_tokens(full_text)
+        model = (
+            self.config.llm.chat_model
+            if self.config.llm.use_chat_for_completion
+            else self.config.llm.completion_model
+        )
         MAX_INPUT_TOKENS = (
-            self.config.llm.context_length[self.config.llm.completion_model]
+            self.config.llm.context_length[model]
             - self.config.llm.max_output_tokens
             - 100
         )


### PR DESCRIPTION
summarize_docs() was using context len of completion_model always.
But it should use chat_model's context len if llm.use_chat_for_completion is True.

