### PR TITLE
Allow async streaming through callback

### DIFF
--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -106,6 +106,10 @@ def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
     pass
 
 
+async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+    pass
+
+
 class Agent(ABC):
     """
     An Agent is an abstraction that encapsulates mainly two components:
@@ -152,7 +156,7 @@ class Agent(ABC):
 
         self.callbacks = SimpleNamespace(
             start_llm_stream=lambda: noop_fn,
-            start_llm_stream_async=noop_fn,
+            start_llm_stream_async=async_noop_fn,
             cancel_llm_stream=noop_fn,
             finish_llm_stream=noop_fn,
             show_llm_response=noop_fn,
@@ -1610,4 +1614,3 @@ class Agent(ABC):
         if answer != no_answer:
             return (f"{agent_type} says: " + str(answer)).strip()
         return None
-

--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -152,6 +152,7 @@ class Agent(ABC):
 
         self.callbacks = SimpleNamespace(
             start_llm_stream=lambda: noop_fn,
+            start_llm_stream_async=noop_fn,
             cancel_llm_stream=noop_fn,
             finish_llm_stream=noop_fn,
             show_llm_response=noop_fn,
@@ -1609,3 +1610,4 @@ class Agent(ABC):
         if answer != no_answer:
             return (f"{agent_type} says: " + str(answer)).strip()
         return None
+

--- a/langroid/agent/callbacks/chainlit.py
+++ b/langroid/agent/callbacks/chainlit.py
@@ -305,7 +305,7 @@ class ChainlitAgentCallbacks:
 
         return stream_token
 
-    def start_llm_stream_async(self) -> Callable[[str], None]:
+    async def start_llm_stream_async(self) -> Callable[[str], None]:
         """Returns a streaming fn that can be passed to the LLM class"""
         self.stream = cl.Step(
             id=self.curr_step.id if self.curr_step is not None else None,
@@ -322,7 +322,7 @@ class ChainlitAgentCallbacks:
             under parent {self._get_parent_id()}
         """
         )
-        run_sync(self.stream.send())  # type: ignore
+        await self.stream.send()  # type: ignore
 
         async def stream_token(t: str) -> None:
             if self.stream is None:
@@ -668,4 +668,3 @@ class ChainlitTaskCallbacks(ChainlitAgentCallbacks):
         step.output = content or NO_ANSWER
         self.last_step = step
         run_sync(step.send())
-

