### PR TITLE
Changed docstring to point to right path and added tip for installing…

### DIFF
--- a/examples/basic/fn-call-local-simple.py
+++ b/examples/basic/fn-call-local-simple.py
@@ -10,12 +10,12 @@ This is also referred to in various scenarios as "Tools", "Actions" or "Plugins"
 # ollama pull mistral:7b-instruct-v0.2-q4_K_M
 
 # (2) Ensure you've installed the `litellm` extra with Langroid, e.g.
-# pip install langroid[litellm], or if you use the `pyproject.toml` in this repo
-# you can simply use `poetry install`
+# pip install langroid[litellm] (or use pip install langroid\[litellm\] if using zsh),
+or if you use the `pyproject.toml` in this repo you can simply use `poetry install`
 
 # (3) Run like this:
 
-python3 examples/docqa/fn-call-local-simple.py
+python3 examples/basic/fn-call-local-simple.py
 
 """
 import os


### PR DESCRIPTION
… langroid[litellm] is using zsh