### PR TITLE
Fix QdrantDB lock file issue

### DIFF
--- a/docs/notes/qdrant-resource-cleanup.md
+++ b/docs/notes/qdrant-resource-cleanup.md
@@ -1,0 +1,77 @@
+# QdrantDB Resource Cleanup
+
+When using QdrantDB with local storage, it's important to properly release resources
+to avoid file lock conflicts. QdrantDB uses a `.lock` file to prevent concurrent
+access to the same storage directory.
+
+## The Problem
+
+Without proper cleanup, you may encounter this warning:
+
+```
+Error connecting to local QdrantDB at ./qdrant_data:
+Storage folder ./qdrant_data is already accessed by another instance of Qdrant
+client. If you require concurrent access, use Qdrant server instead.
+Switching to ./qdrant_data.new
+```
+
+This happens when a QdrantDB instance isn't properly closed, leaving the lock file
+in place.
+
+## Solutions
+
+### Method 1: Explicit `close()` Method
+
+Always call `close()` when done with a QdrantDB instance:
+
+```python
+from langroid.vector_store.qdrantdb import QdrantDB, QdrantDBConfig
+
+config = QdrantDBConfig(
+    cloud=False,
+    collection_name="my_collection",
+    storage_path="./qdrant_data",
+)
+
+vecdb = QdrantDB(config)
+# ... use the vector database ...
+vecdb.clear_all_collections(really=True)
+
+# Important: Release the lock
+vecdb.close()
+```
+
+### Method 2: Context Manager (Recommended)
+
+Use QdrantDB as a context manager for automatic cleanup:
+
+```python
+from langroid.vector_store.qdrantdb import QdrantDB, QdrantDBConfig
+
+config = QdrantDBConfig(
+    cloud=False,
+    collection_name="my_collection", 
+    storage_path="./qdrant_data",
+)
+
+with QdrantDB(config) as vecdb:
+    # ... use the vector database ...
+    vecdb.clear_all_collections(really=True)
+    # Automatically closed when exiting the context
+```
+
+The context manager ensures cleanup even if an exception occurs.
+
+## When This Matters
+
+This is especially important in scenarios where:
+
+1. You create temporary QdrantDB instances for maintenance (e.g., clearing
+   collections)
+2. Your application restarts frequently during development
+3. Multiple parts of your code need to access the same storage path sequentially
+
+## Note for Cloud Storage
+
+This only affects local storage (`cloud=False`). When using Qdrant cloud service,
+the lock file mechanism is not used.

--- a/issues/pr-qdrant-lock-fix.md
+++ b/issues/pr-qdrant-lock-fix.md
@@ -1,0 +1,31 @@
+# Fix QdrantDB Lock File Issue
+
+## Problem
+When using QdrantDB with local storage, file lock conflicts occurred when:
+1. A QdrantDB instance was created but not properly closed
+2. Another part of the code tried to create a new QdrantDB instance with the same storage path
+3. Qdrant would detect the `.lock` file and create a new storage directory (e.g., `./qdrant_data.new`)
+
+## Solution
+1. **Added `close()` method to QdrantDB** - Calls the underlying client's close method to release the file lock
+2. **Added context manager support** - Implemented `__enter__` and `__exit__` for automatic cleanup
+3. **Fixed DocChatAgent's `clear()` method** - Now closes the old vecdb before creating a new one
+
+## Usage
+```python
+# Option 1: Explicit close
+vecdb = QdrantDB(config)
+vecdb.clear_all_collections(really=True)
+vecdb.close()  # Release the lock
+
+# Option 2: Context manager (automatic cleanup)
+with QdrantDB(config) as vecdb:
+    vecdb.clear_all_collections(really=True)
+    # Automatically closed when exiting context
+```
+
+## Changes
+- `langroid/vector_store/qdrantdb.py`: Added `close()`, `__enter__`, `__exit__` methods
+- `langroid/agent/special/doc_chat_agent.py`: Fixed `clear()` to close old vecdb instance
+
+This fix prevents the proliferation of `.new` directories when using QdrantDB with local storage.