--- a/langroid/agent/callbacks/chainlit.py
+++ b/langroid/agent/callbacks/chainlit.py
@@ -234,6 +234,7 @@ class ChainlitAgentCallbacks:
         so we can alter the display of the first user message.
         """
         agent.callbacks.start_llm_stream = self.start_llm_stream
+        agent.callbacks.start_llm_stream_async = self.start_llm_stream_async
         agent.callbacks.cancel_llm_stream = self.cancel_llm_stream
         agent.callbacks.finish_llm_stream = self.finish_llm_stream
         agent.callbacks.show_llm_response = self.show_llm_response
@@ -301,6 +302,32 @@ class ChainlitAgentCallbacks:
             if self.stream is None:
                 raise ValueError("Stream not initialized")
             run_sync(self.stream.stream_token(t))
+
+        return stream_token
+
+    def start_llm_stream_async(self) -> Callable[[str], None]:
+        """Returns a streaming fn that can be passed to the LLM class"""
+        self.stream = cl.Step(
+            id=self.curr_step.id if self.curr_step is not None else None,
+            name=self._entity_name("llm"),
+            type="llm",
+            parent_id=self._get_parent_id(),
+        )
+        self.last_step = self.stream
+        self.curr_step = None
+        logger.info(
+            f"""
+            Starting LLM stream for {self.agent.config.name}
+            id = {self.stream.id} 
+            under parent {self._get_parent_id()}
+        """
+        )
+        run_sync(self.stream.send())  # type: ignore
+
+        async def stream_token(t: str) -> None:
+            if self.stream is None:
+                raise ValueError("Stream not initialized")
+            await self.stream.stream_token(t)
 
         return stream_token
 
@@ -641,3 +668,4 @@ class ChainlitTaskCallbacks(ChainlitAgentCallbacks):
         step.output = content or NO_ANSWER
         self.last_step = step
         run_sync(step.send())
+

--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -9,7 +9,7 @@ from rich import print
 from rich.console import Console
 from rich.markup import escape
 
-from langroid.agent.base import Agent, AgentConfig, noop_fn
+from langroid.agent.base import Agent, AgentConfig, async_noop_fn, noop_fn
 from langroid.agent.chat_document import ChatDocument
 from langroid.agent.tool_message import ToolMessage
 from langroid.agent.xml_tool_message import XMLToolMessage
@@ -969,10 +969,10 @@ class ChatAgent(Agent):
         functions, fun_call, tools, force_tool = self._function_args()
         assert self.llm is not None
 
-        streamer = noop_fn
+        streamer_async = async_noop_fn
         if self.llm.get_stream():
-            streamer = self.callbacks.start_llm_stream_async()
-        self.llm.config.streamer = streamer
+            streamer_async = await self.callbacks.start_llm_stream_async()
+        self.llm.config.streamer_async = streamer_async
 
         response = await self.llm.achat(
             messages,
@@ -989,7 +989,7 @@ class ChatAgent(Agent):
                     ChatDocument.from_LLMResponse(response, displayed=True),
                 ),
             )
-        self.llm.config.streamer = noop_fn
+        self.llm.config.streamer_async = async_noop_fn
         if response.cached:
             self.callbacks.cancel_llm_stream()
         self._render_llm_response(response)
@@ -1171,4 +1171,3 @@ class ChatAgent(Agent):
             return str(self.message_history[i])
         else:
             return "\n".join([str(m) for m in self.message_history[i:]])
-

--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -971,7 +971,7 @@ class ChatAgent(Agent):
 
         streamer = noop_fn
         if self.llm.get_stream():
-            streamer = self.callbacks.start_llm_stream()
+            streamer = self.callbacks.start_llm_stream_async()
         self.llm.config.streamer = streamer
 
         response = await self.llm.achat(
@@ -1171,3 +1171,4 @@ class ChatAgent(Agent):
             return str(self.message_history[i])
         else:
             return "\n".join([str(m) for m in self.message_history[i:]])
+

--- a/langroid/language_models/base.py
+++ b/langroid/language_models/base.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from enum import Enum
 from typing import (
     Any,
+    Awaitable,
     Callable,
     Dict,
     List,
@@ -33,6 +34,10 @@ def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
     pass
 
 
+async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+    pass
+
+
 FunctionCallTypes = Literal["none", "auto"]
 ToolChoiceTypes = Literal["none", "auto", "required"]
 ToolTypes = Literal["function"]
@@ -45,6 +50,7 @@ class LLMConfig(BaseSettings):
 
     type: str = "openai"
     streamer: Optional[Callable[[Any], None]] = noop_fn
+    streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
     api_base: str | None = None
     formatter: None | str = None
     timeout: int = 20  # timeout for API requests

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -836,10 +836,10 @@ class OpenAIGPT(LanguageModel):
                 sys.stdout.flush()
                 await self.config.streamer_async(event_args)
 
-        if event_tool_deltas is not None:
+        if event_tool_deltas is not None and not silent:
             # print out streaming tool calls, if not async
             for td in event_tool_deltas:
-                if td["function"]["name"] is not None and not silent:
+                if td["function"]["name"] is not None:
                     tool_fn_name = td["function"]["name"]
                     sys.stdout.write(
                         Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -820,41 +820,37 @@ class OpenAIGPT(LanguageModel):
             if not silent:
                 sys.stdout.write(Colors().GREEN + event_text)
                 sys.stdout.flush()
-            await self.config.streamer(event_text)
+                await self.config.streamer_async(event_text)
         if event_fn_name:
             function_name = event_fn_name
             has_function = True
             if not silent:
                 sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
                 sys.stdout.flush()
-
-            await self.config.streamer(event_fn_name)
+                await self.config.streamer_async(event_fn_name)
 
         if event_args:
             function_args += event_args
             if not silent:
                 sys.stdout.write(Colors().GREEN + event_args)
                 sys.stdout.flush()
-
-            await self.config.streamer(event_args)
+                await self.config.streamer_async(event_args)
 
         if event_tool_deltas is not None:
             # print out streaming tool calls, if not async
             for td in event_tool_deltas:
-                if td["function"]["name"] is not None:
+                if td["function"]["name"] is not None and not silent:
                     tool_fn_name = td["function"]["name"]
-                    if not silent:
-                        sys.stdout.write(
-                            Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
-                        )
-                        sys.stdout.flush()
-                    await self.config.streamer(tool_fn_name)
+                    sys.stdout.write(
+                        Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
+                    )
+                    sys.stdout.flush()
+                    await self.config.streamer_async(tool_fn_name)
                 if td["function"]["arguments"] != "":
                     tool_fn_args = td["function"]["arguments"]
-                    if not silent:
-                        sys.stdout.write(Colors().GREEN + tool_fn_args)
-                        sys.stdout.flush()
-                    await self.config.streamer(tool_fn_args)
+                    sys.stdout.write(Colors().GREEN + tool_fn_args)
+                    sys.stdout.flush()
+                    await self.config.streamer_async(tool_fn_args)
 
         # show this delta in the stream
         if choices[0].get("finish_reason", "") in [
@@ -1779,4 +1775,3 @@ class OpenAIGPT(LanguageModel):
         else:
             response_dict = response.model_dump()
         return self._process_chat_completion_response(cached, response_dict)
-

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -688,7 +688,6 @@ class OpenAIGPT(LanguageModel):
         completion: str = "",
         function_args: str = "",
         function_name: str = "",
-        is_async: bool = False,
     ) -> Tuple[bool, bool, str, str]:
         """Process state vars while processing a streaming API response.
             Returns a tuple consisting of:
