### PR TITLE
Sparse retrieval - 2

### DIFF
--- a/tests/main/test_vector_stores.py
+++ b/tests/main/test_vector_stores.py
@@ -74,7 +74,7 @@ def vecdb(request) -> VectorStore:
         yield qd_cloud
         qd_cloud.delete_collection(collection_name=qd_cfg_cloud.collection_name)
         return
-    
+
     if request.param == "qdrant_hybrid_cloud":
         qd_dir = ".qdrant/cloud/" + embed_cfg.model_type
         qd_cfg_cloud = QdrantDBConfig(
@@ -83,7 +83,7 @@ def vecdb(request) -> VectorStore:
             storage_path=qd_dir,
             embedding=embed_cfg,
             use_sparse_embeddings=True,
-            sparse_embedding_model='prithvida/Splade_PP_en_v1',
+            sparse_embedding_model="naver/splade-v3-distilbert",
         )
         qd_cloud = QdrantDB(qd_cfg_cloud)
         qd_cloud.add_documents(stored_docs)


### PR DESCRIPTION
This PR contains changes to add an optional feature of sparse-retrieval using Qdrant.
Qdrant recently added the capability to index sparse vectors - [here](https://qdrant.tech/articles/sparse-vectors/)
I am currently using qdrant's [fastembed](https://qdrant.github.io/fastembed/examples/SPLADE_with_FastEmbed/) to get sparse embedding.

This PR is related to a [different PR](https://github.com/langroid/langroid/pull/450)
I have resolved conflicts and fixed styling issues in this PR.