### PR TITLE
feat: lancedb, schemaless ingest , pydantic_v2.v1  compat + remove convoluted pydantic schema wrangling

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -116,7 +116,7 @@ jobs:
       continue-on-error: true
 
 
-    - name: Retry FAILED tests ONLY with gpt-4 instead of gpt-4o (no coverage)
+    - name: Retry FAILED tests ONLY with gpt-4 instead of gpt-4o
       id: second_test
       if: steps.first_test.outcome == 'failure'
       env:
@@ -124,22 +124,6 @@ jobs:
       run: |
         poetry run coverage run --append --source=langroid \
           -m pytest --m gpt-4 -rf --show-capture=no \
-          --first-test-file=tests/main/test_llm.py \
-          --first-test-file=tests/main/test_llm_async.py \
-          --first-test-file=tests/main/test_task_inf_loop.py \
-          --first-test-file=tests/main/test_task.py \
-          --first-test-file=tests/main/test_lance_doc_chat_agent.py \
-          --lf --last-failed-no-failures none \
-          tests/main tests/extras/test_hf_embeddings.py tests/extras/test_fastembed_embeddings.py
-      continue-on-error: true
-
-    - name: Install Pydantic 1.x to pass lancedb tests
-      run: poetry add "pydantic<2.0.0"
-    - name: Retry FAILED tests ONLY with pydantic 1.x, gpt-4
-      if: steps.second_test.outcome == 'failure'
-      run: |
-        poetry run coverage run --append --source=langroid \
-          -m pytest --m gpt-4 \
           --first-test-file=tests/main/test_llm.py \
           --first-test-file=tests/main/test_llm_async.py \
           --first-test-file=tests/main/test_task_inf_loop.py \

