### PR TITLE
remove whitespace errors so that flake8 runs normally 

### DIFF
--- a/examples/basic/chat-tool-function.py
+++ b/examples/basic/chat-tool-function.py
@@ -84,7 +84,7 @@ class CompanyInfoTool(lr.agent.ToolMessage):
         print(
             f"""
             Got Valid Company Info.
-            The market cap of {self.company_info.name} is ${mkt_cap/1e9}B.
+            The market cap of {self.company_info.name} is ${mkt_cap / 1e9}B.
             """
         )
         return FinalResultTool(

--- a/examples/basic/multi-agent-round-table.py
+++ b/examples/basic/multi-agent-round-table.py
@@ -68,5 +68,5 @@ for _ in range(10):
     for i, r in enumerate(results):
         if r.content != NO_ANSWER:
             n = int(r.content)
-            print(f"agent{i+1} responded with {n}")
+            print(f"agent{i + 1} responded with {n}")
             break

--- a/langroid/agent/special/doc_chat_agent.py
+++ b/langroid/agent/special/doc_chat_agent.py
@@ -810,7 +810,7 @@ class DocChatAgent(ChatAgent):
         return "\n".join(
             [
                 f"""
-                -----[EXTRACT #{i+1}]----------
+                -----[EXTRACT #{i + 1}]----------
                 {content}
                 {source}
                 -----END OF EXTRACT------------
@@ -866,8 +866,8 @@ class DocChatAgent(ChatAgent):
             # append [i] source, content for each citation
             citations_str = "\n".join(
                 [
-                    f"[^{c}] {passages[c-1].metadata.source}"
-                    f"\n{format_footnote_text(passages[c-1].content)}"
+                    f"[^{c}] {passages[c - 1].metadata.source}"
+                    f"\n{format_footnote_text(passages[c - 1].content)}"
                     for c in citations
                 ]
             )

--- a/langroid/agent/special/neo4j/neo4j_chat_agent.py
+++ b/langroid/agent/special/neo4j/neo4j_chat_agent.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from langroid.pydantic_v1 import BaseModel, BaseSettings
 
 if TYPE_CHECKING:
-    import neo4j
+    import neo4j  # noqa
 
 from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
 from langroid.agent.chat_document import ChatDocument

--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -990,7 +990,7 @@ class Task:
         if not settings.quiet:
             print(
                 f"[bold magenta]{self._enter} Starting Agent "
-                f"{self.name} ({self.message_history_idx+1}) "
+                f"{self.name} ({self.message_history_idx + 1}) "
                 f"{llm_model} [/bold magenta]"
             )
 

--- a/langroid/parsing/repo_loader.py
+++ b/langroid/parsing/repo_loader.py
@@ -162,7 +162,7 @@ class RepoLoader:
             except Exception as e:
                 delay = min(max_delay, base_delay * 2**attempt)
                 logger.info(
-                    f"Attempt {attempt+1} failed with error: {str(e)}. "
+                    f"Attempt {attempt + 1} failed with error: {str(e)}. "
                     f"Retrying in {delay} seconds..."
                 )
                 time.sleep(delay)

--- a/langroid/utils/system.py
+++ b/langroid/utils/system.py
@@ -252,7 +252,7 @@ def read_file(path: str, line_numbers: bool = False) -> str:
     content = file.read_text()
     if line_numbers:
         lines = content.splitlines()
-        numbered_lines = [f"{i+1}: {line}" for i, line in enumerate(lines)]
+        numbered_lines = [f"{i + 1}: {line}" for i, line in enumerate(lines)]
         return "\n".join(numbered_lines)
     return content
 

--- a/tests/main/test_arangodb_chat_agent.py
+++ b/tests/main/test_arangodb_chat_agent.py
@@ -267,7 +267,11 @@ def number_kg_agent(setup_arango, test_database):
 
     # Add plus4 edges:
     plus4_edges = [
-        {"_key": f"plus4_{i}_{i+4}", "_from": f"numbers/n{i}", "_to": f"numbers/n{i+4}"}
+        {
+            "_key": f"plus4_{i}_{i + 4}",
+            "_from": f"numbers/n{i}",
+            "_to": f"numbers/n{i + 4}",
+        }
         for i in number_list
         if i + 4 in number_list
     ]

--- a/tests/main/test_doc_chat_agent.py
+++ b/tests/main/test_doc_chat_agent.py
@@ -1238,7 +1238,7 @@ def test_doc_chat_agent_ingest_paths(test_settings: Settings, vecdb):
     # Create sets of expected and actual metadata
     expected_categories = {"file", "bytes"}
     expected_sources = {
-        _append_metadata_source(s, f"src{i+1}") for i, s in enumerate(orig_sources)
+        _append_metadata_source(s, f"src{i + 1}") for i, s in enumerate(orig_sources)
     }
 
     actual_categories = {d.metadata.category for d in stored}

--- a/tests/main/test_task_run_polymorphic.py
+++ b/tests/main/test_task_run_polymorphic.py
@@ -87,7 +87,7 @@ def test_task_in_out_types(
         def handle(self) -> Any:
             match pair_tool_handler_return_type:
                 case "str":
-                    return f"Here is a pair of numbers: {self.x-1}, {self.x+1}"
+                    return f"Here is a pair of numbers: {self.x - 1}, {self.x + 1}"
                 case "list":
                     return [self.x - 1, self.x + 1]
                 case "dict":

--- a/tests/main/test_tool_orchestration.py
+++ b/tests/main/test_tool_orchestration.py
@@ -522,7 +522,7 @@ def test_send_tools(
             llm=MockLMConfig(
                 response_fn=lambda x: (
                     f"""
-                    result is {int(x)//5}, apply the number-handling rules to 
+                    result is {int(x) // 5}, apply the number-handling rules to 
                     decide what to do next
                     """
                 ),
@@ -537,7 +537,7 @@ def test_send_tools(
             llm=MockLMConfig(
                 response_fn=lambda x: (
                     f"""
-                 result is {int(x)//10}, apply the number-handling rules to
+                 result is {int(x) // 10}, apply the number-handling rules to
                  decide what to do next
                  """
                 ),


### PR DESCRIPTION
Remove whitespace errors so that flake8 runs normally and  control reaches to mypy in make check.