### PR TITLE
toml py ^3.10, avoid bounding < 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = ["pyproject.toml"]
 
 # =============== MAIN DEPS ==============
 [tool.poetry.dependencies]
-python = ">=3.10,<3.12"
+python = "^3.10"
 
 # =========== OPTIONALS ==============================
 chromadb = {version=">=0.4.21, <=0.4.23", optional=true}


### PR DESCRIPTION
Thanks @nimish for raising this.