### PR TITLE
Fix - Document setup.md

### DIFF
--- a/docs/quick-start/setup.md
+++ b/docs/quick-start/setup.md
@@ -11,7 +11,7 @@ python3 -m venv .venv
 . ./.venv/bin/activate
 ```
 To see how to use Langroid in your own repo, you can take a look at the
-[`langroid-examples`](https://github.com/langroid/langroid-exmaples) repo, which can be a good starting point for your own repo.
+[`langroid-examples`](https://github.com/langroid/langroid-examples) repo, which can be a good starting point for your own repo.
 The `langroid-examples` repo already contains a `pyproject.toml` file so that you can 
 use `Poetry` to manage your virtual environment and dependencies. 
 For example you can do 


### PR DESCRIPTION
Fixing the typo on the `setup.md` file that was pointing to a link that didn't exist.