### PR TITLE
azure openai: bring your own client

### DIFF
--- a/docs/notes/custom-azure-client.md
+++ b/docs/notes/custom-azure-client.md
@@ -1,0 +1,35 @@
+# Custom Azure OpenAI client
+
+By default, Langroid manages the configuration and creation 
+of the Azure OpenAI client (see the [Setup guide](https://langroid.github.io/langroid/quick-start/setup/#microsoft-azure-openai-setupoptional)
+for details). In most cases, the available configuration options
+are sufficient, but if you need to manage any options that
+are not exposed, you instead have the option of providing a custom
+client.
+
+In order to use a custom client, you must provide a function that
+returns the configured client. Depending on whether you need to make
+synchronous or asynchronous calls, you need to provide the appropriate
+client. A sketch of how this is done (supporting both sync and async calls)
+is given below:
+
+```python
+def get_azure_openai_client():
+    return AzureOpenAI(...)
+
+def get_azure_openai_async_client():
+    return AsyncAzureOpenAI(...)
+
+lm_config = lm.AzureConfig(
+    azure_openai_client_provider=get_azure_openai_client,
+    azure_openai_async_client_provider=get_azure_openai_async_client,
+)
+```
+
+## Microsoft Entra ID Authentication
+
+A key use case for a custom client is [Microsoft Entra ID 
+authentication](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity).
+Here you need to provide an `azure_ad_token_provider` to the client. 
+For examples on this, see [examples/basic/chat-azure-client.py](https://github.com/langroid/langroid/blob/main/examples/basic/chat-azure-client.py) 
+and [examples/basic/chat-azure-async-client.py](https://github.com/langroid/langroid/blob/main/examples/basic/chat-azure-async-client.py).

--- a/examples/basic/chat-azure-async-client.py
+++ b/examples/basic/chat-azure-async-client.py
@@ -1,0 +1,66 @@
+"""
+Example showing how to use Langroid with Azure OpenAI and Entra ID
+authentication by providing a custom client.
+
+This is an async version of the example in chat-azure-client.py.
+
+For more details see here:
+https://langroid.github.io/langroid/notes/custom-azure-client/
+https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity
+
+"""
+
+import os
+
+import azure.identity as azure_identity
+import azure.identity.aio as azure_identity_async
+from dotenv import load_dotenv
+from openai import AsyncAzureOpenAI, AzureOpenAI
+
+import langroid as lr
+import langroid.language_models as lm
+
+load_dotenv()
+
+
+def get_azure_openai_client():
+    return AzureOpenAI(
+        api_version="2024-10-21",
+        azure_endpoint=os.environ["AZURE_OPENAI_API_BASE"],
+        azure_ad_token_provider=azure_identity.get_bearer_token_provider(
+            azure_identity.DefaultAzureCredential(),
+            "https://cognitiveservices.azure.com/.default",
+        ),
+    )
+
+
+def get_azure_openai_async_client():
+    return AsyncAzureOpenAI(
+        api_version="2024-10-21",
+        azure_endpoint=os.environ["AZURE_OPENAI_API_BASE"],
+        azure_ad_token_provider=azure_identity_async.get_bearer_token_provider(
+            azure_identity_async.DefaultAzureCredential(),
+            "https://cognitiveservices.azure.com/.default",
+        ),
+    )
+
+
+lm_config = lm.AzureConfig(
+    azure_openai_client_provider=get_azure_openai_client,
+    azure_openai_async_client_provider=get_azure_openai_async_client,
+)
+
+
+async def main():
+    agent = lr.ChatAgent(lr.ChatAgentConfig(llm=lm_config))
+    task = lr.Task(agent, interactive=False)
+    response = await task.run_async(
+        "Who is the president of the United States? Reply and end with DONE"
+    )
+    print(response)
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/examples/basic/chat-azure-client.py
+++ b/examples/basic/chat-azure-client.py
@@ -1,0 +1,43 @@
+"""
+Example showing how to use Langroid with Azure OpenAI and Entra ID
+authentication by providing a custom client.
+
+For an async version of this example, see chat-azure-async-client.py.
+
+For more details see here:
+https://langroid.github.io/langroid/notes/custom-azure-client/
+https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity
+
+"""
+
+import os
+
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from dotenv import load_dotenv
+from openai import AzureOpenAI
+
+import langroid as lr
+import langroid.language_models as lm
+
+load_dotenv()
+
+
+def get_azure_openai_client():
+    return AzureOpenAI(
+        api_version="2024-10-21",
+        azure_endpoint=os.environ["AZURE_OPENAI_API_BASE"],
+        azure_ad_token_provider=get_bearer_token_provider(
+            DefaultAzureCredential(),
+            "https://cognitiveservices.azure.com/.default",
+        ),
+    )
+
+
+lm_config = lm.AzureConfig(
+    azure_openai_client_provider=get_azure_openai_client,
+)
+
+if __name__ == "__main__":
+    agent = lr.ChatAgent(lr.ChatAgentConfig(llm=lm_config))
+    task = lr.Task(agent, interactive=False)
+    task.run("Who is the president of the United States? Reply and end with DONE")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
       - GLHF.chat Support: notes/glhf-chat.md
       - Structured Output: notes/structured-output.md
       - Tool Handler Name: notes/tool-message-handler.md
+      - Custom Azure OpenAI client: notes/custom-azure-client.md
 
   - Examples:
     - Guide: examples/guide.md


### PR DESCRIPTION
I'm facing the same problem as in issue #534, this is how I've addressed it in my fork. Instead of adding more options to the AzureConfig class, I've added an option for providing custom clients.

Example:
```python
import os

import azure.identity as azure_identity
import azure.identity.aio as azure_identity_async
from dotenv import load_dotenv
from openai import AsyncAzureOpenAI, AzureOpenAI

import langroid as lr
import langroid.language_models as lm

load_dotenv()


def get_azure_openai_client():
    return AzureOpenAI(
        api_version="2024-02-15-preview",
        azure_endpoint=os.environ["AZURE_OPENAI_API_BASE"],
        azure_ad_token_provider=azure_identity.get_bearer_token_provider(
            azure_identity.DefaultAzureCredential(),
            "https://cognitiveservices.azure.com/.default",
        ),
    )


def get_azure_openai_async_client():
    return AsyncAzureOpenAI(
        api_version="2024-02-15-preview",
        azure_endpoint=os.environ["AZURE_OPENAI_API_BASE"],
        azure_ad_token_provider=azure_identity_async.get_bearer_token_provider(
            azure_identity_async.DefaultAzureCredential(),
            "https://cognitiveservices.azure.com/.default",
        ),
    )


lm_config = lm.AzureConfig(
    azure_openai_client_provider=get_azure_openai_client,
    azure_openai_async_client_provider=get_azure_openai_async_client,
)

if __name__ == "__main__":
    agent = lr.ChatAgent(lr.ChatAgentConfig(llm=lm_config))
    task = lr.Task(agent, interactive=False)
    task.run("Who is the president of the United States? Reply and end with DONE")
```

For me, this implementation has an added benefit: I use [Langfuse](https://github.com/langfuse/langfuse) for observability, and their [integration](https://langfuse.com/docs/sdk/python/decorators) relies on using a custom openai client which I can now easily pass to Langroid. If this is a use-case you also want to support, then it might be worth considering make a similar change to the (non-Azure) openai config class.


