### PR TITLE
Infer request

### DIFF
--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -792,11 +792,7 @@ class Agent(ABC):
             json_data = properties
         request = json_data.get("request")
 
-        if (
-            request is None
-            or not (isinstance(request, str))
-            or request not in self.llm_tools_handled
-        ):
+        if request is None:
             handled = [self.llm_tools_map[r] for r in self.llm_tools_handled]
 
             def maybe_parse(tool: type[ToolMessage]) -> Optional[ToolMessage]:
@@ -818,6 +814,12 @@ class Agent(ABC):
                 return candidate_tools[0]
             else:
                 return None
+
+        if (
+            not (isinstance(request, str))
+            or request not in self.llm_tools_handled
+        ):
+            return None
 
         message_class = self.llm_tools_map.get(request)
         if message_class is None:

--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -815,7 +815,7 @@ class Agent(ABC):
             else:
                 return None
 
-        if not (isinstance(request, str)) or request not in self.llm_tools_handled:
+        if not isinstance(request, str) or request not in self.llm_tools_handled:
             return None
 
         message_class = self.llm_tools_map.get(request)

--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -792,7 +792,7 @@ class Agent(ABC):
             json_data = properties
         request = json_data.get("request")
 
-        if request is None:
+        if request is None and len(json_data) > 0:
             handled = [self.llm_tools_map[r] for r in self.llm_tools_handled]
 
             def maybe_parse(tool: type[ToolMessage]) -> Optional[ToolMessage]:

--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -815,10 +815,7 @@ class Agent(ABC):
             else:
                 return None
 
-        if (
-            not (isinstance(request, str))
-            or request not in self.llm_tools_handled
-        ):
+        if not (isinstance(request, str)) or request not in self.llm_tools_handled:
             return None
 
         message_class = self.llm_tools_map.get(request)

--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -427,11 +427,11 @@ class ChatAgent(Agent):
                 but the Assistant fn-calling seems to pay attn to these,
                 and if we don't want this, we should set this to False.)
         """
+        if require_recipient and message_class is not None:
+            message_class = message_class.require_recipient()
         super().enable_message_handling(message_class)  # enables handling only
         tools = self._get_tool_list(message_class)
         if message_class is not None:
-            if require_recipient:
-                message_class = message_class.require_recipient()
             request = message_class.default_value("request")
             llm_function = message_class.llm_function_schema(defaults=include_defaults)
             self.llm_functions_map[request] = llm_function

--- a/langroid/agent/tool_message.py
+++ b/langroid/agent/tool_message.py
@@ -49,6 +49,7 @@ class ToolMessage(ABC, BaseModel):
         # do not include these fields in the generated schema
         # since we don't require the LLM to specify them
         schema_extra = {"exclude": {"purpose", "result"}}
+        extra = "forbid"
 
     @classmethod
     def instructions(cls) -> str:

--- a/langroid/agent/tool_message.py
+++ b/langroid/agent/tool_message.py
@@ -35,12 +35,10 @@ class ToolMessage(ABC, BaseModel):
         request (str): name of agent method to map to.
         purpose (str): purpose of agent method, expressed in general terms.
             (This is used when auto-generating the tool instruction to the LLM)
-        result (str): example of result of agent method.
     """
 
     request: str
     purpose: str
-    result: str = ""
 
     class Config:
         arbitrary_types_allowed = False
@@ -48,8 +46,7 @@ class ToolMessage(ABC, BaseModel):
         validate_assignment = True
         # do not include these fields in the generated schema
         # since we don't require the LLM to specify them
-        schema_extra = {"exclude": {"purpose", "result"}}
-        extra = "forbid"
+        schema_extra = {"exclude": {"purpose"}}
 
     @classmethod
     def instructions(cls) -> str:
@@ -111,13 +108,13 @@ class ToolMessage(ABC, BaseModel):
         return "\n\n".join(examples_jsons)
 
     def to_json(self) -> str:
-        return self.json(indent=4, exclude={"result", "purpose"})
+        return self.json(indent=4, exclude={"purpose"})
 
     def json_example(self) -> str:
-        return self.json(indent=4, exclude={"result", "purpose"})
+        return self.json(indent=4, exclude={"purpose"})
 
     def dict_example(self) -> Dict[str, Any]:
-        return self.dict(exclude={"result", "purpose"})
+        return self.dict(exclude={"purpose"})
 
     @classmethod
     def default_value(cls, f: str) -> Any:
@@ -221,9 +218,7 @@ class ToolMessage(ABC, BaseModel):
                 if "description" not in parameters["properties"][name]:
                     parameters["properties"][name]["description"] = description
 
