### PR TITLE
task tool fixes

### DIFF
--- a/examples/docqa/lease.txt
+++ b/examples/docqa/lease.txt
@@ -39,7 +39,7 @@ ARTICLE IV - DETERMINATION OF RENT
 
 
 
-Section 1. Monthly Rent: The Tenant agrees to pay the Landlord and the Landlord agrees to accept, during the term hereof, at such place as the Landlord shall from time to time direct by notice to the Tenant, monthly rent of $40,000.
+Section 1. Monthly Rent: The Tenant agrees to pay the Landlord and the Landlord agrees to accept, during the term hereof, at such place as the Landlord shall from time to time direct by notice to the Tenant, monthly rent of $100,000.
 
 
 Section 2.  Late Fee.  A late fee in the amount of 5% of the Monthly Rent shall be assessed if payment is not postmarked or received by Landlord on or before the tenth day of each month.

--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -235,9 +235,8 @@ class ChatAgent(Agent):
         # if any of the enabled classes has json_group_instructions, then use that,
         # else fall back to ToolMessage.json_group_instructions
         for msg_cls in enabled_classes:
-            if (
-                hasattr(msg_cls, "json_group_instructions")
-                and callable(getattr(msg_cls, "json_group_instructions"))
+            if hasattr(msg_cls, "json_group_instructions") and callable(
+                getattr(msg_cls, "json_group_instructions")
             ):
                 return msg_cls.json_group_instructions().format(
                     json_instructions=json_instructions

--- a/langroid/agent/chat_document.py
+++ b/langroid/agent/chat_document.py
@@ -84,7 +84,7 @@ class ChatDocument(Document):
             json_data = json.loads(j)
             tool = json_data.get("request")
             if tool is not None:
-                tools.append(tool)
+                tools.append(str(tool))
         return tools
 
     def log_fields(self) -> ChatDocLoggerFields:


### PR DESCRIPTION
- ChatAgent: json_instructions() new `tool` arg; improve json_group_instructions
- system.py LazyLoad class (not used)
- pydantic_utils: simple_schema(), get_field_names()
- json.py replace_undefined() to handle unquoted values
- ToolMessage (unused) code to use simple schema for langroid-tools
- task.py fix SEND_TO parsing, handling
- ChatDocument convert tool to str before logging
- ChatAgent - handle json_group_instructions as static method
- examples/docqa/lease.txt fix rent discrepancy
- examples/docqa/chat.py reorg
