### PR TITLE
fix: RichFileLogger too many open files error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.11.9
+  rev: v0.11.10
   hooks:
     - id: ruff

--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -578,19 +578,24 @@ class Task:
         return self.pending_message
 
     def init_loggers(self) -> None:
+        """Initialise per-task Rich and TSV loggers."""
+        from langroid.utils.logging import RichFileLogger
+
         if self.caller is not None and self.caller.logger is not None:
             self.logger = self.caller.logger
         elif self.logger is None:
             self.logger = RichFileLogger(
                 str(Path(self.config.logs_dir) / f"{self.name}.log"),
+                append=True,
                 color=self.color_log,
             )
 
         if self.caller is not None and self.caller.tsv_logger is not None:
             self.tsv_logger = self.caller.tsv_logger
         elif self.tsv_logger is None:
+            # unique logger name ensures a distinct `logging.Logger` object
             self.tsv_logger = setup_file_logger(
-                "tsv_logger",
+                f"tsv_logger.{self.name}.{id(self)}",
                 str(Path(self.config.logs_dir) / f"{self.name}.tsv"),
             )
             header = ChatDocLoggerFields().tsv_header()
@@ -1039,6 +1044,10 @@ class Task:
                 f"[bold magenta]{self._leave} Finished Agent "
                 f"{self.name} ({n_messages}) [/bold magenta]"
             )
+        # Close RichFileLogger FD when the top-level task is done.
+        if self.caller is None and isinstance(self.logger, RichFileLogger):
+            self.logger.close()
+            self.logger = None
 
     def step(self, turns: int = -1) -> ChatDocument | None:
         """

--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -1044,10 +1044,6 @@ class Task:
                 f"[bold magenta]{self._leave} Finished Agent "
                 f"{self.name} ({n_messages}) [/bold magenta]"
             )
-        # Close RichFileLogger FD when the top-level task is done.
-        if self.caller is None and isinstance(self.logger, RichFileLogger):
-            self.logger.close()
-            self.logger = None
 
     def step(self, turns: int = -1) -> ChatDocument | None:
         """

--- a/langroid/embedding_models/models.py
+++ b/langroid/embedding_models/models.py
@@ -521,7 +521,7 @@ class GeminiEmbeddings(EmbeddingModel):
         for batch in batched(texts, self.config.batch_size):
             result = self.client.models.embed_content(  # type: ignore[attr-defined]
                 model=self.config.model_name,
-                contents=batch,
+                contents=batch,  # type: ignore
             )
 
             if not hasattr(result, "embeddings") or not isinstance(
@@ -532,7 +532,9 @@ class GeminiEmbeddings(EmbeddingModel):
                 )
 
             # Extract .values from ContentEmbedding objects
-            all_embeddings.extend([emb.values for emb in result.embeddings])
+            all_embeddings.extend(
+                [emb.values for emb in result.embeddings]  # type: ignore
+            )
 
         return all_embeddings
 

--- a/tests/main/test_rich_file_logger.py
+++ b/tests/main/test_rich_file_logger.py
@@ -66,3 +66,26 @@ def test_fd_limit(tmp_path: Path) -> None:
             raise AssertionError(f"Error: {errs[0]!r}") from errs[0]
     finally:
         resource.setrlimit(resource.RLIMIT_NOFILE, (soft0, hard0))
+
+
+
+def test_write_after_peer_close(tmp_path: Path) -> None:
+    """
+    Scenario that used to raise `ValueError: I/O operation on closed file`.
+
+    Two RichFileLogger handles are created for the same path. One is closed,
+    the other continues to write. The test passes if no exception is raised.
+    """
+    log_path = tmp_path / "late_write.log"
+
+    logger1 = RichFileLogger(str(log_path), append=True, color=False)
+    logger2 = RichFileLogger(str(log_path), append=True, color=False)
+
+    # Close the first handle
+    logger1.close()
+
+    # Second handle must still be functional
+    logger2.log("log entry after peer close")
+
+    # Clean up
+    logger2.close()

--- a/tests/main/test_rich_file_logger.py
+++ b/tests/main/test_rich_file_logger.py
@@ -1,8 +1,5 @@
-"""Regression-test for the shared-FD RichFileLogger implementation."""
-
 from __future__ import annotations
 
-import resource  # noqa: E402  pylint: disable=wrong-import-position
 import sys
 import threading
 from pathlib import Path
@@ -13,109 +10,59 @@ import pytest
 from langroid.utils.logging import RichFileLogger
 
 
