### PR TITLE
feat: task.run/run_async polymorphism support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.6.1
+  rev: v0.6.2
   hooks:
     - id: ruff

--- a/examples/basic/multi-agent-search-critic-no-orch/assistant_agent.py
+++ b/examples/basic/multi-agent-search-critic-no-orch/assistant_agent.py
@@ -4,7 +4,7 @@ for SearcherAgent to answer, and then presents the final answer; It then conside
 feedback from CriticAgent, and may ask more questions or present the final answer
 using a corrected reasoning.
 
-Flow:
+Flow: (L stands for LLM, i.e. llm_response; A stands for Agent i.e. agent_response)
 
 User Q ->
 [L] -> QuestionTool(q1) ->
@@ -125,7 +125,7 @@ class AssistantAgent(lr.ChatAgent):
 
 
 def make_assistant_task(
-    model: str,
+    model: str = "",
     restart: bool = True,
 ) -> lr.Task:
     llm_config = lm.OpenAIGPTConfig(
@@ -171,3 +171,10 @@ def make_assistant_task(
     )
 
     return assistant_task
+
+
+if __name__ == "__main__":
+    # restart = False, to preserve state across task.run() calls
+    task = make_assistant_task(restart=False)
+    question = task.run("which planet has more moons, Jupiter or Saturn?")
+    assert isinstance(question.tool_messages[0], QuestionTool)

--- a/examples/basic/multi-agent-search-critic-no-orch/main.py
+++ b/examples/basic/multi-agent-search-critic-no-orch/main.py
@@ -100,7 +100,7 @@ def main(
         tool = assistant_task.run(question, return_type=lr.ToolMessage)
 
         while True:
-            if tool is None or not isinstance(tool, (QuestionTool, FinalAnswerTool)):
+            if not isinstance(tool, (QuestionTool, FinalAnswerTool)):
                 # no tool => nudge
                 tool = assistant_task.run(
                     f"""
@@ -115,7 +115,6 @@ def main(
                 tool = assistant_task.run(answer_tool, return_type=lr.ToolMessage)
             else:
                 # FinalAnswerTool => get feedback
-                assert isinstance(tool, FinalAnswerTool)
                 fb_tool = critic_feedback(tool)
                 if fb_tool.suggested_fix == "":
                     # no suggested fix => return tool (which is a FinalAnswerTool)

--- a/examples/basic/multi-agent-search-critic-no-orch/main.py
+++ b/examples/basic/multi-agent-search-critic-no-orch/main.py
@@ -80,17 +80,13 @@ def main(
         """
         Take a QuestionTool, return an AnswerTool
         """
-        answer_tool = search_task.run(qtool, return_type=AnswerTool)
-        assert isinstance(answer_tool, AnswerTool)
-        return answer_tool
+        return search_task.run(qtool, return_type=AnswerTool)
 
     def critic_feedback(fa: FinalAnswerTool) -> FeedbackTool:
         """
         Take a FinalAnswerTool, return a FeedbackTool
         """
-        fb_tool = critic_task.run(fa, return_type=FeedbackTool)
-        assert isinstance(fb_tool, FeedbackTool)
-        return fb_tool
+        return critic_task.run(fa, return_type=FeedbackTool)
 
     def query_to_final_answer(question: str) -> FinalAnswerTool:
         """

--- a/examples/basic/multi-agent-search-critic-no-orch/main.py
+++ b/examples/basic/multi-agent-search-critic-no-orch/main.py
@@ -40,12 +40,12 @@ import typer
 from dotenv import load_dotenv
 from rich import print
 from rich.prompt import Prompt
+import langroid as lr
 from .tools import QuestionTool, AnswerTool, FinalAnswerTool, FeedbackTool
 from .search_agent import make_search_task
 from .critic_agent import make_critic_task
 from .assistant_agent import make_assistant_task
 from langroid.utils.configuration import Settings, set_global
-from langroid.agent.chat_document import ChatDocument
 
 app = typer.Typer()
 
@@ -76,27 +76,21 @@ def main(
     search_task = make_search_task(model)
     critic_task = make_critic_task(model)
 
-    def search_answer(qtool: QuestionTool) -> ChatDocument:
+    def search_answer(qtool: QuestionTool) -> AnswerTool:
         """
         Take a QuestionTool, return an AnswerTool
         """
-        response = search_task.run(
-            search_task.agent.create_user_response(tool_messages=[qtool])
-        )
-        assert len(response.tool_messages) == 1
-        assert isinstance(response.tool_messages[0], AnswerTool)
-        return response
+        answer_tool = search_task.run(qtool, return_type=AnswerTool)
+        assert isinstance(answer_tool, AnswerTool)
+        return answer_tool
 
-    def critic_feedback(fa: FinalAnswerTool) -> ChatDocument:
+    def critic_feedback(fa: FinalAnswerTool) -> FeedbackTool:
         """
         Take a FinalAnswerTool, return a FeedbackTool
         """
-        response = critic_task.run(
-            critic_task.agent.create_user_response(tool_messages=[fa])
-        )
-        assert len(response.tool_messages) == 1
-        assert isinstance(response.tool_messages[0], FeedbackTool)
-        return response
+        fb_tool = critic_task.run(fa, return_type=FeedbackTool)
+        assert isinstance(fb_tool, FeedbackTool)
+        return fb_tool
 
     def query_to_final_answer(question: str) -> FinalAnswerTool:
         """
@@ -107,33 +101,32 @@ def main(
         question_tool_name = QuestionTool.default_value("request")
         final_answer_tool_name = FinalAnswerTool.default_value("request")
 
-        response = assistant_task.run(question)
+        tool = assistant_task.run(question, return_type=lr.ToolMessage)
 
         while True:
-            if len(response.tool_messages) == 0 or not isinstance(
-                response.tool_messages[0], (QuestionTool, FinalAnswerTool)
-            ):
+            if tool is None or not isinstance(tool, (QuestionTool, FinalAnswerTool)):
                 # no tool => nudge
-                response = assistant_task.run(
+                tool = assistant_task.run(
                     f"""
                      You forgot to use one of the tools:
                      `{question_tool_name}` or `{final_answer_tool_name}`.
-                     """
+                     """,
+                    return_type=lr.ToolMessage,
                 )
-            elif isinstance(response.tool_messages[0], QuestionTool):
+            elif isinstance(tool, QuestionTool):
                 # QuestionTool => get search result
-                answer_doc = search_answer(response.tool_messages[0])
-                response = assistant_task.run(answer_doc)
+                answer_tool = search_answer(tool)
+                tool = assistant_task.run(answer_tool, return_type=lr.ToolMessage)
             else:
                 # FinalAnswerTool => get feedback
-                assert isinstance(response.tool_messages[0], FinalAnswerTool)
-                feedback_doc = critic_feedback(response.tool_messages[0])
-                if feedback_doc.tool_messages[0].suggested_fix == "":
-                    # no suggested fix => DONE
-                    return response.tool_messages[0]
+                assert isinstance(tool, FinalAnswerTool)
+                fb_tool = critic_feedback(tool)
+                if fb_tool.suggested_fix == "":
+                    # no suggested fix => return tool (which is a FinalAnswerTool)
+                    return tool
                 else:
                     # suggested fix => ask again
-                    response = assistant_task.run(feedback_doc)
+                    tool = assistant_task.run(fb_tool, return_type=lr.ToolMessage)
 
     # Interactive loop with user
     while True:

--- a/examples/basic/tool-extract-short-example.py
+++ b/examples/basic/tool-extract-short-example.py
@@ -10,7 +10,7 @@ python3 examples/basic/tool-extract-short-example.py
 
 import langroid as lr
 from langroid.pydantic_v1 import BaseModel, Field
-from langroid.agent.tool_message import FinalResultTool
+from langroid.agent.tools.orchestration import ResultTool
 
 
 # desired output structure
@@ -47,18 +47,18 @@ class CompanyInfoTool(lr.agent.ToolMessage):
             ),
         ]
 
-    def handle(self) -> FinalResultTool:
+    def handle(self) -> ResultTool:
         """Handle LLM's structured output if it matches CompanyInfo structure.
         This suffices for a "stateless" tool.
         If the tool handling requires agent state, then
         instead of this `handle` method, define a `company_info_tool`
         method in the agent.
-        Since this method is returning a  FinalResultTool,
-        the task of this agent as well as any parent tasks will be terminated,
-        with this tool T appearing in the final ChatDocument's `tool_messages` list.
+        Since this method is returning a  ResultTool,
+        the task of this agent will be terminated,
+        with this tool T appearing in the result ChatDocument's `tool_messages` list.
         """
         mkt_cap = self.company_info.shares * self.company_info.price
-        return FinalResultTool(
+        return ResultTool(
             market_cap=mkt_cap,
             info=self.company_info,
             comment="success",  # arbitrary undeclared fields allowed
@@ -90,7 +90,7 @@ result = task.run(
 # note the result.tool_messages will be a list containing
 # an obj of type FinalResultTool, so we can extract fields from it.
 company_result = result.tool_messages[0]
-assert isinstance(company_result, FinalResultTool)
+assert isinstance(company_result, ResultTool)
 assert isinstance(company_result.info, CompanyInfo)
 
 info = company_result.info

--- a/langroid/agent/__init__.py
+++ b/langroid/agent/__init__.py
@@ -6,7 +6,7 @@ from .chat_document import (
     ChatDocument,
 )
 from .chat_agent import ChatAgentConfig, ChatAgent
-from .tool_message import ToolMessage, FinalResultTool
+from .tool_message import ToolMessage
 from .task import Task
 
 from . import base
@@ -29,7 +29,6 @@ __all__ = [
     "ChatAgent",
     "ChatAgentConfig",
     "ToolMessage",
-    "FinalResultTool",
     "Task",
     "base",
     "chat_document",

--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -347,7 +347,7 @@ class Agent(ABC):
     def create_agent_response(
         self,
         content: str | None = None,
-        content_any: Any | None = None,
+        content_any: Any = None,
         tool_messages: List[ToolMessage] = [],
         oai_tool_calls: Optional[List[OpenAIToolCall]] = None,
         oai_tool_choice: ToolChoiceTypes | Dict[str, Dict[str, str] | str] = "auto",
@@ -551,7 +551,7 @@ class Agent(ABC):
         self,
         e: Entity,
         content: str | None = None,
-        content_any: Any | None = None,
+        content_any: Any = None,
         tool_messages: List[ToolMessage] = [],
         oai_tool_calls: Optional[List[OpenAIToolCall]] = None,
         oai_tool_choice: ToolChoiceTypes | Dict[str, Dict[str, str] | str] = "auto",
@@ -576,7 +576,7 @@ class Agent(ABC):
     def create_user_response(
         self,
         content: str | None = None,
-        content_any: Any | None = None,
+        content_any: Any = None,
         tool_messages: List[ToolMessage] = [],
         oai_tool_calls: List[OpenAIToolCall] | None = None,
         oai_tool_choice: ToolChoiceTypes | Dict[str, Dict[str, str] | str] = "auto",
@@ -708,7 +708,7 @@ class Agent(ABC):
     def create_llm_response(
         self,
         content: str | None = None,
-        content_any: Any | None = None,
+        content_any: Any = None,
         tool_messages: List[ToolMessage] = [],
         oai_tool_calls: None | List[OpenAIToolCall] = None,
         oai_tool_choice: ToolChoiceTypes | Dict[str, Dict[str, str] | str] = "auto",
@@ -1364,9 +1364,12 @@ class Agent(ABC):
         if get_origin(output_type) is list:
             list_element_type = get_args(output_type)[0]
             if issubclass(list_element_type, ToolMessage):
-                # output_type = List[<ToolMessage],
-                # i.e. list of ToolMessage-derived objects
-                return cast(T, tools)
+                # list_element_type is a subclass of ToolMessage:
+                # We output a list of objects derived from list_element_type
+                return cast(
+                    T,
+                    [t for t in tools if isinstance(t, list_element_type)],
+                )
         elif get_origin(output_type) is None and issubclass(output_type, ToolMessage):
             # output_type is a subclass of ToolMessage:
             # return the first tool that has this specific output_type

--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -718,7 +718,7 @@ class Task:
     @overload
     async def run_async(  # noqa
         self,
-        msg: Any|None = None,
+        msg: Any | None = None,
         *,
         turns: int = -1,
         caller: None | Task = None,
@@ -731,7 +731,7 @@ class Task:
     @overload
     async def run_async(  # noqa
         self,
-        msg: Any|None = None,
+        msg: Any | None = None,
         *,
         turns: int = -1,
         caller: None | Task = None,
@@ -744,7 +744,7 @@ class Task:
 
     async def run_async(
         self,
-        msg: Any|None = None,
+        msg: Any | None = None,
         turns: int = -1,
         caller: None | Task = None,
         max_cost: float = 0,

--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -600,7 +600,7 @@ class Task:
     @overload
     def run(  # noqa
         self,
-        msg: Any | None = None,
+        msg: Any = None,
         *,
         turns: int = -1,
         caller: None | Task = None,
@@ -613,7 +613,7 @@ class Task:
     @overload
     def run(  # noqa
         self,
-        msg: Any | None = None,
+        msg: Any = None,
         *,
         turns: int = -1,
         caller: None | Task = None,
@@ -626,7 +626,7 @@ class Task:
 
     def run(
         self,
-        msg: Any | None = None,
+        msg: Any = None,
         turns: int = -1,
         caller: None | Task = None,
         max_cost: float = 0,
@@ -732,7 +732,7 @@ class Task:
     @overload
     async def run_async(  # noqa
         self,
-        msg: Any | None = None,
+        msg: Any = None,
         *,
         turns: int = -1,
         caller: None | Task = None,
@@ -745,7 +745,7 @@ class Task:
     @overload
     async def run_async(  # noqa
         self,
-        msg: Any | None = None,
+        msg: Any = None,
         *,
         turns: int = -1,
         caller: None | Task = None,
@@ -758,7 +758,7 @@ class Task:
 
     async def run_async(
         self,
-        msg: Any | None = None,
+        msg: Any = None,
         turns: int = -1,
         caller: None | Task = None,
         max_cost: float = 0,

--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -718,7 +718,7 @@ class Task:
     @overload
     async def run_async(  # noqa
         self,
-        msg: Any,
+        msg: Any|None = None,
         *,
         turns: int = -1,
         caller: None | Task = None,
@@ -731,7 +731,7 @@ class Task:
     @overload
     async def run_async(  # noqa
         self,
-        msg: Any,
+        msg: Any|None = None,
         *,
         turns: int = -1,
         caller: None | Task = None,
@@ -744,7 +744,7 @@ class Task:
 
     async def run_async(
         self,
-        msg: Any,
+        msg: Any|None = None,
         turns: int = -1,
         caller: None | Task = None,
         max_cost: float = 0,

--- a/langroid/agent/tools/__init__.py
+++ b/langroid/agent/tools/__init__.py
@@ -13,6 +13,8 @@ from .orchestration import (
     SendTool,
     AgentSendTool,
     DonePassTool,
+    ResultTool,
+    FinalResultTool,
 )
 
 __all__ = [
@@ -31,4 +33,6 @@ __all__ = [
     "PassTool",
     "SendTool",
     "AgentSendTool",
+    "ResultTool",
+    "FinalResultTool",
 ]

--- a/langroid/language_models/mock_lm.py
+++ b/langroid/language_models/mock_lm.py
@@ -10,6 +10,7 @@ from langroid.language_models.base import (
     OpenAIToolSpec,
     ToolChoiceTypes,
 )
+from langroid.utils.types import to_string
 
 
 def none_fn(x: str) -> None | str:
@@ -43,11 +44,11 @@ class MockLM(LanguageModel):
         # - response_dict
         # - response_fn
         # - default_response
+        mapped_response = self.config.response_dict.get(
+            msg, self.config.response_fn(msg) or self.config.default_response
+        )
         return lm.LLMResponse(
-            message=self.config.response_dict.get(
-                msg,
-                self.config.response_fn(msg) or self.config.default_response,
-            ),
+            message=to_string(mapped_response),
             cached=False,
         )
 

--- a/langroid/parsing/web_search.py
+++ b/langroid/parsing/web_search.py
@@ -48,10 +48,13 @@ class WebSearchResult:
         return self.full_content[: self.max_summary_length]
 
     def get_full_content(self) -> str:
-        response: Response = requests.get(self.link)
-        soup: BeautifulSoup = BeautifulSoup(response.text, "lxml")
-        text = " ".join(soup.stripped_strings)
-        return text[: self.max_content_length]
+        try:
+            response: Response = requests.get(self.link)
+            soup: BeautifulSoup = BeautifulSoup(response.text, "lxml")
+            text = " ".join(soup.stripped_strings)
+            return text[: self.max_content_length]
+        except Exception as e:
+            return f"Error fetching content from {self.link}: {e}"
 
     def __str__(self) -> str:
         return f"Title: {self.title}\nLink: {self.link}\nSummary: {self.summary}"

--- a/langroid/utils/types.py
+++ b/langroid/utils/types.py
@@ -9,12 +9,12 @@ PrimitiveType = Union[int, float, bool, str]
 T = TypeVar("T")
 
 
-def is_instance_of(obj: Any, type_hint: Type[T]) -> bool:
+def is_instance_of(obj: Any, type_hint: Type[T] | Any) -> bool:
     """
     Check if an object is an instance of a type hint, e.g.
     to check whether x is of type `List[ToolMessage]` or type `int`
     """
-    if get_origin(type_hint) is Any:
+    if type_hint == Any:
         return True
 
     if type_hint is type(obj):

--- a/langroid/utils/types.py
+++ b/langroid/utils/types.py
@@ -14,7 +14,7 @@ def is_instance_of(obj: Any, type_hint: Type[T]) -> bool:
     Check if an object is an instance of a type hint, e.g.
     to check whether x is of type `List[ToolMessage]` or type `int`
     """
-    if type_hint is Any:
+    if get_origin(type_hint) is Any:
         return True
 
     if type_hint is type(obj):

--- a/langroid/utils/types.py
+++ b/langroid/utils/types.py
@@ -1,0 +1,93 @@
+import json
+import logging
+from typing import Any, Optional, Type, TypeVar, Union, get_args, get_origin
+
+from langroid.pydantic_v1 import BaseModel
+
+logger = logging.getLogger(__name__)
+PrimitiveType = Union[int, float, bool, str]
+T = TypeVar("T")
+
+
+def is_instance_of(obj: Any, type_hint: Type[T]) -> bool:
+    """
+    Check if an object is an instance of a type hint, e.g.
+    to check whether x is of type `List[ToolMessage]` or type `int`
+    """
+    if type_hint is Any:
+        return True
+
+    if type_hint is type(obj):
+        return True
+
+    origin = get_origin(type_hint)
+    args = get_args(type_hint)
+
+    if origin is Union:
+        return any(is_instance_of(obj, arg) for arg in args)
+
+    if origin:  # e.g. List, Dict, Tuple, Set
+        if isinstance(obj, origin):
+            # check if all items in obj are of the required types
+            if args:
+                if isinstance(obj, (list, tuple, set)):
+                    return all(is_instance_of(item, args[0]) for item in obj)
+                if isinstance(obj, dict):
+                    return all(
+                        is_instance_of(k, args[0]) and is_instance_of(v, args[1])
+                        for k, v in obj.items()
+                    )
+            return True
+        else:
+            return False
+
+    return isinstance(obj, type_hint)
+
+
+def to_string(msg: Any) -> str:
+    """
+    Best-effort conversion of arbitrary msg to str.
+    Return empty string if conversion fails.
+    """
+    if msg is None:
+        return ""
+    if isinstance(msg, str):
+        return msg
+    if isinstance(msg, BaseModel):
+        return msg.json()
+    # last resort: use json.dumps() or str() to make it a str
+    try:
+        return json.dumps(msg)
+    except Exception:
+        try:
+            return str(msg)
+        except Exception as e:
+            logger.error(
+                f"""
+                Error converting msg to str: {e}", 
+                """,
+                exc_info=True,
+            )
+            return ""
+
+
+def from_string(
+    s: str,
+    output_type: Type[PrimitiveType],
+) -> Optional[PrimitiveType]:
+    if output_type is int:
+        try:
+            return int(s)
+        except ValueError:
+            return None
+    elif output_type is float:
+        try:
+            return float(s)
+        except ValueError:
+            return None
+    elif output_type is bool:
+        return s.lower() in ("true", "yes", "1")
+    elif output_type is str:
+        return s
+    else:
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ fastembed = ["fastembed"]
 [tool.poetry.group.dev.dependencies]
 black = {extras = ["jupyter"], version = "^24.3.0"}
 flake8 = "^6.0.0"
-mypy = "^1.7.0"
+mypy = "^1.11.2"
 ruff = "^0.2.2"
 pre-commit = "^3.3.2"
 autopep8 = "^2.0.2"

--- a/tests/main/test_stateless_tool_messages.py
+++ b/tests/main/test_stateless_tool_messages.py
@@ -68,8 +68,9 @@ def test_enable_message(
     msg_class: Optional[ToolMessage], use: bool, handle: bool, force: bool
 ):
     agent.enable_message(msg_class, use=use, handle=handle, force=force)
+    usable_tools = agent.llm_tools_usable
     tools = agent._get_tool_list(msg_class)
-    for tool in tools:
+    for tool in set(tools).intersection(usable_tools):
         assert tool in agent.llm_tools_map
         if msg_class is not None:
             assert agent.llm_tools_map[tool] == msg_class
@@ -132,7 +133,7 @@ def test_agent_handle_message():
     """
     agent.enable_message(SquareTool)
     assert agent.handle_message(NONE_MSG) is None
-    assert agent.handle_message(SQUARE_MSG) == "144"
+    assert agent.handle_message(SQUARE_MSG).content == "144"
 
     agent.disable_message_handling(SquareTool)
     assert agent.handle_message(SQUARE_MSG) is None
@@ -141,7 +142,7 @@ def test_agent_handle_message():
     assert agent.handle_message(SQUARE_MSG) is None
 
     agent.enable_message(SquareTool)
-    assert agent.handle_message(SQUARE_MSG) == "144"
+    assert agent.handle_message(SQUARE_MSG).content == "144"
 
 
 BAD_SQUARE_MSG = """
@@ -209,7 +210,7 @@ def test_llm_tool_message(
     llm_msg = agent.llm_response_forget(prompt)
     assert isinstance(agent.get_tool_messages(llm_msg)[0], message_class)
 
-    agent_result = agent.handle_message(llm_msg)
+    agent_result = agent.handle_message(llm_msg).content
     assert result.lower() in agent_result.lower()
 
 
@@ -258,5 +259,5 @@ async def test_llm_tool_message_async(
     llm_msg = await agent.llm_response_forget_async(prompt)
     assert isinstance(agent.get_tool_messages(llm_msg)[0], message_class)
 
-    agent_result = agent.handle_message(llm_msg)
+    agent_result = agent.handle_message(llm_msg).content
     assert result.lower() in agent_result.lower()

--- a/tests/main/test_task.py
+++ b/tests/main/test_task.py
@@ -692,7 +692,7 @@ def test_task_tool_responses():
         x: int
 
         def handle(self) -> str:
-            return DoneTool(content=self.x // 2) # note: content can be any type
+            return DoneTool(content=self.x // 2)  # note: content can be any type
 
     class ProcessTool(ToolMessage):
         request = "process"

--- a/tests/main/test_task.py
+++ b/tests/main/test_task.py
@@ -692,7 +692,7 @@ def test_task_tool_responses():
         x: int
 
         def handle(self) -> str:
-            return DoneTool(content=str(self.x // 2))
+            return DoneTool(content=self.x // 2) # note: content can be any type
 
     class ProcessTool(ToolMessage):
         request = "process"
@@ -764,5 +764,5 @@ def test_task_tool_responses():
     result = processor_task.run(str(16))
     assert result.content == str(8)
 
-    result = processor_task.run(str(10))
-    assert result.content == str(11)
+    result = processor_task.run(10, return_type=int)
+    assert result == 11

--- a/tests/main/test_task_run_polymorphic.py
+++ b/tests/main/test_task_run_polymorphic.py
@@ -39,16 +39,6 @@ def test_task_in_out_types(
     i.e., task.run() can take a variety of input types and return desired output type
     """
 
-    # TODO
-    # - add more input types, like list, dict etc
-    # - add more handler-result types, e.g. GenPair tool can return other than str,
-    #   e.g. list of 2 nums, pydantic Pair object etc
-    # - AgentDoneTool should accept content of any type, which we can stick into
-    # content_any field etc. Maybe same thing for DoneTool
-    #  - have a good way to check for compound types inside
-    #  ToolMessage.find_value_of_type, e.g. list, dict etc
-    # - carefully define content_any in various places
-
     class Pair(BaseModel):
         x: int
         y: int

--- a/tests/main/test_task_run_polymorphic.py
+++ b/tests/main/test_task_run_polymorphic.py
@@ -1,0 +1,190 @@
+"""
+Other tests for Task are in test_chat_agent.py
+"""
+
+from typing import Any, Dict, List
+
+import pytest
+
+import langroid as lr
+from langroid.agent.tool_message import ToolMessage
+from langroid.agent.tools.orchestration import AgentDoneTool, ResultTool
+from langroid.pydantic_v1 import BaseModel
+
+
+@pytest.mark.parametrize(
+    "input_type",
+    ["GenPair", "Pair", "str", "int", "list", "dict"],
+)
+@pytest.mark.parametrize(
+    "pair_tool_handler_return_type",
+    [
+        "Pair",
+        "str",
+        "list",
+        "dict",
+    ],
+)
+@pytest.mark.parametrize("final_result_type", ["agent_done_tool", "result_tool"])
+def test_task_in_out_types(
+    input_type: str,
+    pair_tool_handler_return_type: str,
+    final_result_type: str,
+):
+    """
+    Test that we can have:
+
+    result: TypeOut = task.run(input: TypeIn, return_type: TypeOut)
+
+    i.e., task.run() can take a variety of input types and return desired output type
+    """
+
+    # TODO
+    # - add more input types, like list, dict etc
+    # - add more handler-result types, e.g. GenPair tool can return other than str,
+    #   e.g. list of 2 nums, pydantic Pair object etc
+    # - AgentDoneTool should accept content of any type, which we can stick into
+    # content_any field etc. Maybe same thing for DoneTool
+    #  - have a good way to check for compound types inside
+    #  ToolMessage.find_value_of_type, e.g. list, dict etc
+    # - carefully define content_any in various places
+
+    class Pair(BaseModel):
+        x: int
+        y: int
+
+    class DetailedAnswer(BaseModel):
+        comment: str
+        answer: int
+
+    class CoolTool(lr.ToolMessage):
+        request: str = "cool_tool"
+        purpose: str = "to request the Cool Transform of a number <pair>"
+
+        pair: Pair
+
+        def handle(self) -> ResultTool:
+            match final_result_type:
+                case "result_tool":
+                    return ResultTool(
+                        answer=self.pair.x + self.pair.y,  # integer result
+                        details=DetailedAnswer(  # Pydantic model result
+                            comment="The CoolTransform is just the sum of the numbers",
+                            answer=self.pair.x + self.pair.y,
+                        ),
+                        dictionary=dict(
+                            comment="The CoolTransform is just the sum of the numbers",
+                            answer=self.pair.x + self.pair.y,
+                        ),
+                    )
+                case "agent_done_tool":
+                    return AgentDoneTool(
+                        content=DetailedAnswer(
+                            comment="The CoolTransform is just the sum of the numbers",
+                            answer=self.pair.x + self.pair.y,
+                        )
+                    )
+
+    cool_tool_name = CoolTool.default_value("request")
+
+    class GenPairTool(lr.ToolMessage):
+        request: str = "input_tool"
+        purpose: str = "to generate a number-pair from an integer <x>"
+
+        x: int
+
+        def handle(self) -> Any:
+            match pair_tool_handler_return_type:
+                case "str":
+                    return f"Here is a pair of numbers: {self.x-1}, {self.x+1}"
+                case "list":
+                    return [self.x - 1, self.x + 1]
+                case "dict":
+                    return dict(first=self.x - 1, second=self.x + 1)
+                case "Pair":
+                    return Pair(x=self.x - 1, y=self.x + 1)
+
+    gen_pair_tool_name = GenPairTool.default_value("request")
+
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            name="MyAgent",
+            system_message=f"""
+            When you receive a PAIR of numbers, request the Cool Transform of the pair,
+            using the TOOL: `{cool_tool_name}`
+            
+            When you receive a SINGLE number, generate a PAIR of numbers from it,
+            using the TOOL: `{gen_pair_tool_name}`
+            """,
+        )
+    )
+    agent.enable_message([CoolTool, GenPairTool])
+
+    task = lr.Task(agent=agent, interactive=False)
+
+    match input_type:
+        case "str":
+            msg = "Get the Cool Transform of the numbers: 2, 4"
+        case "int":
+            msg = 3
+        case "list":
+            msg = [2, 4]
+        case "dict":
+            msg = dict(first=2, second=4)
+        case "GenPair":
+            msg = GenPairTool(x=3)  # agent handler generates a Pair obj, list, etc.
+        case "Pair":
+            msg = Pair(x=2, y=4)  # gets converted to str via .json()
+
+    if final_result_type == "agent_done_tool":
+        result = task.run(msg)
+        # default result -> Optional[ChatDocument]
+        assert isinstance(result, lr.ChatDocument)
+        # in the `content_any` field of the final ChatDocument,
+        # an arbitrary type can be stored, as returned by AgentDoneTool(content=...)
+        assert isinstance(result.content_any, DetailedAnswer)
+        assert result.content_any.answer == 6
+        assert result.content_any.comment != ""
+
+        result = task.run(msg, return_type=DetailedAnswer)
+        assert isinstance(result, DetailedAnswer)
+        assert result.answer == 6
+        assert result.comment != ""
+
+    else:
+        # default result -> Optional[ChatDocument]
+        result = task.run(msg)
+        tools = agent.get_tool_messages(result)
+        assert isinstance(tools[0], ResultTool)
+        assert tools[0].answer == 6
+
+        result = task.run(msg, return_type=ResultTool)
+        assert isinstance(result, ResultTool)
+        assert result.answer == 6
+
+        result = task.run(msg, return_type=List[ResultTool])
+        assert isinstance(result, list) and isinstance(result[0], ResultTool)
+        assert result[0].answer == 6
+
+        result = task.run(msg, return_type=ToolMessage)
+        assert isinstance(result, ResultTool)
+        assert result.answer == 6
+
+        result = task.run(msg, return_type=int)
+        assert result == 6
+
+        # check handling of invalid return type: receive None
+        result = task.run(msg, return_type=Pair)
+        assert result is None
+
+        # check we can return a Pydantic model
+        result = task.run(msg, return_type=DetailedAnswer)
+        assert isinstance(result, DetailedAnswer)
+        assert result.answer == 6
+        assert result.comment != ""
+
+        # check we can return a dictionary
+        result = task.run(msg, return_type=Dict[str, Any])
+        assert isinstance(result, dict)
+        assert result["answer"] == 6
+        assert result["comment"] != ""

--- a/tests/main/test_tool_messages_async.py
+++ b/tests/main/test_tool_messages_async.py
@@ -184,7 +184,7 @@ async def test_llm_tool_message(
     llm_msg = await agent.llm_response_forget_async(prompt)
     assert isinstance(agent.get_tool_messages(llm_msg)[0], message_class)
 
-    agent_result = agent.handle_message(llm_msg)
+    agent_result = agent.handle_message(llm_msg).content
     assert result.lower() in agent_result.lower()
 
 

--- a/tests/main/test_web_search_tools.py
+++ b/tests/main/test_web_search_tools.py
@@ -66,7 +66,7 @@ def test_agent_google_search_tool(
     assert isinstance(agent.get_tool_messages(llm_msg)[0], search_tool_cls)
 
     try:
-        agent_result = agent.handle_message(llm_msg)
+        agent_result = agent.handle_message(llm_msg).content
     except DuckDuckGoSearchException as e:
         pytest.skip(f"Skipping test: {e}")
     assert len(agent_result.split("\n\n")) == 3


### PR DESCRIPTION
This PR supports `task.run/run_async` polymorphism, see this test: https://github.com/langroid/langroid/blob/task-run-polymorphism/tests/main/test_task_run_polymorphic.py

And also see an example of using this polymorphism to simplify a multi-agent search-critic system without inter-agent orchestration:
https://github.com/langroid/langroid/blob/task-run-polymorphism/examples/basic/multi-agent-search-critic-no-orch/main.py

The syntax is:
```
result = task.run(any_type_input, return_type=MyReturnType)
```

I looked into avoiding having to specify `return_type` and instead infer it from a result variable type-annotation, something like:

```
result: MyReturnType = task.run(some_input)
```

but it involves using unsafe things like inspecting the call frame.


@nilspalumbo Let me know if you have any ideas for enhancing etc
(No need to review the entire PR just the resulting end-user API, whether it can be enhanced, and if so, should this PR be merged and your enhancement can be on top of it)