--- a/langroid/agent/special/doc_chat_agent.py
+++ b/langroid/agent/special/doc_chat_agent.py
@@ -685,7 +685,7 @@ class DocChatAgent(ChatAgent):
             return response
         if query_str == "":
             return ChatDocument(
-                content=NO_ANSWER,
+                content=NO_ANSWER + " since query was empty",
                 metadata=ChatDocMetaData(
                     source="No query provided",
                     sender=Entity.LLM,

--- a/langroid/agent/special/lance_rag/critic_agent.py
+++ b/langroid/agent/special/lance_rag/critic_agent.py
@@ -37,20 +37,30 @@ class QueryPlanCriticConfig(LanceQueryPlanAgentConfig):
     system_message = f"""
     You are an expert at carefully planning a query that needs to be answered
     based on a large collection of documents. These docs have a special `content` field
-    and additional FILTERABLE fields in the SCHEMA below:
+    and additional FILTERABLE fields in the SCHEMA below, along with the 
+    SAMPLE VALUES for each field, and the DTYPE in PANDAS TERMINOLOGY.
     
     {{doc_schema}}
     
+    The ORIGINAL QUERY is handled by a QUERY PLANNER who sends the PLAN to an ASSISTANT,
+    who returns an ANSWER.
+    
     You will receive a QUERY PLAN consisting of:
-    - ORIGINAL QUERY, 
-    - SQL-Like FILTER, WHICH CAN BE EMPTY (and it's fine if results sound reasonable)
+    - ORIGINAL QUERY from the user, which a QUERY PLANNER processes,
+      to create a QUERY PLAN, to be handled by an ASSISTANT.
+    - PANDAS-LIKE FILTER, WHICH CAN BE EMPTY (and it's fine if results sound reasonable)
       FILTER SHOULD ONLY BE USED IF EXPLICITLY REQUIRED BY THE QUERY.
-    - REPHRASED QUERY that will be used to match against the CONTENT (not filterable)
-         of the documents.
+    - REPHRASED QUERY (CANNOT BE EMPTY) that will be used to match against the 
+      CONTENT (not filterable) of the documents.
       In general the REPHRASED QUERY should be relied upon to match the CONTENT 
       of the docs. Thus the REPHRASED QUERY itself acts like a 
       SEMANTIC/LEXICAL/FUZZY FILTER since the Assistant is able to use it to match 
-      the CONTENT of the docs in various ways (semantic, lexical, fuzzy, etc.).         
+      the CONTENT of the docs in various ways (semantic, lexical, fuzzy, etc.). 
+        Keep in mind that the ASSISTANT does NOT know anything about the FILTER fields,
+        so the REPHRASED QUERY should NOT mention ANY FILTER fields.
+        The assistant will answer based on documents whose CONTENTS match the QUERY, 
+        possibly REPHRASED. 
+        !!!!****THE REPHRASED QUERY SHOULD NEVER BE EMPTY****!!!
     - DATAFRAME CALCULATION, which must be a SINGLE LINE calculation (or empty),
         [NOTE ==> This calculation is applied AFTER the FILTER and REPHRASED QUERY.],
     - ANSWER received from an assistant that used this QUERY PLAN.

--- a/langroid/agent/special/lance_rag/query_planner_agent.py
+++ b/langroid/agent/special/lance_rag/query_planner_agent.py
@@ -43,23 +43,27 @@ class LanceQueryPlanAgentConfig(ChatAgentConfig):
     You will receive a QUERY, to be answered based on an EXTREMELY LARGE collection
     of documents you DO NOT have access to, but your ASSISTANT does.
     You only know that these documents have a special `content` field
-    and additional FILTERABLE fields in the SCHEMA below:  
+    and additional FILTERABLE fields in the SCHEMA below, along with the 
+    SAMPLE VALUES for each field, and the DTYPE in PANDAS TERMINOLOGY.
     
     {{doc_schema}}
     
     Based on the QUERY and the above SCHEMA, your task is to determine a QUERY PLAN,
     consisting of:
-    -  a FILTER (can be empty string) that would help the ASSISTANT to answer the query.
+    -  a PANDAS-TYPE FILTER (can be empty string) that would help the ASSISTANT to 
+        answer the query.
         Remember the FILTER can refer to ANY fields in the above SCHEMA
         EXCEPT the `content` field of the documents. 
         ONLY USE A FILTER IF EXPLICITLY MENTIONED IN THE QUERY.
         TO get good results, for STRING MATCHES, consider using LIKE instead of =, e.g.
         "CEO LIKE '%Jobs%'" instead of "CEO = 'Steve Jobs'"
-    - a possibly REPHRASED QUERY to be answerable given the FILTER.
+        YOUR FILTER MUST BE A PANDAS-TYPE FILTER, respecting the shown DTYPES.        
+    - a possibly REPHRASED QUERY (CANNOT BE EMPTY) to be answerable given the FILTER.
         Keep in mind that the ASSISTANT does NOT know anything about the FILTER fields,
         so the REPHRASED QUERY should NOT mention ANY FILTER fields.
         The assistant will answer based on documents whose CONTENTS match the QUERY, 
         possibly REPHRASED. 
+        !!!!****THE REPHRASED QUERY SHOULD NEVER BE EMPTY****!!!
     - an OPTIONAL SINGLE-LINE Pandas-dataframe calculation/aggregation string 
         that can be used to calculate the answer to the original query, 
         e.g. "df["rating"].mean()",
@@ -99,7 +103,7 @@ class LanceQueryPlanAgentConfig(ChatAgentConfig):
         hence this computation will give the total deaths in shoplifting crimes.
     ------------- END OF EXAMPLE ----------------
     
-    The FILTER must be a SQL-like condition, e.g. 
+    The FILTER must be a PANDAS-like condition, e.g. 
     "year > 2000 AND genre = 'ScienceFiction'".
     To ensure you get useful results, you should make your FILTER 
     NOT TOO STRICT, e.g. look for approximate match using LIKE, etc.

--- a/langroid/agent/special/lance_tools.py
+++ b/langroid/agent/special/lance_tools.py
@@ -1,16 +1,21 @@
 import logging
 
 from langroid.agent.tool_message import ToolMessage
-from langroid.pydantic_v1 import BaseModel
+from langroid.pydantic_v1 import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
 
 class QueryPlan(BaseModel):
-    original_query: str
-    query: str
-    filter: str
-    dataframe_calc: str = ""
+    original_query: str = Field(..., description="The original query for reference")
+    query: str = Field(..., description="A possibly NON-EMPTY rephrased query")
+    filter: str = Field(
+        "",
+        description="Filter condition if needed (or empty if no filter is needed)",
+    )
+    dataframe_calc: str = Field(
+        "", description="An optional Pandas-dataframe calculation/aggregation string"
+    )
 
 
 class QueryPlanTool(ToolMessage):
@@ -19,8 +24,9 @@ class QueryPlanTool(ToolMessage):
     Given a user's query, generate a query <plan> consisting of:
     - <original_query> - the original query for reference
     - <filter> condition if needed (or empty string if no filter is needed)
-    - <query> - a possibly rephrased query that can be used to match the CONTENT
-        of the documents (can be same as <original_query> if no rephrasing is needed)
+    - <query> - a possibly NON-EMPTY rephrased query that can be used to match the 
+        CONTENT of the documents 
+        (can be same as <original_query> if no rephrasing is needed)
     - <dataframe_calc> - a Pandas-dataframe calculation/aggregation string
         that can be used to calculate the answer 
         (or empty string if no calculation is needed).
@@ -34,7 +40,7 @@ class QueryPlanAnswerTool(ToolMessage):
     Assemble query <plan> and <answer>
     """
     plan: QueryPlan
-    answer: str
+    answer: str = Field(..., description="The answer received from the assistant")
 
 
 class QueryPlanFeedbackTool(ToolMessage):

--- a/langroid/vector_store/base.py
+++ b/langroid/vector_store/base.py
@@ -1,14 +1,14 @@
 import copy
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple, Type
 
 import numpy as np
 import pandas as pd
 
 from langroid.embedding_models.base import EmbeddingModel, EmbeddingModelsConfig
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.mytypes import Document
+from langroid.mytypes import DocMetaData, Document
 from langroid.pydantic_v1 import BaseSettings
 from langroid.utils.algorithms.graph import components, topological_sort
 from langroid.utils.configuration import settings
@@ -32,6 +32,9 @@ class VectorStoreConfig(BaseSettings):
     timeout: int = 60
     host: str = "127.0.0.1"
     port: int = 6333
+    # used when parsing search results back as Document objects
+    document_class: Type[Document] = Document
+    metadata_class: Type[DocMetaData] = DocMetaData
     # compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
 
 
@@ -113,8 +116,7 @@ class VectorStore(ABC):
         """
 
         self.config.collection_name = collection_name
-        if collection_name not in self.list_collections() or replace:
-            self.create_collection(collection_name, replace=replace)
+        self.config.replace_collection = replace
 
     @abstractmethod
     def create_collection(self, collection_name: str, replace: bool = False) -> None:

--- a/langroid/vector_store/chromadb.py
+++ b/langroid/vector_store/chromadb.py
@@ -8,7 +8,7 @@ from langroid.embedding_models.base import (
 )
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
 from langroid.exceptions import LangroidImportError
-from langroid.mytypes import DocMetaData, Document
+from langroid.mytypes import Document
 from langroid.utils.configuration import settings
 from langroid.utils.output.printing import print_long_text
 from langroid.vector_store.base import VectorStore, VectorStoreConfig
@@ -200,7 +200,9 @@ class ChromaDB(VectorStore):
             else:
                 m["window_ids"] = m["window_ids"].split(",")
         docs = [
-            Document(content=d, metadata=DocMetaData(**m))
+            self.config.document_class(
+                content=d, metadata=self.config.metadata_class(**m)
+            )
             for d, m in zip(contents, metadatas)
         ]
         return docs

--- a/langroid/vector_store/qdrantdb.py
+++ b/langroid/vector_store/qdrantdb.py
@@ -380,7 +380,11 @@ class QdrantDB(VectorStore):
                 with_payload=True,
                 with_vectors=False,
             )
-            docs += [Document(**record.payload) for record in results]  # type: ignore
+            docs += [
+                self.config.document_class(**record.payload)  # type: ignore
+                for record in results
+            ]
+            # ignore
             if next_page_offset is None:
                 break
             offset = next_page_offset  # type: ignore
@@ -451,7 +455,7 @@ class QdrantDB(VectorStore):
         ]  # 2D list -> 1D list
         scores = [match.score for match in search_result if match is not None]
         docs = [
-            Document(**(match.payload))  # type: ignore
+            self.config.document_class(**(match.payload))  # type: ignore
             for match in search_result
             if match is not None
         ]

--- a/tests/main/test_doc_chat_agent.py
+++ b/tests/main/test_doc_chat_agent.py
@@ -199,7 +199,7 @@ warnings.filterwarnings(
 
 
 @pytest.mark.parametrize(
-    "vecdb", ["qdrant_local", "qdrant_cloud", "chroma", "lancedb"], indirect=True
+    "vecdb", ["lancedb", "qdrant_local", "qdrant_cloud", "chroma"], indirect=True
 )
 @pytest.mark.parametrize("query, expected", QUERY_EXPECTED_PAIRS)
 def test_doc_chat_agent_llm(test_settings: Settings, agent, query: str, expected: str):
@@ -221,7 +221,7 @@ def test_doc_chat_agent_llm(test_settings: Settings, agent, query: str, expected
 
 
 @pytest.mark.parametrize(
-    "vecdb", ["qdrant_cloud", "qdrant_local", "chroma", "lancedb"], indirect=True
+    "vecdb", ["lancedb", "qdrant_cloud", "qdrant_local", "chroma"], indirect=True
 )
 @pytest.mark.parametrize("query, expected", QUERY_EXPECTED_PAIRS)
 @pytest.mark.asyncio
@@ -406,7 +406,7 @@ class _MyDocChatAgentConfig(DocChatAgentConfig):
     )
 
 
-@pytest.mark.parametrize("vecdb", ["chroma", "qdrant_local", "lancedb"], indirect=True)
+@pytest.mark.parametrize("vecdb", ["lancedb", "chroma", "qdrant_local"], indirect=True)
 @pytest.mark.parametrize(
     "splitter", [Splitter.PARA_SENTENCE, Splitter.SIMPLE, Splitter.TOKENS]
 )
@@ -611,7 +611,7 @@ def test_doc_chat_add_content_fields(
     assert "2084" in response.content and "1989" in response.content
 
 
-@pytest.mark.parametrize("vecdb", ["chroma", "qdrant_local", "lancedb"], indirect=True)
+@pytest.mark.parametrize("vecdb", ["lancedb", "chroma", "qdrant_local"], indirect=True)
 @pytest.mark.parametrize(
     "splitter", [Splitter.PARA_SENTENCE, Splitter.SIMPLE, Splitter.TOKENS]
 )

--- a/tests/main/test_lance_doc_chat_agent.py
+++ b/tests/main/test_lance_doc_chat_agent.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 import pandas as pd
 import pytest
 
@@ -118,16 +116,12 @@ embed_cfg = OpenAIEmbeddingsConfig()
         ),
     ],
 )
-@pytest.mark.parametrize("flatten", [True, False])
 @pytest.mark.parametrize("split", [False, True])
-@pytest.mark.parametrize("doc_cls", [Document, MovieDoc])
 def test_lance_doc_chat_agent(
     test_settings: Settings,
-    flatten: bool,
     split: bool,
     query: str,
     expected: str,
-    doc_cls: Type[Document],
 ):
     # note that the (query, ans) pairs are accumulated into the
     # internal dialog history of the agent.
@@ -140,8 +134,7 @@ def test_lance_doc_chat_agent(
         collection_name="test-lance-2",
         storage_path=ldb_dir,
         embedding=embed_cfg,
-        document_class=doc_cls,
-        flatten=flatten,
+        document_class=MovieDoc,
     )
 
     cfg = DocChatAgentConfig(
@@ -159,7 +152,7 @@ def test_lance_doc_chat_agent(
     task = LanceRAGTaskCreator.new(agent, interactive=False)
 
     result = task.run(query)
-    assert NO_ANSWER in result.content or expected in result.content
+    assert result is None or NO_ANSWER in result.content or expected in result.content
 
 
 # dummy pandas dataframe from text
@@ -209,11 +202,7 @@ class FlatMovieDoc(Document):
     metadata: DocMetaData = DocMetaData()
 
 
-@pytest.mark.parametrize("flatten", [False, True])
-def test_lance_doc_chat_agent_df_query_plan(
-    test_settings: Settings,
-    flatten: bool,
-):
+def test_lance_doc_chat_agent_df_query_plan(test_settings: Settings):
     """Test handling of manually-created query plan"""
 
     set_global(test_settings)
@@ -227,7 +216,6 @@ def test_lance_doc_chat_agent_df_query_plan(
         storage_path=ldb_dir,
         embedding=embed_cfg,
         document_class=FlatMovieDoc,
-        flatten=flatten,
     )
 
     cfg = DocChatAgentConfig(
@@ -281,10 +269,8 @@ def test_lance_doc_chat_agent_df_query_plan(
         ),
     ],
 )
-@pytest.mark.parametrize("flatten", [False, True])
 def test_lance_doc_chat_agent_df(
     test_settings: Settings,
-    flatten: bool,
     query: str,
     expected: str,
 ):
@@ -299,7 +285,6 @@ def test_lance_doc_chat_agent_df(
         storage_path=ldb_dir,
         embedding=embed_cfg,
         document_class=FlatMovieDoc,
-        flatten=flatten,
     )
 
     cfg = DocChatAgentConfig(
@@ -319,7 +304,7 @@ def test_lance_doc_chat_agent_df(
     task = LanceRAGTaskCreator.new(agent, interactive=False)
 
     result = task.run(query)
-    assert NO_ANSWER in result.content or expected in result.content
+    assert result is None or NO_ANSWER in result.content or expected in result.content
 
 
 def test_lance_doc_chat_df_direct(test_settings: Settings):


### PR DESCRIPTION
Simplifies lancedb doc ingest -- do not create a collection (i.e. "table") until we try to add data -- this eliminates a lot of convoluted pydantic-related attempting to create and update schemas. This was making lancedb not compatible with pydantic v2, which is not fixed.