--- a/issues/qdrant-lock-issue-spec-changes.md
+++ b/issues/qdrant-lock-issue-spec-changes.md
@@ -1,0 +1,200 @@
+# QdrantDB Lock File Conflict Issue - Changes and Best Practices
+
+## Summary of Changes
+
+This document describes the changes made to resolve the QdrantDB lock file conflict issue described in `qdrant-lock-issue-spec.md`.
+
+## Problem Recap
+
+When using QdrantDB with local storage, a file lock conflict occurred when:
+1. A QdrantDB instance was created (e.g., to clear collections)
+2. The instance was not properly disposed/closed
+3. Another part of the code tried to create a new QdrantDB instance
+4. Qdrant detected the `.lock` file and created a new storage directory (e.g., `./qdrant_data.new`)
+
+## Implemented Solution
+
+### 1. Added `close()` Method
+
+Added an explicit `close()` method to the QdrantDB class:
+
+```python
+def close(self) -> None:
+    """
+    Close the QdrantDB client and release any resources (e.g., file locks).
+    This is especially important for local storage to release the .lock file.
+    """
+    if hasattr(self.client, "close"):
+        # QdrantLocal has a close method that releases the lock
+        self.client.close()
+        logger.info(f"Closed QdrantDB connection for {self.config.storage_path}")
+```
+
+### 2. Added Context Manager Support
+
+Implemented `__enter__` and `__exit__` methods to support Python's context manager protocol:
+
+```python
+def __enter__(self) -> "QdrantDB":
+    """Context manager entry."""
+    return self
+
+def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    """Context manager exit - ensure cleanup even if an exception occurred."""
+    self.close()
+```
+
+### 3. Added Type Import
+
+Added `Any` to the type imports to support the context manager type hints:
+
+```python
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, TypeVar
+```
+
+## Best Practices for Using QdrantDB
+
+### Important Note
+
+The underlying `qdrant_client` library does not implement the context manager protocol. However, **Langroid's QdrantDB wrapper now provides context manager support** to ensure proper cleanup of resources, especially the file lock used by QdrantLocal.
+
+### Recommended: Use Context Manager (Most Pythonic)
+
+The context manager approach is the **recommended best practice** for Langroid's QdrantDB as it guarantees cleanup even if exceptions occur:
+
+```python
+from langroid.vector_store.qdrantdb import QdrantDB, QdrantDBConfig
+
+config = QdrantDBConfig(
+    cloud=False,
+    collection_name="my_collection",
+    storage_path="./qdrant_data",
+)
+
+# Recommended approach
+with QdrantDB(config) as vecdb:
+    # Use the vector database
+    vecdb.add_documents(documents)
+    results = vecdb.similar_texts_with_scores("query text", k=5)
+    vecdb.clear_empty_collections()
+    # Automatically closed when exiting the context
+```
+
+### Alternative: Explicit `close()` Method
+
+If you cannot use a context manager (e.g., when the QdrantDB instance needs to persist across multiple methods), use explicit `close()`:
+
+```python
+class MyDocProcessor:
+    def __init__(self):
+        config = QdrantDBConfig(
+            cloud=False,
+            collection_name="my_collection",
+            storage_path="./qdrant_data",
+        )
+        self.vecdb = QdrantDB(config)
+    
+    def process_documents(self, docs):
+        self.vecdb.add_documents(docs)
+    
+    def search(self, query):
+        return self.vecdb.similar_texts_with_scores(query, k=5)
+    
+    def cleanup(self):
+        # Important: Call this when done
+        self.vecdb.close()
+```
+
+### When Using with DocChatAgent
+
+When using QdrantDB with DocChatAgent, the agent manages the vector store lifecycle, so you don't need to worry about closing it manually:
+
+```python
+from langroid.agent.special.doc_chat_agent import DocChatAgent, DocChatAgentConfig
+
+# DocChatAgent manages the QdrantDB lifecycle
+agent = DocChatAgent(
+    DocChatAgentConfig(
+        vecdb=QdrantDBConfig(
+            cloud=False,
+            collection_name="doc_chat",
+            storage_path="./qdrant_data",
+        )
+    )
+)
+# The agent will handle cleanup appropriately
+```
+
+### For Temporary Operations
+
+For one-off operations like clearing collections, always use context manager:
+
+```python
+# Clear all collections
+with QdrantDB(config) as vecdb:
+    vecdb.clear_all_collections(really=True, prefix="temp_")
+
+# Clear and recreate
+with QdrantDB(config) as vecdb:
+    vecdb.delete_collection("old_collection")
+    vecdb.create_collection("new_collection", replace=True)
+```
+
+## Important Notes
+
+1. **Cloud Storage**: This issue only affects local storage (`cloud=False`). When using Qdrant cloud service, file locking is not used.
+
+2. **Backward Compatibility**: Existing code will continue to work without changes, but may show warnings about lock conflicts and create `.new` directories.
+
+3. **Multiple Processes**: If you genuinely need multiple processes to access the same Qdrant storage simultaneously, use Qdrant server instead of local storage.
+
+## Testing
+
+Comprehensive tests were added to verify the fix:
+- `tests/main/test_qdrant_lock_release.py` - Unit tests for close() and context manager
+- `tests/main/test_qdrant_lock_scenario.py` - Reproduces the exact issue scenario
+- `tests/main/test_qdrant_warning_capture.py` - Captures and verifies warning messages
+
+All tests pass and confirm that:
+- Without proper cleanup: `.new` directories are created (the bug)
+- With `close()` or context manager: No `.new` directories (fixed)
+
+## Migration Guide
+
+If you have existing code that creates temporary QdrantDB instances:
+
+**Before (problematic):**
+```python
+vecdb = QdrantDB(config)
+vecdb.clear_all_collections(really=True)
+# Lock file remains, causing issues
+```
+
+**After (fixed):**
+```python
+# Option 1: Context manager (preferred)
+with QdrantDB(config) as vecdb:
+    vecdb.clear_all_collections(really=True)
+
+# Option 2: Explicit close
+vecdb = QdrantDB(config)
+vecdb.clear_all_collections(really=True)
+vecdb.close()
+```
+
+## Why This Matters
+
+While the `qdrant_client` library handles some cleanup via its `__del__` method, this is not reliable because:
+1. Python's garbage collector doesn't guarantee when `__del__` will be called
+2. In some cases (circular references, interpreter shutdown), `__del__` may not be called at all
+3. The file lock remains until the process ends, preventing other instances from using the same storage
+
+By adding explicit `close()` and context manager support to Langroid's QdrantDB wrapper, we ensure:
+- Immediate release of the file lock when done
+- No proliferation of `.new` directories
+- Predictable resource cleanup
+- Better development experience (no need to manually delete lock files)
+
+## Conclusion
+
+The QdrantDB lock file issue has been resolved by adding proper resource cleanup mechanisms to Langroid's QdrantDB wrapper. While the underlying `qdrant_client` doesn't provide context manager support, Langroid now offers both context manager and explicit `close()` methods. The context manager approach is the recommended best practice as it ensures cleanup even in error scenarios. For cases where context managers aren't suitable, the explicit `close()` method provides a reliable alternative.

