### PR TITLE
preserve Task's loggers if set by user

### DIFF
--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -570,7 +570,7 @@ class Task:
 
         if self.caller is not None and self.caller.logger is not None:
             self.logger = self.caller.logger
-        else:
+        elif self.logger is None:
             self.logger = RichFileLogger(
                 str(Path(self.config.logs_dir) / f"{self.name}.log"),
                 color=self.color_log,
@@ -578,7 +578,7 @@ class Task:
 
         if self.caller is not None and self.caller.tsv_logger is not None:
             self.tsv_logger = self.caller.tsv_logger
-        else:
+        elif self.tsv_caller is None:
             self.tsv_logger = setup_file_logger(
                 "tsv_logger",
                 str(Path(self.config.logs_dir) / f"{self.name}.tsv"),


### PR DESCRIPTION
Current `Task.init()` implementation ALWAYS sets `logger` / `tsv_logger` in `Task` either to caller's loggers or to default implementation. Thus it's impossible to configure custom loggers for the task without some dirty hacks - see [discussion#622](https://github.com/langroid/langroid/discussions/622).

This PR delivers a simple fix that preserves Task's loggers if set by user.
