### PR TITLE
fix: XMLToolMessage parsing raise exception

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.6.9
+  rev: v0.7.0
   hooks:
     - id: ruff

--- a/langroid/agent/xml_tool_message.py
+++ b/langroid/agent/xml_tool_message.py
@@ -107,12 +107,17 @@ class XMLToolMessage(ToolMessage):
             Optional["XMLToolMessage"]: An instance of the class if parsing succeeds,
                 None otherwise.
         """
-        parsed_data = cls.extract_field_values(formatted_string)
-        if parsed_data is None:
-            return None
+        try:
+            parsed_data = cls.extract_field_values(formatted_string)
+            if parsed_data is None:
+                return None
 
-        # Use Pydantic's parse_obj to create and validate the instance
-        return cls.parse_obj(parsed_data)
+            # Use Pydantic's parse_obj to create and validate the instance
+            return cls.parse_obj(parsed_data)
+        except Exception as e:
+            from langroid.exceptions import XMLException
+
+            raise XMLException(f"Error parsing XML: {str(e)}")
 
     @classmethod
     def find_verbatim_fields(

--- a/langroid/exceptions.py
+++ b/langroid/exceptions.py
@@ -1,6 +1,11 @@
 from typing import Optional
 
 
+class XMLException(Exception):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
 class InfiniteLoopException(Exception):
     def __init__(self, message: str = "Infinite loop detected", *args: object) -> None:
         super().__init__(message, *args)


### PR DESCRIPTION
During XML tool handling, we want to raise an exception and return a string back to the LLM rather than crash (similar to how we do with JSON tools).