### PR TITLE
Remove unused meilisearch dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ sentence-transformers = {version="2.2.2", optional=true}
 torch = {version="2.0.0", optional=true}
 psycopg2 = {version="^2.9.7", optional=true}
 pymysql = {version = "^1.1.0", optional = true}
-meilisearch = {version="^0.28.3", optional=true}
 meilisearch-python-sdk = {version="^2.2.3", optional=true}
 litellm = {version = "^1.30.1", optional = true}
 metaphor-python = {version = "^0.1.23", optional = true}
@@ -134,7 +133,7 @@ mkdocs = [
     "mkdocs-gen-files", "mkdocs-literate-nav",
     "mkdocs-section-index", "mkdocs-jupyter", "mkdocs-rss-plugin"
 ]
-meilisearch = ["meilisearch", "meilisearch-python-sdk"]
+meilisearch = ["meilisearch-python-sdk"]
 momento = ["momento"]
 
 


### PR DESCRIPTION
See [this comment](https://github.com/langroid/langroid/issues/358#issuecomment-2156511142) in #358 for context.

I didn't find anywhere that the `meilisearch` package was used, only `meilisearch-python-sdk`, so I was able to remove the dependency without any other changes.