@@ -708,7 +707,98 @@ class OpenAIGPT(LanguageModel):
         event_args = ""
         event_fn_name = ""
         event_tool_deltas: Optional[List[Dict[str, Any]]] = None
-        silent = is_async and self.config.async_stream_quiet
+        # The first two events in the stream of Azure OpenAI is useless.
+        # In the 1st: choices list is empty, in the 2nd: the dict delta has null content
+        if chat:
+            delta = choices[0].get("delta", {})
+            event_text = delta.get("content", "")
+            if "function_call" in delta and delta["function_call"] is not None:
+                if "name" in delta["function_call"]:
+                    event_fn_name = delta["function_call"]["name"]
+                if "arguments" in delta["function_call"]:
+                    event_args = delta["function_call"]["arguments"]
+            if "tool_calls" in delta and delta["tool_calls"] is not None:
+                # it's a list of deltas, usually just one
+                event_tool_deltas = delta["tool_calls"]
+                tool_deltas += event_tool_deltas
+        else:
+            event_text = choices[0]["text"]
+        if event_text:
+            completion += event_text
+            sys.stdout.write(Colors().GREEN + event_text)
+            sys.stdout.flush()
+            self.config.streamer(event_text)
+        if event_fn_name:
+            function_name = event_fn_name
+            has_function = True
+            sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
+            sys.stdout.flush()
+            self.config.streamer(event_fn_name)
+
+        if event_args:
+            function_args += event_args
+            sys.stdout.write(Colors().GREEN + event_args)
+            sys.stdout.flush()
+            self.config.streamer(event_args)
+
+        if event_tool_deltas is not None:
+            # print out streaming tool calls, if not async
+            for td in event_tool_deltas:
+                if td["function"]["name"] is not None:
+                    tool_fn_name = td["function"]["name"]
+                    sys.stdout.write(
+                        Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
+                    )
+                    sys.stdout.flush()
+                    self.config.streamer(tool_fn_name)
+                if td["function"]["arguments"] != "":
+                    tool_fn_args = td["function"]["arguments"]
+                    sys.stdout.write(Colors().GREEN + tool_fn_args)
+                    sys.stdout.flush()
+                    self.config.streamer(tool_fn_args)
+
+        # show this delta in the stream
+        if choices[0].get("finish_reason", "") in [
+            "stop",
+            "function_call",
+            "tool_calls",
+        ]:
+            # for function_call, finish_reason does not necessarily
+            # contain "function_call" as mentioned in the docs.
+            # So we check for "stop" or "function_call" here.
+            return True, has_function, function_name, function_args, completion
+        return False, has_function, function_name, function_args, completion
+
+    @no_type_check
+    async def _process_stream_event_async(
+        self,
+        event,
+        chat: bool = False,
+        tool_deltas: List[Dict[str, Any]] = [],
+        has_function: bool = False,
+        completion: str = "",
+        function_args: str = "",
+        function_name: str = "",
+    ) -> Tuple[bool, bool, str, str]:
+        """Process state vars while processing a streaming API response.
+            Returns a tuple consisting of:
+        - is_break: whether to break out of the loop
+        - has_function: whether the response contains a function_call
+        - function_name: name of the function
+        - function_args: args of the function
+        """
+        # convert event obj (of type ChatCompletionChunk) to dict so rest of code,
+        # which expects dicts, works as it did before switching to openai v1.x
+        if not isinstance(event, dict):
+            event = event.model_dump()
+
+        choices = event.get("choices", [{}])
+        if len(choices) == 0:
+            choices = [{}]
+        event_args = ""
+        event_fn_name = ""
+        event_tool_deltas: Optional[List[Dict[str, Any]]] = None
+        silent = self.config.async_stream_quiet
         # The first two events in the stream of Azure OpenAI is useless.
         # In the 1st: choices list is empty, in the 2nd: the dict delta has null content
         if chat:
