### PR TITLE
Fix broken assistants update call.

### DIFF
--- a/langroid/agent/openai_assistant.py
+++ b/langroid/agent/openai_assistant.py
@@ -206,19 +206,17 @@ class OpenAIAssistant(ChatAgent):
         functions, _, _, _ = self._function_args()
         if functions is None:
             return
-        # add the functions to the assistant:
+        # add the function to the assistant:
         if self.assistant is None:
             raise ValueError("Assistant is None")
-        tools = self.assistant.tools
-        tools.extend(
-            [
-                {
-                    "type": "function",  # type: ignore
-                    "function": f.dict(),
-                }
-                for f in functions
-            ]
-        )
+        tools = [
+            {
+                "type": "function",  # type: ignore
+                "function": f.dict(),
+            }
+            for f in functions
+        ]
+        # OpenAI assistants API fail if existing function is in update.
         self.assistant = self.assistants.update(
             self.assistant.id,
             tools=tools,  # type: ignore


### PR DESCRIPTION
The current OpenAI assistants API (`openai.resources.beta.assistants.update`) does not support having an existing function in the functions list, it fails with a "Function must have unique names error". Since `enable_message` will be recursively called for lists, or sequentially called when the user adds multiple tools in sequence, this will always fail with more than one tool. Instead, just add the last tool as a function. 

This does seem like a strange implementation from OpenAI as the `update` is really an append only operation for functions then.