### PR TITLE
feat: add AIML API provider

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -20,6 +20,7 @@ NEO4J_DATABASE=typically neo4j
 EXA_API_KEY=your-exa-search-key
 LANGDB_API_KEY=your-langdb-api-key
 LANGDB_PROJECT_ID=your-langdb-project-id
+AIML_API_KEY=your-aimlapi-api-key
 
 
 

--- a/docs/tutorials/llm-usage-options.md
+++ b/docs/tutorials/llm-usage-options.md
@@ -231,6 +231,7 @@ fact two possibilities here:
     - [groq](https://groq.com/) amazingly it is free, and you can run `llama-3.1-70b`
     - [cerebras](https://cerebras.ai/)
     - [open-router](https://openrouter.ai/)
+    - [AI/ML API](https://aimlapi.com/app/?utm_source=langroid&utm_medium=github&utm_campaign=integration)
 - The LLM is running on your computer. This is a good option if your machine has sufficient RAM to accommodate the LLM you are trying to run, and if you are 
 concerned about data privacy. The most user-friendly option is [Ollama](https://github.com/ollama/ollama); see more below.
 

--- a/docs/tutorials/local-llm-setup.md
+++ b/docs/tutorials/local-llm-setup.md
@@ -168,6 +168,33 @@ Besides using specific LLMs, OpenRouter also has smart routing/load-balancing.
 OpenRouter is also convenient for using proprietary LLMs (e.g. gemini, amazon) via 
 a single convenient API.
 
+## Custom LLMs via AI/ML API
+
+AI/ML API is a **flexible OpenAI-compatible platform** that supports over 300 models (e.g. DeepSeek, GPT-4o, Gemini, Claude, and more) with **enterprise-grade rate limits** and **global low-latency hosting**. See the [official model list](https://aimlapi.com/models?utm_source=langroid&utm_medium=github&utm_campaign=integration).
+
+Using it with Langroid is simple and similar to Groq or OpenRouter:
+
+* Set the `AIML_API_KEY` in your environment or `.env` file
+* Set `chat_model` in your `OpenAIGPTConfig` to `aimlapi/<model_name>`, for example:
+  `aimlapi/openai/gpt-4o-mini`, `aimlapi/google/gemini-2.5-flash`, or `aimlapi/anthropic/claude-sonnet-4.5`
+
+Optionally, set a custom `api_base`, if not using the default `https://api.aimlapi.com/v1`.
+
+This setup gives you access to powerful open and proprietary LLMs via a unified interface, ideal for:
+
+* avoiding per-provider account setup,
+* getting fast inference without local model deployment,
+* switching between models via a single flag.
+
+
+### 🔗 Website: [https://aimlapi.com/](https://aimlapi.com/app/?utm_source=langroid&utm_medium=github&utm_campaign=integration)
+
+### 🔗 Docs: [https://docs.aimlapi.com/](https://docs.aimlapi.com/?utm_source=langroid&utm_medium=github&utm_campaign=integration)
+
+---
+
+Если нужно, добавлю вариант с CLI запуском `run_api.py` как в твоём примере.
+
 ## "Local" LLMs hosted on GLHF.chat
 
 See [glhf.chat](https://glhf.chat/chat/create) for a list of available models.

--- a/docs/tutorials/non-openai-llms.md
+++ b/docs/tutorials/non-openai-llms.md
@@ -147,6 +147,36 @@ To use OpenRouter with Langroid:
 
 For more details, see the [Local LLM Setup guide](local-llm-setup.md#local-llms-available-on-openrouter).
 
+### AI/ML API
+
+[AI/ML API](https://aimlapi.com/app/?utm_source=langroid&utm_medium=github&utm_campaign=integration) provides access to over 300 models (e.g. DeepSeek, GPT-4o, Gemini, Claude) via an OpenAI-compatible API with smart routing, high rate limits, and low-latency global infrastructure.
+
+To use AI/ML API with Langroid:
+
+* Set up your `AIML_API_KEY` environment variable
+* Set `chat_model="aimlapi/<model_name>"` in the `OpenAIGPTConfig`, e.g.:
+
+  ```python
+  chat_model = "aimlapi/openai/gpt-4o-mini"
+  ```
+
+Optionally, you can also configure the API base:
+
+```python
+cfg = OpenAIGPTConfig(
+    chat_model="aimlapi/openai/gpt-4o-mini",
+    api_base="https://api.aimlapi.com/v1",
+    api_key=os.getenv("AIML_API_KEY")
+)
+```
+
+For more details and available models, see the:
+### 🧠 [Model List](https://aimlapi.com/models?utm_source=langroid&utm_medium=github&utm_campaign=integration)
+
+#### 📘 [Official AI/ML API Docs](https://docs.aimlapi.com/?utm_source=langroid&utm_medium=github&utm_campaign=integration)
+
+---
+
 ## Working with the created `OpenAIGPTConfig` object
 
 From here you can proceed as usual, creating instances of `OpenAIGPT`,
@@ -215,4 +245,3 @@ When the `--m` option is omitted, the default OpenAI GPT4 model is used.
 
 
 
-    

--- a/docs/tutorials/supported-models.md
+++ b/docs/tutorials/supported-models.md
@@ -57,6 +57,7 @@ and which environment variable to set for the API key.
 | MiniMax       | `minimax/MiniMax-M2.7`                                   | `MINIMAX_API_KEY` |
 | GLHF          | `glhf/hf:Qwen/Qwen2.5-Coder-32B-Instruct`                | `GLHF_API_KEY` |
 | OpenRouter    | `openrouter/deepseek/deepseek-r1-distill-llama-70b:free` | `OPENROUTER_API_KEY` |
+| AI/ML API     | `aimlapi/gpt-3.5-turbo`                                   | `AIML_API_KEY` |
 | Ollama        | `ollama/qwen2.5`                                         | `OLLAMA_API_KEY` (usually `ollama`) |
 | VLLM          | `vllm/mistral-7b-instruct`                               | `VLLM_API_KEY` |
 | LlamaCPP      | `llamacpp/localhost:8080`                                | `LLAMA_API_KEY` |

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -98,6 +98,7 @@ OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
 GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
 MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+AIML_API_BASE_URL = "https://api.aimlapi.com/v1"
 OLLAMA_API_KEY = "ollama"
 
 VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
@@ -553,6 +554,7 @@ class OpenAIGPT(LanguageModel):
         self.is_minimax = self.is_minimax_model()
         self.is_glhf = self.config.chat_model.startswith("glhf/")
         self.is_openrouter = self.config.chat_model.startswith("openrouter/")
+        self.is_aimlapi = self.config.chat_model.startswith("aimlapi/")
         self.is_langdb = self.config.chat_model.startswith("langdb/")
         self.is_portkey = self.config.chat_model.startswith("portkey/")
         self.is_litellm_proxy = self.config.chat_model.startswith("litellm-proxy/")
@@ -619,6 +621,15 @@ class OpenAIGPT(LanguageModel):
                 if self.api_key == OPENAI_API_KEY:
                     self.api_key = os.getenv("OPENROUTER_API_KEY", DUMMY_API_KEY)
                 self.api_base = OPENROUTER_BASE_URL
+            elif self.is_aimlapi:
+                self.config.chat_model = self.config.chat_model.replace(
+                    "aimlapi/", ""
+                )
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("AIML_API_KEY", DUMMY_API_KEY)
+                self.api_base = AIML_API_BASE_URL
+                self.config.headers["HTTP-Referer"] = 'https://github.com/langroid/langroid'
+                self.config.headers["X-Title"] = 'langroid'
             elif self.is_deepseek:
                 self.config.chat_model = self.config.chat_model.replace("deepseek/", "")
                 self.api_base = DEEPSEEK_BASE_URL

--- a/tests/main/test_llm.py
+++ b/tests/main/test_llm.py
@@ -313,11 +313,13 @@ def test_keys():
         "gemini",
         "glhf",
         "openrouter",
+        "aimlapi",
         "deepseek",
         "cerebras",
     ]
     key_dict = {p: f"{p.upper()}_API_KEY" for p in providers}
     key_dict["llamacpp"] = "LLAMA_API_KEY"
+    key_dict["aimlapi"] = "AIML_API_KEY"
 
     for p, var in key_dict.items():
         os.environ[var] = p
@@ -382,6 +384,28 @@ def test_llm_langdb(model: str):
 )
 def test_llm_openrouter(model: str):
     # override any chat model passed via --m arg to pytest cmd
+    settings.chat_model = model
+    llm_config = lm.OpenAIGPTConfig(
+        chat_model=model,
+    )
+    llm = lm.OpenAIGPT(config=llm_config)
+    result = llm.chat("what is 3+4?")
+    assert "7" in result.message
+    if result.cached:
+        assert result.usage.total_tokens == 0
+    else:
+        assert result.usage.total_tokens > 0
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "aimlapi/openai/gpt-4o-mini",
+        "aimlapi/google/gemini-2.5-flash",
+        "aimlapi/anthropic/claude-sonnet-4.5",
+    ],
+)
+def test_llm_aimlapi(model: str):
     settings.chat_model = model
     llm_config = lm.OpenAIGPTConfig(
         chat_model=model,

--- a/tests/main/test_llm_async.py
+++ b/tests/main/test_llm_async.py
@@ -174,6 +174,29 @@ async def test_llm_openrouter(model: str):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model",
+    [
+        "aimlapi/openai/gpt-4o-mini",
+        "aimlapi/google/gemini-2.5-flash",
+        "aimlapi/anthropic/claude-sonnet-4.5",
+    ],
+)
+async def test_llm_aimlapi(model: str):
+    settings.chat_model = model
+    llm_config = lm.OpenAIGPTConfig(
+        chat_model=model,
+    )
+    llm = lm.OpenAIGPT(config=llm_config)
+    result = await llm.achat("what is 3+4?")
+    assert "7" in result.message
+    if result.cached:
+        assert result.usage.total_tokens == 0
+    else:
+        assert result.usage.total_tokens > 0
+
+
+@pytest.mark.asyncio
 async def test_llm_pdf_attachment_async():
     """Test sending a PDF file attachment to the LLM asynchronously."""
     from pathlib import Path


### PR DESCRIPTION
### What does this PR do?

This PR adds support for the **AI/ML API** provider — a flexible, OpenAI-compatible platform that offers access to 300+ models (e.g., GPT-4o, Claude, Gemini, DeepSeek).
It enables users to configure and use ^Gimlapi/<model> as a valid chat_model within Langroid.

### ✅ Changes included:

* AIML_API_KEY added to .env-template
* Docs updated (llm-usage-options.md, 
on-openai-llms.md, local-llm-setup.md, supported-models.md)
* ^Gimlapi/ support added in openai_gpt.py for config parsing and base URL override
* Custom headers X-Title and Referer added for tracking
* Sync and async test cases for several ^Gimlapi/* models
* Provider key logic extended in 	est_keys()

### 📘 Documentation
Documentation added in the following files:

- llm-usage-options.md
- non-openai-llms.md
- local-llm-setup.md
- supported-models.md

---

### 🧪 Verification

All added tests (	est_llm_aimlapi, 	est_llm_aimlapi_async) pass and return expected values for AIMLAPI models.

---

Let me know if anything should be adjusted or restructured!

Closes #860