### PR TITLE
improved RecipientTool for msg routing

### DIFF
--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -231,7 +231,7 @@ class Agent(ABC):
         ]
         return "\n\n".join(sample_convo)
 
-    def message_format_instructions(self) -> str:
+    def json_tool_format_instructions(self) -> str:
         """
         Generate a string containing instructions to the LLM on when to format
         requests/questions as JSON, based on the currently enabled message classes.
@@ -428,7 +428,7 @@ class Agent(ABC):
         if msg.content != "":
             return self.get_json_tool_messages(msg.content)
 
-        # otherwise, we check look for a `function_call`
+        # otherwise, we look for a `function_call`
         fun_call_cls = self.get_function_call_class(msg)
         return [fun_call_cls] if fun_call_cls is not None else []
 
@@ -608,9 +608,9 @@ class Agent(ABC):
     ) -> Optional[str]:
         """
         Send a request to another agent, possibly after confirming with the user.
-        This is not currently used, since we rely on the task loop and "TO:" syntax
-        to send requests to other agents. It is generally best to avoid using this
-        method.
+        This is not currently used, since we rely on the task loop and
+        `RecipientTool` to address requests to other agents. It is generally best to
+        avoid using this method.
 
         Args:
             agent (Agent): agent to ask

--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 from contextlib import ExitStack
 from typing import Dict, List, Optional, Set, Type, cast, no_type_check
@@ -68,7 +69,9 @@ class ChatAgent(Agent):
         super().__init__(config)
         self.config: ChatAgentConfig = config
         self.message_history: List[LLMMessage] = []
-        self.json_instructions_idx: int = -1
+        self.tool_instructions_added: bool = False
+        # system-level instructions for using tools/functions
+        self.system_tool_instructions: str = ""
         self.llm_functions_map: Dict[str, LLMFunctionSpec] = {}
         self.llm_functions_handled: Set[str] = set()
         self.llm_functions_usable: Set[str] = set()
@@ -113,6 +116,23 @@ class ChatAgent(Agent):
             ]
         )
 
+    def augment_system_message(self, message: str) -> None:
+        """
+        Augment the system message with the given message.
+        Args:
+            message (str): system message
+        """
+        if len(self.message_history) > 0:
+            if self.message_history[0].role == Role.SYSTEM:
+                self.message_history[0].content = (
+                    self.message_history[0].content + "\n\n" + message
+                )
+        else:
+            if self.task_messages[0].role == Role.SYSTEM:
+                self.task_messages[0].content = (
+                    self.task_messages[0].content + "\n\n" + message
+                )
+
     def add_user_message(self, message: str) -> None:
         """
         Add a user message to the message history.
@@ -147,6 +167,7 @@ class ChatAgent(Agent):
         use: bool = True,
         handle: bool = True,
         force: bool = False,
+        require_recipient: bool = False,
     ) -> None:
         """
         Add the tool (message class) to the agent, and enable either
@@ -165,11 +186,15 @@ class ChatAgent(Agent):
             force: whether to FORCE the agent (LLM) to USE the specific
                  tool represented by `message_class`.
                  `force` is ignored if `message_class` is None.
+            require_recipient: whether to require that recipient be specified
+                when using the tool message (only applies if `use` is True).
 
         """
         super().enable_message_handling(message_class)  # enables handling only
         tools = self._get_tool_list(message_class)
         if message_class is not None:
+            if require_recipient:
+                message_class = message_class.require_recipient()
             request = message_class.default_value("request")
             llm_function = message_class.llm_function_schema()
             self.llm_functions_map[request] = llm_function
@@ -177,6 +202,14 @@ class ChatAgent(Agent):
                 self.llm_function_force = dict(name=request)
             else:
                 self.llm_function_force = None
+            if hasattr(message_class, "instructions") and inspect.ismethod(
+                message_class.instructions
+            ):
+                # save tool instructions so that when LLM is ready
+                # to respond (i.e. either when a wrapping Task is started,
+                # or when the LLM is directly queried),
+                # we can append to system msg.
+                self.system_tool_instructions = message_class.instructions()
         n_usable_tools = len(self.llm_tools_usable)
         for t in tools:
             if handle:
@@ -198,7 +231,7 @@ class ChatAgent(Agent):
         # But for now leave as is.
         if len(self.llm_tools_usable) != n_usable_tools and self.config.use_tools:
             # Update JSON format instructions if the set of usable tools has changed
-            self.update_message_instructions()
+            self.update_json_tool_instructions()
 
     def disable_message_handling(
         self,
@@ -242,23 +275,27 @@ class ChatAgent(Agent):
                 self.llm_tools_usable.discard(r)
                 self.llm_functions_usable.discard(r)
 
-    def update_message_instructions(self) -> None:
+    def update_json_tool_instructions(self) -> None:
         """
         Add special instructions on situations when the LLM should send JSON-formatted
         messages, and save the index position of these instructions in the
