### PR TITLE
removing ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,6 @@ Then instantiate the `DocChatAgent`, ingest the docs into the vector-store:
 
 ```python
 agent = DocChatAgent(config)
-agent.ingest()
 ```
 Then we can either ask the agent one-off questions,
 ```python


### PR DESCRIPTION
I know this is not intended to be a runnable example, but based on the sequence by the time of creating the agent the URLs will be ingested by default, and when we call `ingest`, the files will be ingested again. 