### PR TITLE
support azure via -m flag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.2.2
+  rev: v0.3.0
   hooks:
     - id: ruff


### PR DESCRIPTION
Azure can be provided using the flag `-m` without the need to make modifications to the`llm_config`. Here is an example `python3.11 examples/basic/chat.py -m azure`
