### PR TITLE
fix: invalid default for start_llm_stream_async

### DIFF
--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -116,6 +116,10 @@ async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
     pass
 
 
+async def async_lambda_noop_fn() -> Callable[..., None]:
+    return async_noop_fn
+
+
 class Agent(ABC):
     """
     An Agent is an abstraction that encapsulates mainly two components:
@@ -169,7 +173,7 @@ class Agent(ABC):
 
         self.callbacks = SimpleNamespace(
             start_llm_stream=lambda: noop_fn,
-            start_llm_stream_async=async_noop_fn,
+            start_llm_stream_async=async_lambda_noop_fn,
             cancel_llm_stream=noop_fn,
             finish_llm_stream=noop_fn,
             show_llm_response=noop_fn,


### PR DESCRIPTION
Running `task.run_async(...)` fails if `async_stream_quiet=False` because the default for `callbacks.start_llm_stream_async` doesn't return a function as it should, so an exception is raised when it is called (which only happens if `async_stream_quiet=False`).