### PR TITLE
feat: Add enable_loggers flag to TaskConfig for optional logger creation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.11.13
+  rev: v0.12.0
   hooks:
     - id: ruff

--- a/docs/notes/task-termination.md
+++ b/docs/notes/task-termination.md
@@ -82,6 +82,7 @@ agent.enable_message(DoneTool)
 The `done_sequences` feature allows you to specify sequences of events that trigger task completion. This provides fine-grained control over task termination based on conversation patterns.
 
 **Key Features:**
+
 - Specify multiple termination sequences
 - Use convenient DSL syntax or full object syntax
 - Strict consecutive matching (no skipping events)
@@ -119,6 +120,7 @@ task = Task(agent, config=config)
 | `C[pattern]` | Content matching regex | `CONTENT_MATCH` |
 
 **Examples:**
+
 - `"T, A"` - Any tool followed by agent handling
 - `"T[search], A, T[calculator], A"` - Search tool, then calculator tool
 - `"L, C[complete|done|finished]"` - LLM response containing completion words
@@ -252,6 +254,7 @@ Events must occur consecutively without intervening messages:
 ```
 
 ### Performance
+
 - Efficient O(n) traversal where n is sequence length
 - No full history scan needed
 - Early termination on first matching sequence
@@ -343,15 +346,18 @@ task = Task(agent, config=config)  # No subclassing needed
 ## Troubleshooting
 
 **Sequence not matching?**
+
 - Check that events are truly consecutive (no intervening messages)
 - Use logging to see the actual message chain
 - Verify tool names match exactly
 
 **Type errors with DSL?**
+
 - Ensure you're using strings for DSL patterns
 - Check that tool names in `T[name]` don't contain special characters
 
 **Performance concerns?**
+
 - Sequences only traverse as deep as needed
 - Consider shorter sequences for better performance
 - Use specific tool names to avoid unnecessary checks

--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -153,6 +153,7 @@ class TaskConfig(BaseModel):
     inf_loop_wait_factor: int = 5
     restart_as_subtask: bool = False
     logs_dir: str = "logs"
+    enable_loggers: bool = True
     addressing_prefix: str = ""
     allow_subtask_multi_oai_tools: bool = True
     recognize_string_signals: bool = True
@@ -633,6 +634,9 @@ class Task:
     def init_loggers(self) -> None:
         """Initialise per-task Rich and TSV loggers."""
         from langroid.utils.logging import RichFileLogger
+
+        if not self.config.enable_loggers:
+            return
 
         if self.caller is not None and self.caller.logger is not None:
             self.logger = self.caller.logger

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,7 +109,7 @@ nav:
       - Large Tool Results: notes/large-tool-results.md
       - GLHF.chat Support: notes/glhf-chat.md
       - Structured Output: notes/structured-output.md
-      - Tool Handler Name: notes/tool-message-handler.md
+      - Tool Handlers: notes/tool-message-handler.md
       - Task Termination: notes/task-termination.md
       - Llama.cpp Embeddings: notes/llama-cpp-embeddings.md
       - Azure OpenAI models: notes/azure-openai-models.md

--- a/tests/main/test_task_optional_logger.py
+++ b/tests/main/test_task_optional_logger.py
@@ -1,0 +1,88 @@
+"""Test optional logger functionality in Task."""
+
+from pathlib import Path
+
+import pytest
+
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.agent.chat_document import ChatDocMetaData, ChatDocument
+from langroid.agent.task import Task, TaskConfig
+from langroid.language_models.mock_lm import MockLMConfig
+from langroid.mytypes import Entity
+
+
+def test_task_default_loggers_enabled() -> None:
+    """Test that loggers are created by default."""
+    # Create a simple mock agent
+    llm_config = MockLMConfig(response_dict={"user": "Hello from test!"})
+    agent_config = ChatAgentConfig(llm=llm_config, name="TestAgent")
+    agent = ChatAgent(agent_config)
+
+    # Default behavior - loggers should be created
+    task_config = TaskConfig(logs_dir="test_logs")
+    task = Task(agent, name="task_with_loggers", config=task_config)
+
+    # Initialize the task to trigger logger creation
+    task.init()
+
+    # Check if loggers were created
+    assert task.logger is not None
+    assert task.tsv_logger is not None
+
+    # Clean up log files
+    log_path = Path("test_logs/task_with_loggers.log")
+    tsv_path = Path("test_logs/task_with_loggers.tsv")
+    if log_path.exists():
+        log_path.unlink()
+    if tsv_path.exists():
+        tsv_path.unlink()
+
+    # Clean up test_logs directory if empty
+    test_logs_dir = Path("test_logs")
+    if test_logs_dir.exists() and not any(test_logs_dir.iterdir()):
+        test_logs_dir.rmdir()
+
+
+def test_task_loggers_disabled() -> None:
+    """Test that loggers are not created when enable_loggers=False."""
+    # Create a simple mock agent
+    llm_config = MockLMConfig(response_dict={"user": "Hello from test!"})
+    agent_config = ChatAgentConfig(llm=llm_config, name="TestAgent")
+    agent = ChatAgent(agent_config)
+
+    # With loggers disabled
+    task_config = TaskConfig(logs_dir="test_logs", enable_loggers=False)
+    task = Task(agent, name="task_without_loggers", config=task_config)
+
+    # Initialize the task - loggers should NOT be created
+    task.init()
+
+    # Check if loggers were NOT created
+    assert task.logger is None
+    assert task.tsv_logger is None
+
+
+def test_log_message_with_none_loggers() -> None:
+    """Test that log_message handles None loggers gracefully."""
+    # Create a simple mock agent
+    llm_config = MockLMConfig(response_dict={"user": "Hello from test!"})
+    agent_config = ChatAgentConfig(llm=llm_config, name="TestAgent")
+    agent = ChatAgent(agent_config)
+
+    # With loggers disabled
+    task_config = TaskConfig(logs_dir="test_logs", enable_loggers=False)
+    task = Task(agent, name="task_without_loggers", config=task_config)
+
+    # Initialize the task
+    task.init()
+
+    # Create a test message
+    msg = ChatDocument(
+        content="Test message", metadata=ChatDocMetaData(sender=Entity.USER)
+    )
+
+    # This should not raise any exceptions
+    task.log_message(Entity.USER, msg)
+
+    # If we get here without exception, the test passes
+    assert True

--- a/uv.lock
+++ b/uv.lock
@@ -2790,7 +2790,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2
 
 [[package]]
 name = "langroid"
-version = "0.54.2"
+version = "0.55.0"
 source = { editable = "." }
 dependencies = [
     { name = "adb-cloud-connector" },


### PR DESCRIPTION
## Summary
- Added `enable_loggers: bool = True` field to TaskConfig to allow disabling automatic logger creation
- Modified init_loggers() to check the flag before creating RichFileLogger and TsvLogger
- Maintains backward compatibility (loggers created by default)

## Motivation
Fixes #865 - Users previously had to create "noop" logger classes to disable logging, which was hacky and inefficient. This provides a clean way to opt out of automatic logger creation.

## Changes
1. Added `enable_loggers` field to TaskConfig with default value `True`
2. Modified `init_loggers()` to return early when `enable_loggers=False`
3. Added comprehensive tests to verify the feature works correctly

## Test plan
- [x] Added pytest tests in `tests/main/test_task_optional_logger.py`
- [x] Tests verify loggers are created by default (backward compatibility)
- [x] Tests verify loggers are not created when flag is False
- [x] Tests verify log_message handles None loggers gracefully
- [x] All tests pass