### PR TITLE
add event type to stream callback

### DIFF
--- a/langroid/agent/callbacks/chainlit.py
+++ b/langroid/agent/callbacks/chainlit.py
@@ -20,6 +20,7 @@ from chainlit.logger import logger
 
 import langroid as lr
 import langroid.language_models as lm
+from langroid.language_models import StreamEventType
 from langroid.utils.configuration import settings
 from langroid.utils.constants import NO_ANSWER
 
@@ -295,7 +296,7 @@ class ChainlitAgentCallbacks:
         """
         )
 
-        def stream_token(t: str) -> None:
+        def stream_token(t: str, e: StreamEventType) -> None:
             if self.stream is None:
                 raise ValueError("Stream not initialized")
             run_sync(self.stream.stream_token(t))
@@ -321,7 +322,7 @@ class ChainlitAgentCallbacks:
             """
         )
 
-        async def stream_token(t: str) -> None:
+        async def stream_token(t: str, e: StreamEventType) -> None:
             if self.stream is None:
                 raise ValueError("Stream not initialized")
             await self.stream.stream_token(t)

--- a/langroid/language_models/__init__.py
+++ b/langroid/language_models/__init__.py
@@ -6,6 +6,7 @@ from . import azure_openai
 from . import prompt_formatter
 
 from .base import (
+    StreamEventType,
     LLMConfig,
     LLMMessage,
     LLMFunctionCall,
@@ -33,6 +34,7 @@ __all__ = [
     "openai_gpt",
     "azure_openai",
     "prompt_formatter",
+    "StreamEventType",
     "LLMConfig",
     "LLMMessage",
     "LLMFunctionCall",

--- a/langroid/language_models/base.py
+++ b/langroid/language_models/base.py
@@ -42,6 +42,14 @@ ToolChoiceTypes = Literal["none", "auto", "required"]
 ToolTypes = Literal["function"]
 
 
+class StreamEventType(Enum):
+    TEXT = 1
+    FUNC_NAME = 2
+    FUNC_ARGS = 3
+    TOOL_NAME = 4
+    TOOL_ARGS = 5
+
+
 class LLMConfig(BaseSettings):
     """
     Common configuration for all language models.

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -43,6 +43,7 @@ from langroid.language_models.base import (
     OpenAIToolCall,
     OpenAIToolSpec,
     Role,
+    StreamEventType,
     ToolChoiceTypes,
 )
 from langroid.language_models.config import HFPromptFormatterConfig
@@ -875,19 +876,19 @@ class OpenAIGPT(LanguageModel):
             completion += event_text
             sys.stdout.write(Colors().GREEN + event_text)
             sys.stdout.flush()
-            self.config.streamer(event_text)
+            self.config.streamer(event_text, StreamEventType.TEXT)
         if event_fn_name:
             function_name = event_fn_name
             has_function = True
             sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
             sys.stdout.flush()
-            self.config.streamer(event_fn_name)
+            self.config.streamer(event_fn_name, StreamEventType.FUNC_NAME)
 
         if event_args:
             function_args += event_args
             sys.stdout.write(Colors().GREEN + event_args)
             sys.stdout.flush()
-            self.config.streamer(event_args)
+            self.config.streamer(event_args, StreamEventType.FUNC_ARGS)
 
         if event_tool_deltas is not None:
             # print out streaming tool calls, if not async
@@ -898,12 +899,12 @@ class OpenAIGPT(LanguageModel):
                         Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
                     )
                     sys.stdout.flush()
-                    self.config.streamer(tool_fn_name)
+                    self.config.streamer(tool_fn_name, StreamEventType.TOOL_NAME)
                 if td["function"]["arguments"] != "":
                     tool_fn_args = td["function"]["arguments"]
                     sys.stdout.write(Colors().GREEN + tool_fn_args)
                     sys.stdout.flush()
-                    self.config.streamer(tool_fn_args)
+                    self.config.streamer(tool_fn_args, StreamEventType.TOOL_ARGS)
 
         # show this delta in the stream
         if finish_reason in [
@@ -968,21 +969,23 @@ class OpenAIGPT(LanguageModel):
             if not silent:
                 sys.stdout.write(Colors().GREEN + event_text)
                 sys.stdout.flush()
-                await self.config.streamer_async(event_text)
+                await self.config.streamer_async(event_text, StreamEventType.TEXT)
         if event_fn_name:
             function_name = event_fn_name
             has_function = True
             if not silent:
                 sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
                 sys.stdout.flush()
-                await self.config.streamer_async(event_fn_name)
+                await self.config.streamer_async(
+                    event_fn_name, StreamEventType.FUNC_NAME
+                )
 
         if event_args:
             function_args += event_args
             if not silent:
                 sys.stdout.write(Colors().GREEN + event_args)
                 sys.stdout.flush()
-                await self.config.streamer_async(event_args)
+                await self.config.streamer_async(event_args, StreamEventType.FUNC_ARGS)
 
         if event_tool_deltas is not None and not silent:
             # print out streaming tool calls, if not async
@@ -993,12 +996,16 @@ class OpenAIGPT(LanguageModel):
                         Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
                     )
                     sys.stdout.flush()
-                    await self.config.streamer_async(tool_fn_name)
+                    await self.config.streamer_async(
+                        tool_fn_name, StreamEventType.TOOL_NAME
+                    )
                 if td["function"]["arguments"] != "":
                     tool_fn_args = td["function"]["arguments"]
                     sys.stdout.write(Colors().GREEN + tool_fn_args)
                     sys.stdout.flush()
-                    await self.config.streamer_async(tool_fn_args)
+                    await self.config.streamer_async(
+                        tool_fn_args, StreamEventType.TOOL_ARGS
+                    )
 
         # show this delta in the stream
         if choices[0].get("finish_reason", "") in [


### PR DESCRIPTION
I'm building a solution where multiple agents interact via ToolMessages in order to come up with an answer for a user. Any given agent may be the one replying to the user. As soon as an agent is ready to respond to the user, the answer should be streamed to the user and not relayed back to a "controlling" agent (in order to minimize waiting time). I've implemented this using callbacks (based on [callbacks/chainlit.py](https://github.com/langroid/langroid/blob/main/langroid/agent/callbacks/chainlit.py)) which stream to a web app.

My problem is that function calls (i.e. any communication between agents) should never be streamed to the user. In order to achieve this I need to provide the event type to the callback function. This PR implements that functionality.

Note: While I have updated [callbacks/chainlit.py](https://github.com/langroid/langroid/blob/main/langroid/agent/callbacks/chainlit.py) to reflect this change, I have not tested it.
