### PR TITLE
refactor: improve DocChatAgent retrieval configuration and deprecation handling

### DIFF
--- a/langroid/agent/special/doc_chat_agent.py
+++ b/langroid/agent/special/doc_chat_agent.py
@@ -1403,8 +1403,9 @@ class DocChatAgent(ChatAgent):
             # so we need to take the top n_similar_chunks from the combined list
             passages = [
                 id2doc[id]
-                for i, (id, _) in enumerate(id2_reciprocal_score.items())
-                if i < self.config.n_similar_chunks
+                for id, _ in list(id2_reciprocal_score.items())[
+                    : self.config.n_similar_chunks
+                ]
             ]
             # passages must have distinct ids
             assert len(passages) == len(set([d.id() for d in passages])), (

--- a/langroid/parsing/parser.py
+++ b/langroid/parsing/parser.py
@@ -120,7 +120,7 @@ class ParsingConfig(BaseSettings):
     # aim to have at least this many chars per chunk when truncating due to punctuation
     min_chunk_chars: int = 350
     discard_chunk_chars: int = 5  # discard chunks with fewer than this many chars
-    n_similar_docs: Optional[int] = 4  # deprecated
+    n_similar_docs: Optional[int] = None  # deprecated
     n_neighbor_ids: int = 5  # window size to store around each chunk
     separators: List[str] = ["\n\n", "\n", " ", ""]
     token_encoding_model: str = "text-embedding-3-small"

--- a/tests/main/test_doc_chat_agent.py
+++ b/tests/main/test_doc_chat_agent.py
@@ -556,6 +556,11 @@ def test_reciprocal_rank_fusion(test_settings: Settings, vecdb):
         use_bm25_search=True,
         use_fuzzy_match=True,
         use_reciprocal_rank_fusion=True,
+        parsing=ParsingConfig(
+            splitter=Splitter.SIMPLE,
+            n_neighbor_ids=5,
+            n_similar_docs=None,  # Ensure we don't trigger backward compatibility
+        ),
     )
     cfg.n_similar_chunks = 3
     cfg.n_relevant_chunks = 3

--- a/uv.lock
+++ b/uv.lock
@@ -2790,7 +2790,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2
 
 [[package]]
 name = "langroid"
-version = "0.56.5"
+version = "0.56.6"
 source = { editable = "." }
 dependencies = [
     { name = "adb-cloud-connector" },


### PR DESCRIPTION
## Summary
- Optimize reciprocal rank fusion passage selection by using list slicing instead of enumerate with conditional
- Set deprecated `n_similar_docs` parameter default to `None` to avoid backward compatibility issues
- Update tests to handle the deprecated parameter explicitly

## Changes
1. **Performance optimization in DocChatAgent**: Replace enumerate-based filtering with cleaner list slicing for selecting top passages from reciprocal rank fusion results
2. **Deprecation handling**: Change `n_similar_docs` default from `4` to `None` in ParsingConfig
3. **Test updates**: Explicitly set `n_similar_docs=None` in tests to ensure deprecated parameter doesn't interfere

## Testing
- Updated existing tests to handle the deprecated parameter
- All tests pass with the new configuration

🤖 Generated with [Claude Code](https://claude.ai/code)