### PR TITLE
enhancement: allow setting ollama api_base on OpenAIGPTConfig

### DIFF
--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -421,7 +421,15 @@ class OpenAIGPT(LanguageModel):
                 self.api_base = "http://" + self.api_base
         elif self.config.chat_model.startswith("ollama/"):
             self.config.ollama = True
-            self.api_base = OLLAMA_BASE_URL
+            
+            # allow setting ollama base url via code as well
+            # if not set or empty, use the default OLLAMA_BASE_URL
+            # otherwise use the value set in the config.
+            if self.config.api_base is None or len(self.config.api_base) == 0:
+                self.api_base = OLLAMA_BASE_URL
+            else:
+                self.api_base = self.config.api_base
+ 
             self.api_key = OLLAMA_API_KEY
             self.config.chat_model = self.config.chat_model.replace("ollama/", "")
         else:


### PR DESCRIPTION
Hi,

submitting this small PR in case other ollama users stumble upon this.
This allows setting api_base, like with other openai-compatible API's for ollama as well. Allowing users to use multiple ollama API's endpoints in their code.

Example:

```
....
llm_cfg_2 = lm.OpenAIGPTConfig(
    chat_model="ollama/starcoder2:15b-instruct-v0.1-q3_K_S", 
    api_base="http://ollama-host2.local:11434/v1"
)
agent_2_cfg = lr.ChatAgentConfig(llm=llm_cfg_2)
...
```


Previously, api_base was always overriden by either default value (localhost) or environment value if it exists.
This change allows for more flexibility, while retaining support for the environment value and the previous default as well.