### PR TITLE
Fix: gpt4o on Azure, Momento, tool message parsing

### DIFF
--- a/langroid/language_models/azure_openai.py
+++ b/langroid/language_models/azure_openai.py
@@ -133,12 +133,15 @@ class AzureGPT(OpenAIGPT):
         """
         Handles the setting of the GPT-4 model in the configuration.
         This function checks the `model_version` in the configuration.
-        If the version is not set, it raises a ValueError indicating that the model
-        version needs to be specified in the ``.env`` file.
-        It sets `OpenAIChatModel.GPT4_TURBO` if the version is
-        '1106-Preview', otherwise, it defaults to setting `OpenAIChatModel.GPT4`.
+        If the version is not set, it raises a ValueError indicating
+        that the model version needs to be specified in the ``.env``
+        file.  It sets `OpenAIChatMode.GPT4o` if the version is
+        '2024-05-13', `OpenAIChatModel.GPT4_TURBO` if the version is
+        '1106-Preview', otherwise, it defaults to setting
+        `OpenAIChatModel.GPT4`.
         """
         VERSION_1106_PREVIEW = "1106-Preview"
+        VERSION_GPT4o = "2024-05-13"
 
         if self.config.model_version == "":
             raise ValueError(
@@ -146,7 +149,9 @@ class AzureGPT(OpenAIGPT):
                 "Please set it to the chat model version used in your deployment."
             )
 
-        if self.config.model_version == VERSION_1106_PREVIEW:
+        if self.config.model_version == VERSION_GPT4o:
+            self.config.chat_model = OpenAIChatModel.GPT4o
+        elif self.config.model_version == VERSION_1106_PREVIEW:
             self.config.chat_model = OpenAIChatModel.GPT4_TURBO
         else:
             self.config.chat_model = OpenAIChatModel.GPT4

--- a/langroid/language_models/base.py
+++ b/langroid/language_models/base.py
@@ -234,6 +234,7 @@ class LLMResponse(BaseModel):
             # in this case we ignore message, since all information is in function_call
             msg = ""
             args = self.function_call.arguments
+            recipient = ""
             if isinstance(args, dict):
                 recipient = args.get("recipient", "")
             return recipient, msg

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -1,4 +1,3 @@
-import ast
 import hashlib
 import json
 import logging
@@ -797,7 +796,7 @@ class OpenAIGPT(LanguageModel):
         args = {}
         if has_function and function_args != "":
             try:
