### PR TITLE
Add Llama.cpp Embeddings Support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.8.3
+  rev: v0.8.4
   hooks:
     - id: ruff

--- a/docs/notes/llama-cpp-embeddings.md
+++ b/docs/notes/llama-cpp-embeddings.md
@@ -1,0 +1,30 @@
+# Local embeddings provision via llama.cpp server
+
+As of Langroid v0.X.X, you can use llama.cpp as provider of embeddings
+to any of Langroid's vector stores, allowing access to a wide variety of
+GGUF-compatible embedding models, e.g. [nomic-ai's Embed Text V1.5](https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF).
+
+When defining a VecDB, you can provide an instance of 
+`LlamaCppServerEmbeddingsConfig` to the VecDB config to instantiate
+the llama.cpp embeddings server handler.
+
+To configure the `LlamaCppServerEmbeddingsConfig`, there are several
+parameters that should be adjusted, these are:
+
+```python
+embed_cfg = LlamaCppServerEmbeddingsConfig(
+    api_base="your-address-here", # IP + Port, e.g. localhost:5001
+    dims=768,  # Change this to match the dimensions of your embedding model
+    context_length=2048, # Change to match the config of the model.
+    batch_size=2048, # Safest to ensure this matches context_length
+    )
+```
+
+The above configuration is sufficient for a server running the example
+nomic embedding model with the command:
+```
+./llama-server -ngl 100 -c 2048 -m ~/nomic-embed-text-v1.5.Q8_0.gguf --host IP_ADDRESS --port PORT --embeddings -b 2048 -ub 2048
+```
+
+An example setup can be found inside [examples/docqa/chat.py](https://github.com/langroid/langroid/blob/main/examples/docqa/chat.py).
+

--- a/langroid/embedding_models/__init__.py
+++ b/langroid/embedding_models/__init__.py
@@ -9,8 +9,10 @@ from .base import (
 from .models import (
     OpenAIEmbeddings,
     OpenAIEmbeddingsConfig,
-    SentenceTransformerEmbeddingsConfig,
     SentenceTransformerEmbeddings,
+    SentenceTransformerEmbeddingsConfig,
+    LlamaCppServerEmbeddings,
+    LlamaCppServerEmbeddingsConfig,
     embedding_model,
 )
 from .remote_embeds import (
@@ -27,8 +29,10 @@ __all__ = [
     "EmbeddingModelsConfig",
     "OpenAIEmbeddings",
     "OpenAIEmbeddingsConfig",
-    "SentenceTransformerEmbeddingsConfig",
     "SentenceTransformerEmbeddings",
+    "SentenceTransformerEmbeddingsConfig",
+    "LlamaCppServerEmbeddings",
+    "LlamaCppServerEmbeddingsConfig",
     "embedding_model",
     "RemoteEmbeddingsConfig",
     "RemoteEmbeddings",

--- a/langroid/embedding_models/base.py
+++ b/langroid/embedding_models/base.py
@@ -30,6 +30,8 @@ class EmbeddingModel(ABC):
             OpenAIEmbeddingsConfig,
             SentenceTransformerEmbeddings,
             SentenceTransformerEmbeddingsConfig,
+            LlamaCppServerEmbeddings,
+            LlamaCppServerEmbeddingsConfig
         )
         from langroid.embedding_models.remote_embeds import (
             RemoteEmbeddings,
@@ -44,6 +46,8 @@ class EmbeddingModel(ABC):
             return SentenceTransformerEmbeddings(config)
         elif isinstance(config, FastEmbedEmbeddingsConfig):
             return FastEmbedEmbeddings(config)
+        elif isinstance(config, LlamaCppServerEmbeddingsConfig):
+            return LlamaCppServerEmbeddings(config)
         else:
             raise ValueError(f"Unknown embedding config: {config.__repr_name__}")
 

--- a/langroid/embedding_models/base.py
+++ b/langroid/embedding_models/base.py
@@ -26,12 +26,12 @@ class EmbeddingModel(ABC):
         from langroid.embedding_models.models import (
             FastEmbedEmbeddings,
             FastEmbedEmbeddingsConfig,
+            LlamaCppServerEmbeddings,
+            LlamaCppServerEmbeddingsConfig,
             OpenAIEmbeddings,
             OpenAIEmbeddingsConfig,
             SentenceTransformerEmbeddings,
             SentenceTransformerEmbeddingsConfig,
-            LlamaCppServerEmbeddings,
-            LlamaCppServerEmbeddingsConfig
         )
         from langroid.embedding_models.remote_embeds import (
             RemoteEmbeddings,

--- a/langroid/embedding_models/models.py
+++ b/langroid/embedding_models/models.py
@@ -246,10 +246,11 @@ class FastEmbedEmbeddings(EmbeddingModel):
         return len(embed_func(["text"])[0])
 
 
+LCSEC = LlamaCppServerEmbeddingsConfig
+
+
 class LlamaCppServerEmbeddings(EmbeddingModel):
-    def __init__(
-        self, config: LlamaCppServerEmbeddingsConfig = LlamaCppServerEmbeddingsConfig()
-    ):
+    def __init__(self, config: LCSEC = LCSEC()):
         super().__init__()
         self.config = config
 

--- a/langroid/embedding_models/models.py
+++ b/langroid/embedding_models/models.py
@@ -50,9 +50,7 @@ class FastEmbedEmbeddingsConfig(EmbeddingModelsConfig):
 
 
 class LlamaCppServerEmbeddingsConfig(EmbeddingModelsConfig):
-    api_key: str = ""
     api_base: str = ""
-    dims: int = 1536
     context_length: int = 8192
 
 

--- a/langroid/embedding_models/models.py
+++ b/langroid/embedding_models/models.py
@@ -261,54 +261,54 @@ class LlamaCppServerEmbeddings(EmbeddingModel):
                 """
             )
 
-        self.tokenise_url = self.config.api_base + "/tokenize"
-        self.detokenise_url = self.config.api_base + "/detokenize"
+        self.tokenize_url = self.config.api_base + "/tokenize"
+        self.detokenize_url = self.config.api_base + "/detokenize"
         self.embedding_url = self.config.api_base + "/embeddings"
 
-    def tokenise_string(self, text: str) -> List[int]:
+    def tokenize_string(self, text: str) -> List[int]:
         data = {"content": text, "add_special": False, "with_pieces": False}
-        response = requests.post(self.tokenise_url, json=data)
+        response = requests.post(self.tokenize_url, json=data)
 
         if response.status_code == 200:
             tokens = response.json()["tokens"]
             if type(tokens) is not List[int]:
                 raise ValueError(
-                    """Tokeniser endpoint has not returned the correct format. 
+                    """Tokenizer endpoint has not returned the correct format. 
                    Is the URL correct?
                 """
                 )
             return tokens
         else:
             raise requests.HTTPError(
-                self.tokenise_url,
+                self.tokenize_url,
                 response.status_code,
                 "Failed to connect to tokenisation provider",
             )
 
-    def detokenise_string(self, tokens: List[int]) -> str:
+    def detokenize_string(self, tokens: List[int]) -> str:
         data = {"tokens": tokens}
-        response = requests.post(self.detokenise_url, json=data)
+        response = requests.post(self.detokenize_url, json=data)
 
         if response.status_code == 200:
             text = response.json()["content"]
             if not isinstance(text, str):
                 raise ValueError(
-                    """Deokeniser endpoint has not returned the correct format. 
+                    """Deokenizer endpoint has not returned the correct format. 
                    Is the URL correct?
                 """
                 )
             return text
         else:
             raise requests.HTTPError(
-                self.detokenise_url,
+                self.detokenize_url,
                 response.status_code,
                 "Failed to connect to detokenisation provider",
             )
 
     def truncate_string_to_context_size(self, text: str) -> str:
-        tokens = self.tokenise_string(text)
+        tokens = self.tokenize_string(text)
         tokens = tokens[: self.config.context_length]
-        return self.detokenise_string(tokens)
+        return self.detokenize_string(tokens)
 
     def generate_embedding(self, text: str) -> List[int | float]:
         data = {"content": text}

--- a/langroid/embedding_models/models.py
+++ b/langroid/embedding_models/models.py
@@ -1,10 +1,9 @@
 import atexit
 import os
-import requests
-import json
 from functools import cached_property
 from typing import Any, Callable, Dict, List, Optional
 
+import requests
 import tiktoken
 from dotenv import load_dotenv
 from openai import OpenAI
@@ -247,77 +246,97 @@ class FastEmbedEmbeddings(EmbeddingModel):
     def embedding_dims(self) -> int:
         embed_func = self.embedding_fn()
         return len(embed_func(["text"])[0])
-    
+
 
 class LlamaCppServerEmbeddings(EmbeddingModel):
-    def __init__(self, config: LlamaCppServerEmbeddingsConfig = LlamaCppServerEmbeddingsConfig()):
+    def __init__(
+        self, config: LlamaCppServerEmbeddingsConfig = LlamaCppServerEmbeddingsConfig()
+    ):
         super().__init__()
         self.config = config
 
-        # Llama Server embeddings requires an address for all tokenisation/embedding functions
         if self.config.api_base == "":
             raise ValueError(
                 """Api Base MUST be set for Llama Server Embeddings.
                 """
             )
-        
+
         self.tokenise_url = self.config.api_base + "/tokenize"
         self.detokenise_url = self.config.api_base + "/detokenize"
         self.embedding_url = self.config.api_base + "/embeddings"
 
     def tokenise_string(self, text: str) -> List[int]:
-        data = {
-            "content" : text,
-            "add_special" : False,
-            "with_pieces" : False
-        }
+        data = {"content": text, "add_special": False, "with_pieces": False}
         response = requests.post(self.tokenise_url, json=data)
 
         if response.status_code == 200:
             tokens = response.json()["tokens"]
+            if type(tokens) is not List[int]:
+                raise ValueError(
+                    """Tokeniser endpoint has not returned the correct format. 
+                   Is the URL correct?
+                """
+                )
             return tokens
         else:
-            raise requests.HTTPError(self.tokenise_url, response.status_code, "Failed to connect to tokenisation provider")
+            raise requests.HTTPError(
+                self.tokenise_url,
+                response.status_code,
+                "Failed to connect to tokenisation provider",
+            )
 
     def detokenise_string(self, tokens: List[int]) -> str:
-        data = {
-            "tokens" : tokens
-        }
+        data = {"tokens": tokens}
         response = requests.post(self.detokenise_url, json=data)
 
         if response.status_code == 200:
             text = response.json()["content"]
+            if not isinstance(text, str):
+                raise ValueError(
+                    """Deokeniser endpoint has not returned the correct format. 
+                   Is the URL correct?
+                """
+                )
             return text
         else:
-            raise requests.HTTPError(self.detokenise_url, response.status_code, "Failed to connect to detokenisation provider")
-    
+            raise requests.HTTPError(
+                self.detokenise_url,
+                response.status_code,
+                "Failed to connect to detokenisation provider",
+            )
+
     def truncate_string_to_context_size(self, text: str) -> str:
         tokens = self.tokenise_string(text)
-        tokens = tokens[:self.config.context_length]
-        return self.detokenise_string(self, tokens)
-    
-    def generate_embedding(self, text: str) -> Embeddings:
-        data = {
-            "content" : text
-        }
+        tokens = tokens[: self.config.context_length]
+        return self.detokenise_string(tokens)
+
+    def generate_embedding(self, text: str) -> List[int | float]:
+        data = {"content": text}
         response = requests.post(self.embedding_url, json=data)
 
         if response.status_code == 200:
             embedding = response.json()["embedding"]
+            if type(embedding) is not List[int | float]:
+                raise ValueError(
+                    """Embedding endpoint has not returned the correct format. 
+                   Is the URL correct?
+                """
+                )
             return embedding
         else:
-            raise requests.HTTPError(self.embedding_url, response.status_code, "Failed to connect to embedding provider")
-    
-    # TODO - Check if llama.cpp server support sending the tokens directly instead of a string.
+            raise requests.HTTPError(
+                self.embedding_url,
+                response.status_code,
+                "Failed to connect to embedding provider",
+            )
+
     def embedding_fn(self) -> Callable[[List[str]], Embeddings]:
         def fn(texts: List[str]) -> Embeddings:
             return [
-                [
-                    self.generate_embedding(
-                        self.truncate_string_to_context_size(text)
-                    )
-                ] for text in texts
+                self.generate_embedding(self.truncate_string_to_context_size(text))
+                for text in texts
             ]
+
         return fn
 
     @property
@@ -328,7 +347,8 @@ class LlamaCppServerEmbeddings(EmbeddingModel):
 def embedding_model(embedding_fn_type: str = "openai") -> EmbeddingModel:
     """
     Args:
-        embedding_fn_type: "openai" or "fastembed" or "llamacppserver" or "sentencetransformer" # others soon
+        embedding_fn_type: "openai" or "fastembed" or
+                           "llamacppserver" or "sentencetransformer" # others soon
     Returns:
         EmbeddingModel
     """
@@ -337,6 +357,6 @@ def embedding_model(embedding_fn_type: str = "openai") -> EmbeddingModel:
     elif embedding_fn_type == "fastembed":
         return FastEmbedEmbeddings  # type: ignore
     elif embedding_fn_type == "llamacppserver":
-        return LlamaCppServerEmbeddings # type: ignore
+        return LlamaCppServerEmbeddings  # type: ignore
     else:  # default sentence transformer
         return SentenceTransformerEmbeddings  # type: ignore

--- a/langroid/embedding_models/models.py
+++ b/langroid/embedding_models/models.py
@@ -133,11 +133,11 @@ class EmbeddingFunctionCallable:
         elif isinstance(self.embed_model, LlamaCppServerEmbeddings):
             for input_string in input:
                 tokenized_text = self.embed_model.tokenize_string(input_string)
-                for batch in batched(tokenized_text, self.batch_size):
-                    result = self.embed_model.generate_embedding(
-                        self.embed_model.detokenize_string(batch)
+                for token_batch in batched(tokenized_text, self.batch_size):
+                    gen_embedding = self.embed_model.generate_embedding(
+                        self.embed_model.detokenize_string(list(token_batch))
                     )
-                    embeds.append(result)
+                    embeds.append(gen_embedding)
         return embeds
 
 

--- a/langroid/vector_store/chromadb.py
+++ b/langroid/vector_store/chromadb.py
@@ -35,6 +35,7 @@ class ChromaDB(VectorStore):
         self.client = chromadb.Client(
             chromadb.config.Settings(
                 # chroma_db_impl="duckdb+parquet",
+                # is_persistent=bool(config.storage_path),
                 persist_directory=config.storage_path,
             )
         )
@@ -124,6 +125,13 @@ class ChromaDB(VectorStore):
             m["window_ids"] = ",".join(m["window_ids"])
 
         ids = [str(d.id()) for d in documents]
+
+        colls = self.list_collections(empty=True)
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        if self.config.collection_name not in colls:
+            self.create_collection(self.config.collection_name, replace=True)
+
         self.collection.add(
             # embedding_models=embedding_models,
             documents=contents,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
       - GLHF.chat Support: notes/glhf-chat.md
       - Structured Output: notes/structured-output.md
       - Tool Handler Name: notes/tool-message-handler.md
+      - Llama.cpp Embeddings: notes/llama-cpp-embeddings.md
 
   - Examples:
     - Guide: examples/guide.md

--- a/tests/extras/test_doc_chat_agent_llamacpp.py
+++ b/tests/extras/test_doc_chat_agent_llamacpp.py
@@ -34,7 +34,10 @@ from langroid.vector_store.lancedb import LanceDB, LanceDBConfig
 from langroid.vector_store.qdrantdb import QdrantDB, QdrantDBConfig
 
 """
-    Pytest for running Langroid with llama.cpp server acting as the embeddings host.
+    Pytest for running Langroid DocAgent with llama.cpp server acting as the 
+    embeddings host.
+    Not designed for main usage, but this has been useful for validating if local models
+    are sufficient to run Langroid. Feel free to delete!
 
     You can find an example of how to run llama.cpp server as an embeddings host in
     docs/notes/llama-cpp-embeddings.md

--- a/tests/extras/test_llamacpp_embeddings.py
+++ b/tests/extras/test_llamacpp_embeddings.py
@@ -1,0 +1,45 @@
+"""
+Test for HuggingFace embeddings.
+This depends on sentence-transformers being installed:
+ poetry install -E hf-embeddings
+"""
+
+from langroid.embedding_models.base import EmbeddingModel
+from langroid.embedding_models.models import LlamaCppServerEmbeddingsConfig
+
+"""
+    Pytest for llama.cpp server acting as the embeddings host.
+
+    You can find an example of how to run llama.cpp server as an embeddings host in
+    docs/notes/llama-cpp-embeddings.md
+    
+    You must fill out the following variables or the test will fail:
+
+    embedding_address       - This is a string containing the IP address and 
+                              port of the llama.cpp server 
+                              e.g. "http://localhost:51060"
+    embed_context_length    - This is the context length of the model you have
+                              loaded into llama.cpp server
+    embedding_dimensions    - The dimensions of the embeddings returned from
+                              the model.
+
+"""
+
+embedding_address: str = "http://localhost:51060"
+embed_context_length: int = 2048
+embedding_dimensions: int = 768
+
+
+def test_embeddings():
+    sentence_cfg = LlamaCppServerEmbeddingsConfig(
+        api_base=embedding_address,
+        context_length=embed_context_length,
+        batch_size=embed_context_length,
+        dims=embedding_dimensions,
+    )
+
+    sentence_model = EmbeddingModel.create(sentence_cfg)
+
+    sentence_fn = sentence_model.embedding_fn()
+
+    assert len(sentence_fn(["hello"])[0]) == sentence_model.embedding_dims

--- a/tests/main/test_doc_chat_agent_llamacpp.py
+++ b/tests/main/test_doc_chat_agent_llamacpp.py
@@ -1,0 +1,1006 @@
+import logging
+import os
+import warnings
+from types import SimpleNamespace
+from typing import List, Optional
+
+import pandas as pd
+import pytest
+
+from langroid import ChatDocument
+from langroid.agent.batch import run_batch_task_gen, run_batch_tasks
+from langroid.agent.chat_agent import ChatAgent
+from langroid.agent.special.doc_chat_agent import (
+    DocChatAgent,
+    DocChatAgentConfig,
+    RetrievalTool,
+)
+from langroid.agent.special.lance_doc_chat_agent import LanceDocChatAgent
+from langroid.agent.task import Task
+from langroid.embedding_models.models import LlamaCppServerEmbeddingsConfig
+from langroid.language_models import GeminiModel, OpenAIChatModel
+from langroid.language_models.openai_gpt import OpenAIGPTConfig
+from langroid.mytypes import DocMetaData, Document, Entity
+from langroid.parsing.parser import ParsingConfig, Splitter
+from langroid.parsing.utils import generate_random_text
+from langroid.prompts.prompts_config import PromptsConfig
+from langroid.utils.configuration import Settings, set_global
+from langroid.utils.constants import DONE
+from langroid.utils.output.citations import extract_markdown_references
+from langroid.utils.system import rmdir
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+from langroid.vector_store.chromadb import ChromaDB, ChromaDBConfig
+from langroid.vector_store.lancedb import LanceDB, LanceDBConfig
+from langroid.vector_store.qdrantdb import QdrantDB, QdrantDBConfig
+
+"""
+    Pytest for running Langroid with llama.cpp server acting as the embeddings host.
+
+    You can find an example of how to run llama.cpp server as an embeddings host in
+    docs/notes/llama-cpp-embeddings.md
+    
+    You must fill out the following variables or the tests will fail:
+
+    embedding_address       - This is a string containing the IP address and 
+                              port of the llama.cpp server 
+                              e.g. "http://localhost:51060"
+    embed_context_length    - This is the context length of the model you have
+                              loaded into llama.cpp server
+    embedding_dimensions    - The dimensions of the embeddings returned from
+                              the model.
+
+    By default, the test uses OpenAI as it's LLM, however you can set
+    override_openai_model = True
+    and then subsequently set a model as standard, e.g.
+    openai_model_override = "local/localhost:5001/v1"
+
+"""
+
+override_openai_model: bool = False
+openai_model_override: str = "local/localhost:5001/v1"
+
+embedding_address: str = "http://localhost:51060"
+embed_context_length: int = 2048
+embedding_dimensions: int = 768
+
+
+class MyDocMetaData(DocMetaData):
+    id: str
+
+
+class MyDoc(Document):
+    content: str
+    metadata: MyDocMetaData
+
+
+documents: List[Document] = [
+    Document(
+        content="""
+        In the year 2050, GPT10 was released. 
+        
+        In 2057, paperclips were seen all over the world. 
+        
+        Global warming was solved in 2060. 
+        
+        In 2045, the Tour de France was still going on.
+        They were still using bicycles. 
+        
+        There was one more ice age in 2040.
+        """,
+        metadata=DocMetaData(source="wikipedia"),
+    ),
+    Document(
+        content="""
+    We are living in an alternate universe where Lancaster is the capital of England.
+        
+    Charlie Chaplin was a great comedian.
+        
+    Charlie Chaplin was born in 1889.
+        
+    Beethoven was born in 1770.
+        
+    In the year 2050, all countries merged into Lithuania.
+    """,
+        metadata=DocMetaData(source="almanac"),
+    ),
+]
+
+QUERY_EXPECTED_PAIRS = [
+    ("what happened in the year 2050?", "GPT10, Lithuania"),
+    ("what is the capital of England?", "Lancaster"),
+    ("Who was Charlie Chaplin?", "comedian"),
+    ("When was global warming solved?", "2060"),
+    ("What do we know about paperclips?", "2057"),
+]
+
+for _ in range(100):
+    documents.append(
+        Document(
+            content=generate_random_text(5),
+            metadata=DocMetaData(source="random"),
+        )
+    )
+
+# We need to override the global test_settings in order to allow us to run
+# the local model in this test. If we don't, then we'll constantly get issues.
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def test_settings(request):
+    base_settings = dict(
+        debug=request.config.getoption("--show"),
+        cache_type=request.config.getoption("--ct"),
+        stream=not request.config.getoption("--ns"),
+        max_turns=request.config.getoption("--turns"),
+    )
+
+    if request.node.get_closest_marker("fallback"):
+        # we're in a test marked as requiring fallback,
+        # so we re-run with a sequence of settings, mainly
+        # on `chat_model` and `cache`.
+        logger.warning("Running test with fallback settings")
+        models = [request.config.getoption("--m")]
+        if OpenAIChatModel.GPT4o not in models:
+            # we may be using a weaker model, so add GPT4o as first fallback
+            models.append(OpenAIChatModel.GPT4o)
+        models.append(GeminiModel.GEMINI_2_FLASH)
+        caches = [True] + [False] * (len(models) - 1)
+        retry_count = getattr(request.node, "retry_count", 0)
+        model = (
+            models[retry_count]
+            if retry_count < len(models)
+            else request.config.getoption("--m")
+        )
+        cache = caches[retry_count] if retry_count < len(caches) else False
+        logger.warning(f"Retry count: {retry_count}, model: {model}, cache: {cache}")
+    else:
+        model = request.config.getoption("--m")
+        cache = not request.config.getoption("--nc")
+
+    if override_openai_model:
+        model = ""
+
+    yield Settings(**base_settings, chat_model=model, cache=cache)
+
+
+embed_cfg = LlamaCppServerEmbeddingsConfig(
+    api_base=embedding_address,
+    context_length=embed_context_length,
+    batch_size=embed_context_length,
+    dims=embedding_dimensions,
+    model_type="llamacpp",
+)
+
+global_llm: OpenAIGPTConfig = OpenAIGPTConfig(chat_model=openai_model_override)
+
+
+@pytest.fixture(scope="function")
+def vecdb(test_settings: Settings, request) -> VectorStore:
+    set_global(test_settings)
+    if request.param == "qdrant_local":
+        qd_dir = ":memory:"
+        qd_cfg = QdrantDBConfig(
+            cloud=False,
+            collection_name="test-" + embed_cfg.model_type,
+            storage_path=qd_dir,
+            embedding=embed_cfg,
+        )
+        qd = QdrantDB(qd_cfg)
+        yield qd
+        return
+
+    if request.param == "chroma":
+        cd_dir = ".chroma/" + embed_cfg.model_type
+        rmdir(cd_dir)
+        cd_cfg = ChromaDBConfig(
+            collection_name="test-" + embed_cfg.model_type,
+            storage_path=cd_dir,
+            embedding=embed_cfg,
+        )
+        cd = ChromaDB(cd_cfg)
+        yield cd
+        rmdir(cd_dir)
+        return
+
+    if request.param == "lancedb":
+        ldb_dir = ".lancedb/data/" + embed_cfg.model_type
+        rmdir(ldb_dir)
+        ldb_cfg = LanceDBConfig(
+            cloud=False,
+            collection_name="test-" + embed_cfg.model_type,
+            storage_path=ldb_dir,
+            embedding=embed_cfg,
+            document_class=MyDoc,  # IMPORTANT, to ensure table has full schema!
+        )
+        ldb = LanceDB(ldb_cfg)
+        yield ldb
+        rmdir(ldb_dir)
+        return
+
+
+class _TestDocChatAgentConfig(DocChatAgentConfig):
+    cross_encoder_reranking_model = ""
+    n_query_rephrases = 0
+    debug: bool = False
+    stream: bool = False  # allow streaming where needed
+    conversation_mode = False
+    vecdb: VectorStoreConfig | None = None
+
+    llm = global_llm
+
+    parsing: ParsingConfig = ParsingConfig(
+        splitter=Splitter.SIMPLE,
+        n_similar_docs=3,
+    )
+
+    prompts: PromptsConfig = PromptsConfig(
+        max_tokens=1000,
+    )
+
+
+config = _TestDocChatAgentConfig()
+set_global(Settings(cache=False))  # allow cacheing
+
+
+@pytest.fixture(scope="function")
+def agent(test_settings: Settings, vecdb) -> DocChatAgent:
+    set_global(test_settings)
+    agent = DocChatAgent(config)
+    agent.vecdb = vecdb
+    agent.ingest_docs(documents)
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+    return agent
+
+
+warnings.filterwarnings(
+    "ignore",
+    message="Token indices sequence length.*",
+    # category=UserWarning,
+    module="transformers",
+)
+
+
+@pytest.mark.parametrize("vecdb", ["lancedb", "qdrant_local", "chroma"], indirect=True)
+@pytest.mark.parametrize("query, expected", QUERY_EXPECTED_PAIRS)
+def test_doc_chat_agent_llm(test_settings: Settings, agent, query: str, expected: str):
+    """
+    Test directly using `llm_response` method of DocChatAgent.
+    """
+
+    # note that the (query, ans) pairs are accumulated into the
+    # internal dialog history of the agent.
+    set_global(test_settings)
+    agent.config.conversation_mode = False
+    result = agent.llm_response(query)
+    ans = result.content
+    refs = extract_markdown_references(ans)
+    sources = extract_markdown_references(result.metadata.source)
+    assert refs == sources
+    expected = [e.strip() for e in expected.split(",")]
+    assert all([e in ans for e in expected])
+
+
+@pytest.mark.parametrize("vecdb", ["lancedb", "qdrant_local", "chroma"], indirect=True)
+@pytest.mark.parametrize("query, expected", QUERY_EXPECTED_PAIRS)
+@pytest.mark.asyncio
+async def test_doc_chat_agent_llm_async(
+    test_settings: Settings, agent, query: str, expected: str
+):
+    """
+    Test directly using `llm_response_async` method of DocChatAgent.
+    """
+
+    # note that the (query, ans) pairs are accumulated into the
+    # internal dialog history of the agent.
+    set_global(test_settings)
+    agent.config.conversation_mode = False
+    ans = (await agent.llm_response_async(query)).content
+    expected = [e.strip() for e in expected.split(",")]
+    assert all([e in ans for e in expected])
+
+
+@pytest.mark.parametrize("query, expected", QUERY_EXPECTED_PAIRS)
+@pytest.mark.parametrize("vecdb", ["qdrant_local", "chroma"], indirect=True)
+def test_doc_chat_agent_task(test_settings: Settings, agent, query, expected):
+    """
+    Test DocChatAgent wrapped in a Task.
+    """
+    set_global(test_settings)
+    agent.config.conversation_mode = True
+    task = Task(agent, restart=True)
+    task.init()
+    # LLM responds to Sys msg, initiates conv, says thank you, etc.
+    task.step()
+
+    agent.default_human_response = query
+    task.step()  # user asks query
+    task.step()  # LLM answers
+    ans = task.pending_message.content.lower()
+    expected = [e.strip() for e in expected.split(",")]
+    assert all([e.lower() in ans for e in expected])
+    assert task.pending_message.metadata.sender == Entity.LLM
+
+
+class RetrievalAgent(DocChatAgent):
+    def llm_response(
+        self,
+        message: None | str | ChatDocument = None,
+    ) -> Optional[ChatDocument]:
+        # override the DocChatAgent's LLM response,
+        # to just use ChatAgent's LLM response - this ensures that the system msg
+        # is respected, and it uses the `retrieval_tool` as instructed.
+        return ChatAgent.llm_response(self, message)
+
+
+@pytest.fixture(scope="function")
+def retrieval_agent(test_settings: Settings, vecdb) -> RetrievalAgent:
+    set_global(test_settings)
+    agent = RetrievalAgent(config)
+    agent.vecdb = vecdb
+    agent.ingest_docs(documents)
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+    return agent
+
+
+@pytest.mark.parametrize("vecdb", ["qdrant_local"], indirect=True)
+@pytest.mark.parametrize(
+    "query, expected",
+    [
+        ("Capital of England", "Lancaster"),
+        ("Who was Charlie Chaplin?", "comedian"),
+        ("Events in the year 2050", "Lithuania, GPT10"),
+    ],
+)
+def test_retrieval_tool(
+    test_settings: Settings, retrieval_agent, query: str, expected: str
+):
+    set_global(test_settings)
+    retrieval_agent.enable_message(RetrievalTool)
+    task = Task(
+        retrieval_agent,
+        restart=True,
+        interactive=False,
+        system_message=f"""
+        To answer user's query, use the `retrieval_tool` to retrieve relevant passages, 
+        and ONLY then answer the query. 
+        In case the query is simply a topic or search phrase, 
+        guess what the user may want to know, and formulate it as a 
+        question to be answered, and use this as the `query` field in the 
+        `retrieval_tool`. 
+        
+        IMPORTANT: Your answer MUST ONLY be based on the retrieved passages,
+        REGARDLESS of how IMPLAUSIBLE the answer may seem, and 
+        REGARDLESS of whether you think the answer is correct or not.
+        
+        When you are ready to show your answer, say {DONE}, followed by the answer.
+        """,
+    )
+    # 3 turns:
+    # 1. LLM gen `retrieval_tool` request
+    # 2. Agent gen `retrieval_tool` response (i.e. returns relevant passages)
+    # 3. LLM gen answer based on passages
+    ans = task.run(query, turns=3).content
+    expected = [e.strip() for e in expected.split(",")]
+    assert all([e in ans for e in expected])
+
+
+@pytest.fixture(scope="function")
+def new_agent(test_settings: Settings, vecdb) -> DocChatAgent:
+    set_global(test_settings)
+    agent = DocChatAgent(config)
+    agent.vecdb = vecdb
+    agent.ingest_docs(documents)
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+    return agent
+
+
+@pytest.mark.parametrize("vecdb", ["qdrant_local", "chroma"], indirect=True)
+@pytest.mark.parametrize("conv_mode", [True, False])
+def test_doc_chat_followup(test_settings: Settings, new_agent, conv_mode: bool):
+    """
+    Test whether follow-up question is handled correctly.
+    """
+    new_agent.config.conversation_mode = conv_mode
+    set_global(test_settings)
+    task = Task(
+        new_agent,
+        interactive=False,
+        restart=False,  # don't restart, so we can ask follow-up questions
+        done_if_response=[Entity.LLM],
+        done_if_no_response=[Entity.LLM],
+    )
+    result = task.run("Who was Charlie Chaplin?")
+    assert "comedian" in result.content.lower()
+
+    result = task.run("When was he born?")
+    assert "1889" in result.content
+
+
+@pytest.mark.parametrize("vecdb", ["qdrant_local", "chroma"], indirect=True)
+@pytest.mark.parametrize("conv_mode", [True, False])
+@pytest.mark.asyncio
+async def test_doc_chat_followup_async(
+    test_settings: Settings, new_agent, conv_mode: bool
+):
+    """
+    Test whether follow-up question is handled correctly (in async mode).
+    """
+    new_agent.config.conversation_mode = conv_mode
+    set_global(test_settings)
+    task = Task(
+        new_agent,
+        interactive=False,
+        restart=False,  # don't restart, so we can ask follow-up questions
+        done_if_response=[Entity.LLM],
+        done_if_no_response=[Entity.LLM],
+    )
+    result = await task.run_async("Who was Charlie Chaplin?")
+    assert "comedian" in result.content.lower()
+
+    result = await task.run_async("When was he born?")
+    assert "1889" in result.content
+
+
+# setup config for retrieval test, with n_neighbor_chunks=2
+# and parser.n_neighbor_ids = 5
+class _MyDocChatAgentConfig(DocChatAgentConfig):
+    cross_encoder_reranking_model = ""
+    n_query_rephrases = 0
+    n_neighbor_chunks = 2
+    debug: bool = False
+    stream: bool = True  # allow streaming where needed
+    conversation_mode = True
+    vecdb: VectorStoreConfig | None = None
+
+    llm = global_llm
+
+    parsing: ParsingConfig = ParsingConfig(
+        splitter=Splitter.SIMPLE,
+        n_similar_docs=2,
+        n_neighbor_ids=5,
+    )
+
+
+@pytest.mark.parametrize("vecdb", ["lancedb", "chroma", "qdrant_local"], indirect=True)
+@pytest.mark.parametrize(
+    "splitter", [Splitter.PARA_SENTENCE, Splitter.SIMPLE, Splitter.TOKENS]
+)
+@pytest.mark.parametrize("conv_mode", [True, False])
+def test_doc_chat_retrieval(
+    test_settings: Settings, vecdb, splitter: Splitter, conv_mode: bool
+):
+    """
+    Test window retrieval of relevant doc-chunks.
+    Check that we are retrieving 2 neighbors around each match.
+    """
+    agent = DocChatAgent(
+        _MyDocChatAgentConfig(
+            llm=global_llm,
+            parsing=ParsingConfig(
+                splitter=splitter,
+                n_similar_docs=3,
+            ),
+        )
+    )
+    agent.config.conversation_mode = conv_mode
+    agent.vecdb = vecdb
+
+    set_global(test_settings)
+
+    phrases = SimpleNamespace(
+        CATS="Cats are quiet and clean.",
+        DOGS="Dogs are loud and messy.",
+        PIGS="Pigs cannot fly.",
+        GIRAFFES="Giraffes are tall and vegetarian.",
+        BATS="Bats are blind.",
+        COWS="Cows are peaceful.",
+        GIRAFFES2="Giraffes are really strange animals.",
+        HYENAS="Hyenas are dangerous and fast.",
+        ZEBRAS="Zebras are bizarre with stripes.",
+    )
+    text = "\n\n".join(vars(phrases).values())
+    agent.clear()
+    agent.ingest_docs([Document(content=text, metadata={"source": "animals"})])
+    results = agent.get_relevant_chunks("What are giraffes like?")
+
+    # All phrases except the CATS phrase should be in the results
+    # since they are all within 2 chunks of a giraffe phrase.
+    # (The CAT phrase is 3 chunks away, so it should not be in the results.)
+    all_but_cats = [p for p in vars(phrases).values() if "Cats" not in p]
+    # check that each phrases occurs in exactly one result
+    assert (
+        sum(p in r.content for p in all_but_cats for r in results)
+        == len(vars(phrases)) - 1
+    )
+
+    agent.clear()
+
+
+@pytest.mark.parametrize("vecdb", ["qdrant_local", "chroma"], indirect=True)
+def test_doc_chat_rerank_diversity(test_settings: Settings, vecdb):
+    """
+    Test that reranking by diversity works.
+    """
+
+    cfg = _MyDocChatAgentConfig(
+        llm=global_llm,
+        n_neighbor_chunks=0,
+    )
+    cfg.parsing.n_similar_docs = 8
+    agent = DocChatAgent(cfg)
+    agent.vecdb = vecdb
+
+    set_global(test_settings)
+
+    phrases = SimpleNamespace(
+        g1="Giraffes are tall.",
+        g2="Giraffes are vegetarian.",
+        g3="Giraffes are strange.",
+        g4="Giraffes are fast.",
+        g5="Giraffes are known to be tall.",
+        g6="Giraffes are considered strange.",
+        g7="Giraffes move fast.",
+        g8="Giraffes are definitely vegetarian.",
+    )
+    docs = [
+        Document(content=p, metadata=DocMetaData(source="user"))
+        for p in vars(phrases).values()
+    ]
+    reranked = agent.rerank_with_diversity(docs)
+
+    # assert that each phrase tall, vegetarian, strange, fast
+    # occurs exactly once in top 4 phrases
+    for p in ["tall", "vegetarian", "strange", "fast"]:
+        assert sum(p in r.content for r in reranked[:4]) == 1
+
+
+@pytest.mark.parametrize("vecdb", ["qdrant_local", "chroma"], indirect=True)
+def test_reciprocal_rank_fusion(test_settings: Settings, vecdb):
+    """
+    Test that RRF (Reciprocal Rank Fusion) works.
+    """
+
+    cfg = _MyDocChatAgentConfig(
+        llm=global_llm,
+        n_neighbor_chunks=0,
+        cross_encoder_reranking_model="",
+        use_bm25_search=True,
+        use_fuzzy_match=True,
+        use_reciprocal_rank_fusion=True,
+    )
+    cfg.parsing.n_similar_docs = 3
+    agent = DocChatAgent(cfg)
+    agent.vecdb = vecdb
+
+    set_global(test_settings)
+
+    phrases = SimpleNamespace(
+        g1="time flies like an arrow",
+        g2="a fly is very small",
+        g3="we like apples",
+        g4="the river bank got flooded",
+        g5="there was a run on the bank",
+        g6="JPMChase is a bank",
+        g7="Chase is one of the banks",
+    )
+    docs = [
+        Document(content=p, metadata=DocMetaData(source="user"))
+        for p in vars(phrases).values()
+    ]
+    agent.ingest_docs(docs, split=False)
+    chunks = agent.get_relevant_chunks("I like to chase banks")
+    assert len(chunks) == 3
+    assert any(phrases.g7 in chunk.content for chunk in chunks)
+    assert any(phrases.g6 in chunk.content for chunk in chunks)
+
+    chunks = agent.get_relevant_chunks("I like oranges")
+    assert len(chunks) == 3
+    assert any(phrases.g3 in chunk.content for chunk in chunks)
+    assert any(phrases.g1 in chunk.content for chunk in chunks)
+
+
+@pytest.mark.parametrize("vecdb", ["qdrant_local", "chroma"], indirect=True)
+def test_doc_chat_rerank_periphery(test_settings: Settings, vecdb):
+    """
+    Test that reranking to periphery works.
+    """
+
+    cfg = _MyDocChatAgentConfig(
+        llm=global_llm,
+        n_neighbor_chunks=0,
+    )
+    cfg.parsing.n_similar_docs = 8
+    agent = DocChatAgent(cfg)
+    agent.vecdb = vecdb
+
+    set_global(test_settings)
+
+    docs = [
+        Document(content=str(i), metadata=DocMetaData(source="user")) for i in range(10)
+    ]
+    reranked = agent.rerank_to_periphery(docs)
+    numbers = [int(d.content) for d in reranked]
+    assert numbers == [0, 2, 4, 6, 8, 9, 7, 5, 3, 1]
+
+
+data = {
+    "id": ["A100", "B200", "C300", "D400", "E500"],
+    "year": [1955, 1977, 1989, 2001, 2015],
+    "author": [
+        "Isaac Maximov",
+        "J.K. Bowling",
+        "George Morewell",
+        "J.R.R. Bolshine",
+        "Hugo Wellington",
+    ],
+    "title": [
+        "The Last Question",
+        "Harry Potter",
+        "2084",
+        "The Lord of the Rings",
+        "The Time Machine",
+    ],
+    "summary": [
+        "A story exploring the concept of entropy and the end of the universe.",
+        "The adventures of a young wizard and his friends at a magical school.",
+        "A dystopian novel about a totalitarian regime and the concept of freedom.",
+        "An epic fantasy tale of a quest to destroy a powerful ring.",
+        "A science fiction novel about time travel and its consequences.",
+    ],
+}
+
+df = pd.DataFrame(data)
+
+
+@pytest.mark.parametrize("metadata", [[], ["id", "year"], ["year"]])
+@pytest.mark.parametrize("vecdb", ["lancedb", "qdrant_local", "chroma"], indirect=True)
+def test_doc_chat_ingest_df(
+    test_settings: Settings,
+    vecdb,
+    metadata,
+):
+    """Check we can ingest from a dataframe and run queries."""
+    set_global(test_settings)
+
+    sys_msg = "You will be asked to answer questions based on short book descriptions."
+    agent_cfg = DocChatAgentConfig(
+        llm=global_llm,
+        system_message=sys_msg,
+        cross_encoder_reranking_model="",
+    )
+    if isinstance(vecdb, LanceDB):
+        agent = LanceDocChatAgent(agent_cfg)
+    else:
+        agent = DocChatAgent(agent_cfg)
+    agent.vecdb = vecdb
+    agent.ingest_dataframe(df, content="summary", metadata=metadata)
+    response = agent.llm_response(
+        """
+        What concept does the book dealing with the end of the universe explore?
+        """
+    )
+    assert "entropy" in response.content.lower()
+
+
+@pytest.mark.parametrize("metadata", [[], ["id", "year"], ["year"]])
+@pytest.mark.parametrize("vecdb", ["lancedb", "qdrant_local", "chroma"], indirect=True)
+def test_doc_chat_add_content_fields(
+    test_settings: Settings,
+    vecdb,
+    metadata,
+):
+    """Check we can ingest from a dataframe,
+    with additional fields inserted into content,
+    and run queries that refer to those fields."""
+
+    set_global(test_settings)
+
+    sys_msg = "You will be asked to answer questions based on short movie descriptions."
+    agent_cfg = DocChatAgentConfig(
+        llm=global_llm,
+        system_message=sys_msg,
+        cross_encoder_reranking_model="",
+        add_fields_to_content=["year", "author", "title"],
+    )
+    if isinstance(vecdb, LanceDB):
+        agent = LanceDocChatAgent(agent_cfg)
+    else:
+        agent = DocChatAgent(agent_cfg)
+    agent.vecdb = vecdb
+    agent.ingest_dataframe(df, content="summary", metadata=metadata)
+    response = agent.llm_response(
+        """
+        What was the title of the book by George Morewell and when was it written?
+        """
+    )
+    assert "2084" in response.content and "1989" in response.content
+
+
+@pytest.mark.parametrize("vecdb", ["lancedb", "chroma", "qdrant_local"], indirect=True)
+@pytest.mark.parametrize(
+    "splitter", [Splitter.PARA_SENTENCE, Splitter.SIMPLE, Splitter.TOKENS]
+)
+def test_doc_chat_incremental_ingest(
+    test_settings: Settings, vecdb, splitter: Splitter
+):
+    """
+    Check that we are able ingest documents incrementally.
+    """
+    agent = DocChatAgent(
+        _MyDocChatAgentConfig(
+            llm=global_llm,
+            parsing=ParsingConfig(
+                splitter=splitter,
+                n_similar_docs=3,
+            ),
+        )
+    )
+    agent.vecdb = vecdb
+
+    set_global(test_settings)
+
+    phrases = SimpleNamespace(
+        CATS="Cats are quiet and clean.",
+        DOGS="Dogs are loud and messy.",
+        PIGS="Pigs cannot fly.",
+        GIRAFFES="Giraffes are tall and vegetarian.",
+        BATS="Bats are blind.",
+        COWS="Cows are peaceful.",
+        GIRAFFES2="Giraffes are really strange animals.",
+        HYENAS="Hyenas are dangerous and fast.",
+        ZEBRAS="Zebras are bizarre with stripes.",
+    )
+    sentences = list(vars(phrases).values())
+    docs1 = [
+        Document(content=s, metadata=dict(source="animals")) for s in sentences[:4]
+    ]
+
+    docs2 = [
+        Document(content=s, metadata=dict(source="animals")) for s in sentences[4:]
+    ]
+    agent.ingest_docs(docs1)
+    agent.ingest_docs(docs2)
+    results = agent.get_relevant_chunks("What do we know about Pigs?")
+    assert any("fly" in r.content for r in results)
+
+    results = agent.get_relevant_chunks("What do we know about Hyenas?")
+    assert any("fast" in r.content for r in results) or any(
+        "dangerous" in r.content for r in results
+    )
+
+
+@pytest.mark.parametrize("vecdb", ["chroma", "qdrant_local"], indirect=True)
+@pytest.mark.parametrize(
+    "splitter", [Splitter.PARA_SENTENCE, Splitter.SIMPLE, Splitter.TOKENS]
+)
+@pytest.mark.parametrize("source", ["bytes", "path"])
+def test_doc_chat_ingest_paths(
+    test_settings: Settings,
+    vecdb,
+    splitter: Splitter,
+    source,
+):
+    """
+    Test DocChatAgent.ingest_doc_paths
+    """
+    agent = DocChatAgent(
+        _MyDocChatAgentConfig(
+            llm=global_llm,
+            parsing=ParsingConfig(
+                splitter=splitter,
+                n_similar_docs=3,
+            ),
+        )
+    )
+    agent.vecdb = vecdb
+
+    set_global(test_settings)
+
+    phrases = SimpleNamespace(
+        CATS="Cats are quiet and clean.",
+        DOGS="Dogs are loud and messy.",
+        PIGS="Pigs cannot fly.",
+        GIRAFFES="Giraffes are tall and vegetarian.",
+        BATS="Bats are blind.",
+        COWS="Cows are peaceful.",
+        GIRAFFES2="Giraffes are really strange animals.",
+        HYENAS="Hyenas are dangerous and fast.",
+        ZEBRAS="Zebras are bizarre with stripes.",
+    )
+    sentences = list(vars(phrases).values())
+
+    # create temp files containing each sentence, using tempfile pkg
+    import tempfile
+
+    for s in sentences:
+        if source == "path":
+            with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+                f.write(s)
+                f.close()
+                agent.ingest_doc_paths([f.name])
+        else:
+            agent.ingest_doc_paths([s.encode()])
+
+    results = agent.get_relevant_chunks("What do we know about Pigs?")
+    assert any("fly" in r.content for r in results)
+
+    results = agent.get_relevant_chunks("What do we know about Hyenas?")
+    assert any("fast" in r.content for r in results) or any(
+        "dangerous" in r.content for r in results
+    )
+
+
+@pytest.mark.parametrize("vecdb", ["chroma", "lancedb", "qdrant_local"], indirect=True)
+@pytest.mark.parametrize(
+    "splitter", [Splitter.PARA_SENTENCE, Splitter.SIMPLE, Splitter.TOKENS]
+)
+@pytest.mark.parametrize("metadata_dict", [True, False])
+def test_doc_chat_ingest_path_metadata(
+    test_settings: Settings,
+    vecdb,
+    splitter: Splitter,
+    metadata_dict: bool,  # whether metadata is dict or DocMetaData
+):
+    """
+    Test DocChatAgent.ingest_doc_paths, with metadata
+    """
+    agent = DocChatAgent(
+        _MyDocChatAgentConfig(
+            llm=global_llm,
+            parsing=ParsingConfig(
+                splitter=splitter,
+                n_similar_docs=3,
+            ),
+        )
+    )
+    agent.vecdb = vecdb
+
+    set_global(test_settings)
+
+    # create a list of dicts, each containing a sentence about an animal
+    # and a metadata field indicating the animal's name, species, and diet
+    animals = [
+        {
+            "content": "Cats are quiet and clean.",
+            "metadata": {
+                "name": "cat",
+                "species": "feline",
+                "diet": "carnivore",
+            },
+        },
+        {
+            "content": "Dogs are loud and messy.",
+            "metadata": {
+                "name": "dog",
+                "species": "canine",
+                "diet": "omnivore",
+            },
+        },
+        {
+            "content": "Pigs cannot fly.",
+            "metadata": {
+                "name": "pig",
+                "species": "porcine",
+                "diet": "omnivore",
+            },
+        },
+    ]
+
+    class AnimalMetadata(DocMetaData):
+        name: str
+        species: str
+        diet: str
+
+    animal_metadata_list = [AnimalMetadata(**a["metadata"]) for a in animals]
+
+    # put each animal content in a separate file
+    import tempfile
+
+    for animal in animals:
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write(animal["content"])
+            f.close()
+            animal["path"] = f.name
+
+    agent.clear()
+    # ingest with per-file metadata
+    agent.ingest_doc_paths(
+        [a["path"] for a in animals],
+        metadata=(
+            [a["metadata"] for a in animals] if metadata_dict else animal_metadata_list
+        ),
+    )
+
+    results = agent.get_relevant_chunks("What do we know about Pigs?")
+    assert any("fly" in r.content for r in results)
+    # assert about metadata
+    assert any("porcine" in r.metadata.species for r in results)
+
+    # clear out the agent docs and the underlying vecdb collection
+    agent.clear()
+
+    # ingest with single metadata for ALL animals
+    agent.ingest_doc_paths(
+        [a["path"] for a in animals],
+        metadata=(
+            dict(type="animal", category="living")
+            if metadata_dict
+            else DocMetaData(type="animal", category="living")
+        ),
+    )
+
+    results = agent.get_relevant_chunks("What do we know about dogs?")
+    assert any("messy" in r.content for r in results)
+    assert all(r.metadata.type == "animal" for r in results)
+
+    agent.clear()
+
+
+@pytest.mark.parametrize("vecdb", ["chroma", "lancedb", "qdrant_local"], indirect=True)
+def test_doc_chat_batch(test_settings: Settings, vecdb):
+    """
+    Test batch run of queries to multiple instances of DocChatAgent,
+    which share the same vector-db.
+    """
+
+    set_global(test_settings)
+    doc_agents = [DocChatAgent(_MyDocChatAgentConfig(llm=global_llm)) for _ in range(2)]
+
+    # attach a common vector-db to all agents
+    for a in doc_agents:
+        a.vecdb = vecdb
+
+    docs = [
+        Document(
+            content="""
+            Filidor Dinkoyevsky wrote a book called "The Sisters Karenina".
+            It is loosely based on the life of the Anya Karvenina,
+            from a book by Tolsitoy a few years earlier.
+            """,
+            metadata=DocMetaData(source="tweakipedia"),
+        ),
+        Document(
+            content="""
+            The novel "Searching for Sebastian Night" was written by Vlad Nabikov.
+            It is an intriguing tale about the author's search for his lost brother,
+            and is a meditation on the nature of loss and memory.
+            """,
+            metadata=DocMetaData(source="tweakipedia"),
+        ),
+    ]
+
+    # note we only need to ingest docs using one of the agents,
+    # since they share the same vector-db
+    doc_agents[0].ingest_docs(docs, split=False)
+
+    questions = [
+        "What book did Vlad Nabikov write?",
+        "Who wrote the book about the Karenina sisters?",
+    ]
+
+    # (1) test that we can create a single task and use run_batch_tasks
+    task = Task(doc_agents[0], name="DocAgent", interactive=False, single_round=True)
+    results = run_batch_tasks(task, questions)
+
+    assert "Sebastian" in results[0].content
+    assert "Dinkoyevsky" in results[1].content
+
+    # (2) test that we can create a task-generator fn and use run_batch_task_gen
+
+    # create a task-generator fn, to create one per question
+    def gen_task(i: int):
+        return Task(
+            doc_agents[i],
+            name=f"DocAgent-{i}",
+            interactive=False,
+            single_round=True,
+        )
+
+    results = run_batch_task_gen(gen_task, questions)
+
+    assert "Sebastian" in results[0].content
+    assert "Dinkoyevsky" in results[1].content
+
+    for a in doc_agents:
+        a.clear()


### PR DESCRIPTION
This PR adds support for using llama.cpp server as a provider of embeddings.

Although llama.cpp server provides an OpenAI compatible endpoint for any embeddings model, tiktoken is often not the right tokeniser so it's not possible to use the OpenAIEmbeddings pathway.

In order to account for how the tokeniser changes based on the model, the implementation uses llama.cpp server's endpoints for tokenisation as opposed to trying to handle it locally - it'll use a lot more API calls, but the benefit of being locally hosted is this shouldn't really matter!