-def _create_many(log_path: str, n: int = 20) -> List[RichFileLogger]:
-    """Return `n` RichFileLogger instances that target the same file."""
-    return [RichFileLogger(log_path, append=True, color=False) for _ in range(n)]
+def _make(path: str, n: int) -> List[RichFileLogger]:
+    return [RichFileLogger(path, append=True, color=False) for _ in range(n)]
 
 
-@pytest.mark.parametrize("n_loggers", [1, 5, 20])
-def test_single_fd_reused(tmp_path: Path, n_loggers: int) -> None:
-    """
-    Ensure that all RichFileLogger instances writing to the same file
-    share ONE open file descriptor, and that `.close()` frees it.
-    """
-    file_path = tmp_path / "shared.log"
-    loggers = _create_many(str(file_path), n=n_loggers)
-
-    # All instances must be the very same object (singleton per file)
-    first = loggers[0]
-    assert all(inst is first for inst in loggers)
-
-    # They must have the exact same underlying fd
-    first_fd = first.file.fileno()
-    assert all(inst.file.fileno() == first_fd for inst in loggers)
-
-    # Write something; should not raise
-    first.log("hi")
-
-    # Closing once must mark the fd closed and remove the instance
-    first.close()
-    assert first.file.closed
-    assert str(file_path) not in RichFileLogger._instances
-
-    # Creating again after close should yield a fresh instance + fd
-    fresh = RichFileLogger(str(file_path), append=True, color=False)
-    assert fresh is not first
-    assert not fresh.file.closed
-    fresh.close()
-
-
-# Linux/mac only – `resource` is not available on Windows.
-
-
-def _stress_writer(
-    start: threading.Event,
-    errors: List[BaseException],
-    log_path: str,
-) -> None:
-    """Wait for the `start` event then write to the shared logger many times."""
+def _stress(start: threading.Event, errs: list[BaseException], path: str) -> None:
     start.wait()
     try:
-        logger = RichFileLogger(log_path, append=True, color=False)
+        log = RichFileLogger(path, append=True, color=False)
         for _ in range(50):
-            logger.log("hello")
-    except BaseException as exc:  # want to catch the OSError 24
-        errors.append(exc)
+            log.log("hi")
+    except BaseException as exc:  # noqa: BLE001
+        errs.append(exc)
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="resource.RLIMIT_NOFILE is POSIX only",
-)
-def test_rich_file_logger_does_not_exhaust_fd(tmp_path: Path) -> None:
-    """
-    Regression-test for issue “Too many open files”.
+@pytest.mark.parametrize("n", [1, 5, 50])
+def test_singleton_and_fd(tmp_path: Path, n: int) -> None:
+    file_path = tmp_path / "shared.log"
+    loggers = _make(str(file_path), n)
 
-    We artificially lower the soft RLIMIT_NOFILE to a small number, then start
-    many threads that *simultaneously* write to the same `RichFileLogger`.
-    With the **fixed** implementation only ONE file descriptor is ever open,
-    so no thread raises `OSError: [Errno 24] Too many open files`.
+    first = loggers[0]
+    assert all(lg is first for lg in loggers)
+    fd = first.file.fileno()
+    assert all(lg.file.fileno() == fd for lg in loggers)
 
-    With the **old** implementation every call to `log()` did its own
-    `open(..., "a")`, so the test reproducibly hit the limit and failed.
-    """
-    # Save & reduce the soft limit for the duration of the test
-    soft_orig, hard_orig = resource.getrlimit(resource.RLIMIT_NOFILE)
-    soft_test = 32  # small number that we will overflow without the fix
-    resource.setrlimit(resource.RLIMIT_NOFILE, (soft_test, hard_orig))
+    first.log("one")
+
+    # close once per acquisition ➜ final close closes fd
+    for _ in range(n):
+        first.close()
+    assert first.file.closed
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="posix only")
+def test_fd_limit(tmp_path: Path) -> None:
+    import resource  # type: ignore
+
+    soft0, hard0 = resource.getrlimit(resource.RLIMIT_NOFILE)
+    resource.setrlimit(resource.RLIMIT_NOFILE, (32, hard0))
 
     try:
-        log_file = str(tmp_path / "shared.log")
-        threads: List[threading.Thread] = []
-        errors: List[BaseException] = []
-        starter = threading.Event()
-
-        for _ in range(64):  # > soft_test to trigger exhaustion without fix
-            t = threading.Thread(
-                target=_stress_writer,
-                args=(starter, errors, log_file),
-                daemon=True,
-            )
-            threads.append(t)
+        path = str(tmp_path / "stress.log")
+        errs: list[BaseException] = []
+        start = threading.Event()
+        ths = [
+            threading.Thread(target=_stress, args=(start, errs, path), daemon=True)
+            for _ in range(64)
+        ]
+        for t in ths:
             t.start()
-
-        starter.set()  # let all threads proceed together
-
-        for t in threads:
+        start.set()
+        for t in ths:
             t.join()
-
-        if errors:
-            # Show first error to aid debugging
-            raise AssertionError(f"Errors occurred: {errors[0]!r}") from errors[0]
-
-        # Additionally ensure the logger left no open fd when closed
-        RichFileLogger(log_file, append=True, color=False).close()
-        assert log_file not in RichFileLogger._instances  # type: ignore[attr-defined]
+        if errs:
+            raise AssertionError(f"Error: {errs[0]!r}") from errs[0]
     finally:
-        # Restore original limits to avoid side effects on other tests
-        resource.setrlimit(resource.RLIMIT_NOFILE, (soft_orig, hard_orig))
+        resource.setrlimit(resource.RLIMIT_NOFILE, (soft0, hard0))