-        message history.
+        message history. Note this specifically only relates to the
+        Langroid JSON tools mechanism, not the LLM-native function-calling.
         """
-        # note according to the openai-cookbook, GPT-3.5 pays less attention to the
-        # system messages, so we add the instructions as a user message
-        # TODO need to adapt this based on model type.
-        json_instructions = super().message_format_instructions()
-        if self.json_instructions_idx < 0:
+        # Add the instructions as a user message...
+        # TODO need to adapt this based on model type, as some models may
+        # pay more attention to system message.
+        json_instructions = super().json_tool_format_instructions()
+        if not self.tool_instructions_added:
             self.task_messages.append(
                 LLMMessage(role=Role.USER, content=json_instructions)
             )
-            self.json_instructions_idx = len(self.task_messages) - 1
+            self.tool_instructions_added = True
         else:
-            self.task_messages[self.json_instructions_idx].content = json_instructions
+            # json_instructions will contain instructions on ALL tools,
+            # so it is ok to overwrite the last message in the task_messages,
+            # since we know it is a tool-instruction msg.
+            self.task_messages[-1].content = json_instructions
 
         # Note that task_messages is the initial set of messages created to set up
         # the task, and they may not yet have been sent to the LLM at this point.
@@ -267,7 +304,7 @@ class ChatAgent(Agent):
         # update the self.message_history as well, since this history will be sent to
         # the LLM on each round, after appending the latest assistant, user msgs.
         if len(self.message_history) > 0:
-            self.message_history[self.json_instructions_idx].content = json_instructions
+            self.message_history[-1].content = json_instructions
 
     @no_type_check
     def llm_response(
@@ -292,6 +329,11 @@ class ChatAgent(Agent):
         if len(self.message_history) == 0:
             # task_messages have not yet been loaded, so load them
             self.message_history = self.task_messages.copy()
+            # first message is system msg, augment if needed
+            if self.system_tool_instructions != "":
+                self.message_history[0].content += (
+                    "\n\n" + self.system_tool_instructions
+                )
             # for debugging, show the initial message history
             if settings.debug:
                 print(

--- a/langroid/parsing/json.py
+++ b/langroid/parsing/json.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import Any, List
 
 import regex
 
@@ -37,3 +37,28 @@ def extract_top_level_json(s: str) -> List[str]:
     ]
 
     return top_level_jsons
+
+
+def top_level_json_field(s: str, f: str) -> Any:
+    """
+    Extract the value of a field f from a top-level JSON object.
+    If there are multiple, just return the first.
+
+    Args:
+        s (str): The input string to search for JSON substrings.
+        f (str): The field to extract from the JSON object.
+
+    Returns:
+        str: The value of the field f in the top-level JSON object, if any.
+            Otherwise, return an empty string.
+    """
+
+    jsons = extract_top_level_json(s)
+    if len(jsons) == 0:
+        return ""
+    for j in jsons:
+        json_data = json.loads(j)
+        if f in json_data:
+            return json_data[f]
+
+    return ""

--- a/langroid/utils/pydantic_utils.py
+++ b/langroid/utils/pydantic_utils.py
@@ -1,0 +1,8 @@
+from typing import Type
+
+from pydantic import BaseModel
+
+
+def has_field(model_class: Type[BaseModel], field_name: str) -> bool:
+    """Check if a Pydantic model class has a field with the given name."""
+    return field_name in model_class.__fields__

--- a/tests/main/test_multi_agent_complex.py
+++ b/tests/main/test_multi_agent_complex.py
@@ -94,7 +94,12 @@ EXPONENTIALS = "3**5 8**3 9**3"
 
 
 @pytest.mark.parametrize("fn_api", [True, False])
-def test_agents_with_validator(test_settings: Settings, fn_api: bool):
+@pytest.mark.parametrize("constrain_recipients", [True, False])
+def test_agents_with_validator(
+    test_settings: Settings,
+    fn_api: bool,
+    constrain_recipients: bool,
+):
     set_global(test_settings)
     master_cfg = _TestChatAgentConfig(name="Master")
 
@@ -131,7 +136,14 @@ def test_agents_with_validator(test_settings: Settings, fn_api: bool):
 
     # For a given exponential computation, plans a sequence of multiplications.
     planner = _PlannerAgent(planner_cfg)
-    planner.enable_message(RecipientTool)
+
+    if constrain_recipients:
+        planner.enable_message(
+            RecipientTool.create(recipients=["Master", "Multiplier"])
+        )
+    else:
+        planner.enable_message(RecipientTool)
+
     task_planner = Task(
         planner,
         llm_delegate=True,
@@ -144,12 +156,8 @@ def test_agents_with_validator(test_settings: Settings, fn_api: bool):
                 exponential you receive from "Master", you have to ask a sequence of
                 multiplication questions to "Multiplier", to figure out the 
                 exponential.
-                Since you are talking to both Master and Multipler, 
-                you must use the `recipient_message` tool/function-call to 
-                clarify who your message is for, by setting the `recipient` field
-                to either "Master" or "Multiplier", and the `content` field to
-                the message you want to send to the recipient. 
-                multiplication. When you have your final answer, report your answer
+                
+                When you have your final answer, report your answer
                 back to "Master" using the same `recipient_message` tool/function-call.
                 
                 When asking the Multipler, remember to only present your 

--- a/tests/main/test_recipient_tool.py
+++ b/tests/main/test_recipient_tool.py
@@ -28,16 +28,36 @@ import pytest
 
 from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
 from langroid.agent.task import Task
+from langroid.agent.tool_message import ToolMessage
 from langroid.agent.tools.recipient_tool import RecipientTool
 from langroid.language_models.openai_gpt import OpenAIChatModel, OpenAIGPTConfig
 from langroid.utils.configuration import Settings, set_global
 
 INPUT_NUMBERS = [1, 100, 2, 21, 4, 40, 33]
-TRANSFORMED_NUMBERS = [4, 50, 1, 64, 2, 20, 100]
+TRANSFORMED_NUMBERS = [4, 10000, 1, 64, 2, 1600, 100]
+
+
+class SquareTool(ToolMessage):
+    request: str = "square"
+    purpose: str = "To square a <number>, when it is a multiple of 10."
+    number: int
+
+    # this is a stateless tool, so we can define the handler here,
+    # without having to define a `square` method in the agent.
+    def handle(self) -> str:
+        if self.number % 10 == 0:
+            return str(self.number**2)
+        else:
+            return "-1"
 
 
 @pytest.mark.parametrize("fn_api", [True, False])
-def test_agents_with_recipient_tool(test_settings: Settings, fn_api: bool):
+@pytest.mark.parametrize("constrain_recipients", [True, False])
+def test_agents_with_recipient_tool(
+    test_settings: Settings,
+    fn_api: bool,
+    constrain_recipients: bool,
+):
     set_global(test_settings)
     config = ChatAgentConfig(
         llm=OpenAIGPTConfig(
@@ -48,57 +68,89 @@ def test_agents_with_recipient_tool(test_settings: Settings, fn_api: bool):
         vecdb=None,
     )
     processor_agent = ChatAgent(config)
-    processor_agent.enable_message(RecipientTool)
+
+    if constrain_recipients:
+        processor_agent.enable_message(
+            RecipientTool.create(recipients=["EvenHandler", "OddHandler"])
+        )
+    else:
+        processor_agent.enable_message(RecipientTool)
+
+    processor_agent.enable_message(
+        SquareTool, require_recipient=True, use=True, handle=False
+    )
     processor_task = Task(
         processor_agent,
         name="Processor",
         default_human_response="",
         only_user_quits_root=False,
         system_message=f"""
