### PR TITLE
remove duplicate EmbeddingModel initialization in vectore_store c'tors

### DIFF
--- a/langroid/vector_store/chromadb.py
+++ b/langroid/vector_store/chromadb.py
@@ -3,7 +3,6 @@ import logging
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from langroid.embedding_models.base import (
-    EmbeddingModel,
     EmbeddingModelsConfig,
 )
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
@@ -32,8 +31,7 @@ class ChromaDB(VectorStore):
         except ImportError:
             raise LangroidImportError("chromadb", "chromadb")
         self.config = config
-        emb_model = EmbeddingModel.create(config.embedding)
-        self.embedding_fn = emb_model.embedding_fn()
+        self.embedding_fn = self.embedding_model.embedding_fn()
         self.client = chromadb.Client(
             chromadb.config.Settings(
                 # chroma_db_impl="duckdb+parquet",
@@ -64,7 +62,7 @@ class ChromaDB(VectorStore):
             self.client.delete_collection(name=c.name)
         logger.warning(
             f"""
-            Deleted {n_empty_deletes} empty collections and 
+            Deleted {n_empty_deletes} empty collections and
             {n_non_empty_deletes} non-empty collections.
             """
         )

--- a/langroid/vector_store/lancedb.py
+++ b/langroid/vector_store/lancedb.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from lancedb.query import LanceVectorQueryBuilder
 
 from langroid.embedding_models.base import (
-    EmbeddingModel,
     EmbeddingModelsConfig,
 )
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
@@ -61,9 +60,8 @@ class LanceDB(VectorStore):
             raise LangroidImportError("lancedb", "lancedb")
 
         self.config: LanceDBConfig = config
-        emb_model = EmbeddingModel.create(config.embedding)
-        self.embedding_fn: EmbeddingFunction = emb_model.embedding_fn()
-        self.embedding_dim = emb_model.embedding_dims
+        self.embedding_fn: EmbeddingFunction = self.embedding_model.embedding_fn()
+        self.embedding_dim = self.embedding_model.embedding_dims
         self.host = config.host
         self.port = config.port
         self.is_from_dataframe = False  # were docs ingested from a dataframe?
@@ -123,7 +121,7 @@ class LanceDB(VectorStore):
             self.client.drop_table(name)
         logger.warning(
             f"""
-            Deleted {n_empty_deletes} empty collections and 
+            Deleted {n_empty_deletes} empty collections and
             {n_non_empty_deletes} non-empty collections.
             """
         )
@@ -344,7 +342,7 @@ class LanceDB(VectorStore):
             raise ValueError(
                 f"""
             Error validating LanceDB result: {e}
-            HINT: This could happen when you're re-using an 
+            HINT: This could happen when you're re-using an
             existing LanceDB store with a different schema.
             Try deleting your local lancedb storage at `{self.config.storage_path}`
             re-ingesting your documents and/or replacing the collections.

--- a/langroid/vector_store/momento.py
+++ b/langroid/vector_store/momento.py
@@ -34,7 +34,6 @@ except ImportError:
 
 
 from langroid.embedding_models.base import (
-    EmbeddingModel,
     EmbeddingModelsConfig,
 )
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
@@ -62,9 +61,8 @@ class MomentoVI(VectorStore):
             raise LangroidImportError("momento", "momento")
         self.distance = SimilarityMetric.COSINE_SIMILARITY
         self.config: MomentoVIConfig = config
-        emb_model = EmbeddingModel.create(config.embedding)
-        self.embedding_fn: EmbeddingFunction = emb_model.embedding_fn()
-        self.embedding_dim = emb_model.embedding_dims
+        self.embedding_fn: EmbeddingFunction = self.embedding_model.embedding_fn()
+        self.embedding_dim = self.embedding_model.embedding_dims
         self.host = config.host
         self.port = config.port
         load_dotenv()
@@ -72,8 +70,8 @@ class MomentoVI(VectorStore):
         if config.cloud:
             if api_key is None:
                 raise ValueError(
-                    """MOMENTO_API_KEY env variable must be set to 
-                    MomentoVI hosted service. Please set this in your .env file. 
+                    """MOMENTO_API_KEY env variable must be set to
+                    MomentoVI hosted service. Please set this in your .env file.
                     """
                 )
             self.client = PreviewVectorIndexClient(

--- a/langroid/vector_store/qdrantdb.py
+++ b/langroid/vector_store/qdrantdb.py
@@ -23,7 +23,6 @@ from qdrant_client.http.models import (
 )
 
 from langroid.embedding_models.base import (
-    EmbeddingModel,
     EmbeddingModelsConfig,
 )
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
@@ -77,16 +76,15 @@ class QdrantDB(VectorStore):
     def __init__(self, config: QdrantDBConfig = QdrantDBConfig()):
         super().__init__(config)
         self.config: QdrantDBConfig = config
-        emb_model = EmbeddingModel.create(config.embedding)
-        self.embedding_fn: EmbeddingFunction = emb_model.embedding_fn()
-        self.embedding_dim = emb_model.embedding_dims
+        self.embedding_fn: EmbeddingFunction = self.embedding_model.embedding_fn()
+        self.embedding_dim = self.embedding_model.embedding_dims
         if self.config.use_sparse_embeddings:
             try:
                 from transformers import AutoModelForMaskedLM, AutoTokenizer
             except ImportError:
                 raise ImportError(
                     """
-                    To use sparse embeddings, 
+                    To use sparse embeddings,
                     you must install langroid with the [transformers] extra, e.g.:
                     pip install "langroid[transformers]"
                     """
@@ -117,10 +115,10 @@ class QdrantDB(VectorStore):
                 config.cloud = True
         elif config.cloud and None in [key, url]:
             logger.warning(
-                f"""QDRANT_API_KEY, QDRANT_API_URL env variable must be set to use 
-                QdrantDB in cloud mode. Please set these values 
-                in your .env file. 
-                Switching to local storage at {config.storage_path} 
+                f"""QDRANT_API_KEY, QDRANT_API_URL env variable must be set to use
+                QdrantDB in cloud mode. Please set these values
+                in your .env file.
+                Switching to local storage at {config.storage_path}
                 """
             )
             config.cloud = False
@@ -189,7 +187,7 @@ class QdrantDB(VectorStore):
             self.client.delete_collection(collection_name=name)
         logger.warning(
             f"""
-            Deleted {n_empty_deletes} empty collections and 
+            Deleted {n_empty_deletes} empty collections and
             {n_non_empty_deletes} non-empty collections.
             """
         )


### PR DESCRIPTION
Most of vector_store constructors create a duplicate EmbeddingModel instance instead of using the one from the base class.
For "local" embedding models - e.g. FastEmbedEmbeddings - constructors are relatively slow, so this adds an unneeded delay on Agent instance creation.