### PR TITLE
DocChatAgent fix, respect OLLAMA_HOST, multi-schema context description generation

### DIFF
--- a/examples/basic/chat-search-assistant-local.py
+++ b/examples/basic/chat-search-assistant-local.py
@@ -51,7 +51,7 @@ class QuestionTool(lr.ToolMessage):
     question: str
 
     @classmethod
-    def examples(cls) -> List["ToolMessage"]:
+    def examples(cls) -> List[lr.ToolMessage]:
         return [
             cls(question="Which superconductor material was discovered in 2023?"),
             cls(question="What AI innovation did Meta achieve in 2024?"),

--- a/examples/chainlit/chat-search-assistant-local.py
+++ b/examples/chainlit/chat-search-assistant-local.py
@@ -30,7 +30,7 @@ class QuestionTool(lr.ToolMessage):
     question: str
 
     @classmethod
-    def examples(cls) -> List["ToolMessage"]:
+    def examples(cls) -> List[lr.ToolMessage]:
         return [
             cls(question="Which superconductor material was discovered in 2023?"),
             cls(question="What AI innovation did Meta achieve in 2024?"),

--- a/langroid/agent/special/sql/sql_chat_agent.py
+++ b/langroid/agent/special/sql/sql_chat_agent.py
@@ -182,7 +182,9 @@ class SQLChatAgent(ChatAgent):
     def _init_table_metadata(self) -> None:
         """Initialize metadata for the tables present in the database."""
         if not self.config.context_descriptions and isinstance(self.engine, Engine):
-            self.config.context_descriptions = extract_schema_descriptions(self.engine)
+            self.config.context_descriptions = extract_schema_descriptions(
+                self.engine, self.config.multi_schema
+            )
 
         if self.config.use_schema_tools:
             self.table_metadata = populate_metadata_with_schema_tools(

--- a/langroid/agent/tool_message.py
+++ b/langroid/agent/tool_message.py
@@ -82,7 +82,7 @@ class ToolMessage(ABC, BaseModel):
         ex = choice(cls.examples())
         return ex.json_example()
 
-    def to_json(self):
+    def to_json(self) -> str:
         return self.json(indent=4, exclude={"result", "purpose"})
 
     def json_example(self) -> str:

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -54,7 +54,11 @@ from langroid.utils.system import friendly_error
 
 logging.getLogger("openai").setLevel(logging.ERROR)
 
-OLLAMA_BASE_URL = "http://localhost:11434/v1"
+if "OLLAMA_HOST" in os.environ:
+    OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
+else:
+    OLLAMA_BASE_URL = "http://localhost:11434/v1"
+
 OLLAMA_API_KEY = "ollama"
 
 


### PR DESCRIPTION
Fixes a bug in `DocChatAgent` which ignores all but the last URL in the `doc_paths`, respects `OLLAMA_HOST` when using Ollama's built in OpenAI API endpoint, adds default context description generation in the multi-schema case and adds tests.