### PR TITLE
Fix: cache miss on download_nltk_resource

### DIFF
--- a/langroid/parsing/search.py
+++ b/langroid/parsing/search.py
@@ -118,7 +118,7 @@ def preprocess_text(text: str) -> str:
         str: The preprocessed text.
     """
     # Ensure the NLTK resources are available
-    for resource in ["punkt", "wordnet", "stopwords"]:
+    for resource in ["tokenizers/punkt", "corpora/wordnet", "corpora/stopwords"]:
         download_nltk_resource(resource)
 
     # Lowercase the text

--- a/langroid/parsing/utils.py
+++ b/langroid/parsing/utils.py
@@ -28,12 +28,13 @@ def download_nltk_resource(resource: str) -> None:
     try:
         nltk.data.find(resource)
     except LookupError:
-        nltk.download(resource, quiet=True)
+        model = resource.split("/")[-1]
+        nltk.download(model, quiet=True)
 
 
 # Download punkt_tab resource at module import
-download_nltk_resource("punkt_tab")
-download_nltk_resource("gutenberg")
+download_nltk_resource("tokenizers/punkt_tab")
+download_nltk_resource("corpora/gutenberg")
 
 T = TypeVar("T")
 


### PR DESCRIPTION
- when using [find](https://www.nltk.org/_modules/nltk/data.html) nltk requires the  `<subdirectory>/<model>` format.
- when downloading nltk requires `<model>` format.

This means that previously we were always getting cache misses since we only passed in the model name.

**Note:** may also help with #407 