### PR TITLE
feat: Add TaskTool for delegating tasks to sub-agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+**/*.venv
 env/
 venv/
 ENV/

--- a/docs/notes/task-tool.md
+++ b/docs/notes/task-tool.md
@@ -1,0 +1,98 @@
+# TaskTool: Spawning Sub-Agents for Task Delegation
+
+## Overview
+
+`TaskTool` allows agents to **spawn sub-agents** to handle specific tasks. When an agent encounters a task that requires specialized tools or isolated execution, it can spawn a new sub-agent with exactly the capabilities needed for that task.
+
+This enables agents to dynamically create a hierarchy of specialized workers, each focused on their specific subtask with only the tools they need.
+
+## When to Use TaskTool
+
+TaskTool is useful when:
+- Different parts of a task require different specialized tools
+- You want to isolate tool access for specific operations  
+- A task involves recursive or nested operations
+- You need different LLM models for different subtasks
+
+## How It Works
+
+1. The parent agent decides to spawn a sub-agent and specifies:
+   - A system message defining the sub-agent's role
+   - A prompt for the sub-agent to process
+   - Which tools the sub-agent should have access to
+   - Optional model and iteration limits
+
+2. TaskTool spawns the new sub-agent, runs the task, and returns the result to the parent.
+
+## Usage Example
+
+```python
+from langroid.agent.tools.task_tool import TaskTool
+
+# Enable TaskTool for your agent
+agent.enable_message([TaskTool, YourCustomTool], use=True, handle=True)
+
+# Agent can now spawn sub-agents for tasks
+response = {
+    "request": "task_tool",
+    "system_message": "You are a calculator. Use the multiply_tool to compute products.",
+    "prompt": "Calculate 5 * 7",
+    "tools": ["multiply_tool"],
+    "model": "gpt-4o-mini",  # optional
+    "max_iterations": 5       # optional
+}
+```
+
+## Field Reference
+
+**Required fields:**
+- `system_message`: Instructions for the sub-agent's role and behavior
+- `prompt`: The specific task/question for the sub-agent
+- `tools`: List of tool names. Special values: `["ALL"]` or `["NONE"]`
+
+**Optional fields:**
+- `model`: LLM model name (default: "gpt-4o-mini")
+- `max_iterations`: Task iteration limit (default: 10)
+
+## Example: Nested Operations
+
+Consider computing `Nebrowski(10, Nebrowski(3, 2))` where Nebrowski is a custom operation. The main agent spawns sub-agents to handle each operation:
+
+```python
+# Main agent spawns first sub-agent for inner operation:
+{
+    "request": "task_tool",
+    "system_message": "Compute Nebrowski operations using the nebrowski_tool.",
+    "prompt": "Compute Nebrowski(3, 2)",
+    "tools": ["nebrowski_tool"]
+}
+
+# Then spawns another sub-agent for outer operation:
+{
+    "request": "task_tool",
+    "system_message": "Compute Nebrowski operations using the nebrowski_tool.",
+    "prompt": "Compute Nebrowski(10, 11)",  # where 11 is the previous result
+    "tools": ["nebrowski_tool"]
+}
+```
+
+## Working Examples
+
+See [`tests/main/test_task_tool.py`](https://github.com/langroid/langroid/blob/main/tests/main/test_task_tool.py) for complete examples including:
+- Basic task delegation with mock agents
+- Nested operations with custom tools
+- Real LLM usage patterns
+
+## Important Notes
+
+- Spawned sub-agents run non-interactively (no human input)
+- `DoneTool` is automatically enabled for all sub-agents
+- Only tools known to the parent agent can be delegated
+- Results are returned as `ChatDocument` objects
+
+## Best Practices
+
+1. **Clear Instructions**: Provide specific system messages that explain the sub-agent's role and tool usage
+2. **Tool Availability**: Ensure delegated tools are enabled for the parent agent
+3. **Appropriate Models**: Use simpler/faster models for simple subtasks
+4. **Iteration Limits**: Set reasonable limits based on task complexity

--- a/examples/basic/done_sequences_example.py
+++ b/examples/basic/done_sequences_example.py
@@ -23,7 +23,6 @@ chain without intervening messages. This ensures predictable behavior and effici
 matching.
 """
 
-import langroid as lr
 from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
 from langroid.agent.task import (
     AgentEvent,
@@ -86,12 +85,12 @@ def example0_dsl_syntax():
         ]
     )
 
-    task = Task(agent, config=config)
+    _ = Task(agent, config=config)
     print("Task configured with multiple DSL patterns.")
     print(
         "Will complete on any of: tool use, calculator use, quit words, or L->T->A->L sequence"
     )
-    # result = task.run("What is 25 * 4?")
+    # _ = task.run("What is 25 * 4?")
     # print(f"Final result: {result.content}")
 
 
@@ -130,8 +129,8 @@ def example1_tool_then_agent():
 
     task = Task(agent, config=config)
     print("Task will complete after any tool is used and handled.")
-    result = task.run("What is 25 * 4?")
-    print(f"Final result: {result.content}")
+    _ = task.run("What is 25 * 4?")
+    # print(f"Final result: {_.content}")
 
 
 def example2_specific_tool_sequence():
@@ -169,7 +168,7 @@ def example2_specific_tool_sequence():
     print("Task will complete only after calculator tool is used.")
     print("Try: 'Search for Python tutorials' (won't complete task)")
     print("Then try: 'Calculate 15 + 27' (will complete task)")
-    result = task.run()
+    _ = task.run()
 
 
 def example3_conversation_pattern():
@@ -206,7 +205,7 @@ def example3_conversation_pattern():
 
     task = Task(agent, config=config)
     print("Task will complete after: acknowledgment -> tool use -> handling -> summary")
-    result = task.run(
+    _ = task.run(
         "I need to calculate the area of a rectangle with width 12 and height 8"
     )
 
@@ -269,7 +268,7 @@ def example4_multiple_completion_paths():
     print("1. Say 'quit' or 'exit'")
     print("2. Use the calculator tool")
     print("3. Use the search tool twice")
-    result = task.run()
+    _ = task.run()
 
 
 def example5_combining_with_existing_options():
@@ -302,7 +301,7 @@ def example5_combining_with_existing_options():
 
     task = Task(agent, config=config)
     print("Task will complete as soon as any tool is generated (done_if_tool=True)")
-    result = task.run("Calculate 5 + 5")
+    _ = task.run("Calculate 5 + 5")
 
 
 if __name__ == "__main__":

--- a/langroid/agent/chat_document.py
+++ b/langroid/agent/chat_document.py
@@ -268,7 +268,7 @@ class ChatDocument(Document):
     @staticmethod
     def _clean_fn_call(fc: LLMFunctionCall | None) -> None:
         # Sometimes an OpenAI LLM (esp gpt-4o) may generate a function-call
-        # with odditities:
+        # with oddities:
         # (a) the `name` is set, as well as `arguments.request` is set,
         #  and in langroid we use the `request` value as the `name`.
         #  In this case we override the `name` with the `request` value.

--- a/langroid/agent/done_sequence_parser.py
+++ b/langroid/agent/done_sequence_parser.py
@@ -13,8 +13,6 @@ Examples:
 import re
 from typing import List, Union
 
-from langroid.pydantic_v1 import BaseModel
-
 from .task import AgentEvent, DoneSequence, EventType
 
 

--- a/langroid/agent/tools/agent_tool.py
+++ b/langroid/agent/tools/agent_tool.py
@@ -1,0 +1,148 @@
+"""
+AgentTool: A tool that allows agents to spawn sub-agents with specific tools enabled.
+"""
+
+from typing import List, Optional
+
+import langroid.language_models as lm
+from langroid import ChatDocument
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.agent.task import Task
+from langroid.agent.tool_message import ToolMessage
+from langroid.agent.tools.orchestration import DoneTool
+from langroid.pydantic_v1 import Field
+
+
+class AgentTool(ToolMessage):
+    """
+    Tool that spawns a sub-agent with specified tools to handle a task.
+    """
+
+    request: str = "agent_tool"
+    purpose: str = """
+        <HowToUse>
+        Use this tool to delegate a task to a sub-agent with specific tools enabled.
+        The sub-agent will be created with the specified tools and will run the task
+        non-interactively. Here is how to set the fields:
+        
+        - `system_message`: 
+        
+
+    """
+
+    # Parameters for the agent tool
+
+    system_message: Optional[str] = Field(
+        ...,
+        description="""
+        Optional system message to configure the sub-agent's general behavior.
+            A good system message will have these components:
+            - Inform the sub-agent of its role, e.g. "You are a financial analyst."
+            - Clear spec of the task
+            - Any additional general context needed for the task, such as a
+              (part of a) document, or data items, etc.
+            - Specify when to use certain tools, e.g. 
+                "You MUST use the 'stock_data' tool to extract stock information.
+        """,
+    )
+
+    prompt: str = Field(
+        ...,
+        description="""
+            The prompt to run the sub-agent with. This differs from the agent's
+            system message: Whereas the system message configures the sub-agent's
+            general role and task, the prompt is the specific input that the sub-agent
+            will process. In LLM terms, the system message is sent to the LLM as
+            the first message, with role = "system" or "developer", and 
+            the prompt is sent as a message with role = "user".
+            EXAMPLE: system_message = "You are a financial analyst, when the 
+                user asks about the share-price of a company, 
+                you must use your tools to do the research, and 
+                return the final answer to the user."
+            
+            prompt = "What is the share-price of Apple Inc.?"
+            """,
+    )
+
+    tools: List[str] = Field(
+        ...,
+        description="""
+        A list of tool names to enable for the sub-agent.
+        This must be a list of strings referring to the names of tools
+        that are known to you. 
+        If you want to enable all tools, you can set this field
+         to a singleton list containing 'ALL'
+        To disable all tools, set it to a singleton list containing 'NONE'
+        """,
+    )
+    model: str = Field(
+        default=None,
+        description="""
+            Optional name of the LLM model to use for the sub-agent, e.g. 'gpt-4.1'
+            If omitted, the sub-agent will use the same model as yours.
+            """,
+    )
+    max_iterations: Optional[int] = Field(
+        default=None,
+        description="Optional max iterations for the sub-agent to run the task",
+    )
+
+    def handle(self, agent: ChatAgent) -> Optional[ChatDocument]:
+        """
+        Handle the AgentTool by creating a sub-agent with specified tools
+        and running the task non-interactively.
+
+        Args:
+            agent: The parent ChatAgent that is handling this tool
+        """
+        # Create chat agent config with system message if provided
+        # TODO: Maybe we just copy the parent agent's config and override chat_model?
+        #   -- but what if parent agent has a MockLMConfig?
+        llm_config = lm.OpenAIGPTConfig(
+            chat_model=self.model or "gpt-4.1-mini",  # Default model if not specified
+        )
+        config = ChatAgentConfig(
+            llm=llm_config,
+            system_message=f"""
+                {self.system_message}
+                
+                When you are finished with your task, you MUST
+                use the TOOL `{DoneTool.name()}` to end the task
+                and return the result.                
+            """,
+        )
+
+        # Create the sub-agent
+        sub_agent = ChatAgent(config)
+
+        # Enable the specified tools for the sub-agent
+        # Convert tool names to actual tool classes using parent agent's tools_map
+        if self.tools == ["ALL"]:
+            # Enable all tools from the parent agent:
+            # This is the list of all tools KNOWN (whether usable or handle-able or not)
+            tool_classes = [
+                agent.llm_tools_map[t]
+                for t in agent.llm_tools_known
+                if t in agent.llm_tools_map and t != self.request
+                # Exclude the AgentTool itself!
+            ]
+        elif self.tools == ["NONE"]:
+            # No tools enabled
+            tool_classes = []
+        else:
+            # Enable only specified tools
+            tool_classes = [
+                agent.llm_tools_map[tool_name]
+                for tool_name in self.tools
+                if tool_name in agent.llm_tools_map
+            ]
+
+        # always enable the DoneTool to signal task completion
+        sub_agent.enable_message(tool_classes + [DoneTool], use=True, handle=True)
+
+        # Create a non-interactive task
+        task = Task(sub_agent, interactive=False)
+
+        # Run the task on the prompt, and return the result
+        result = task.run(self.prompt, turns=self.max_iterations or 10)
+        return result

--- a/langroid/agent/tools/task_tool.py
+++ b/langroid/agent/tools/task_tool.py
@@ -1,5 +1,6 @@
 """
-AgentTool: A tool that allows agents to spawn sub-agents with specific tools enabled.
+TaskTool: A tool that allows agents to delegate a task to a sub-agent with
+    specific tools enabled.
 """
 
 from typing import List, Optional
@@ -13,12 +14,12 @@ from langroid.agent.tools.orchestration import DoneTool
 from langroid.pydantic_v1 import Field
 
 
-class AgentTool(ToolMessage):
+class TaskTool(ToolMessage):
     """
     Tool that spawns a sub-agent with specified tools to handle a task.
     """
 
-    request: str = "agent_tool"
+    request: str = "task_tool"
     purpose: str = """
         <HowToUse>
         Use this tool to delegate a task to a sub-agent with specific tools enabled.
@@ -51,9 +52,9 @@ class AgentTool(ToolMessage):
         description="""
             The prompt to run the sub-agent with. This differs from the agent's
             system message: Whereas the system message configures the sub-agent's
-            general role and task, the prompt is the specific input that the sub-agent
-            will process. In LLM terms, the system message is sent to the LLM as
-            the first message, with role = "system" or "developer", and 
+            GENERAL role and goals, the `prompt` is the SPECIFIC input that the 
+            sub-agent will process. In LLM terms, the system message is sent to the 
+            LLM as the first message, with role = "system" or "developer", and 
             the prompt is sent as a message with role = "user".
             EXAMPLE: system_message = "You are a financial analyst, when the 
                 user asks about the share-price of a company, 
@@ -89,7 +90,7 @@ class AgentTool(ToolMessage):
 
     def handle(self, agent: ChatAgent) -> Optional[ChatDocument]:
         """
-        Handle the AgentTool by creating a sub-agent with specified tools
+        Handle the TaskTool by creating a sub-agent with specified tools
         and running the task non-interactively.
 
         Args:
@@ -124,7 +125,7 @@ class AgentTool(ToolMessage):
                 agent.llm_tools_map[t]
                 for t in agent.llm_tools_known
                 if t in agent.llm_tools_map and t != self.request
-                # Exclude the AgentTool itself!
+                # Exclude the TaskTool itself!
             ]
         elif self.tools == ["NONE"]:
             # No tools enabled

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
       - Image, PDF Input: notes/file-input.md
       - MCP Tools: notes/mcp-tools.md
       - Code-Injection Protection: notes/code-injection-protection.md
+      - TaskTool: notes/task-tool.md
 
   - Examples:
     - Guide: examples/guide.md

--- a/scripts/fix-pydantic-imports.sh
+++ b/scripts/fix-pydantic-imports.sh
@@ -14,8 +14,8 @@ directories=("langroid" "examples" "tests")
 
 # Function to perform replacements and log changes
 replace_and_log() {
-    # Use find to locate all .py files in the specified directories
-    find "${directories[@]}" -type f -name '*.py' | while read -r file; do
+    # Use find to locate all .py files in the specified directories, excluding .venv directories
+    find "${directories[@]}" -type f -name '*.py' -not -path '*/.venv/*' | while read -r file; do
         # Check and replace lines starting with specific patterns
         if grep -q '^from pydantic ' "$file" && grep -v '# keep' "$file" | grep -q '^from pydantic '; then
             sed -i'' -e  '/^from pydantic .*# keep/!s/^from pydantic /from langroid.pydantic_v1 /' "$file"

--- a/tests/main/test_done_sequences.py
+++ b/tests/main/test_done_sequences.py
@@ -2,10 +2,7 @@
 Tests for the done_sequences feature in Task.
 """
 
-import pytest
-
 from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
-from langroid.agent.chat_document import ChatDocument
 from langroid.agent.task import (
     AgentEvent,
     DoneSequence,
@@ -15,7 +12,6 @@ from langroid.agent.task import (
 )
 from langroid.agent.tool_message import ToolMessage
 from langroid.language_models.mock_lm import MockLMConfig
-from langroid.mytypes import Entity
 from langroid.utils.configuration import Settings, set_global
 
 

--- a/tests/main/test_done_sequences_dsl.py
+++ b/tests/main/test_done_sequences_dsl.py
@@ -1,7 +1,5 @@
 """Tests for done sequences DSL integration with Task."""
 
-import pytest
-
 from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
 from langroid.agent.task import Task, TaskConfig
 from langroid.agent.tool_message import ToolMessage

--- a/tests/main/test_task.py
+++ b/tests/main/test_task.py
@@ -995,6 +995,7 @@ async def test_task_output_format_sequence_async():
     for x in range(5):
         await test_sequence(x)
 
+
 def test_done_if_tool(test_settings: Settings):
     """Test that task terminates when LLM generates a tool and done_if_tool=True"""
 

--- a/tests/main/test_task_optional_logger.py
+++ b/tests/main/test_task_optional_logger.py
@@ -2,8 +2,6 @@
 
 from pathlib import Path
 
-import pytest
-
 from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
 from langroid.agent.chat_document import ChatDocMetaData, ChatDocument
 from langroid.agent.task import Task, TaskConfig

--- a/tests/main/test_task_tool.py
+++ b/tests/main/test_task_tool.py
@@ -1,0 +1,151 @@
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.agent.task import Task, TaskConfig
+from langroid.agent.tool_message import ToolMessage
+from langroid.agent.tools.orchestration import DoneTool
+from langroid.agent.tools.task_tool import TaskTool
+from langroid.language_models.mock_lm import MockLMConfig
+from langroid.language_models.openai_gpt import OpenAIGPTConfig
+
+
+class MultiplierTool(ToolMessage):
+    """A simple calculator tool for testing."""
+
+    request: str = "multiplier_tool"
+    purpose: str = "To calculate the product of two numbers."
+    a: int
+    b: int
+
+    def handle(self) -> str:
+        return self.a * self.b
+
+
+def test_task_tool_mock_main_agent():
+    """
+    Test that when MockAgent uses TaskTool, it  properly spawns a sub-agent
+    that can use tools and complete tasks.
+    """
+
+    # Configure the main agent to use TaskTool:
+    # The MockLM has a fixed response, which is the TaskTool request
+    main_config = ChatAgentConfig(
+        llm=MockLMConfig(
+            default_response=TaskTool(
+                system_message=f"""
+                    You are a calculator assistant. When asked to 
+                    calculate, use the TOOL `{MultiplierTool.name()}` to multiply the 
+                    numbers, then use the TOOL `{DoneTool.name()}` to return the result
+                    """,
+                prompt="Multiply 5 and 7",
+                model="gpt-4.1-mini",
+                tools=["multiplier_tool"],
+                max_iterations=5,
+            ).json()
+        ),
+        name="MainAgent",
+    )
+    main_agent = ChatAgent(main_config)
+
+    # Enable TaskTool and MultiplierTool for the main agent.
+    # The MultiplierTool must be enabled for the main agent,
+    # since the TaskTool handler will create a sub-agent that uses it,
+    # and the handler only has access to tools enabled for the main agent.
+    main_agent.enable_message([TaskTool, MultiplierTool], use=True, handle=True)
+
+    # Create main task that stops after handling the task_tool
+    task = Task(
+        main_agent,
+        name="MainTask",
+        interactive=False,
+        config=TaskConfig(
+            done_sequences=["T,A"],  # LLM (Tool (TaskTool)), Agent(Handled) -> done
+        ),
+    )
+
+    # Run the task
+    result = task.run(msg="Please calculate something")
+
+    # The result should be from the sub-agent's execution
+    assert result is not None, "Task should return a result"
+    assert "35" in result.content, "Result should contain the multiplication result"
+
+
+class NebrowskiTool(ToolMessage):
+    """A tool that computes the exotic Nebrowski operation."""
+
+    request: str = "nebrowski_tool"
+    purpose: str = """
+        To compute the Nebrowski operation of two numbers: 
+        neb(a,b) = 3a + b
+    """
+    a: int
+    b: int
+
+    def handle(self) -> str:
+        # The Nebrowski operation: 3a + b
+        result = 3 * self.a + self.b
+        return f"Nebrowski({self.a}, {self.b}) = {result}"
+
+
+def test_task_tool_real_llm_nebrowski():
+    """
+    Test that a real LLM agent can compute nested Nebrowski operations
+    by using TaskTool to delegate each Nebrowski computation to sub-agents.
+    """
+
+    # Configure the main agent with a real LLM
+    main_config = ChatAgentConfig(
+        llm=OpenAIGPTConfig(),  # Uses default model
+        handle_llm_no_tool="you forgot to use one of your TOOLs!",
+        system_message=f"""
+        You are a Nebrowski operation specialist. The Nebrowski operation is an exotic 
+        mathematical function that takes two numbers and produces a result.
+        BUT you do NOT know how to compute it yourself!
+        
+        When the user asks you to compute nested Nebrowski operations like 
+        Nebrowski(a, Nebrowski(b, c)), you MUST:
+        
+        1. Break it down into individual Nebrowski operations
+        2. Use the TOOL `{TaskTool.name()}` to delegate each Nebrowski 
+            operation to a sub-agent
+        3. The sub-agent knows how to use the `{NebrowskiTool.name()}` tool
+        
+        For example, to compute Nebrowski(10, Nebrowski(3, 2)):
+        - First compute inner: Nebrowski(3, 2) = result1 (using TaskTool)
+        - Then compute outer: Nebrowski(10, result1) (using TaskTool)
+        - Return the final result
+        
+        IMPORTANT: You must use TaskTool for EACH Nebrowski operation.
+        Configure the TaskTool with:
+        - system_message: Instructions for the sub-agent to compute Nebrowski
+        - prompt: The specific Nebrowski task (e.g., "Compute Nebrowski(3, 2)")
+        - tools: ["nebrowski_tool"]
+        - model: "gpt-4o-mini"
+        
+        Remember: You cannot compute Nebrowski operations yourself - you must 
+        delegate to sub-agents!
+        
+        You MUST use the TOOL `{DoneTool.name()}` to return the final result!
+        """,
+        name="NebrowskiAgent",
+    )
+    main_agent = ChatAgent(main_config)
+
+    # Enable TaskTool and NebrowskiTool
+    main_agent.enable_message(
+        [DoneTool, TaskTool, NebrowskiTool], use=True, handle=True
+    )
+
+    # Create task with appropriate configuration
+    task = Task(
+        main_agent,
+        name="NebrowskiTask",
+        interactive=False,
+    )
+
+    # Run the task - compute Nebrowski(10, Nebrowski(3, 2))
+    # Expected: Nebrowski(3, 2) = 11, then Nebrowski(10, 25) = 41
+    result = task.run("Compute Nebrowski(10, Nebrowski(3, 2))", turns=15)
+
+    # Verify the result
+    assert result is not None, "Task should return a result"
+    assert "41" in result.content, "Result should contain the final Nebrowski result"

--- a/uv.lock
+++ b/uv.lock
@@ -2790,7 +2790,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2
 
 [[package]]
 name = "langroid"
-version = "0.55.0"
+version = "0.55.1"
 source = { editable = "." }
 dependencies = [
     { name = "adb-cloud-connector" },


### PR DESCRIPTION
## Summary
- Introduces `TaskTool`, a new tool that allows agents to delegate tasks to sub-agents with specific tools enabled
- Enables hierarchical task decomposition and specialized agent collaboration
- Provides a clean abstraction for complex multi-step workflows

## Motivation
Many complex tasks benefit from being broken down into subtasks handled by specialized agents. TaskTool provides a structured way for agents to:
- Delegate specific operations they cannot perform themselves
- Create sub-agents with only the tools needed for a specific task
- Maintain clear separation of concerns in multi-agent systems

## Implementation Details
- `TaskTool` accepts a system message, prompt, list of tools, and optional configuration
- Creates a sub-agent with the specified tools enabled
- Runs the task non-interactively and returns the result to the parent agent
- Automatically enables `DoneTool` for sub-agents to signal task completion

## Test Plan
The PR includes comprehensive tests demonstrating:
1. **Mock agent test**: Verifies basic functionality with a calculator example
2. **Nebrowski operation test**: Shows nested task delegation with an exotic mathematical operation that requires specialized handling

## Example Usage
```python
# Agent delegates a complex calculation to a sub-agent
response = agent.llm_response("""
{
    "request": "task_tool",
    "system_message": "You are a calculator. Use the multiplier_tool to multiply numbers.",
    "prompt": "Calculate 5 * 7",
    "tools": ["multiplier_tool"],
    "max_iterations": 5
}
""")
```

## Future Enhancements
- Support for passing agent configuration from parent to child
- Ability to share context/memory between parent and sub-agents
- Support for asynchronous task delegation