### PR TITLE
feat: add marker-pdf parser to document_parsers

### DIFF
--- a/docs/notes/marker-pdf.md
+++ b/docs/notes/marker-pdf.md
@@ -1,0 +1,85 @@
+
+---
+
+# **Using `marker` as a PDF Parser in `langroid`**  
+
+## **Installation**  
+
+### **Standard Installation**  
+To use `marker` as a PDF parser in `langroid`, install it with:  
+
+```bash
+pip install langroid[marker-pdf]
+```
+
+#### **For Intel-Mac Users**  
+If you are on an **Intel Mac**, `docling` and `marker` cannot be used due to a **transformers version conflict**.  
+To resolve this, manually install `marker-pdf` with:  
+
+```bash
+pip install marker-pdf[full]
+```
+
+Make sure to install this within your `langroid` virtual environment.
+
+---
+
+## **Example: Parsing a PDF with `marker` in `langroid`**  
+
+```python
+from langroid.parsing.document_parser import DocumentParser
+from langroid.parsing.parser import MarkerConfig, ParsingConfig, PdfParsingConfig
+from dotenv import load_dotenv
+import os
+
+# Load environment variables
+load_dotenv()
+gemini_api_key = os.environ.get("GEMINI_API_KEY")
+
+# Path to your PDF file
+path = "<path_to_your_pdf_file>"
+
+# Define parsing configuration
+parsing_config = ParsingConfig(
+    n_neighbor_ids=2,  # Number of neighboring sections to keep
+    pdf=PdfParsingConfig(
+        library="marker",  # Use `marker` as the PDF parsing library
+        marker_config=MarkerConfig(
+            config_dict={
+                "use_llm": True,  # Enable high-quality LLM processing
+                "gemini_api_key": gemini_api_key,  # API key for Gemini LLM
+            }
+        )
+    ),
+)
+
+# Create the parser and extract the document
+marker_parser = DocumentParser.create(path, parsing_config)
+doc = marker_parser.get_doc()
+```
+
+---
+
+## **Explanation of Configuration Options**  
+
+If you want to use the default configuration, you can omit `marker_config` entirely.
+
+### **Key Parameters in `MarkerConfig`**
+| Parameter        | Description |
+|-----------------|-------------|
+| `use_llm`       | Set to `True` to enable higher-quality processing using LLMs. |
+| `gemini_api_key` | Google Gemini API key for LLM-enhanced parsing. |
+
+
+
+You can further customize `config_dict` by referring to [`marker_pdf`'s documentation](https://github.com/VikParuchuri/marker/blob/master/README.md).  
+
+Alternatively, run the following command to view available options:  
+
+```sh
+marker_single --help
+```
+
+This will display all supported parameters, which you can pass as needed in `config_dict`.
+
+---

--- a/langroid/parsing/document_parser.py
+++ b/langroid/parsing/document_parser.py
@@ -150,6 +150,8 @@ class DocumentParser(Parser):
                 return ImagePdfParser(source, config)
             elif config.pdf.library == "gemini":
                 return GeminiPdfParser(source, config)
+            elif config.pdf.library == "marker":
+                return MarkerPdfParser(source, config)
             else:
                 raise ValueError(
                     f"Unsupported PDF library specified: {config.pdf.library}"
@@ -1354,5 +1356,87 @@ class GeminiPdfParser(DocumentParser):
         """
         return Document(
             content=page,
+            metadata=DocMetaData(source=self.source),
+        )
+
+
+class MarkerPdfParser(DocumentParser):
+    DEFAULT_CONFIG = {"paginate_output": True, "output_format": "markdown"}
+
+    def __init__(self, source: Union[str, bytes], config: ParsingConfig):
+        super().__init__(source, config)
+        user_config = (
+            config.pdf.marker_config.config_dict if config.pdf.marker_config else {}
+        )
+
+        self.config_dict = {**MarkerPdfParser.DEFAULT_CONFIG, **user_config}
+
+    def iterate_pages(self) -> Generator[Tuple[int, Any], None, None]:
+        """
+        Yield each page in the PDF using `marker`.
+        """
+        try:
+            from marker.converters.pdf import PdfConverter
+        except ImportError:
+            raise LangroidImportError(
+                "marker-pdf", ["marker-pdf", "pdf-parsers", "all", "doc-chat"]
+            )
+
+        import re
+
+        from marker.config.parser import ConfigParser
+        from marker.models import create_model_dict
+        from marker.output import save_output
+
+        config_parser = ConfigParser(self.config_dict)
+        converter = PdfConverter(
+            config=config_parser.generate_config_dict(),
+            artifact_dict=create_model_dict(),
+            processor_list=config_parser.get_processors(),
+            renderer=config_parser.get_renderer(),
+            llm_service=config_parser.get_llm_service(),
+        )
+        doc_path = self.source
+        if doc_path == "bytes":
+            # write to tmp file, then use that path
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as temp_file:
+                temp_file.write(self.doc_bytes.getvalue())
+                doc_path = temp_file.name
+
+        output_dir = Path(str(Path(doc_path).with_suffix("")) + "-pages")
+        os.makedirs(output_dir, exist_ok=True)
+        filename = Path(doc_path).stem + "_converted"
+
+        rendered = converter(doc_path)
+        save_output(rendered, output_dir=output_dir, fname_base=filename)
+        file_path = output_dir / f"{filename}.md"
+
+        with open(file_path, "r", encoding="utf-8") as f:
+            full_markdown = f.read()
+
+        # Corrected regex for splitting pages
+        pages = re.split(r"\{\d+\}----+", full_markdown)
+
+        # Remove leading/trailing empty pages
+        pages = [page.strip() for page in pages if page.strip()]
+
+        # Yield each page with its index
+        for i, page in enumerate(pages):
+            yield i, page
+
+    def get_document_from_page(self, page: str) -> Document:
+        """
+        Get Document object from a given 1-page markdown file,
+        possibly containing image refs.
+
+        Args:
+            page (str): The page we get by splitting large md file from
+            marker
+
+        Returns:
+            Document: Document object, with content and possible metadata.
+        """
+        return Document(
+            content=self.fix_text(page),
             metadata=DocMetaData(source=self.source),
         )

--- a/langroid/parsing/document_parser.py
+++ b/langroid/parsing/document_parser.py
@@ -1415,15 +1415,14 @@ class MarkerPdfParser(DocumentParser):
         with open(file_path, "r", encoding="utf-8") as f:
             full_markdown = f.read()
 
-        # Corrected regex for splitting pages
+        # Regex for splitting pages
         pages = re.split(r"\{\d+\}----+", full_markdown)
 
-        # Remove leading/trailing empty pages
-        pages = [page.strip() for page in pages if page.strip()]
-
-        # Yield each page with its index
-        for i, page in enumerate(pages):
-            yield i, page
+        page_no = 0
+        for page in pages:
+            if page.strip():
+                yield page_no, page
+            page_no += 1
 
     def get_document_from_page(self, page: str) -> Document:
         """

--- a/langroid/parsing/document_parser.py
+++ b/langroid/parsing/document_parser.py
@@ -1376,7 +1376,7 @@ class MarkerPdfParser(DocumentParser):
         Yield each page in the PDF using `marker`.
         """
         try:
-            from marker.converters.pdf import PdfConverter
+            import marker  # noqa
         except ImportError:
             raise LangroidImportError(
                 "marker-pdf", ["marker-pdf", "pdf-parsers", "all", "doc-chat"]
@@ -1385,6 +1385,7 @@ class MarkerPdfParser(DocumentParser):
         import re
 
         from marker.config.parser import ConfigParser
+        from marker.converters.pdf import PdfConverter
         from marker.models import create_model_dict
         from marker.output import save_output
 

--- a/langroid/parsing/parser.py
+++ b/langroid/parsing/parser.py
@@ -38,8 +38,13 @@ class GeminiConfig(BaseSettings):
     requests_per_minute: Optional[int] = 5
 
 
-class PdfParsingConfig(BaseParsingConfig):
+class MarkerConfig(BaseSettings):
+    """Configuration for Markitdown-based parsing."""
 
+    config_dict: Dict[str, Any] = {}
+
+
+class PdfParsingConfig(BaseParsingConfig):
     library: Literal[
         "fitz",
         "pymupdf4llm",
@@ -49,16 +54,26 @@ class PdfParsingConfig(BaseParsingConfig):
         "pdf2image",
         "markitdown",
         "gemini",
+        "marker",
     ] = "pymupdf4llm"
     gemini_config: Optional[GeminiConfig] = None
+    marker_config: Optional[MarkerConfig] = None
 
     @root_validator(pre=True)
-    def enable_gemini_config(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        """Ensure GeminiConfig is set only when library is 'gemini'."""
-        if values.get("library") == "gemini":
-            values["gemini_config"] = values.get("gemini_config") or GeminiConfig()
+    def enable_configs(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Ensure correct config is set based on library selection."""
+        library = values.get("library")
+
+        if library == "gemini":
+            values.setdefault("gemini_config", GeminiConfig())
         else:
             values["gemini_config"] = None
+
+        if library == "marker":
+            values.setdefault("marker_config", MarkerConfig())
+        else:
+            values["marker_config"] = None
+
         return values
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,7 @@ nav:
       - PGVector: notes/pgvector.md
       - Pinecone: notes/pinecone.md
       - Tavily Search Tool: notes/tavily_search.md
+      - Marker Pdf Parser: notes/marker-pdf.md
 
   - Examples:
     - Guide: examples/guide.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ docx = [
 ]
 
 marker-pdf = [
-    "marker-pdf>=1.6.0; sys_platform != 'darwin' or platform_machine != 'x86_64'"
+    "marker-pdf[full]>=1.6.0; sys_platform != 'darwin' or platform_machine != 'x86_64'"
 ]
 
 scrapy = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ doc-chat = [
     "pytesseract<0.4.0,>=0.3.10",
     "python-docx<2.0.0,>=1.1.0",
     "unstructured[docx,pdf,pptx]<1.0.0,>=0.16.15",
+    "marker-pdf"
 ]
 
 hf-transformers = [
@@ -122,6 +123,7 @@ all = [
     "fastembed<0.4.0,>=0.3.1",
     "pgvector>=0.3.6",
     "psycopg2-binary>=2.9.10",
+    "marker-pdf",
 ]
 
 # More granular groupings
@@ -147,10 +149,15 @@ pdf-parsers = [
     "pdf2image<2.0.0,>=1.17.0",
     "pytesseract<0.4.0,>=0.3.10",
     "markitdown>=0.0.1a3",
+    "marker-pdf",
 ]
 
 docx = [
     "python-docx<2.0.0,>=1.1.0",
+]
+
+marker-pdf = [
+    "marker-pdf>=1.6.0; sys_platform != 'darwin' or platform_machine != 'x86_64'"
 ]
 
 scrapy = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,8 @@ docx = [
 ]
 
 marker-pdf = [
-    "marker-pdf[full]>=1.6.0; sys_platform != 'darwin' or platform_machine != 'x86_64'"
+    "marker-pdf[full]>=1.6.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+    "opencv-python>=4.11.0.86",
 ]
 
 scrapy = [

--- a/tests/extras/test_marker_pdf_parser.py
+++ b/tests/extras/test_marker_pdf_parser.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import pytest
+
+from langroid.parsing.document_parser import DocumentParser
+from langroid.parsing.parser import ParsingConfig, PdfParsingConfig
+
+
+@pytest.mark.parametrize("pdf_file", ["imagenet.pdf"])
+def test_marker_pdf_parser(pdf_file):
+    current_dir = Path(__file__).resolve().parent
+    path = current_dir.parent / "main" / "data" / pdf_file
+
+    parsing_config = ParsingConfig(
+        n_neighbor_ids=2,
+        pdf=PdfParsingConfig(
+            library="marker",
+        ),
+    )
+
+    marker_parser = DocumentParser.create(
+        path.as_posix(),
+        parsing_config,
+    )
+    doc = marker_parser.get_doc()
+
+    # Check the results
+    assert isinstance(doc.content, str)
+    assert len(doc.content) > 0  # assuming the PDF is not empty
+    assert doc.metadata.source == str(path)
+    docs = marker_parser.get_doc_chunks()
+    assert len(docs) > 0
+    assert all(d.metadata.is_chunk for d in docs)
+    n = len(docs)
+    k = marker_parser.config.n_neighbor_ids
+    if n > 2 * k + 1:
+        assert len(docs[n // 2].metadata.window_ids) == 2 * k + 1


### PR DESCRIPTION
Address #707 
Not including in `pytest` as it downloads ~4GB of ocr models and takes almost 7-8 minutes on cpu to complete the tests.
Please ensure if it works as intended on intel-mac.