-        You are given this list of numbers:
-        {INPUT_NUMBERS} 
-        Your goal is to apply a transformation to each number.
+        You are given this list of {len(INPUT_NUMBERS)} numbers:
+        {INPUT_NUMBERS}. 
+        You have to transform each number to a new POSITIVE value.
         However you do not know how to do this transformation.
-        You can take the help of two people to perform the 
-        transformation.
-        If the number is even, send it to EvenHandler,
-        and if it is odd, send it to OddHandler.
+        You can send the number to one of two people to do the 
+        transformation: 
+        - EvenHandler (who handles only even numbers),
+        - OddHandler (who handles only odd numbers). 
         
-        IMPORTANT: send the numbers ONE AT A TIME
+        There are 3 cases, depending on the number n
         
-        The handlers will transform the number and give you a new number.        
-        If you send it to the wrong person, you will receive a negative value.
-        Your aim is to never get a negative number, so you must 
-        clearly specify who you are sending the number to, using the
-        `recipient_message` tool/function-call, where the `content` field
-        is the number you want to send, and the `recipient` field is the name
-        of the intended recipient, either "EvenHandler" or "OddHandler".
+        (a) If n is even:
+         (a.1) if n is a multiple of 10, send it to EvenHandler,
+             using the `square` tool/function-call, specifying the `recipient` field 
+             as "EvenHandler".
+         (a.2) if n is NOT a multiple of 10, send it to EvenHandler,
+             
+        (b) If n is odd, send it to OddHandler. 
         