-                args = ast.literal_eval(function_args.strip())
+                args = json.loads(function_args.strip())
             except (SyntaxError, ValueError):
                 logging.warning(
                     f"Parsing OpenAI function args failed: {function_args};"

--- a/langroid/parsing/parse_json.py
+++ b/langroid/parsing/parse_json.py
@@ -1,5 +1,6 @@
+import ast
 import json
-from typing import Any, Iterator, List
+from typing import Any, Dict, Iterator, List, Union
 
 import yaml
 from pyparsing import nestedExpr, originalTextFor
@@ -71,6 +72,31 @@ def add_quotes(s: str) -> str:
         return json.dumps(dct)
     except Exception:
         return s
+
+
+def parse_imperfect_json(json_string: str) -> Union[Dict[str, Any], List[Any]]:
+    if not json_string.strip():
+        raise ValueError("Empty string is not valid JSON")
+
+    # First, try parsing with ast.literal_eval
+    try:
+        result = ast.literal_eval(json_string)
+        if isinstance(result, (dict, list)):
+            return result
+    except (ValueError, SyntaxError):
+        pass
+
+    # If ast.literal_eval fails or returns non-dict/list, try json.loads
+    try:
+        str = add_quotes(json_string)
+        result = json.loads(str)
+        if isinstance(result, (dict, list)):
+            return result
+    except json.JSONDecodeError:
+        pass
+
+    # If all methods fail, raise ValueError
+    raise ValueError(f"Unable to parse as JSON: {json_string}")
 
 
 def repair_newlines(s: str) -> str:

--- a/langroid/vector_store/momento.py
+++ b/langroid/vector_store/momento.py
@@ -1,6 +1,7 @@
 """
 Momento Vector Index.
 https://docs.momentohq.com/vector-index/develop/api-reference
+DEPRECATED: API is unstable.
 """
 
 from __future__ import annotations

--- a/langroid/vector_store/qdrantdb.py
+++ b/langroid/vector_store/qdrantdb.py
@@ -102,11 +102,12 @@ class QdrantDB(VectorStore):
         load_dotenv()
         key = os.getenv("QDRANT_API_KEY")
         url = os.getenv("QDRANT_API_URL")
-        if config.cloud and None in [key, url]:
+        if config.cloud and url is None:
             logger.warning(
-                f"""QDRANT_API_KEY, QDRANT_API_URL env variable must be set to use 
-                QdrantDB in cloud mode. Please set these values 
-                in your .env file. 
+                f"""QDRANT_API_URL env variable must be set to use 
+                QdrantDB in cloud mode. If using Qdrant Cloud rather
+                than local docker mode, QDRANT_API_KEY must be set
+                as well. Please set these values in your .env file. 
                 Switching to local storage at {config.storage_path} 
                 """
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ python = ">=3.10,<3.13"
 
 # =========== OPTIONALS ==============================
 chromadb = {version=">=0.4.21, <=0.4.23", optional=true}
-momento = {version="^1.10.2", optional=true}
+momento = {version=">=1.10.2, < 1.21", optional=true}
 unstructured = {extras = ["docx", "pptx", "pdf"], version = ">=0.10.16,<0.10.18", optional=true}
 sentence-transformers = {version="^2.2.2", optional=true}
 torch = {version="^2.0.0", optional=true}

--- a/tests/main/test_json.py
+++ b/tests/main/test_json.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from langroid.parsing.parse_json import extract_top_level_json
+from langroid.parsing.parse_json import extract_top_level_json, parse_imperfect_json
 
 
 @pytest.mark.parametrize(
@@ -66,3 +66,64 @@ def test_extract_top_level_json(s, expected):
     expected = [json.loads(s.replace("'", '"')) for s in expected]
     assert len(top_level_jsons) == len(expected)
     assert top_level_jsons == expected
+
+
+@pytest.mark.parametrize(
+    "input_json,expected_output",
+    [
+        ('{"key": "value", "number": 42}', {"key": "value", "number": 42}),
+        (
+            '{"key": "value", "number": 42,}',
+            {"key": "value", "number": 42},
+        ),  # extra comma
+        ('{"key": null}', {"key": None}),
+        ('{"t": true, "f": false}', {"t": True, "f": False}),
+        ("{'key': 'value'}", {"key": "value"}),
+        ("{'key': (1, 2, 3)}", {"key": (1, 2, 3)}),
+        ("{key: 'value'}", {"key": "value"}),
+        ("{'key': value}", {"key": "value"}),
+        ("{key: value}", {"key": "value"}),
+        ("[1, 2, 3]", [1, 2, 3]),
+        (
+            """
+    {
+        "string": "Hello, World!",
+        "number": 42,
+        "float": 3.14,
+        "boolean": true,
+        "null": null,
+        "array": [1, 2, 3],
+        "object": {"nested": "value"},
+        "mixed_array": [1, "two", {"three": 3}]
+    }
+    """,
+            {
+                "string": "Hello, World!",
+                "number": 42,
+                "float": 3.14,
+                "boolean": True,
+                "null": None,
+                "array": [1, 2, 3],
+                "object": {"nested": "value"},
+                "mixed_array": [1, "two", {"three": 3}],
+            },
+        ),
+    ],
+)
+def test_parse_imperfect_json(input_json, expected_output):
+    assert parse_imperfect_json(input_json) == expected_output
+
+
+@pytest.mark.parametrize(
+    "invalid_input",
+    [
+        "{key: 'value',,,}",
+        "",
+        "not a json string",
+        "True",  # This is a valid Python literal, but not a dict or list
+        "42",  # This is a valid Python literal, but not a dict or list
+    ],
+)
+def test_invalid_json_raises_error(invalid_input):
+    with pytest.raises(ValueError):
+        parse_imperfect_json(invalid_input)


### PR DESCRIPTION
Corrects OpenAI tool message parsing to use `json.loads` rather than `ast.literal_eval`, enabling correct parsing of Booleans. Handles GPT4o on Azure. As API keys are not required by Qdrant in docker mode (which we treat as "cloud" mode), removes that restriction. Freezes Momento as the vector client we use is removed in the latest release.