### PR TITLE
force sequential scheduling async handler tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.8.2
+  rev: v0.8.3
   hooks:
     - id: ruff


### PR DESCRIPTION
Resolves #640. Replaces `asyncio.sleep` in `tests/main/test_async_handlers.py` with sequential scheduling using `asyncio.Event`.