-        excludes = (
-            ["result", "purpose"] if request else ["request", "result", "purpose"]
-        )
+        excludes = ["purpose"] if request else ["request", "purpose"]
         # exclude 'excludes' from parameters["properties"]:
         parameters["properties"] = {
             field: details
@@ -264,5 +259,5 @@ class ToolMessage(ABC, BaseModel):
         Returns:
             Dict[str, Any]: simplified schema
         """
-        schema = generate_simple_schema(cls, exclude=["result", "purpose"])
+        schema = generate_simple_schema(cls, exclude=["purpose"])
         return schema

--- a/tests/main/test_recipient_tool.py
+++ b/tests/main/test_recipient_tool.py
@@ -128,11 +128,7 @@ def test_agents_with_recipient_tool(
         SquareTool,
         use=False,  # LLM of this agent does not need to generate this tool/fn-call
         handle=True,  # this agent needs to handle this tool/fn-call
-        # since recipient is required when this tool is used (generated),
-        # we must preserve this setting here, otherwise the presence of
-        # "recipient" field will raise an error due to
-        # ToolMessage's Config.extra="forbid" setting!
-        require_recipient=True,
+        require_recipient=False,
     )
     even_task = Task(
         even_agent,

--- a/tests/main/test_recipient_tool.py
+++ b/tests/main/test_recipient_tool.py
@@ -97,9 +97,8 @@ def test_agents_with_recipient_tool(
         
         (a) If n is even:
          (a.1) if n is a multiple of 10, send it to EvenHandler,
-             using the `square` tool/function-call, specifying the `intended_recipient` 
-             field 
-             as "EvenHandler".
+             using the `square` tool/function-call, specifying the `recipient` 
+             field as "EvenHandler".
          (a.2) if n is NOT a multiple of 10, send it to EvenHandler,
              
         (b) If n is odd, send it to OddHandler. 
@@ -129,7 +128,11 @@ def test_agents_with_recipient_tool(
         SquareTool,
         use=False,  # LLM of this agent does not need to generate this tool/fn-call
         handle=True,  # this agent needs to handle this tool/fn-call
-        require_recipient=False,  # this agent does not need to specify recipient
+        # since recipient is required when this tool is used (generated),
+        # we must preserve this setting here, otherwise the presence of
+        # "recipient" field will raise an error due to
+        # ToolMessage's Config.extra="forbid" setting!
+        require_recipient=True,
     )
     even_task = Task(
         even_agent,

--- a/tests/main/test_recipient_tool_async.py
+++ b/tests/main/test_recipient_tool_async.py
@@ -130,11 +130,7 @@ async def test_agents_with_recipient_tool(
         SquareTool,
         use=False,  # LLM of this agent does not need to generate this tool/fn-call
         handle=True,  # this agent needs to handle this tool/fn-call
-        # since recipient is required when this tool is used (generated),
-        # we must preserve this setting here, otherwise the presence of
-        # "recipient" field will raise an error due to
-        # ToolMessage's Config.extra="forbid" setting!
-        require_recipient=True,
+        require_recipient=False,
     )
     even_task = Task(
         even_agent,

--- a/tests/main/test_recipient_tool_async.py
+++ b/tests/main/test_recipient_tool_async.py
@@ -130,7 +130,11 @@ async def test_agents_with_recipient_tool(
         SquareTool,
         use=False,  # LLM of this agent does not need to generate this tool/fn-call
         handle=True,  # this agent needs to handle this tool/fn-call
-        require_recipient=False,  # this agent does not to specify recipient
+        # since recipient is required when this tool is used (generated),
+        # we must preserve this setting here, otherwise the presence of
+        # "recipient" field will raise an error due to
+        # ToolMessage's Config.extra="forbid" setting!
+        require_recipient=True,
     )
     even_task = Task(
         even_agent,

--- a/tests/main/test_tool_messages.py
+++ b/tests/main/test_tool_messages.py
@@ -398,10 +398,12 @@ def test_agent_infer_tool(
     agent = ChatAgent(cfg)
     agent.enable_message(NabroskiTool)
     agent.enable_message(GaussTool)
+    agent.enable_message(EulerTool, handle=False)
 
-    # Nabrowski is the only option prior to enabling EulerTool
+    # Nabrowski is the only option prior to enabling EulerTool handling
     assert agent.agent_response(nabrowski_or_euler_request).content == "6"
 
+    # Enable handling EulerTool, this makes nabrowski_or_euler_request ambiguous
     agent.enable_message(EulerTool)
 
     # Gauss is the only option


### PR DESCRIPTION
When only one handled `ToolMessage` is compatible with the arguments provided by the LLM, but the LLM did not specify `request` (especially common on weaker models, but still occurs with GPT-4o), uses the only compatible function call.