### PR TITLE
Bug fix for handling of variable length utf-8 chars

### DIFF
--- a/langroid/agent/special/doc_chat_agent.py
+++ b/langroid/agent/special/doc_chat_agent.py
@@ -66,7 +66,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DOC_CHAT_INSTRUCTIONS = """
 Your task is to answer questions about various documents.
-You will be given various passages from these documents, and asked to answer questions 
+You will be given various passages from these documents, and asked to answer questions
 about them, or summarize them into coherent answers.
 """
 
@@ -76,7 +76,7 @@ You are a helpful assistant, helping me understand a collection of documents.
 
 has_sentence_transformers = False
 try:
-    from sentence_transformer import SentenceTransformer  # noqa: F401
+    from sentence_transformers import SentenceTransformer  # noqa: F401
 
     has_sentence_transformers = True
 except ImportError:
@@ -339,7 +339,7 @@ class DocChatAgent(ChatAgent):
         n_paths = len(paths)
         print(
             f"""
-        [green]I have processed the following {n_urls} URLs 
+        [green]I have processed the following {n_urls} URLs
         and {n_paths} docs into {n_splits} parts:
         """.strip()
         )
@@ -443,7 +443,7 @@ class DocChatAgent(ChatAgent):
         if content not in df.columns:
             raise ValueError(
                 f"""
-                Content column {content} not in dataframe, 
+                Content column {content} not in dataframe,
                 so we cannot ingest into the DocChatAgent.
                 Please specify the `content` parameter as a suitable
                 text-based column in the dataframe.
@@ -816,12 +816,12 @@ class DocChatAgent(ChatAgent):
                 # Adjust this prompt depending on context.
                 answer = self.llm_response_forget(
                     f"""
-                    Give an ideal answer to the following query, 
-                    in up to 3 sentences. Do not explain yourself, 
-                    and do not apologize, just show 
+                    Give an ideal answer to the following query,
+                    in up to 3 sentences. Do not explain yourself,
+                    and do not apologize, just show
                     a good possible answer, even if you do not have any information.
                     Preface your answer with "HYPOTHETICAL ANSWER: "
-                    
+
                     QUERY: {query}
                     """
                 ).content
@@ -1293,9 +1293,9 @@ class DocChatAgent(ChatAgent):
             logger.warning(
                 """
                 No docs to summarize! Perhaps you are re-using a previously
-                defined collection? 
+                defined collection?
                 In that case, we don't have access to the original docs.
-                To create a summary, use a new collection, and specify a list of docs. 
+                To create a summary, use a new collection, and specify a list of docs.
                 """
             )
             return None
@@ -1318,7 +1318,7 @@ class DocChatAgent(ChatAgent):
             )
         prompt = f"""
         {instruction}
-        
+
         FULL TEXT:
         {full_text}
         """.strip()

--- a/langroid/parsing/document_parser.py
+++ b/langroid/parsing/document_parser.py
@@ -24,6 +24,17 @@ class DocumentType(str, Enum):
     DOC = "doc"
     TXT = "txt"
 
+def find_last_full_char(possible_unicode: bytes) -> int:
+    """
+    Find the index of the last full character in a byte string.
+    Returns:
+        int: The index of the last full unicode character.
+    """
+
+    for i in range(len(possible_unicode) - 1, 0, -1):
+        if (possible_unicode[i] & 0xC0) != 0x80:
+            return i
+    return 0
 
 def is_plain_text(path_or_bytes: str | bytes) -> bool:
     if isinstance(path_or_bytes, str):
@@ -38,6 +49,8 @@ def is_plain_text(path_or_bytes: str | bytes) -> bool:
         content = path_or_bytes[:1024]
     try:
         # Attempt to decode the content as UTF-8
+        content = content[: find_last_full_char(content)]
+
         _ = content.decode("utf-8")
         # Additional checks can go here, e.g., to verify that the content
         # doesn't contain too many unusual characters for it to be considered text
@@ -466,7 +479,7 @@ class UnstructuredPDFParser(DocumentParser):
             raise ImportError(
                 """
                 The `unstructured` library is not installed by default with langroid.
-                To include this library, please install langroid with the 
+                To include this library, please install langroid with the
                 `unstructured` extra by running `pip install "langroid[unstructured]"`
                 or equivalent.
                 """
@@ -483,7 +496,7 @@ class UnstructuredPDFParser(DocumentParser):
                 The `unstructured` library failed to parse the pdf.
                 Please try a different library by setting the `library` field
                 in the `pdf` section of the `parsing` field in the config file.
-                Supported libraries are: 
+                Supported libraries are:
                 fitz, pypdf, pdfplumber, unstructured
                 """
             )
@@ -529,7 +542,7 @@ class UnstructuredDocxParser(DocumentParser):
             raise ImportError(
                 """
                 The `unstructured` library is not installed by default with langroid.
-                To include this library, please install langroid with the 
+                To include this library, please install langroid with the
                 `unstructured` extra by running `pip install "langroid[unstructured]"`
                 or equivalent.
                 """
@@ -580,7 +593,7 @@ class UnstructuredDocParser(UnstructuredDocxParser):
             raise ImportError(
                 """
                 The `unstructured` library is not installed by default with langroid.
-                To include this library, please install langroid with the 
+                To include this library, please install langroid with the
                 `unstructured` extra by running `pip install "langroid[unstructured]"`
                 or equivalent.
                 """

--- a/langroid/parsing/document_parser.py
+++ b/langroid/parsing/document_parser.py
@@ -24,9 +24,12 @@ class DocumentType(str, Enum):
     DOC = "doc"
     TXT = "txt"
 
+
 def find_last_full_char(possible_unicode: bytes) -> int:
     """
     Find the index of the last full character in a byte string.
+    Args:
+        possible_unicode (bytes): The bytes to check.
     Returns:
         int: The index of the last full unicode character.
     """
@@ -36,7 +39,15 @@ def find_last_full_char(possible_unicode: bytes) -> int:
             return i
     return 0
 
+
 def is_plain_text(path_or_bytes: str | bytes) -> bool:
+    """
+    Check if a file is plain text by attempting to decode it as UTF-8.
+    Args:
+        path_or_bytes (str|bytes): The file path or bytes object.
+    Returns:
+        bool: True if the file is plain text, False otherwise.
+    """
     if isinstance(path_or_bytes, str):
         if path_or_bytes.startswith(("http://", "https://")):
             response = requests.get(path_or_bytes)


### PR DESCRIPTION
When trying to guess the doc type, landroid reads in the first 1024 bytes and tries to decode it as utf-8.

Utf-8 has variable length characters. It is quite easy for the 1024 byte boundary to fall in the middle of a character. This causes us to wrongly assume we aren't dealing with utf-8.

Here is an example that shows the problem:

```python
my_str = "abc﷽🤦🏻‍♂️🤦🏻‍♂️🤦🏻‍♂️"
print(len(my_str)) # 19
b = my_str.encode('utf-8')
print(len(b)) # 57 bytes that represent 19 chars
content = b[:50] #choose to cut it off at 50 for this example

try:
    _ = content.decode("utf-8")
    print(True)
except UnicodeDecodeError:
    print(False) # prints False


def find_last_full_char(str_to_test):
    for i in range(len(str_to_test) -1, 0, -1):
        if (str_to_test[i] & 0xC0) != 0x80:
            return i

content = b[:find_last_full_char(b)]

try:
    _ = content.decode("utf-8")
    print(True) # prints True
except UnicodeDecodeError:
    print(False)
```

I also added a missing `docstring` and fixed a typo that pops up when trying to use non-openai embeddings. LMK, if I should put those in a different PR. 