### PR TITLE
call Agent callbacks in quiet mode

### DIFF
--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -414,20 +414,20 @@ class Agent(ABC):
         results = self.handle_message(msg)
         if results is None:
             return None
+        if isinstance(results, str):
+            results_str = results
+        elif isinstance(results, ChatDocument):
+            results_str = results.content
+        elif isinstance(results, dict):
+            results_str = json.dumps(results, indent=2)
         if not settings.quiet:
-            if isinstance(results, str):
-                results_str = results
-            elif isinstance(results, ChatDocument):
-                results_str = results.content
-            elif isinstance(results, dict):
-                results_str = json.dumps(results, indent=2)
             console.print(f"[red]{self.indent}", end="")
             print(f"[red]Agent: {escape(results_str)}")
-            maybe_json = len(extract_top_level_json(results_str)) > 0
-            self.callbacks.show_agent_response(
-                content=results_str,
-                language="json" if maybe_json else "text",
-            )
+        maybe_json = len(extract_top_level_json(results_str)) > 0
+        self.callbacks.show_agent_response(
+            content=results_str,
+            language="json" if maybe_json else "text",
+        )
         if isinstance(results, ChatDocument):
             # Preserve trail of tool_ids for OpenAI Assistant fn-calls
             results.metadata.tool_ids = (

--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -1065,25 +1065,27 @@ class ChatAgent(Agent):
             # streaming was enabled, AND we did not find a cached response.
             # If we are here, it means the response has not yet been displayed.
             cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
+            chat_doc = (
+                response
+                if isinstance(response, ChatDocument)
+                else ChatDocument.from_LLMResponse(response, displayed=True)
+            )
+            # TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
             if not settings.quiet:
-                chat_doc = (
-                    response
-                    if isinstance(response, ChatDocument)
-                    else ChatDocument.from_LLMResponse(response, displayed=True)
-                )
-                # TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
                 print(cached + "[green]" + escape(str(response)))
-                self.callbacks.show_llm_response(
-                    content=str(response),
-                    is_tool=self.has_tool_message_attempt(chat_doc),
-                    cached=is_cached,
-                )
+            self.callbacks.show_llm_response(
+                content=str(response),
+                is_tool=self.has_tool_message_attempt(chat_doc),
+                cached=is_cached,
+            )
         if isinstance(response, LLMResponse):
             # we are in the context immediately after an LLM responded,
             # we won't have citations yet, so we're done
             return
-        if response.metadata.has_citation and not settings.quiet:
-            print("[grey37]SOURCES:\n" + escape(response.metadata.source) + "[/grey37]")
+        if response.metadata.has_citation:
+            if not settings.quiet:
+                print("[grey37]SOURCES:\n" +
+                      escape(response.metadata.source) + "[/grey37]")
             self.callbacks.show_llm_response(
                 content=str(response.metadata.source),
                 is_tool=False,


### PR DESCRIPTION
`settings.quiet` is used to suppress various print's to the console.
It should NOT disable calling agent's `callbacks`.
See [discussion#622](https://github.com/langroid/langroid/discussions/622) for details.