### PR TITLE
fix: remove bumpversion.cfg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,0 @@
-[bumpversion]
-current_version = 0.1.0
-commit = True
-tag = True
-
-[bumpversion:file:pyproject.toml]


### PR DESCRIPTION
bumpversion.cfg no longer needed  as we are using commitizen for version management