--- a/tests/main/test_rich_file_logger.py
+++ b/tests/main/test_rich_file_logger.py
@@ -1,0 +1,121 @@
+"""Regression-test for the shared-FD RichFileLogger implementation."""
+
+from __future__ import annotations
+
+import resource  # noqa: E402  pylint: disable=wrong-import-position
+import sys
+import threading
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from langroid.utils.logging import RichFileLogger
+
+
+def _create_many(log_path: str, n: int = 20) -> List[RichFileLogger]:
+    """Return `n` RichFileLogger instances that target the same file."""
+    return [RichFileLogger(log_path, append=True, color=False) for _ in range(n)]
+
+
+@pytest.mark.parametrize("n_loggers", [1, 5, 20])
+def test_single_fd_reused(tmp_path: Path, n_loggers: int) -> None:
+    """
+    Ensure that all RichFileLogger instances writing to the same file
+    share ONE open file descriptor, and that `.close()` frees it.
+    """
+    file_path = tmp_path / "shared.log"
+    loggers = _create_many(str(file_path), n=n_loggers)
+
+    # All instances must be the very same object (singleton per file)
+    first = loggers[0]
+    assert all(inst is first for inst in loggers)
+
+    # They must have the exact same underlying fd
+    first_fd = first.file.fileno()
+    assert all(inst.file.fileno() == first_fd for inst in loggers)
+
+    # Write something; should not raise
+    first.log("hi")
+
+    # Closing once must mark the fd closed and remove the instance
+    first.close()
+    assert first.file.closed
+    assert str(file_path) not in RichFileLogger._instances
+
+    # Creating again after close should yield a fresh instance + fd
+    fresh = RichFileLogger(str(file_path), append=True, color=False)
+    assert fresh is not first
+    assert not fresh.file.closed
+    fresh.close()
+
+
+# Linux/mac only – `resource` is not available on Windows.
+
+
+def _stress_writer(
+    start: threading.Event,
+    errors: List[BaseException],
+    log_path: str,
+) -> None:
+    """Wait for the `start` event then write to the shared logger many times."""
+    start.wait()
+    try:
+        logger = RichFileLogger(log_path, append=True, color=False)
+        for _ in range(50):
+            logger.log("hello")
+    except BaseException as exc:  # want to catch the OSError 24
+        errors.append(exc)
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="resource.RLIMIT_NOFILE is POSIX only",
+)
+def test_rich_file_logger_does_not_exhaust_fd(tmp_path: Path) -> None:
+    """
+    Regression-test for issue “Too many open files”.
+
+    We artificially lower the soft RLIMIT_NOFILE to a small number, then start
+    many threads that *simultaneously* write to the same `RichFileLogger`.
+    With the **fixed** implementation only ONE file descriptor is ever open,
+    so no thread raises `OSError: [Errno 24] Too many open files`.
+
+    With the **old** implementation every call to `log()` did its own
+    `open(..., "a")`, so the test reproducibly hit the limit and failed.
+    """
+    # Save & reduce the soft limit for the duration of the test
+    soft_orig, hard_orig = resource.getrlimit(resource.RLIMIT_NOFILE)
+    soft_test = 32  # small number that we will overflow without the fix
+    resource.setrlimit(resource.RLIMIT_NOFILE, (soft_test, hard_orig))
+
+    try:
+        log_file = str(tmp_path / "shared.log")
+        threads: List[threading.Thread] = []
+        errors: List[BaseException] = []
+        starter = threading.Event()
+
+        for _ in range(64):  # > soft_test to trigger exhaustion without fix
+            t = threading.Thread(
+                target=_stress_writer,
+                args=(starter, errors, log_file),
+                daemon=True,
+            )
+            threads.append(t)
+            t.start()
+
+        starter.set()  # let all threads proceed together
+
+        for t in threads:
+            t.join()
+
+        if errors:
+            # Show first error to aid debugging
+            raise AssertionError(f"Errors occurred: {errors[0]!r}") from errors[0]
+
+        # Additionally ensure the logger left no open fd when closed
+        RichFileLogger(log_file, append=True, color=False).close()
+        assert log_file not in RichFileLogger._instances  # type: ignore[attr-defined]
+    finally:
+        # Restore original limits to avoid side effects on other tests
+        resource.setrlimit(resource.RLIMIT_NOFILE, (soft_orig, hard_orig))


### PR DESCRIPTION
• Re-implemented `RichFileLogger`
  – singleton per log-file, reference-counted, thread-safe  
  – only one file descriptor is kept open for each *.log* file  
  – no risk of “Too many open files”; writes are serialised; fd is closed
   automatically when the process ends

• Removed explicit logger‐close in `Task._post_run_loop` to avoid writes on a
  closed file by concurrent subtasks.

• Added pytest regression suite:  
  – verifies singleton/FD sharing  
  – stress-test under artificially low `RLIMIT_NOFILE` reproduces former crash;
    now passes.

No breaking API changes.