### PR TITLE
Fixed `DuckduckgoSearchTool` code doc

### DIFF
--- a/langroid/agent/tools/duckduckgo_search_tool.py
+++ b/langroid/agent/tools/duckduckgo_search_tool.py
@@ -1,24 +1,8 @@
 """
-A tool to trigger a Metaphor search for a given query,
-(https://docs.exa.ai/reference/getting-started)
-and return the top results with their titles, links, summaries.
-Since the tool is stateless (i.e. does not need
+A tool to trigger a DuckDuckGo search for a given query, and return the top results with
+their titles, links, summaries. Since the tool is stateless (i.e. does not need
 access to agent state), it can be enabled for any agent, without having to define a
-special method inside the agent: `agent.enable_message(MetaphorSearchTool)`
-
-NOTE: To use this tool, you need to:
-
-* set the METAPHOR_API_KEY environment variables in
-your `.env` file, e.g. `METAPHOR_API_KEY=your_api_key_here`
-(Note as of 28 Jan 2023, Metaphor renamed to Exa, so you can also use
-`EXA_API_KEY=your_api_key_here`)
-
-* install langroid with the `metaphor` extra, e.g.
-`pip install langroid[metaphor]` or `poetry add langroid[metaphor]`
-(it installs the `metaphor-python` package from pypi).
-
-For more information, please refer to the official docs:
-https://metaphor.systems/
+special method inside the agent: `agent.enable_message(DuckduckgoSearchTool)`
 """
 
 from typing import List
@@ -41,8 +25,8 @@ class DuckduckgoSearchTool(ToolMessage):
 
     def handle(self) -> str:
         """
-        Conducts a search using the metaphor API based on the provided query
-        and number of results by triggering a metaphor_search.
+        Conducts a search using DuckDuckGo based on the provided query
+        and number of results by triggering a duckduckgo_search.
 
         Returns:
             str: A formatted string containing the titles, links, and


### PR DESCRIPTION
I simply noticed that the `DuckduckgoSearchTool` code doc was the same of the `MetaphorSearchTool`, so I modified the `DuckduckgoSearchTool` code doc following the other search tool doc provided.