@@ -730,37 +820,41 @@ class OpenAIGPT(LanguageModel):
             if not silent:
                 sys.stdout.write(Colors().GREEN + event_text)
                 sys.stdout.flush()
-                self.config.streamer(event_text)
+            await self.config.streamer(event_text)
         if event_fn_name:
             function_name = event_fn_name
             has_function = True
             if not silent:
                 sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
                 sys.stdout.flush()
-                self.config.streamer(event_fn_name)
+
+            await self.config.streamer(event_fn_name)
 
         if event_args:
             function_args += event_args
             if not silent:
                 sys.stdout.write(Colors().GREEN + event_args)
                 sys.stdout.flush()
-                self.config.streamer(event_args)
 
-        if event_tool_deltas is not None and not silent:
+            await self.config.streamer(event_args)
+
+        if event_tool_deltas is not None:
             # print out streaming tool calls, if not async
             for td in event_tool_deltas:
                 if td["function"]["name"] is not None:
                     tool_fn_name = td["function"]["name"]
-                    sys.stdout.write(
-                        Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
-                    )
-                    sys.stdout.flush()
-                    self.config.streamer(tool_fn_name)
+                    if not silent:
+                        sys.stdout.write(
+                            Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
+                        )
+                        sys.stdout.flush()
+                    await self.config.streamer(tool_fn_name)
                 if td["function"]["arguments"] != "":
                     tool_fn_args = td["function"]["arguments"]
-                    sys.stdout.write(Colors().GREEN + tool_fn_args)
-                    sys.stdout.flush()
-                    self.config.streamer(tool_fn_args)
+                    if not silent:
+                        sys.stdout.write(Colors().GREEN + tool_fn_args)
+                        sys.stdout.flush()
+                    await self.config.streamer(tool_fn_args)
 
         # show this delta in the stream
         if choices[0].get("finish_reason", "") in [
@@ -862,7 +956,7 @@ class OpenAIGPT(LanguageModel):
                     function_name,
                     function_args,
                     completion,
-                ) = self._process_stream_event(
+                ) = await self._process_stream_event_async(
                     event,
                     chat=chat,
                     tool_deltas=tool_deltas,
@@ -870,7 +964,6 @@ class OpenAIGPT(LanguageModel):
                     completion=completion,
                     function_args=function_args,
                     function_name=function_name,
-                    is_async=True,
                 )
                 if is_break:
                     break
@@ -1686,3 +1779,4 @@ class OpenAIGPT(LanguageModel):
         else:
             response_dict = response.model_dump()
         return self._process_chat_completion_response(cached, response_dict)
+


### PR DESCRIPTION
The main problem is that langroid only supports streaming tokens in sync mode even in async function. This can be seen as `OpenAIGPT._stream_response_async` calls `_process_stream_event` with sync streamer callback, for this reason  `ChainlitAgentCallbacks.start_llm_stream` passes sync callback `stream_token` to `self.llm.config.streamer`  wraps `cl.Step.self.stream.stream_token(t)` into `run_sync()`  which makes it inefficient, this is especially evident if I need LLM to stream a large chunk of text, in while llm has already streamed it, run_sync still continues to stream it in ui. 

For this purpose I added the ability to pass an asynchronous streamer callback for asynchronous responses, this significantly improves the speed of streaming from the agent to the UI.