--- a/langroid/agent/special/doc_chat_agent.py
+++ b/langroid/agent/special/doc_chat_agent.py
@@ -314,6 +314,10 @@ class DocChatAgent(ChatAgent):
             # Note we may have used a vecdb with a config.collection_name
             # different from the agent's config.vecdb.collection_name!!
             self.vecdb.delete_collection(collection_name)
+            # Close the old vecdb before creating a new one
+            old_vecdb = self.vecdb
+            if old_vecdb and hasattr(old_vecdb, "close"):
+                old_vecdb.close()
             self.vecdb = VectorStore.create(self.vecdb.config)
         except Exception as e:
             logger.warning(


### PR DESCRIPTION
## Summary

This PR fixes the QdrantDB lock file issue where using local storage could result in `.new` directories being created when the file lock wasn't properly released.

## Problem
When using QdrantDB with local storage, a file lock conflict occurred in scenarios like:
- Creating a QdrantDB instance to clear collections without closing it
- DocChatAgent's `clear()` method creating a new vecdb without closing the old one
- Multiple sequential operations on the same storage path

## Solution
1. Added `close()` method to QdrantDB class
2. Added context manager support (`__enter__`/`__exit__`)  
3. Fixed DocChatAgent's `clear()` method to close old vecdb

## Documentation
See detailed documentation in:
- [PR notes](https://github.com/langroid/langroid/blob/fix-qdrant-lock-issue/issues/pr-qdrant-lock-fix.md)
- [Issue analysis and changes](https://github.com/langroid/langroid/blob/fix-qdrant-lock-issue/issues/qdrant-lock-issue-spec-changes.md)
- [Usage guide](https://github.com/langroid/langroid/blob/fix-qdrant-lock-issue/docs/notes/qdrant-resource-cleanup.md)