-        You are also forgetful when it comes to numbers bigger than 10.
-        When a number is bigger than 10, just send your number without specifying
-        a recipient, as a simple non-JSON string, and do this without explaining why 
-        you are doing this, and do not correct yourself until I remind you.
-        When I receive this message, I will remind you to correct this, and you can 
-        then correct yourself. For example when trying to transform 25, since it is 
-        bigger than 10, you will send me simply the  message "25", and say nothing else.
+        IMPORTANT: send the numbers ONE AT A TIME. Your message content
+        should ONLY be numbers, do not say anything else, other than specifying
+        recipients etc.
         
-        Once all numbers in the given list have been transformed, 
-        say DONE and show me the result.
+        The handlers will transform the number and give you the result.
+        If you deviate from the above rules 
+        (i.e. you send it to the wrong person or using the wrong tool/function), 
+        you will receive a value of -10.
+        Your task is to avoid getting negative values, by making sure you
+        follow the above rules. If you ever get a negative value, correct yourself
+        in the next step.
+        
+        Once all {len(INPUT_NUMBERS)} numbers in the given list have been transformed
+        to positive values, say DONE and show me the result, showing only the 
+        positive transformations, in the same order as the original list.
         
         Start by requesting a transformation for the first number.
+        Be very concise in your messages, do not say anything unnecessary.
         """,
         llm_delegate=True,
         single_round=False,
     )
+
+    # You are also forgetful when it comes to numbers bigger than 10.
+    # When a number is bigger than 10, just send your number without specifying
+    # a recipient, as a simple non-JSON string, and do this without explaining why
+    # you are doing this, and do not correct yourself until I remind you.
+    # When I receive this message, I will remind you to correct this, and you can
+    # then correct yourself. For example when trying to transform 25, since it is
+    # bigger than 10, you will send me simply the  message "25", and say nothing else.
+
     even_agent = ChatAgent(config)
+    even_agent.enable_message(
+        SquareTool,
+        use=False,  # LLM of this agent does not need to generate this tool/fn-call
+        handle=True,  # this agent needs to handle this tool/fn-call
+        require_recipient=False,  # this agent does not to specify recipient
+    )
     even_task = Task(
         even_agent,
         name="EvenHandler",
         default_human_response="",
         system_message="""
         You will be given a number. 
-        If it is even, divide by 2 and say the result, nothing else.
-        If it is odd, say -10
+        If it is not a multiple of 10, and even, 
+        divide by 2 and say the result, nothing else.
+        Otherwise, say -10
         """,
         single_round=True,  # task done after 1 step() with valid response
     )


### PR DESCRIPTION
- pydantic_utils.py
- method rename, comment
- json.py +top_level_json_field()
- ToolMessage.require_recipient()
- pydantic_utils mod
- language_models/base.py: better extraction of "recipient"
- ChatDocument.from_LLMResponse: improve recipient extraction
- chat_agent.py: support RecipientTool mechanism
- RecipienTool: create(recipients=...) to specify allowed recipients instructions() to generate tool instrucs
- test_recipient_tool, test_multi_agent_complex to test RecipientTool
