### PR TITLE
support use of existing embedding model in VectorStore

### DIFF
--- a/langroid/vector_store/base.py
+++ b/langroid/vector_store/base.py
@@ -30,6 +30,7 @@ class VectorStoreConfig(BaseSettings):
     embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig(
         model_type="openai",
     )
+    embedding_model: Optional[EmbeddingModel] = None
     timeout: int = 60
     host: str = "127.0.0.1"
     port: int = 6333
@@ -46,7 +47,10 @@ class VectorStore(ABC):
 
     def __init__(self, config: VectorStoreConfig):
         self.config = config
-        self.embedding_model = EmbeddingModel.create(config.embedding)
+        if config.embedding_model is None:
+            self.embedding_model = EmbeddingModel.create(config.embedding)
+        else:
+            self.embedding_model = config.embedding_model
 
     @staticmethod
     def create(config: VectorStoreConfig) -> Optional["VectorStore"]:


### PR DESCRIPTION
Some embedding models - e.g. `FastEmbed` - do a LOT during their initialization.
Therefore for multi-tenant / multi-agent environments it makes sense to re-use the same model for all `VectorStore` instances (used by `Agent` instances). However current `VectorStore` implementation doesn't allow this - as it calls `VectorStore.create(config.embedding)` on instance initialization.

This simple patch adds `embedding_model` attribute to `VectorStoreConfig` class. When this attribute is specified, existing embedding model is used during `VectorStore` initialization.

And just to small clarification: while it is possible to use the same `VectorStore` for multiple agents, in many cases it's not appropriate - as each agent has it's own documents/vector-data.