### PR TITLE
docs: fix code block formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ For many practical scenarios, you may need additional optional dependencies:
 - For "chat with databases", use the `db` extra:
     ```bash
     pip install "langroid[db]"
-    ``
+    ```
 - You can specify multiple extras by separating them with commas, e.g.:
     ```bash
     pip install "langroid[doc-chat,db]"


### PR DESCRIPTION

Hey,  

I noticed that the code block for the installation instructions in the README wasn't displaying quite right because of an issue with the backticks. I've updated the formatting so it should now be clearer and easier to follow.  

Hope this little fix makes things a bit more user-friendly for everyone. Please feel free to share any thoughts or further suggestions!  

Thanks!