### PR TITLE
change: parameter name to 'message' in llm_response and llm_response_async

### DIFF
--- a/examples/basic/multi-agent-triage.py
+++ b/examples/basic/multi-agent-triage.py
@@ -147,9 +147,9 @@ def main(model: str = ""):
     class CoursesAgent(lr.agent.special.DocChatAgent):
         def llm_response(
             self,
-            query: None | str | ChatDocument = None,
+            message: None | str | ChatDocument = None,
         ) -> Optional[ChatDocument]:
-            answer = super().llm_response(query)
+            answer = super().llm_response(message)
             if answer is None:
                 return None
             return self.create_llm_response(
@@ -183,9 +183,9 @@ def main(model: str = ""):
     class FinanceAgent(lr.agent.special.DocChatAgent):
         def llm_response(
             self,
-            query: None | str | ChatDocument = None,
+            message: None | str | ChatDocument = None,
         ) -> Optional[ChatDocument]:
-            answer = super().llm_response(query)
+            answer = super().llm_response(message)
             if answer is None:
                 return None
             return self.create_llm_response(

--- a/examples/chainlit/chat-search-rag.py
+++ b/examples/chainlit/chat-search-rag.py
@@ -95,9 +95,9 @@ class DDGSearchDocChatAgent(DocChatAgent):
 
     def llm_response_async(
         self,
-        query: None | str | ChatDocument = None,
+        message: None | str | ChatDocument = None,
     ) -> Optional[ChatDocument]:
-        return ChatAgent.llm_response_async(self, query)
+        return ChatAgent.llm_response_async(self, message)
 
     def relevant_extracts(self, msg: RelevantExtractsTool) -> str:
         """Get docs/extracts relevant to the query, from vecdb"""

--- a/examples/chainlit/non-callback/chat-search-no-callback.py
+++ b/examples/chainlit/non-callback/chat-search-no-callback.py
@@ -24,16 +24,16 @@ from langroid.agent.tools.metaphor_search_tool import MetaphorSearchTool
 
 
 @cl.step(name="LLM Response")
-async def llm_response(msg: str) -> lr.ChatDocument:
+async def llm_response(message: str) -> lr.ChatDocument:
     agent: lr.ChatAgent = cl.user_session.get("agent")
-    response = await agent.llm_response_async(msg)
+    response = await agent.llm_response_async(message)
     return response
 
 
 @cl.step(name="Agent Tool Handler")
-async def agent_response(msg: lr.ChatDocument) -> lr.ChatDocument:
+async def agent_response(message: lr.ChatDocument) -> lr.ChatDocument:
     agent: lr.ChatAgent = cl.user_session.get("agent")
-    response = await agent.agent_response_async(msg)
+    response = await agent.agent_response_async(message)
     return response
 
 

--- a/examples/docqa/chat-multi-extract-local.py
+++ b/examples/docqa/chat-multi-extract-local.py
@@ -127,7 +127,7 @@ class QuestionGeneratorAgent(ChatAgent):
 class MyDocChatAgent(DocChatAgent):
     def llm_response(
         self,
-        query: None | str | ChatDocument = None,
+        message: None | str | ChatDocument = None,
     ) -> Optional[ChatDocument]:
         """
         Override the default LLM response to return the full document,
@@ -137,7 +137,7 @@ class MyDocChatAgent(DocChatAgent):
         since we are extracting separate pieces of info from docs)
         """
         n_msgs = len(self.message_history)
-        response = super().llm_response(query)
+        response = super().llm_response(message)
         # If there is a response, then we will have two additional
         # messages in the message history, i.e. the user message and the
         # assistant response. We want to (carefully) remove these two messages.

--- a/examples/docqa/chat-search-filter.py
+++ b/examples/docqa/chat-search-filter.py
@@ -148,9 +148,9 @@ class SearchDocChatAgent(DocChatAgent):
 
     def llm_response(
         self,
-        query: None | str | ChatDocument = None,
+        message: None | str | ChatDocument = None,
     ) -> ChatDocument | None:
-        return ChatAgent.llm_response(self, query)
+        return ChatAgent.llm_response(self, message)
 
     def relevant_extracts(self, msg: RelevantExtractsTool) -> str:
         """Get docs/extracts relevant to the query, from vecdb"""

--- a/examples/docqa/chat-search.py
+++ b/examples/docqa/chat-search.py
@@ -86,9 +86,9 @@ class SearchDocChatAgent(DocChatAgent):
 
     def llm_response(
         self,
-        query: None | str | ChatDocument = None,
+        message: None | str | ChatDocument = None,
     ) -> ChatDocument | None:
-        return ChatAgent.llm_response(self, query)
+        return ChatAgent.llm_response(self, message)
 
     def handle_message_fallback(self, msg: str | ChatDocument) -> Any:
         if isinstance(msg, ChatDocument) and msg.metadata.sender == lr.Entity.LLM:

--- a/examples/docqa/doc-aware-chat.py
+++ b/examples/docqa/doc-aware-chat.py
@@ -67,10 +67,10 @@ class DocAwareChatAgent(DocChatAgent):
 
     def llm_response(
         self,
-        query: None | str | ChatDocument = None,
+        message: None | str | ChatDocument = None,
     ) -> Optional[ChatDocument]:
         # override DocChatAgent's default llm_response
-        return ChatAgent.llm_response(self, query)
+        return ChatAgent.llm_response(self, message)
 
     def handle_message_fallback(self, msg: str | ChatDocument) -> Any:
         # we are here if there is no tool in the msg

--- a/examples/docqa/doc-aware-compose-2.py
+++ b/examples/docqa/doc-aware-compose-2.py
@@ -51,10 +51,10 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 class DocAgent(DocChatAgent):
     def llm_response(
         self,
-        query: None | str | ChatDocument = None,
+        message: None | str | ChatDocument = None,
     ) -> Optional[ChatDocument]:
         # Augment the response
-        results = super().llm_response(query).content
+        results = super().llm_response(message).content
         return self.create_llm_response(
             f"""
             Summary answer FROM DocAgent:

--- a/examples/docqa/doc-aware-guide-2.py
+++ b/examples/docqa/doc-aware-guide-2.py
@@ -38,10 +38,10 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 class DocAgent(DocChatAgent):
     def llm_response(
         self,
-        query: None | str | ChatDocument = None,
+        message: None | str | ChatDocument = None,
     ) -> Optional[ChatDocument]:
         # Augment the response
-        results = super().llm_response(query).content
+        results = super().llm_response(message).content
         return self.create_llm_response(
             f"""
             Summary answer FROM DocAgent:

--- a/examples/docqa/doc-based-troubleshooting.py
+++ b/examples/docqa/doc-based-troubleshooting.py
@@ -40,10 +40,10 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 class DocAgent(DocChatAgent):
     def llm_response(
         self,
-        query: None | str | ChatDocument = None,
+        message: None | str | ChatDocument = None,
     ) -> Optional[ChatDocument]:
         # Augment the response
-        results = super().llm_response(query).content
+        results = super().llm_response(message).content
         return self.create_llm_response(
             f"""
             Summary answer FROM DocAgent:

--- a/examples/docqa/filter-multi-doc-query-plan.py
+++ b/examples/docqa/filter-multi-doc-query-plan.py
@@ -60,11 +60,11 @@ class QueryPlanTool(lr.ToolMessage):
 class FilterDocAgent(lr.agent.special.DocChatAgent):
     def llm_response(
         self,
-        query: None | str | ChatDocument = None,
+        message: None | str | ChatDocument = None,
     ) -> Optional[ChatDocument]:
         """Override DocChatAgent's default method,
         to call ChatAgent's llm_response, so it emits the QueryPlanTool"""
-        return lr.ChatAgent.llm_response(self, query)
+        return lr.ChatAgent.llm_response(self, message)
 
     def query_plan(self, msg: QueryPlanTool) -> str:
         """Handle query plan tool"""

--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -756,18 +756,18 @@ class Agent(ABC):
     @no_type_check
     async def llm_response_async(
         self,
-        msg: Optional[str | ChatDocument] = None,
+        message: Optional[str | ChatDocument] = None,
     ) -> Optional[ChatDocument]:
         """
         Asynch version of `llm_response`. See there for details.
         """
-        if msg is None or not self.llm_can_respond(msg):
+        if message is None or not self.llm_can_respond(message):
             return None
 
-        if isinstance(msg, ChatDocument):
-            prompt = msg.content
+        if isinstance(message, ChatDocument):
+            prompt = message.content
         else:
-            prompt = msg
+            prompt = message
 
         output_len = self.config.llm.max_output_tokens
         if self.num_tokens(prompt) + output_len > self.llm.completion_context_length():
@@ -807,29 +807,31 @@ class Agent(ABC):
             )
         cdoc = ChatDocument.from_LLMResponse(response, displayed=True)
         # Preserve trail of tool_ids for OpenAI Assistant fn-calls
-        cdoc.metadata.tool_ids = [] if isinstance(msg, str) else msg.metadata.tool_ids
+        cdoc.metadata.tool_ids = (
+            [] if isinstance(message, str) else message.metadata.tool_ids
+        )
         return cdoc
 
     @no_type_check
     def llm_response(
         self,
-        msg: Optional[str | ChatDocument] = None,
+        message: Optional[str | ChatDocument] = None,
     ) -> Optional[ChatDocument]:
         """
         LLM response to a prompt.
         Args:
-            msg (str|ChatDocument): prompt string, or ChatDocument object
+            message (str|ChatDocument): prompt string, or ChatDocument object
 
         Returns:
             Response from LLM, packaged as a ChatDocument
         """
-        if msg is None or not self.llm_can_respond(msg):
+        if message is None or not self.llm_can_respond(message):
             return None
 
-        if isinstance(msg, ChatDocument):
-            prompt = msg.content
+        if isinstance(message, ChatDocument):
+            prompt = message.content
         else:
-            prompt = msg
+            prompt = message
 
         with ExitStack() as stack:  # for conditionally using rich spinner
             if not self.llm.get_stream():
@@ -879,7 +881,9 @@ class Agent(ABC):
         )
         cdoc = ChatDocument.from_LLMResponse(response, displayed=True)
         # Preserve trail of tool_ids for OpenAI Assistant fn-calls
-        cdoc.metadata.tool_ids = [] if isinstance(msg, str) else msg.metadata.tool_ids
+        cdoc.metadata.tool_ids = (
+            [] if isinstance(message, str) else message.metadata.tool_ids
+        )
         return cdoc
 
     def has_tool_message_attempt(self, msg: str | ChatDocument | None) -> bool:

--- a/langroid/agent/special/doc_chat_agent.py
+++ b/langroid/agent/special/doc_chat_agent.py
@@ -663,15 +663,15 @@ class DocChatAgent(ChatAgent):
 
     def llm_response(
         self,
-        query: None | str | ChatDocument = None,
+        message: None | str | ChatDocument = None,
     ) -> Optional[ChatDocument]:
-        if not self.llm_can_respond(query):
+        if not self.llm_can_respond(message):
             return None
         query_str: str | None
-        if isinstance(query, ChatDocument):
-            query_str = query.content
+        if isinstance(message, ChatDocument):
+            query_str = message.content
         else:
-            query_str = query
+            query_str = message
         if query_str is None or query_str.startswith("!"):
             # direct query to LLM
             query_str = query_str[1:] if query_str is not None else None
@@ -714,16 +714,16 @@ class DocChatAgent(ChatAgent):
 
     async def llm_response_async(
         self,
-        query: None | str | ChatDocument = None,
+        message: None | str | ChatDocument = None,
     ) -> Optional[ChatDocument]:
         apply_nest_asyncio()
-        if not self.llm_can_respond(query):
+        if not self.llm_can_respond(message):
             return None
         query_str: str | None
-        if isinstance(query, ChatDocument):
-            query_str = query.content
+        if isinstance(message, ChatDocument):
+            query_str = message.content
         else:
-            query_str = query
+            query_str = message
         if query_str is None or query_str.startswith("!"):
             # direct query to LLM
             query_str = query_str[1:] if query_str is not None else None

--- a/tests/main/test_doc_chat_agent.py
+++ b/tests/main/test_doc_chat_agent.py
@@ -265,12 +265,12 @@ def test_doc_chat_agent_task(test_settings: Settings, agent):
 class RetrievalAgent(DocChatAgent):
     def llm_response(
         self,
-        query: None | str | ChatDocument = None,
+        message: None | str | ChatDocument = None,
     ) -> Optional[ChatDocument]:
         # override the DocChatAgent's LLM response,
         # to just use ChatAgent's LLM response - this ensures that the system msg
         # is respected, and it uses the `retrieval_tool` as instructed.
-        return ChatAgent.llm_response(self, query)
+        return ChatAgent.llm_response(self, message)
 
 
 @pytest.fixture(scope="function")

--- a/tests/main/test_retriever_agent.py
+++ b/tests/main/test_retriever_agent.py
@@ -141,7 +141,7 @@ def test_retriever_agent(
     not_expected: str,
 ) -> None:
     set_global(test_settings)
-    response = agent.llm_response(query=query).content
+    response = agent.llm_response(message=query).content
     assert all([k in response for k in expected.split(",")])
     assert all([k not in response for k in not_expected.split(",")])
 


### PR DESCRIPTION
Uniformized to `message` the parameter in the `llm_response` agents classes methods.