### PR TITLE
Fix DoneSequence parent chain issues and agent ID initialization

### DIFF
--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -137,6 +137,7 @@ class Agent(ABC):
 
     def __init__(self, config: AgentConfig = AgentConfig()):
         self.config = config
+        self.id = ObjectRegistry.new_id()  # Initialize agent ID
         self.lock = asyncio.Lock()  # for async access to update self.llm.usage_cost
         self.dialog: List[Tuple[str, str]] = []  # seq of LLM (prompt, response) tuples
         self.llm_tools_map: Dict[str, Type[ToolMessage]] = {}
@@ -685,6 +686,7 @@ class Agent(ABC):
             results.metadata.tool_ids = (
                 [] if msg is None or isinstance(msg, str) else msg.metadata.tool_ids
             )
+            results.metadata.agent_id = self.id
             return results
         sender_name = self.config.name
         if isinstance(msg, ChatDocument) and msg.function_call is not None:
@@ -703,6 +705,7 @@ class Agent(ABC):
             metadata=ChatDocMetaData(
                 source=Entity.AGENT,
                 sender=Entity.AGENT,
+                agent_id=self.id,
                 sender_name=sender_name,
                 oai_tool_id=oai_tool_id,
                 # preserve trail of tool_ids for OpenAI Assistant fn-calls
@@ -967,6 +970,7 @@ class Agent(ABC):
             return ChatDocument(
                 content=user_msg,
                 metadata=ChatDocMetaData(
+                    agent_id=self.id,
                     source=source,
                     sender=sender,
                     # preserve trail of tool_ids for OpenAI Assistant fn-calls

--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -615,7 +615,10 @@ class Task:
             if isinstance(msg, ChatDocument):
                 # carefully deep-copy: fresh metadata.id, register
                 # as new obj in registry
+                original_parent_id = msg.metadata.parent_id
                 self.pending_message = ChatDocument.deepcopy(msg)
+                # Preserve the parent pointer from the original message
+                self.pending_message.metadata.parent_id = original_parent_id
             if self.pending_message is not None and self.caller is not None:
                 # msg may have come from `caller`, so we pretend this is from
                 # the CURRENT task's USER entity
@@ -623,7 +626,11 @@ class Task:
                 # update parent, child, agent pointers
                 if msg is not None:
                     msg.metadata.child_id = self.pending_message.metadata.id
-                    self.pending_message.metadata.parent_id = msg.metadata.id
+                    # Only override parent_id if it wasn't already set in the
+                    # original message. This preserves parent chains from TaskTool
+                    if not msg.metadata.parent_id:
+                        self.pending_message.metadata.parent_id = msg.metadata.id
+            if self.pending_message is not None:
                 self.pending_message.metadata.agent_id = self.agent.id
 
         self._show_pending_message_if_debug()
@@ -2250,24 +2257,33 @@ class Task:
     def _get_message_chain(
         self, msg: ChatDocument | None, max_depth: Optional[int] = None
     ) -> List[ChatDocument]:
-        """Get the chain of messages by following parent pointers."""
+        """Get the chain of messages using agent's message history."""
         if max_depth is None:
             # Get max depth needed from all sequences
             max_depth = 50  # default fallback
             if self._parsed_done_sequences:
                 max_depth = max(len(seq.events) for seq in self._parsed_done_sequences)
 
-        chain = []
-        current = msg
-        depth = 0
+        # Get chat document IDs from message history
+        doc_ids = [
+            m.chat_document_id for m in self.agent.message_history if m.chat_document_id
+        ]
 
-        while current is not None and depth < max_depth:
-            chain.append(current)
-            current = current.parent
-            depth += 1
+        # Add current message ID if it exists and is not already the last one
+        if msg:
+            msg_id = msg.id()
+            if not doc_ids or doc_ids[-1] != msg_id:
+                doc_ids.append(msg_id)
 
-        # Reverse to get chronological order (oldest first)
-        return list(reversed(chain))
+        # Take only the last max_depth elements
+        relevant_ids = doc_ids[-max_depth:]
+
+        # Convert IDs to ChatDocuments and filter out None values
+        return [
+            doc
+            for doc_id in relevant_ids
+            if (doc := ChatDocument.from_id(doc_id)) is not None
+        ]
 
     def _matches_event(self, actual: AgentEvent, expected: AgentEvent) -> bool:
         """Check if an actual event matches an expected event pattern."""

--- a/llms-compressed.txt
+++ b/llms-compressed.txt
@@ -34,7 +34,7 @@ The content is organized as follows:
 <notes>
 - Some files may have been excluded based on .gitignore rules and Repomix's configuration
 - Binary files are not included in this packed representation. Please refer to the Repository Structure section for a complete list of file paths, including binary files
-- Files matching these patterns are excluded: .*/**, !.github, !.github/**, data/**, **/data/**, **/*.csv, logs/**, build/**, dist/**, *.egg-info/**, __pycache__/**, **/*.pyc, .pytest_cache/**, .mypy_cache/**, .ruff_cache/**, venv/**, env/**, .env, **/*.json, llms.txt, llms-compressed.txt, llms-128k.txt, file-list.txt, file-list-updated.txt, examples/data/**, examples/docqa/docs/**, examples/logs/**, tests/cache/**, tests/logs/**, **/*.pkl, **/*.pickle, **/*.db, **/*.sqlite, **/*.log, **/node_modules/**, **/*.min.js, **/*.map, coverage/**, htmlcov/**, .coverage, *.orig, *.tmp, *.bak, *.swp, *.swo, **/docker-compose*.yml, visual_log.sh, **/*_converted.md, **/page_*.md, **/page-*.md, tests/main/dummy-pages/**, tests/main/data/**/*.txt, **/*.pb2.py, **/*.pb2_grpc.py
+- Files matching these patterns are excluded: .*/**, !.github, !.github/**, data/**, **/data/**, **/*.csv, logs/**, build/**, dist/**, *.egg-info/**, __pycache__/**, **/*.pyc, .pytest_cache/**, .mypy_cache/**, .ruff_cache/**, venv/**, env/**, .env, **/*.json, llms.txt, llms-compressed.txt, llms-128k.txt, llms-no-tests.txt, llms-no-tests-compressed.txt, llms-no-tests-no-examples.txt, llms-no-tests-no-examples-compressed.txt, file-list.txt, file-list-updated.txt, examples/data/**, examples/docqa/docs/**, examples/logs/**, tests/cache/**, tests/logs/**, **/*.pkl, **/*.pickle, **/*.db, **/*.sqlite, **/*.log, **/node_modules/**, **/*.min.js, **/*.map, coverage/**, htmlcov/**, .coverage, *.orig, *.tmp, *.bak, *.swp, *.swo, **/docker-compose*.yml, visual_log.sh, **/*_converted.md, **/page_*.md, **/page-*.md, tests/main/dummy-pages/**, tests/main/data/**/*.txt, **/*.pb2.py, **/*.pb2_grpc.py
 - Files matching patterns in .gitignore are excluded
 - Files matching default ignore patterns are excluded
 - Content has been compressed - code blocks are separated by ⋮---- delimiter
@@ -518,6 +518,7 @@ release-notes/
   v0-56-0-task-tool.md
   v0-56-11-openai-client-caching.md
   v0-56-12-cached-tokens-support.md
+  v0-56-13-done-sequences-parent-chain-fixes.md
   v0-56-2-table-chat-fix.md
   v0-56-4-handler-params.md
   v0-56-6-doc-chat-refactor.md
@@ -12782,6 +12783,30 @@ def ingest(self) -> None
 records = self.get_records()
 </file>
 
+<file path="langroid/agent/tools/mcp/__init__.py">
+__all__ = [
+</file>
+
+<file path="langroid/agent/tools/mcp/decorators.py">
+"""Decorator: declare a ToolMessage class bound to a FastMCP tool.
+
+    Usage:
+        @fastmcp_tool("/path/to/server.py", "get_weather")
+        class WeatherTool:
+            def pretty(self) -> str:
+                return f"Temp is {self.temperature}"
+    """
+⋮----
+def decorator(user_cls: Type[ToolMessage]) -> Type[ToolMessage]
+⋮----
+# build the “real” ToolMessage subclass for this server/tool
+RealTool: Type[ToolMessage] = get_tool(server, tool_name)
+⋮----
+# copy user‐defined methods / attributes onto RealTool
+⋮----
+# preserve the user’s original name if you like:
+</file>
+
 <file path="langroid/agent/tools/__init__.py">
 __all__ = [
 </file>
@@ -20838,6 +20863,125 @@ FORWARD_USER = "user"  # forward msg to user
 DONE = "done"  # task done
 </file>
 
+<file path="release-notes/v0-56-13-done-sequences-parent-chain-fixes.md">
+# v0.56.13: DoneSequences Parent Chain and Agent ID Fixes
+
+## Summary
+
+This release fixes critical issues with the DoneSequence implementation, parent pointer chain preservation in TaskTool, and agent ID initialization. These fixes ensure that task termination sequences work correctly with subtasks and that message lineage is properly maintained across agent boundaries.
+
+## Key Fixes
+
+### 1. Agent ID Initialization Fix
+
+**Problem**: The `Agent.id` field was incorrectly returning a `FieldInfo` object instead of an actual ID string because `Agent` is not a Pydantic model but was using Pydantic's `Field` syntax.
+
+**Solution**: Added proper ID initialization in `Agent.__init__()`:
+```python
+self.id = ObjectRegistry.new_id()  # Initialize agent ID
+```
+
+**Impact**: This ensures that `agent_id` is correctly set in `ChatDocument` metadata, which is crucial for tracking which agent owns which messages.
+
+### 2. DoneSequence Message Chain Fix
+
+**Problem**: The `_get_message_chain` method in `Task` was traversing parent pointers to build the message chain. When subtasks are involved, parent pointers can cross agent boundaries, incorrectly including messages from subtask agents in the parent task's chain.
+
+**Solution**: Replaced parent pointer traversal with agent message history:
+```python
+def _get_message_chain(self, msg: ChatDocument | None, max_depth: Optional[int] = None) -> List[ChatDocument]:
+    """Get the chain of messages using agent's message history."""
+    # Get chat document IDs from message history
+    doc_ids = [m.chat_document_id for m in self.agent.message_history 
+               if m.chat_document_id]
+    
+    # Add current message ID if it exists and is not already the last one
+    if msg:
+        msg_id = msg.id()
+        if not doc_ids or doc_ids[-1] != msg_id:
+            doc_ids.append(msg_id)
+    
+    # Take only the last max_depth elements
+    relevant_ids = doc_ids[-max_depth:]
+    
+    # Convert IDs to ChatDocuments
+    return [doc for doc_id in relevant_ids 
+            if (doc := ChatDocument.from_id(doc_id)) is not None]
+```
+
+**Impact**: DoneSequences now correctly check only messages from the current agent, preventing incorrect task termination when subtasks generate matching sequences.
+
+### 3. Parent Pointer Preservation in Task.init()
+
+**Problem**: When `ChatDocument.deepcopy()` is called during `task.init()`, it resets `parent_id` and `child_id` to empty strings, breaking the parent chain. This particularly affected TaskTool when creating subtasks with parent pointers.
+
+**Solution**: Modified `task.init()` to preserve the original parent_id after deepcopy:
+```python
+if isinstance(msg, ChatDocument):
+    original_parent_id = msg.metadata.parent_id
+    self.pending_message = ChatDocument.deepcopy(msg)
+    # Preserve the parent pointer from the original message
+    self.pending_message.metadata.parent_id = original_parent_id
+```
+
+Additionally, added conditional logic to only override parent_id when necessary:
+```python
+if self.pending_message is not None and self.caller is not None:
+    # Only override parent_id if it wasn't already set in the original message
+    if not msg.metadata.parent_id:
+        self.pending_message.metadata.parent_id = msg.metadata.id
+```
+
+**Impact**: Parent chains are now preserved when TaskTool creates subtasks, maintaining proper message lineage.
+
+### 4. TaskTool Parent-Child Relationship
+
+**Problem**: TaskTool was only setting the parent pointer on the prompt ChatDocument but not the corresponding child pointer on the TaskTool message.
+
+**Solution**: Added bidirectional parent-child relationship in TaskTool handlers:
+```python
+if chat_doc is not None:
+    prompt_doc = ChatDocument(
+        content=self.prompt,
+        metadata=ChatDocMetaData(
+            parent_id=chat_doc.id(),
+            agent_id=agent.id,
+            sender=chat_doc.metadata.sender,
+        )
+    )
+    # Set bidirectional parent-child relationship
+    chat_doc.metadata.child_id = prompt_doc.id()
+```
+
+**Impact**: Complete bidirectional parent-child chains are maintained, improving message traceability.
+
+## Tests Added
+
+Added comprehensive test `test_task_init_preserves_parent_id()` in `test_task.py` that verifies:
+- Parent IDs are preserved during ChatDocument deep copying
+- Conditional parent_id override logic works correctly for subtasks
+- Parent chains are maintained in various scenarios
+
+## Breaking Changes
+
+None. All changes are backward compatible bug fixes.
+
+## Migration Guide
+
+No migration needed. The fixes will automatically apply to existing code.
+
+## Technical Details
+
+The core issue was that DoneSequences were incorrectly checking messages across agent boundaries due to parent pointer traversal. Combined with the agent ID initialization bug and parent chain breaks in deepcopy, this caused incorrect task termination behavior. The fixes ensure:
+
+1. Each agent's messages are properly tagged with the agent's ID
+2. DoneSequence checking is confined to the current agent's message history
+3. Parent chains are preserved through TaskTool subtask creation
+4. Bidirectional parent-child relationships are maintained
+
+These changes work together to ensure proper message lineage and task termination behavior in multi-agent systems.
+</file>
+
 <file path="tests/extras/sql/test_automatic_context_extraction.py">
 """
 Test automatic context description extraction from mysql and postgres databases.
@@ -27708,67 +27852,6 @@ mysql_user = root
 exclude = .*,.*/.*,.*/*,.*/*.*
 max-line-length = 88
 ignore = W291, W293, E501, E203, W503
-</file>
-
-<file path="ai-instructions/claude-repomix-instructions.md">
-# AI Instructions for Setting Up Repomix
-
-## Task Overview
-Set up [repomix](https://github.com/yamadashy/repomix) to generate LLM-friendly repository exports. This creates text files that can be uploaded to AI models for code analysis.
-
-## Steps to Complete
-
-### 1. Install Repomix
-```bash
-npm install -g repomix
-```
-
-### 2. Create repomix.config.json
-Create a configuration file in the repository root with:
-- **Include patterns**: Source code files (*.py, *.js, *.md, *.yaml, *.yml, *.toml)
-- **Exclude patterns**: Data directories, logs, node_modules, JSON files, generated files
-- **Security check**: Enable to prevent sensitive data inclusion
-
-### 3. Configure Include/Exclude Patterns
-- Include only source code directories and documentation
-- Exclude data/, logs/, build artifacts, dependencies
-- Add `llms*.txt` to exclusions to prevent recursive inclusion
-
-### 4. Test Configuration (Optional)
-```bash
-# Generate file list only for inspection
-repomix --no-files -o file-list.txt
-```
-This allows you to review which files will be included before generating the full output.
-
-### 5. Generate Output Versions
-
-Use the Makefile targets to generate repomix files:
-
-```bash
-# Generate all variants (recommended)
-make repomix-all
-
-# Or generate specific versions:
-make repomix          # llms.txt and llms-compressed.txt (includes tests)
-make repomix-no-tests # llms-no-tests.txt and llms-no-tests-compressed.txt
-```
-
-All commands use `git ls-files` to ensure only git-tracked files are included.
-
-### 6. Verify Results
-- Check file sizes and token counts in repomix output
-- Ensure no sensitive data is included
-- Confirm only relevant source files are packaged
-
-## Expected Outcome
-Four text files optimized for different LLM contexts:
-- `llms.txt`: Full version with tests for comprehensive analysis
-- `llms-compressed.txt`: Compressed version with tests
-- `llms-no-tests.txt`: Full version without tests for focused source code analysis
-- `llms-no-tests-compressed.txt`: Compressed version without tests for smaller contexts
-
-The files contain only git-tracked source code with proper exclusions for clean, focused LLM consumption.
 </file>
 
 <file path="ai-notes/Langroid-repo-docs.md">
@@ -35688,6 +35771,37 @@ langdb_model = OpenAIGPT(langdb_config)
 response = langdb_model.chat(
 </file>
 
+<file path="examples/mcp/biomcp.py">
+"""
+Simple example of using the BioMCP server.
+
+https://github.com/genomoncology/biomcp
+
+The server offers several tools, and we can enable ALL of them to be used
+by a Langroid agent.
+
+Run like this:
+
+    uv run examples/mcp/biomcp.py --model gpt-4.1-mini
+
+"""
+⋮----
+async def main(model: str = "")
+⋮----
+transport = StdioTransport(
+all_tools = await get_tools_async(transport)
+⋮----
+agent = lr.ChatAgent(
+⋮----
+# forward to user when LLM doesn't use a tool
+⋮----
+# enable the agent to use all tools
+⋮----
+# make task with interactive=False =>
+# waits for user only when LLM doesn't use a tool
+task = lr.Task(agent, interactive=False)
+</file>
+
 <file path="examples/mcp/exa-web-search.py">
 """
 Simple example of using the Exa Web Search MCP Server to
@@ -35735,6 +35849,199 @@ def run_main(**kwargs) -> None
         Args:
             **kwargs: Keyword arguments to pass to the main function.
         """
+</file>
+
+<file path="examples/mcp/gitmcp.py">
+"""
+Simple example of using the GitMCP server to "chat" about a GitHub repository.
+
+https://github.com/idosal/git-mcp
+
+The server offers several tools, and we can enable ALL of them to be used
+by a Langroid agent.
+
+Run like this (-m model optional; defaults to gpt-4.1-mini):
+
+    uv run examples/mcp/gitmcp.py -m ollama/qwen2.5-coder:32b
+
+"""
+⋮----
+def get_gitmcp_url() -> str
+⋮----
+console = Console()
+⋮----
+short_pattern = re.compile(r"^([^/]+)/([^/]+)$")
+url_pattern = re.compile(
+⋮----
+user_input = Prompt.ask(
+m = short_pattern.match(user_input)
+⋮----
+m = url_pattern.match(user_input)
+⋮----
+github_url = f"https://github.com/{owner}/{repo}"
+⋮----
+gitmcp_url = f"https://gitmcp.io/{owner}/{repo}"
+⋮----
+class SendUserTool(SendTool)
+⋮----
+request: str = "send_user"
+purpose: str = "Send <content> to user"
+to: str = "user"
+content: str = Field(
+⋮----
+async def main(model: str = "")
+⋮----
+gitmcp_url = get_gitmcp_url()
+⋮----
+transport = SSETransport(
+all_tools: List[lr.ToolMessage] = await get_tools_async(transport)
+⋮----
+agent = lr.ChatAgent(
+⋮----
+# forward to user when LLM doesn't use a tool
+⋮----
+# enable the agent to use all tools
+⋮----
+# configure task to NOT recognize string-based signals like DONE,
+# since those could occur in the retrieved text!
+task_cfg = lr.TaskConfig(recognize_string_signals=False)
+# make task with interactive=False =>
+# waits for user only when LLM doesn't use a tool
+⋮----
+task = lr.Task(agent, config=task_cfg, interactive=False)
+</file>
+
+<file path="examples/mcp/mcp-fetch.py">
+"""
+Simple example of using the Anthropic Fetch MCP Server to get web-site content.
+
+Fetch MCP Server: https://github.com/modelcontextprotocol/servers/tree/main/src/fetch
+
+Run like this:
+
+    uv run examples/mcp/mcp-fetch.py --model gpt-4.1-mini
+
+Ask questions like:
+
+Summarize the content of this page:
+https://www.anthropic.com/news/model-context-protocol
+"""
+⋮----
+async def main(model: str = "")
+⋮----
+transport = UvxStdioTransport(
+FetchTool = await get_tool_async(transport, "fetch")
+agent = lr.ChatAgent(
+⋮----
+# forward to user when LLM doesn't use a tool
+⋮----
+# enable the agent to use the fetch tool
+⋮----
+# make task with interactive=False =>
+# waits for user only when LLM doesn't use a tool
+task = lr.Task(agent, interactive=False)
+</file>
+
+<file path="examples/mcp/mcp-file-system.py">
+"""
+Example: Expose local file-system operations via an in-memory FastMCP server.
+
+Run like this:
+
+uv run examples/mcp/mcp-file-system.py --model gpt-4.1-mini
+
+Then ask your agent to list, write, or read files.
+"""
+⋮----
+def create_fs_mcp_server() -> FastMCP
+⋮----
+"""Return a FastMCP server exposing list/read/write file tools."""
+server = FastMCP("FsServer")
+⋮----
+"""List file names in the given directory."""
+⋮----
+"""Write text to a file; return True on success."""
+⋮----
+"""Read and return the content of a text file."""
+⋮----
+# use decorator to create a Langroid ToolMessage with a custom handle_async method
+⋮----
+@mcp_tool(create_fs_mcp_server(), "write_file")
+class WriteFileTool(lr.ToolMessage)
+⋮----
+"""Tool to write text to a file."""
+⋮----
+async def handle_async(self) -> str
+⋮----
+"""Invoke `write_file` and report the result."""
+ok = await self.call_tool_async()  # type: ignore
+⋮----
+@mcp_tool(create_fs_mcp_server(), "read_file")
+class ReadFileTool(lr.ToolMessage)
+⋮----
+"""Tool to read the content of a text file."""
+⋮----
+"""Invoke `read_file` and return its contents."""
+text = await self.call_tool_async()  # type: ignore
+⋮----
+async def main(model: str = "") -> None
+⋮----
+"""
+    Launch a ChatAgent that can list, write, and read files.
+
+    Args:
+    model: Optional LLM model name (defaults to gpt-4.1-mini).
+    """
+agent = lr.ChatAgent(
+⋮----
+# create ListFilesTool using the helper function get_tool_async
+ListFilesTool = await get_tool_async(create_fs_mcp_server(), "list_files")
+⋮----
+# enable all three tools
+⋮----
+# create a non-interactive task
+task = lr.Task(agent, interactive=False)
+⋮----
+# instruct the agent
+prompt = """
+result = await task.run_async(prompt, turns=3)
+⋮----
+def _run(**kwargs: str) -> None
+⋮----
+"""Fire entry point to run the async main function."""
+</file>
+
+<file path="examples/mcp/memory.py">
+"""
+Simple example of using the Memory MCP server:
+https://github.com/modelcontextprotocol/servers/tree/main/src/memory
+This server gives your agent persistent memory using a local Knowledge Graph,
+so when you re-start the chat it will remember what you talked about last time.
+
+
+The server offers several tools, and we can enable ALL of them to be used
+by a Langroid agent.
+
+Run like this (-m model optional; defaults to gpt-4.1-mini):
+
+    uv run examples/mcp/memory.py --m ollama/qwen2.5-coder:32b
+
+"""
+⋮----
+async def main(model: str = "")
+⋮----
+agent = lr.ChatAgent(
+⋮----
+# forward to user when LLM doesn't use a tool
+⋮----
+transport = NpxStdioTransport(
+tools = await get_tools_async(transport)
+⋮----
+# enable the agent to use all tools
+⋮----
+# make task with interactive=False =>
+# waits for user only when LLM doesn't use a tool
+task = lr.Task(agent, interactive=False)
 </file>
 
 <file path="examples/multi-agent-debate/chainlit_utils.py">
@@ -39466,30 +39773,6 @@ docs = self.vecdb._lance_result_to_docs(result)
 scores = [r["score"] for r in result.to_list()]
 </file>
 
-<file path="langroid/agent/tools/mcp/__init__.py">
-__all__ = [
-</file>
-
-<file path="langroid/agent/tools/mcp/decorators.py">
-"""Decorator: declare a ToolMessage class bound to a FastMCP tool.
-
-    Usage:
-        @fastmcp_tool("/path/to/server.py", "get_weather")
-        class WeatherTool:
-            def pretty(self) -> str:
-                return f"Temp is {self.temperature}"
-    """
-⋮----
-def decorator(user_cls: Type[ToolMessage]) -> Type[ToolMessage]
-⋮----
-# build the “real” ToolMessage subclass for this server/tool
-RealTool: Type[ToolMessage] = get_tool(server, tool_name)
-⋮----
-# copy user‐defined methods / attributes onto RealTool
-⋮----
-# preserve the user’s original name if you like:
-</file>
-
 <file path="langroid/agent/batch.py">
 T = TypeVar("T")
 U = TypeVar("U")
@@ -42890,160 +43173,6 @@ sync_result = agent.handle_both_sync_async(msg)
 async_result = await agent.handle_both_sync_async_async(msg)
 </file>
 
-<file path="Makefile">
-.PHONY: setup check lint tests docs nodocs loc
-
-SHELL := /bin/bash
-
-.PHONY: setup update
-
-setup: ## Setup the git pre-commit hooks
-	uv run pre-commit install
-
-update: ## Update the git pre-commit hooks
-	uv run pre-commit autoupdate
-
-.PHONY: type-check
-type-check:
-	@uv run pre-commit install
-	@uv run pre-commit autoupdate
-	@uv run pre-commit run --all-files
-	@echo "Running black..."
-	@uv run black --check .
-	@echo "Running ruff check (without fix)..."
-	@uv run ruff check .
-	@echo "Running mypy...";
-	@uv run mypy -p langroid
-	@echo "All checks passed!"
-
-.PHONY: lint
-lint:
-	uv run black .
-	uv run ruff check . --fix
-	@echo "Auto-fixing issues in examples folder..."
-	@uv run ruff check examples/ --fix-only --no-force-exclude
-
-.PHONY: stubs
-stubs:
-	@echo "Generating Python stubs for the langroid package..."
-	@uv run stubgen -p langroid -o stubs
-	@echo "Stubs generated in the 'stubs' directory"
-
-.PHONY: fix-pydantic
-
-# Entry to replace pydantic imports in specified directories
-fix-pydantic:
-	@echo "Fixing pydantic imports..."
-	@chmod +x scripts/fix-pydantic-imports.sh
-	@./scripts/fix-pydantic-imports.sh
-
-.PHONY: check
-check: fix-pydantic lint type-check
-
-.PHONY: tests
-tests:
-	pytest tests/main --basetemp=/tmp/pytest
-
-
-docs:
-	@# Kill any existing 'mkdocs serve' processes.
-	@pkill -f "mkdocs serve" 2>/dev/null || true
-	@# Build the documentation.
-	mkdocs build
-	@# Serve the documentation in the background.
-	mkdocs serve &
-	@echo "Documentation is being served in the background."
-	@echo "You can access the documentation at http://127.0.0.1:8000/"
-
-nodocs:
-	@# Kill any existing 'mkdocs serve' processes.
-	@pkill -f "mkdocs serve" 2>/dev/null || echo "No 'mkdocs serve' process found."
-	@echo "Stopped serving documentation."
-
-
-loc:
-	@echo "Lines in git-tracked files python files:"
-	@git ls-files | grep '\.py$$' | xargs cat | grep -v '^\s*$$' | wc -l
-
-.PHONY: repomix repomix-no-tests repomix-all
-
-repomix: ## Generate llms.txt and llms-compressed.txt (includes tests)
-	@echo "Generating llms.txt (with tests)..."
-	@git ls-files | repomix --stdin
-	@echo "Generating llms-compressed.txt..."
-	@git ls-files | repomix --stdin --compress -o llms-compressed.txt
-	@echo "Generated llms.txt and llms-compressed.txt"
-
-repomix-no-tests: ## Generate llms-no-tests.txt (excludes tests)
-	@echo "Generating llms-no-tests.txt (without tests)..."
-	@git ls-files | grep -v "^tests/" | repomix --stdin -o llms-no-tests.txt
-	@echo "Generating llms-no-tests-compressed.txt..."
-	@git ls-files | grep -v "^tests/" | repomix --stdin --compress -o llms-no-tests-compressed.txt
-	@echo "Generated llms-no-tests.txt and llms-no-tests-compressed.txt"
-
-repomix-all: repomix repomix-no-tests ## Generate all repomix variants
-
-.PHONY: revert-tag
-revert-tag:
-	@LATEST_TAG=$$(git describe --tags --abbrev=0) && \
-	echo "Deleting tag: $$LATEST_TAG" && \
-	git tag -d $$LATEST_TAG
-
-.PHONY: revert-bump
-revert-bump:
-	@if git log -1 --pretty=%B | grep -q "bump"; then \
-		git reset --hard HEAD~1; \
-		echo "Reverted last commit (bump commit)"; \
-	else \
-		echo "Last commit was not a bump commit"; \
-	fi
-
-.PHONY: revert
-revert: revert-bump revert-tag
-	
-.PHONY: bump-patch
-bump-patch:
-	@cz bump --increment PATCH
-
-.PHONY: bump-minor
-bump-minor:
-	@cz bump --increment MINOR 
-
-.PHONY: bump-major
-bump-major:
-	@cz bump --increment MAJOR 
-
-.PHONY: build
-build:
-	@uv build
-
-.PHONY: push
-push:
-	@git push origin main
-	@git push origin --tags
-
-.PHONY: clean
-clean:
-	-rm -rf dist/*
-
-.PHONY: release
-release:
-	@VERSION=$$(cz version -p | cut -d' ' -f2) && gh release create $${VERSION} dist/*
-
-.PHONY: all-patch
-all-patch: bump-patch clean build push release
-
-.PHONY: all-minor
-all-minor: bump-minor clean build push release
-
-.PHONY: all-major
-all-major: bump-major clean build push release
-
-.PHONY: publish
-publish:
-	uv publish
-</file>
-
 <file path="SECURITY.md">
 # Security Policy
 
@@ -43081,6 +43210,70 @@ Once a security vulnerability is reported, we will work to:
 - Investigate and confirm the issue.
 - Develop a patch or mitigation strategy.
 - Publish the fix and disclose the advisory publicly after the resolution.
+</file>
+
+<file path="ai-instructions/claude-repomix-instructions.md">
+# AI Instructions for Setting Up Repomix
+
+## Task Overview
+Set up [repomix](https://github.com/yamadashy/repomix) to generate LLM-friendly repository exports. This creates text files that can be uploaded to AI models for code analysis.
+
+## Steps to Complete
+
+### 1. Install Repomix
+```bash
+npm install -g repomix
+```
+
+### 2. Create repomix.config.json
+Create a configuration file in the repository root with:
+- **Include patterns**: Source code files (*.py, *.js, *.md, *.yaml, *.yml, *.toml)
+- **Exclude patterns**: Data directories, logs, node_modules, JSON files, generated files
+- **Security check**: Enable to prevent sensitive data inclusion
+
+### 3. Configure Include/Exclude Patterns
+- Include only source code directories and documentation
+- Exclude data/, logs/, build artifacts, dependencies
+- Add `llms*.txt` to exclusions to prevent recursive inclusion
+
+### 4. Test Configuration (Optional)
+```bash
+# Generate file list only for inspection
+repomix --no-files -o file-list.txt
+```
+This allows you to review which files will be included before generating the full output.
+
+### 5. Generate Output Versions
+
+Use the Makefile targets to generate repomix files:
+
+```bash
+# Generate all variants (recommended)
+make repomix-all
+
+# Or generate specific versions:
+make repomix                      # llms.txt and llms-compressed.txt (includes tests)
+make repomix-no-tests             # llms-no-tests.txt and llms-no-tests-compressed.txt
+make repomix-no-tests-no-examples # llms-no-tests-no-examples.txt and compressed version
+```
+
+All commands use `git ls-files` to ensure only git-tracked files are included.
+
+### 6. Verify Results
+- Check file sizes and token counts in repomix output
+- Ensure no sensitive data is included
+- Confirm only relevant source files are packaged
+
+## Expected Outcome
+Six text files optimized for different LLM contexts:
+- `llms.txt`: Full version with tests and examples (870K tokens)
+- `llms-compressed.txt`: Compressed version with tests and examples (513K tokens)
+- `llms-no-tests.txt`: Full version without tests (677K tokens)
+- `llms-no-tests-compressed.txt`: Compressed version without tests (433K tokens)
+- `llms-no-tests-no-examples.txt`: Core library code only (no tests/examples)
+- `llms-no-tests-no-examples-compressed.txt`: Compressed core library code (285K tokens)
+
+The files contain only git-tracked source code with proper exclusions for clean, focused LLM consumption.
 </file>
 
 <file path="ai-notes/handler-parameter-analysis-notes.md">
@@ -46107,37 +46300,6 @@ task = lr.Task(agent)
 # Set up settings
 </file>
 
-<file path="examples/mcp/biomcp.py">
-"""
-Simple example of using the BioMCP server.
-
-https://github.com/genomoncology/biomcp
-
-The server offers several tools, and we can enable ALL of them to be used
-by a Langroid agent.
-
-Run like this:
-
-    uv run examples/mcp/biomcp.py --model gpt-4.1-mini
-
-"""
-⋮----
-async def main(model: str = "")
-⋮----
-transport = StdioTransport(
-all_tools = await get_tools_async(transport)
-⋮----
-agent = lr.ChatAgent(
-⋮----
-# forward to user when LLM doesn't use a tool
-⋮----
-# enable the agent to use all tools
-⋮----
-# make task with interactive=False =>
-# waits for user only when LLM doesn't use a tool
-task = lr.Task(agent, interactive=False)
-</file>
-
 <file path="examples/mcp/chainlit-mcp.py">
 """
 Variant of gitmcp.py that works via the Chainlit UI library,
@@ -46176,199 +46338,6 @@ agent = lr.ChatAgent(
 ⋮----
 task_cfg = lr.TaskConfig(recognize_string_signals=False)
 task = lr.Task(agent, config=task_cfg, interactive=False)
-</file>
-
-<file path="examples/mcp/gitmcp.py">
-"""
-Simple example of using the GitMCP server to "chat" about a GitHub repository.
-
-https://github.com/idosal/git-mcp
-
-The server offers several tools, and we can enable ALL of them to be used
-by a Langroid agent.
-
-Run like this (-m model optional; defaults to gpt-4.1-mini):
-
-    uv run examples/mcp/gitmcp.py -m ollama/qwen2.5-coder:32b
-
-"""
-⋮----
-def get_gitmcp_url() -> str
-⋮----
-console = Console()
-⋮----
-short_pattern = re.compile(r"^([^/]+)/([^/]+)$")
-url_pattern = re.compile(
-⋮----
-user_input = Prompt.ask(
-m = short_pattern.match(user_input)
-⋮----
-m = url_pattern.match(user_input)
-⋮----
-github_url = f"https://github.com/{owner}/{repo}"
-⋮----
-gitmcp_url = f"https://gitmcp.io/{owner}/{repo}"
-⋮----
-class SendUserTool(SendTool)
-⋮----
-request: str = "send_user"
-purpose: str = "Send <content> to user"
-to: str = "user"
-content: str = Field(
-⋮----
-async def main(model: str = "")
-⋮----
-gitmcp_url = get_gitmcp_url()
-⋮----
-transport = SSETransport(
-all_tools: List[lr.ToolMessage] = await get_tools_async(transport)
-⋮----
-agent = lr.ChatAgent(
-⋮----
-# forward to user when LLM doesn't use a tool
-⋮----
-# enable the agent to use all tools
-⋮----
-# configure task to NOT recognize string-based signals like DONE,
-# since those could occur in the retrieved text!
-task_cfg = lr.TaskConfig(recognize_string_signals=False)
-# make task with interactive=False =>
-# waits for user only when LLM doesn't use a tool
-⋮----
-task = lr.Task(agent, config=task_cfg, interactive=False)
-</file>
-
-<file path="examples/mcp/mcp-fetch.py">
-"""
-Simple example of using the Anthropic Fetch MCP Server to get web-site content.
-
-Fetch MCP Server: https://github.com/modelcontextprotocol/servers/tree/main/src/fetch
-
-Run like this:
-
-    uv run examples/mcp/mcp-fetch.py --model gpt-4.1-mini
-
-Ask questions like:
-
-Summarize the content of this page:
-https://www.anthropic.com/news/model-context-protocol
-"""
-⋮----
-async def main(model: str = "")
-⋮----
-transport = UvxStdioTransport(
-FetchTool = await get_tool_async(transport, "fetch")
-agent = lr.ChatAgent(
-⋮----
-# forward to user when LLM doesn't use a tool
-⋮----
-# enable the agent to use the fetch tool
-⋮----
-# make task with interactive=False =>
-# waits for user only when LLM doesn't use a tool
-task = lr.Task(agent, interactive=False)
-</file>
-
-<file path="examples/mcp/mcp-file-system.py">
-"""
-Example: Expose local file-system operations via an in-memory FastMCP server.
-
-Run like this:
-
-uv run examples/mcp/mcp-file-system.py --model gpt-4.1-mini
-
-Then ask your agent to list, write, or read files.
-"""
-⋮----
-def create_fs_mcp_server() -> FastMCP
-⋮----
-"""Return a FastMCP server exposing list/read/write file tools."""
-server = FastMCP("FsServer")
-⋮----
-"""List file names in the given directory."""
-⋮----
-"""Write text to a file; return True on success."""
-⋮----
-"""Read and return the content of a text file."""
-⋮----
-# use decorator to create a Langroid ToolMessage with a custom handle_async method
-⋮----
-@mcp_tool(create_fs_mcp_server(), "write_file")
-class WriteFileTool(lr.ToolMessage)
-⋮----
-"""Tool to write text to a file."""
-⋮----
-async def handle_async(self) -> str
-⋮----
-"""Invoke `write_file` and report the result."""
-ok = await self.call_tool_async()  # type: ignore
-⋮----
-@mcp_tool(create_fs_mcp_server(), "read_file")
-class ReadFileTool(lr.ToolMessage)
-⋮----
-"""Tool to read the content of a text file."""
-⋮----
-"""Invoke `read_file` and return its contents."""
-text = await self.call_tool_async()  # type: ignore
-⋮----
-async def main(model: str = "") -> None
-⋮----
-"""
-    Launch a ChatAgent that can list, write, and read files.
-
-    Args:
-    model: Optional LLM model name (defaults to gpt-4.1-mini).
-    """
-agent = lr.ChatAgent(
-⋮----
-# create ListFilesTool using the helper function get_tool_async
-ListFilesTool = await get_tool_async(create_fs_mcp_server(), "list_files")
-⋮----
-# enable all three tools
-⋮----
-# create a non-interactive task
-task = lr.Task(agent, interactive=False)
-⋮----
-# instruct the agent
-prompt = """
-result = await task.run_async(prompt, turns=3)
-⋮----
-def _run(**kwargs: str) -> None
-⋮----
-"""Fire entry point to run the async main function."""
-</file>
-
-<file path="examples/mcp/memory.py">
-"""
-Simple example of using the Memory MCP server:
-https://github.com/modelcontextprotocol/servers/tree/main/src/memory
-This server gives your agent persistent memory using a local Knowledge Graph,
-so when you re-start the chat it will remember what you talked about last time.
-
-
-The server offers several tools, and we can enable ALL of them to be used
-by a Langroid agent.
-
-Run like this (-m model optional; defaults to gpt-4.1-mini):
-
-    uv run examples/mcp/memory.py --m ollama/qwen2.5-coder:32b
-
-"""
-⋮----
-async def main(model: str = "")
-⋮----
-agent = lr.ChatAgent(
-⋮----
-# forward to user when LLM doesn't use a tool
-⋮----
-transport = NpxStdioTransport(
-tools = await get_tools_async(transport)
-⋮----
-# enable the agent to use all tools
-⋮----
-# make task with interactive=False =>
-# waits for user only when LLM doesn't use a tool
-task = lr.Task(agent, interactive=False)
 </file>
 
 <file path="examples/mcp/openmemory.py">
@@ -49869,6 +49838,466 @@ result = task.run(
 # check there is non-empty response content
 </file>
 
+<file path="tests/main/test_mcp_tools.py">
+# note we use pydantic v2 to define MCP server
+from pydantic import BaseModel, Field  # keep - need pydantic v2 for MCP server
+⋮----
+class SubItem(BaseModel)
+⋮----
+"""A sub‐item with a value and multiplier."""
+⋮----
+val: int = Field(..., description="Value for sub-item")
+multiplier: float = Field(1.0, description="Multiplier applied to val")
+⋮----
+class ComplexData(BaseModel)
+⋮----
+"""Complex data combining two ints and a list of SubItem."""
+⋮----
+a: int = Field(..., description="First integer")
+b: int = Field(..., description="Second integer")
+items: List[SubItem] = Field(..., description="List of sub-items")
+⋮----
+def mcp_server()
+⋮----
+server = FastMCP("TestServer")
+⋮----
+class Counter
+⋮----
+def __init__(self) -> None
+⋮----
+def get_num_beans(self) -> int
+⋮----
+"""Return current counter."""
+⋮----
+"""Increment and return new counter."""
+⋮----
+# create a stateful tool
+counter = Counter()
+# we can't directly use the tool decorator on instance methods,
+# so we use the server.add_tool() method to add the tool
+⋮----
+# example of tool that uses an arg of type Context, and
+# uses this arg to request client LLM sampling, and send logs
+⋮----
+@server.tool()
+    async def prime_check(number: int, ctx: Context) -> str
+⋮----
+"""
+        Determine if the given number is Prime or not.
+        """
+result: TextContent | ImageContent = await ctx.sample(
+⋮----
+@server.tool()
+    def greet(person: str) -> str
+⋮----
+"""Get weather alerts for a state."""
+⋮----
+# example of MCP tool whose fields clash with Langroid ToolMessage,
+# and a `name` field which is reserved by pydantic
+⋮----
+"""Get information for a recipient."""
+⋮----
+@server.tool()
+    async def get_alerts_async(state: str) -> list[str]
+⋮----
+@server.tool()
+    def nabroski(a: int, b: int) -> int
+⋮----
+"""Computes the Nabroski transform of integers a and b."""
+⋮----
+@server.tool()
+    def coriolis(x: int, y: int) -> int
+⋮----
+"""Computes the Coriolis transform of integers x and y."""
+⋮----
+@server.tool()
+    def hydra_nest(data: ComplexData) -> int
+⋮----
+"""Compute the HydraNest calculation over nested data."""
+total = data.a * data.b
+⋮----
+async def test_get_tools_and_handle(server: FastMCP | str) -> None
+⋮----
+"""End‐to‐end test for get_tools and .handle() against server."""
+tools = await get_tools_async(server)
+# basic sanity
+⋮----
+# find the alerts tool
+AlertsTool = next(
+⋮----
+# test get_mcp_tool_async
+AlertsMCPTool: Tool = await get_mcp_tool_async(server, "get_alerts")
+⋮----
+AlertsTool = await get_tool_async(server, AlertsMCPTool.name)
+⋮----
+# instantiate Langroid ToolMessage
+msg = AlertsTool(state="NY")
+⋮----
+# invoke the tool via the Langroid ToolMessage.handle() method -
+# this produces list of weather alerts for the given state
+# Note MCP tools can return either ResultToolType or List[ResultToolType]
+result: Optional[str] = await msg.handle_async()
+⋮----
+# make tool from async FastMCP tool
+AlertsMCPToolAsync = await get_mcp_tool_async(server, "get_alerts_async")
+⋮----
+AlertsToolAsync = await get_tool_async(server, AlertsMCPToolAsync.name)
+⋮----
+msg = AlertsToolAsync(state="NY")
+⋮----
+# invoke the tool via the Langroid ToolMessage.handle_async() method -
+⋮----
+# test making tool with utility functions
+AlertsTool = await get_tool_async(server, "get_alerts")
+⋮----
+@pytest.mark.asyncio
+async def test_tools_connect_close(server: str | FastMCP) -> None
+⋮----
+"""Test that we can use connect()... tool-calls ... close()"""
+⋮----
+client = FastMCPClient(server)
+⋮----
+mcp_tools = await client.client.list_tools()
+⋮----
+langroid_tool_classes = await client.get_tools_async()
+⋮----
+AlertsMCPTool = await get_mcp_tool_async(server, "get_alerts")
+⋮----
+result = await msg.handle_async()
+⋮----
+@pytest.mark.asyncio
+async def test_stateful_tool() -> None
+⋮----
+# instantiate the server
+server = mcp_server()
+⋮----
+# get tools from the SAME instance of the server
+AddBeansTool = await get_tool_async(server, "add_beans")
+⋮----
+GetNumBeansTool = await get_tool_async(server, "get_num_beans")
+⋮----
+add_beans_msg = AddBeansTool(x=5)
+⋮----
+result = await add_beans_msg.handle_async()
+⋮----
+get_num_beans_msg = GetNumBeansTool()
+⋮----
+result = await get_num_beans_msg.handle_async()
+⋮----
+@pytest.mark.asyncio
+async def test_tool_with_context_and_sampling() -> None
+⋮----
+"""Handle a sampling request from server"""
+# simulate an LLM call
+⋮----
+PrimeCheckTool = await get_tool_async(
+⋮----
+# assert that "ctx" is NOT a field in the tool
+⋮----
+prime_check_msg = PrimeCheckTool(number=7)
+⋮----
+result = await prime_check_msg.handle_async()
+⋮----
+@pytest.mark.asyncio
+async def test_mcp_tool_schemas() -> None
+⋮----
+"""
+    Test that descriptions, field-descriptions of MCP tools are preserved
+    when we translate them to Langroid ToolMessage classes. This is important
+    since the LLM is shown these, and helps with tool-call accuracy.
+    """
+# make a langroid AlertsTool from the corresponding MCP tool
+AlertsTool = await get_tool_async(mcp_server(), "get_alerts")
+⋮----
+description = "Get weather alerts for a state."
+⋮----
+schema: lm.LLMFunctionSpec = AlertsTool.llm_function_schema()
+⋮----
+InfoTool = await get_tool_async(mcp_server(), "info_tool")
+⋮----
+description = "Get information for a recipient."
+⋮----
+# instantiate InfoTool
+msg = InfoTool(
+⋮----
+# call the tool
+⋮----
+@pytest.mark.asyncio
+async def test_single_output() -> None
+⋮----
+"""Test that a tool with a single string output works
+    similarly to one that has a list of strings outputs."""
+⋮----
+OneAlertTool = await get_tool_async(mcp_server(), "get_one_alert")
+⋮----
+msg = OneAlertTool(state="NY")
+⋮----
+# we expect a list containing a single str
+⋮----
+@pytest.mark.asyncio
+async def test_agent_mcp_tools() -> None
+⋮----
+"""Test that a Langroid ChatAgent can use and handle MCP tools."""
+⋮----
+agent = lr.ChatAgent(
+⋮----
+NabroskiTool: lr.ToolMessage = await get_tool_async(server, "nabroski")
+⋮----
+response: lr.ChatDocument = await agent.llm_response_async(
+tools = agent.get_tool_messages(response)
+⋮----
+result: lr.ChatDocument = await agent.agent_response_async(response)
+# TODO assert needs to take LLM tool-forgetting into account
+⋮----
+task = lr.Task(agent, interactive=False)
+result: lr.ChatDocument = await task.run_async(
+⋮----
+# test MCP tool with fields that clash with Langroid ToolMessage
+InfoTool = await get_tool_async(server, "info_tool")
+⋮----
+# Need to define the tools outside async def,
+# since the decorator uses asyncio.run() to wrap around an async fn
+⋮----
+@mcp_tool(mcp_server(), "get_alerts")
+class GetAlertsTool(lr.ToolMessage)
+⋮----
+"""Tool to get weather alerts."""
+⋮----
+async def my_handler(self) -> str
+⋮----
+alert = await self.handle_async()
+⋮----
+@mcp_tool(mcp_server(), "nabroski")
+class NabroskiTool(lr.ToolMessage)
+⋮----
+"""Tool to get Nabroski transform."""
+⋮----
+result = await self.handle_async()
+⋮----
+@pytest.mark.asyncio
+async def test_fastmcp_decorator() -> None
+⋮----
+"""Test that the mcp_tool decorator works as expected."""
+⋮----
+msg = GetAlertsTool(state="NY")
+⋮----
+result = await msg.my_handler()
+⋮----
+result = await task.run_async("What is the nabroski transform of 5 and 3?", turns=3)
+⋮----
+@mcp_tool(mcp_server(), "hydra_nest")
+class HydraNestTool(lr.ToolMessage)
+⋮----
+"""Tool for computing HydraNest calculation."""
+⋮----
+"""Call hydra_nest and format result."""
+⋮----
+@pytest.mark.asyncio
+async def test_complex_tool_decorator() -> None
+⋮----
+"""Test that compute_complex via decorator works end‐to‐end."""
+# build nested input
+payload = {
+msg = HydraNestTool(**payload)
+⋮----
+# call handler
+⋮----
+expected = int(4 * 5 + 2 * 1.5 + 3 * 2.0)
+⋮----
+# round‐trip via an agent
+⋮----
+prompt = """
+response = await task.run_async(prompt, turns=3)
+⋮----
+@pytest.mark.asyncio
+async def test_multiple_tools(prompt, tool_name, expected) -> None
+⋮----
+"""
+    Test one-shot enabling of multiple tools.
+    """
+⋮----
+all_tools = await get_tools_async(mcp_server())
+⋮----
+tool = next(
+⋮----
+# test that agent (LLM) can pick right tool based on prompt
+prompt = "use one of your TOOLs to answer this: " + prompt
+response: lr.ChatDocument = await agent.llm_response_async(prompt)
+⋮----
+# test in a task
+⋮----
+result: lr.ChatDocument = await task.run_async(prompt, turns=3)
+⋮----
+@pytest.mark.asyncio
+async def test_npxstdio_transport() -> None
+⋮----
+"""
+    Test that we can create Langroid ToolMessage from an MCP server
+    via npx stdio transport, for example the `exa-mcp-server`:
+    https://github.com/exa-labs/exa-mcp-server
+    """
+transport = NpxStdioTransport(
+tools = await get_tools_async(transport)
+⋮----
+WebSearchTool = await get_tool_async(transport, "web_search_exa")
+⋮----
+# Note: we shouldn't have to explicitly beg the LLM to use the tool here
+# but I've found that even GPT-4o sometimes fails to use the tool
+question = """
+response = await agent.llm_response_async(question)
+⋮----
+result: lr.ChatDocument = await task.run_async(question, turns=3)
+⋮----
+transport = UvxStdioTransport(
+⋮----
+# `tool_name` is a misleading name -- it really refers to the
+# MCP server, which offers several tools
+⋮----
+@mcp_tool(transport, "git_status")
+class GitStatusTool(lr.ToolMessage)
+⋮----
+"""Tool to get git status."""
+⋮----
+async def handle_async(self) -> str
+⋮----
+"""
+        When defining a class explicitly with the @mcp_tool decorator,
+        we have the flexibility to define our own `handle_async` method
+        which calls the call_tool_async method, which in turn calls the
+        MCP server's call_tool method.
+        Returns:
+
+        """
+status = await self.call_tool_async()
+⋮----
+@pytest.mark.asyncio
+async def test_uvxstdio_transport() -> None
+⋮----
+"""
+    Test that we can create Langroid ToolMessage from an MCP server
+    via uvx stdio transport. We use this example `git` MCP server:
+    https://github.com/modelcontextprotocol/servers/tree/main/src/git
+    """
+⋮----
+GitStatusTool = await get_tool_async(transport, "git_status")
+⋮----
+response = await agent.llm_response_async(prompt)
+⋮----
+# test GitStatusTool created via @mcp_tool decorator
+⋮----
+@pytest.mark.asyncio
+async def test_npxstdio_transport_memory() -> None
+⋮----
+"""
+    Test that we can create Langroid ToolMessage from the `memory` MCP server
+    via npx stdio transport:
+    https://github.com/modelcontextprotocol/servers/tree/main/src/memory
+    """
+⋮----
+task = lr.Task(agent, interactive=False, restart=False)
+⋮----
+@pytest.mark.asyncio
+async def test_persist_connection() -> None
+⋮----
+"""Test that persist_connection keeps the connection open between tool calls."""
+⋮----
+# Create client with persist_connection=True
+⋮----
+# First tool call - this should create and keep the connection open
+tool1 = await client.get_tool_async("add_beans")
+⋮----
+# Check that client connection is established
+⋮----
+initial_client = client.client
+⋮----
+# Second tool call - should reuse the same connection
+tool2 = await client.get_tool_async("get_num_beans")
+⋮----
+# Verify the same client connection was reused
+⋮----
+# Call the tools to ensure they work
+add_msg = tool1(x=5)
+result1 = await add_msg.handle_async()
+assert result1 == "5"  # handle_async returns string for backward compatibility
+⋮----
+get_msg = tool2()
+result2 = await get_msg.handle_async()
+assert result2 == "5"  # handle_async returns string for backward compatibility
+⋮----
+@pytest.mark.asyncio
+async def test_handle_async_with_images() -> None
+⋮----
+"""Test that response_async returns ChatDocument with file attachments."""
+# Create a mock server that returns image content
+server = FastMCP("ImageServer")
+⋮----
+@server.tool()
+    async def get_chart() -> List[TextContent | ImageContent]
+⋮----
+"""Get a chart with image."""
+⋮----
+data="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",  # noqa: E501
+⋮----
+# Get the tool and test response_async
+⋮----
+ChartTool = await client.get_tool_async("get_chart")
+⋮----
+# Create a mock agent
+agent = lr.ChatAgent(lr.ChatAgentConfig())
+⋮----
+# Test response_async method
+chart_msg = ChartTool()
+response = await chart_msg.handle_async(agent)
+⋮----
+# Verify we got a ChatDocument
+⋮----
+# Verify we have file attachments in the files attribute
+⋮----
+# Verify the file is an image
+file = response.files[0]
+⋮----
+@pytest.mark.asyncio
+async def test_forward_text_resources() -> None
+⋮----
+"""Test that forward_text_resources setting works correctly."""
+⋮----
+server = FastMCP("TextResourceServer")
+⋮----
+# Test the _convert_tool_result method directly with mocked data
+⋮----
+# Create a mock CallToolResult with text and text resource
+mock_result = CallToolResult(
+⋮----
+# Test with forward_text_resources=True
+result = client._convert_tool_result("test_tool", mock_result)
+⋮----
+# Should include both the main text and the resource text
+⋮----
+# Test with forward_text_resources=False
+⋮----
+# Should only include the main text, not the resource text
+⋮----
+@pytest.mark.asyncio
+async def test_forward_blob_resources() -> None
+⋮----
+"""Test that forward_blob_resources setting works correctly."""
+⋮----
+server = FastMCP("BlobResourceServer")
+⋮----
+# Small PNG data (1x1 blue pixel)
+png_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAD0lEQVR42mNkYPhfz/ADAAKAA4RkT4UVAAAAAElFTkSuQmCC"  # noqa: E501
+⋮----
+# Create a mock CallToolResult with text and blob resource
+⋮----
+# Test with forward_blob_resources=True
+⋮----
+# Should have text content and file attachment
+⋮----
+# Test with forward_blob_resources=False
+⋮----
+# Should only have text content, no file attachments
+</file>
+
 <file path="tests/main/test_rich_file_logger.py">
 def _make(path: str, n: int) -> List[RichFileLogger]
 ⋮----
@@ -50227,6 +50656,366 @@ dmypy.json
 sessions/
 commands/
 .claude/
+</file>
+
+<file path="docs/notes/mcp-tools.md">
+# Langroid MCP Integration
+
+Langroid provides seamless integration with Model Context Protocol (MCP) servers via 
+two methods, both of which involve creating Langroid `ToolMessage` subclasses
+corresponding to the MCP tools: 
+
+1. Programmatic creation of Langroid tools using `get_tool_async`, 
+   `get_tools_async` from the tool definitions defined on an MCP server.
+2. Declarative creation of Langroid tools using the **`@mcp_tool` decorator**, which allows
+   customizing the tool-handling behavior beyond what is provided by the MCP server.
+
+This integration allows _any_ LLM (that is good enough to do function-calling via prompts) to use any MCP server.
+See the following to understand the integration better:
+
+- example python scripts under [`examples/mcp`](https://github.com/langroid/langroid/tree/main/examples/mcp)
+- [`tests/main/test_mcp_tools.py`](https://github.com/langroid/langroid/blob/main/tests/main/test_mcp_tools.py)
+
+---
+
+## 1. Connecting to an MCP server via transport specification
+
+Before creating Langroid tools, we first need to define and connect to an MCP server
+via a [FastMCP](https://gofastmcp.com/getting-started/welcome) client. 
+There are several ways to connect to a server, depending on how it is defined. 
+Each of these uses a different type of [transport](https://gofastmcp.com/clients/transports).
+
+The typical pattern to use with Langroid is as follows:
+
+- define an MCP server transport
+- create a `ToolMessage` subclass using the `@mcp_tool` decorator or 
+  `get_tool_async()` function, with the transport as the first argument
+
+
+Langroid's MCP integration will work with any of [transports](https://gofastmcp.com/clients/transportsl) 
+supported by FastMCP.
+Below we go over some common ways to define transports and extract tools from the servers.
+
+1. **Local Python script**
+2. **In-memory FastMCP server** - useful for testing and for simple in-memory servers
+   that don't need to be run as a separate process.
+3. **NPX stdio transport**
+4. **UVX stdio transport**
+5. **Generic stdio transport** – launch any CLI‐based MCP server via stdin/stdout
+6. **Network SSE transport** – connect to HTTP/S MCP servers via `SSETransport`
+
+
+All examples below use the async helpers to create Langroid tools (`ToolMessage` subclasses):
+
+```python
+from langroid.agent.tools.mcp import (
+    get_tools_async,
+    get_tool_async,
+)
+```
+
+---
+
+#### Path to a Python Script
+
+Point at your MCP‐server entrypoint, e.g., to the `weather.py` script in the 
+langroid repo (based on the [Anthropic quick-start guide](https://modelcontextprotocol.io/quickstart/server)):
+
+```python
+async def example_script_path() -> None:
+    server = "tests/main/mcp/weather-server-python/weather.py"
+    tools = await get_tools_async(server) # all tools available
+    AlertTool = await get_tool_async(server, "get_alerts") # specific tool
+
+    # instantiate the tool with a specific input
+    msg = AlertTool(state="CA")
+    
+    # Call the tool via handle_async()
+    alerts = await msg.handle_async()
+    print(alerts)
+```
+
+---
+
+#### In-Memory FastMCP Server
+
+Define your server with `FastMCP(...)` and pass the instance:
+
+```python
+from fastmcp.server import FastMCP
+from pydantic import BaseModel, Field
+
+class CounterInput(BaseModel):
+    start: int = Field(...)
+
+def make_server() -> FastMCP:
+    server = FastMCP("CounterServer")
+
+    @server.tool()
+    def increment(data: CounterInput) -> int:
+        """Increment start by 1."""
+        return data.start + 1
+
+    return server
+
+async def example_in_memory() -> None:
+    server = make_server()
+    tools = await get_tools_async(server)
+    IncTool = await get_tool_async(server, "increment")
+
+    result = await IncTool(start=41).handle_async()
+    print(result)  # 42
+```
+
+See the [`mcp-file-system.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/mcp-file-system.py)
+script for a working example of this.
+
+---
+
+#### NPX stdio Transport
+
+Use any npm-installed MCP server via `npx`, e.g., the 
+[Exa web-search MCP server](https://docs.exa.ai/examples/exa-mcp):
+
+```python
+from fastmcp.client.transports import NpxStdioTransport
+
+transport = NpxStdioTransport(
+    package="exa-mcp-server",
+    env_vars={"EXA_API_KEY": "…"},
+)
+
+async def example_npx() -> None:
+    tools = await get_tools_async(transport)
+    SearchTool = await get_tool_async(transport, "web_search_exa")
+
+    results = await SearchTool(
+        query="How does Langroid integrate with MCP?"
+    ).handle_async()
+    print(results)
+```
+
+For a fully working example, see the script [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py).
+
+---
+
+#### UVX stdio Transport
+
+Connect to a UVX-based MCP server, e.g., the [Git MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
+
+```python
+from fastmcp.client.transports import UvxStdioTransport
+
+transport = UvxStdioTransport(tool_name="mcp-server-git")
+
+async def example_uvx() -> None:
+    tools = await get_tools_async(transport)
+    GitStatus = await get_tool_async(transport, "git_status")
+
+    status = await GitStatus(path=".").handle_async()
+    print(status)
+```
+
+--- 
+
+#### Generic stdio Transport
+
+Use `StdioTransport` to run any MCP server as a subprocess over stdio:
+
+```python
+from fastmcp.client.transports import StdioTransport
+from langroid.agent.tools.mcp import get_tools_async, get_tool_async
+
+
+async def example_stdio() -> None:
+    """Example: any CLI‐based MCP server via StdioTransport."""
+    transport: StdioTransport = StdioTransport(
+        command="uv",
+        args=["run", "--with", "biomcp-python", "biomcp", "run"],
+    )
+    tools: list[type] = await get_tools_async(transport)
+    BioTool = await get_tool_async(transport, "tool_name")
+    result: str = await BioTool(param="value").handle_async()
+    print(result)
+```
+
+See the full example in [`examples/mcp/biomcp.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/biomcp.py).
+
+---
+
+#### Network SSE Transport
+
+Use `SSETransport` to connect to a FastMCP server over HTTP/S:
+
+```python
+from fastmcp.client.transports import SSETransport
+from langroid.agent.tools.mcp import (
+    get_tools_async,
+    get_tool_async,
+)
+
+
+async def example_sse() -> None:
+    """Example: connect to an HTTP/S MCP server via SSETransport."""
+    url: str = "https://localhost:8000/sse"
+    transport: SSETransport = SSETransport(
+        url=url, headers={"Authorization": "Bearer TOKEN"}
+    )
+    tools: list[type] = await get_tools_async(transport)
+    ExampleTool = await get_tool_async(transport, "tool_name")
+    result: str = await ExampleTool(param="value").handle_async()
+    print(result)
+```    
+
+---
+
+With these patterns you can list tools, generate Pydantic-backed `ToolMessage` classes,
+and invoke them via `.handle_async()`, all with zero boilerplate client setup. 
+As the `FastMCP` library adds other types of transport (e.g., `StreamableHTTPTransport`),
+the pattern of usage with Langroid will remain the same.
+
+
+---
+
+## 2. Create Langroid Tools declaratively using the `@mcp_tool` decorator
+
+The above examples showed how you can create Langroid tools programmatically using
+the helper functions `get_tool_async()` and `get_tools_async()`,
+with the first argument being the transport to the MCP server. The `@mcp_tool` decorator
+works in the same way: 
+
+- **Arguments to the decorator**
+    1. `server_spec`: path/URL/`FastMCP`/`ClientTransport`, as mentioned above.
+    2. `tool_name`: name of a specific MCP tool
+
+- **Behavior**
+    - Generates a `ToolMessage` subclass with all input fields typed.
+    - Provides a `call_tool_async()` under the hood -- this is the "raw" MCP tool call,
+      returning a string.
+    - If you define your own `handle_async()`, it overrides the default. Typically,
+you would override it to customize either the input or the output of the tool call, or both.
+    - If you don't define your own `handle_async()`, it defaults to just returning the
+      value of the `call_tool_async()` method.
+
+Here is a simple example of using the `@mcp_tool` decorator to create a Langroid tool:
+
+```python
+from fastmcp.server import FastMCP
+from langroid.agent.tools.mcp import mcp_tool
+import langroid as lr
+
+# Define your MCP server (pydantic v2 for schema)
+server = FastMCP("MyServer")
+
+@mcp_tool(server, "greet")
+class GreetTool(lr.ToolMessage):
+    """Say hello to someone."""
+
+    async def handle_async(self) -> str:
+        # Customize post-processing
+        raw = await self.call_tool_async()
+        return f"💬 {raw}"
+```
+
+Using the decorator method allows you to customize the `handle_async` method of the
+tool, or add additional fields to the `ToolMessage`. 
+You may want to customize the input to the tool, or the tool result before it is sent back to 
+the LLM. If you don't override it, the default behavior is to simply return the value of 
+the "raw" MCP tool call `await self.call_tool_async()`. 
+
+```python
+@mcp_tool(server, "calculate")
+class CalcTool(ToolMessage):
+    """Perform complex calculation."""
+
+    async def handle_async(self) -> str:
+        result = await self.call_tool_async()
+        # Add context or emojis, etc.
+        return f"🧮 Result is *{result}*"
+```
+
+---
+
+## 3. Enabling Tools in Your Agent
+
+Once you’ve created a Langroid `ToolMessage` subclass from an MCP server, 
+you can enable it on a `ChatAgent`, just like you normally would. Below is an example of using 
+the [Exa MCP server](https://docs.exa.ai/examples/exa-mcp) to create a 
+Langroid web search tool, enable a `ChatAgent` to use it, and then set up a `Task` to 
+run the agent loop.
+
+First we must define the appropriate `ClientTransport` for the MCP server:
+```python
+# define the transport
+transport = NpxStdioTransport(
+    package="exa-mcp-server",
+    env_vars=dict(EXA_API_KEY=os.getenv("EXA_API_KEY")),
+)
+```
+
+Then we use the `@mcp_tool` decorator to create a `ToolMessage` 
+subclass representing the web search tool. Note that one reason to use the decorator
+to define our tool is so we can specify a custom `handle_async` method that
+controls what is sent to the LLM after the actual raw MCP tool-call
+(the `call_tool_async` method) is made.
+
+```python
+# the second arg specifically refers to the `web_search_exa` tool available
+# on the server defined by the `transport` variable.
+@mcp_tool(transport, "web_search_exa")
+class ExaSearchTool(lr.ToolMessage):
+    async def handle_async(self):
+        result: str = await self.call_tool_async()
+        return f"""
+        Below are the results of the web search:
+        
+        <WebSearchResult>
+        {result}
+        </WebSearchResult>
+        
+        Use these results to answer the user's original question.
+        """
+
+```
+
+If we did not want to override the `handle_async` method, we could simply have
+created the `ExaSearchTool` class programmatically via the `get_tool_async` 
+function as shown above, i.e.:
+
+```python
+from langroid.agent.tools.mcp import get_tool_async
+
+ExaSearchTool = awwait
+get_tool_async(transport, "web_search_exa")
+```
+
+We can now define our main function where we create our `ChatAgent`,
+attach the `ExaSearchTool` to it, define the `Task`, and run the task loop.
+
+```python
+async def main():
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            # forward to user when LLM doesn't use a tool
+            handle_llm_no_tool=NonToolAction.FORWARD_USER,
+            llm=lm.OpenAIGPTConfig(
+                max_output_tokens=1000,
+                # this defaults to True, but we set it to False so we can see output
+                async_stream_quiet=False,
+            ),
+        )
+    )
+
+    # enable the agent to use the web-search tool
+    agent.enable_message(ExaSearchTool)
+    # make task with interactive=False =>
+    # waits for user only when LLM doesn't use a tool
+    task = lr.Task(agent, interactive=False)
+    await task.run_async()
+```
+
+See [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py) for a full 
+working example of this.
 </file>
 
 <file path="examples/basic/planner-workflow-simple.py">
@@ -51867,466 +52656,6 @@ response_dict = response.model_dump()
 cached, hashed_key, response = await self._achat_completions_with_backoff(  # type: ignore
 </file>
 
-<file path="tests/main/test_mcp_tools.py">
-# note we use pydantic v2 to define MCP server
-from pydantic import BaseModel, Field  # keep - need pydantic v2 for MCP server
-⋮----
-class SubItem(BaseModel)
-⋮----
-"""A sub‐item with a value and multiplier."""
-⋮----
-val: int = Field(..., description="Value for sub-item")
-multiplier: float = Field(1.0, description="Multiplier applied to val")
-⋮----
-class ComplexData(BaseModel)
-⋮----
-"""Complex data combining two ints and a list of SubItem."""
-⋮----
-a: int = Field(..., description="First integer")
-b: int = Field(..., description="Second integer")
-items: List[SubItem] = Field(..., description="List of sub-items")
-⋮----
-def mcp_server()
-⋮----
-server = FastMCP("TestServer")
-⋮----
-class Counter
-⋮----
-def __init__(self) -> None
-⋮----
-def get_num_beans(self) -> int
-⋮----
-"""Return current counter."""
-⋮----
-"""Increment and return new counter."""
-⋮----
-# create a stateful tool
-counter = Counter()
-# we can't directly use the tool decorator on instance methods,
-# so we use the server.add_tool() method to add the tool
-⋮----
-# example of tool that uses an arg of type Context, and
-# uses this arg to request client LLM sampling, and send logs
-⋮----
-@server.tool()
-    async def prime_check(number: int, ctx: Context) -> str
-⋮----
-"""
-        Determine if the given number is Prime or not.
-        """
-result: TextContent | ImageContent = await ctx.sample(
-⋮----
-@server.tool()
-    def greet(person: str) -> str
-⋮----
-"""Get weather alerts for a state."""
-⋮----
-# example of MCP tool whose fields clash with Langroid ToolMessage,
-# and a `name` field which is reserved by pydantic
-⋮----
-"""Get information for a recipient."""
-⋮----
-@server.tool()
-    async def get_alerts_async(state: str) -> list[str]
-⋮----
-@server.tool()
-    def nabroski(a: int, b: int) -> int
-⋮----
-"""Computes the Nabroski transform of integers a and b."""
-⋮----
-@server.tool()
-    def coriolis(x: int, y: int) -> int
-⋮----
-"""Computes the Coriolis transform of integers x and y."""
-⋮----
-@server.tool()
-    def hydra_nest(data: ComplexData) -> int
-⋮----
-"""Compute the HydraNest calculation over nested data."""
-total = data.a * data.b
-⋮----
-async def test_get_tools_and_handle(server: FastMCP | str) -> None
-⋮----
-"""End‐to‐end test for get_tools and .handle() against server."""
-tools = await get_tools_async(server)
-# basic sanity
-⋮----
-# find the alerts tool
-AlertsTool = next(
-⋮----
-# test get_mcp_tool_async
-AlertsMCPTool: Tool = await get_mcp_tool_async(server, "get_alerts")
-⋮----
-AlertsTool = await get_tool_async(server, AlertsMCPTool.name)
-⋮----
-# instantiate Langroid ToolMessage
-msg = AlertsTool(state="NY")
-⋮----
-# invoke the tool via the Langroid ToolMessage.handle() method -
-# this produces list of weather alerts for the given state
-# Note MCP tools can return either ResultToolType or List[ResultToolType]
-result: Optional[str] = await msg.handle_async()
-⋮----
-# make tool from async FastMCP tool
-AlertsMCPToolAsync = await get_mcp_tool_async(server, "get_alerts_async")
-⋮----
-AlertsToolAsync = await get_tool_async(server, AlertsMCPToolAsync.name)
-⋮----
-msg = AlertsToolAsync(state="NY")
-⋮----
-# invoke the tool via the Langroid ToolMessage.handle_async() method -
-⋮----
-# test making tool with utility functions
-AlertsTool = await get_tool_async(server, "get_alerts")
-⋮----
-@pytest.mark.asyncio
-async def test_tools_connect_close(server: str | FastMCP) -> None
-⋮----
-"""Test that we can use connect()... tool-calls ... close()"""
-⋮----
-client = FastMCPClient(server)
-⋮----
-mcp_tools = await client.client.list_tools()
-⋮----
-langroid_tool_classes = await client.get_tools_async()
-⋮----
-AlertsMCPTool = await get_mcp_tool_async(server, "get_alerts")
-⋮----
-result = await msg.handle_async()
-⋮----
-@pytest.mark.asyncio
-async def test_stateful_tool() -> None
-⋮----
-# instantiate the server
-server = mcp_server()
-⋮----
-# get tools from the SAME instance of the server
-AddBeansTool = await get_tool_async(server, "add_beans")
-⋮----
-GetNumBeansTool = await get_tool_async(server, "get_num_beans")
-⋮----
-add_beans_msg = AddBeansTool(x=5)
-⋮----
-result = await add_beans_msg.handle_async()
-⋮----
-get_num_beans_msg = GetNumBeansTool()
-⋮----
-result = await get_num_beans_msg.handle_async()
-⋮----
-@pytest.mark.asyncio
-async def test_tool_with_context_and_sampling() -> None
-⋮----
-"""Handle a sampling request from server"""
-# simulate an LLM call
-⋮----
-PrimeCheckTool = await get_tool_async(
-⋮----
-# assert that "ctx" is NOT a field in the tool
-⋮----
-prime_check_msg = PrimeCheckTool(number=7)
-⋮----
-result = await prime_check_msg.handle_async()
-⋮----
-@pytest.mark.asyncio
-async def test_mcp_tool_schemas() -> None
-⋮----
-"""
-    Test that descriptions, field-descriptions of MCP tools are preserved
-    when we translate them to Langroid ToolMessage classes. This is important
-    since the LLM is shown these, and helps with tool-call accuracy.
-    """
-# make a langroid AlertsTool from the corresponding MCP tool
-AlertsTool = await get_tool_async(mcp_server(), "get_alerts")
-⋮----
-description = "Get weather alerts for a state."
-⋮----
-schema: lm.LLMFunctionSpec = AlertsTool.llm_function_schema()
-⋮----
-InfoTool = await get_tool_async(mcp_server(), "info_tool")
-⋮----
-description = "Get information for a recipient."
-⋮----
-# instantiate InfoTool
-msg = InfoTool(
-⋮----
-# call the tool
-⋮----
-@pytest.mark.asyncio
-async def test_single_output() -> None
-⋮----
-"""Test that a tool with a single string output works
-    similarly to one that has a list of strings outputs."""
-⋮----
-OneAlertTool = await get_tool_async(mcp_server(), "get_one_alert")
-⋮----
-msg = OneAlertTool(state="NY")
-⋮----
-# we expect a list containing a single str
-⋮----
-@pytest.mark.asyncio
-async def test_agent_mcp_tools() -> None
-⋮----
-"""Test that a Langroid ChatAgent can use and handle MCP tools."""
-⋮----
-agent = lr.ChatAgent(
-⋮----
-NabroskiTool: lr.ToolMessage = await get_tool_async(server, "nabroski")
-⋮----
-response: lr.ChatDocument = await agent.llm_response_async(
-tools = agent.get_tool_messages(response)
-⋮----
-result: lr.ChatDocument = await agent.agent_response_async(response)
-# TODO assert needs to take LLM tool-forgetting into account
-⋮----
-task = lr.Task(agent, interactive=False)
-result: lr.ChatDocument = await task.run_async(
-⋮----
-# test MCP tool with fields that clash with Langroid ToolMessage
-InfoTool = await get_tool_async(server, "info_tool")
-⋮----
-# Need to define the tools outside async def,
-# since the decorator uses asyncio.run() to wrap around an async fn
-⋮----
-@mcp_tool(mcp_server(), "get_alerts")
-class GetAlertsTool(lr.ToolMessage)
-⋮----
-"""Tool to get weather alerts."""
-⋮----
-async def my_handler(self) -> str
-⋮----
-alert = await self.handle_async()
-⋮----
-@mcp_tool(mcp_server(), "nabroski")
-class NabroskiTool(lr.ToolMessage)
-⋮----
-"""Tool to get Nabroski transform."""
-⋮----
-result = await self.handle_async()
-⋮----
-@pytest.mark.asyncio
-async def test_fastmcp_decorator() -> None
-⋮----
-"""Test that the mcp_tool decorator works as expected."""
-⋮----
-msg = GetAlertsTool(state="NY")
-⋮----
-result = await msg.my_handler()
-⋮----
-result = await task.run_async("What is the nabroski transform of 5 and 3?", turns=3)
-⋮----
-@mcp_tool(mcp_server(), "hydra_nest")
-class HydraNestTool(lr.ToolMessage)
-⋮----
-"""Tool for computing HydraNest calculation."""
-⋮----
-"""Call hydra_nest and format result."""
-⋮----
-@pytest.mark.asyncio
-async def test_complex_tool_decorator() -> None
-⋮----
-"""Test that compute_complex via decorator works end‐to‐end."""
-# build nested input
-payload = {
-msg = HydraNestTool(**payload)
-⋮----
-# call handler
-⋮----
-expected = int(4 * 5 + 2 * 1.5 + 3 * 2.0)
-⋮----
-# round‐trip via an agent
-⋮----
-prompt = """
-response = await task.run_async(prompt, turns=3)
-⋮----
-@pytest.mark.asyncio
-async def test_multiple_tools(prompt, tool_name, expected) -> None
-⋮----
-"""
-    Test one-shot enabling of multiple tools.
-    """
-⋮----
-all_tools = await get_tools_async(mcp_server())
-⋮----
-tool = next(
-⋮----
-# test that agent (LLM) can pick right tool based on prompt
-prompt = "use one of your TOOLs to answer this: " + prompt
-response: lr.ChatDocument = await agent.llm_response_async(prompt)
-⋮----
-# test in a task
-⋮----
-result: lr.ChatDocument = await task.run_async(prompt, turns=3)
-⋮----
-@pytest.mark.asyncio
-async def test_npxstdio_transport() -> None
-⋮----
-"""
-    Test that we can create Langroid ToolMessage from an MCP server
-    via npx stdio transport, for example the `exa-mcp-server`:
-    https://github.com/exa-labs/exa-mcp-server
-    """
-transport = NpxStdioTransport(
-tools = await get_tools_async(transport)
-⋮----
-WebSearchTool = await get_tool_async(transport, "web_search_exa")
-⋮----
-# Note: we shouldn't have to explicitly beg the LLM to use the tool here
-# but I've found that even GPT-4o sometimes fails to use the tool
-question = """
-response = await agent.llm_response_async(question)
-⋮----
-result: lr.ChatDocument = await task.run_async(question, turns=3)
-⋮----
-transport = UvxStdioTransport(
-⋮----
-# `tool_name` is a misleading name -- it really refers to the
-# MCP server, which offers several tools
-⋮----
-@mcp_tool(transport, "git_status")
-class GitStatusTool(lr.ToolMessage)
-⋮----
-"""Tool to get git status."""
-⋮----
-async def handle_async(self) -> str
-⋮----
-"""
-        When defining a class explicitly with the @mcp_tool decorator,
-        we have the flexibility to define our own `handle_async` method
-        which calls the call_tool_async method, which in turn calls the
-        MCP server's call_tool method.
-        Returns:
-
-        """
-status = await self.call_tool_async()
-⋮----
-@pytest.mark.asyncio
-async def test_uvxstdio_transport() -> None
-⋮----
-"""
-    Test that we can create Langroid ToolMessage from an MCP server
-    via uvx stdio transport. We use this example `git` MCP server:
-    https://github.com/modelcontextprotocol/servers/tree/main/src/git
-    """
-⋮----
-GitStatusTool = await get_tool_async(transport, "git_status")
-⋮----
-response = await agent.llm_response_async(prompt)
-⋮----
-# test GitStatusTool created via @mcp_tool decorator
-⋮----
-@pytest.mark.asyncio
-async def test_npxstdio_transport_memory() -> None
-⋮----
-"""
-    Test that we can create Langroid ToolMessage from the `memory` MCP server
-    via npx stdio transport:
-    https://github.com/modelcontextprotocol/servers/tree/main/src/memory
-    """
-⋮----
-task = lr.Task(agent, interactive=False, restart=False)
-⋮----
-@pytest.mark.asyncio
-async def test_persist_connection() -> None
-⋮----
-"""Test that persist_connection keeps the connection open between tool calls."""
-⋮----
-# Create client with persist_connection=True
-⋮----
-# First tool call - this should create and keep the connection open
-tool1 = await client.get_tool_async("add_beans")
-⋮----
-# Check that client connection is established
-⋮----
-initial_client = client.client
-⋮----
-# Second tool call - should reuse the same connection
-tool2 = await client.get_tool_async("get_num_beans")
-⋮----
-# Verify the same client connection was reused
-⋮----
-# Call the tools to ensure they work
-add_msg = tool1(x=5)
-result1 = await add_msg.handle_async()
-assert result1 == "5"  # handle_async returns string for backward compatibility
-⋮----
-get_msg = tool2()
-result2 = await get_msg.handle_async()
-assert result2 == "5"  # handle_async returns string for backward compatibility
-⋮----
-@pytest.mark.asyncio
-async def test_handle_async_with_images() -> None
-⋮----
-"""Test that response_async returns ChatDocument with file attachments."""
-# Create a mock server that returns image content
-server = FastMCP("ImageServer")
-⋮----
-@server.tool()
-    async def get_chart() -> List[TextContent | ImageContent]
-⋮----
-"""Get a chart with image."""
-⋮----
-data="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",  # noqa: E501
-⋮----
-# Get the tool and test response_async
-⋮----
-ChartTool = await client.get_tool_async("get_chart")
-⋮----
-# Create a mock agent
-agent = lr.ChatAgent(lr.ChatAgentConfig())
-⋮----
-# Test response_async method
-chart_msg = ChartTool()
-response = await chart_msg.handle_async(agent)
-⋮----
-# Verify we got a ChatDocument
-⋮----
-# Verify we have file attachments in the files attribute
-⋮----
-# Verify the file is an image
-file = response.files[0]
-⋮----
-@pytest.mark.asyncio
-async def test_forward_text_resources() -> None
-⋮----
-"""Test that forward_text_resources setting works correctly."""
-⋮----
-server = FastMCP("TextResourceServer")
-⋮----
-# Test the _convert_tool_result method directly with mocked data
-⋮----
-# Create a mock CallToolResult with text and text resource
-mock_result = CallToolResult(
-⋮----
-# Test with forward_text_resources=True
-result = client._convert_tool_result("test_tool", mock_result)
-⋮----
-# Should include both the main text and the resource text
-⋮----
-# Test with forward_text_resources=False
-⋮----
-# Should only include the main text, not the resource text
-⋮----
-@pytest.mark.asyncio
-async def test_forward_blob_resources() -> None
-⋮----
-"""Test that forward_blob_resources setting works correctly."""
-⋮----
-server = FastMCP("BlobResourceServer")
-⋮----
-# Small PNG data (1x1 blue pixel)
-png_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAD0lEQVR42mNkYPhfz/ADAAKAA4RkT4UVAAAAAElFTkSuQmCC"  # noqa: E501
-⋮----
-# Create a mock CallToolResult with text and blob resource
-⋮----
-# Test with forward_blob_resources=True
-⋮----
-# Should have text content and file attachment
-⋮----
-# Test with forward_blob_resources=False
-⋮----
-# Should only have text content, no file attachments
-</file>
-
 <file path="tests/main/test_task_tool.py">
 class MultiplierTool(ToolMessage)
 ⋮----
@@ -52425,16 +52754,44 @@ def test_task_tool_all_tools()
 ⋮----
 tools=["ALL"],  # Enable all tools
 ⋮----
-# Enable multiple tools for the main agent
+# Set up multiple tools for the main agent
 ⋮----
 # Create task
 ⋮----
 done_sequences=["T,A"],  # LLM (Tool), Agent(Handled) -> done
 ⋮----
+# Run the task: input text is immaterial since the
+# MockLM is hard-coded to return the TaskTool request
 result = task.run(msg="Test all tools")
 ⋮----
 # Verify that the sub-agent had access to all tools
 # Expected: Multiply 4 and 6 = 24, Nebrowski(3, 5) = 14
+⋮----
+# Verify that parent chain is maintained through TaskTool
+# When TaskTool creates a prompt ChatDocument with parent_id pointing to the
+# TaskTool message, and passes it to the subtask, the subtask's init() method
+# should preserve that parent_id even though it deep copies the message.
+# This ensures the parent chain is not broken.
+⋮----
+# Traverse up the parent chain to find the TaskTool message
+current = result
+task_tool_found = False
+depth = 0
+# Prevent infinite loops, and allow enough look-back
+# to accommodate tool-forgetting retries that may occur.
+max_depth = 40
+⋮----
+# Check if current message is from TaskTool
+⋮----
+task_tool_found = True
+⋮----
+# Also check if it's a tool message with TaskTool request
+⋮----
+tool_messages = main_agent.try_get_tool_messages(current.content)
+⋮----
+pass  # Not a tool message
+⋮----
+current = current.parent
 ⋮----
 def test_task_tool_none_tools()
 ⋮----
@@ -52844,6 +53201,37 @@ task_with_return_type = Task(
 ⋮----
 result_typed = task_with_return_type.run("Process with type", turns=10)
 # Task should terminate and return the SimpleTool instance
+⋮----
+def test_task_init_preserves_parent_id()
+⋮----
+"""Test that task.init() preserves parent_id when deep copying ChatDocument"""
+⋮----
+# Create an agent
+agent = ChatAgent(ChatAgentConfig(name="TestAgent"))
+⋮----
+# Test 1: Basic parent_id preservation
+parent_doc = ChatDocument(
+child_doc = ChatDocument(
+⋮----
+# The pending message should preserve the parent_id
+⋮----
+# Test 2: With caller (subtask scenario)
+caller_task = Task(agent, interactive=False, name="CallerTask")
+sub_task = Task(agent, interactive=False, name="SubTask")
+⋮----
+# When message already has parent_id, it should be preserved
+msg_with_parent = ChatDocument(
+⋮----
+# Set caller to simulate subtask scenario
+⋮----
+# Parent_id should still be preserved (not overridden to msg.id)
+⋮----
+# Test 3: With caller but no original parent_id
+msg_no_parent = ChatDocument(
+⋮----
+sub_task2 = Task(agent, interactive=False, name="SubTask2")
+⋮----
+# Since original had no parent_id, it should be set to msg.id
 </file>
 
 <file path="tests/main/test_tool_handler.py">
@@ -53432,364 +53820,166 @@ agent.enable_message([Tool1, Tool2, Tool3])  # Pass list of tool classes
 - Tokens are not needed for public repositories and can cause GitHub rendering issues
 </file>
 
-<file path="docs/notes/mcp-tools.md">
-# Langroid MCP Integration
-
-Langroid provides seamless integration with Model Context Protocol (MCP) servers via 
-two methods, both of which involve creating Langroid `ToolMessage` subclasses
-corresponding to the MCP tools: 
-
-1. Programmatic creation of Langroid tools using `get_tool_async`, 
-   `get_tools_async` from the tool definitions defined on an MCP server.
-2. Declarative creation of Langroid tools using the **`@mcp_tool` decorator**, which allows
-   customizing the tool-handling behavior beyond what is provided by the MCP server.
-
-This integration allows _any_ LLM (that is good enough to do function-calling via prompts) to use any MCP server.
-See the following to understand the integration better:
-
-- example python scripts under [`examples/mcp`](https://github.com/langroid/langroid/tree/main/examples/mcp)
-- [`tests/main/test_mcp_tools.py`](https://github.com/langroid/langroid/blob/main/tests/main/test_mcp_tools.py)
-
----
-
-## 1. Connecting to an MCP server via transport specification
-
-Before creating Langroid tools, we first need to define and connect to an MCP server
-via a [FastMCP](https://gofastmcp.com/getting-started/welcome) client. 
-There are several ways to connect to a server, depending on how it is defined. 
-Each of these uses a different type of [transport](https://gofastmcp.com/clients/transports).
-
-The typical pattern to use with Langroid is as follows:
-
-- define an MCP server transport
-- create a `ToolMessage` subclass using the `@mcp_tool` decorator or 
-  `get_tool_async()` function, with the transport as the first argument
-
-
-Langroid's MCP integration will work with any of [transports](https://gofastmcp.com/clients/transportsl) 
-supported by FastMCP.
-Below we go over some common ways to define transports and extract tools from the servers.
-
-1. **Local Python script**
-2. **In-memory FastMCP server** - useful for testing and for simple in-memory servers
-   that don't need to be run as a separate process.
-3. **NPX stdio transport**
-4. **UVX stdio transport**
-5. **Generic stdio transport** – launch any CLI‐based MCP server via stdin/stdout
-6. **Network SSE transport** – connect to HTTP/S MCP servers via `SSETransport`
-
-
-All examples below use the async helpers to create Langroid tools (`ToolMessage` subclasses):
-
-```python
-from langroid.agent.tools.mcp import (
-    get_tools_async,
-    get_tool_async,
-)
-```
-
----
-
-#### Path to a Python Script
-
-Point at your MCP‐server entrypoint, e.g., to the `weather.py` script in the 
-langroid repo (based on the [Anthropic quick-start guide](https://modelcontextprotocol.io/quickstart/server)):
-
-```python
-async def example_script_path() -> None:
-    server = "tests/main/mcp/weather-server-python/weather.py"
-    tools = await get_tools_async(server) # all tools available
-    AlertTool = await get_tool_async(server, "get_alerts") # specific tool
-
-    # instantiate the tool with a specific input
-    msg = AlertTool(state="CA")
-    
-    # Call the tool via handle_async()
-    alerts = await msg.handle_async()
-    print(alerts)
-```
-
----
-
-#### In-Memory FastMCP Server
-
-Define your server with `FastMCP(...)` and pass the instance:
-
-```python
-from fastmcp.server import FastMCP
-from pydantic import BaseModel, Field
-
-class CounterInput(BaseModel):
-    start: int = Field(...)
-
-def make_server() -> FastMCP:
-    server = FastMCP("CounterServer")
-
-    @server.tool()
-    def increment(data: CounterInput) -> int:
-        """Increment start by 1."""
-        return data.start + 1
-
-    return server
-
-async def example_in_memory() -> None:
-    server = make_server()
-    tools = await get_tools_async(server)
-    IncTool = await get_tool_async(server, "increment")
-
-    result = await IncTool(start=41).handle_async()
-    print(result)  # 42
-```
-
-See the [`mcp-file-system.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/mcp-file-system.py)
-script for a working example of this.
-
----
-
-#### NPX stdio Transport
-
-Use any npm-installed MCP server via `npx`, e.g., the 
-[Exa web-search MCP server](https://docs.exa.ai/examples/exa-mcp):
-
-```python
-from fastmcp.client.transports import NpxStdioTransport
-
-transport = NpxStdioTransport(
-    package="exa-mcp-server",
-    env_vars={"EXA_API_KEY": "…"},
-)
-
-async def example_npx() -> None:
-    tools = await get_tools_async(transport)
-    SearchTool = await get_tool_async(transport, "web_search_exa")
-
-    results = await SearchTool(
-        query="How does Langroid integrate with MCP?"
-    ).handle_async()
-    print(results)
-```
-
-For a fully working example, see the script [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py).
-
----
-
-#### UVX stdio Transport
-
-Connect to a UVX-based MCP server, e.g., the [Git MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
-
-```python
-from fastmcp.client.transports import UvxStdioTransport
-
-transport = UvxStdioTransport(tool_name="mcp-server-git")
-
-async def example_uvx() -> None:
-    tools = await get_tools_async(transport)
-    GitStatus = await get_tool_async(transport, "git_status")
-
-    status = await GitStatus(path=".").handle_async()
-    print(status)
-```
-
---- 
-
-#### Generic stdio Transport
-
-Use `StdioTransport` to run any MCP server as a subprocess over stdio:
-
-```python
-from fastmcp.client.transports import StdioTransport
-from langroid.agent.tools.mcp import get_tools_async, get_tool_async
-
-
-async def example_stdio() -> None:
-    """Example: any CLI‐based MCP server via StdioTransport."""
-    transport: StdioTransport = StdioTransport(
-        command="uv",
-        args=["run", "--with", "biomcp-python", "biomcp", "run"],
-    )
-    tools: list[type] = await get_tools_async(transport)
-    BioTool = await get_tool_async(transport, "tool_name")
-    result: str = await BioTool(param="value").handle_async()
-    print(result)
-```
-
-See the full example in [`examples/mcp/biomcp.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/biomcp.py).
-
----
-
-#### Network SSE Transport
-
-Use `SSETransport` to connect to a FastMCP server over HTTP/S:
-
-```python
-from fastmcp.client.transports import SSETransport
-from langroid.agent.tools.mcp import (
-    get_tools_async,
-    get_tool_async,
-)
-
-
-async def example_sse() -> None:
-    """Example: connect to an HTTP/S MCP server via SSETransport."""
-    url: str = "https://localhost:8000/sse"
-    transport: SSETransport = SSETransport(
-        url=url, headers={"Authorization": "Bearer TOKEN"}
-    )
-    tools: list[type] = await get_tools_async(transport)
-    ExampleTool = await get_tool_async(transport, "tool_name")
-    result: str = await ExampleTool(param="value").handle_async()
-    print(result)
-```    
-
----
-
-With these patterns you can list tools, generate Pydantic-backed `ToolMessage` classes,
-and invoke them via `.handle_async()`, all with zero boilerplate client setup. 
-As the `FastMCP` library adds other types of transport (e.g., `StreamableHTTPTransport`),
-the pattern of usage with Langroid will remain the same.
-
-
----
-
-## 2. Create Langroid Tools declaratively using the `@mcp_tool` decorator
-
-The above examples showed how you can create Langroid tools programmatically using
-the helper functions `get_tool_async()` and `get_tools_async()`,
-with the first argument being the transport to the MCP server. The `@mcp_tool` decorator
-works in the same way: 
-
-- **Arguments to the decorator**
-    1. `server_spec`: path/URL/`FastMCP`/`ClientTransport`, as mentioned above.
-    2. `tool_name`: name of a specific MCP tool
-
-- **Behavior**
-    - Generates a `ToolMessage` subclass with all input fields typed.
-    - Provides a `call_tool_async()` under the hood -- this is the "raw" MCP tool call,
-      returning a string.
-    - If you define your own `handle_async()`, it overrides the default. Typically,
-you would override it to customize either the input or the output of the tool call, or both.
-    - If you don't define your own `handle_async()`, it defaults to just returning the
-      value of the `call_tool_async()` method.
-
-Here is a simple example of using the `@mcp_tool` decorator to create a Langroid tool:
-
-```python
-from fastmcp.server import FastMCP
-from langroid.agent.tools.mcp import mcp_tool
-import langroid as lr
-
-# Define your MCP server (pydantic v2 for schema)
-server = FastMCP("MyServer")
-
-@mcp_tool(server, "greet")
-class GreetTool(lr.ToolMessage):
-    """Say hello to someone."""
-
-    async def handle_async(self) -> str:
-        # Customize post-processing
-        raw = await self.call_tool_async()
-        return f"💬 {raw}"
-```
-
-Using the decorator method allows you to customize the `handle_async` method of the
-tool, or add additional fields to the `ToolMessage`. 
-You may want to customize the input to the tool, or the tool result before it is sent back to 
-the LLM. If you don't override it, the default behavior is to simply return the value of 
-the "raw" MCP tool call `await self.call_tool_async()`. 
-
-```python
-@mcp_tool(server, "calculate")
-class CalcTool(ToolMessage):
-    """Perform complex calculation."""
-
-    async def handle_async(self) -> str:
-        result = await self.call_tool_async()
-        # Add context or emojis, etc.
-        return f"🧮 Result is *{result}*"
-```
-
----
-
-## 3. Enabling Tools in Your Agent
-
-Once you’ve created a Langroid `ToolMessage` subclass from an MCP server, 
-you can enable it on a `ChatAgent`, just like you normally would. Below is an example of using 
-the [Exa MCP server](https://docs.exa.ai/examples/exa-mcp) to create a 
-Langroid web search tool, enable a `ChatAgent` to use it, and then set up a `Task` to 
-run the agent loop.
-
-First we must define the appropriate `ClientTransport` for the MCP server:
-```python
-# define the transport
-transport = NpxStdioTransport(
-    package="exa-mcp-server",
-    env_vars=dict(EXA_API_KEY=os.getenv("EXA_API_KEY")),
-)
-```
-
-Then we use the `@mcp_tool` decorator to create a `ToolMessage` 
-subclass representing the web search tool. Note that one reason to use the decorator
-to define our tool is so we can specify a custom `handle_async` method that
-controls what is sent to the LLM after the actual raw MCP tool-call
-(the `call_tool_async` method) is made.
-
-```python
-# the second arg specifically refers to the `web_search_exa` tool available
-# on the server defined by the `transport` variable.
-@mcp_tool(transport, "web_search_exa")
-class ExaSearchTool(lr.ToolMessage):
-    async def handle_async(self):
-        result: str = await self.call_tool_async()
-        return f"""
-        Below are the results of the web search:
-        
-        <WebSearchResult>
-        {result}
-        </WebSearchResult>
-        
-        Use these results to answer the user's original question.
-        """
-
-```
-
-If we did not want to override the `handle_async` method, we could simply have
-created the `ExaSearchTool` class programmatically via the `get_tool_async` 
-function as shown above, i.e.:
-
-```python
-from langroid.agent.tools.mcp import get_tool_async
-
-ExaSearchTool = awwait
-get_tool_async(transport, "web_search_exa")
-```
-
-We can now define our main function where we create our `ChatAgent`,
-attach the `ExaSearchTool` to it, define the `Task`, and run the task loop.
-
-```python
-async def main():
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            # forward to user when LLM doesn't use a tool
-            handle_llm_no_tool=NonToolAction.FORWARD_USER,
-            llm=lm.OpenAIGPTConfig(
-                max_output_tokens=1000,
-                # this defaults to True, but we set it to False so we can see output
-                async_stream_quiet=False,
-            ),
-        )
-    )
-
-    # enable the agent to use the web-search tool
-    agent.enable_message(ExaSearchTool)
-    # make task with interactive=False =>
-    # waits for user only when LLM doesn't use a tool
-    task = lr.Task(agent, interactive=False)
-    await task.run_async()
-```
-
-See [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py) for a full 
-working example of this.
+<file path="Makefile">
+.PHONY: setup check lint tests docs nodocs loc
+
+SHELL := /bin/bash
+
+.PHONY: setup update
+
+setup: ## Setup the git pre-commit hooks
+	uv run pre-commit install
+
+update: ## Update the git pre-commit hooks
+	uv run pre-commit autoupdate
+
+.PHONY: type-check
+type-check:
+	@uv run pre-commit install
+	@uv run pre-commit autoupdate
+	@uv run pre-commit run --all-files
+	@echo "Running black..."
+	@uv run black --check .
+	@echo "Running ruff check (without fix)..."
+	@uv run ruff check .
+	@echo "Running mypy...";
+	@uv run mypy -p langroid
+	@echo "All checks passed!"
+
+.PHONY: lint
+lint:
+	uv run black .
+	uv run ruff check . --fix
+	@echo "Auto-fixing issues in examples folder..."
+	@uv run ruff check examples/ --fix-only --no-force-exclude
+
+.PHONY: stubs
+stubs:
+	@echo "Generating Python stubs for the langroid package..."
+	@uv run stubgen -p langroid -o stubs
+	@echo "Stubs generated in the 'stubs' directory"
+
+.PHONY: fix-pydantic
+
+# Entry to replace pydantic imports in specified directories
+fix-pydantic:
+	@echo "Fixing pydantic imports..."
+	@chmod +x scripts/fix-pydantic-imports.sh
+	@./scripts/fix-pydantic-imports.sh
+
+
+.PHONY: tests
+tests:
+	pytest tests/main --basetemp=/tmp/pytest
+
+
+docs:
+	@# Kill any existing 'mkdocs serve' processes.
+	@pkill -f "mkdocs serve" 2>/dev/null || true
+	@# Build the documentation.
+	mkdocs build
+	@# Serve the documentation in the background.
+	mkdocs serve &
+	@echo "Documentation is being served in the background."
+	@echo "You can access the documentation at http://127.0.0.1:8000/"
+
+nodocs:
+	@# Kill any existing 'mkdocs serve' processes.
+	@pkill -f "mkdocs serve" 2>/dev/null || echo "No 'mkdocs serve' process found."
+	@echo "Stopped serving documentation."
+
+
+loc:
+	@echo "Lines in git-tracked files python files:"
+	@git ls-files | grep '\.py$$' | xargs cat | grep -v '^\s*$$' | wc -l
+
+.PHONY: repomix repomix-no-tests repomix-all
+
+repomix: ## Generate llms.txt and llms-compressed.txt (includes tests)
+	@echo "Generating llms.txt (with tests)..."
+	@git ls-files | repomix --stdin
+	@echo "Generating llms-compressed.txt..."
+	@git ls-files | repomix --stdin --compress -o llms-compressed.txt
+	@echo "Generated llms.txt and llms-compressed.txt"
+
+repomix-no-tests: ## Generate llms-no-tests.txt (excludes tests)
+	@echo "Generating llms-no-tests.txt (without tests)..."
+	@git ls-files | grep -v "^tests/" | repomix --stdin -o llms-no-tests.txt
+	@echo "Generating llms-no-tests-compressed.txt..."
+	@git ls-files | grep -v "^tests/" | repomix --stdin --compress -o llms-no-tests-compressed.txt
+	@echo "Generated llms-no-tests.txt and llms-no-tests-compressed.txt"
+
+repomix-no-tests-no-examples: ## Generate llms-no-tests-no-examples.txt (excludes tests and examples)
+	@echo "Generating llms-no-tests-no-examples.txt (without tests and examples)..."
+	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin -o llms-no-tests-no-examples.txt
+	@echo "Generating llms-no-tests-no-examples-compressed.txt..."
+	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin --compress -o llms-no-tests-no-examples-compressed.txt
+	@echo "Generated llms-no-tests-no-examples.txt and llms-no-tests-no-examples-compressed.txt"
+
+repomix-all: repomix repomix-no-tests repomix-no-tests-no-examples ## Generate all repomix variants
+
+.PHONY: check
+check: fix-pydantic lint type-check repomix-all
+
+.PHONY: revert-tag
+revert-tag:
+	@LATEST_TAG=$$(git describe --tags --abbrev=0) && \
+	echo "Deleting tag: $$LATEST_TAG" && \
+	git tag -d $$LATEST_TAG
+
+.PHONY: revert-bump
+revert-bump:
+	@if git log -1 --pretty=%B | grep -q "bump"; then \
+		git reset --hard HEAD~1; \
+		echo "Reverted last commit (bump commit)"; \
+	else \
+		echo "Last commit was not a bump commit"; \
+	fi
+
+.PHONY: revert
+revert: revert-bump revert-tag
+	
+.PHONY: bump-patch
+bump-patch:
+	@cz bump --increment PATCH
+
+.PHONY: bump-minor
+bump-minor:
+	@cz bump --increment MINOR 
+
+.PHONY: bump-major
+bump-major:
+	@cz bump --increment MAJOR 
+
+.PHONY: build
+build:
+	@uv build
+
+.PHONY: push
+push:
+	@git push origin main
+	@git push origin --tags
+
+.PHONY: clean
+clean:
+	-rm -rf dist/*
+
+.PHONY: release
+release:
+	@VERSION=$$(cz version -p | cut -d' ' -f2) && gh release create $${VERSION} dist/*
+
+.PHONY: all-patch
+all-patch: bump-patch clean build push release
+
+.PHONY: all-minor
+all-minor: bump-minor clean build push release
+
+.PHONY: all-major
+all-major: bump-major clean build push release
+
+.PHONY: publish
+publish:
+	uv publish
 </file>
 
 <file path="examples/mcp/any-mcp.py">
@@ -54721,6 +54911,307 @@ def justify_response(self) -> ChatDocument | None
 source = self.response.metadata.source
 </file>
 
+<file path="langroid/agent/tools/mcp/fastmcp_client.py">
+load_dotenv()  # load environment variables from .env
+⋮----
+FastMCPServerSpec: TypeAlias = str | FastMCP[Any] | ClientTransport | AnyUrl
+⋮----
+class FastMCPClient
+⋮----
+"""A client for interacting with a FastMCP server.
+
+    Provides async context manager functionality to safely manage resources.
+    """
+⋮----
+logger = logging.getLogger(__name__)
+_cm: Optional[Client] = None
+client: Optional[Client] = None
+⋮----
+sampling_handler: SamplingHandler | None = None,  # type: ignore
+roots: RootsList | RootsHandler | None = None,  # type: ignore
+⋮----
+"""Initialize the FastMCPClient.
+
+        Args:
+            server: FastMCP server or path to such a server
+        """
+⋮----
+async def __aenter__(self) -> "FastMCPClient"
+⋮----
+"""Enter the async context manager and connect inner client."""
+# create inner client context manager
+⋮----
+# actually enter it (opens the session)
+self.client = await self._cm.__aenter__()  # type: ignore
+⋮----
+async def connect(self) -> None
+⋮----
+"""Open the underlying session."""
+⋮----
+async def close(self) -> None
+⋮----
+"""Close the underlying session."""
+⋮----
+"""Exit the async context manager and close inner client."""
+# exit and close the inner fastmcp.Client
+⋮----
+await self._cm.__aexit__(exc_type, exc_val, exc_tb)  # type: ignore
+⋮----
+def __del__(self) -> None
+⋮----
+"""Warn about unclosed persistent connections."""
+⋮----
+"""Convert a JSON Schema snippet into a (type, Field) tuple.
+
+        Args:
+            name: Name of the field.
+            schema: JSON Schema for this field.
+            prefix: Prefix to use for nested model names.
+
+        Returns:
+            A tuple of (python_type, Field(...)) for create_model.
+        """
+t = schema.get("type")
+default = schema.get("default", ...)
+desc = schema.get("description")
+# Object → nested BaseModel
+⋮----
+sub_name = f"{prefix}_{name.capitalize()}"
+sub_fields: Dict[str, Tuple[type, Any]] = {}
+⋮----
+submodel = create_model(  # type: ignore
+return submodel, Field(default=default, description=desc)  # type: ignore
+# Array → List of items
+⋮----
+return List[item_type], Field(default=default, description=desc)  # type: ignore
+# Primitive types
+⋮----
+# Fallback or unions
+⋮----
+# Default fallback
+⋮----
+async def get_tool_async(self, tool_name: str) -> Type[ToolMessage]
+⋮----
+"""
+        Create a Langroid ToolMessage subclass from the MCP Tool
+        with the given `tool_name`.
+        """
+⋮----
+target = await self.get_mcp_tool_async(tool_name)
+⋮----
+props = target.inputSchema.get("properties", {})
+fields: Dict[str, Tuple[type, Any]] = {}
+⋮----
+# Convert target.name to CamelCase and add Tool suffix
+parts = target.name.replace("-", "_").split("_")
+camel_case = "".join(part.capitalize() for part in parts)
+model_name = f"{camel_case}Tool"
+⋮----
+# IMPORTANT: Avoid clashes with reserved field names in Langroid ToolMessage!
+# First figure out which field names are reserved
+reserved = set(_BaseToolMessage.__annotations__.keys())
+⋮----
+renamed: Dict[str, str] = {}
+new_fields: Dict[str, Tuple[type, Any]] = {}
+⋮----
+new_name = fname + "__"
+⋮----
+# now replace fields with our renamed‐aware mapping
+fields = new_fields
+⋮----
+# create Langroid ToolMessage subclass, with expected fields.
+tool_model = cast(
+⋮----
+create_model(  # type: ignore[call-overload]
+⋮----
+# Store ALL client configuration needed to recreate a client
+client_config = {
+⋮----
+tool_model._client_config = client_config  # type: ignore [attr-defined]
+tool_model._renamed_fields = renamed  # type: ignore[attr-defined]
+⋮----
+# 2) define an arg-free call_tool_async()
+async def call_tool_async(itself: ToolMessage) -> Any
+⋮----
+# pack up the payload
+payload = itself.dict(
+⋮----
+# restore any renamed fields
+for orig, new in itself.__class__._renamed_fields.items():  # type: ignore
+⋮----
+client_cfg = getattr(itself.__class__, "_client_config", None)  # type: ignore
+⋮----
+# Fallback or error - ideally _client_config should always exist
+⋮----
+# Connect the client if not yet connected and keep the connection open
+⋮----
+# open a fresh client, call the tool, then close
+async with FastMCPClient(**client_cfg) as client:  # type: ignore
+⋮----
+tool_model.call_tool_async = call_tool_async  # type: ignore
+⋮----
+# 3) define handle_async() method with optional agent parameter
+⋮----
+"""
+                Auto-generated handler for MCP tool. Returns ChatDocument with files
+                if files are present and agent is provided, otherwise returns text.
+
+                To override: define your own handle_async method with matching signature
+                if you need file handling, or simpler signature if you only need text.
+                """
+response = await self.call_tool_async()  # type: ignore[attr-defined]
+⋮----
+# If we have files and an agent is provided, return a ChatDocument
+⋮----
+# Otherwise, just return the text content
+⋮----
+# add the handle_async() method to the tool model
+tool_model.handle_async = handle_async  # type: ignore
+⋮----
+async def get_tools_async(self) -> List[Type[ToolMessage]]
+⋮----
+"""
+        Get all available tools as Langroid ToolMessage classes,
+        handling nested schemas, with `handle_async` methods
+        """
+⋮----
+resp = await self.client.list_tools()
+⋮----
+async def get_mcp_tool_async(self, name: str) -> Optional[Tool]
+⋮----
+"""Find the "original" MCP Tool (i.e. of type mcp.types.Tool) on the server
+         matching `name`, or None if missing. This contains the metadata for the tool:
+         name, description, inputSchema, etc.
+
+        Args:
+            name: Name of the tool to look up.
+
+        Returns:
+            The raw Tool object from the server, or None.
+        """
+⋮----
+resp: List[Tool] = await self.client.list_tools()
+⋮----
+# Log more detailed error information
+error_content = None
+⋮----
+error_content = [
+⋮----
+error_content = [f"Could not extract error content: {str(e)}"]
+⋮----
+results_text = [
+results_file = []
+⋮----
+"""Call an MCP tool with the given arguments.
+
+        Args:
+            tool_name: Name of the tool to call.
+            arguments: Arguments to pass to the tool.
+
+        Returns:
+            The result of the tool call.
+        """
+⋮----
+result: CallToolResult = await self.client.session.call_tool(
+results = self._convert_tool_result(tool_name, result)
+⋮----
+# ==============================================================================
+# Convenience functions (wrappers around FastMCPClient methods)
+# These are useful for one-off calls without needing to manage the
+# FastMCPClient context explicitly.
+⋮----
+"""Get a single Langroid ToolMessage subclass for a specific MCP tool name (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        tool_name: The name of the tool to retrieve.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A dynamically created Langroid ToolMessage subclass representing the
+        requested tool.
+    """
+⋮----
+"""Get a single Langroid ToolMessage subclass
+    for a specific MCP tool name (synchronous).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
+    async `get_tool_async` function using `asyncio.run()`.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        tool_name: The name of the tool to retrieve.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A dynamically created Langroid ToolMessage subclass representing the
+        requested tool.
+    """
+⋮----
+"""Get all available tools as Langroid ToolMessage subclasses (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A list of dynamically created Langroid ToolMessage subclasses
+        representing all available tools on the server.
+    """
+⋮----
+"""Get all available tools as Langroid ToolMessage subclasses (synchronous).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
+    async `get_tools_async` function using `asyncio.run()`.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A list of dynamically created Langroid ToolMessage subclasses
+        representing all available tools on the server.
+    """
+⋮----
+"""Get the raw MCP Tool object for a specific tool name (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient to
+    retrieve the tool definition from the server.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        name: The name of the tool to look up.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor.
+
+    Returns:
+        The raw `mcp.types.Tool` object from the server, or `None` if the tool
+        is not found.
+    """
+⋮----
+"""Get all available raw MCP Tool objects from the server (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient to
+    retrieve the list of tool definitions from the server.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor.
+
+    Returns:
+        A list of raw `mcp.types.Tool` objects available on the server.
+    """
+</file>
+
 <file path="langroid/agent/tools/task_tool.py">
 """
 TaskTool: A tool that allows agents to delegate a task to a sub-agent with
@@ -54768,9 +55259,6 @@ agent_name = self.agent_name or f"agent-{str(uuid.uuid4())[:8]}"
 # TODO: Maybe we just copy the parent agent's config and override chat_model?
 #   -- but what if parent agent has a MockLMConfig?
 llm_config = lm.OpenAIGPTConfig(
-⋮----
-chat_model=self.model or "gpt-4.1-mini",  # Default model if not specified
-⋮----
 config = ChatAgentConfig(
 ⋮----
 # Create the sub-agent
@@ -54795,8 +55283,6 @@ tool_classes = []
 # Create a non-interactive task
 task = Task(sub_agent, interactive=False)
 ⋮----
-def handle(self, agent: ChatAgent) -> Optional[ChatDocument]
-⋮----
 """
 
         Handle the TaskTool by creating a sub-agent with specified tools
@@ -54804,13 +55290,19 @@ def handle(self, agent: ChatAgent) -> Optional[ChatDocument]
 
         Args:
             agent: The parent ChatAgent that is handling this tool
+            chat_doc: The ChatDocument containing this tool message
         """
 ⋮----
 task = self._set_up_task(agent)
-# Run the task on the prompt, and return the result
-result = task.run(self.prompt, turns=self.max_iterations or 10)
 ⋮----
-async def handle_async(self, agent: ChatAgent) -> Optional[ChatDocument]
+# Create a ChatDocument for the prompt with parent pointer
+prompt_doc = None
+⋮----
+prompt_doc = ChatDocument(
+# Set bidirectional parent-child relationship
+⋮----
+# Run the task with the ChatDocument or string prompt
+result = task.run(prompt_doc or self.prompt, turns=self.max_iterations or 10)
 ⋮----
 """
         Async method to handle the TaskTool by creating a sub-agent with specified tools
@@ -54818,11 +55310,12 @@ async def handle_async(self, agent: ChatAgent) -> Optional[ChatDocument]
 
         Args:
             agent: The parent ChatAgent that is handling this tool
+            chat_doc: The ChatDocument containing this tool message
         """
 ⋮----
 # TODO eventually allow the various task setup configs,
 #  including termination conditions
-result = await task.run_async(self.prompt, turns=self.max_iterations or 10)
+result = await task.run_async(
 </file>
 
 <file path="langroid/agent/task.py">
@@ -55213,11 +55706,17 @@ last_agent_msg = self.agent.message_history[-1]
 ⋮----
 # carefully deep-copy: fresh metadata.id, register
 # as new obj in registry
+original_parent_id = msg.metadata.parent_id
+⋮----
+# Preserve the parent pointer from the original message
 ⋮----
 # msg may have come from `caller`, so we pretend this is from
 # the CURRENT task's USER entity
 ⋮----
 # update parent, child, agent pointers
+⋮----
+# Only override parent_id if it wasn't already set in the
+# original message. This preserves parent chains from TaskTool
 ⋮----
 def init_loggers(self) -> None
 ⋮----
@@ -55960,20 +56459,24 @@ sender_name = responder.value
 ⋮----
 sender_name = responder.name
 ⋮----
-"""Get the chain of messages by following parent pointers."""
+"""Get the chain of messages using agent's message history."""
 ⋮----
 # Get max depth needed from all sequences
 max_depth = 50  # default fallback
 ⋮----
 max_depth = max(len(seq.events) for seq in self._parsed_done_sequences)
 ⋮----
-chain = []
-current = msg
-depth = 0
+# Get chat document IDs from message history
+doc_ids = [
 ⋮----
-current = current.parent
+# Add current message ID if it exists and is not already the last one
 ⋮----
-# Reverse to get chronological order (oldest first)
+msg_id = msg.id()
+⋮----
+# Take only the last max_depth elements
+relevant_ids = doc_ids[-max_depth:]
+⋮----
+# Convert IDs to ChatDocuments and filter out None values
 ⋮----
 def _matches_event(self, actual: AgentEvent, expected: AgentEvent) -> bool
 ⋮----
@@ -57346,307 +57849,6 @@ tonifier_task = lr.Task(tonifier, interactive=False)
 result = planner_task.run("Sequentially all processes to this number: 5")
 </file>
 
-<file path="langroid/agent/tools/mcp/fastmcp_client.py">
-load_dotenv()  # load environment variables from .env
-⋮----
-FastMCPServerSpec: TypeAlias = str | FastMCP[Any] | ClientTransport | AnyUrl
-⋮----
-class FastMCPClient
-⋮----
-"""A client for interacting with a FastMCP server.
-
-    Provides async context manager functionality to safely manage resources.
-    """
-⋮----
-logger = logging.getLogger(__name__)
-_cm: Optional[Client] = None
-client: Optional[Client] = None
-⋮----
-sampling_handler: SamplingHandler | None = None,  # type: ignore
-roots: RootsList | RootsHandler | None = None,  # type: ignore
-⋮----
-"""Initialize the FastMCPClient.
-
-        Args:
-            server: FastMCP server or path to such a server
-        """
-⋮----
-async def __aenter__(self) -> "FastMCPClient"
-⋮----
-"""Enter the async context manager and connect inner client."""
-# create inner client context manager
-⋮----
-# actually enter it (opens the session)
-self.client = await self._cm.__aenter__()  # type: ignore
-⋮----
-async def connect(self) -> None
-⋮----
-"""Open the underlying session."""
-⋮----
-async def close(self) -> None
-⋮----
-"""Close the underlying session."""
-⋮----
-"""Exit the async context manager and close inner client."""
-# exit and close the inner fastmcp.Client
-⋮----
-await self._cm.__aexit__(exc_type, exc_val, exc_tb)  # type: ignore
-⋮----
-def __del__(self) -> None
-⋮----
-"""Warn about unclosed persistent connections."""
-⋮----
-"""Convert a JSON Schema snippet into a (type, Field) tuple.
-
-        Args:
-            name: Name of the field.
-            schema: JSON Schema for this field.
-            prefix: Prefix to use for nested model names.
-
-        Returns:
-            A tuple of (python_type, Field(...)) for create_model.
-        """
-t = schema.get("type")
-default = schema.get("default", ...)
-desc = schema.get("description")
-# Object → nested BaseModel
-⋮----
-sub_name = f"{prefix}_{name.capitalize()}"
-sub_fields: Dict[str, Tuple[type, Any]] = {}
-⋮----
-submodel = create_model(  # type: ignore
-return submodel, Field(default=default, description=desc)  # type: ignore
-# Array → List of items
-⋮----
-return List[item_type], Field(default=default, description=desc)  # type: ignore
-# Primitive types
-⋮----
-# Fallback or unions
-⋮----
-# Default fallback
-⋮----
-async def get_tool_async(self, tool_name: str) -> Type[ToolMessage]
-⋮----
-"""
-        Create a Langroid ToolMessage subclass from the MCP Tool
-        with the given `tool_name`.
-        """
-⋮----
-target = await self.get_mcp_tool_async(tool_name)
-⋮----
-props = target.inputSchema.get("properties", {})
-fields: Dict[str, Tuple[type, Any]] = {}
-⋮----
-# Convert target.name to CamelCase and add Tool suffix
-parts = target.name.replace("-", "_").split("_")
-camel_case = "".join(part.capitalize() for part in parts)
-model_name = f"{camel_case}Tool"
-⋮----
-# IMPORTANT: Avoid clashes with reserved field names in Langroid ToolMessage!
-# First figure out which field names are reserved
-reserved = set(_BaseToolMessage.__annotations__.keys())
-⋮----
-renamed: Dict[str, str] = {}
-new_fields: Dict[str, Tuple[type, Any]] = {}
-⋮----
-new_name = fname + "__"
-⋮----
-# now replace fields with our renamed‐aware mapping
-fields = new_fields
-⋮----
-# create Langroid ToolMessage subclass, with expected fields.
-tool_model = cast(
-⋮----
-create_model(  # type: ignore[call-overload]
-⋮----
-# Store ALL client configuration needed to recreate a client
-client_config = {
-⋮----
-tool_model._client_config = client_config  # type: ignore [attr-defined]
-tool_model._renamed_fields = renamed  # type: ignore[attr-defined]
-⋮----
-# 2) define an arg-free call_tool_async()
-async def call_tool_async(itself: ToolMessage) -> Any
-⋮----
-# pack up the payload
-payload = itself.dict(
-⋮----
-# restore any renamed fields
-for orig, new in itself.__class__._renamed_fields.items():  # type: ignore
-⋮----
-client_cfg = getattr(itself.__class__, "_client_config", None)  # type: ignore
-⋮----
-# Fallback or error - ideally _client_config should always exist
-⋮----
-# Connect the client if not yet connected and keep the connection open
-⋮----
-# open a fresh client, call the tool, then close
-async with FastMCPClient(**client_cfg) as client:  # type: ignore
-⋮----
-tool_model.call_tool_async = call_tool_async  # type: ignore
-⋮----
-# 3) define handle_async() method with optional agent parameter
-⋮----
-"""
-                Auto-generated handler for MCP tool. Returns ChatDocument with files
-                if files are present and agent is provided, otherwise returns text.
-
-                To override: define your own handle_async method with matching signature
-                if you need file handling, or simpler signature if you only need text.
-                """
-response = await self.call_tool_async()  # type: ignore[attr-defined]
-⋮----
-# If we have files and an agent is provided, return a ChatDocument
-⋮----
-# Otherwise, just return the text content
-⋮----
-# add the handle_async() method to the tool model
-tool_model.handle_async = handle_async  # type: ignore
-⋮----
-async def get_tools_async(self) -> List[Type[ToolMessage]]
-⋮----
-"""
-        Get all available tools as Langroid ToolMessage classes,
-        handling nested schemas, with `handle_async` methods
-        """
-⋮----
-resp = await self.client.list_tools()
-⋮----
-async def get_mcp_tool_async(self, name: str) -> Optional[Tool]
-⋮----
-"""Find the "original" MCP Tool (i.e. of type mcp.types.Tool) on the server
-         matching `name`, or None if missing. This contains the metadata for the tool:
-         name, description, inputSchema, etc.
-
-        Args:
-            name: Name of the tool to look up.
-
-        Returns:
-            The raw Tool object from the server, or None.
-        """
-⋮----
-resp: List[Tool] = await self.client.list_tools()
-⋮----
-# Log more detailed error information
-error_content = None
-⋮----
-error_content = [
-⋮----
-error_content = [f"Could not extract error content: {str(e)}"]
-⋮----
-results_text = [
-results_file = []
-⋮----
-"""Call an MCP tool with the given arguments.
-
-        Args:
-            tool_name: Name of the tool to call.
-            arguments: Arguments to pass to the tool.
-
-        Returns:
-            The result of the tool call.
-        """
-⋮----
-result: CallToolResult = await self.client.session.call_tool(
-results = self._convert_tool_result(tool_name, result)
-⋮----
-# ==============================================================================
-# Convenience functions (wrappers around FastMCPClient methods)
-# These are useful for one-off calls without needing to manage the
-# FastMCPClient context explicitly.
-⋮----
-"""Get a single Langroid ToolMessage subclass for a specific MCP tool name (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        tool_name: The name of the tool to retrieve.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A dynamically created Langroid ToolMessage subclass representing the
-        requested tool.
-    """
-⋮----
-"""Get a single Langroid ToolMessage subclass
-    for a specific MCP tool name (synchronous).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
-    async `get_tool_async` function using `asyncio.run()`.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        tool_name: The name of the tool to retrieve.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A dynamically created Langroid ToolMessage subclass representing the
-        requested tool.
-    """
-⋮----
-"""Get all available tools as Langroid ToolMessage subclasses (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A list of dynamically created Langroid ToolMessage subclasses
-        representing all available tools on the server.
-    """
-⋮----
-"""Get all available tools as Langroid ToolMessage subclasses (synchronous).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
-    async `get_tools_async` function using `asyncio.run()`.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A list of dynamically created Langroid ToolMessage subclasses
-        representing all available tools on the server.
-    """
-⋮----
-"""Get the raw MCP Tool object for a specific tool name (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient to
-    retrieve the tool definition from the server.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        name: The name of the tool to look up.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor.
-
-    Returns:
-        The raw `mcp.types.Tool` object from the server, or `None` if the tool
-        is not found.
-    """
-⋮----
-"""Get all available raw MCP Tool objects from the server (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient to
-    retrieve the list of tool definitions from the server.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor.
-
-    Returns:
-        A list of raw `mcp.types.Tool` objects available on the server.
-    """
-</file>
-
 <file path="langroid/agent/base.py">
 ORCHESTRATION_STRINGS = [DONE, PASS, PASS_TO, SEND_TO]
 console = Console(quiet=settings.quiet)
@@ -57701,6 +57903,7 @@ oai_tool_id2call: Dict[str, OpenAIToolCall] = {}
 ⋮----
 def __init__(self, config: AgentConfig = AgentConfig())
 ⋮----
+self.id = ObjectRegistry.new_id()  # Initialize agent ID
 self.lock = asyncio.Lock()  # for async access to update self.llm.usage_cost
 self.dialog: List[Tuple[str, str]] = []  # seq of LLM (prompt, response) tuples
 ⋮----

--- a/llms-no-tests-compressed.txt
+++ b/llms-no-tests-compressed.txt
@@ -34,7 +34,7 @@ The content is organized as follows:
 <notes>
 - Some files may have been excluded based on .gitignore rules and Repomix's configuration
 - Binary files are not included in this packed representation. Please refer to the Repository Structure section for a complete list of file paths, including binary files
-- Files matching these patterns are excluded: .*/**, !.github, !.github/**, data/**, **/data/**, **/*.csv, logs/**, build/**, dist/**, *.egg-info/**, __pycache__/**, **/*.pyc, .pytest_cache/**, .mypy_cache/**, .ruff_cache/**, venv/**, env/**, .env, **/*.json, llms.txt, llms-compressed.txt, llms-128k.txt, file-list.txt, file-list-updated.txt, examples/data/**, examples/docqa/docs/**, examples/logs/**, tests/cache/**, tests/logs/**, **/*.pkl, **/*.pickle, **/*.db, **/*.sqlite, **/*.log, **/node_modules/**, **/*.min.js, **/*.map, coverage/**, htmlcov/**, .coverage, *.orig, *.tmp, *.bak, *.swp, *.swo, **/docker-compose*.yml, visual_log.sh, **/*_converted.md, **/page_*.md, **/page-*.md, tests/main/dummy-pages/**, tests/main/data/**/*.txt, **/*.pb2.py, **/*.pb2_grpc.py
+- Files matching these patterns are excluded: .*/**, !.github, !.github/**, data/**, **/data/**, **/*.csv, logs/**, build/**, dist/**, *.egg-info/**, __pycache__/**, **/*.pyc, .pytest_cache/**, .mypy_cache/**, .ruff_cache/**, venv/**, env/**, .env, **/*.json, llms.txt, llms-compressed.txt, llms-128k.txt, llms-no-tests.txt, llms-no-tests-compressed.txt, llms-no-tests-no-examples.txt, llms-no-tests-no-examples-compressed.txt, file-list.txt, file-list-updated.txt, examples/data/**, examples/docqa/docs/**, examples/logs/**, tests/cache/**, tests/logs/**, **/*.pkl, **/*.pickle, **/*.db, **/*.sqlite, **/*.log, **/node_modules/**, **/*.min.js, **/*.map, coverage/**, htmlcov/**, .coverage, *.orig, *.tmp, *.bak, *.swp, *.swo, **/docker-compose*.yml, visual_log.sh, **/*_converted.md, **/page_*.md, **/page-*.md, tests/main/dummy-pages/**, tests/main/data/**/*.txt, **/*.pb2.py, **/*.pb2_grpc.py
 - Files matching patterns in .gitignore are excluded
 - Files matching default ignore patterns are excluded
 - Content has been compressed - code blocks are separated by ⋮---- delimiter
@@ -518,6 +518,7 @@ release-notes/
   v0-56-0-task-tool.md
   v0-56-11-openai-client-caching.md
   v0-56-12-cached-tokens-support.md
+  v0-56-13-done-sequences-parent-chain-fixes.md
   v0-56-2-table-chat-fix.md
   v0-56-4-handler-params.md
   v0-56-6-doc-chat-refactor.md
@@ -12676,6 +12677,30 @@ def ingest(self) -> None
 records = self.get_records()
 </file>
 
+<file path="langroid/agent/tools/mcp/__init__.py">
+__all__ = [
+</file>
+
+<file path="langroid/agent/tools/mcp/decorators.py">
+"""Decorator: declare a ToolMessage class bound to a FastMCP tool.
+
+    Usage:
+        @fastmcp_tool("/path/to/server.py", "get_weather")
+        class WeatherTool:
+            def pretty(self) -> str:
+                return f"Temp is {self.temperature}"
+    """
+⋮----
+def decorator(user_cls: Type[ToolMessage]) -> Type[ToolMessage]
+⋮----
+# build the “real” ToolMessage subclass for this server/tool
+RealTool: Type[ToolMessage] = get_tool(server, tool_name)
+⋮----
+# copy user‐defined methods / attributes onto RealTool
+⋮----
+# preserve the user’s original name if you like:
+</file>
+
 <file path="langroid/agent/tools/__init__.py">
 __all__ = [
 </file>
@@ -20732,6 +20757,125 @@ FORWARD_USER = "user"  # forward msg to user
 DONE = "done"  # task done
 </file>
 
+<file path="release-notes/v0-56-13-done-sequences-parent-chain-fixes.md">
+# v0.56.13: DoneSequences Parent Chain and Agent ID Fixes
+
+## Summary
+
+This release fixes critical issues with the DoneSequence implementation, parent pointer chain preservation in TaskTool, and agent ID initialization. These fixes ensure that task termination sequences work correctly with subtasks and that message lineage is properly maintained across agent boundaries.
+
+## Key Fixes
+
+### 1. Agent ID Initialization Fix
+
+**Problem**: The `Agent.id` field was incorrectly returning a `FieldInfo` object instead of an actual ID string because `Agent` is not a Pydantic model but was using Pydantic's `Field` syntax.
+
+**Solution**: Added proper ID initialization in `Agent.__init__()`:
+```python
+self.id = ObjectRegistry.new_id()  # Initialize agent ID
+```
+
+**Impact**: This ensures that `agent_id` is correctly set in `ChatDocument` metadata, which is crucial for tracking which agent owns which messages.
+
+### 2. DoneSequence Message Chain Fix
+
+**Problem**: The `_get_message_chain` method in `Task` was traversing parent pointers to build the message chain. When subtasks are involved, parent pointers can cross agent boundaries, incorrectly including messages from subtask agents in the parent task's chain.
+
+**Solution**: Replaced parent pointer traversal with agent message history:
+```python
+def _get_message_chain(self, msg: ChatDocument | None, max_depth: Optional[int] = None) -> List[ChatDocument]:
+    """Get the chain of messages using agent's message history."""
+    # Get chat document IDs from message history
+    doc_ids = [m.chat_document_id for m in self.agent.message_history 
+               if m.chat_document_id]
+    
+    # Add current message ID if it exists and is not already the last one
+    if msg:
+        msg_id = msg.id()
+        if not doc_ids or doc_ids[-1] != msg_id:
+            doc_ids.append(msg_id)
+    
+    # Take only the last max_depth elements
+    relevant_ids = doc_ids[-max_depth:]
+    
+    # Convert IDs to ChatDocuments
+    return [doc for doc_id in relevant_ids 
+            if (doc := ChatDocument.from_id(doc_id)) is not None]
+```
+
+**Impact**: DoneSequences now correctly check only messages from the current agent, preventing incorrect task termination when subtasks generate matching sequences.
+
+### 3. Parent Pointer Preservation in Task.init()
+
+**Problem**: When `ChatDocument.deepcopy()` is called during `task.init()`, it resets `parent_id` and `child_id` to empty strings, breaking the parent chain. This particularly affected TaskTool when creating subtasks with parent pointers.
+
+**Solution**: Modified `task.init()` to preserve the original parent_id after deepcopy:
+```python
+if isinstance(msg, ChatDocument):
+    original_parent_id = msg.metadata.parent_id
+    self.pending_message = ChatDocument.deepcopy(msg)
+    # Preserve the parent pointer from the original message
+    self.pending_message.metadata.parent_id = original_parent_id
+```
+
+Additionally, added conditional logic to only override parent_id when necessary:
+```python
+if self.pending_message is not None and self.caller is not None:
+    # Only override parent_id if it wasn't already set in the original message
+    if not msg.metadata.parent_id:
+        self.pending_message.metadata.parent_id = msg.metadata.id
+```
+
+**Impact**: Parent chains are now preserved when TaskTool creates subtasks, maintaining proper message lineage.
+
+### 4. TaskTool Parent-Child Relationship
+
+**Problem**: TaskTool was only setting the parent pointer on the prompt ChatDocument but not the corresponding child pointer on the TaskTool message.
+
+**Solution**: Added bidirectional parent-child relationship in TaskTool handlers:
+```python
+if chat_doc is not None:
+    prompt_doc = ChatDocument(
+        content=self.prompt,
+        metadata=ChatDocMetaData(
+            parent_id=chat_doc.id(),
+            agent_id=agent.id,
+            sender=chat_doc.metadata.sender,
+        )
+    )
+    # Set bidirectional parent-child relationship
+    chat_doc.metadata.child_id = prompt_doc.id()
+```
+
+**Impact**: Complete bidirectional parent-child chains are maintained, improving message traceability.
+
+## Tests Added
+
+Added comprehensive test `test_task_init_preserves_parent_id()` in `test_task.py` that verifies:
+- Parent IDs are preserved during ChatDocument deep copying
+- Conditional parent_id override logic works correctly for subtasks
+- Parent chains are maintained in various scenarios
+
+## Breaking Changes
+
+None. All changes are backward compatible bug fixes.
+
+## Migration Guide
+
+No migration needed. The fixes will automatically apply to existing code.
+
+## Technical Details
+
+The core issue was that DoneSequences were incorrectly checking messages across agent boundaries due to parent pointer traversal. Combined with the agent ID initialization bug and parent chain breaks in deepcopy, this caused incorrect task termination behavior. The fixes ensure:
+
+1. Each agent's messages are properly tagged with the agent's ID
+2. DoneSequence checking is confined to the current agent's message history
+3. Parent chains are preserved through TaskTool subtask creation
+4. Bidirectional parent-child relationships are maintained
+
+These changes work together to ensure proper message lineage and task termination behavior in multi-agent systems.
+</file>
+
 <file path=".blackignore">
 ./examples/urlqa/chat-clear.py
 </file>
@@ -21291,67 +21435,6 @@ mysql_user = root
 exclude = .*,.*/.*,.*/*,.*/*.*
 max-line-length = 88
 ignore = W291, W293, E501, E203, W503
-</file>
-
-<file path="ai-instructions/claude-repomix-instructions.md">
-# AI Instructions for Setting Up Repomix
-
-## Task Overview
-Set up [repomix](https://github.com/yamadashy/repomix) to generate LLM-friendly repository exports. This creates text files that can be uploaded to AI models for code analysis.
-
-## Steps to Complete
-
-### 1. Install Repomix
-```bash
-npm install -g repomix
-```
-
-### 2. Create repomix.config.json
-Create a configuration file in the repository root with:
-- **Include patterns**: Source code files (*.py, *.js, *.md, *.yaml, *.yml, *.toml)
-- **Exclude patterns**: Data directories, logs, node_modules, JSON files, generated files
-- **Security check**: Enable to prevent sensitive data inclusion
-
-### 3. Configure Include/Exclude Patterns
-- Include only source code directories and documentation
-- Exclude data/, logs/, build artifacts, dependencies
-- Add `llms*.txt` to exclusions to prevent recursive inclusion
-
-### 4. Test Configuration (Optional)
-```bash
-# Generate file list only for inspection
-repomix --no-files -o file-list.txt
-```
-This allows you to review which files will be included before generating the full output.
-
-### 5. Generate Output Versions
-
-Use the Makefile targets to generate repomix files:
-
-```bash
-# Generate all variants (recommended)
-make repomix-all
-
-# Or generate specific versions:
-make repomix          # llms.txt and llms-compressed.txt (includes tests)
-make repomix-no-tests # llms-no-tests.txt and llms-no-tests-compressed.txt
-```
-
-All commands use `git ls-files` to ensure only git-tracked files are included.
-
-### 6. Verify Results
-- Check file sizes and token counts in repomix output
-- Ensure no sensitive data is included
-- Confirm only relevant source files are packaged
-
-## Expected Outcome
-Four text files optimized for different LLM contexts:
-- `llms.txt`: Full version with tests for comprehensive analysis
-- `llms-compressed.txt`: Compressed version with tests
-- `llms-no-tests.txt`: Full version without tests for focused source code analysis
-- `llms-no-tests-compressed.txt`: Compressed version without tests for smaller contexts
-
-The files contain only git-tracked source code with proper exclusions for clean, focused LLM consumption.
 </file>
 
 <file path="ai-notes/Langroid-repo-docs.md">
@@ -29271,6 +29354,37 @@ langdb_model = OpenAIGPT(langdb_config)
 response = langdb_model.chat(
 </file>
 
+<file path="examples/mcp/biomcp.py">
+"""
+Simple example of using the BioMCP server.
+
+https://github.com/genomoncology/biomcp
+
+The server offers several tools, and we can enable ALL of them to be used
+by a Langroid agent.
+
+Run like this:
+
+    uv run examples/mcp/biomcp.py --model gpt-4.1-mini
+
+"""
+⋮----
+async def main(model: str = "")
+⋮----
+transport = StdioTransport(
+all_tools = await get_tools_async(transport)
+⋮----
+agent = lr.ChatAgent(
+⋮----
+# forward to user when LLM doesn't use a tool
+⋮----
+# enable the agent to use all tools
+⋮----
+# make task with interactive=False =>
+# waits for user only when LLM doesn't use a tool
+task = lr.Task(agent, interactive=False)
+</file>
+
 <file path="examples/mcp/exa-web-search.py">
 """
 Simple example of using the Exa Web Search MCP Server to
@@ -29318,6 +29432,199 @@ def run_main(**kwargs) -> None
         Args:
             **kwargs: Keyword arguments to pass to the main function.
         """
+</file>
+
+<file path="examples/mcp/gitmcp.py">
+"""
+Simple example of using the GitMCP server to "chat" about a GitHub repository.
+
+https://github.com/idosal/git-mcp
+
+The server offers several tools, and we can enable ALL of them to be used
+by a Langroid agent.
+
+Run like this (-m model optional; defaults to gpt-4.1-mini):
+
+    uv run examples/mcp/gitmcp.py -m ollama/qwen2.5-coder:32b
+
+"""
+⋮----
+def get_gitmcp_url() -> str
+⋮----
+console = Console()
+⋮----
+short_pattern = re.compile(r"^([^/]+)/([^/]+)$")
+url_pattern = re.compile(
+⋮----
+user_input = Prompt.ask(
+m = short_pattern.match(user_input)
+⋮----
+m = url_pattern.match(user_input)
+⋮----
+github_url = f"https://github.com/{owner}/{repo}"
+⋮----
+gitmcp_url = f"https://gitmcp.io/{owner}/{repo}"
+⋮----
+class SendUserTool(SendTool)
+⋮----
+request: str = "send_user"
+purpose: str = "Send <content> to user"
+to: str = "user"
+content: str = Field(
+⋮----
+async def main(model: str = "")
+⋮----
+gitmcp_url = get_gitmcp_url()
+⋮----
+transport = SSETransport(
+all_tools: List[lr.ToolMessage] = await get_tools_async(transport)
+⋮----
+agent = lr.ChatAgent(
+⋮----
+# forward to user when LLM doesn't use a tool
+⋮----
+# enable the agent to use all tools
+⋮----
+# configure task to NOT recognize string-based signals like DONE,
+# since those could occur in the retrieved text!
+task_cfg = lr.TaskConfig(recognize_string_signals=False)
+# make task with interactive=False =>
+# waits for user only when LLM doesn't use a tool
+⋮----
+task = lr.Task(agent, config=task_cfg, interactive=False)
+</file>
+
+<file path="examples/mcp/mcp-fetch.py">
+"""
+Simple example of using the Anthropic Fetch MCP Server to get web-site content.
+
+Fetch MCP Server: https://github.com/modelcontextprotocol/servers/tree/main/src/fetch
+
+Run like this:
+
+    uv run examples/mcp/mcp-fetch.py --model gpt-4.1-mini
+
+Ask questions like:
+
+Summarize the content of this page:
+https://www.anthropic.com/news/model-context-protocol
+"""
+⋮----
+async def main(model: str = "")
+⋮----
+transport = UvxStdioTransport(
+FetchTool = await get_tool_async(transport, "fetch")
+agent = lr.ChatAgent(
+⋮----
+# forward to user when LLM doesn't use a tool
+⋮----
+# enable the agent to use the fetch tool
+⋮----
+# make task with interactive=False =>
+# waits for user only when LLM doesn't use a tool
+task = lr.Task(agent, interactive=False)
+</file>
+
+<file path="examples/mcp/mcp-file-system.py">
+"""
+Example: Expose local file-system operations via an in-memory FastMCP server.
+
+Run like this:
+
+uv run examples/mcp/mcp-file-system.py --model gpt-4.1-mini
+
+Then ask your agent to list, write, or read files.
+"""
+⋮----
+def create_fs_mcp_server() -> FastMCP
+⋮----
+"""Return a FastMCP server exposing list/read/write file tools."""
+server = FastMCP("FsServer")
+⋮----
+"""List file names in the given directory."""
+⋮----
+"""Write text to a file; return True on success."""
+⋮----
+"""Read and return the content of a text file."""
+⋮----
+# use decorator to create a Langroid ToolMessage with a custom handle_async method
+⋮----
+@mcp_tool(create_fs_mcp_server(), "write_file")
+class WriteFileTool(lr.ToolMessage)
+⋮----
+"""Tool to write text to a file."""
+⋮----
+async def handle_async(self) -> str
+⋮----
+"""Invoke `write_file` and report the result."""
+ok = await self.call_tool_async()  # type: ignore
+⋮----
+@mcp_tool(create_fs_mcp_server(), "read_file")
+class ReadFileTool(lr.ToolMessage)
+⋮----
+"""Tool to read the content of a text file."""
+⋮----
+"""Invoke `read_file` and return its contents."""
+text = await self.call_tool_async()  # type: ignore
+⋮----
+async def main(model: str = "") -> None
+⋮----
+"""
+    Launch a ChatAgent that can list, write, and read files.
+
+    Args:
+    model: Optional LLM model name (defaults to gpt-4.1-mini).
+    """
+agent = lr.ChatAgent(
+⋮----
+# create ListFilesTool using the helper function get_tool_async
+ListFilesTool = await get_tool_async(create_fs_mcp_server(), "list_files")
+⋮----
+# enable all three tools
+⋮----
+# create a non-interactive task
+task = lr.Task(agent, interactive=False)
+⋮----
+# instruct the agent
+prompt = """
+result = await task.run_async(prompt, turns=3)
+⋮----
+def _run(**kwargs: str) -> None
+⋮----
+"""Fire entry point to run the async main function."""
+</file>
+
+<file path="examples/mcp/memory.py">
+"""
+Simple example of using the Memory MCP server:
+https://github.com/modelcontextprotocol/servers/tree/main/src/memory
+This server gives your agent persistent memory using a local Knowledge Graph,
+so when you re-start the chat it will remember what you talked about last time.
+
+
+The server offers several tools, and we can enable ALL of them to be used
+by a Langroid agent.
+
+Run like this (-m model optional; defaults to gpt-4.1-mini):
+
+    uv run examples/mcp/memory.py --m ollama/qwen2.5-coder:32b
+
+"""
+⋮----
+async def main(model: str = "")
+⋮----
+agent = lr.ChatAgent(
+⋮----
+# forward to user when LLM doesn't use a tool
+⋮----
+transport = NpxStdioTransport(
+tools = await get_tools_async(transport)
+⋮----
+# enable the agent to use all tools
+⋮----
+# make task with interactive=False =>
+# waits for user only when LLM doesn't use a tool
+task = lr.Task(agent, interactive=False)
 </file>
 
 <file path="examples/multi-agent-debate/chainlit_utils.py">
@@ -33049,30 +33356,6 @@ docs = self.vecdb._lance_result_to_docs(result)
 scores = [r["score"] for r in result.to_list()]
 </file>
 
-<file path="langroid/agent/tools/mcp/__init__.py">
-__all__ = [
-</file>
-
-<file path="langroid/agent/tools/mcp/decorators.py">
-"""Decorator: declare a ToolMessage class bound to a FastMCP tool.
-
-    Usage:
-        @fastmcp_tool("/path/to/server.py", "get_weather")
-        class WeatherTool:
-            def pretty(self) -> str:
-                return f"Temp is {self.temperature}"
-    """
-⋮----
-def decorator(user_cls: Type[ToolMessage]) -> Type[ToolMessage]
-⋮----
-# build the “real” ToolMessage subclass for this server/tool
-RealTool: Type[ToolMessage] = get_tool(server, tool_name)
-⋮----
-# copy user‐defined methods / attributes onto RealTool
-⋮----
-# preserve the user’s original name if you like:
-</file>
-
 <file path="langroid/agent/batch.py">
 T = TypeVar("T")
 U = TypeVar("U")
@@ -34633,160 +34916,6 @@ replace_and_log() {
 replace_and_log
 </file>
 
-<file path="Makefile">
-.PHONY: setup check lint tests docs nodocs loc
-
-SHELL := /bin/bash
-
-.PHONY: setup update
-
-setup: ## Setup the git pre-commit hooks
-	uv run pre-commit install
-
-update: ## Update the git pre-commit hooks
-	uv run pre-commit autoupdate
-
-.PHONY: type-check
-type-check:
-	@uv run pre-commit install
-	@uv run pre-commit autoupdate
-	@uv run pre-commit run --all-files
-	@echo "Running black..."
-	@uv run black --check .
-	@echo "Running ruff check (without fix)..."
-	@uv run ruff check .
-	@echo "Running mypy...";
-	@uv run mypy -p langroid
-	@echo "All checks passed!"
-
-.PHONY: lint
-lint:
-	uv run black .
-	uv run ruff check . --fix
-	@echo "Auto-fixing issues in examples folder..."
-	@uv run ruff check examples/ --fix-only --no-force-exclude
-
-.PHONY: stubs
-stubs:
-	@echo "Generating Python stubs for the langroid package..."
-	@uv run stubgen -p langroid -o stubs
-	@echo "Stubs generated in the 'stubs' directory"
-
-.PHONY: fix-pydantic
-
-# Entry to replace pydantic imports in specified directories
-fix-pydantic:
-	@echo "Fixing pydantic imports..."
-	@chmod +x scripts/fix-pydantic-imports.sh
-	@./scripts/fix-pydantic-imports.sh
-
-.PHONY: check
-check: fix-pydantic lint type-check
-
-.PHONY: tests
-tests:
-	pytest tests/main --basetemp=/tmp/pytest
-
-
-docs:
-	@# Kill any existing 'mkdocs serve' processes.
-	@pkill -f "mkdocs serve" 2>/dev/null || true
-	@# Build the documentation.
-	mkdocs build
-	@# Serve the documentation in the background.
-	mkdocs serve &
-	@echo "Documentation is being served in the background."
-	@echo "You can access the documentation at http://127.0.0.1:8000/"
-
-nodocs:
-	@# Kill any existing 'mkdocs serve' processes.
-	@pkill -f "mkdocs serve" 2>/dev/null || echo "No 'mkdocs serve' process found."
-	@echo "Stopped serving documentation."
-
-
-loc:
-	@echo "Lines in git-tracked files python files:"
-	@git ls-files | grep '\.py$$' | xargs cat | grep -v '^\s*$$' | wc -l
-
-.PHONY: repomix repomix-no-tests repomix-all
-
-repomix: ## Generate llms.txt and llms-compressed.txt (includes tests)
-	@echo "Generating llms.txt (with tests)..."
-	@git ls-files | repomix --stdin
-	@echo "Generating llms-compressed.txt..."
-	@git ls-files | repomix --stdin --compress -o llms-compressed.txt
-	@echo "Generated llms.txt and llms-compressed.txt"
-
-repomix-no-tests: ## Generate llms-no-tests.txt (excludes tests)
-	@echo "Generating llms-no-tests.txt (without tests)..."
-	@git ls-files | grep -v "^tests/" | repomix --stdin -o llms-no-tests.txt
-	@echo "Generating llms-no-tests-compressed.txt..."
-	@git ls-files | grep -v "^tests/" | repomix --stdin --compress -o llms-no-tests-compressed.txt
-	@echo "Generated llms-no-tests.txt and llms-no-tests-compressed.txt"
-
-repomix-all: repomix repomix-no-tests ## Generate all repomix variants
-
-.PHONY: revert-tag
-revert-tag:
-	@LATEST_TAG=$$(git describe --tags --abbrev=0) && \
-	echo "Deleting tag: $$LATEST_TAG" && \
-	git tag -d $$LATEST_TAG
-
-.PHONY: revert-bump
-revert-bump:
-	@if git log -1 --pretty=%B | grep -q "bump"; then \
-		git reset --hard HEAD~1; \
-		echo "Reverted last commit (bump commit)"; \
-	else \
-		echo "Last commit was not a bump commit"; \
-	fi
-
-.PHONY: revert
-revert: revert-bump revert-tag
-	
-.PHONY: bump-patch
-bump-patch:
-	@cz bump --increment PATCH
-
-.PHONY: bump-minor
-bump-minor:
-	@cz bump --increment MINOR 
-
-.PHONY: bump-major
-bump-major:
-	@cz bump --increment MAJOR 
-
-.PHONY: build
-build:
-	@uv build
-
-.PHONY: push
-push:
-	@git push origin main
-	@git push origin --tags
-
-.PHONY: clean
-clean:
-	-rm -rf dist/*
-
-.PHONY: release
-release:
-	@VERSION=$$(cz version -p | cut -d' ' -f2) && gh release create $${VERSION} dist/*
-
-.PHONY: all-patch
-all-patch: bump-patch clean build push release
-
-.PHONY: all-minor
-all-minor: bump-minor clean build push release
-
-.PHONY: all-major
-all-major: bump-major clean build push release
-
-.PHONY: publish
-publish:
-	uv publish
-</file>
-
 <file path="SECURITY.md">
 # Security Policy
 
@@ -34824,6 +34953,70 @@ Once a security vulnerability is reported, we will work to:
 - Investigate and confirm the issue.
 - Develop a patch or mitigation strategy.
 - Publish the fix and disclose the advisory publicly after the resolution.
+</file>
+
+<file path="ai-instructions/claude-repomix-instructions.md">
+# AI Instructions for Setting Up Repomix
+
+## Task Overview
+Set up [repomix](https://github.com/yamadashy/repomix) to generate LLM-friendly repository exports. This creates text files that can be uploaded to AI models for code analysis.
+
+## Steps to Complete
+
+### 1. Install Repomix
+```bash
+npm install -g repomix
+```
+
+### 2. Create repomix.config.json
+Create a configuration file in the repository root with:
+- **Include patterns**: Source code files (*.py, *.js, *.md, *.yaml, *.yml, *.toml)
+- **Exclude patterns**: Data directories, logs, node_modules, JSON files, generated files
+- **Security check**: Enable to prevent sensitive data inclusion
+
+### 3. Configure Include/Exclude Patterns
+- Include only source code directories and documentation
+- Exclude data/, logs/, build artifacts, dependencies
+- Add `llms*.txt` to exclusions to prevent recursive inclusion
+
+### 4. Test Configuration (Optional)
+```bash
+# Generate file list only for inspection
+repomix --no-files -o file-list.txt
+```
+This allows you to review which files will be included before generating the full output.
+
+### 5. Generate Output Versions
+
+Use the Makefile targets to generate repomix files:
+
+```bash
+# Generate all variants (recommended)
+make repomix-all
+
+# Or generate specific versions:
+make repomix                      # llms.txt and llms-compressed.txt (includes tests)
+make repomix-no-tests             # llms-no-tests.txt and llms-no-tests-compressed.txt
+make repomix-no-tests-no-examples # llms-no-tests-no-examples.txt and compressed version
+```
+
+All commands use `git ls-files` to ensure only git-tracked files are included.
+
+### 6. Verify Results
+- Check file sizes and token counts in repomix output
+- Ensure no sensitive data is included
+- Confirm only relevant source files are packaged
+
+## Expected Outcome
+Six text files optimized for different LLM contexts:
+- `llms.txt`: Full version with tests and examples (870K tokens)
+- `llms-compressed.txt`: Compressed version with tests and examples (513K tokens)
+- `llms-no-tests.txt`: Full version without tests (677K tokens)
+- `llms-no-tests-compressed.txt`: Compressed version without tests (433K tokens)
+- `llms-no-tests-no-examples.txt`: Core library code only (no tests/examples)
+- `llms-no-tests-no-examples-compressed.txt`: Compressed core library code (285K tokens)
+
+The files contain only git-tracked source code with proper exclusions for clean, focused LLM consumption.
 </file>
 
 <file path="ai-notes/handler-parameter-analysis-notes.md">
@@ -37850,37 +38043,6 @@ task = lr.Task(agent)
 # Set up settings
 </file>
 
-<file path="examples/mcp/biomcp.py">
-"""
-Simple example of using the BioMCP server.
-
-https://github.com/genomoncology/biomcp
-
-The server offers several tools, and we can enable ALL of them to be used
-by a Langroid agent.
-
-Run like this:
-
-    uv run examples/mcp/biomcp.py --model gpt-4.1-mini
-
-"""
-⋮----
-async def main(model: str = "")
-⋮----
-transport = StdioTransport(
-all_tools = await get_tools_async(transport)
-⋮----
-agent = lr.ChatAgent(
-⋮----
-# forward to user when LLM doesn't use a tool
-⋮----
-# enable the agent to use all tools
-⋮----
-# make task with interactive=False =>
-# waits for user only when LLM doesn't use a tool
-task = lr.Task(agent, interactive=False)
-</file>
-
 <file path="examples/mcp/chainlit-mcp.py">
 """
 Variant of gitmcp.py that works via the Chainlit UI library,
@@ -37919,199 +38081,6 @@ agent = lr.ChatAgent(
 ⋮----
 task_cfg = lr.TaskConfig(recognize_string_signals=False)
 task = lr.Task(agent, config=task_cfg, interactive=False)
-</file>
-
-<file path="examples/mcp/gitmcp.py">
-"""
-Simple example of using the GitMCP server to "chat" about a GitHub repository.
-
-https://github.com/idosal/git-mcp
-
-The server offers several tools, and we can enable ALL of them to be used
-by a Langroid agent.
-
-Run like this (-m model optional; defaults to gpt-4.1-mini):
-
-    uv run examples/mcp/gitmcp.py -m ollama/qwen2.5-coder:32b
-
-"""
-⋮----
-def get_gitmcp_url() -> str
-⋮----
-console = Console()
-⋮----
-short_pattern = re.compile(r"^([^/]+)/([^/]+)$")
-url_pattern = re.compile(
-⋮----
-user_input = Prompt.ask(
-m = short_pattern.match(user_input)
-⋮----
-m = url_pattern.match(user_input)
-⋮----
-github_url = f"https://github.com/{owner}/{repo}"
-⋮----
-gitmcp_url = f"https://gitmcp.io/{owner}/{repo}"
-⋮----
-class SendUserTool(SendTool)
-⋮----
-request: str = "send_user"
-purpose: str = "Send <content> to user"
-to: str = "user"
-content: str = Field(
-⋮----
-async def main(model: str = "")
-⋮----
-gitmcp_url = get_gitmcp_url()
-⋮----
-transport = SSETransport(
-all_tools: List[lr.ToolMessage] = await get_tools_async(transport)
-⋮----
-agent = lr.ChatAgent(
-⋮----
-# forward to user when LLM doesn't use a tool
-⋮----
-# enable the agent to use all tools
-⋮----
-# configure task to NOT recognize string-based signals like DONE,
-# since those could occur in the retrieved text!
-task_cfg = lr.TaskConfig(recognize_string_signals=False)
-# make task with interactive=False =>
-# waits for user only when LLM doesn't use a tool
-⋮----
-task = lr.Task(agent, config=task_cfg, interactive=False)
-</file>
-
-<file path="examples/mcp/mcp-fetch.py">
-"""
-Simple example of using the Anthropic Fetch MCP Server to get web-site content.
-
-Fetch MCP Server: https://github.com/modelcontextprotocol/servers/tree/main/src/fetch
-
-Run like this:
-
-    uv run examples/mcp/mcp-fetch.py --model gpt-4.1-mini
-
-Ask questions like:
-
-Summarize the content of this page:
-https://www.anthropic.com/news/model-context-protocol
-"""
-⋮----
-async def main(model: str = "")
-⋮----
-transport = UvxStdioTransport(
-FetchTool = await get_tool_async(transport, "fetch")
-agent = lr.ChatAgent(
-⋮----
-# forward to user when LLM doesn't use a tool
-⋮----
-# enable the agent to use the fetch tool
-⋮----
-# make task with interactive=False =>
-# waits for user only when LLM doesn't use a tool
-task = lr.Task(agent, interactive=False)
-</file>
-
-<file path="examples/mcp/mcp-file-system.py">
-"""
-Example: Expose local file-system operations via an in-memory FastMCP server.
-
-Run like this:
-
-uv run examples/mcp/mcp-file-system.py --model gpt-4.1-mini
-
-Then ask your agent to list, write, or read files.
-"""
-⋮----
-def create_fs_mcp_server() -> FastMCP
-⋮----
-"""Return a FastMCP server exposing list/read/write file tools."""
-server = FastMCP("FsServer")
-⋮----
-"""List file names in the given directory."""
-⋮----
-"""Write text to a file; return True on success."""
-⋮----
-"""Read and return the content of a text file."""
-⋮----
-# use decorator to create a Langroid ToolMessage with a custom handle_async method
-⋮----
-@mcp_tool(create_fs_mcp_server(), "write_file")
-class WriteFileTool(lr.ToolMessage)
-⋮----
-"""Tool to write text to a file."""
-⋮----
-async def handle_async(self) -> str
-⋮----
-"""Invoke `write_file` and report the result."""
-ok = await self.call_tool_async()  # type: ignore
-⋮----
-@mcp_tool(create_fs_mcp_server(), "read_file")
-class ReadFileTool(lr.ToolMessage)
-⋮----
-"""Tool to read the content of a text file."""
-⋮----
-"""Invoke `read_file` and return its contents."""
-text = await self.call_tool_async()  # type: ignore
-⋮----
-async def main(model: str = "") -> None
-⋮----
-"""
-    Launch a ChatAgent that can list, write, and read files.
-
-    Args:
-    model: Optional LLM model name (defaults to gpt-4.1-mini).
-    """
-agent = lr.ChatAgent(
-⋮----
-# create ListFilesTool using the helper function get_tool_async
-ListFilesTool = await get_tool_async(create_fs_mcp_server(), "list_files")
-⋮----
-# enable all three tools
-⋮----
-# create a non-interactive task
-task = lr.Task(agent, interactive=False)
-⋮----
-# instruct the agent
-prompt = """
-result = await task.run_async(prompt, turns=3)
-⋮----
-def _run(**kwargs: str) -> None
-⋮----
-"""Fire entry point to run the async main function."""
-</file>
-
-<file path="examples/mcp/memory.py">
-"""
-Simple example of using the Memory MCP server:
-https://github.com/modelcontextprotocol/servers/tree/main/src/memory
-This server gives your agent persistent memory using a local Knowledge Graph,
-so when you re-start the chat it will remember what you talked about last time.
-
-
-The server offers several tools, and we can enable ALL of them to be used
-by a Langroid agent.
-
-Run like this (-m model optional; defaults to gpt-4.1-mini):
-
-    uv run examples/mcp/memory.py --m ollama/qwen2.5-coder:32b
-
-"""
-⋮----
-async def main(model: str = "")
-⋮----
-agent = lr.ChatAgent(
-⋮----
-# forward to user when LLM doesn't use a tool
-⋮----
-transport = NpxStdioTransport(
-tools = await get_tools_async(transport)
-⋮----
-# enable the agent to use all tools
-⋮----
-# make task with interactive=False =>
-# waits for user only when LLM doesn't use a tool
-task = lr.Task(agent, interactive=False)
 </file>
 
 <file path="examples/mcp/openmemory.py">
@@ -40965,6 +40934,366 @@ commands/
 .claude/
 </file>
 
+<file path="docs/notes/mcp-tools.md">
+# Langroid MCP Integration
+
+Langroid provides seamless integration with Model Context Protocol (MCP) servers via 
+two methods, both of which involve creating Langroid `ToolMessage` subclasses
+corresponding to the MCP tools: 
+
+1. Programmatic creation of Langroid tools using `get_tool_async`, 
+   `get_tools_async` from the tool definitions defined on an MCP server.
+2. Declarative creation of Langroid tools using the **`@mcp_tool` decorator**, which allows
+   customizing the tool-handling behavior beyond what is provided by the MCP server.
+
+This integration allows _any_ LLM (that is good enough to do function-calling via prompts) to use any MCP server.
+See the following to understand the integration better:
+
+- example python scripts under [`examples/mcp`](https://github.com/langroid/langroid/tree/main/examples/mcp)
+- [`tests/main/test_mcp_tools.py`](https://github.com/langroid/langroid/blob/main/tests/main/test_mcp_tools.py)
+
+---
+
+## 1. Connecting to an MCP server via transport specification
+
+Before creating Langroid tools, we first need to define and connect to an MCP server
+via a [FastMCP](https://gofastmcp.com/getting-started/welcome) client. 
+There are several ways to connect to a server, depending on how it is defined. 
+Each of these uses a different type of [transport](https://gofastmcp.com/clients/transports).
+
+The typical pattern to use with Langroid is as follows:
+
+- define an MCP server transport
+- create a `ToolMessage` subclass using the `@mcp_tool` decorator or 
+  `get_tool_async()` function, with the transport as the first argument
+
+
+Langroid's MCP integration will work with any of [transports](https://gofastmcp.com/clients/transportsl) 
+supported by FastMCP.
+Below we go over some common ways to define transports and extract tools from the servers.
+
+1. **Local Python script**
+2. **In-memory FastMCP server** - useful for testing and for simple in-memory servers
+   that don't need to be run as a separate process.
+3. **NPX stdio transport**
+4. **UVX stdio transport**
+5. **Generic stdio transport** – launch any CLI‐based MCP server via stdin/stdout
+6. **Network SSE transport** – connect to HTTP/S MCP servers via `SSETransport`
+
+
+All examples below use the async helpers to create Langroid tools (`ToolMessage` subclasses):
+
+```python
+from langroid.agent.tools.mcp import (
+    get_tools_async,
+    get_tool_async,
+)
+```
+
+---
+
+#### Path to a Python Script
+
+Point at your MCP‐server entrypoint, e.g., to the `weather.py` script in the 
+langroid repo (based on the [Anthropic quick-start guide](https://modelcontextprotocol.io/quickstart/server)):
+
+```python
+async def example_script_path() -> None:
+    server = "tests/main/mcp/weather-server-python/weather.py"
+    tools = await get_tools_async(server) # all tools available
+    AlertTool = await get_tool_async(server, "get_alerts") # specific tool
+
+    # instantiate the tool with a specific input
+    msg = AlertTool(state="CA")
+    
+    # Call the tool via handle_async()
+    alerts = await msg.handle_async()
+    print(alerts)
+```
+
+---
+
+#### In-Memory FastMCP Server
+
+Define your server with `FastMCP(...)` and pass the instance:
+
+```python
+from fastmcp.server import FastMCP
+from pydantic import BaseModel, Field
+
+class CounterInput(BaseModel):
+    start: int = Field(...)
+
+def make_server() -> FastMCP:
+    server = FastMCP("CounterServer")
+
+    @server.tool()
+    def increment(data: CounterInput) -> int:
+        """Increment start by 1."""
+        return data.start + 1
+
+    return server
+
+async def example_in_memory() -> None:
+    server = make_server()
+    tools = await get_tools_async(server)
+    IncTool = await get_tool_async(server, "increment")
+
+    result = await IncTool(start=41).handle_async()
+    print(result)  # 42
+```
+
+See the [`mcp-file-system.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/mcp-file-system.py)
+script for a working example of this.
+
+---
+
+#### NPX stdio Transport
+
+Use any npm-installed MCP server via `npx`, e.g., the 
+[Exa web-search MCP server](https://docs.exa.ai/examples/exa-mcp):
+
+```python
+from fastmcp.client.transports import NpxStdioTransport
+
+transport = NpxStdioTransport(
+    package="exa-mcp-server",
+    env_vars={"EXA_API_KEY": "…"},
+)
+
+async def example_npx() -> None:
+    tools = await get_tools_async(transport)
+    SearchTool = await get_tool_async(transport, "web_search_exa")
+
+    results = await SearchTool(
+        query="How does Langroid integrate with MCP?"
+    ).handle_async()
+    print(results)
+```
+
+For a fully working example, see the script [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py).
+
+---
+
+#### UVX stdio Transport
+
+Connect to a UVX-based MCP server, e.g., the [Git MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
+
+```python
+from fastmcp.client.transports import UvxStdioTransport
+
+transport = UvxStdioTransport(tool_name="mcp-server-git")
+
+async def example_uvx() -> None:
+    tools = await get_tools_async(transport)
+    GitStatus = await get_tool_async(transport, "git_status")
+
+    status = await GitStatus(path=".").handle_async()
+    print(status)
+```
+
+--- 
+
+#### Generic stdio Transport
+
+Use `StdioTransport` to run any MCP server as a subprocess over stdio:
+
+```python
+from fastmcp.client.transports import StdioTransport
+from langroid.agent.tools.mcp import get_tools_async, get_tool_async
+
+
+async def example_stdio() -> None:
+    """Example: any CLI‐based MCP server via StdioTransport."""
+    transport: StdioTransport = StdioTransport(
+        command="uv",
+        args=["run", "--with", "biomcp-python", "biomcp", "run"],
+    )
+    tools: list[type] = await get_tools_async(transport)
+    BioTool = await get_tool_async(transport, "tool_name")
+    result: str = await BioTool(param="value").handle_async()
+    print(result)
+```
+
+See the full example in [`examples/mcp/biomcp.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/biomcp.py).
+
+---
+
+#### Network SSE Transport
+
+Use `SSETransport` to connect to a FastMCP server over HTTP/S:
+
+```python
+from fastmcp.client.transports import SSETransport
+from langroid.agent.tools.mcp import (
+    get_tools_async,
+    get_tool_async,
+)
+
+
+async def example_sse() -> None:
+    """Example: connect to an HTTP/S MCP server via SSETransport."""
+    url: str = "https://localhost:8000/sse"
+    transport: SSETransport = SSETransport(
+        url=url, headers={"Authorization": "Bearer TOKEN"}
+    )
+    tools: list[type] = await get_tools_async(transport)
+    ExampleTool = await get_tool_async(transport, "tool_name")
+    result: str = await ExampleTool(param="value").handle_async()
+    print(result)
+```    
+
+---
+
+With these patterns you can list tools, generate Pydantic-backed `ToolMessage` classes,
+and invoke them via `.handle_async()`, all with zero boilerplate client setup. 
+As the `FastMCP` library adds other types of transport (e.g., `StreamableHTTPTransport`),
+the pattern of usage with Langroid will remain the same.
+
+
+---
+
+## 2. Create Langroid Tools declaratively using the `@mcp_tool` decorator
+
+The above examples showed how you can create Langroid tools programmatically using
+the helper functions `get_tool_async()` and `get_tools_async()`,
+with the first argument being the transport to the MCP server. The `@mcp_tool` decorator
+works in the same way: 
+
+- **Arguments to the decorator**
+    1. `server_spec`: path/URL/`FastMCP`/`ClientTransport`, as mentioned above.
+    2. `tool_name`: name of a specific MCP tool
+
+- **Behavior**
+    - Generates a `ToolMessage` subclass with all input fields typed.
+    - Provides a `call_tool_async()` under the hood -- this is the "raw" MCP tool call,
+      returning a string.
+    - If you define your own `handle_async()`, it overrides the default. Typically,
+you would override it to customize either the input or the output of the tool call, or both.
+    - If you don't define your own `handle_async()`, it defaults to just returning the
+      value of the `call_tool_async()` method.
+
+Here is a simple example of using the `@mcp_tool` decorator to create a Langroid tool:
+
+```python
+from fastmcp.server import FastMCP
+from langroid.agent.tools.mcp import mcp_tool
+import langroid as lr
+
+# Define your MCP server (pydantic v2 for schema)
+server = FastMCP("MyServer")
+
+@mcp_tool(server, "greet")
+class GreetTool(lr.ToolMessage):
+    """Say hello to someone."""
+
+    async def handle_async(self) -> str:
+        # Customize post-processing
+        raw = await self.call_tool_async()
+        return f"💬 {raw}"
+```
+
+Using the decorator method allows you to customize the `handle_async` method of the
+tool, or add additional fields to the `ToolMessage`. 
+You may want to customize the input to the tool, or the tool result before it is sent back to 
+the LLM. If you don't override it, the default behavior is to simply return the value of 
+the "raw" MCP tool call `await self.call_tool_async()`. 
+
+```python
+@mcp_tool(server, "calculate")
+class CalcTool(ToolMessage):
+    """Perform complex calculation."""
+
+    async def handle_async(self) -> str:
+        result = await self.call_tool_async()
+        # Add context or emojis, etc.
+        return f"🧮 Result is *{result}*"
+```
+
+---
+
+## 3. Enabling Tools in Your Agent
+
+Once you’ve created a Langroid `ToolMessage` subclass from an MCP server, 
+you can enable it on a `ChatAgent`, just like you normally would. Below is an example of using 
+the [Exa MCP server](https://docs.exa.ai/examples/exa-mcp) to create a 
+Langroid web search tool, enable a `ChatAgent` to use it, and then set up a `Task` to 
+run the agent loop.
+
+First we must define the appropriate `ClientTransport` for the MCP server:
+```python
+# define the transport
+transport = NpxStdioTransport(
+    package="exa-mcp-server",
+    env_vars=dict(EXA_API_KEY=os.getenv("EXA_API_KEY")),
+)
+```
+
+Then we use the `@mcp_tool` decorator to create a `ToolMessage` 
+subclass representing the web search tool. Note that one reason to use the decorator
+to define our tool is so we can specify a custom `handle_async` method that
+controls what is sent to the LLM after the actual raw MCP tool-call
+(the `call_tool_async` method) is made.
+
+```python
+# the second arg specifically refers to the `web_search_exa` tool available
+# on the server defined by the `transport` variable.
+@mcp_tool(transport, "web_search_exa")
+class ExaSearchTool(lr.ToolMessage):
+    async def handle_async(self):
+        result: str = await self.call_tool_async()
+        return f"""
+        Below are the results of the web search:
+        
+        <WebSearchResult>
+        {result}
+        </WebSearchResult>
+        
+        Use these results to answer the user's original question.
+        """
+
+```
+
+If we did not want to override the `handle_async` method, we could simply have
+created the `ExaSearchTool` class programmatically via the `get_tool_async` 
+function as shown above, i.e.:
+
+```python
+from langroid.agent.tools.mcp import get_tool_async
+
+ExaSearchTool = awwait
+get_tool_async(transport, "web_search_exa")
+```
+
+We can now define our main function where we create our `ChatAgent`,
+attach the `ExaSearchTool` to it, define the `Task`, and run the task loop.
+
+```python
+async def main():
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            # forward to user when LLM doesn't use a tool
+            handle_llm_no_tool=NonToolAction.FORWARD_USER,
+            llm=lm.OpenAIGPTConfig(
+                max_output_tokens=1000,
+                # this defaults to True, but we set it to False so we can see output
+                async_stream_quiet=False,
+            ),
+        )
+    )
+
+    # enable the agent to use the web-search tool
+    agent.enable_message(ExaSearchTool)
+    # make task with interactive=False =>
+    # waits for user only when LLM doesn't use a tool
+    task = lr.Task(agent, interactive=False)
+    await task.run_async()
+```
+
+See [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py) for a full 
+working example of this.
+</file>
+
 <file path="examples/basic/planner-workflow-simple.py">
 """
 Illustrates a Planner agent orchestrating a multi-step workflow by using tools that
@@ -42902,364 +43231,166 @@ agent.enable_message([Tool1, Tool2, Tool3])  # Pass list of tool classes
 - Tokens are not needed for public repositories and can cause GitHub rendering issues
 </file>
 
-<file path="docs/notes/mcp-tools.md">
-# Langroid MCP Integration
-
-Langroid provides seamless integration with Model Context Protocol (MCP) servers via 
-two methods, both of which involve creating Langroid `ToolMessage` subclasses
-corresponding to the MCP tools: 
-
-1. Programmatic creation of Langroid tools using `get_tool_async`, 
-   `get_tools_async` from the tool definitions defined on an MCP server.
-2. Declarative creation of Langroid tools using the **`@mcp_tool` decorator**, which allows
-   customizing the tool-handling behavior beyond what is provided by the MCP server.
-
-This integration allows _any_ LLM (that is good enough to do function-calling via prompts) to use any MCP server.
-See the following to understand the integration better:
-
-- example python scripts under [`examples/mcp`](https://github.com/langroid/langroid/tree/main/examples/mcp)
-- [`tests/main/test_mcp_tools.py`](https://github.com/langroid/langroid/blob/main/tests/main/test_mcp_tools.py)
-
----
-
-## 1. Connecting to an MCP server via transport specification
-
-Before creating Langroid tools, we first need to define and connect to an MCP server
-via a [FastMCP](https://gofastmcp.com/getting-started/welcome) client. 
-There are several ways to connect to a server, depending on how it is defined. 
-Each of these uses a different type of [transport](https://gofastmcp.com/clients/transports).
-
-The typical pattern to use with Langroid is as follows:
-
-- define an MCP server transport
-- create a `ToolMessage` subclass using the `@mcp_tool` decorator or 
-  `get_tool_async()` function, with the transport as the first argument
-
-
-Langroid's MCP integration will work with any of [transports](https://gofastmcp.com/clients/transportsl) 
-supported by FastMCP.
-Below we go over some common ways to define transports and extract tools from the servers.
-
-1. **Local Python script**
-2. **In-memory FastMCP server** - useful for testing and for simple in-memory servers
-   that don't need to be run as a separate process.
-3. **NPX stdio transport**
-4. **UVX stdio transport**
-5. **Generic stdio transport** – launch any CLI‐based MCP server via stdin/stdout
-6. **Network SSE transport** – connect to HTTP/S MCP servers via `SSETransport`
-
-
-All examples below use the async helpers to create Langroid tools (`ToolMessage` subclasses):
-
-```python
-from langroid.agent.tools.mcp import (
-    get_tools_async,
-    get_tool_async,
-)
-```
-
----
-
-#### Path to a Python Script
-
-Point at your MCP‐server entrypoint, e.g., to the `weather.py` script in the 
-langroid repo (based on the [Anthropic quick-start guide](https://modelcontextprotocol.io/quickstart/server)):
-
-```python
-async def example_script_path() -> None:
-    server = "tests/main/mcp/weather-server-python/weather.py"
-    tools = await get_tools_async(server) # all tools available
-    AlertTool = await get_tool_async(server, "get_alerts") # specific tool
-
-    # instantiate the tool with a specific input
-    msg = AlertTool(state="CA")
-    
-    # Call the tool via handle_async()
-    alerts = await msg.handle_async()
-    print(alerts)
-```
-
----
-
-#### In-Memory FastMCP Server
-
-Define your server with `FastMCP(...)` and pass the instance:
-
-```python
-from fastmcp.server import FastMCP
-from pydantic import BaseModel, Field
-
-class CounterInput(BaseModel):
-    start: int = Field(...)
-
-def make_server() -> FastMCP:
-    server = FastMCP("CounterServer")
-
-    @server.tool()
-    def increment(data: CounterInput) -> int:
-        """Increment start by 1."""
-        return data.start + 1
-
-    return server
-
-async def example_in_memory() -> None:
-    server = make_server()
-    tools = await get_tools_async(server)
-    IncTool = await get_tool_async(server, "increment")
-
-    result = await IncTool(start=41).handle_async()
-    print(result)  # 42
-```
-
-See the [`mcp-file-system.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/mcp-file-system.py)
-script for a working example of this.
-
----
-
-#### NPX stdio Transport
-
-Use any npm-installed MCP server via `npx`, e.g., the 
-[Exa web-search MCP server](https://docs.exa.ai/examples/exa-mcp):
-
-```python
-from fastmcp.client.transports import NpxStdioTransport
-
-transport = NpxStdioTransport(
-    package="exa-mcp-server",
-    env_vars={"EXA_API_KEY": "…"},
-)
-
-async def example_npx() -> None:
-    tools = await get_tools_async(transport)
-    SearchTool = await get_tool_async(transport, "web_search_exa")
-
-    results = await SearchTool(
-        query="How does Langroid integrate with MCP?"
-    ).handle_async()
-    print(results)
-```
-
-For a fully working example, see the script [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py).
-
----
-
-#### UVX stdio Transport
-
-Connect to a UVX-based MCP server, e.g., the [Git MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
-
-```python
-from fastmcp.client.transports import UvxStdioTransport
-
-transport = UvxStdioTransport(tool_name="mcp-server-git")
-
-async def example_uvx() -> None:
-    tools = await get_tools_async(transport)
-    GitStatus = await get_tool_async(transport, "git_status")
-
-    status = await GitStatus(path=".").handle_async()
-    print(status)
-```
-
---- 
-
-#### Generic stdio Transport
-
-Use `StdioTransport` to run any MCP server as a subprocess over stdio:
-
-```python
-from fastmcp.client.transports import StdioTransport
-from langroid.agent.tools.mcp import get_tools_async, get_tool_async
-
-
-async def example_stdio() -> None:
-    """Example: any CLI‐based MCP server via StdioTransport."""
-    transport: StdioTransport = StdioTransport(
-        command="uv",
-        args=["run", "--with", "biomcp-python", "biomcp", "run"],
-    )
-    tools: list[type] = await get_tools_async(transport)
-    BioTool = await get_tool_async(transport, "tool_name")
-    result: str = await BioTool(param="value").handle_async()
-    print(result)
-```
-
-See the full example in [`examples/mcp/biomcp.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/biomcp.py).
-
----
-
-#### Network SSE Transport
-
-Use `SSETransport` to connect to a FastMCP server over HTTP/S:
-
-```python
-from fastmcp.client.transports import SSETransport
-from langroid.agent.tools.mcp import (
-    get_tools_async,
-    get_tool_async,
-)
-
-
-async def example_sse() -> None:
-    """Example: connect to an HTTP/S MCP server via SSETransport."""
-    url: str = "https://localhost:8000/sse"
-    transport: SSETransport = SSETransport(
-        url=url, headers={"Authorization": "Bearer TOKEN"}
-    )
-    tools: list[type] = await get_tools_async(transport)
-    ExampleTool = await get_tool_async(transport, "tool_name")
-    result: str = await ExampleTool(param="value").handle_async()
-    print(result)
-```    
-
----
-
-With these patterns you can list tools, generate Pydantic-backed `ToolMessage` classes,
-and invoke them via `.handle_async()`, all with zero boilerplate client setup. 
-As the `FastMCP` library adds other types of transport (e.g., `StreamableHTTPTransport`),
-the pattern of usage with Langroid will remain the same.
-
-
----
-
-## 2. Create Langroid Tools declaratively using the `@mcp_tool` decorator
-
-The above examples showed how you can create Langroid tools programmatically using
-the helper functions `get_tool_async()` and `get_tools_async()`,
-with the first argument being the transport to the MCP server. The `@mcp_tool` decorator
-works in the same way: 
-
-- **Arguments to the decorator**
-    1. `server_spec`: path/URL/`FastMCP`/`ClientTransport`, as mentioned above.
-    2. `tool_name`: name of a specific MCP tool
-
-- **Behavior**
-    - Generates a `ToolMessage` subclass with all input fields typed.
-    - Provides a `call_tool_async()` under the hood -- this is the "raw" MCP tool call,
-      returning a string.
-    - If you define your own `handle_async()`, it overrides the default. Typically,
-you would override it to customize either the input or the output of the tool call, or both.
-    - If you don't define your own `handle_async()`, it defaults to just returning the
-      value of the `call_tool_async()` method.
-
-Here is a simple example of using the `@mcp_tool` decorator to create a Langroid tool:
-
-```python
-from fastmcp.server import FastMCP
-from langroid.agent.tools.mcp import mcp_tool
-import langroid as lr
-
-# Define your MCP server (pydantic v2 for schema)
-server = FastMCP("MyServer")
-
-@mcp_tool(server, "greet")
-class GreetTool(lr.ToolMessage):
-    """Say hello to someone."""
-
-    async def handle_async(self) -> str:
-        # Customize post-processing
-        raw = await self.call_tool_async()
-        return f"💬 {raw}"
-```
-
-Using the decorator method allows you to customize the `handle_async` method of the
-tool, or add additional fields to the `ToolMessage`. 
-You may want to customize the input to the tool, or the tool result before it is sent back to 
-the LLM. If you don't override it, the default behavior is to simply return the value of 
-the "raw" MCP tool call `await self.call_tool_async()`. 
-
-```python
-@mcp_tool(server, "calculate")
-class CalcTool(ToolMessage):
-    """Perform complex calculation."""
-
-    async def handle_async(self) -> str:
-        result = await self.call_tool_async()
-        # Add context or emojis, etc.
-        return f"🧮 Result is *{result}*"
-```
-
----
-
-## 3. Enabling Tools in Your Agent
-
-Once you’ve created a Langroid `ToolMessage` subclass from an MCP server, 
-you can enable it on a `ChatAgent`, just like you normally would. Below is an example of using 
-the [Exa MCP server](https://docs.exa.ai/examples/exa-mcp) to create a 
-Langroid web search tool, enable a `ChatAgent` to use it, and then set up a `Task` to 
-run the agent loop.
-
-First we must define the appropriate `ClientTransport` for the MCP server:
-```python
-# define the transport
-transport = NpxStdioTransport(
-    package="exa-mcp-server",
-    env_vars=dict(EXA_API_KEY=os.getenv("EXA_API_KEY")),
-)
-```
-
-Then we use the `@mcp_tool` decorator to create a `ToolMessage` 
-subclass representing the web search tool. Note that one reason to use the decorator
-to define our tool is so we can specify a custom `handle_async` method that
-controls what is sent to the LLM after the actual raw MCP tool-call
-(the `call_tool_async` method) is made.
-
-```python
-# the second arg specifically refers to the `web_search_exa` tool available
-# on the server defined by the `transport` variable.
-@mcp_tool(transport, "web_search_exa")
-class ExaSearchTool(lr.ToolMessage):
-    async def handle_async(self):
-        result: str = await self.call_tool_async()
-        return f"""
-        Below are the results of the web search:
-        
-        <WebSearchResult>
-        {result}
-        </WebSearchResult>
-        
-        Use these results to answer the user's original question.
-        """
-
-```
-
-If we did not want to override the `handle_async` method, we could simply have
-created the `ExaSearchTool` class programmatically via the `get_tool_async` 
-function as shown above, i.e.:
-
-```python
-from langroid.agent.tools.mcp import get_tool_async
-
-ExaSearchTool = awwait
-get_tool_async(transport, "web_search_exa")
-```
-
-We can now define our main function where we create our `ChatAgent`,
-attach the `ExaSearchTool` to it, define the `Task`, and run the task loop.
-
-```python
-async def main():
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            # forward to user when LLM doesn't use a tool
-            handle_llm_no_tool=NonToolAction.FORWARD_USER,
-            llm=lm.OpenAIGPTConfig(
-                max_output_tokens=1000,
-                # this defaults to True, but we set it to False so we can see output
-                async_stream_quiet=False,
-            ),
-        )
-    )
-
-    # enable the agent to use the web-search tool
-    agent.enable_message(ExaSearchTool)
-    # make task with interactive=False =>
-    # waits for user only when LLM doesn't use a tool
-    task = lr.Task(agent, interactive=False)
-    await task.run_async()
-```
-
-See [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py) for a full 
-working example of this.
+<file path="Makefile">
+.PHONY: setup check lint tests docs nodocs loc
+
+SHELL := /bin/bash
+
+.PHONY: setup update
+
+setup: ## Setup the git pre-commit hooks
+	uv run pre-commit install
+
+update: ## Update the git pre-commit hooks
+	uv run pre-commit autoupdate
+
+.PHONY: type-check
+type-check:
+	@uv run pre-commit install
+	@uv run pre-commit autoupdate
+	@uv run pre-commit run --all-files
+	@echo "Running black..."
+	@uv run black --check .
+	@echo "Running ruff check (without fix)..."
+	@uv run ruff check .
+	@echo "Running mypy...";
+	@uv run mypy -p langroid
+	@echo "All checks passed!"
+
+.PHONY: lint
+lint:
+	uv run black .
+	uv run ruff check . --fix
+	@echo "Auto-fixing issues in examples folder..."
+	@uv run ruff check examples/ --fix-only --no-force-exclude
+
+.PHONY: stubs
+stubs:
+	@echo "Generating Python stubs for the langroid package..."
+	@uv run stubgen -p langroid -o stubs
+	@echo "Stubs generated in the 'stubs' directory"
+
+.PHONY: fix-pydantic
+
+# Entry to replace pydantic imports in specified directories
+fix-pydantic:
+	@echo "Fixing pydantic imports..."
+	@chmod +x scripts/fix-pydantic-imports.sh
+	@./scripts/fix-pydantic-imports.sh
+
+
+.PHONY: tests
+tests:
+	pytest tests/main --basetemp=/tmp/pytest
+
+
+docs:
+	@# Kill any existing 'mkdocs serve' processes.
+	@pkill -f "mkdocs serve" 2>/dev/null || true
+	@# Build the documentation.
+	mkdocs build
+	@# Serve the documentation in the background.
+	mkdocs serve &
+	@echo "Documentation is being served in the background."
+	@echo "You can access the documentation at http://127.0.0.1:8000/"
+
+nodocs:
+	@# Kill any existing 'mkdocs serve' processes.
+	@pkill -f "mkdocs serve" 2>/dev/null || echo "No 'mkdocs serve' process found."
+	@echo "Stopped serving documentation."
+
+
+loc:
+	@echo "Lines in git-tracked files python files:"
+	@git ls-files | grep '\.py$$' | xargs cat | grep -v '^\s*$$' | wc -l
+
+.PHONY: repomix repomix-no-tests repomix-all
+
+repomix: ## Generate llms.txt and llms-compressed.txt (includes tests)
+	@echo "Generating llms.txt (with tests)..."
+	@git ls-files | repomix --stdin
+	@echo "Generating llms-compressed.txt..."
+	@git ls-files | repomix --stdin --compress -o llms-compressed.txt
+	@echo "Generated llms.txt and llms-compressed.txt"
+
+repomix-no-tests: ## Generate llms-no-tests.txt (excludes tests)
+	@echo "Generating llms-no-tests.txt (without tests)..."
+	@git ls-files | grep -v "^tests/" | repomix --stdin -o llms-no-tests.txt
+	@echo "Generating llms-no-tests-compressed.txt..."
+	@git ls-files | grep -v "^tests/" | repomix --stdin --compress -o llms-no-tests-compressed.txt
+	@echo "Generated llms-no-tests.txt and llms-no-tests-compressed.txt"
+
+repomix-no-tests-no-examples: ## Generate llms-no-tests-no-examples.txt (excludes tests and examples)
+	@echo "Generating llms-no-tests-no-examples.txt (without tests and examples)..."
+	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin -o llms-no-tests-no-examples.txt
+	@echo "Generating llms-no-tests-no-examples-compressed.txt..."
+	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin --compress -o llms-no-tests-no-examples-compressed.txt
+	@echo "Generated llms-no-tests-no-examples.txt and llms-no-tests-no-examples-compressed.txt"
+
+repomix-all: repomix repomix-no-tests repomix-no-tests-no-examples ## Generate all repomix variants
+
+.PHONY: check
+check: fix-pydantic lint type-check repomix-all
+
+.PHONY: revert-tag
+revert-tag:
+	@LATEST_TAG=$$(git describe --tags --abbrev=0) && \
+	echo "Deleting tag: $$LATEST_TAG" && \
+	git tag -d $$LATEST_TAG
+
+.PHONY: revert-bump
+revert-bump:
+	@if git log -1 --pretty=%B | grep -q "bump"; then \
+		git reset --hard HEAD~1; \
+		echo "Reverted last commit (bump commit)"; \
+	else \
+		echo "Last commit was not a bump commit"; \
+	fi
+
+.PHONY: revert
+revert: revert-bump revert-tag
+	
+.PHONY: bump-patch
+bump-patch:
+	@cz bump --increment PATCH
+
+.PHONY: bump-minor
+bump-minor:
+	@cz bump --increment MINOR 
+
+.PHONY: bump-major
+bump-major:
+	@cz bump --increment MAJOR 
+
+.PHONY: build
+build:
+	@uv build
+
+.PHONY: push
+push:
+	@git push origin main
+	@git push origin --tags
+
+.PHONY: clean
+clean:
+	-rm -rf dist/*
+
+.PHONY: release
+release:
+	@VERSION=$$(cz version -p | cut -d' ' -f2) && gh release create $${VERSION} dist/*
+
+.PHONY: all-patch
+all-patch: bump-patch clean build push release
+
+.PHONY: all-minor
+all-minor: bump-minor clean build push release
+
+.PHONY: all-major
+all-major: bump-major clean build push release
+
+.PHONY: publish
+publish:
+	uv publish
 </file>
 
 <file path="examples/mcp/any-mcp.py">
@@ -44191,6 +44322,307 @@ def justify_response(self) -> ChatDocument | None
 source = self.response.metadata.source
 </file>
 
+<file path="langroid/agent/tools/mcp/fastmcp_client.py">
+load_dotenv()  # load environment variables from .env
+⋮----
+FastMCPServerSpec: TypeAlias = str | FastMCP[Any] | ClientTransport | AnyUrl
+⋮----
+class FastMCPClient
+⋮----
+"""A client for interacting with a FastMCP server.
+
+    Provides async context manager functionality to safely manage resources.
+    """
+⋮----
+logger = logging.getLogger(__name__)
+_cm: Optional[Client] = None
+client: Optional[Client] = None
+⋮----
+sampling_handler: SamplingHandler | None = None,  # type: ignore
+roots: RootsList | RootsHandler | None = None,  # type: ignore
+⋮----
+"""Initialize the FastMCPClient.
+
+        Args:
+            server: FastMCP server or path to such a server
+        """
+⋮----
+async def __aenter__(self) -> "FastMCPClient"
+⋮----
+"""Enter the async context manager and connect inner client."""
+# create inner client context manager
+⋮----
+# actually enter it (opens the session)
+self.client = await self._cm.__aenter__()  # type: ignore
+⋮----
+async def connect(self) -> None
+⋮----
+"""Open the underlying session."""
+⋮----
+async def close(self) -> None
+⋮----
+"""Close the underlying session."""
+⋮----
+"""Exit the async context manager and close inner client."""
+# exit and close the inner fastmcp.Client
+⋮----
+await self._cm.__aexit__(exc_type, exc_val, exc_tb)  # type: ignore
+⋮----
+def __del__(self) -> None
+⋮----
+"""Warn about unclosed persistent connections."""
+⋮----
+"""Convert a JSON Schema snippet into a (type, Field) tuple.
+
+        Args:
+            name: Name of the field.
+            schema: JSON Schema for this field.
+            prefix: Prefix to use for nested model names.
+
+        Returns:
+            A tuple of (python_type, Field(...)) for create_model.
+        """
+t = schema.get("type")
+default = schema.get("default", ...)
+desc = schema.get("description")
+# Object → nested BaseModel
+⋮----
+sub_name = f"{prefix}_{name.capitalize()}"
+sub_fields: Dict[str, Tuple[type, Any]] = {}
+⋮----
+submodel = create_model(  # type: ignore
+return submodel, Field(default=default, description=desc)  # type: ignore
+# Array → List of items
+⋮----
+return List[item_type], Field(default=default, description=desc)  # type: ignore
+# Primitive types
+⋮----
+# Fallback or unions
+⋮----
+# Default fallback
+⋮----
+async def get_tool_async(self, tool_name: str) -> Type[ToolMessage]
+⋮----
+"""
+        Create a Langroid ToolMessage subclass from the MCP Tool
+        with the given `tool_name`.
+        """
+⋮----
+target = await self.get_mcp_tool_async(tool_name)
+⋮----
+props = target.inputSchema.get("properties", {})
+fields: Dict[str, Tuple[type, Any]] = {}
+⋮----
+# Convert target.name to CamelCase and add Tool suffix
+parts = target.name.replace("-", "_").split("_")
+camel_case = "".join(part.capitalize() for part in parts)
+model_name = f"{camel_case}Tool"
+⋮----
+# IMPORTANT: Avoid clashes with reserved field names in Langroid ToolMessage!
+# First figure out which field names are reserved
+reserved = set(_BaseToolMessage.__annotations__.keys())
+⋮----
+renamed: Dict[str, str] = {}
+new_fields: Dict[str, Tuple[type, Any]] = {}
+⋮----
+new_name = fname + "__"
+⋮----
+# now replace fields with our renamed‐aware mapping
+fields = new_fields
+⋮----
+# create Langroid ToolMessage subclass, with expected fields.
+tool_model = cast(
+⋮----
+create_model(  # type: ignore[call-overload]
+⋮----
+# Store ALL client configuration needed to recreate a client
+client_config = {
+⋮----
+tool_model._client_config = client_config  # type: ignore [attr-defined]
+tool_model._renamed_fields = renamed  # type: ignore[attr-defined]
+⋮----
+# 2) define an arg-free call_tool_async()
+async def call_tool_async(itself: ToolMessage) -> Any
+⋮----
+# pack up the payload
+payload = itself.dict(
+⋮----
+# restore any renamed fields
+for orig, new in itself.__class__._renamed_fields.items():  # type: ignore
+⋮----
+client_cfg = getattr(itself.__class__, "_client_config", None)  # type: ignore
+⋮----
+# Fallback or error - ideally _client_config should always exist
+⋮----
+# Connect the client if not yet connected and keep the connection open
+⋮----
+# open a fresh client, call the tool, then close
+async with FastMCPClient(**client_cfg) as client:  # type: ignore
+⋮----
+tool_model.call_tool_async = call_tool_async  # type: ignore
+⋮----
+# 3) define handle_async() method with optional agent parameter
+⋮----
+"""
+                Auto-generated handler for MCP tool. Returns ChatDocument with files
+                if files are present and agent is provided, otherwise returns text.
+
+                To override: define your own handle_async method with matching signature
+                if you need file handling, or simpler signature if you only need text.
+                """
+response = await self.call_tool_async()  # type: ignore[attr-defined]
+⋮----
+# If we have files and an agent is provided, return a ChatDocument
+⋮----
+# Otherwise, just return the text content
+⋮----
+# add the handle_async() method to the tool model
+tool_model.handle_async = handle_async  # type: ignore
+⋮----
+async def get_tools_async(self) -> List[Type[ToolMessage]]
+⋮----
+"""
+        Get all available tools as Langroid ToolMessage classes,
+        handling nested schemas, with `handle_async` methods
+        """
+⋮----
+resp = await self.client.list_tools()
+⋮----
+async def get_mcp_tool_async(self, name: str) -> Optional[Tool]
+⋮----
+"""Find the "original" MCP Tool (i.e. of type mcp.types.Tool) on the server
+         matching `name`, or None if missing. This contains the metadata for the tool:
+         name, description, inputSchema, etc.
+
+        Args:
+            name: Name of the tool to look up.
+
+        Returns:
+            The raw Tool object from the server, or None.
+        """
+⋮----
+resp: List[Tool] = await self.client.list_tools()
+⋮----
+# Log more detailed error information
+error_content = None
+⋮----
+error_content = [
+⋮----
+error_content = [f"Could not extract error content: {str(e)}"]
+⋮----
+results_text = [
+results_file = []
+⋮----
+"""Call an MCP tool with the given arguments.
+
+        Args:
+            tool_name: Name of the tool to call.
+            arguments: Arguments to pass to the tool.
+
+        Returns:
+            The result of the tool call.
+        """
+⋮----
+result: CallToolResult = await self.client.session.call_tool(
+results = self._convert_tool_result(tool_name, result)
+⋮----
+# ==============================================================================
+# Convenience functions (wrappers around FastMCPClient methods)
+# These are useful for one-off calls without needing to manage the
+# FastMCPClient context explicitly.
+⋮----
+"""Get a single Langroid ToolMessage subclass for a specific MCP tool name (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        tool_name: The name of the tool to retrieve.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A dynamically created Langroid ToolMessage subclass representing the
+        requested tool.
+    """
+⋮----
+"""Get a single Langroid ToolMessage subclass
+    for a specific MCP tool name (synchronous).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
+    async `get_tool_async` function using `asyncio.run()`.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        tool_name: The name of the tool to retrieve.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A dynamically created Langroid ToolMessage subclass representing the
+        requested tool.
+    """
+⋮----
+"""Get all available tools as Langroid ToolMessage subclasses (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A list of dynamically created Langroid ToolMessage subclasses
+        representing all available tools on the server.
+    """
+⋮----
+"""Get all available tools as Langroid ToolMessage subclasses (synchronous).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
+    async `get_tools_async` function using `asyncio.run()`.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A list of dynamically created Langroid ToolMessage subclasses
+        representing all available tools on the server.
+    """
+⋮----
+"""Get the raw MCP Tool object for a specific tool name (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient to
+    retrieve the tool definition from the server.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        name: The name of the tool to look up.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor.
+
+    Returns:
+        The raw `mcp.types.Tool` object from the server, or `None` if the tool
+        is not found.
+    """
+⋮----
+"""Get all available raw MCP Tool objects from the server (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient to
+    retrieve the list of tool definitions from the server.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor.
+
+    Returns:
+        A list of raw `mcp.types.Tool` objects available on the server.
+    """
+</file>
+
 <file path="langroid/agent/tools/task_tool.py">
 """
 TaskTool: A tool that allows agents to delegate a task to a sub-agent with
@@ -44238,9 +44670,6 @@ agent_name = self.agent_name or f"agent-{str(uuid.uuid4())[:8]}"
 # TODO: Maybe we just copy the parent agent's config and override chat_model?
 #   -- but what if parent agent has a MockLMConfig?
 llm_config = lm.OpenAIGPTConfig(
-⋮----
-chat_model=self.model or "gpt-4.1-mini",  # Default model if not specified
-⋮----
 config = ChatAgentConfig(
 ⋮----
 # Create the sub-agent
@@ -44265,8 +44694,6 @@ tool_classes = []
 # Create a non-interactive task
 task = Task(sub_agent, interactive=False)
 ⋮----
-def handle(self, agent: ChatAgent) -> Optional[ChatDocument]
-⋮----
 """
 
         Handle the TaskTool by creating a sub-agent with specified tools
@@ -44274,13 +44701,19 @@ def handle(self, agent: ChatAgent) -> Optional[ChatDocument]
 
         Args:
             agent: The parent ChatAgent that is handling this tool
+            chat_doc: The ChatDocument containing this tool message
         """
 ⋮----
 task = self._set_up_task(agent)
-# Run the task on the prompt, and return the result
-result = task.run(self.prompt, turns=self.max_iterations or 10)
 ⋮----
-async def handle_async(self, agent: ChatAgent) -> Optional[ChatDocument]
+# Create a ChatDocument for the prompt with parent pointer
+prompt_doc = None
+⋮----
+prompt_doc = ChatDocument(
+# Set bidirectional parent-child relationship
+⋮----
+# Run the task with the ChatDocument or string prompt
+result = task.run(prompt_doc or self.prompt, turns=self.max_iterations or 10)
 ⋮----
 """
         Async method to handle the TaskTool by creating a sub-agent with specified tools
@@ -44288,11 +44721,12 @@ async def handle_async(self, agent: ChatAgent) -> Optional[ChatDocument]
 
         Args:
             agent: The parent ChatAgent that is handling this tool
+            chat_doc: The ChatDocument containing this tool message
         """
 ⋮----
 # TODO eventually allow the various task setup configs,
 #  including termination conditions
-result = await task.run_async(self.prompt, turns=self.max_iterations or 10)
+result = await task.run_async(
 </file>
 
 <file path="langroid/agent/task.py">
@@ -44683,11 +45117,17 @@ last_agent_msg = self.agent.message_history[-1]
 ⋮----
 # carefully deep-copy: fresh metadata.id, register
 # as new obj in registry
+original_parent_id = msg.metadata.parent_id
+⋮----
+# Preserve the parent pointer from the original message
 ⋮----
 # msg may have come from `caller`, so we pretend this is from
 # the CURRENT task's USER entity
 ⋮----
 # update parent, child, agent pointers
+⋮----
+# Only override parent_id if it wasn't already set in the
+# original message. This preserves parent chains from TaskTool
 ⋮----
 def init_loggers(self) -> None
 ⋮----
@@ -45430,20 +45870,24 @@ sender_name = responder.value
 ⋮----
 sender_name = responder.name
 ⋮----
-"""Get the chain of messages by following parent pointers."""
+"""Get the chain of messages using agent's message history."""
 ⋮----
 # Get max depth needed from all sequences
 max_depth = 50  # default fallback
 ⋮----
 max_depth = max(len(seq.events) for seq in self._parsed_done_sequences)
 ⋮----
-chain = []
-current = msg
-depth = 0
+# Get chat document IDs from message history
+doc_ids = [
 ⋮----
-current = current.parent
+# Add current message ID if it exists and is not already the last one
 ⋮----
-# Reverse to get chronological order (oldest first)
+msg_id = msg.id()
+⋮----
+# Take only the last max_depth elements
+relevant_ids = doc_ids[-max_depth:]
+⋮----
+# Convert IDs to ChatDocuments and filter out None values
 ⋮----
 def _matches_event(self, actual: AgentEvent, expected: AgentEvent) -> bool
 ⋮----
@@ -46816,307 +47260,6 @@ tonifier_task = lr.Task(tonifier, interactive=False)
 result = planner_task.run("Sequentially all processes to this number: 5")
 </file>
 
-<file path="langroid/agent/tools/mcp/fastmcp_client.py">
-load_dotenv()  # load environment variables from .env
-⋮----
-FastMCPServerSpec: TypeAlias = str | FastMCP[Any] | ClientTransport | AnyUrl
-⋮----
-class FastMCPClient
-⋮----
-"""A client for interacting with a FastMCP server.
-
-    Provides async context manager functionality to safely manage resources.
-    """
-⋮----
-logger = logging.getLogger(__name__)
-_cm: Optional[Client] = None
-client: Optional[Client] = None
-⋮----
-sampling_handler: SamplingHandler | None = None,  # type: ignore
-roots: RootsList | RootsHandler | None = None,  # type: ignore
-⋮----
-"""Initialize the FastMCPClient.
-
-        Args:
-            server: FastMCP server or path to such a server
-        """
-⋮----
-async def __aenter__(self) -> "FastMCPClient"
-⋮----
-"""Enter the async context manager and connect inner client."""
-# create inner client context manager
-⋮----
-# actually enter it (opens the session)
-self.client = await self._cm.__aenter__()  # type: ignore
-⋮----
-async def connect(self) -> None
-⋮----
-"""Open the underlying session."""
-⋮----
-async def close(self) -> None
-⋮----
-"""Close the underlying session."""
-⋮----
-"""Exit the async context manager and close inner client."""
-# exit and close the inner fastmcp.Client
-⋮----
-await self._cm.__aexit__(exc_type, exc_val, exc_tb)  # type: ignore
-⋮----
-def __del__(self) -> None
-⋮----
-"""Warn about unclosed persistent connections."""
-⋮----
-"""Convert a JSON Schema snippet into a (type, Field) tuple.
-
-        Args:
-            name: Name of the field.
-            schema: JSON Schema for this field.
-            prefix: Prefix to use for nested model names.
-
-        Returns:
-            A tuple of (python_type, Field(...)) for create_model.
-        """
-t = schema.get("type")
-default = schema.get("default", ...)
-desc = schema.get("description")
-# Object → nested BaseModel
-⋮----
-sub_name = f"{prefix}_{name.capitalize()}"
-sub_fields: Dict[str, Tuple[type, Any]] = {}
-⋮----
-submodel = create_model(  # type: ignore
-return submodel, Field(default=default, description=desc)  # type: ignore
-# Array → List of items
-⋮----
-return List[item_type], Field(default=default, description=desc)  # type: ignore
-# Primitive types
-⋮----
-# Fallback or unions
-⋮----
-# Default fallback
-⋮----
-async def get_tool_async(self, tool_name: str) -> Type[ToolMessage]
-⋮----
-"""
-        Create a Langroid ToolMessage subclass from the MCP Tool
-        with the given `tool_name`.
-        """
-⋮----
-target = await self.get_mcp_tool_async(tool_name)
-⋮----
-props = target.inputSchema.get("properties", {})
-fields: Dict[str, Tuple[type, Any]] = {}
-⋮----
-# Convert target.name to CamelCase and add Tool suffix
-parts = target.name.replace("-", "_").split("_")
-camel_case = "".join(part.capitalize() for part in parts)
-model_name = f"{camel_case}Tool"
-⋮----
-# IMPORTANT: Avoid clashes with reserved field names in Langroid ToolMessage!
-# First figure out which field names are reserved
-reserved = set(_BaseToolMessage.__annotations__.keys())
-⋮----
-renamed: Dict[str, str] = {}
-new_fields: Dict[str, Tuple[type, Any]] = {}
-⋮----
-new_name = fname + "__"
-⋮----
-# now replace fields with our renamed‐aware mapping
-fields = new_fields
-⋮----
-# create Langroid ToolMessage subclass, with expected fields.
-tool_model = cast(
-⋮----
-create_model(  # type: ignore[call-overload]
-⋮----
-# Store ALL client configuration needed to recreate a client
-client_config = {
-⋮----
-tool_model._client_config = client_config  # type: ignore [attr-defined]
-tool_model._renamed_fields = renamed  # type: ignore[attr-defined]
-⋮----
-# 2) define an arg-free call_tool_async()
-async def call_tool_async(itself: ToolMessage) -> Any
-⋮----
-# pack up the payload
-payload = itself.dict(
-⋮----
-# restore any renamed fields
-for orig, new in itself.__class__._renamed_fields.items():  # type: ignore
-⋮----
-client_cfg = getattr(itself.__class__, "_client_config", None)  # type: ignore
-⋮----
-# Fallback or error - ideally _client_config should always exist
-⋮----
-# Connect the client if not yet connected and keep the connection open
-⋮----
-# open a fresh client, call the tool, then close
-async with FastMCPClient(**client_cfg) as client:  # type: ignore
-⋮----
-tool_model.call_tool_async = call_tool_async  # type: ignore
-⋮----
-# 3) define handle_async() method with optional agent parameter
-⋮----
-"""
-                Auto-generated handler for MCP tool. Returns ChatDocument with files
-                if files are present and agent is provided, otherwise returns text.
-
-                To override: define your own handle_async method with matching signature
-                if you need file handling, or simpler signature if you only need text.
-                """
-response = await self.call_tool_async()  # type: ignore[attr-defined]
-⋮----
-# If we have files and an agent is provided, return a ChatDocument
-⋮----
-# Otherwise, just return the text content
-⋮----
-# add the handle_async() method to the tool model
-tool_model.handle_async = handle_async  # type: ignore
-⋮----
-async def get_tools_async(self) -> List[Type[ToolMessage]]
-⋮----
-"""
-        Get all available tools as Langroid ToolMessage classes,
-        handling nested schemas, with `handle_async` methods
-        """
-⋮----
-resp = await self.client.list_tools()
-⋮----
-async def get_mcp_tool_async(self, name: str) -> Optional[Tool]
-⋮----
-"""Find the "original" MCP Tool (i.e. of type mcp.types.Tool) on the server
-         matching `name`, or None if missing. This contains the metadata for the tool:
-         name, description, inputSchema, etc.
-
-        Args:
-            name: Name of the tool to look up.
-
-        Returns:
-            The raw Tool object from the server, or None.
-        """
-⋮----
-resp: List[Tool] = await self.client.list_tools()
-⋮----
-# Log more detailed error information
-error_content = None
-⋮----
-error_content = [
-⋮----
-error_content = [f"Could not extract error content: {str(e)}"]
-⋮----
-results_text = [
-results_file = []
-⋮----
-"""Call an MCP tool with the given arguments.
-
-        Args:
-            tool_name: Name of the tool to call.
-            arguments: Arguments to pass to the tool.
-
-        Returns:
-            The result of the tool call.
-        """
-⋮----
-result: CallToolResult = await self.client.session.call_tool(
-results = self._convert_tool_result(tool_name, result)
-⋮----
-# ==============================================================================
-# Convenience functions (wrappers around FastMCPClient methods)
-# These are useful for one-off calls without needing to manage the
-# FastMCPClient context explicitly.
-⋮----
-"""Get a single Langroid ToolMessage subclass for a specific MCP tool name (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        tool_name: The name of the tool to retrieve.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A dynamically created Langroid ToolMessage subclass representing the
-        requested tool.
-    """
-⋮----
-"""Get a single Langroid ToolMessage subclass
-    for a specific MCP tool name (synchronous).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
-    async `get_tool_async` function using `asyncio.run()`.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        tool_name: The name of the tool to retrieve.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A dynamically created Langroid ToolMessage subclass representing the
-        requested tool.
-    """
-⋮----
-"""Get all available tools as Langroid ToolMessage subclasses (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A list of dynamically created Langroid ToolMessage subclasses
-        representing all available tools on the server.
-    """
-⋮----
-"""Get all available tools as Langroid ToolMessage subclasses (synchronous).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
-    async `get_tools_async` function using `asyncio.run()`.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A list of dynamically created Langroid ToolMessage subclasses
-        representing all available tools on the server.
-    """
-⋮----
-"""Get the raw MCP Tool object for a specific tool name (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient to
-    retrieve the tool definition from the server.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        name: The name of the tool to look up.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor.
-
-    Returns:
-        The raw `mcp.types.Tool` object from the server, or `None` if the tool
-        is not found.
-    """
-⋮----
-"""Get all available raw MCP Tool objects from the server (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient to
-    retrieve the list of tool definitions from the server.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor.
-
-    Returns:
-        A list of raw `mcp.types.Tool` objects available on the server.
-    """
-</file>
-
 <file path="langroid/agent/base.py">
 ORCHESTRATION_STRINGS = [DONE, PASS, PASS_TO, SEND_TO]
 console = Console(quiet=settings.quiet)
@@ -47171,6 +47314,7 @@ oai_tool_id2call: Dict[str, OpenAIToolCall] = {}
 ⋮----
 def __init__(self, config: AgentConfig = AgentConfig())
 ⋮----
+self.id = ObjectRegistry.new_id()  # Initialize agent ID
 self.lock = asyncio.Lock()  # for async access to update self.llm.usage_cost
 self.dialog: List[Tuple[str, str]] = []  # seq of LLM (prompt, response) tuples
 ⋮----

--- a/llms-no-tests-no-examples-compressed.txt
+++ b/llms-no-tests-no-examples-compressed.txt
@@ -307,6 +307,7 @@ release-notes/
   v0-56-0-task-tool.md
   v0-56-11-openai-client-caching.md
   v0-56-12-cached-tokens-support.md
+  v0-56-13-done-sequences-parent-chain-fixes.md
   v0-56-2-table-chat-fix.md
   v0-56-4-handler-params.md
   v0-56-6-doc-chat-refactor.md
@@ -8389,6 +8390,30 @@ def ingest(self) -> None
 records = self.get_records()
 </file>
 
+<file path="langroid/agent/tools/mcp/__init__.py">
+__all__ = [
+</file>
+
+<file path="langroid/agent/tools/mcp/decorators.py">
+"""Decorator: declare a ToolMessage class bound to a FastMCP tool.
+
+    Usage:
+        @fastmcp_tool("/path/to/server.py", "get_weather")
+        class WeatherTool:
+            def pretty(self) -> str:
+                return f"Temp is {self.temperature}"
+    """
+⋮----
+def decorator(user_cls: Type[ToolMessage]) -> Type[ToolMessage]
+⋮----
+# build the “real” ToolMessage subclass for this server/tool
+RealTool: Type[ToolMessage] = get_tool(server, tool_name)
+⋮----
+# copy user‐defined methods / attributes onto RealTool
+⋮----
+# preserve the user’s original name if you like:
+</file>
+
 <file path="langroid/agent/tools/__init__.py">
 __all__ = [
 </file>
@@ -16445,6 +16470,125 @@ FORWARD_USER = "user"  # forward msg to user
 DONE = "done"  # task done
 </file>
 
+<file path="release-notes/v0-56-13-done-sequences-parent-chain-fixes.md">
+# v0.56.13: DoneSequences Parent Chain and Agent ID Fixes
+
+## Summary
+
+This release fixes critical issues with the DoneSequence implementation, parent pointer chain preservation in TaskTool, and agent ID initialization. These fixes ensure that task termination sequences work correctly with subtasks and that message lineage is properly maintained across agent boundaries.
+
+## Key Fixes
+
+### 1. Agent ID Initialization Fix
+
+**Problem**: The `Agent.id` field was incorrectly returning a `FieldInfo` object instead of an actual ID string because `Agent` is not a Pydantic model but was using Pydantic's `Field` syntax.
+
+**Solution**: Added proper ID initialization in `Agent.__init__()`:
+```python
+self.id = ObjectRegistry.new_id()  # Initialize agent ID
+```
+
+**Impact**: This ensures that `agent_id` is correctly set in `ChatDocument` metadata, which is crucial for tracking which agent owns which messages.
+
+### 2. DoneSequence Message Chain Fix
+
+**Problem**: The `_get_message_chain` method in `Task` was traversing parent pointers to build the message chain. When subtasks are involved, parent pointers can cross agent boundaries, incorrectly including messages from subtask agents in the parent task's chain.
+
+**Solution**: Replaced parent pointer traversal with agent message history:
+```python
+def _get_message_chain(self, msg: ChatDocument | None, max_depth: Optional[int] = None) -> List[ChatDocument]:
+    """Get the chain of messages using agent's message history."""
+    # Get chat document IDs from message history
+    doc_ids = [m.chat_document_id for m in self.agent.message_history 
+               if m.chat_document_id]
+    
+    # Add current message ID if it exists and is not already the last one
+    if msg:
+        msg_id = msg.id()
+        if not doc_ids or doc_ids[-1] != msg_id:
+            doc_ids.append(msg_id)
+    
+    # Take only the last max_depth elements
+    relevant_ids = doc_ids[-max_depth:]
+    
+    # Convert IDs to ChatDocuments
+    return [doc for doc_id in relevant_ids 
+            if (doc := ChatDocument.from_id(doc_id)) is not None]
+```
+
+**Impact**: DoneSequences now correctly check only messages from the current agent, preventing incorrect task termination when subtasks generate matching sequences.
+
+### 3. Parent Pointer Preservation in Task.init()
+
+**Problem**: When `ChatDocument.deepcopy()` is called during `task.init()`, it resets `parent_id` and `child_id` to empty strings, breaking the parent chain. This particularly affected TaskTool when creating subtasks with parent pointers.
+
+**Solution**: Modified `task.init()` to preserve the original parent_id after deepcopy:
+```python
+if isinstance(msg, ChatDocument):
+    original_parent_id = msg.metadata.parent_id
+    self.pending_message = ChatDocument.deepcopy(msg)
+    # Preserve the parent pointer from the original message
+    self.pending_message.metadata.parent_id = original_parent_id
+```
+
+Additionally, added conditional logic to only override parent_id when necessary:
+```python
+if self.pending_message is not None and self.caller is not None:
+    # Only override parent_id if it wasn't already set in the original message
+    if not msg.metadata.parent_id:
+        self.pending_message.metadata.parent_id = msg.metadata.id
+```
+
+**Impact**: Parent chains are now preserved when TaskTool creates subtasks, maintaining proper message lineage.
+
+### 4. TaskTool Parent-Child Relationship
+
+**Problem**: TaskTool was only setting the parent pointer on the prompt ChatDocument but not the corresponding child pointer on the TaskTool message.
+
+**Solution**: Added bidirectional parent-child relationship in TaskTool handlers:
+```python
+if chat_doc is not None:
+    prompt_doc = ChatDocument(
+        content=self.prompt,
+        metadata=ChatDocMetaData(
+            parent_id=chat_doc.id(),
+            agent_id=agent.id,
+            sender=chat_doc.metadata.sender,
+        )
+    )
+    # Set bidirectional parent-child relationship
+    chat_doc.metadata.child_id = prompt_doc.id()
+```
+
+**Impact**: Complete bidirectional parent-child chains are maintained, improving message traceability.
+
+## Tests Added
+
+Added comprehensive test `test_task_init_preserves_parent_id()` in `test_task.py` that verifies:
+- Parent IDs are preserved during ChatDocument deep copying
+- Conditional parent_id override logic works correctly for subtasks
+- Parent chains are maintained in various scenarios
+
+## Breaking Changes
+
+None. All changes are backward compatible bug fixes.
+
+## Migration Guide
+
+No migration needed. The fixes will automatically apply to existing code.
+
+## Technical Details
+
+The core issue was that DoneSequences were incorrectly checking messages across agent boundaries due to parent pointer traversal. Combined with the agent ID initialization bug and parent chain breaks in deepcopy, this caused incorrect task termination behavior. The fixes ensure:
+
+1. Each agent's messages are properly tagged with the agent's ID
+2. DoneSequence checking is confined to the current agent's message history
+3. Parent chains are preserved through TaskTool subtask creation
+4. Bidirectional parent-child relationships are maintained
+
+These changes work together to ensure proper message lineage and task termination behavior in multi-agent systems.
+</file>
+
 <file path=".blackignore">
 ./examples/urlqa/chat-clear.py
 </file>
@@ -17004,70 +17148,6 @@ mysql_user = root
 exclude = .*,.*/.*,.*/*,.*/*.*
 max-line-length = 88
 ignore = W291, W293, E501, E203, W503
-</file>
-
-<file path="ai-instructions/claude-repomix-instructions.md">
-# AI Instructions for Setting Up Repomix
-
-## Task Overview
-Set up [repomix](https://github.com/yamadashy/repomix) to generate LLM-friendly repository exports. This creates text files that can be uploaded to AI models for code analysis.
-
-## Steps to Complete
-
-### 1. Install Repomix
-```bash
-npm install -g repomix
-```
-
-### 2. Create repomix.config.json
-Create a configuration file in the repository root with:
-- **Include patterns**: Source code files (*.py, *.js, *.md, *.yaml, *.yml, *.toml)
-- **Exclude patterns**: Data directories, logs, node_modules, JSON files, generated files
-- **Security check**: Enable to prevent sensitive data inclusion
-
-### 3. Configure Include/Exclude Patterns
-- Include only source code directories and documentation
-- Exclude data/, logs/, build artifacts, dependencies
-- Add `llms*.txt` to exclusions to prevent recursive inclusion
-
-### 4. Test Configuration (Optional)
-```bash
-# Generate file list only for inspection
-repomix --no-files -o file-list.txt
-```
-This allows you to review which files will be included before generating the full output.
-
-### 5. Generate Output Versions
-
-Use the Makefile targets to generate repomix files:
-
-```bash
-# Generate all variants (recommended)
-make repomix-all
-
-# Or generate specific versions:
-make repomix                      # llms.txt and llms-compressed.txt (includes tests)
-make repomix-no-tests             # llms-no-tests.txt and llms-no-tests-compressed.txt
-make repomix-no-tests-no-examples # llms-no-tests-no-examples.txt and compressed version
-```
-
-All commands use `git ls-files` to ensure only git-tracked files are included.
-
-### 6. Verify Results
-- Check file sizes and token counts in repomix output
-- Ensure no sensitive data is included
-- Confirm only relevant source files are packaged
-
-## Expected Outcome
-Six text files optimized for different LLM contexts:
-- `llms.txt`: Full version with tests and examples (870K tokens)
-- `llms-compressed.txt`: Compressed version with tests and examples (513K tokens)
-- `llms-no-tests.txt`: Full version without tests (677K tokens)
-- `llms-no-tests-compressed.txt`: Compressed version without tests (433K tokens)
-- `llms-no-tests-no-examples.txt`: Core library code only (no tests/examples)
-- `llms-no-tests-no-examples-compressed.txt`: Compressed core library code (285K tokens)
-
-The files contain only git-tracked source code with proper exclusions for clean, focused LLM consumption.
 </file>
 
 <file path="ai-notes/Langroid-repo-docs.md">
@@ -20303,30 +20383,6 @@ docs = self.vecdb._lance_result_to_docs(result)
 scores = [r["score"] for r in result.to_list()]
 </file>
 
-<file path="langroid/agent/tools/mcp/__init__.py">
-__all__ = [
-</file>
-
-<file path="langroid/agent/tools/mcp/decorators.py">
-"""Decorator: declare a ToolMessage class bound to a FastMCP tool.
-
-    Usage:
-        @fastmcp_tool("/path/to/server.py", "get_weather")
-        class WeatherTool:
-            def pretty(self) -> str:
-                return f"Temp is {self.temperature}"
-    """
-⋮----
-def decorator(user_cls: Type[ToolMessage]) -> Type[ToolMessage]
-⋮----
-# build the “real” ToolMessage subclass for this server/tool
-RealTool: Type[ToolMessage] = get_tool(server, tool_name)
-⋮----
-# copy user‐defined methods / attributes onto RealTool
-⋮----
-# preserve the user’s original name if you like:
-</file>
-
 <file path="langroid/agent/batch.py">
 T = TypeVar("T")
 U = TypeVar("U")
@@ -21887,167 +21943,6 @@ replace_and_log() {
 replace_and_log
 </file>
 
-<file path="Makefile">
-.PHONY: setup check lint tests docs nodocs loc
-
-SHELL := /bin/bash
-
-.PHONY: setup update
-
-setup: ## Setup the git pre-commit hooks
-	uv run pre-commit install
-
-update: ## Update the git pre-commit hooks
-	uv run pre-commit autoupdate
-
-.PHONY: type-check
-type-check:
-	@uv run pre-commit install
-	@uv run pre-commit autoupdate
-	@uv run pre-commit run --all-files
-	@echo "Running black..."
-	@uv run black --check .
-	@echo "Running ruff check (without fix)..."
-	@uv run ruff check .
-	@echo "Running mypy...";
-	@uv run mypy -p langroid
-	@echo "All checks passed!"
-
-.PHONY: lint
-lint:
-	uv run black .
-	uv run ruff check . --fix
-	@echo "Auto-fixing issues in examples folder..."
-	@uv run ruff check examples/ --fix-only --no-force-exclude
-
-.PHONY: stubs
-stubs:
-	@echo "Generating Python stubs for the langroid package..."
-	@uv run stubgen -p langroid -o stubs
-	@echo "Stubs generated in the 'stubs' directory"
-
-.PHONY: fix-pydantic
-
-# Entry to replace pydantic imports in specified directories
-fix-pydantic:
-	@echo "Fixing pydantic imports..."
-	@chmod +x scripts/fix-pydantic-imports.sh
-	@./scripts/fix-pydantic-imports.sh
-
-.PHONY: check
-check: fix-pydantic lint type-check
-
-.PHONY: tests
-tests:
-	pytest tests/main --basetemp=/tmp/pytest
-
-
-docs:
-	@# Kill any existing 'mkdocs serve' processes.
-	@pkill -f "mkdocs serve" 2>/dev/null || true
-	@# Build the documentation.
-	mkdocs build
-	@# Serve the documentation in the background.
-	mkdocs serve &
-	@echo "Documentation is being served in the background."
-	@echo "You can access the documentation at http://127.0.0.1:8000/"
-
-nodocs:
-	@# Kill any existing 'mkdocs serve' processes.
-	@pkill -f "mkdocs serve" 2>/dev/null || echo "No 'mkdocs serve' process found."
-	@echo "Stopped serving documentation."
-
-
-loc:
-	@echo "Lines in git-tracked files python files:"
-	@git ls-files | grep '\.py$$' | xargs cat | grep -v '^\s*$$' | wc -l
-
-.PHONY: repomix repomix-no-tests repomix-all
-
-repomix: ## Generate llms.txt and llms-compressed.txt (includes tests)
-	@echo "Generating llms.txt (with tests)..."
-	@git ls-files | repomix --stdin
-	@echo "Generating llms-compressed.txt..."
-	@git ls-files | repomix --stdin --compress -o llms-compressed.txt
-	@echo "Generated llms.txt and llms-compressed.txt"
-
-repomix-no-tests: ## Generate llms-no-tests.txt (excludes tests)
-	@echo "Generating llms-no-tests.txt (without tests)..."
-	@git ls-files | grep -v "^tests/" | repomix --stdin -o llms-no-tests.txt
-	@echo "Generating llms-no-tests-compressed.txt..."
-	@git ls-files | grep -v "^tests/" | repomix --stdin --compress -o llms-no-tests-compressed.txt
-	@echo "Generated llms-no-tests.txt and llms-no-tests-compressed.txt"
-
-repomix-no-tests-no-examples: ## Generate llms-no-tests-no-examples.txt (excludes tests and examples)
-	@echo "Generating llms-no-tests-no-examples.txt (without tests and examples)..."
-	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin -o llms-no-tests-no-examples.txt
-	@echo "Generating llms-no-tests-no-examples-compressed.txt..."
-	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin --compress -o llms-no-tests-no-examples-compressed.txt
-	@echo "Generated llms-no-tests-no-examples.txt and llms-no-tests-no-examples-compressed.txt"
-
-repomix-all: repomix repomix-no-tests repomix-no-tests-no-examples ## Generate all repomix variants
-
-.PHONY: revert-tag
-revert-tag:
-	@LATEST_TAG=$$(git describe --tags --abbrev=0) && \
-	echo "Deleting tag: $$LATEST_TAG" && \
-	git tag -d $$LATEST_TAG
-
-.PHONY: revert-bump
-revert-bump:
-	@if git log -1 --pretty=%B | grep -q "bump"; then \
-		git reset --hard HEAD~1; \
-		echo "Reverted last commit (bump commit)"; \
-	else \
-		echo "Last commit was not a bump commit"; \
-	fi
-
-.PHONY: revert
-revert: revert-bump revert-tag
-	
-.PHONY: bump-patch
-bump-patch:
-	@cz bump --increment PATCH
-
-.PHONY: bump-minor
-bump-minor:
-	@cz bump --increment MINOR 
-
-.PHONY: bump-major
-bump-major:
-	@cz bump --increment MAJOR 
-
-.PHONY: build
-build:
-	@uv build
-
-.PHONY: push
-push:
-	@git push origin main
-	@git push origin --tags
-
-.PHONY: clean
-clean:
-	-rm -rf dist/*
-
-.PHONY: release
-release:
-	@VERSION=$$(cz version -p | cut -d' ' -f2) && gh release create $${VERSION} dist/*
-
-.PHONY: all-patch
-all-patch: bump-patch clean build push release
-
-.PHONY: all-minor
-all-minor: bump-minor clean build push release
-
-.PHONY: all-major
-all-major: bump-major clean build push release
-
-.PHONY: publish
-publish:
-	uv publish
-</file>
-
 <file path="SECURITY.md">
 # Security Policy
 
@@ -22085,6 +21980,70 @@ Once a security vulnerability is reported, we will work to:
 - Investigate and confirm the issue.
 - Develop a patch or mitigation strategy.
 - Publish the fix and disclose the advisory publicly after the resolution.
+</file>
+
+<file path="ai-instructions/claude-repomix-instructions.md">
+# AI Instructions for Setting Up Repomix
+
+## Task Overview
+Set up [repomix](https://github.com/yamadashy/repomix) to generate LLM-friendly repository exports. This creates text files that can be uploaded to AI models for code analysis.
+
+## Steps to Complete
+
+### 1. Install Repomix
+```bash
+npm install -g repomix
+```
+
+### 2. Create repomix.config.json
+Create a configuration file in the repository root with:
+- **Include patterns**: Source code files (*.py, *.js, *.md, *.yaml, *.yml, *.toml)
+- **Exclude patterns**: Data directories, logs, node_modules, JSON files, generated files
+- **Security check**: Enable to prevent sensitive data inclusion
+
+### 3. Configure Include/Exclude Patterns
+- Include only source code directories and documentation
+- Exclude data/, logs/, build artifacts, dependencies
+- Add `llms*.txt` to exclusions to prevent recursive inclusion
+
+### 4. Test Configuration (Optional)
+```bash
+# Generate file list only for inspection
+repomix --no-files -o file-list.txt
+```
+This allows you to review which files will be included before generating the full output.
+
+### 5. Generate Output Versions
+
+Use the Makefile targets to generate repomix files:
+
+```bash
+# Generate all variants (recommended)
+make repomix-all
+
+# Or generate specific versions:
+make repomix                      # llms.txt and llms-compressed.txt (includes tests)
+make repomix-no-tests             # llms-no-tests.txt and llms-no-tests-compressed.txt
+make repomix-no-tests-no-examples # llms-no-tests-no-examples.txt and compressed version
+```
+
+All commands use `git ls-files` to ensure only git-tracked files are included.
+
+### 6. Verify Results
+- Check file sizes and token counts in repomix output
+- Ensure no sensitive data is included
+- Confirm only relevant source files are packaged
+
+## Expected Outcome
+Six text files optimized for different LLM contexts:
+- `llms.txt`: Full version with tests and examples (870K tokens)
+- `llms-compressed.txt`: Compressed version with tests and examples (513K tokens)
+- `llms-no-tests.txt`: Full version without tests (677K tokens)
+- `llms-no-tests-compressed.txt`: Compressed version without tests (433K tokens)
+- `llms-no-tests-no-examples.txt`: Core library code only (no tests/examples)
+- `llms-no-tests-no-examples-compressed.txt`: Compressed core library code (285K tokens)
+
+The files contain only git-tracked source code with proper exclusions for clean, focused LLM consumption.
 </file>
 
 <file path="ai-notes/handler-parameter-analysis-notes.md">
@@ -25114,6 +25073,366 @@ commands/
 .claude/
 </file>
 
+<file path="docs/notes/mcp-tools.md">
+# Langroid MCP Integration
+
+Langroid provides seamless integration with Model Context Protocol (MCP) servers via 
+two methods, both of which involve creating Langroid `ToolMessage` subclasses
+corresponding to the MCP tools: 
+
+1. Programmatic creation of Langroid tools using `get_tool_async`, 
+   `get_tools_async` from the tool definitions defined on an MCP server.
+2. Declarative creation of Langroid tools using the **`@mcp_tool` decorator**, which allows
+   customizing the tool-handling behavior beyond what is provided by the MCP server.
+
+This integration allows _any_ LLM (that is good enough to do function-calling via prompts) to use any MCP server.
+See the following to understand the integration better:
+
+- example python scripts under [`examples/mcp`](https://github.com/langroid/langroid/tree/main/examples/mcp)
+- [`tests/main/test_mcp_tools.py`](https://github.com/langroid/langroid/blob/main/tests/main/test_mcp_tools.py)
+
+---
+
+## 1. Connecting to an MCP server via transport specification
+
+Before creating Langroid tools, we first need to define and connect to an MCP server
+via a [FastMCP](https://gofastmcp.com/getting-started/welcome) client. 
+There are several ways to connect to a server, depending on how it is defined. 
+Each of these uses a different type of [transport](https://gofastmcp.com/clients/transports).
+
+The typical pattern to use with Langroid is as follows:
+
+- define an MCP server transport
+- create a `ToolMessage` subclass using the `@mcp_tool` decorator or 
+  `get_tool_async()` function, with the transport as the first argument
+
+
+Langroid's MCP integration will work with any of [transports](https://gofastmcp.com/clients/transportsl) 
+supported by FastMCP.
+Below we go over some common ways to define transports and extract tools from the servers.
+
+1. **Local Python script**
+2. **In-memory FastMCP server** - useful for testing and for simple in-memory servers
+   that don't need to be run as a separate process.
+3. **NPX stdio transport**
+4. **UVX stdio transport**
+5. **Generic stdio transport** – launch any CLI‐based MCP server via stdin/stdout
+6. **Network SSE transport** – connect to HTTP/S MCP servers via `SSETransport`
+
+
+All examples below use the async helpers to create Langroid tools (`ToolMessage` subclasses):
+
+```python
+from langroid.agent.tools.mcp import (
+    get_tools_async,
+    get_tool_async,
+)
+```
+
+---
+
+#### Path to a Python Script
+
+Point at your MCP‐server entrypoint, e.g., to the `weather.py` script in the 
+langroid repo (based on the [Anthropic quick-start guide](https://modelcontextprotocol.io/quickstart/server)):
+
+```python
+async def example_script_path() -> None:
+    server = "tests/main/mcp/weather-server-python/weather.py"
+    tools = await get_tools_async(server) # all tools available
+    AlertTool = await get_tool_async(server, "get_alerts") # specific tool
+
+    # instantiate the tool with a specific input
+    msg = AlertTool(state="CA")
+    
+    # Call the tool via handle_async()
+    alerts = await msg.handle_async()
+    print(alerts)
+```
+
+---
+
+#### In-Memory FastMCP Server
+
+Define your server with `FastMCP(...)` and pass the instance:
+
+```python
+from fastmcp.server import FastMCP
+from pydantic import BaseModel, Field
+
+class CounterInput(BaseModel):
+    start: int = Field(...)
+
+def make_server() -> FastMCP:
+    server = FastMCP("CounterServer")
+
+    @server.tool()
+    def increment(data: CounterInput) -> int:
+        """Increment start by 1."""
+        return data.start + 1
+
+    return server
+
+async def example_in_memory() -> None:
+    server = make_server()
+    tools = await get_tools_async(server)
+    IncTool = await get_tool_async(server, "increment")
+
+    result = await IncTool(start=41).handle_async()
+    print(result)  # 42
+```
+
+See the [`mcp-file-system.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/mcp-file-system.py)
+script for a working example of this.
+
+---
+
+#### NPX stdio Transport
+
+Use any npm-installed MCP server via `npx`, e.g., the 
+[Exa web-search MCP server](https://docs.exa.ai/examples/exa-mcp):
+
+```python
+from fastmcp.client.transports import NpxStdioTransport
+
+transport = NpxStdioTransport(
+    package="exa-mcp-server",
+    env_vars={"EXA_API_KEY": "…"},
+)
+
+async def example_npx() -> None:
+    tools = await get_tools_async(transport)
+    SearchTool = await get_tool_async(transport, "web_search_exa")
+
+    results = await SearchTool(
+        query="How does Langroid integrate with MCP?"
+    ).handle_async()
+    print(results)
+```
+
+For a fully working example, see the script [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py).
+
+---
+
+#### UVX stdio Transport
+
+Connect to a UVX-based MCP server, e.g., the [Git MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
+
+```python
+from fastmcp.client.transports import UvxStdioTransport
+
+transport = UvxStdioTransport(tool_name="mcp-server-git")
+
+async def example_uvx() -> None:
+    tools = await get_tools_async(transport)
+    GitStatus = await get_tool_async(transport, "git_status")
+
+    status = await GitStatus(path=".").handle_async()
+    print(status)
+```
+
+--- 
+
+#### Generic stdio Transport
+
+Use `StdioTransport` to run any MCP server as a subprocess over stdio:
+
+```python
+from fastmcp.client.transports import StdioTransport
+from langroid.agent.tools.mcp import get_tools_async, get_tool_async
+
+
+async def example_stdio() -> None:
+    """Example: any CLI‐based MCP server via StdioTransport."""
+    transport: StdioTransport = StdioTransport(
+        command="uv",
+        args=["run", "--with", "biomcp-python", "biomcp", "run"],
+    )
+    tools: list[type] = await get_tools_async(transport)
+    BioTool = await get_tool_async(transport, "tool_name")
+    result: str = await BioTool(param="value").handle_async()
+    print(result)
+```
+
+See the full example in [`examples/mcp/biomcp.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/biomcp.py).
+
+---
+
+#### Network SSE Transport
+
+Use `SSETransport` to connect to a FastMCP server over HTTP/S:
+
+```python
+from fastmcp.client.transports import SSETransport
+from langroid.agent.tools.mcp import (
+    get_tools_async,
+    get_tool_async,
+)
+
+
+async def example_sse() -> None:
+    """Example: connect to an HTTP/S MCP server via SSETransport."""
+    url: str = "https://localhost:8000/sse"
+    transport: SSETransport = SSETransport(
+        url=url, headers={"Authorization": "Bearer TOKEN"}
+    )
+    tools: list[type] = await get_tools_async(transport)
+    ExampleTool = await get_tool_async(transport, "tool_name")
+    result: str = await ExampleTool(param="value").handle_async()
+    print(result)
+```    
+
+---
+
+With these patterns you can list tools, generate Pydantic-backed `ToolMessage` classes,
+and invoke them via `.handle_async()`, all with zero boilerplate client setup. 
+As the `FastMCP` library adds other types of transport (e.g., `StreamableHTTPTransport`),
+the pattern of usage with Langroid will remain the same.
+
+
+---
+
+## 2. Create Langroid Tools declaratively using the `@mcp_tool` decorator
+
+The above examples showed how you can create Langroid tools programmatically using
+the helper functions `get_tool_async()` and `get_tools_async()`,
+with the first argument being the transport to the MCP server. The `@mcp_tool` decorator
+works in the same way: 
+
+- **Arguments to the decorator**
+    1. `server_spec`: path/URL/`FastMCP`/`ClientTransport`, as mentioned above.
+    2. `tool_name`: name of a specific MCP tool
+
+- **Behavior**
+    - Generates a `ToolMessage` subclass with all input fields typed.
+    - Provides a `call_tool_async()` under the hood -- this is the "raw" MCP tool call,
+      returning a string.
+    - If you define your own `handle_async()`, it overrides the default. Typically,
+you would override it to customize either the input or the output of the tool call, or both.
+    - If you don't define your own `handle_async()`, it defaults to just returning the
+      value of the `call_tool_async()` method.
+
+Here is a simple example of using the `@mcp_tool` decorator to create a Langroid tool:
+
+```python
+from fastmcp.server import FastMCP
+from langroid.agent.tools.mcp import mcp_tool
+import langroid as lr
+
+# Define your MCP server (pydantic v2 for schema)
+server = FastMCP("MyServer")
+
+@mcp_tool(server, "greet")
+class GreetTool(lr.ToolMessage):
+    """Say hello to someone."""
+
+    async def handle_async(self) -> str:
+        # Customize post-processing
+        raw = await self.call_tool_async()
+        return f"💬 {raw}"
+```
+
+Using the decorator method allows you to customize the `handle_async` method of the
+tool, or add additional fields to the `ToolMessage`. 
+You may want to customize the input to the tool, or the tool result before it is sent back to 
+the LLM. If you don't override it, the default behavior is to simply return the value of 
+the "raw" MCP tool call `await self.call_tool_async()`. 
+
+```python
+@mcp_tool(server, "calculate")
+class CalcTool(ToolMessage):
+    """Perform complex calculation."""
+
+    async def handle_async(self) -> str:
+        result = await self.call_tool_async()
+        # Add context or emojis, etc.
+        return f"🧮 Result is *{result}*"
+```
+
+---
+
+## 3. Enabling Tools in Your Agent
+
+Once you’ve created a Langroid `ToolMessage` subclass from an MCP server, 
+you can enable it on a `ChatAgent`, just like you normally would. Below is an example of using 
+the [Exa MCP server](https://docs.exa.ai/examples/exa-mcp) to create a 
+Langroid web search tool, enable a `ChatAgent` to use it, and then set up a `Task` to 
+run the agent loop.
+
+First we must define the appropriate `ClientTransport` for the MCP server:
+```python
+# define the transport
+transport = NpxStdioTransport(
+    package="exa-mcp-server",
+    env_vars=dict(EXA_API_KEY=os.getenv("EXA_API_KEY")),
+)
+```
+
+Then we use the `@mcp_tool` decorator to create a `ToolMessage` 
+subclass representing the web search tool. Note that one reason to use the decorator
+to define our tool is so we can specify a custom `handle_async` method that
+controls what is sent to the LLM after the actual raw MCP tool-call
+(the `call_tool_async` method) is made.
+
+```python
+# the second arg specifically refers to the `web_search_exa` tool available
+# on the server defined by the `transport` variable.
+@mcp_tool(transport, "web_search_exa")
+class ExaSearchTool(lr.ToolMessage):
+    async def handle_async(self):
+        result: str = await self.call_tool_async()
+        return f"""
+        Below are the results of the web search:
+        
+        <WebSearchResult>
+        {result}
+        </WebSearchResult>
+        
+        Use these results to answer the user's original question.
+        """
+
+```
+
+If we did not want to override the `handle_async` method, we could simply have
+created the `ExaSearchTool` class programmatically via the `get_tool_async` 
+function as shown above, i.e.:
+
+```python
+from langroid.agent.tools.mcp import get_tool_async
+
+ExaSearchTool = awwait
+get_tool_async(transport, "web_search_exa")
+```
+
+We can now define our main function where we create our `ChatAgent`,
+attach the `ExaSearchTool` to it, define the `Task`, and run the task loop.
+
+```python
+async def main():
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            # forward to user when LLM doesn't use a tool
+            handle_llm_no_tool=NonToolAction.FORWARD_USER,
+            llm=lm.OpenAIGPTConfig(
+                max_output_tokens=1000,
+                # this defaults to True, but we set it to False so we can see output
+                async_stream_quiet=False,
+            ),
+        )
+    )
+
+    # enable the agent to use the web-search tool
+    agent.enable_message(ExaSearchTool)
+    # make task with interactive=False =>
+    # waits for user only when LLM doesn't use a tool
+    task = lr.Task(agent, interactive=False)
+    await task.run_async()
+```
+
+See [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py) for a full 
+working example of this.
+</file>
+
 <file path="langroid/language_models/base.py">
 logger = logging.getLogger(__name__)
 ⋮----
@@ -26875,364 +27194,166 @@ agent.enable_message([Tool1, Tool2, Tool3])  # Pass list of tool classes
 - Tokens are not needed for public repositories and can cause GitHub rendering issues
 </file>
 
-<file path="docs/notes/mcp-tools.md">
-# Langroid MCP Integration
-
-Langroid provides seamless integration with Model Context Protocol (MCP) servers via 
-two methods, both of which involve creating Langroid `ToolMessage` subclasses
-corresponding to the MCP tools: 
-
-1. Programmatic creation of Langroid tools using `get_tool_async`, 
-   `get_tools_async` from the tool definitions defined on an MCP server.
-2. Declarative creation of Langroid tools using the **`@mcp_tool` decorator**, which allows
-   customizing the tool-handling behavior beyond what is provided by the MCP server.
-
-This integration allows _any_ LLM (that is good enough to do function-calling via prompts) to use any MCP server.
-See the following to understand the integration better:
-
-- example python scripts under [`examples/mcp`](https://github.com/langroid/langroid/tree/main/examples/mcp)
-- [`tests/main/test_mcp_tools.py`](https://github.com/langroid/langroid/blob/main/tests/main/test_mcp_tools.py)
-
----
-
-## 1. Connecting to an MCP server via transport specification
-
-Before creating Langroid tools, we first need to define and connect to an MCP server
-via a [FastMCP](https://gofastmcp.com/getting-started/welcome) client. 
-There are several ways to connect to a server, depending on how it is defined. 
-Each of these uses a different type of [transport](https://gofastmcp.com/clients/transports).
-
-The typical pattern to use with Langroid is as follows:
-
-- define an MCP server transport
-- create a `ToolMessage` subclass using the `@mcp_tool` decorator or 
-  `get_tool_async()` function, with the transport as the first argument
-
-
-Langroid's MCP integration will work with any of [transports](https://gofastmcp.com/clients/transportsl) 
-supported by FastMCP.
-Below we go over some common ways to define transports and extract tools from the servers.
-
-1. **Local Python script**
-2. **In-memory FastMCP server** - useful for testing and for simple in-memory servers
-   that don't need to be run as a separate process.
-3. **NPX stdio transport**
-4. **UVX stdio transport**
-5. **Generic stdio transport** – launch any CLI‐based MCP server via stdin/stdout
-6. **Network SSE transport** – connect to HTTP/S MCP servers via `SSETransport`
-
-
-All examples below use the async helpers to create Langroid tools (`ToolMessage` subclasses):
-
-```python
-from langroid.agent.tools.mcp import (
-    get_tools_async,
-    get_tool_async,
-)
-```
-
----
-
-#### Path to a Python Script
-
-Point at your MCP‐server entrypoint, e.g., to the `weather.py` script in the 
-langroid repo (based on the [Anthropic quick-start guide](https://modelcontextprotocol.io/quickstart/server)):
-
-```python
-async def example_script_path() -> None:
-    server = "tests/main/mcp/weather-server-python/weather.py"
-    tools = await get_tools_async(server) # all tools available
-    AlertTool = await get_tool_async(server, "get_alerts") # specific tool
-
-    # instantiate the tool with a specific input
-    msg = AlertTool(state="CA")
-    
-    # Call the tool via handle_async()
-    alerts = await msg.handle_async()
-    print(alerts)
-```
-
----
-
-#### In-Memory FastMCP Server
-
-Define your server with `FastMCP(...)` and pass the instance:
-
-```python
-from fastmcp.server import FastMCP
-from pydantic import BaseModel, Field
-
-class CounterInput(BaseModel):
-    start: int = Field(...)
-
-def make_server() -> FastMCP:
-    server = FastMCP("CounterServer")
-
-    @server.tool()
-    def increment(data: CounterInput) -> int:
-        """Increment start by 1."""
-        return data.start + 1
-
-    return server
-
-async def example_in_memory() -> None:
-    server = make_server()
-    tools = await get_tools_async(server)
-    IncTool = await get_tool_async(server, "increment")
-
-    result = await IncTool(start=41).handle_async()
-    print(result)  # 42
-```
-
-See the [`mcp-file-system.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/mcp-file-system.py)
-script for a working example of this.
-
----
-
-#### NPX stdio Transport
-
-Use any npm-installed MCP server via `npx`, e.g., the 
-[Exa web-search MCP server](https://docs.exa.ai/examples/exa-mcp):
-
-```python
-from fastmcp.client.transports import NpxStdioTransport
-
-transport = NpxStdioTransport(
-    package="exa-mcp-server",
-    env_vars={"EXA_API_KEY": "…"},
-)
-
-async def example_npx() -> None:
-    tools = await get_tools_async(transport)
-    SearchTool = await get_tool_async(transport, "web_search_exa")
-
-    results = await SearchTool(
-        query="How does Langroid integrate with MCP?"
-    ).handle_async()
-    print(results)
-```
-
-For a fully working example, see the script [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py).
-
----
-
-#### UVX stdio Transport
-
-Connect to a UVX-based MCP server, e.g., the [Git MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
-
-```python
-from fastmcp.client.transports import UvxStdioTransport
-
-transport = UvxStdioTransport(tool_name="mcp-server-git")
-
-async def example_uvx() -> None:
-    tools = await get_tools_async(transport)
-    GitStatus = await get_tool_async(transport, "git_status")
-
-    status = await GitStatus(path=".").handle_async()
-    print(status)
-```
-
---- 
-
-#### Generic stdio Transport
-
-Use `StdioTransport` to run any MCP server as a subprocess over stdio:
-
-```python
-from fastmcp.client.transports import StdioTransport
-from langroid.agent.tools.mcp import get_tools_async, get_tool_async
-
-
-async def example_stdio() -> None:
-    """Example: any CLI‐based MCP server via StdioTransport."""
-    transport: StdioTransport = StdioTransport(
-        command="uv",
-        args=["run", "--with", "biomcp-python", "biomcp", "run"],
-    )
-    tools: list[type] = await get_tools_async(transport)
-    BioTool = await get_tool_async(transport, "tool_name")
-    result: str = await BioTool(param="value").handle_async()
-    print(result)
-```
-
-See the full example in [`examples/mcp/biomcp.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/biomcp.py).
-
----
-
-#### Network SSE Transport
-
-Use `SSETransport` to connect to a FastMCP server over HTTP/S:
-
-```python
-from fastmcp.client.transports import SSETransport
-from langroid.agent.tools.mcp import (
-    get_tools_async,
-    get_tool_async,
-)
-
-
-async def example_sse() -> None:
-    """Example: connect to an HTTP/S MCP server via SSETransport."""
-    url: str = "https://localhost:8000/sse"
-    transport: SSETransport = SSETransport(
-        url=url, headers={"Authorization": "Bearer TOKEN"}
-    )
-    tools: list[type] = await get_tools_async(transport)
-    ExampleTool = await get_tool_async(transport, "tool_name")
-    result: str = await ExampleTool(param="value").handle_async()
-    print(result)
-```    
-
----
-
-With these patterns you can list tools, generate Pydantic-backed `ToolMessage` classes,
-and invoke them via `.handle_async()`, all with zero boilerplate client setup. 
-As the `FastMCP` library adds other types of transport (e.g., `StreamableHTTPTransport`),
-the pattern of usage with Langroid will remain the same.
-
-
----
-
-## 2. Create Langroid Tools declaratively using the `@mcp_tool` decorator
-
-The above examples showed how you can create Langroid tools programmatically using
-the helper functions `get_tool_async()` and `get_tools_async()`,
-with the first argument being the transport to the MCP server. The `@mcp_tool` decorator
-works in the same way: 
-
-- **Arguments to the decorator**
-    1. `server_spec`: path/URL/`FastMCP`/`ClientTransport`, as mentioned above.
-    2. `tool_name`: name of a specific MCP tool
-
-- **Behavior**
-    - Generates a `ToolMessage` subclass with all input fields typed.
-    - Provides a `call_tool_async()` under the hood -- this is the "raw" MCP tool call,
-      returning a string.
-    - If you define your own `handle_async()`, it overrides the default. Typically,
-you would override it to customize either the input or the output of the tool call, or both.
-    - If you don't define your own `handle_async()`, it defaults to just returning the
-      value of the `call_tool_async()` method.
-
-Here is a simple example of using the `@mcp_tool` decorator to create a Langroid tool:
-
-```python
-from fastmcp.server import FastMCP
-from langroid.agent.tools.mcp import mcp_tool
-import langroid as lr
-
-# Define your MCP server (pydantic v2 for schema)
-server = FastMCP("MyServer")
-
-@mcp_tool(server, "greet")
-class GreetTool(lr.ToolMessage):
-    """Say hello to someone."""
-
-    async def handle_async(self) -> str:
-        # Customize post-processing
-        raw = await self.call_tool_async()
-        return f"💬 {raw}"
-```
-
-Using the decorator method allows you to customize the `handle_async` method of the
-tool, or add additional fields to the `ToolMessage`. 
-You may want to customize the input to the tool, or the tool result before it is sent back to 
-the LLM. If you don't override it, the default behavior is to simply return the value of 
-the "raw" MCP tool call `await self.call_tool_async()`. 
-
-```python
-@mcp_tool(server, "calculate")
-class CalcTool(ToolMessage):
-    """Perform complex calculation."""
-
-    async def handle_async(self) -> str:
-        result = await self.call_tool_async()
-        # Add context or emojis, etc.
-        return f"🧮 Result is *{result}*"
-```
-
----
-
-## 3. Enabling Tools in Your Agent
-
-Once you’ve created a Langroid `ToolMessage` subclass from an MCP server, 
-you can enable it on a `ChatAgent`, just like you normally would. Below is an example of using 
-the [Exa MCP server](https://docs.exa.ai/examples/exa-mcp) to create a 
-Langroid web search tool, enable a `ChatAgent` to use it, and then set up a `Task` to 
-run the agent loop.
-
-First we must define the appropriate `ClientTransport` for the MCP server:
-```python
-# define the transport
-transport = NpxStdioTransport(
-    package="exa-mcp-server",
-    env_vars=dict(EXA_API_KEY=os.getenv("EXA_API_KEY")),
-)
-```
-
-Then we use the `@mcp_tool` decorator to create a `ToolMessage` 
-subclass representing the web search tool. Note that one reason to use the decorator
-to define our tool is so we can specify a custom `handle_async` method that
-controls what is sent to the LLM after the actual raw MCP tool-call
-(the `call_tool_async` method) is made.
-
-```python
-# the second arg specifically refers to the `web_search_exa` tool available
-# on the server defined by the `transport` variable.
-@mcp_tool(transport, "web_search_exa")
-class ExaSearchTool(lr.ToolMessage):
-    async def handle_async(self):
-        result: str = await self.call_tool_async()
-        return f"""
-        Below are the results of the web search:
-        
-        <WebSearchResult>
-        {result}
-        </WebSearchResult>
-        
-        Use these results to answer the user's original question.
-        """
-
-```
-
-If we did not want to override the `handle_async` method, we could simply have
-created the `ExaSearchTool` class programmatically via the `get_tool_async` 
-function as shown above, i.e.:
-
-```python
-from langroid.agent.tools.mcp import get_tool_async
-
-ExaSearchTool = awwait
-get_tool_async(transport, "web_search_exa")
-```
-
-We can now define our main function where we create our `ChatAgent`,
-attach the `ExaSearchTool` to it, define the `Task`, and run the task loop.
-
-```python
-async def main():
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            # forward to user when LLM doesn't use a tool
-            handle_llm_no_tool=NonToolAction.FORWARD_USER,
-            llm=lm.OpenAIGPTConfig(
-                max_output_tokens=1000,
-                # this defaults to True, but we set it to False so we can see output
-                async_stream_quiet=False,
-            ),
-        )
-    )
-
-    # enable the agent to use the web-search tool
-    agent.enable_message(ExaSearchTool)
-    # make task with interactive=False =>
-    # waits for user only when LLM doesn't use a tool
-    task = lr.Task(agent, interactive=False)
-    await task.run_async()
-```
-
-See [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py) for a full 
-working example of this.
+<file path="Makefile">
+.PHONY: setup check lint tests docs nodocs loc
+
+SHELL := /bin/bash
+
+.PHONY: setup update
+
+setup: ## Setup the git pre-commit hooks
+	uv run pre-commit install
+
+update: ## Update the git pre-commit hooks
+	uv run pre-commit autoupdate
+
+.PHONY: type-check
+type-check:
+	@uv run pre-commit install
+	@uv run pre-commit autoupdate
+	@uv run pre-commit run --all-files
+	@echo "Running black..."
+	@uv run black --check .
+	@echo "Running ruff check (without fix)..."
+	@uv run ruff check .
+	@echo "Running mypy...";
+	@uv run mypy -p langroid
+	@echo "All checks passed!"
+
+.PHONY: lint
+lint:
+	uv run black .
+	uv run ruff check . --fix
+	@echo "Auto-fixing issues in examples folder..."
+	@uv run ruff check examples/ --fix-only --no-force-exclude
+
+.PHONY: stubs
+stubs:
+	@echo "Generating Python stubs for the langroid package..."
+	@uv run stubgen -p langroid -o stubs
+	@echo "Stubs generated in the 'stubs' directory"
+
+.PHONY: fix-pydantic
+
+# Entry to replace pydantic imports in specified directories
+fix-pydantic:
+	@echo "Fixing pydantic imports..."
+	@chmod +x scripts/fix-pydantic-imports.sh
+	@./scripts/fix-pydantic-imports.sh
+
+
+.PHONY: tests
+tests:
+	pytest tests/main --basetemp=/tmp/pytest
+
+
+docs:
+	@# Kill any existing 'mkdocs serve' processes.
+	@pkill -f "mkdocs serve" 2>/dev/null || true
+	@# Build the documentation.
+	mkdocs build
+	@# Serve the documentation in the background.
+	mkdocs serve &
+	@echo "Documentation is being served in the background."
+	@echo "You can access the documentation at http://127.0.0.1:8000/"
+
+nodocs:
+	@# Kill any existing 'mkdocs serve' processes.
+	@pkill -f "mkdocs serve" 2>/dev/null || echo "No 'mkdocs serve' process found."
+	@echo "Stopped serving documentation."
+
+
+loc:
+	@echo "Lines in git-tracked files python files:"
+	@git ls-files | grep '\.py$$' | xargs cat | grep -v '^\s*$$' | wc -l
+
+.PHONY: repomix repomix-no-tests repomix-all
+
+repomix: ## Generate llms.txt and llms-compressed.txt (includes tests)
+	@echo "Generating llms.txt (with tests)..."
+	@git ls-files | repomix --stdin
+	@echo "Generating llms-compressed.txt..."
+	@git ls-files | repomix --stdin --compress -o llms-compressed.txt
+	@echo "Generated llms.txt and llms-compressed.txt"
+
+repomix-no-tests: ## Generate llms-no-tests.txt (excludes tests)
+	@echo "Generating llms-no-tests.txt (without tests)..."
+	@git ls-files | grep -v "^tests/" | repomix --stdin -o llms-no-tests.txt
+	@echo "Generating llms-no-tests-compressed.txt..."
+	@git ls-files | grep -v "^tests/" | repomix --stdin --compress -o llms-no-tests-compressed.txt
+	@echo "Generated llms-no-tests.txt and llms-no-tests-compressed.txt"
+
+repomix-no-tests-no-examples: ## Generate llms-no-tests-no-examples.txt (excludes tests and examples)
+	@echo "Generating llms-no-tests-no-examples.txt (without tests and examples)..."
+	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin -o llms-no-tests-no-examples.txt
+	@echo "Generating llms-no-tests-no-examples-compressed.txt..."
+	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin --compress -o llms-no-tests-no-examples-compressed.txt
+	@echo "Generated llms-no-tests-no-examples.txt and llms-no-tests-no-examples-compressed.txt"
+
+repomix-all: repomix repomix-no-tests repomix-no-tests-no-examples ## Generate all repomix variants
+
+.PHONY: check
+check: fix-pydantic lint type-check repomix-all
+
+.PHONY: revert-tag
+revert-tag:
+	@LATEST_TAG=$$(git describe --tags --abbrev=0) && \
+	echo "Deleting tag: $$LATEST_TAG" && \
+	git tag -d $$LATEST_TAG
+
+.PHONY: revert-bump
+revert-bump:
+	@if git log -1 --pretty=%B | grep -q "bump"; then \
+		git reset --hard HEAD~1; \
+		echo "Reverted last commit (bump commit)"; \
+	else \
+		echo "Last commit was not a bump commit"; \
+	fi
+
+.PHONY: revert
+revert: revert-bump revert-tag
+	
+.PHONY: bump-patch
+bump-patch:
+	@cz bump --increment PATCH
+
+.PHONY: bump-minor
+bump-minor:
+	@cz bump --increment MINOR 
+
+.PHONY: bump-major
+bump-major:
+	@cz bump --increment MAJOR 
+
+.PHONY: build
+build:
+	@uv build
+
+.PHONY: push
+push:
+	@git push origin main
+	@git push origin --tags
+
+.PHONY: clean
+clean:
+	-rm -rf dist/*
+
+.PHONY: release
+release:
+	@VERSION=$$(cz version -p | cut -d' ' -f2) && gh release create $${VERSION} dist/*
+
+.PHONY: all-patch
+all-patch: bump-patch clean build push release
+
+.PHONY: all-minor
+all-minor: bump-minor clean build push release
+
+.PHONY: all-major
+all-major: bump-major clean build push release
+
+.PHONY: publish
+publish:
+	uv publish
 </file>
 
 <file path="langroid/agent/special/doc_chat_agent.py">
@@ -28118,6 +28239,307 @@ def justify_response(self) -> ChatDocument | None
 source = self.response.metadata.source
 </file>
 
+<file path="langroid/agent/tools/mcp/fastmcp_client.py">
+load_dotenv()  # load environment variables from .env
+⋮----
+FastMCPServerSpec: TypeAlias = str | FastMCP[Any] | ClientTransport | AnyUrl
+⋮----
+class FastMCPClient
+⋮----
+"""A client for interacting with a FastMCP server.
+
+    Provides async context manager functionality to safely manage resources.
+    """
+⋮----
+logger = logging.getLogger(__name__)
+_cm: Optional[Client] = None
+client: Optional[Client] = None
+⋮----
+sampling_handler: SamplingHandler | None = None,  # type: ignore
+roots: RootsList | RootsHandler | None = None,  # type: ignore
+⋮----
+"""Initialize the FastMCPClient.
+
+        Args:
+            server: FastMCP server or path to such a server
+        """
+⋮----
+async def __aenter__(self) -> "FastMCPClient"
+⋮----
+"""Enter the async context manager and connect inner client."""
+# create inner client context manager
+⋮----
+# actually enter it (opens the session)
+self.client = await self._cm.__aenter__()  # type: ignore
+⋮----
+async def connect(self) -> None
+⋮----
+"""Open the underlying session."""
+⋮----
+async def close(self) -> None
+⋮----
+"""Close the underlying session."""
+⋮----
+"""Exit the async context manager and close inner client."""
+# exit and close the inner fastmcp.Client
+⋮----
+await self._cm.__aexit__(exc_type, exc_val, exc_tb)  # type: ignore
+⋮----
+def __del__(self) -> None
+⋮----
+"""Warn about unclosed persistent connections."""
+⋮----
+"""Convert a JSON Schema snippet into a (type, Field) tuple.
+
+        Args:
+            name: Name of the field.
+            schema: JSON Schema for this field.
+            prefix: Prefix to use for nested model names.
+
+        Returns:
+            A tuple of (python_type, Field(...)) for create_model.
+        """
+t = schema.get("type")
+default = schema.get("default", ...)
+desc = schema.get("description")
+# Object → nested BaseModel
+⋮----
+sub_name = f"{prefix}_{name.capitalize()}"
+sub_fields: Dict[str, Tuple[type, Any]] = {}
+⋮----
+submodel = create_model(  # type: ignore
+return submodel, Field(default=default, description=desc)  # type: ignore
+# Array → List of items
+⋮----
+return List[item_type], Field(default=default, description=desc)  # type: ignore
+# Primitive types
+⋮----
+# Fallback or unions
+⋮----
+# Default fallback
+⋮----
+async def get_tool_async(self, tool_name: str) -> Type[ToolMessage]
+⋮----
+"""
+        Create a Langroid ToolMessage subclass from the MCP Tool
+        with the given `tool_name`.
+        """
+⋮----
+target = await self.get_mcp_tool_async(tool_name)
+⋮----
+props = target.inputSchema.get("properties", {})
+fields: Dict[str, Tuple[type, Any]] = {}
+⋮----
+# Convert target.name to CamelCase and add Tool suffix
+parts = target.name.replace("-", "_").split("_")
+camel_case = "".join(part.capitalize() for part in parts)
+model_name = f"{camel_case}Tool"
+⋮----
+# IMPORTANT: Avoid clashes with reserved field names in Langroid ToolMessage!
+# First figure out which field names are reserved
+reserved = set(_BaseToolMessage.__annotations__.keys())
+⋮----
+renamed: Dict[str, str] = {}
+new_fields: Dict[str, Tuple[type, Any]] = {}
+⋮----
+new_name = fname + "__"
+⋮----
+# now replace fields with our renamed‐aware mapping
+fields = new_fields
+⋮----
+# create Langroid ToolMessage subclass, with expected fields.
+tool_model = cast(
+⋮----
+create_model(  # type: ignore[call-overload]
+⋮----
+# Store ALL client configuration needed to recreate a client
+client_config = {
+⋮----
+tool_model._client_config = client_config  # type: ignore [attr-defined]
+tool_model._renamed_fields = renamed  # type: ignore[attr-defined]
+⋮----
+# 2) define an arg-free call_tool_async()
+async def call_tool_async(itself: ToolMessage) -> Any
+⋮----
+# pack up the payload
+payload = itself.dict(
+⋮----
+# restore any renamed fields
+for orig, new in itself.__class__._renamed_fields.items():  # type: ignore
+⋮----
+client_cfg = getattr(itself.__class__, "_client_config", None)  # type: ignore
+⋮----
+# Fallback or error - ideally _client_config should always exist
+⋮----
+# Connect the client if not yet connected and keep the connection open
+⋮----
+# open a fresh client, call the tool, then close
+async with FastMCPClient(**client_cfg) as client:  # type: ignore
+⋮----
+tool_model.call_tool_async = call_tool_async  # type: ignore
+⋮----
+# 3) define handle_async() method with optional agent parameter
+⋮----
+"""
+                Auto-generated handler for MCP tool. Returns ChatDocument with files
+                if files are present and agent is provided, otherwise returns text.
+
+                To override: define your own handle_async method with matching signature
+                if you need file handling, or simpler signature if you only need text.
+                """
+response = await self.call_tool_async()  # type: ignore[attr-defined]
+⋮----
+# If we have files and an agent is provided, return a ChatDocument
+⋮----
+# Otherwise, just return the text content
+⋮----
+# add the handle_async() method to the tool model
+tool_model.handle_async = handle_async  # type: ignore
+⋮----
+async def get_tools_async(self) -> List[Type[ToolMessage]]
+⋮----
+"""
+        Get all available tools as Langroid ToolMessage classes,
+        handling nested schemas, with `handle_async` methods
+        """
+⋮----
+resp = await self.client.list_tools()
+⋮----
+async def get_mcp_tool_async(self, name: str) -> Optional[Tool]
+⋮----
+"""Find the "original" MCP Tool (i.e. of type mcp.types.Tool) on the server
+         matching `name`, or None if missing. This contains the metadata for the tool:
+         name, description, inputSchema, etc.
+
+        Args:
+            name: Name of the tool to look up.
+
+        Returns:
+            The raw Tool object from the server, or None.
+        """
+⋮----
+resp: List[Tool] = await self.client.list_tools()
+⋮----
+# Log more detailed error information
+error_content = None
+⋮----
+error_content = [
+⋮----
+error_content = [f"Could not extract error content: {str(e)}"]
+⋮----
+results_text = [
+results_file = []
+⋮----
+"""Call an MCP tool with the given arguments.
+
+        Args:
+            tool_name: Name of the tool to call.
+            arguments: Arguments to pass to the tool.
+
+        Returns:
+            The result of the tool call.
+        """
+⋮----
+result: CallToolResult = await self.client.session.call_tool(
+results = self._convert_tool_result(tool_name, result)
+⋮----
+# ==============================================================================
+# Convenience functions (wrappers around FastMCPClient methods)
+# These are useful for one-off calls without needing to manage the
+# FastMCPClient context explicitly.
+⋮----
+"""Get a single Langroid ToolMessage subclass for a specific MCP tool name (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        tool_name: The name of the tool to retrieve.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A dynamically created Langroid ToolMessage subclass representing the
+        requested tool.
+    """
+⋮----
+"""Get a single Langroid ToolMessage subclass
+    for a specific MCP tool name (synchronous).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
+    async `get_tool_async` function using `asyncio.run()`.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        tool_name: The name of the tool to retrieve.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A dynamically created Langroid ToolMessage subclass representing the
+        requested tool.
+    """
+⋮----
+"""Get all available tools as Langroid ToolMessage subclasses (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A list of dynamically created Langroid ToolMessage subclasses
+        representing all available tools on the server.
+    """
+⋮----
+"""Get all available tools as Langroid ToolMessage subclasses (synchronous).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
+    async `get_tools_async` function using `asyncio.run()`.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A list of dynamically created Langroid ToolMessage subclasses
+        representing all available tools on the server.
+    """
+⋮----
+"""Get the raw MCP Tool object for a specific tool name (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient to
+    retrieve the tool definition from the server.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        name: The name of the tool to look up.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor.
+
+    Returns:
+        The raw `mcp.types.Tool` object from the server, or `None` if the tool
+        is not found.
+    """
+⋮----
+"""Get all available raw MCP Tool objects from the server (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient to
+    retrieve the list of tool definitions from the server.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor.
+
+    Returns:
+        A list of raw `mcp.types.Tool` objects available on the server.
+    """
+</file>
+
 <file path="langroid/agent/tools/task_tool.py">
 """
 TaskTool: A tool that allows agents to delegate a task to a sub-agent with
@@ -28165,9 +28587,6 @@ agent_name = self.agent_name or f"agent-{str(uuid.uuid4())[:8]}"
 # TODO: Maybe we just copy the parent agent's config and override chat_model?
 #   -- but what if parent agent has a MockLMConfig?
 llm_config = lm.OpenAIGPTConfig(
-⋮----
-chat_model=self.model or "gpt-4.1-mini",  # Default model if not specified
-⋮----
 config = ChatAgentConfig(
 ⋮----
 # Create the sub-agent
@@ -28192,8 +28611,6 @@ tool_classes = []
 # Create a non-interactive task
 task = Task(sub_agent, interactive=False)
 ⋮----
-def handle(self, agent: ChatAgent) -> Optional[ChatDocument]
-⋮----
 """
 
         Handle the TaskTool by creating a sub-agent with specified tools
@@ -28201,13 +28618,19 @@ def handle(self, agent: ChatAgent) -> Optional[ChatDocument]
 
         Args:
             agent: The parent ChatAgent that is handling this tool
+            chat_doc: The ChatDocument containing this tool message
         """
 ⋮----
 task = self._set_up_task(agent)
-# Run the task on the prompt, and return the result
-result = task.run(self.prompt, turns=self.max_iterations or 10)
 ⋮----
-async def handle_async(self, agent: ChatAgent) -> Optional[ChatDocument]
+# Create a ChatDocument for the prompt with parent pointer
+prompt_doc = None
+⋮----
+prompt_doc = ChatDocument(
+# Set bidirectional parent-child relationship
+⋮----
+# Run the task with the ChatDocument or string prompt
+result = task.run(prompt_doc or self.prompt, turns=self.max_iterations or 10)
 ⋮----
 """
         Async method to handle the TaskTool by creating a sub-agent with specified tools
@@ -28215,11 +28638,12 @@ async def handle_async(self, agent: ChatAgent) -> Optional[ChatDocument]
 
         Args:
             agent: The parent ChatAgent that is handling this tool
+            chat_doc: The ChatDocument containing this tool message
         """
 ⋮----
 # TODO eventually allow the various task setup configs,
 #  including termination conditions
-result = await task.run_async(self.prompt, turns=self.max_iterations or 10)
+result = await task.run_async(
 </file>
 
 <file path="langroid/agent/task.py">
@@ -28610,11 +29034,17 @@ last_agent_msg = self.agent.message_history[-1]
 ⋮----
 # carefully deep-copy: fresh metadata.id, register
 # as new obj in registry
+original_parent_id = msg.metadata.parent_id
+⋮----
+# Preserve the parent pointer from the original message
 ⋮----
 # msg may have come from `caller`, so we pretend this is from
 # the CURRENT task's USER entity
 ⋮----
 # update parent, child, agent pointers
+⋮----
+# Only override parent_id if it wasn't already set in the
+# original message. This preserves parent chains from TaskTool
 ⋮----
 def init_loggers(self) -> None
 ⋮----
@@ -29357,20 +29787,24 @@ sender_name = responder.value
 ⋮----
 sender_name = responder.name
 ⋮----
-"""Get the chain of messages by following parent pointers."""
+"""Get the chain of messages using agent's message history."""
 ⋮----
 # Get max depth needed from all sequences
 max_depth = 50  # default fallback
 ⋮----
 max_depth = max(len(seq.events) for seq in self._parsed_done_sequences)
 ⋮----
-chain = []
-current = msg
-depth = 0
+# Get chat document IDs from message history
+doc_ids = [
 ⋮----
-current = current.parent
+# Add current message ID if it exists and is not already the last one
 ⋮----
-# Reverse to get chronological order (oldest first)
+msg_id = msg.id()
+⋮----
+# Take only the last max_depth elements
+relevant_ids = doc_ids[-max_depth:]
+⋮----
+# Convert IDs to ChatDocuments and filter out None values
 ⋮----
 def _matches_event(self, actual: AgentEvent, expected: AgentEvent) -> bool
 ⋮----
@@ -30592,307 +31026,6 @@ agent.enable_message(MySubAgentTool, use=False, handle=False)
 4. **Iteration Limits**: Set reasonable limits based on task complexity
 </file>
 
-<file path="langroid/agent/tools/mcp/fastmcp_client.py">
-load_dotenv()  # load environment variables from .env
-⋮----
-FastMCPServerSpec: TypeAlias = str | FastMCP[Any] | ClientTransport | AnyUrl
-⋮----
-class FastMCPClient
-⋮----
-"""A client for interacting with a FastMCP server.
-
-    Provides async context manager functionality to safely manage resources.
-    """
-⋮----
-logger = logging.getLogger(__name__)
-_cm: Optional[Client] = None
-client: Optional[Client] = None
-⋮----
-sampling_handler: SamplingHandler | None = None,  # type: ignore
-roots: RootsList | RootsHandler | None = None,  # type: ignore
-⋮----
-"""Initialize the FastMCPClient.
-
-        Args:
-            server: FastMCP server or path to such a server
-        """
-⋮----
-async def __aenter__(self) -> "FastMCPClient"
-⋮----
-"""Enter the async context manager and connect inner client."""
-# create inner client context manager
-⋮----
-# actually enter it (opens the session)
-self.client = await self._cm.__aenter__()  # type: ignore
-⋮----
-async def connect(self) -> None
-⋮----
-"""Open the underlying session."""
-⋮----
-async def close(self) -> None
-⋮----
-"""Close the underlying session."""
-⋮----
-"""Exit the async context manager and close inner client."""
-# exit and close the inner fastmcp.Client
-⋮----
-await self._cm.__aexit__(exc_type, exc_val, exc_tb)  # type: ignore
-⋮----
-def __del__(self) -> None
-⋮----
-"""Warn about unclosed persistent connections."""
-⋮----
-"""Convert a JSON Schema snippet into a (type, Field) tuple.
-
-        Args:
-            name: Name of the field.
-            schema: JSON Schema for this field.
-            prefix: Prefix to use for nested model names.
-
-        Returns:
-            A tuple of (python_type, Field(...)) for create_model.
-        """
-t = schema.get("type")
-default = schema.get("default", ...)
-desc = schema.get("description")
-# Object → nested BaseModel
-⋮----
-sub_name = f"{prefix}_{name.capitalize()}"
-sub_fields: Dict[str, Tuple[type, Any]] = {}
-⋮----
-submodel = create_model(  # type: ignore
-return submodel, Field(default=default, description=desc)  # type: ignore
-# Array → List of items
-⋮----
-return List[item_type], Field(default=default, description=desc)  # type: ignore
-# Primitive types
-⋮----
-# Fallback or unions
-⋮----
-# Default fallback
-⋮----
-async def get_tool_async(self, tool_name: str) -> Type[ToolMessage]
-⋮----
-"""
-        Create a Langroid ToolMessage subclass from the MCP Tool
-        with the given `tool_name`.
-        """
-⋮----
-target = await self.get_mcp_tool_async(tool_name)
-⋮----
-props = target.inputSchema.get("properties", {})
-fields: Dict[str, Tuple[type, Any]] = {}
-⋮----
-# Convert target.name to CamelCase and add Tool suffix
-parts = target.name.replace("-", "_").split("_")
-camel_case = "".join(part.capitalize() for part in parts)
-model_name = f"{camel_case}Tool"
-⋮----
-# IMPORTANT: Avoid clashes with reserved field names in Langroid ToolMessage!
-# First figure out which field names are reserved
-reserved = set(_BaseToolMessage.__annotations__.keys())
-⋮----
-renamed: Dict[str, str] = {}
-new_fields: Dict[str, Tuple[type, Any]] = {}
-⋮----
-new_name = fname + "__"
-⋮----
-# now replace fields with our renamed‐aware mapping
-fields = new_fields
-⋮----
-# create Langroid ToolMessage subclass, with expected fields.
-tool_model = cast(
-⋮----
-create_model(  # type: ignore[call-overload]
-⋮----
-# Store ALL client configuration needed to recreate a client
-client_config = {
-⋮----
-tool_model._client_config = client_config  # type: ignore [attr-defined]
-tool_model._renamed_fields = renamed  # type: ignore[attr-defined]
-⋮----
-# 2) define an arg-free call_tool_async()
-async def call_tool_async(itself: ToolMessage) -> Any
-⋮----
-# pack up the payload
-payload = itself.dict(
-⋮----
-# restore any renamed fields
-for orig, new in itself.__class__._renamed_fields.items():  # type: ignore
-⋮----
-client_cfg = getattr(itself.__class__, "_client_config", None)  # type: ignore
-⋮----
-# Fallback or error - ideally _client_config should always exist
-⋮----
-# Connect the client if not yet connected and keep the connection open
-⋮----
-# open a fresh client, call the tool, then close
-async with FastMCPClient(**client_cfg) as client:  # type: ignore
-⋮----
-tool_model.call_tool_async = call_tool_async  # type: ignore
-⋮----
-# 3) define handle_async() method with optional agent parameter
-⋮----
-"""
-                Auto-generated handler for MCP tool. Returns ChatDocument with files
-                if files are present and agent is provided, otherwise returns text.
-
-                To override: define your own handle_async method with matching signature
-                if you need file handling, or simpler signature if you only need text.
-                """
-response = await self.call_tool_async()  # type: ignore[attr-defined]
-⋮----
-# If we have files and an agent is provided, return a ChatDocument
-⋮----
-# Otherwise, just return the text content
-⋮----
-# add the handle_async() method to the tool model
-tool_model.handle_async = handle_async  # type: ignore
-⋮----
-async def get_tools_async(self) -> List[Type[ToolMessage]]
-⋮----
-"""
-        Get all available tools as Langroid ToolMessage classes,
-        handling nested schemas, with `handle_async` methods
-        """
-⋮----
-resp = await self.client.list_tools()
-⋮----
-async def get_mcp_tool_async(self, name: str) -> Optional[Tool]
-⋮----
-"""Find the "original" MCP Tool (i.e. of type mcp.types.Tool) on the server
-         matching `name`, or None if missing. This contains the metadata for the tool:
-         name, description, inputSchema, etc.
-
-        Args:
-            name: Name of the tool to look up.
-
-        Returns:
-            The raw Tool object from the server, or None.
-        """
-⋮----
-resp: List[Tool] = await self.client.list_tools()
-⋮----
-# Log more detailed error information
-error_content = None
-⋮----
-error_content = [
-⋮----
-error_content = [f"Could not extract error content: {str(e)}"]
-⋮----
-results_text = [
-results_file = []
-⋮----
-"""Call an MCP tool with the given arguments.
-
-        Args:
-            tool_name: Name of the tool to call.
-            arguments: Arguments to pass to the tool.
-
-        Returns:
-            The result of the tool call.
-        """
-⋮----
-result: CallToolResult = await self.client.session.call_tool(
-results = self._convert_tool_result(tool_name, result)
-⋮----
-# ==============================================================================
-# Convenience functions (wrappers around FastMCPClient methods)
-# These are useful for one-off calls without needing to manage the
-# FastMCPClient context explicitly.
-⋮----
-"""Get a single Langroid ToolMessage subclass for a specific MCP tool name (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        tool_name: The name of the tool to retrieve.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A dynamically created Langroid ToolMessage subclass representing the
-        requested tool.
-    """
-⋮----
-"""Get a single Langroid ToolMessage subclass
-    for a specific MCP tool name (synchronous).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
-    async `get_tool_async` function using `asyncio.run()`.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        tool_name: The name of the tool to retrieve.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A dynamically created Langroid ToolMessage subclass representing the
-        requested tool.
-    """
-⋮----
-"""Get all available tools as Langroid ToolMessage subclasses (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A list of dynamically created Langroid ToolMessage subclasses
-        representing all available tools on the server.
-    """
-⋮----
-"""Get all available tools as Langroid ToolMessage subclasses (synchronous).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
-    async `get_tools_async` function using `asyncio.run()`.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A list of dynamically created Langroid ToolMessage subclasses
-        representing all available tools on the server.
-    """
-⋮----
-"""Get the raw MCP Tool object for a specific tool name (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient to
-    retrieve the tool definition from the server.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        name: The name of the tool to look up.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor.
-
-    Returns:
-        The raw `mcp.types.Tool` object from the server, or `None` if the tool
-        is not found.
-    """
-⋮----
-"""Get all available raw MCP Tool objects from the server (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient to
-    retrieve the list of tool definitions from the server.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor.
-
-    Returns:
-        A list of raw `mcp.types.Tool` objects available on the server.
-    """
-</file>
-
 <file path="langroid/agent/base.py">
 ORCHESTRATION_STRINGS = [DONE, PASS, PASS_TO, SEND_TO]
 console = Console(quiet=settings.quiet)
@@ -30947,6 +31080,7 @@ oai_tool_id2call: Dict[str, OpenAIToolCall] = {}
 ⋮----
 def __init__(self, config: AgentConfig = AgentConfig())
 ⋮----
+self.id = ObjectRegistry.new_id()  # Initialize agent ID
 self.lock = asyncio.Lock()  # for async access to update self.llm.usage_cost
 self.dialog: List[Tuple[str, str]] = []  # seq of LLM (prompt, response) tuples
 ⋮----

--- a/llms-no-tests-no-examples.txt
+++ b/llms-no-tests-no-examples.txt
@@ -305,6 +305,7 @@ release-notes/
   v0-56-0-task-tool.md
   v0-56-11-openai-client-caching.md
   v0-56-12-cached-tokens-support.md
+  v0-56-13-done-sequences-parent-chain-fixes.md
   v0-56-2-table-chat-fix.md
   v0-56-4-handler-params.md
   v0-56-6-doc-chat-refactor.md
@@ -10618,6 +10619,67 @@ class RetrieverAgent(DocChatAgent):
             logger.warning("Vector store not configured. Cannot ingest records.")
         else:
             self.vecdb.add_documents(records)
+</file>
+
+<file path="langroid/agent/tools/mcp/__init__.py">
+from .decorators import mcp_tool
+from .fastmcp_client import (
+    FastMCPClient,
+    get_tool,
+    get_tool_async,
+    get_tools,
+    get_tools_async,
+    get_mcp_tool_async,
+    get_mcp_tools_async,
+)
+
+
+__all__ = [
+    "mcp_tool",
+    "FastMCPClient",
+    "get_tool",
+    "get_tool_async",
+    "get_tools",
+    "get_tools_async",
+    "get_mcp_tool_async",
+    "get_mcp_tools_async",
+]
+</file>
+
+<file path="langroid/agent/tools/mcp/decorators.py">
+from typing import Callable, Type
+
+from langroid.agent.tool_message import ToolMessage
+from langroid.agent.tools.mcp.fastmcp_client import get_tool
+
+
+def mcp_tool(
+    server: str, tool_name: str
+) -> Callable[[Type[ToolMessage]], Type[ToolMessage]]:
+    """Decorator: declare a ToolMessage class bound to a FastMCP tool.
+
+    Usage:
+        @fastmcp_tool("/path/to/server.py", "get_weather")
+        class WeatherTool:
+            def pretty(self) -> str:
+                return f"Temp is {self.temperature}"
+    """
+
+    def decorator(user_cls: Type[ToolMessage]) -> Type[ToolMessage]:
+        # build the “real” ToolMessage subclass for this server/tool
+        RealTool: Type[ToolMessage] = get_tool(server, tool_name)
+
+        # copy user‐defined methods / attributes onto RealTool
+        for name, attr in user_cls.__dict__.items():
+            if name.startswith("__") and name.endswith("__"):
+                continue
+            setattr(RealTool, name, attr)
+
+        # preserve the user’s original name if you like:
+        RealTool.__name__ = user_cls.__name__
+        return RealTool
+
+    return decorator
 </file>
 
 <file path="langroid/agent/tools/__init__.py">
@@ -25430,6 +25492,125 @@ class NonToolAction(str, Enum):
     DONE = "done"  # task done
 </file>
 
+<file path="release-notes/v0-56-13-done-sequences-parent-chain-fixes.md">
+# v0.56.13: DoneSequences Parent Chain and Agent ID Fixes
+
+## Summary
+
+This release fixes critical issues with the DoneSequence implementation, parent pointer chain preservation in TaskTool, and agent ID initialization. These fixes ensure that task termination sequences work correctly with subtasks and that message lineage is properly maintained across agent boundaries.
+
+## Key Fixes
+
+### 1. Agent ID Initialization Fix
+
+**Problem**: The `Agent.id` field was incorrectly returning a `FieldInfo` object instead of an actual ID string because `Agent` is not a Pydantic model but was using Pydantic's `Field` syntax.
+
+**Solution**: Added proper ID initialization in `Agent.__init__()`:
+```python
+self.id = ObjectRegistry.new_id()  # Initialize agent ID
+```
+
+**Impact**: This ensures that `agent_id` is correctly set in `ChatDocument` metadata, which is crucial for tracking which agent owns which messages.
+
+### 2. DoneSequence Message Chain Fix
+
+**Problem**: The `_get_message_chain` method in `Task` was traversing parent pointers to build the message chain. When subtasks are involved, parent pointers can cross agent boundaries, incorrectly including messages from subtask agents in the parent task's chain.
+
+**Solution**: Replaced parent pointer traversal with agent message history:
+```python
+def _get_message_chain(self, msg: ChatDocument | None, max_depth: Optional[int] = None) -> List[ChatDocument]:
+    """Get the chain of messages using agent's message history."""
+    # Get chat document IDs from message history
+    doc_ids = [m.chat_document_id for m in self.agent.message_history 
+               if m.chat_document_id]
+    
+    # Add current message ID if it exists and is not already the last one
+    if msg:
+        msg_id = msg.id()
+        if not doc_ids or doc_ids[-1] != msg_id:
+            doc_ids.append(msg_id)
+    
+    # Take only the last max_depth elements
+    relevant_ids = doc_ids[-max_depth:]
+    
+    # Convert IDs to ChatDocuments
+    return [doc for doc_id in relevant_ids 
+            if (doc := ChatDocument.from_id(doc_id)) is not None]
+```
+
+**Impact**: DoneSequences now correctly check only messages from the current agent, preventing incorrect task termination when subtasks generate matching sequences.
+
+### 3. Parent Pointer Preservation in Task.init()
+
+**Problem**: When `ChatDocument.deepcopy()` is called during `task.init()`, it resets `parent_id` and `child_id` to empty strings, breaking the parent chain. This particularly affected TaskTool when creating subtasks with parent pointers.
+
+**Solution**: Modified `task.init()` to preserve the original parent_id after deepcopy:
+```python
+if isinstance(msg, ChatDocument):
+    original_parent_id = msg.metadata.parent_id
+    self.pending_message = ChatDocument.deepcopy(msg)
+    # Preserve the parent pointer from the original message
+    self.pending_message.metadata.parent_id = original_parent_id
+```
+
+Additionally, added conditional logic to only override parent_id when necessary:
+```python
+if self.pending_message is not None and self.caller is not None:
+    # Only override parent_id if it wasn't already set in the original message
+    if not msg.metadata.parent_id:
+        self.pending_message.metadata.parent_id = msg.metadata.id
+```
+
+**Impact**: Parent chains are now preserved when TaskTool creates subtasks, maintaining proper message lineage.
+
+### 4. TaskTool Parent-Child Relationship
+
+**Problem**: TaskTool was only setting the parent pointer on the prompt ChatDocument but not the corresponding child pointer on the TaskTool message.
+
+**Solution**: Added bidirectional parent-child relationship in TaskTool handlers:
+```python
+if chat_doc is not None:
+    prompt_doc = ChatDocument(
+        content=self.prompt,
+        metadata=ChatDocMetaData(
+            parent_id=chat_doc.id(),
+            agent_id=agent.id,
+            sender=chat_doc.metadata.sender,
+        )
+    )
+    # Set bidirectional parent-child relationship
+    chat_doc.metadata.child_id = prompt_doc.id()
+```
+
+**Impact**: Complete bidirectional parent-child chains are maintained, improving message traceability.
+
+## Tests Added
+
+Added comprehensive test `test_task_init_preserves_parent_id()` in `test_task.py` that verifies:
+- Parent IDs are preserved during ChatDocument deep copying
+- Conditional parent_id override logic works correctly for subtasks
+- Parent chains are maintained in various scenarios
+
+## Breaking Changes
+
+None. All changes are backward compatible bug fixes.
+
+## Migration Guide
+
+No migration needed. The fixes will automatically apply to existing code.
+
+## Technical Details
+
+The core issue was that DoneSequences were incorrectly checking messages across agent boundaries due to parent pointer traversal. Combined with the agent ID initialization bug and parent chain breaks in deepcopy, this caused incorrect task termination behavior. The fixes ensure:
+
+1. Each agent's messages are properly tagged with the agent's ID
+2. DoneSequence checking is confined to the current agent's message history
+3. Parent chains are preserved through TaskTool subtask creation
+4. Bidirectional parent-child relationships are maintained
+
+These changes work together to ensure proper message lineage and task termination behavior in multi-agent systems.
+</file>
+
 <file path=".blackignore">
 ./examples/urlqa/chat-clear.py
 </file>
@@ -25989,70 +26170,6 @@ mysql_user = root
 exclude = .*,.*/.*,.*/*,.*/*.*
 max-line-length = 88
 ignore = W291, W293, E501, E203, W503
-</file>
-
-<file path="ai-instructions/claude-repomix-instructions.md">
-# AI Instructions for Setting Up Repomix
-
-## Task Overview
-Set up [repomix](https://github.com/yamadashy/repomix) to generate LLM-friendly repository exports. This creates text files that can be uploaded to AI models for code analysis.
-
-## Steps to Complete
-
-### 1. Install Repomix
-```bash
-npm install -g repomix
-```
-
-### 2. Create repomix.config.json
-Create a configuration file in the repository root with:
-- **Include patterns**: Source code files (*.py, *.js, *.md, *.yaml, *.yml, *.toml)
-- **Exclude patterns**: Data directories, logs, node_modules, JSON files, generated files
-- **Security check**: Enable to prevent sensitive data inclusion
-
-### 3. Configure Include/Exclude Patterns
-- Include only source code directories and documentation
-- Exclude data/, logs/, build artifacts, dependencies
-- Add `llms*.txt` to exclusions to prevent recursive inclusion
-
-### 4. Test Configuration (Optional)
-```bash
-# Generate file list only for inspection
-repomix --no-files -o file-list.txt
-```
-This allows you to review which files will be included before generating the full output.
-
-### 5. Generate Output Versions
-
-Use the Makefile targets to generate repomix files:
-
-```bash
-# Generate all variants (recommended)
-make repomix-all
-
-# Or generate specific versions:
-make repomix                      # llms.txt and llms-compressed.txt (includes tests)
-make repomix-no-tests             # llms-no-tests.txt and llms-no-tests-compressed.txt
-make repomix-no-tests-no-examples # llms-no-tests-no-examples.txt and compressed version
-```
-
-All commands use `git ls-files` to ensure only git-tracked files are included.
-
-### 6. Verify Results
-- Check file sizes and token counts in repomix output
-- Ensure no sensitive data is included
-- Confirm only relevant source files are packaged
-
-## Expected Outcome
-Six text files optimized for different LLM contexts:
-- `llms.txt`: Full version with tests and examples (870K tokens)
-- `llms-compressed.txt`: Compressed version with tests and examples (513K tokens)
-- `llms-no-tests.txt`: Full version without tests (677K tokens)
-- `llms-no-tests-compressed.txt`: Compressed version without tests (433K tokens)
-- `llms-no-tests-no-examples.txt`: Core library code only (no tests/examples)
-- `llms-no-tests-no-examples-compressed.txt`: Compressed core library code (285K tokens)
-
-The files contain only git-tracked source code with proper exclusions for clean, focused LLM consumption.
 </file>
 
 <file path="ai-notes/Langroid-repo-docs.md">
@@ -29837,67 +29954,6 @@ class LanceDocChatAgent(DocChatAgent):
         return list(zip(docs, scores))
 </file>
 
-<file path="langroid/agent/tools/mcp/__init__.py">
-from .decorators import mcp_tool
-from .fastmcp_client import (
-    FastMCPClient,
-    get_tool,
-    get_tool_async,
-    get_tools,
-    get_tools_async,
-    get_mcp_tool_async,
-    get_mcp_tools_async,
-)
-
-
-__all__ = [
-    "mcp_tool",
-    "FastMCPClient",
-    "get_tool",
-    "get_tool_async",
-    "get_tools",
-    "get_tools_async",
-    "get_mcp_tool_async",
-    "get_mcp_tools_async",
-]
-</file>
-
-<file path="langroid/agent/tools/mcp/decorators.py">
-from typing import Callable, Type
-
-from langroid.agent.tool_message import ToolMessage
-from langroid.agent.tools.mcp.fastmcp_client import get_tool
-
-
-def mcp_tool(
-    server: str, tool_name: str
-) -> Callable[[Type[ToolMessage]], Type[ToolMessage]]:
-    """Decorator: declare a ToolMessage class bound to a FastMCP tool.
-
-    Usage:
-        @fastmcp_tool("/path/to/server.py", "get_weather")
-        class WeatherTool:
-            def pretty(self) -> str:
-                return f"Temp is {self.temperature}"
-    """
-
-    def decorator(user_cls: Type[ToolMessage]) -> Type[ToolMessage]:
-        # build the “real” ToolMessage subclass for this server/tool
-        RealTool: Type[ToolMessage] = get_tool(server, tool_name)
-
-        # copy user‐defined methods / attributes onto RealTool
-        for name, attr in user_cls.__dict__.items():
-            if name.startswith("__") and name.endswith("__"):
-                continue
-            setattr(RealTool, name, attr)
-
-        # preserve the user’s original name if you like:
-        RealTool.__name__ = user_cls.__name__
-        return RealTool
-
-    return decorator
-</file>
-
 <file path="langroid/agent/batch.py">
 import asyncio
 import copy
@@ -32477,167 +32533,6 @@ replace_and_log() {
 replace_and_log
 </file>
 
-<file path="Makefile">
-.PHONY: setup check lint tests docs nodocs loc
-
-SHELL := /bin/bash
-
-.PHONY: setup update
-
-setup: ## Setup the git pre-commit hooks
-	uv run pre-commit install
-
-update: ## Update the git pre-commit hooks
-	uv run pre-commit autoupdate
-
-.PHONY: type-check
-type-check:
-	@uv run pre-commit install
-	@uv run pre-commit autoupdate
-	@uv run pre-commit run --all-files
-	@echo "Running black..."
-	@uv run black --check .
-	@echo "Running ruff check (without fix)..."
-	@uv run ruff check .
-	@echo "Running mypy...";
-	@uv run mypy -p langroid
-	@echo "All checks passed!"
-
-.PHONY: lint
-lint:
-	uv run black .
-	uv run ruff check . --fix
-	@echo "Auto-fixing issues in examples folder..."
-	@uv run ruff check examples/ --fix-only --no-force-exclude
-
-.PHONY: stubs
-stubs:
-	@echo "Generating Python stubs for the langroid package..."
-	@uv run stubgen -p langroid -o stubs
-	@echo "Stubs generated in the 'stubs' directory"
-
-.PHONY: fix-pydantic
-
-# Entry to replace pydantic imports in specified directories
-fix-pydantic:
-	@echo "Fixing pydantic imports..."
-	@chmod +x scripts/fix-pydantic-imports.sh
-	@./scripts/fix-pydantic-imports.sh
-
-.PHONY: check
-check: fix-pydantic lint type-check
-
-.PHONY: tests
-tests:
-	pytest tests/main --basetemp=/tmp/pytest
-
-
-docs:
-	@# Kill any existing 'mkdocs serve' processes.
-	@pkill -f "mkdocs serve" 2>/dev/null || true
-	@# Build the documentation.
-	mkdocs build
-	@# Serve the documentation in the background.
-	mkdocs serve &
-	@echo "Documentation is being served in the background."
-	@echo "You can access the documentation at http://127.0.0.1:8000/"
-
-nodocs:
-	@# Kill any existing 'mkdocs serve' processes.
-	@pkill -f "mkdocs serve" 2>/dev/null || echo "No 'mkdocs serve' process found."
-	@echo "Stopped serving documentation."
-
-
-loc:
-	@echo "Lines in git-tracked files python files:"
-	@git ls-files | grep '\.py$$' | xargs cat | grep -v '^\s*$$' | wc -l
-
-.PHONY: repomix repomix-no-tests repomix-all
-
-repomix: ## Generate llms.txt and llms-compressed.txt (includes tests)
-	@echo "Generating llms.txt (with tests)..."
-	@git ls-files | repomix --stdin
-	@echo "Generating llms-compressed.txt..."
-	@git ls-files | repomix --stdin --compress -o llms-compressed.txt
-	@echo "Generated llms.txt and llms-compressed.txt"
-
-repomix-no-tests: ## Generate llms-no-tests.txt (excludes tests)
-	@echo "Generating llms-no-tests.txt (without tests)..."
-	@git ls-files | grep -v "^tests/" | repomix --stdin -o llms-no-tests.txt
-	@echo "Generating llms-no-tests-compressed.txt..."
-	@git ls-files | grep -v "^tests/" | repomix --stdin --compress -o llms-no-tests-compressed.txt
-	@echo "Generated llms-no-tests.txt and llms-no-tests-compressed.txt"
-
-repomix-no-tests-no-examples: ## Generate llms-no-tests-no-examples.txt (excludes tests and examples)
-	@echo "Generating llms-no-tests-no-examples.txt (without tests and examples)..."
-	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin -o llms-no-tests-no-examples.txt
-	@echo "Generating llms-no-tests-no-examples-compressed.txt..."
-	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin --compress -o llms-no-tests-no-examples-compressed.txt
-	@echo "Generated llms-no-tests-no-examples.txt and llms-no-tests-no-examples-compressed.txt"
-
-repomix-all: repomix repomix-no-tests repomix-no-tests-no-examples ## Generate all repomix variants
-
-.PHONY: revert-tag
-revert-tag:
-	@LATEST_TAG=$$(git describe --tags --abbrev=0) && \
-	echo "Deleting tag: $$LATEST_TAG" && \
-	git tag -d $$LATEST_TAG
-
-.PHONY: revert-bump
-revert-bump:
-	@if git log -1 --pretty=%B | grep -q "bump"; then \
-		git reset --hard HEAD~1; \
-		echo "Reverted last commit (bump commit)"; \
-	else \
-		echo "Last commit was not a bump commit"; \
-	fi
-
-.PHONY: revert
-revert: revert-bump revert-tag
-	
-.PHONY: bump-patch
-bump-patch:
-	@cz bump --increment PATCH
-
-.PHONY: bump-minor
-bump-minor:
-	@cz bump --increment MINOR 
-
-.PHONY: bump-major
-bump-major:
-	@cz bump --increment MAJOR 
-
-.PHONY: build
-build:
-	@uv build
-
-.PHONY: push
-push:
-	@git push origin main
-	@git push origin --tags
-
-.PHONY: clean
-clean:
-	-rm -rf dist/*
-
-.PHONY: release
-release:
-	@VERSION=$$(cz version -p | cut -d' ' -f2) && gh release create $${VERSION} dist/*
-
-.PHONY: all-patch
-all-patch: bump-patch clean build push release
-
-.PHONY: all-minor
-all-minor: bump-minor clean build push release
-
-.PHONY: all-major
-all-major: bump-major clean build push release
-
-.PHONY: publish
-publish:
-	uv publish
-</file>
-
 <file path="SECURITY.md">
 # Security Policy
 
@@ -32675,6 +32570,70 @@ Once a security vulnerability is reported, we will work to:
 - Investigate and confirm the issue.
 - Develop a patch or mitigation strategy.
 - Publish the fix and disclose the advisory publicly after the resolution.
+</file>
+
+<file path="ai-instructions/claude-repomix-instructions.md">
+# AI Instructions for Setting Up Repomix
+
+## Task Overview
+Set up [repomix](https://github.com/yamadashy/repomix) to generate LLM-friendly repository exports. This creates text files that can be uploaded to AI models for code analysis.
+
+## Steps to Complete
+
+### 1. Install Repomix
+```bash
+npm install -g repomix
+```
+
+### 2. Create repomix.config.json
+Create a configuration file in the repository root with:
+- **Include patterns**: Source code files (*.py, *.js, *.md, *.yaml, *.yml, *.toml)
+- **Exclude patterns**: Data directories, logs, node_modules, JSON files, generated files
+- **Security check**: Enable to prevent sensitive data inclusion
+
+### 3. Configure Include/Exclude Patterns
+- Include only source code directories and documentation
+- Exclude data/, logs/, build artifacts, dependencies
+- Add `llms*.txt` to exclusions to prevent recursive inclusion
+
+### 4. Test Configuration (Optional)
+```bash
+# Generate file list only for inspection
+repomix --no-files -o file-list.txt
+```
+This allows you to review which files will be included before generating the full output.
+
+### 5. Generate Output Versions
+
+Use the Makefile targets to generate repomix files:
+
+```bash
+# Generate all variants (recommended)
+make repomix-all
+
+# Or generate specific versions:
+make repomix                      # llms.txt and llms-compressed.txt (includes tests)
+make repomix-no-tests             # llms-no-tests.txt and llms-no-tests-compressed.txt
+make repomix-no-tests-no-examples # llms-no-tests-no-examples.txt and compressed version
+```
+
+All commands use `git ls-files` to ensure only git-tracked files are included.
+
+### 6. Verify Results
+- Check file sizes and token counts in repomix output
+- Ensure no sensitive data is included
+- Confirm only relevant source files are packaged
+
+## Expected Outcome
+Six text files optimized for different LLM contexts:
+- `llms.txt`: Full version with tests and examples (870K tokens)
+- `llms-compressed.txt`: Compressed version with tests and examples (513K tokens)
+- `llms-no-tests.txt`: Full version without tests (677K tokens)
+- `llms-no-tests-compressed.txt`: Compressed version without tests (433K tokens)
+- `llms-no-tests-no-examples.txt`: Core library code only (no tests/examples)
+- `llms-no-tests-no-examples-compressed.txt`: Compressed core library code (285K tokens)
+
+The files contain only git-tracked source code with proper exclusions for clean, focused LLM consumption.
 </file>
 
 <file path="ai-notes/handler-parameter-analysis-notes.md">
@@ -38209,6 +38168,366 @@ commands/
 .claude/
 </file>
 
+<file path="docs/notes/mcp-tools.md">
+# Langroid MCP Integration
+
+Langroid provides seamless integration with Model Context Protocol (MCP) servers via 
+two methods, both of which involve creating Langroid `ToolMessage` subclasses
+corresponding to the MCP tools: 
+
+1. Programmatic creation of Langroid tools using `get_tool_async`, 
+   `get_tools_async` from the tool definitions defined on an MCP server.
+2. Declarative creation of Langroid tools using the **`@mcp_tool` decorator**, which allows
+   customizing the tool-handling behavior beyond what is provided by the MCP server.
+
+This integration allows _any_ LLM (that is good enough to do function-calling via prompts) to use any MCP server.
+See the following to understand the integration better:
+
+- example python scripts under [`examples/mcp`](https://github.com/langroid/langroid/tree/main/examples/mcp)
+- [`tests/main/test_mcp_tools.py`](https://github.com/langroid/langroid/blob/main/tests/main/test_mcp_tools.py)
+
+---
+
+## 1. Connecting to an MCP server via transport specification
+
+Before creating Langroid tools, we first need to define and connect to an MCP server
+via a [FastMCP](https://gofastmcp.com/getting-started/welcome) client. 
+There are several ways to connect to a server, depending on how it is defined. 
+Each of these uses a different type of [transport](https://gofastmcp.com/clients/transports).
+
+The typical pattern to use with Langroid is as follows:
+
+- define an MCP server transport
+- create a `ToolMessage` subclass using the `@mcp_tool` decorator or 
+  `get_tool_async()` function, with the transport as the first argument
+
+
+Langroid's MCP integration will work with any of [transports](https://gofastmcp.com/clients/transportsl) 
+supported by FastMCP.
+Below we go over some common ways to define transports and extract tools from the servers.
+
+1. **Local Python script**
+2. **In-memory FastMCP server** - useful for testing and for simple in-memory servers
+   that don't need to be run as a separate process.
+3. **NPX stdio transport**
+4. **UVX stdio transport**
+5. **Generic stdio transport** – launch any CLI‐based MCP server via stdin/stdout
+6. **Network SSE transport** – connect to HTTP/S MCP servers via `SSETransport`
+
+
+All examples below use the async helpers to create Langroid tools (`ToolMessage` subclasses):
+
+```python
+from langroid.agent.tools.mcp import (
+    get_tools_async,
+    get_tool_async,
+)
+```
+
+---
+
+#### Path to a Python Script
+
+Point at your MCP‐server entrypoint, e.g., to the `weather.py` script in the 
+langroid repo (based on the [Anthropic quick-start guide](https://modelcontextprotocol.io/quickstart/server)):
+
+```python
+async def example_script_path() -> None:
+    server = "tests/main/mcp/weather-server-python/weather.py"
+    tools = await get_tools_async(server) # all tools available
+    AlertTool = await get_tool_async(server, "get_alerts") # specific tool
+
+    # instantiate the tool with a specific input
+    msg = AlertTool(state="CA")
+    
+    # Call the tool via handle_async()
+    alerts = await msg.handle_async()
+    print(alerts)
+```
+
+---
+
+#### In-Memory FastMCP Server
+
+Define your server with `FastMCP(...)` and pass the instance:
+
+```python
+from fastmcp.server import FastMCP
+from pydantic import BaseModel, Field
+
+class CounterInput(BaseModel):
+    start: int = Field(...)
+
+def make_server() -> FastMCP:
+    server = FastMCP("CounterServer")
+
+    @server.tool()
+    def increment(data: CounterInput) -> int:
+        """Increment start by 1."""
+        return data.start + 1
+
+    return server
+
+async def example_in_memory() -> None:
+    server = make_server()
+    tools = await get_tools_async(server)
+    IncTool = await get_tool_async(server, "increment")
+
+    result = await IncTool(start=41).handle_async()
+    print(result)  # 42
+```
+
+See the [`mcp-file-system.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/mcp-file-system.py)
+script for a working example of this.
+
+---
+
+#### NPX stdio Transport
+
+Use any npm-installed MCP server via `npx`, e.g., the 
+[Exa web-search MCP server](https://docs.exa.ai/examples/exa-mcp):
+
+```python
+from fastmcp.client.transports import NpxStdioTransport
+
+transport = NpxStdioTransport(
+    package="exa-mcp-server",
+    env_vars={"EXA_API_KEY": "…"},
+)
+
+async def example_npx() -> None:
+    tools = await get_tools_async(transport)
+    SearchTool = await get_tool_async(transport, "web_search_exa")
+
+    results = await SearchTool(
+        query="How does Langroid integrate with MCP?"
+    ).handle_async()
+    print(results)
+```
+
+For a fully working example, see the script [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py).
+
+---
+
+#### UVX stdio Transport
+
+Connect to a UVX-based MCP server, e.g., the [Git MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
+
+```python
+from fastmcp.client.transports import UvxStdioTransport
+
+transport = UvxStdioTransport(tool_name="mcp-server-git")
+
+async def example_uvx() -> None:
+    tools = await get_tools_async(transport)
+    GitStatus = await get_tool_async(transport, "git_status")
+
+    status = await GitStatus(path=".").handle_async()
+    print(status)
+```
+
+--- 
+
+#### Generic stdio Transport
+
+Use `StdioTransport` to run any MCP server as a subprocess over stdio:
+
+```python
+from fastmcp.client.transports import StdioTransport
+from langroid.agent.tools.mcp import get_tools_async, get_tool_async
+
+
+async def example_stdio() -> None:
+    """Example: any CLI‐based MCP server via StdioTransport."""
+    transport: StdioTransport = StdioTransport(
+        command="uv",
+        args=["run", "--with", "biomcp-python", "biomcp", "run"],
+    )
+    tools: list[type] = await get_tools_async(transport)
+    BioTool = await get_tool_async(transport, "tool_name")
+    result: str = await BioTool(param="value").handle_async()
+    print(result)
+```
+
+See the full example in [`examples/mcp/biomcp.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/biomcp.py).
+
+---
+
+#### Network SSE Transport
+
+Use `SSETransport` to connect to a FastMCP server over HTTP/S:
+
+```python
+from fastmcp.client.transports import SSETransport
+from langroid.agent.tools.mcp import (
+    get_tools_async,
+    get_tool_async,
+)
+
+
+async def example_sse() -> None:
+    """Example: connect to an HTTP/S MCP server via SSETransport."""
+    url: str = "https://localhost:8000/sse"
+    transport: SSETransport = SSETransport(
+        url=url, headers={"Authorization": "Bearer TOKEN"}
+    )
+    tools: list[type] = await get_tools_async(transport)
+    ExampleTool = await get_tool_async(transport, "tool_name")
+    result: str = await ExampleTool(param="value").handle_async()
+    print(result)
+```    
+
+---
+
+With these patterns you can list tools, generate Pydantic-backed `ToolMessage` classes,
+and invoke them via `.handle_async()`, all with zero boilerplate client setup. 
+As the `FastMCP` library adds other types of transport (e.g., `StreamableHTTPTransport`),
+the pattern of usage with Langroid will remain the same.
+
+
+---
+
+## 2. Create Langroid Tools declaratively using the `@mcp_tool` decorator
+
+The above examples showed how you can create Langroid tools programmatically using
+the helper functions `get_tool_async()` and `get_tools_async()`,
+with the first argument being the transport to the MCP server. The `@mcp_tool` decorator
+works in the same way: 
+
+- **Arguments to the decorator**
+    1. `server_spec`: path/URL/`FastMCP`/`ClientTransport`, as mentioned above.
+    2. `tool_name`: name of a specific MCP tool
+
+- **Behavior**
+    - Generates a `ToolMessage` subclass with all input fields typed.
+    - Provides a `call_tool_async()` under the hood -- this is the "raw" MCP tool call,
+      returning a string.
+    - If you define your own `handle_async()`, it overrides the default. Typically,
+you would override it to customize either the input or the output of the tool call, or both.
+    - If you don't define your own `handle_async()`, it defaults to just returning the
+      value of the `call_tool_async()` method.
+
+Here is a simple example of using the `@mcp_tool` decorator to create a Langroid tool:
+
+```python
+from fastmcp.server import FastMCP
+from langroid.agent.tools.mcp import mcp_tool
+import langroid as lr
+
+# Define your MCP server (pydantic v2 for schema)
+server = FastMCP("MyServer")
+
+@mcp_tool(server, "greet")
+class GreetTool(lr.ToolMessage):
+    """Say hello to someone."""
+
+    async def handle_async(self) -> str:
+        # Customize post-processing
+        raw = await self.call_tool_async()
+        return f"💬 {raw}"
+```
+
+Using the decorator method allows you to customize the `handle_async` method of the
+tool, or add additional fields to the `ToolMessage`. 
+You may want to customize the input to the tool, or the tool result before it is sent back to 
+the LLM. If you don't override it, the default behavior is to simply return the value of 
+the "raw" MCP tool call `await self.call_tool_async()`. 
+
+```python
+@mcp_tool(server, "calculate")
+class CalcTool(ToolMessage):
+    """Perform complex calculation."""
+
+    async def handle_async(self) -> str:
+        result = await self.call_tool_async()
+        # Add context or emojis, etc.
+        return f"🧮 Result is *{result}*"
+```
+
+---
+
+## 3. Enabling Tools in Your Agent
+
+Once you’ve created a Langroid `ToolMessage` subclass from an MCP server, 
+you can enable it on a `ChatAgent`, just like you normally would. Below is an example of using 
+the [Exa MCP server](https://docs.exa.ai/examples/exa-mcp) to create a 
+Langroid web search tool, enable a `ChatAgent` to use it, and then set up a `Task` to 
+run the agent loop.
+
+First we must define the appropriate `ClientTransport` for the MCP server:
+```python
+# define the transport
+transport = NpxStdioTransport(
+    package="exa-mcp-server",
+    env_vars=dict(EXA_API_KEY=os.getenv("EXA_API_KEY")),
+)
+```
+
+Then we use the `@mcp_tool` decorator to create a `ToolMessage` 
+subclass representing the web search tool. Note that one reason to use the decorator
+to define our tool is so we can specify a custom `handle_async` method that
+controls what is sent to the LLM after the actual raw MCP tool-call
+(the `call_tool_async` method) is made.
+
+```python
+# the second arg specifically refers to the `web_search_exa` tool available
+# on the server defined by the `transport` variable.
+@mcp_tool(transport, "web_search_exa")
+class ExaSearchTool(lr.ToolMessage):
+    async def handle_async(self):
+        result: str = await self.call_tool_async()
+        return f"""
+        Below are the results of the web search:
+        
+        <WebSearchResult>
+        {result}
+        </WebSearchResult>
+        
+        Use these results to answer the user's original question.
+        """
+
+```
+
+If we did not want to override the `handle_async` method, we could simply have
+created the `ExaSearchTool` class programmatically via the `get_tool_async` 
+function as shown above, i.e.:
+
+```python
+from langroid.agent.tools.mcp import get_tool_async
+
+ExaSearchTool = awwait
+get_tool_async(transport, "web_search_exa")
+```
+
+We can now define our main function where we create our `ChatAgent`,
+attach the `ExaSearchTool` to it, define the `Task`, and run the task loop.
+
+```python
+async def main():
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            # forward to user when LLM doesn't use a tool
+            handle_llm_no_tool=NonToolAction.FORWARD_USER,
+            llm=lm.OpenAIGPTConfig(
+                max_output_tokens=1000,
+                # this defaults to True, but we set it to False so we can see output
+                async_stream_quiet=False,
+            ),
+        )
+    )
+
+    # enable the agent to use the web-search tool
+    agent.enable_message(ExaSearchTool)
+    # make task with interactive=False =>
+    # waits for user only when LLM doesn't use a tool
+    task = lr.Task(agent, interactive=False)
+    await task.run_async()
+```
+
+See [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py) for a full 
+working example of this.
+</file>
+
 <file path="langroid/language_models/base.py">
 import json
 import logging
@@ -41539,364 +41858,166 @@ agent.enable_message([Tool1, Tool2, Tool3])  # Pass list of tool classes
 - Tokens are not needed for public repositories and can cause GitHub rendering issues
 </file>
 
-<file path="docs/notes/mcp-tools.md">
-# Langroid MCP Integration
-
-Langroid provides seamless integration with Model Context Protocol (MCP) servers via 
-two methods, both of which involve creating Langroid `ToolMessage` subclasses
-corresponding to the MCP tools: 
-
-1. Programmatic creation of Langroid tools using `get_tool_async`, 
-   `get_tools_async` from the tool definitions defined on an MCP server.
-2. Declarative creation of Langroid tools using the **`@mcp_tool` decorator**, which allows
-   customizing the tool-handling behavior beyond what is provided by the MCP server.
-
-This integration allows _any_ LLM (that is good enough to do function-calling via prompts) to use any MCP server.
-See the following to understand the integration better:
-
-- example python scripts under [`examples/mcp`](https://github.com/langroid/langroid/tree/main/examples/mcp)
-- [`tests/main/test_mcp_tools.py`](https://github.com/langroid/langroid/blob/main/tests/main/test_mcp_tools.py)
-
----
-
-## 1. Connecting to an MCP server via transport specification
-
-Before creating Langroid tools, we first need to define and connect to an MCP server
-via a [FastMCP](https://gofastmcp.com/getting-started/welcome) client. 
-There are several ways to connect to a server, depending on how it is defined. 
-Each of these uses a different type of [transport](https://gofastmcp.com/clients/transports).
-
-The typical pattern to use with Langroid is as follows:
-
-- define an MCP server transport
-- create a `ToolMessage` subclass using the `@mcp_tool` decorator or 
-  `get_tool_async()` function, with the transport as the first argument
-
-
-Langroid's MCP integration will work with any of [transports](https://gofastmcp.com/clients/transportsl) 
-supported by FastMCP.
-Below we go over some common ways to define transports and extract tools from the servers.
-
-1. **Local Python script**
-2. **In-memory FastMCP server** - useful for testing and for simple in-memory servers
-   that don't need to be run as a separate process.
-3. **NPX stdio transport**
-4. **UVX stdio transport**
-5. **Generic stdio transport** – launch any CLI‐based MCP server via stdin/stdout
-6. **Network SSE transport** – connect to HTTP/S MCP servers via `SSETransport`
-
-
-All examples below use the async helpers to create Langroid tools (`ToolMessage` subclasses):
-
-```python
-from langroid.agent.tools.mcp import (
-    get_tools_async,
-    get_tool_async,
-)
-```
-
----
-
-#### Path to a Python Script
-
-Point at your MCP‐server entrypoint, e.g., to the `weather.py` script in the 
-langroid repo (based on the [Anthropic quick-start guide](https://modelcontextprotocol.io/quickstart/server)):
-
-```python
-async def example_script_path() -> None:
-    server = "tests/main/mcp/weather-server-python/weather.py"
-    tools = await get_tools_async(server) # all tools available
-    AlertTool = await get_tool_async(server, "get_alerts") # specific tool
-
-    # instantiate the tool with a specific input
-    msg = AlertTool(state="CA")
-    
-    # Call the tool via handle_async()
-    alerts = await msg.handle_async()
-    print(alerts)
-```
-
----
-
-#### In-Memory FastMCP Server
-
-Define your server with `FastMCP(...)` and pass the instance:
-
-```python
-from fastmcp.server import FastMCP
-from pydantic import BaseModel, Field
-
-class CounterInput(BaseModel):
-    start: int = Field(...)
-
-def make_server() -> FastMCP:
-    server = FastMCP("CounterServer")
-
-    @server.tool()
-    def increment(data: CounterInput) -> int:
-        """Increment start by 1."""
-        return data.start + 1
-
-    return server
-
-async def example_in_memory() -> None:
-    server = make_server()
-    tools = await get_tools_async(server)
-    IncTool = await get_tool_async(server, "increment")
-
-    result = await IncTool(start=41).handle_async()
-    print(result)  # 42
-```
-
-See the [`mcp-file-system.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/mcp-file-system.py)
-script for a working example of this.
-
----
-
-#### NPX stdio Transport
-
-Use any npm-installed MCP server via `npx`, e.g., the 
-[Exa web-search MCP server](https://docs.exa.ai/examples/exa-mcp):
-
-```python
-from fastmcp.client.transports import NpxStdioTransport
-
-transport = NpxStdioTransport(
-    package="exa-mcp-server",
-    env_vars={"EXA_API_KEY": "…"},
-)
-
-async def example_npx() -> None:
-    tools = await get_tools_async(transport)
-    SearchTool = await get_tool_async(transport, "web_search_exa")
-
-    results = await SearchTool(
-        query="How does Langroid integrate with MCP?"
-    ).handle_async()
-    print(results)
-```
-
-For a fully working example, see the script [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py).
-
----
-
-#### UVX stdio Transport
-
-Connect to a UVX-based MCP server, e.g., the [Git MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
-
-```python
-from fastmcp.client.transports import UvxStdioTransport
-
-transport = UvxStdioTransport(tool_name="mcp-server-git")
-
-async def example_uvx() -> None:
-    tools = await get_tools_async(transport)
-    GitStatus = await get_tool_async(transport, "git_status")
-
-    status = await GitStatus(path=".").handle_async()
-    print(status)
-```
-
---- 
-
-#### Generic stdio Transport
-
-Use `StdioTransport` to run any MCP server as a subprocess over stdio:
-
-```python
-from fastmcp.client.transports import StdioTransport
-from langroid.agent.tools.mcp import get_tools_async, get_tool_async
-
-
-async def example_stdio() -> None:
-    """Example: any CLI‐based MCP server via StdioTransport."""
-    transport: StdioTransport = StdioTransport(
-        command="uv",
-        args=["run", "--with", "biomcp-python", "biomcp", "run"],
-    )
-    tools: list[type] = await get_tools_async(transport)
-    BioTool = await get_tool_async(transport, "tool_name")
-    result: str = await BioTool(param="value").handle_async()
-    print(result)
-```
-
-See the full example in [`examples/mcp/biomcp.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/biomcp.py).
-
----
-
-#### Network SSE Transport
-
-Use `SSETransport` to connect to a FastMCP server over HTTP/S:
-
-```python
-from fastmcp.client.transports import SSETransport
-from langroid.agent.tools.mcp import (
-    get_tools_async,
-    get_tool_async,
-)
-
-
-async def example_sse() -> None:
-    """Example: connect to an HTTP/S MCP server via SSETransport."""
-    url: str = "https://localhost:8000/sse"
-    transport: SSETransport = SSETransport(
-        url=url, headers={"Authorization": "Bearer TOKEN"}
-    )
-    tools: list[type] = await get_tools_async(transport)
-    ExampleTool = await get_tool_async(transport, "tool_name")
-    result: str = await ExampleTool(param="value").handle_async()
-    print(result)
-```    
-
----
-
-With these patterns you can list tools, generate Pydantic-backed `ToolMessage` classes,
-and invoke them via `.handle_async()`, all with zero boilerplate client setup. 
-As the `FastMCP` library adds other types of transport (e.g., `StreamableHTTPTransport`),
-the pattern of usage with Langroid will remain the same.
-
-
----
-
-## 2. Create Langroid Tools declaratively using the `@mcp_tool` decorator
-
-The above examples showed how you can create Langroid tools programmatically using
-the helper functions `get_tool_async()` and `get_tools_async()`,
-with the first argument being the transport to the MCP server. The `@mcp_tool` decorator
-works in the same way: 
-
-- **Arguments to the decorator**
-    1. `server_spec`: path/URL/`FastMCP`/`ClientTransport`, as mentioned above.
-    2. `tool_name`: name of a specific MCP tool
-
-- **Behavior**
-    - Generates a `ToolMessage` subclass with all input fields typed.
-    - Provides a `call_tool_async()` under the hood -- this is the "raw" MCP tool call,
-      returning a string.
-    - If you define your own `handle_async()`, it overrides the default. Typically,
-you would override it to customize either the input or the output of the tool call, or both.
-    - If you don't define your own `handle_async()`, it defaults to just returning the
-      value of the `call_tool_async()` method.
-
-Here is a simple example of using the `@mcp_tool` decorator to create a Langroid tool:
-
-```python
-from fastmcp.server import FastMCP
-from langroid.agent.tools.mcp import mcp_tool
-import langroid as lr
-
-# Define your MCP server (pydantic v2 for schema)
-server = FastMCP("MyServer")
-
-@mcp_tool(server, "greet")
-class GreetTool(lr.ToolMessage):
-    """Say hello to someone."""
-
-    async def handle_async(self) -> str:
-        # Customize post-processing
-        raw = await self.call_tool_async()
-        return f"💬 {raw}"
-```
-
-Using the decorator method allows you to customize the `handle_async` method of the
-tool, or add additional fields to the `ToolMessage`. 
-You may want to customize the input to the tool, or the tool result before it is sent back to 
-the LLM. If you don't override it, the default behavior is to simply return the value of 
-the "raw" MCP tool call `await self.call_tool_async()`. 
-
-```python
-@mcp_tool(server, "calculate")
-class CalcTool(ToolMessage):
-    """Perform complex calculation."""
-
-    async def handle_async(self) -> str:
-        result = await self.call_tool_async()
-        # Add context or emojis, etc.
-        return f"🧮 Result is *{result}*"
-```
-
----
-
-## 3. Enabling Tools in Your Agent
-
-Once you’ve created a Langroid `ToolMessage` subclass from an MCP server, 
-you can enable it on a `ChatAgent`, just like you normally would. Below is an example of using 
-the [Exa MCP server](https://docs.exa.ai/examples/exa-mcp) to create a 
-Langroid web search tool, enable a `ChatAgent` to use it, and then set up a `Task` to 
-run the agent loop.
-
-First we must define the appropriate `ClientTransport` for the MCP server:
-```python
-# define the transport
-transport = NpxStdioTransport(
-    package="exa-mcp-server",
-    env_vars=dict(EXA_API_KEY=os.getenv("EXA_API_KEY")),
-)
-```
-
-Then we use the `@mcp_tool` decorator to create a `ToolMessage` 
-subclass representing the web search tool. Note that one reason to use the decorator
-to define our tool is so we can specify a custom `handle_async` method that
-controls what is sent to the LLM after the actual raw MCP tool-call
-(the `call_tool_async` method) is made.
-
-```python
-# the second arg specifically refers to the `web_search_exa` tool available
-# on the server defined by the `transport` variable.
-@mcp_tool(transport, "web_search_exa")
-class ExaSearchTool(lr.ToolMessage):
-    async def handle_async(self):
-        result: str = await self.call_tool_async()
-        return f"""
-        Below are the results of the web search:
-        
-        <WebSearchResult>
-        {result}
-        </WebSearchResult>
-        
-        Use these results to answer the user's original question.
-        """
-
-```
-
-If we did not want to override the `handle_async` method, we could simply have
-created the `ExaSearchTool` class programmatically via the `get_tool_async` 
-function as shown above, i.e.:
-
-```python
-from langroid.agent.tools.mcp import get_tool_async
-
-ExaSearchTool = awwait
-get_tool_async(transport, "web_search_exa")
-```
-
-We can now define our main function where we create our `ChatAgent`,
-attach the `ExaSearchTool` to it, define the `Task`, and run the task loop.
-
-```python
-async def main():
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            # forward to user when LLM doesn't use a tool
-            handle_llm_no_tool=NonToolAction.FORWARD_USER,
-            llm=lm.OpenAIGPTConfig(
-                max_output_tokens=1000,
-                # this defaults to True, but we set it to False so we can see output
-                async_stream_quiet=False,
-            ),
-        )
-    )
-
-    # enable the agent to use the web-search tool
-    agent.enable_message(ExaSearchTool)
-    # make task with interactive=False =>
-    # waits for user only when LLM doesn't use a tool
-    task = lr.Task(agent, interactive=False)
-    await task.run_async()
-```
-
-See [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py) for a full 
-working example of this.
+<file path="Makefile">
+.PHONY: setup check lint tests docs nodocs loc
+
+SHELL := /bin/bash
+
+.PHONY: setup update
+
+setup: ## Setup the git pre-commit hooks
+	uv run pre-commit install
+
+update: ## Update the git pre-commit hooks
+	uv run pre-commit autoupdate
+
+.PHONY: type-check
+type-check:
+	@uv run pre-commit install
+	@uv run pre-commit autoupdate
+	@uv run pre-commit run --all-files
+	@echo "Running black..."
+	@uv run black --check .
+	@echo "Running ruff check (without fix)..."
+	@uv run ruff check .
+	@echo "Running mypy...";
+	@uv run mypy -p langroid
+	@echo "All checks passed!"
+
+.PHONY: lint
+lint:
+	uv run black .
+	uv run ruff check . --fix
+	@echo "Auto-fixing issues in examples folder..."
+	@uv run ruff check examples/ --fix-only --no-force-exclude
+
+.PHONY: stubs
+stubs:
+	@echo "Generating Python stubs for the langroid package..."
+	@uv run stubgen -p langroid -o stubs
+	@echo "Stubs generated in the 'stubs' directory"
+
+.PHONY: fix-pydantic
+
+# Entry to replace pydantic imports in specified directories
+fix-pydantic:
+	@echo "Fixing pydantic imports..."
+	@chmod +x scripts/fix-pydantic-imports.sh
+	@./scripts/fix-pydantic-imports.sh
+
+
+.PHONY: tests
+tests:
+	pytest tests/main --basetemp=/tmp/pytest
+
+
+docs:
+	@# Kill any existing 'mkdocs serve' processes.
+	@pkill -f "mkdocs serve" 2>/dev/null || true
+	@# Build the documentation.
+	mkdocs build
+	@# Serve the documentation in the background.
+	mkdocs serve &
+	@echo "Documentation is being served in the background."
+	@echo "You can access the documentation at http://127.0.0.1:8000/"
+
+nodocs:
+	@# Kill any existing 'mkdocs serve' processes.
+	@pkill -f "mkdocs serve" 2>/dev/null || echo "No 'mkdocs serve' process found."
+	@echo "Stopped serving documentation."
+
+
+loc:
+	@echo "Lines in git-tracked files python files:"
+	@git ls-files | grep '\.py$$' | xargs cat | grep -v '^\s*$$' | wc -l
+
+.PHONY: repomix repomix-no-tests repomix-all
+
+repomix: ## Generate llms.txt and llms-compressed.txt (includes tests)
+	@echo "Generating llms.txt (with tests)..."
+	@git ls-files | repomix --stdin
+	@echo "Generating llms-compressed.txt..."
+	@git ls-files | repomix --stdin --compress -o llms-compressed.txt
+	@echo "Generated llms.txt and llms-compressed.txt"
+
+repomix-no-tests: ## Generate llms-no-tests.txt (excludes tests)
+	@echo "Generating llms-no-tests.txt (without tests)..."
+	@git ls-files | grep -v "^tests/" | repomix --stdin -o llms-no-tests.txt
+	@echo "Generating llms-no-tests-compressed.txt..."
+	@git ls-files | grep -v "^tests/" | repomix --stdin --compress -o llms-no-tests-compressed.txt
+	@echo "Generated llms-no-tests.txt and llms-no-tests-compressed.txt"
+
+repomix-no-tests-no-examples: ## Generate llms-no-tests-no-examples.txt (excludes tests and examples)
+	@echo "Generating llms-no-tests-no-examples.txt (without tests and examples)..."
+	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin -o llms-no-tests-no-examples.txt
+	@echo "Generating llms-no-tests-no-examples-compressed.txt..."
+	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin --compress -o llms-no-tests-no-examples-compressed.txt
+	@echo "Generated llms-no-tests-no-examples.txt and llms-no-tests-no-examples-compressed.txt"
+
+repomix-all: repomix repomix-no-tests repomix-no-tests-no-examples ## Generate all repomix variants
+
+.PHONY: check
+check: fix-pydantic lint type-check repomix-all
+
+.PHONY: revert-tag
+revert-tag:
+	@LATEST_TAG=$$(git describe --tags --abbrev=0) && \
+	echo "Deleting tag: $$LATEST_TAG" && \
+	git tag -d $$LATEST_TAG
+
+.PHONY: revert-bump
+revert-bump:
+	@if git log -1 --pretty=%B | grep -q "bump"; then \
+		git reset --hard HEAD~1; \
+		echo "Reverted last commit (bump commit)"; \
+	else \
+		echo "Last commit was not a bump commit"; \
+	fi
+
+.PHONY: revert
+revert: revert-bump revert-tag
+	
+.PHONY: bump-patch
+bump-patch:
+	@cz bump --increment PATCH
+
+.PHONY: bump-minor
+bump-minor:
+	@cz bump --increment MINOR 
+
+.PHONY: bump-major
+bump-major:
+	@cz bump --increment MAJOR 
+
+.PHONY: build
+build:
+	@uv build
+
+.PHONY: push
+push:
+	@git push origin main
+	@git push origin --tags
+
+.PHONY: clean
+clean:
+	-rm -rf dist/*
+
+.PHONY: release
+release:
+	@VERSION=$$(cz version -p | cut -d' ' -f2) && gh release create $${VERSION} dist/*
+
+.PHONY: all-patch
+all-patch: bump-patch clean build push release
+
+.PHONY: all-minor
+all-minor: bump-minor clean build push release
+
+.PHONY: all-major
+all-major: bump-major clean build push release
+
+.PHONY: publish
+publish:
+	uv publish
 </file>
 
 <file path="langroid/agent/special/doc_chat_agent.py">
@@ -43577,6 +43698,593 @@ class DocChatAgent(ChatAgent):
         return None
 </file>
 
+<file path="langroid/agent/tools/mcp/fastmcp_client.py">
+import asyncio
+import datetime
+import logging
+from base64 import b64decode
+from io import BytesIO
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeAlias, cast
+
+from dotenv import load_dotenv
+from fastmcp.client import Client
+from fastmcp.client.roots import (
+    RootsHandler,
+    RootsList,
+)
+from fastmcp.client.sampling import SamplingHandler
+from fastmcp.client.transports import ClientTransport
+from fastmcp.server import FastMCP
+from mcp.client.session import (
+    LoggingFnT,
+    MessageHandlerFnT,
+)
+from mcp.types import (
+    BlobResourceContents,
+    CallToolResult,
+    EmbeddedResource,
+    ImageContent,
+    TextContent,
+    TextResourceContents,
+    Tool,
+)
+
+from langroid.agent.base import Agent
+from langroid.agent.chat_document import ChatDocument
+from langroid.agent.tool_message import ToolMessage
+from langroid.parsing.file_attachment import FileAttachment
+from langroid.pydantic_v1 import AnyUrl, BaseModel, Field, create_model
+
+load_dotenv()  # load environment variables from .env
+
+FastMCPServerSpec: TypeAlias = str | FastMCP[Any] | ClientTransport | AnyUrl
+
+
+class FastMCPClient:
+    """A client for interacting with a FastMCP server.
+
+    Provides async context manager functionality to safely manage resources.
+    """
+
+    logger = logging.getLogger(__name__)
+    _cm: Optional[Client] = None
+    client: Optional[Client] = None
+
+    def __init__(
+        self,
+        server: FastMCPServerSpec,
+        persist_connection: bool = False,
+        forward_images: bool = True,
+        forward_text_resources: bool = False,
+        forward_blob_resources: bool = False,
+        sampling_handler: SamplingHandler | None = None,  # type: ignore
+        roots: RootsList | RootsHandler | None = None,  # type: ignore
+        log_handler: LoggingFnT | None = None,
+        message_handler: MessageHandlerFnT | None = None,
+        read_timeout_seconds: datetime.timedelta | None = None,
+    ) -> None:
+        """Initialize the FastMCPClient.
+
+        Args:
+            server: FastMCP server or path to such a server
+        """
+        self.server = server
+        self.client = None
+        self._cm = None
+        self.sampling_handler = sampling_handler
+        self.roots = roots
+        self.log_handler = log_handler
+        self.message_handler = message_handler
+        self.read_timeout_seconds = read_timeout_seconds
+        self.persist_connection = persist_connection
+        self.forward_text_resources = forward_text_resources
+        self.forward_blob_resources = forward_blob_resources
+        self.forward_images = forward_images
+
+    async def __aenter__(self) -> "FastMCPClient":
+        """Enter the async context manager and connect inner client."""
+        # create inner client context manager
+        self._cm = Client(
+            self.server,
+            sampling_handler=self.sampling_handler,
+            roots=self.roots,
+            log_handler=self.log_handler,
+            message_handler=self.message_handler,
+            timeout=self.read_timeout_seconds,
+        )
+        # actually enter it (opens the session)
+        self.client = await self._cm.__aenter__()  # type: ignore
+        return self
+
+    async def connect(self) -> None:
+        """Open the underlying session."""
+        await self.__aenter__()
+
+    async def close(self) -> None:
+        """Close the underlying session."""
+        await self.__aexit__(None, None, None)
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[Exception]],
+        exc_val: Optional[Exception],
+        exc_tb: Optional[Any],
+    ) -> None:
+        """Exit the async context manager and close inner client."""
+        # exit and close the inner fastmcp.Client
+        if hasattr(self, "_cm"):
+            if self._cm is not None:
+                await self._cm.__aexit__(exc_type, exc_val, exc_tb)  # type: ignore
+        self.client = None
+        self._cm = None
+
+    def __del__(self) -> None:
+        """Warn about unclosed persistent connections."""
+        if self.client is not None and self.persist_connection:
+            import warnings
+
+            warnings.warn(
+                f"FastMCPClient with persist_connection=True was not properly closed. "
+                f"Connection to {self.server} may leak resources. "
+                f"Use 'async with' or call await client.close()",
+                ResourceWarning,
+                stacklevel=2,
+            )
+
+    def _schema_to_field(
+        self, name: str, schema: Dict[str, Any], prefix: str
+    ) -> Tuple[Any, Any]:
+        """Convert a JSON Schema snippet into a (type, Field) tuple.
+
+        Args:
+            name: Name of the field.
+            schema: JSON Schema for this field.
+            prefix: Prefix to use for nested model names.
+
+        Returns:
+            A tuple of (python_type, Field(...)) for create_model.
+        """
+        t = schema.get("type")
+        default = schema.get("default", ...)
+        desc = schema.get("description")
+        # Object → nested BaseModel
+        if t == "object" and "properties" in schema:
+            sub_name = f"{prefix}_{name.capitalize()}"
+            sub_fields: Dict[str, Tuple[type, Any]] = {}
+            for k, sub_s in schema["properties"].items():
+                ftype, fld = self._schema_to_field(sub_name + k, sub_s, sub_name)
+                sub_fields[k] = (ftype, fld)
+            submodel = create_model(  # type: ignore
+                sub_name,
+                __base__=BaseModel,
+                **sub_fields,
+            )
+            return submodel, Field(default=default, description=desc)  # type: ignore
+        # Array → List of items
+        if t == "array" and "items" in schema:
+            item_type, _ = self._schema_to_field(name, schema["items"], prefix)
+            return List[item_type], Field(default=default, description=desc)  # type: ignore
+        # Primitive types
+        if t == "string":
+            return str, Field(default=default, description=desc)
+        if t == "integer":
+            return int, Field(default=default, description=desc)
+        if t == "number":
+            return float, Field(default=default, description=desc)
+        if t == "boolean":
+            return bool, Field(default=default, description=desc)
+        # Fallback or unions
+        if any(key in schema for key in ("oneOf", "anyOf", "allOf")):
+            self.logger.warning("Unsupported union schema in field %s; using Any", name)
+            return Any, Field(default=default, description=desc)
+        # Default fallback
+        return Any, Field(default=default, description=desc)
+
+    async def get_tool_async(self, tool_name: str) -> Type[ToolMessage]:
+        """
+        Create a Langroid ToolMessage subclass from the MCP Tool
+        with the given `tool_name`.
+        """
+        if not self.client:
+            if self.persist_connection:
+                await self.connect()
+                assert self.client
+            else:
+                raise RuntimeError(
+                    "Client not initialized. Use async with FastMCPClient."
+                )
+        target = await self.get_mcp_tool_async(tool_name)
+        if target is None:
+            raise ValueError(f"No tool named {tool_name}")
+        props = target.inputSchema.get("properties", {})
+        fields: Dict[str, Tuple[type, Any]] = {}
+        for fname, schema in props.items():
+            ftype, fld = self._schema_to_field(fname, schema, target.name)
+            fields[fname] = (ftype, fld)
+
+        # Convert target.name to CamelCase and add Tool suffix
+        parts = target.name.replace("-", "_").split("_")
+        camel_case = "".join(part.capitalize() for part in parts)
+        model_name = f"{camel_case}Tool"
+
+        from langroid.agent.tool_message import ToolMessage as _BaseToolMessage
+
+        # IMPORTANT: Avoid clashes with reserved field names in Langroid ToolMessage!
+        # First figure out which field names are reserved
+        reserved = set(_BaseToolMessage.__annotations__.keys())
+        reserved.update(["recipient", "_handler", "name"])
+        renamed: Dict[str, str] = {}
+        new_fields: Dict[str, Tuple[type, Any]] = {}
+        for fname, (ftype, fld) in fields.items():
+            if fname in reserved:
+                new_name = fname + "__"
+                renamed[fname] = new_name
+                new_fields[new_name] = (ftype, fld)
+            else:
+                new_fields[fname] = (ftype, fld)
+        # now replace fields with our renamed‐aware mapping
+        fields = new_fields
+
+        # create Langroid ToolMessage subclass, with expected fields.
+        tool_model = cast(
+            Type[ToolMessage],
+            create_model(  # type: ignore[call-overload]
+                model_name,
+                request=(str, target.name),
+                purpose=(str, target.description or f"Use the tool {target.name}"),
+                __base__=ToolMessage,
+                **fields,
+            ),
+        )
+        # Store ALL client configuration needed to recreate a client
+        client_config = {
+            "server": self.server,
+            "sampling_handler": self.sampling_handler,
+            "roots": self.roots,
+            "log_handler": self.log_handler,
+            "message_handler": self.message_handler,
+            "read_timeout_seconds": self.read_timeout_seconds,
+        }
+
+        tool_model._client_config = client_config  # type: ignore [attr-defined]
+        tool_model._renamed_fields = renamed  # type: ignore[attr-defined]
+
+        # 2) define an arg-free call_tool_async()
+        async def call_tool_async(itself: ToolMessage) -> Any:
+            from langroid.agent.tools.mcp.fastmcp_client import FastMCPClient
+
+            # pack up the payload
+            payload = itself.dict(
+                exclude=itself.Config.schema_extra["exclude"].union(
+                    ["request", "purpose"]
+                ),
+            )
+
+            # restore any renamed fields
+            for orig, new in itself.__class__._renamed_fields.items():  # type: ignore
+                if new in payload:
+                    payload[orig] = payload.pop(new)
+
+            client_cfg = getattr(itself.__class__, "_client_config", None)  # type: ignore
+            if not client_cfg:
+                # Fallback or error - ideally _client_config should always exist
+                raise RuntimeError(f"Client config missing on {itself.__class__}")
+
+            # Connect the client if not yet connected and keep the connection open
+            if self.persist_connection:
+                if not self.client:
+                    await self.connect()
+
+                return await self.call_mcp_tool(itself.request, payload)
+
+            # open a fresh client, call the tool, then close
+            async with FastMCPClient(**client_cfg) as client:  # type: ignore
+                return await client.call_mcp_tool(itself.request, payload)
+
+        tool_model.call_tool_async = call_tool_async  # type: ignore
+
+        if not hasattr(tool_model, "handle_async"):
+            # 3) define handle_async() method with optional agent parameter
+            from typing import Union
+
+            async def handle_async(
+                self: ToolMessage, agent: Optional[Agent] = None
+            ) -> Union[str, Optional[ChatDocument]]:
+                """
+                Auto-generated handler for MCP tool. Returns ChatDocument with files
+                if files are present and agent is provided, otherwise returns text.
+
+                To override: define your own handle_async method with matching signature
+                if you need file handling, or simpler signature if you only need text.
+                """
+                response = await self.call_tool_async()  # type: ignore[attr-defined]
+                if response is None:
+                    return None
+
+                content, files = response
+
+                # If we have files and an agent is provided, return a ChatDocument
+                if files and agent is not None:
+                    return agent.create_agent_response(
+                        content=content,
+                        files=files,
+                    )
+                else:
+                    # Otherwise, just return the text content
+                    return str(content) if content is not None else None
+
+            # add the handle_async() method to the tool model
+            tool_model.handle_async = handle_async  # type: ignore
+
+        return tool_model
+
+    async def get_tools_async(self) -> List[Type[ToolMessage]]:
+        """
+        Get all available tools as Langroid ToolMessage classes,
+        handling nested schemas, with `handle_async` methods
+        """
+        if not self.client:
+            if self.persist_connection:
+                await self.connect()
+                assert self.client
+            else:
+                raise RuntimeError(
+                    "Client not initialized. Use async with FastMCPClient."
+                )
+        resp = await self.client.list_tools()
+        return [await self.get_tool_async(t.name) for t in resp]
+
+    async def get_mcp_tool_async(self, name: str) -> Optional[Tool]:
+        """Find the "original" MCP Tool (i.e. of type mcp.types.Tool) on the server
+         matching `name`, or None if missing. This contains the metadata for the tool:
+         name, description, inputSchema, etc.
+
+        Args:
+            name: Name of the tool to look up.
+
+        Returns:
+            The raw Tool object from the server, or None.
+        """
+        if not self.client:
+            if self.persist_connection:
+                await self.connect()
+                assert self.client
+            else:
+                raise RuntimeError(
+                    "Client not initialized. Use async with FastMCPClient."
+                )
+        resp: List[Tool] = await self.client.list_tools()
+        return next((t for t in resp if t.name == name), None)
+
+    def _convert_tool_result(
+        self,
+        tool_name: str,
+        result: CallToolResult,
+    ) -> Optional[str | tuple[str, list[FileAttachment]]]:
+        if result.isError:
+            # Log more detailed error information
+            error_content = None
+            if result.content and len(result.content) > 0:
+                try:
+                    error_content = [
+                        item.text if hasattr(item, "text") else str(item)
+                        for item in result.content
+                    ]
+                except Exception as e:
+                    error_content = [f"Could not extract error content: {str(e)}"]
+
+            self.logger.error(
+                f"Error calling MCP tool {tool_name}. Details: {error_content}"
+            )
+            return f"ERROR: Tool call failed - {error_content}"
+
+        results_text = [
+            item.text for item in result.content if isinstance(item, TextContent)
+        ]
+        results_file = []
+
+        for item in result.content:
+            if isinstance(item, ImageContent) and self.forward_images:
+                results_file.append(
+                    FileAttachment.from_bytes(
+                        b64decode(item.data),
+                        mime_type=item.mimeType,
+                    )
+                )
+            elif isinstance(item, EmbeddedResource):
+                if (
+                    isinstance(item.resource, TextResourceContents)
+                    and self.forward_text_resources
+                ):
+                    results_text.append(item.resource.text)
+                elif (
+                    isinstance(item.resource, BlobResourceContents)
+                    and self.forward_blob_resources
+                ):
+                    results_file.append(
+                        FileAttachment.from_io(
+                            BytesIO(b64decode(item.resource.blob)),
+                            mime_type=item.resource.mimeType,
+                        )
+                    )
+
+        return "\n".join(results_text), results_file
+
+    async def call_mcp_tool(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> Optional[tuple[str, list[FileAttachment]]]:
+        """Call an MCP tool with the given arguments.
+
+        Args:
+            tool_name: Name of the tool to call.
+            arguments: Arguments to pass to the tool.
+
+        Returns:
+            The result of the tool call.
+        """
+        if not self.client:
+            if self.persist_connection:
+                await self.connect()
+                assert self.client
+            else:
+                raise RuntimeError(
+                    "Client not initialized. Use async with FastMCPClient."
+                )
+        result: CallToolResult = await self.client.session.call_tool(
+            tool_name,
+            arguments,
+        )
+        results = self._convert_tool_result(tool_name, result)
+
+        if isinstance(results, str):
+            return results, []
+
+        return results
+
+
+# ==============================================================================
+# Convenience functions (wrappers around FastMCPClient methods)
+# These are useful for one-off calls without needing to manage the
+# FastMCPClient context explicitly.
+# ==============================================================================
+
+
+async def get_tool_async(
+    server: FastMCPServerSpec,
+    tool_name: str,
+    **client_kwargs: Any,
+) -> Type[ToolMessage]:
+    """Get a single Langroid ToolMessage subclass for a specific MCP tool name (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        tool_name: The name of the tool to retrieve.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A dynamically created Langroid ToolMessage subclass representing the
+        requested tool.
+    """
+    async with FastMCPClient(server, **client_kwargs) as client:
+        return await client.get_tool_async(tool_name)
+
+
+def get_tool(
+    server: FastMCPServerSpec,
+    tool_name: str,
+    **client_kwargs: Any,
+) -> Type[ToolMessage]:
+    """Get a single Langroid ToolMessage subclass
+    for a specific MCP tool name (synchronous).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
+    async `get_tool_async` function using `asyncio.run()`.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        tool_name: The name of the tool to retrieve.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A dynamically created Langroid ToolMessage subclass representing the
+        requested tool.
+    """
+    return asyncio.run(get_tool_async(server, tool_name, **client_kwargs))
+
+
+async def get_tools_async(
+    server: FastMCPServerSpec,
+    **client_kwargs: Any,
+) -> List[Type[ToolMessage]]:
+    """Get all available tools as Langroid ToolMessage subclasses (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A list of dynamically created Langroid ToolMessage subclasses
+        representing all available tools on the server.
+    """
+    async with FastMCPClient(server, **client_kwargs) as client:
+        return await client.get_tools_async()
+
+
+def get_tools(
+    server: FastMCPServerSpec,
+    **client_kwargs: Any,
+) -> List[Type[ToolMessage]]:
+    """Get all available tools as Langroid ToolMessage subclasses (synchronous).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
+    async `get_tools_async` function using `asyncio.run()`.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A list of dynamically created Langroid ToolMessage subclasses
+        representing all available tools on the server.
+    """
+    return asyncio.run(get_tools_async(server, **client_kwargs))
+
+
+async def get_mcp_tool_async(
+    server: FastMCPServerSpec,
+    name: str,
+    **client_kwargs: Any,
+) -> Optional[Tool]:
+    """Get the raw MCP Tool object for a specific tool name (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient to
+    retrieve the tool definition from the server.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        name: The name of the tool to look up.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor.
+
+    Returns:
+        The raw `mcp.types.Tool` object from the server, or `None` if the tool
+        is not found.
+    """
+    async with FastMCPClient(server, **client_kwargs) as client:
+        return await client.get_mcp_tool_async(name)
+
+
+async def get_mcp_tools_async(
+    server: FastMCPServerSpec,
+    **client_kwargs: Any,
+) -> List[Tool]:
+    """Get all available raw MCP Tool objects from the server (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient to
+    retrieve the list of tool definitions from the server.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor.
+
+    Returns:
+        A list of raw `mcp.types.Tool` objects available on the server.
+    """
+    async with FastMCPClient(server, **client_kwargs) as client:
+        if not client.client:
+            raise RuntimeError("Client not initialized. Use async with FastMCPClient.")
+        return await client.client.list_tools()
+</file>
+
 <file path="langroid/agent/tools/task_tool.py">
 """
 TaskTool: A tool that allows agents to delegate a task to a sub-agent with
@@ -43618,10 +44326,13 @@ class TaskTool(ToolMessage):
     system_message: Optional[str] = Field(
         ...,
         description="""
-        Optional system message to configure the sub-agent's general behavior.
+        Optional system message to configure the sub-agent's general behavior and 
+        to specify the task and its context.
             A good system message will have these components:
             - Inform the sub-agent of its role, e.g. "You are a financial analyst."
-            - Clear spec of the task
+            - Clear spec of the task, with sufficient context for the sub-agent to 
+              understand what it needs to do, since the sub-agent does 
+              NOT have access to your conversation history!
             - Any additional general context needed for the task, such as a
               (part of a) document, or data items, etc.
             - Specify when to use certain tools, e.g. 
@@ -43653,9 +44364,10 @@ class TaskTool(ToolMessage):
         A list of tool names to enable for the sub-agent.
         This must be a list of strings referring to the names of tools
         that are known to you. 
-        If you want to enable all tools, you can set this field
-         to a singleton list containing 'ALL'
-        To disable all tools, set it to a singleton list containing 'NONE'
+        If you want to enable all tools, or you do not have any preference
+        on what tools are enabled for the sub-agent, you can set 
+        this field to a singleton list ['ALL']
+        To disable all tools, set it to a singleton list ['NONE']
         """,
     )
     # TODO: ensure valid model name
@@ -43693,11 +44405,20 @@ class TaskTool(ToolMessage):
         # TODO: Maybe we just copy the parent agent's config and override chat_model?
         #   -- but what if parent agent has a MockLMConfig?
         llm_config = lm.OpenAIGPTConfig(
-            chat_model=self.model or "gpt-4.1-mini",  # Default model if not specified
+            chat_model=self.model or lm.OpenAIChatModel.GPT4_1_MINI,
         )
         config = ChatAgentConfig(
             name=agent_name,
             llm=llm_config,
+            handle_llm_no_tool=f"""
+                You forgot to use one of your TOOLs! Remember that you must either:
+                - use a tool, or a sequence of tools, to complete your task, OR
+                - if you are done with your task, use the `{DoneTool.name()}` tool
+                to return the result.
+                
+                As a reminder, this was your task:
+                {self.prompt}
+                """,
             system_message=f"""
                 {self.system_message}
                 
@@ -43718,7 +44439,9 @@ class TaskTool(ToolMessage):
             tool_classes = [
                 agent.llm_tools_map[t]
                 for t in agent.llm_tools_known
-                if t in agent.llm_tools_map and t != self.request
+                if t in agent.llm_tools_map
+                and t != self.request
+                and agent.llm_tools_map[t]._allow_llm_use
                 # Exclude the TaskTool itself!
             ]
         elif self.tools == ["NONE"]:
@@ -43730,6 +44453,7 @@ class TaskTool(ToolMessage):
                 agent.llm_tools_map[tool_name]
                 for tool_name in self.tools
                 if tool_name in agent.llm_tools_map
+                and agent.llm_tools_map[tool_name]._allow_llm_use
             ]
 
         # always enable the DoneTool to signal task completion
@@ -43740,7 +44464,9 @@ class TaskTool(ToolMessage):
 
         return task
 
-    def handle(self, agent: ChatAgent) -> Optional[ChatDocument]:
+    def handle(
+        self, agent: ChatAgent, chat_doc: Optional[ChatDocument] = None
+    ) -> Optional[ChatDocument]:
         """
 
         Handle the TaskTool by creating a sub-agent with specified tools
@@ -43748,26 +44474,66 @@ class TaskTool(ToolMessage):
 
         Args:
             agent: The parent ChatAgent that is handling this tool
+            chat_doc: The ChatDocument containing this tool message
         """
 
         task = self._set_up_task(agent)
-        # Run the task on the prompt, and return the result
-        result = task.run(self.prompt, turns=self.max_iterations or 10)
+
+        # Create a ChatDocument for the prompt with parent pointer
+        prompt_doc = None
+        if chat_doc is not None:
+            from langroid.agent.chat_document import ChatDocMetaData
+
+            prompt_doc = ChatDocument(
+                content=self.prompt,
+                metadata=ChatDocMetaData(
+                    parent_id=chat_doc.id(),
+                    agent_id=agent.id,
+                    sender=chat_doc.metadata.sender,
+                ),
+            )
+            # Set bidirectional parent-child relationship
+            chat_doc.metadata.child_id = prompt_doc.id()
+
+        # Run the task with the ChatDocument or string prompt
+        result = task.run(prompt_doc or self.prompt, turns=self.max_iterations or 10)
         return result
 
-    async def handle_async(self, agent: ChatAgent) -> Optional[ChatDocument]:
+    async def handle_async(
+        self, agent: ChatAgent, chat_doc: Optional[ChatDocument] = None
+    ) -> Optional[ChatDocument]:
         """
         Async method to handle the TaskTool by creating a sub-agent with specified tools
         and running the task non-interactively.
 
         Args:
             agent: The parent ChatAgent that is handling this tool
+            chat_doc: The ChatDocument containing this tool message
         """
         task = self._set_up_task(agent)
-        # Run the task on the prompt, and return the result
+
+        # Create a ChatDocument for the prompt with parent pointer
+        prompt_doc = None
+        if chat_doc is not None:
+            from langroid.agent.chat_document import ChatDocMetaData
+
+            prompt_doc = ChatDocument(
+                content=self.prompt,
+                metadata=ChatDocMetaData(
+                    parent_id=chat_doc.id(),
+                    agent_id=agent.id,
+                    sender=chat_doc.metadata.sender,
+                ),
+            )
+            # Set bidirectional parent-child relationship
+            chat_doc.metadata.child_id = prompt_doc.id()
+
+        # Run the task with the ChatDocument or string prompt
         # TODO eventually allow the various task setup configs,
         #  including termination conditions
-        result = await task.run_async(self.prompt, turns=self.max_iterations or 10)
+        result = await task.run_async(
+            prompt_doc or self.prompt, turns=self.max_iterations or 10
+        )
         return result
 </file>
 
@@ -44389,7 +45155,10 @@ class Task:
             if isinstance(msg, ChatDocument):
                 # carefully deep-copy: fresh metadata.id, register
                 # as new obj in registry
+                original_parent_id = msg.metadata.parent_id
                 self.pending_message = ChatDocument.deepcopy(msg)
+                # Preserve the parent pointer from the original message
+                self.pending_message.metadata.parent_id = original_parent_id
             if self.pending_message is not None and self.caller is not None:
                 # msg may have come from `caller`, so we pretend this is from
                 # the CURRENT task's USER entity
@@ -44397,7 +45166,11 @@ class Task:
                 # update parent, child, agent pointers
                 if msg is not None:
                     msg.metadata.child_id = self.pending_message.metadata.id
-                    self.pending_message.metadata.parent_id = msg.metadata.id
+                    # Only override parent_id if it wasn't already set in the
+                    # original message. This preserves parent chains from TaskTool
+                    if not msg.metadata.parent_id:
+                        self.pending_message.metadata.parent_id = msg.metadata.id
+            if self.pending_message is not None:
                 self.pending_message.metadata.agent_id = self.agent.id
 
         self._show_pending_message_if_debug()
@@ -46024,24 +46797,33 @@ class Task:
     def _get_message_chain(
         self, msg: ChatDocument | None, max_depth: Optional[int] = None
     ) -> List[ChatDocument]:
-        """Get the chain of messages by following parent pointers."""
+        """Get the chain of messages using agent's message history."""
         if max_depth is None:
             # Get max depth needed from all sequences
             max_depth = 50  # default fallback
             if self._parsed_done_sequences:
                 max_depth = max(len(seq.events) for seq in self._parsed_done_sequences)
 
-        chain = []
-        current = msg
-        depth = 0
+        # Get chat document IDs from message history
+        doc_ids = [
+            m.chat_document_id for m in self.agent.message_history if m.chat_document_id
+        ]
 
-        while current is not None and depth < max_depth:
-            chain.append(current)
-            current = current.parent
-            depth += 1
+        # Add current message ID if it exists and is not already the last one
+        if msg:
+            msg_id = msg.id()
+            if not doc_ids or doc_ids[-1] != msg_id:
+                doc_ids.append(msg_id)
 
-        # Reverse to get chronological order (oldest first)
-        return list(reversed(chain))
+        # Take only the last max_depth elements
+        relevant_ids = doc_ids[-max_depth:]
+
+        # Convert IDs to ChatDocuments and filter out None values
+        return [
+            doc
+            for doc_id in relevant_ids
+            if (doc := ChatDocument.from_id(doc_id)) is not None
+        ]
 
     def _matches_event(self, actual: AgentEvent, expected: AgentEvent) -> bool:
         """Check if an actual event matches an expected event pattern."""
@@ -47313,593 +48095,6 @@ agent.enable_message(MySubAgentTool, use=False, handle=False)
 4. **Iteration Limits**: Set reasonable limits based on task complexity
 </file>
 
-<file path="langroid/agent/tools/mcp/fastmcp_client.py">
-import asyncio
-import datetime
-import logging
-from base64 import b64decode
-from io import BytesIO
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeAlias, cast
-
-from dotenv import load_dotenv
-from fastmcp.client import Client
-from fastmcp.client.roots import (
-    RootsHandler,
-    RootsList,
-)
-from fastmcp.client.sampling import SamplingHandler
-from fastmcp.client.transports import ClientTransport
-from fastmcp.server import FastMCP
-from mcp.client.session import (
-    LoggingFnT,
-    MessageHandlerFnT,
-)
-from mcp.types import (
-    BlobResourceContents,
-    CallToolResult,
-    EmbeddedResource,
-    ImageContent,
-    TextContent,
-    TextResourceContents,
-    Tool,
-)
-
-from langroid.agent.base import Agent
-from langroid.agent.chat_document import ChatDocument
-from langroid.agent.tool_message import ToolMessage
-from langroid.parsing.file_attachment import FileAttachment
-from langroid.pydantic_v1 import AnyUrl, BaseModel, Field, create_model
-
-load_dotenv()  # load environment variables from .env
-
-FastMCPServerSpec: TypeAlias = str | FastMCP[Any] | ClientTransport | AnyUrl
-
-
-class FastMCPClient:
-    """A client for interacting with a FastMCP server.
-
-    Provides async context manager functionality to safely manage resources.
-    """
-
-    logger = logging.getLogger(__name__)
-    _cm: Optional[Client] = None
-    client: Optional[Client] = None
-
-    def __init__(
-        self,
-        server: FastMCPServerSpec,
-        persist_connection: bool = False,
-        forward_images: bool = True,
-        forward_text_resources: bool = False,
-        forward_blob_resources: bool = False,
-        sampling_handler: SamplingHandler | None = None,  # type: ignore
-        roots: RootsList | RootsHandler | None = None,  # type: ignore
-        log_handler: LoggingFnT | None = None,
-        message_handler: MessageHandlerFnT | None = None,
-        read_timeout_seconds: datetime.timedelta | None = None,
-    ) -> None:
-        """Initialize the FastMCPClient.
-
-        Args:
-            server: FastMCP server or path to such a server
-        """
-        self.server = server
-        self.client = None
-        self._cm = None
-        self.sampling_handler = sampling_handler
-        self.roots = roots
-        self.log_handler = log_handler
-        self.message_handler = message_handler
-        self.read_timeout_seconds = read_timeout_seconds
-        self.persist_connection = persist_connection
-        self.forward_text_resources = forward_text_resources
-        self.forward_blob_resources = forward_blob_resources
-        self.forward_images = forward_images
-
-    async def __aenter__(self) -> "FastMCPClient":
-        """Enter the async context manager and connect inner client."""
-        # create inner client context manager
-        self._cm = Client(
-            self.server,
-            sampling_handler=self.sampling_handler,
-            roots=self.roots,
-            log_handler=self.log_handler,
-            message_handler=self.message_handler,
-            timeout=self.read_timeout_seconds,
-        )
-        # actually enter it (opens the session)
-        self.client = await self._cm.__aenter__()  # type: ignore
-        return self
-
-    async def connect(self) -> None:
-        """Open the underlying session."""
-        await self.__aenter__()
-
-    async def close(self) -> None:
-        """Close the underlying session."""
-        await self.__aexit__(None, None, None)
-
-    async def __aexit__(
-        self,
-        exc_type: Optional[type[Exception]],
-        exc_val: Optional[Exception],
-        exc_tb: Optional[Any],
-    ) -> None:
-        """Exit the async context manager and close inner client."""
-        # exit and close the inner fastmcp.Client
-        if hasattr(self, "_cm"):
-            if self._cm is not None:
-                await self._cm.__aexit__(exc_type, exc_val, exc_tb)  # type: ignore
-        self.client = None
-        self._cm = None
-
-    def __del__(self) -> None:
-        """Warn about unclosed persistent connections."""
-        if self.client is not None and self.persist_connection:
-            import warnings
-
-            warnings.warn(
-                f"FastMCPClient with persist_connection=True was not properly closed. "
-                f"Connection to {self.server} may leak resources. "
-                f"Use 'async with' or call await client.close()",
-                ResourceWarning,
-                stacklevel=2,
-            )
-
-    def _schema_to_field(
-        self, name: str, schema: Dict[str, Any], prefix: str
-    ) -> Tuple[Any, Any]:
-        """Convert a JSON Schema snippet into a (type, Field) tuple.
-
-        Args:
-            name: Name of the field.
-            schema: JSON Schema for this field.
-            prefix: Prefix to use for nested model names.
-
-        Returns:
-            A tuple of (python_type, Field(...)) for create_model.
-        """
-        t = schema.get("type")
-        default = schema.get("default", ...)
-        desc = schema.get("description")
-        # Object → nested BaseModel
-        if t == "object" and "properties" in schema:
-            sub_name = f"{prefix}_{name.capitalize()}"
-            sub_fields: Dict[str, Tuple[type, Any]] = {}
-            for k, sub_s in schema["properties"].items():
-                ftype, fld = self._schema_to_field(sub_name + k, sub_s, sub_name)
-                sub_fields[k] = (ftype, fld)
-            submodel = create_model(  # type: ignore
-                sub_name,
-                __base__=BaseModel,
-                **sub_fields,
-            )
-            return submodel, Field(default=default, description=desc)  # type: ignore
-        # Array → List of items
-        if t == "array" and "items" in schema:
-            item_type, _ = self._schema_to_field(name, schema["items"], prefix)
-            return List[item_type], Field(default=default, description=desc)  # type: ignore
-        # Primitive types
-        if t == "string":
-            return str, Field(default=default, description=desc)
-        if t == "integer":
-            return int, Field(default=default, description=desc)
-        if t == "number":
-            return float, Field(default=default, description=desc)
-        if t == "boolean":
-            return bool, Field(default=default, description=desc)
-        # Fallback or unions
-        if any(key in schema for key in ("oneOf", "anyOf", "allOf")):
-            self.logger.warning("Unsupported union schema in field %s; using Any", name)
-            return Any, Field(default=default, description=desc)
-        # Default fallback
-        return Any, Field(default=default, description=desc)
-
-    async def get_tool_async(self, tool_name: str) -> Type[ToolMessage]:
-        """
-        Create a Langroid ToolMessage subclass from the MCP Tool
-        with the given `tool_name`.
-        """
-        if not self.client:
-            if self.persist_connection:
-                await self.connect()
-                assert self.client
-            else:
-                raise RuntimeError(
-                    "Client not initialized. Use async with FastMCPClient."
-                )
-        target = await self.get_mcp_tool_async(tool_name)
-        if target is None:
-            raise ValueError(f"No tool named {tool_name}")
-        props = target.inputSchema.get("properties", {})
-        fields: Dict[str, Tuple[type, Any]] = {}
-        for fname, schema in props.items():
-            ftype, fld = self._schema_to_field(fname, schema, target.name)
-            fields[fname] = (ftype, fld)
-
-        # Convert target.name to CamelCase and add Tool suffix
-        parts = target.name.replace("-", "_").split("_")
-        camel_case = "".join(part.capitalize() for part in parts)
-        model_name = f"{camel_case}Tool"
-
-        from langroid.agent.tool_message import ToolMessage as _BaseToolMessage
-
-        # IMPORTANT: Avoid clashes with reserved field names in Langroid ToolMessage!
-        # First figure out which field names are reserved
-        reserved = set(_BaseToolMessage.__annotations__.keys())
-        reserved.update(["recipient", "_handler", "name"])
-        renamed: Dict[str, str] = {}
-        new_fields: Dict[str, Tuple[type, Any]] = {}
-        for fname, (ftype, fld) in fields.items():
-            if fname in reserved:
-                new_name = fname + "__"
-                renamed[fname] = new_name
-                new_fields[new_name] = (ftype, fld)
-            else:
-                new_fields[fname] = (ftype, fld)
-        # now replace fields with our renamed‐aware mapping
-        fields = new_fields
-
-        # create Langroid ToolMessage subclass, with expected fields.
-        tool_model = cast(
-            Type[ToolMessage],
-            create_model(  # type: ignore[call-overload]
-                model_name,
-                request=(str, target.name),
-                purpose=(str, target.description or f"Use the tool {target.name}"),
-                __base__=ToolMessage,
-                **fields,
-            ),
-        )
-        # Store ALL client configuration needed to recreate a client
-        client_config = {
-            "server": self.server,
-            "sampling_handler": self.sampling_handler,
-            "roots": self.roots,
-            "log_handler": self.log_handler,
-            "message_handler": self.message_handler,
-            "read_timeout_seconds": self.read_timeout_seconds,
-        }
-
-        tool_model._client_config = client_config  # type: ignore [attr-defined]
-        tool_model._renamed_fields = renamed  # type: ignore[attr-defined]
-
-        # 2) define an arg-free call_tool_async()
-        async def call_tool_async(itself: ToolMessage) -> Any:
-            from langroid.agent.tools.mcp.fastmcp_client import FastMCPClient
-
-            # pack up the payload
-            payload = itself.dict(
-                exclude=itself.Config.schema_extra["exclude"].union(
-                    ["request", "purpose"]
-                ),
-            )
-
-            # restore any renamed fields
-            for orig, new in itself.__class__._renamed_fields.items():  # type: ignore
-                if new in payload:
-                    payload[orig] = payload.pop(new)
-
-            client_cfg = getattr(itself.__class__, "_client_config", None)  # type: ignore
-            if not client_cfg:
-                # Fallback or error - ideally _client_config should always exist
-                raise RuntimeError(f"Client config missing on {itself.__class__}")
-
-            # Connect the client if not yet connected and keep the connection open
-            if self.persist_connection:
-                if not self.client:
-                    await self.connect()
-
-                return await self.call_mcp_tool(itself.request, payload)
-
-            # open a fresh client, call the tool, then close
-            async with FastMCPClient(**client_cfg) as client:  # type: ignore
-                return await client.call_mcp_tool(itself.request, payload)
-
-        tool_model.call_tool_async = call_tool_async  # type: ignore
-
-        if not hasattr(tool_model, "handle_async"):
-            # 3) define handle_async() method with optional agent parameter
-            from typing import Union
-
-            async def handle_async(
-                self: ToolMessage, agent: Optional[Agent] = None
-            ) -> Union[str, Optional[ChatDocument]]:
-                """
-                Auto-generated handler for MCP tool. Returns ChatDocument with files
-                if files are present and agent is provided, otherwise returns text.
-
-                To override: define your own handle_async method with matching signature
-                if you need file handling, or simpler signature if you only need text.
-                """
-                response = await self.call_tool_async()  # type: ignore[attr-defined]
-                if response is None:
-                    return None
-
-                content, files = response
-
-                # If we have files and an agent is provided, return a ChatDocument
-                if files and agent is not None:
-                    return agent.create_agent_response(
-                        content=content,
-                        files=files,
-                    )
-                else:
-                    # Otherwise, just return the text content
-                    return str(content) if content is not None else None
-
-            # add the handle_async() method to the tool model
-            tool_model.handle_async = handle_async  # type: ignore
-
-        return tool_model
-
-    async def get_tools_async(self) -> List[Type[ToolMessage]]:
-        """
-        Get all available tools as Langroid ToolMessage classes,
-        handling nested schemas, with `handle_async` methods
-        """
-        if not self.client:
-            if self.persist_connection:
-                await self.connect()
-                assert self.client
-            else:
-                raise RuntimeError(
-                    "Client not initialized. Use async with FastMCPClient."
-                )
-        resp = await self.client.list_tools()
-        return [await self.get_tool_async(t.name) for t in resp]
-
-    async def get_mcp_tool_async(self, name: str) -> Optional[Tool]:
-        """Find the "original" MCP Tool (i.e. of type mcp.types.Tool) on the server
-         matching `name`, or None if missing. This contains the metadata for the tool:
-         name, description, inputSchema, etc.
-
-        Args:
-            name: Name of the tool to look up.
-
-        Returns:
-            The raw Tool object from the server, or None.
-        """
-        if not self.client:
-            if self.persist_connection:
-                await self.connect()
-                assert self.client
-            else:
-                raise RuntimeError(
-                    "Client not initialized. Use async with FastMCPClient."
-                )
-        resp: List[Tool] = await self.client.list_tools()
-        return next((t for t in resp if t.name == name), None)
-
-    def _convert_tool_result(
-        self,
-        tool_name: str,
-        result: CallToolResult,
-    ) -> Optional[str | tuple[str, list[FileAttachment]]]:
-        if result.isError:
-            # Log more detailed error information
-            error_content = None
-            if result.content and len(result.content) > 0:
-                try:
-                    error_content = [
-                        item.text if hasattr(item, "text") else str(item)
-                        for item in result.content
-                    ]
-                except Exception as e:
-                    error_content = [f"Could not extract error content: {str(e)}"]
-
-            self.logger.error(
-                f"Error calling MCP tool {tool_name}. Details: {error_content}"
-            )
-            return f"ERROR: Tool call failed - {error_content}"
-
-        results_text = [
-            item.text for item in result.content if isinstance(item, TextContent)
-        ]
-        results_file = []
-
-        for item in result.content:
-            if isinstance(item, ImageContent) and self.forward_images:
-                results_file.append(
-                    FileAttachment.from_bytes(
-                        b64decode(item.data),
-                        mime_type=item.mimeType,
-                    )
-                )
-            elif isinstance(item, EmbeddedResource):
-                if (
-                    isinstance(item.resource, TextResourceContents)
-                    and self.forward_text_resources
-                ):
-                    results_text.append(item.resource.text)
-                elif (
-                    isinstance(item.resource, BlobResourceContents)
-                    and self.forward_blob_resources
-                ):
-                    results_file.append(
-                        FileAttachment.from_io(
-                            BytesIO(b64decode(item.resource.blob)),
-                            mime_type=item.resource.mimeType,
-                        )
-                    )
-
-        return "\n".join(results_text), results_file
-
-    async def call_mcp_tool(
-        self, tool_name: str, arguments: Dict[str, Any]
-    ) -> Optional[tuple[str, list[FileAttachment]]]:
-        """Call an MCP tool with the given arguments.
-
-        Args:
-            tool_name: Name of the tool to call.
-            arguments: Arguments to pass to the tool.
-
-        Returns:
-            The result of the tool call.
-        """
-        if not self.client:
-            if self.persist_connection:
-                await self.connect()
-                assert self.client
-            else:
-                raise RuntimeError(
-                    "Client not initialized. Use async with FastMCPClient."
-                )
-        result: CallToolResult = await self.client.session.call_tool(
-            tool_name,
-            arguments,
-        )
-        results = self._convert_tool_result(tool_name, result)
-
-        if isinstance(results, str):
-            return results, []
-
-        return results
-
-
-# ==============================================================================
-# Convenience functions (wrappers around FastMCPClient methods)
-# These are useful for one-off calls without needing to manage the
-# FastMCPClient context explicitly.
-# ==============================================================================
-
-
-async def get_tool_async(
-    server: FastMCPServerSpec,
-    tool_name: str,
-    **client_kwargs: Any,
-) -> Type[ToolMessage]:
-    """Get a single Langroid ToolMessage subclass for a specific MCP tool name (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        tool_name: The name of the tool to retrieve.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A dynamically created Langroid ToolMessage subclass representing the
-        requested tool.
-    """
-    async with FastMCPClient(server, **client_kwargs) as client:
-        return await client.get_tool_async(tool_name)
-
-
-def get_tool(
-    server: FastMCPServerSpec,
-    tool_name: str,
-    **client_kwargs: Any,
-) -> Type[ToolMessage]:
-    """Get a single Langroid ToolMessage subclass
-    for a specific MCP tool name (synchronous).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
-    async `get_tool_async` function using `asyncio.run()`.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        tool_name: The name of the tool to retrieve.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A dynamically created Langroid ToolMessage subclass representing the
-        requested tool.
-    """
-    return asyncio.run(get_tool_async(server, tool_name, **client_kwargs))
-
-
-async def get_tools_async(
-    server: FastMCPServerSpec,
-    **client_kwargs: Any,
-) -> List[Type[ToolMessage]]:
-    """Get all available tools as Langroid ToolMessage subclasses (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A list of dynamically created Langroid ToolMessage subclasses
-        representing all available tools on the server.
-    """
-    async with FastMCPClient(server, **client_kwargs) as client:
-        return await client.get_tools_async()
-
-
-def get_tools(
-    server: FastMCPServerSpec,
-    **client_kwargs: Any,
-) -> List[Type[ToolMessage]]:
-    """Get all available tools as Langroid ToolMessage subclasses (synchronous).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
-    async `get_tools_async` function using `asyncio.run()`.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A list of dynamically created Langroid ToolMessage subclasses
-        representing all available tools on the server.
-    """
-    return asyncio.run(get_tools_async(server, **client_kwargs))
-
-
-async def get_mcp_tool_async(
-    server: FastMCPServerSpec,
-    name: str,
-    **client_kwargs: Any,
-) -> Optional[Tool]:
-    """Get the raw MCP Tool object for a specific tool name (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient to
-    retrieve the tool definition from the server.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        name: The name of the tool to look up.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor.
-
-    Returns:
-        The raw `mcp.types.Tool` object from the server, or `None` if the tool
-        is not found.
-    """
-    async with FastMCPClient(server, **client_kwargs) as client:
-        return await client.get_mcp_tool_async(name)
-
-
-async def get_mcp_tools_async(
-    server: FastMCPServerSpec,
-    **client_kwargs: Any,
-) -> List[Tool]:
-    """Get all available raw MCP Tool objects from the server (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient to
-    retrieve the list of tool definitions from the server.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor.
-
-    Returns:
-        A list of raw `mcp.types.Tool` objects available on the server.
-    """
-    async with FastMCPClient(server, **client_kwargs) as client:
-        if not client.client:
-            raise RuntimeError("Client not initialized. Use async with FastMCPClient.")
-        return await client.client.list_tools()
-</file>
-
 <file path="langroid/agent/base.py">
 import asyncio
 import copy
@@ -48040,6 +48235,7 @@ class Agent(ABC):
 
     def __init__(self, config: AgentConfig = AgentConfig()):
         self.config = config
+        self.id = ObjectRegistry.new_id()  # Initialize agent ID
         self.lock = asyncio.Lock()  # for async access to update self.llm.usage_cost
         self.dialog: List[Tuple[str, str]] = []  # seq of LLM (prompt, response) tuples
         self.llm_tools_map: Dict[str, Type[ToolMessage]] = {}
@@ -48588,6 +48784,7 @@ class Agent(ABC):
             results.metadata.tool_ids = (
                 [] if msg is None or isinstance(msg, str) else msg.metadata.tool_ids
             )
+            results.metadata.agent_id = self.id
             return results
         sender_name = self.config.name
         if isinstance(msg, ChatDocument) and msg.function_call is not None:
@@ -48606,6 +48803,7 @@ class Agent(ABC):
             metadata=ChatDocMetaData(
                 source=Entity.AGENT,
                 sender=Entity.AGENT,
+                agent_id=self.id,
                 sender_name=sender_name,
                 oai_tool_id=oai_tool_id,
                 # preserve trail of tool_ids for OpenAI Assistant fn-calls
@@ -48870,6 +49068,7 @@ class Agent(ABC):
             return ChatDocument(
                 content=user_msg,
                 metadata=ChatDocMetaData(
+                    agent_id=self.id,
                     source=source,
                     sender=sender,
                     # preserve trail of tool_ids for OpenAI Assistant fn-calls

--- a/llms-no-tests.txt
+++ b/llms-no-tests.txt
@@ -33,7 +33,7 @@ The content is organized as follows:
 <notes>
 - Some files may have been excluded based on .gitignore rules and Repomix's configuration
 - Binary files are not included in this packed representation. Please refer to the Repository Structure section for a complete list of file paths, including binary files
-- Files matching these patterns are excluded: .*/**, !.github, !.github/**, data/**, **/data/**, **/*.csv, logs/**, build/**, dist/**, *.egg-info/**, __pycache__/**, **/*.pyc, .pytest_cache/**, .mypy_cache/**, .ruff_cache/**, venv/**, env/**, .env, **/*.json, llms.txt, llms-compressed.txt, llms-128k.txt, file-list.txt, file-list-updated.txt, examples/data/**, examples/docqa/docs/**, examples/logs/**, tests/cache/**, tests/logs/**, **/*.pkl, **/*.pickle, **/*.db, **/*.sqlite, **/*.log, **/node_modules/**, **/*.min.js, **/*.map, coverage/**, htmlcov/**, .coverage, *.orig, *.tmp, *.bak, *.swp, *.swo, **/docker-compose*.yml, visual_log.sh, **/*_converted.md, **/page_*.md, **/page-*.md, tests/main/dummy-pages/**, tests/main/data/**/*.txt, **/*.pb2.py, **/*.pb2_grpc.py
+- Files matching these patterns are excluded: .*/**, !.github, !.github/**, data/**, **/data/**, **/*.csv, logs/**, build/**, dist/**, *.egg-info/**, __pycache__/**, **/*.pyc, .pytest_cache/**, .mypy_cache/**, .ruff_cache/**, venv/**, env/**, .env, **/*.json, llms.txt, llms-compressed.txt, llms-128k.txt, llms-no-tests.txt, llms-no-tests-compressed.txt, llms-no-tests-no-examples.txt, llms-no-tests-no-examples-compressed.txt, file-list.txt, file-list-updated.txt, examples/data/**, examples/docqa/docs/**, examples/logs/**, tests/cache/**, tests/logs/**, **/*.pkl, **/*.pickle, **/*.db, **/*.sqlite, **/*.log, **/node_modules/**, **/*.min.js, **/*.map, coverage/**, htmlcov/**, .coverage, *.orig, *.tmp, *.bak, *.swp, *.swo, **/docker-compose*.yml, visual_log.sh, **/*_converted.md, **/page_*.md, **/page-*.md, tests/main/dummy-pages/**, tests/main/data/**/*.txt, **/*.pb2.py, **/*.pb2_grpc.py
 - Files matching patterns in .gitignore are excluded
 - Files matching default ignore patterns are excluded
 - Files are sorted by Git change count (files with more changes are at the bottom)
@@ -516,6 +516,7 @@ release-notes/
   v0-56-0-task-tool.md
   v0-56-11-openai-client-caching.md
   v0-56-12-cached-tokens-support.md
+  v0-56-13-done-sequences-parent-chain-fixes.md
   v0-56-2-table-chat-fix.md
   v0-56-4-handler-params.md
   v0-56-6-doc-chat-refactor.md
@@ -15647,6 +15648,67 @@ class RetrieverAgent(DocChatAgent):
             self.vecdb.add_documents(records)
 </file>
 
+<file path="langroid/agent/tools/mcp/__init__.py">
+from .decorators import mcp_tool
+from .fastmcp_client import (
+    FastMCPClient,
+    get_tool,
+    get_tool_async,
+    get_tools,
+    get_tools_async,
+    get_mcp_tool_async,
+    get_mcp_tools_async,
+)
+
+
+__all__ = [
+    "mcp_tool",
+    "FastMCPClient",
+    "get_tool",
+    "get_tool_async",
+    "get_tools",
+    "get_tools_async",
+    "get_mcp_tool_async",
+    "get_mcp_tools_async",
+]
+</file>
+
+<file path="langroid/agent/tools/mcp/decorators.py">
+from typing import Callable, Type
+
+from langroid.agent.tool_message import ToolMessage
+from langroid.agent.tools.mcp.fastmcp_client import get_tool
+
+
+def mcp_tool(
+    server: str, tool_name: str
+) -> Callable[[Type[ToolMessage]], Type[ToolMessage]]:
+    """Decorator: declare a ToolMessage class bound to a FastMCP tool.
+
+    Usage:
+        @fastmcp_tool("/path/to/server.py", "get_weather")
+        class WeatherTool:
+            def pretty(self) -> str:
+                return f"Temp is {self.temperature}"
+    """
+
+    def decorator(user_cls: Type[ToolMessage]) -> Type[ToolMessage]:
+        # build the “real” ToolMessage subclass for this server/tool
+        RealTool: Type[ToolMessage] = get_tool(server, tool_name)
+
+        # copy user‐defined methods / attributes onto RealTool
+        for name, attr in user_cls.__dict__.items():
+            if name.startswith("__") and name.endswith("__"):
+                continue
+            setattr(RealTool, name, attr)
+
+        # preserve the user’s original name if you like:
+        RealTool.__name__ = user_cls.__name__
+        return RealTool
+
+    return decorator
+</file>
+
 <file path="langroid/agent/tools/__init__.py">
 from . import google_search_tool
 from . import recipient_tool
@@ -30457,6 +30519,125 @@ class NonToolAction(str, Enum):
     DONE = "done"  # task done
 </file>
 
+<file path="release-notes/v0-56-13-done-sequences-parent-chain-fixes.md">
+# v0.56.13: DoneSequences Parent Chain and Agent ID Fixes
+
+## Summary
+
+This release fixes critical issues with the DoneSequence implementation, parent pointer chain preservation in TaskTool, and agent ID initialization. These fixes ensure that task termination sequences work correctly with subtasks and that message lineage is properly maintained across agent boundaries.
+
+## Key Fixes
+
+### 1. Agent ID Initialization Fix
+
+**Problem**: The `Agent.id` field was incorrectly returning a `FieldInfo` object instead of an actual ID string because `Agent` is not a Pydantic model but was using Pydantic's `Field` syntax.
+
+**Solution**: Added proper ID initialization in `Agent.__init__()`:
+```python
+self.id = ObjectRegistry.new_id()  # Initialize agent ID
+```
+
+**Impact**: This ensures that `agent_id` is correctly set in `ChatDocument` metadata, which is crucial for tracking which agent owns which messages.
+
+### 2. DoneSequence Message Chain Fix
+
+**Problem**: The `_get_message_chain` method in `Task` was traversing parent pointers to build the message chain. When subtasks are involved, parent pointers can cross agent boundaries, incorrectly including messages from subtask agents in the parent task's chain.
+
+**Solution**: Replaced parent pointer traversal with agent message history:
+```python
+def _get_message_chain(self, msg: ChatDocument | None, max_depth: Optional[int] = None) -> List[ChatDocument]:
+    """Get the chain of messages using agent's message history."""
+    # Get chat document IDs from message history
+    doc_ids = [m.chat_document_id for m in self.agent.message_history 
+               if m.chat_document_id]
+    
+    # Add current message ID if it exists and is not already the last one
+    if msg:
+        msg_id = msg.id()
+        if not doc_ids or doc_ids[-1] != msg_id:
+            doc_ids.append(msg_id)
+    
+    # Take only the last max_depth elements
+    relevant_ids = doc_ids[-max_depth:]
+    
+    # Convert IDs to ChatDocuments
+    return [doc for doc_id in relevant_ids 
+            if (doc := ChatDocument.from_id(doc_id)) is not None]
+```
+
+**Impact**: DoneSequences now correctly check only messages from the current agent, preventing incorrect task termination when subtasks generate matching sequences.
+
+### 3. Parent Pointer Preservation in Task.init()
+
+**Problem**: When `ChatDocument.deepcopy()` is called during `task.init()`, it resets `parent_id` and `child_id` to empty strings, breaking the parent chain. This particularly affected TaskTool when creating subtasks with parent pointers.
+
+**Solution**: Modified `task.init()` to preserve the original parent_id after deepcopy:
+```python
+if isinstance(msg, ChatDocument):
+    original_parent_id = msg.metadata.parent_id
+    self.pending_message = ChatDocument.deepcopy(msg)
+    # Preserve the parent pointer from the original message
+    self.pending_message.metadata.parent_id = original_parent_id
+```
+
+Additionally, added conditional logic to only override parent_id when necessary:
+```python
+if self.pending_message is not None and self.caller is not None:
+    # Only override parent_id if it wasn't already set in the original message
+    if not msg.metadata.parent_id:
+        self.pending_message.metadata.parent_id = msg.metadata.id
+```
+
+**Impact**: Parent chains are now preserved when TaskTool creates subtasks, maintaining proper message lineage.
+
+### 4. TaskTool Parent-Child Relationship
+
+**Problem**: TaskTool was only setting the parent pointer on the prompt ChatDocument but not the corresponding child pointer on the TaskTool message.
+
+**Solution**: Added bidirectional parent-child relationship in TaskTool handlers:
+```python
+if chat_doc is not None:
+    prompt_doc = ChatDocument(
+        content=self.prompt,
+        metadata=ChatDocMetaData(
+            parent_id=chat_doc.id(),
+            agent_id=agent.id,
+            sender=chat_doc.metadata.sender,
+        )
+    )
+    # Set bidirectional parent-child relationship
+    chat_doc.metadata.child_id = prompt_doc.id()
+```
+
+**Impact**: Complete bidirectional parent-child chains are maintained, improving message traceability.
+
+## Tests Added
+
+Added comprehensive test `test_task_init_preserves_parent_id()` in `test_task.py` that verifies:
+- Parent IDs are preserved during ChatDocument deep copying
+- Conditional parent_id override logic works correctly for subtasks
+- Parent chains are maintained in various scenarios
+
+## Breaking Changes
+
+None. All changes are backward compatible bug fixes.
+
+## Migration Guide
+
+No migration needed. The fixes will automatically apply to existing code.
+
+## Technical Details
+
+The core issue was that DoneSequences were incorrectly checking messages across agent boundaries due to parent pointer traversal. Combined with the agent ID initialization bug and parent chain breaks in deepcopy, this caused incorrect task termination behavior. The fixes ensure:
+
+1. Each agent's messages are properly tagged with the agent's ID
+2. DoneSequence checking is confined to the current agent's message history
+3. Parent chains are preserved through TaskTool subtask creation
+4. Bidirectional parent-child relationships are maintained
+
+These changes work together to ensure proper message lineage and task termination behavior in multi-agent systems.
+</file>
+
 <file path=".blackignore">
 ./examples/urlqa/chat-clear.py
 </file>
@@ -31016,67 +31197,6 @@ mysql_user = root
 exclude = .*,.*/.*,.*/*,.*/*.*
 max-line-length = 88
 ignore = W291, W293, E501, E203, W503
-</file>
-
-<file path="ai-instructions/claude-repomix-instructions.md">
-# AI Instructions for Setting Up Repomix
-
-## Task Overview
-Set up [repomix](https://github.com/yamadashy/repomix) to generate LLM-friendly repository exports. This creates text files that can be uploaded to AI models for code analysis.
-
-## Steps to Complete
-
-### 1. Install Repomix
-```bash
-npm install -g repomix
-```
-
-### 2. Create repomix.config.json
-Create a configuration file in the repository root with:
-- **Include patterns**: Source code files (*.py, *.js, *.md, *.yaml, *.yml, *.toml)
-- **Exclude patterns**: Data directories, logs, node_modules, JSON files, generated files
-- **Security check**: Enable to prevent sensitive data inclusion
-
-### 3. Configure Include/Exclude Patterns
-- Include only source code directories and documentation
-- Exclude data/, logs/, build artifacts, dependencies
-- Add `llms*.txt` to exclusions to prevent recursive inclusion
-
-### 4. Test Configuration (Optional)
-```bash
-# Generate file list only for inspection
-repomix --no-files -o file-list.txt
-```
-This allows you to review which files will be included before generating the full output.
-
-### 5. Generate Output Versions
-
-Use the Makefile targets to generate repomix files:
-
-```bash
-# Generate all variants (recommended)
-make repomix-all
-
-# Or generate specific versions:
-make repomix          # llms.txt and llms-compressed.txt (includes tests)
-make repomix-no-tests # llms-no-tests.txt and llms-no-tests-compressed.txt
-```
-
-All commands use `git ls-files` to ensure only git-tracked files are included.
-
-### 6. Verify Results
-- Check file sizes and token counts in repomix output
-- Ensure no sensitive data is included
-- Confirm only relevant source files are packaged
-
-## Expected Outcome
-Four text files optimized for different LLM contexts:
-- `llms.txt`: Full version with tests for comprehensive analysis
-- `llms-compressed.txt`: Compressed version with tests
-- `llms-no-tests.txt`: Full version without tests for focused source code analysis
-- `llms-no-tests-compressed.txt`: Compressed version without tests for smaller contexts
-
-The files contain only git-tracked source code with proper exclusions for clean, focused LLM consumption.
 </file>
 
 <file path="ai-notes/Langroid-repo-docs.md">
@@ -45213,6 +45333,63 @@ if __name__ == "__main__":
     main()
 </file>
 
+<file path="examples/mcp/biomcp.py">
+"""
+Simple example of using the BioMCP server.
+
+https://github.com/genomoncology/biomcp
+
+The server offers several tools, and we can enable ALL of them to be used
+by a Langroid agent.
+
+Run like this:
+
+    uv run examples/mcp/biomcp.py --model gpt-4.1-mini
+
+"""
+
+from fastmcp.client.transports import StdioTransport
+from fire import Fire
+
+import langroid as lr
+import langroid.language_models as lm
+from langroid.agent.tools.mcp.fastmcp_client import get_tools_async
+from langroid.mytypes import NonToolAction
+
+
+async def main(model: str = ""):
+    transport = StdioTransport(
+        command="uv", args=["run", "--with", "biomcp-python", "biomcp", "run"]
+    )
+    all_tools = await get_tools_async(transport)
+
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            # forward to user when LLM doesn't use a tool
+            handle_llm_no_tool=NonToolAction.FORWARD_USER,
+            llm=lm.OpenAIGPTConfig(
+                chat_model=model or "gpt-4.1-mini",
+                max_output_tokens=1000,
+                async_stream_quiet=False,
+            ),
+        )
+    )
+
+    # enable the agent to use all tools
+    agent.enable_message(all_tools)
+    # make task with interactive=False =>
+    # waits for user only when LLM doesn't use a tool
+    task = lr.Task(agent, interactive=False)
+    await task.run_async(
+        "Based on the TOOLs available to you, greet the user and"
+        "tell them what kinds of help you can provide."
+    )
+
+
+if __name__ == "__main__":
+    Fire(main)
+</file>
+
 <file path="examples/mcp/exa-web-search.py">
 """
 Simple example of using the Exa Web Search MCP Server to
@@ -45296,6 +45473,380 @@ if __name__ == "__main__":
         asyncio.run(main(**kwargs))
 
     Fire(run_main)
+</file>
+
+<file path="examples/mcp/gitmcp.py">
+"""
+Simple example of using the GitMCP server to "chat" about a GitHub repository.
+
+https://github.com/idosal/git-mcp
+
+The server offers several tools, and we can enable ALL of them to be used
+by a Langroid agent.
+
+Run like this (-m model optional; defaults to gpt-4.1-mini):
+
+    uv run examples/mcp/gitmcp.py -m ollama/qwen2.5-coder:32b
+
+"""
+
+from textwrap import dedent
+from typing import List
+
+from fastmcp.client.transports import SSETransport
+from fire import Fire
+
+import langroid as lr
+import langroid.language_models as lm
+from langroid.agent.tools.mcp.fastmcp_client import get_tools_async
+from langroid.agent.tools.orchestration import SendTool
+from langroid.pydantic_v1 import Field
+
+
+def get_gitmcp_url() -> str:
+    from rich.console import Console
+    from rich.prompt import Prompt
+
+    console = Console()
+    import re
+
+    short_pattern = re.compile(r"^([^/]+)/([^/]+)$")
+    url_pattern = re.compile(
+        r"^(?:https?://)?(?:www\.)?github\.com/([^/]+)/([^/]+)(?:\.git)?/?$"
+    )
+
+    while True:
+        user_input = Prompt.ask(
+            "[bold blue]Enter the GitHub repository (owner/repo or full URL)"
+        ).strip()
+        m = short_pattern.match(user_input)
+        if m:
+            owner, repo = m.groups()
+        else:
+            m = url_pattern.match(user_input)
+            if m:
+                owner, repo = m.groups()
+            else:
+                console.print(
+                    "[red]Invalid format. Please enter 'owner/repo' or a full GitHub URL."
+                )
+                continue
+        break
+
+    github_url = f"https://github.com/{owner}/{repo}"
+    console.print(f"Full GitHub URL set to [green]{github_url}[/]")
+
+    gitmcp_url = f"https://gitmcp.io/{owner}/{repo}"
+    console.print(f"GitMCP URL set to [green]{gitmcp_url}[/]")
+    return gitmcp_url
+
+
+class SendUserTool(SendTool):
+    request: str = "send_user"
+    purpose: str = "Send <content> to user"
+    to: str = "user"
+    content: str = Field(
+        ...,
+        description="""
+        Message to send to user, typically answer to user's request,
+        or a clarification question to the user, if user's task/question
+        is not completely clear.
+        """,
+    )
+
+
+async def main(model: str = ""):
+
+    gitmcp_url = get_gitmcp_url()
+
+    transport = SSETransport(
+        url=gitmcp_url,
+    )
+    all_tools: List[lr.ToolMessage] = await get_tools_async(transport)
+
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            # forward to user when LLM doesn't use a tool
+            handle_llm_no_tool="You FORGOT to use one of your TOOLs!",
+            llm=lm.OpenAIGPTConfig(
+                chat_model=model or "gpt-4.1-mini",
+                max_output_tokens=10_000,
+                async_stream_quiet=False,
+            ),
+            system_message=dedent(
+                f"""
+                Make best use of any of the TOOLs available to you,
+                to answer the user's questions.
+                To communicate with the User, you MUST use
+                the TOOL `{SendUserTool.name()}` - typically this would
+                be to either send the user your answer to their query/request,
+                or to ask the user a clarification question, if the user's request
+                is not completely clear.
+                """
+            ),
+        )
+    )
+
+    # enable the agent to use all tools
+    agent.enable_message(all_tools + [SendUserTool])
+    # configure task to NOT recognize string-based signals like DONE,
+    # since those could occur in the retrieved text!
+    task_cfg = lr.TaskConfig(recognize_string_signals=False)
+    # make task with interactive=False =>
+    # waits for user only when LLM doesn't use a tool
+
+    task = lr.Task(agent, config=task_cfg, interactive=False)
+    await task.run_async(
+        "Based on the TOOLs available to you, greet the user and"
+        "tell them what kinds of help you can provide."
+    )
+
+
+if __name__ == "__main__":
+    Fire(main)
+</file>
+
+<file path="examples/mcp/mcp-fetch.py">
+"""
+Simple example of using the Anthropic Fetch MCP Server to get web-site content.
+
+Fetch MCP Server: https://github.com/modelcontextprotocol/servers/tree/main/src/fetch
+
+Run like this:
+
+    uv run examples/mcp/mcp-fetch.py --model gpt-4.1-mini
+
+Ask questions like:
+
+Summarize the content of this page:
+https://www.anthropic.com/news/model-context-protocol
+"""
+
+from fastmcp.client.transports import UvxStdioTransport
+from fire import Fire
+
+import langroid as lr
+import langroid.language_models as lm
+from langroid.agent.tools.mcp.fastmcp_client import get_tool_async
+from langroid.mytypes import NonToolAction
+
+
+async def main(model: str = ""):
+    transport = UvxStdioTransport(
+        tool_name="mcp-server-fetch",
+    )
+    FetchTool = await get_tool_async(transport, "fetch")
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            # forward to user when LLM doesn't use a tool
+            handle_llm_no_tool=NonToolAction.FORWARD_USER,
+            llm=lm.OpenAIGPTConfig(
+                chat_model=model or "gpt-4.1-mini",
+                max_output_tokens=1000,
+                async_stream_quiet=False,
+            ),
+        )
+    )
+
+    # enable the agent to use the fetch tool
+    agent.enable_message(FetchTool)
+    # make task with interactive=False =>
+    # waits for user only when LLM doesn't use a tool
+    task = lr.Task(agent, interactive=False)
+    await task.run_async()
+
+
+if __name__ == "__main__":
+    Fire(main)
+</file>
+
+<file path="examples/mcp/mcp-file-system.py">
+"""
+Example: Expose local file-system operations via an in-memory FastMCP server.
+
+Run like this:
+
+uv run examples/mcp/mcp-file-system.py --model gpt-4.1-mini
+
+Then ask your agent to list, write, or read files.
+"""
+
+import asyncio
+import os
+
+from fastmcp.server import FastMCP
+from fire import Fire
+
+import langroid as lr
+import langroid.language_models as lm
+from langroid.agent.tools.mcp import get_tool_async, mcp_tool
+from langroid.pydantic_v1 import Field
+
+
+def create_fs_mcp_server() -> FastMCP:
+    """Return a FastMCP server exposing list/read/write file tools."""
+    server = FastMCP("FsServer")
+
+    @server.tool()
+    def list_files(
+        directory: str = Field(..., description="Directory path to list")
+    ) -> list[str]:
+        """List file names in the given directory."""
+        try:
+            return os.listdir(directory)
+        except FileNotFoundError:
+            return []
+
+    @server.tool()
+    def write_file(
+        path: str = Field(..., description="Path to write to"),
+        content: str = Field(..., description="Text content to write"),
+    ) -> bool:
+        """Write text to a file; return True on success."""
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+        return True
+
+    @server.tool()
+    def read_file(
+        path: str = Field(..., description="Path of a text file to read")
+    ) -> str:
+        """Read and return the content of a text file."""
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    return server
+
+
+# use decorator to create a Langroid ToolMessage with a custom handle_async method
+@mcp_tool(create_fs_mcp_server(), "write_file")
+class WriteFileTool(lr.ToolMessage):
+    """Tool to write text to a file."""
+
+    async def handle_async(self) -> str:
+        """Invoke `write_file` and report the result."""
+        ok = await self.call_tool_async()  # type: ignore
+        return f"Wrote {self.path}: {ok}"
+
+
+# use decorator to create a Langroid ToolMessage with a custom handle_async method
+@mcp_tool(create_fs_mcp_server(), "read_file")
+class ReadFileTool(lr.ToolMessage):
+    """Tool to read the content of a text file."""
+
+    async def handle_async(self) -> str:
+        """Invoke `read_file` and return its contents."""
+        text = await self.call_tool_async()  # type: ignore
+        return text or ""
+
+
+async def main(model: str = "") -> None:
+    """
+    Launch a ChatAgent that can list, write, and read files.
+
+    Args:
+    model: Optional LLM model name (defaults to gpt-4.1-mini).
+    """
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            llm=lm.OpenAIGPTConfig(
+                chat_model=model or "gpt-4.1-mini",
+                max_output_tokens=500,
+                async_stream_quiet=False,
+            ),
+        )
+    )
+
+    # create ListFilesTool using the helper function get_tool_async
+    ListFilesTool = await get_tool_async(create_fs_mcp_server(), "list_files")
+
+    # enable all three tools
+    agent.enable_message([ListFilesTool, WriteFileTool, ReadFileTool])
+
+    # create a non-interactive task
+    task = lr.Task(agent, interactive=False)
+
+    # instruct the agent
+    prompt = """
+    1. List files in the current directory.
+    2. Write a file 'note.txt' containing "Hello, MCP!".
+    3. Read back 'note.txt'.
+    """
+    result = await task.run_async(prompt, turns=3)
+    print(result.content)
+
+
+if __name__ == "__main__":
+
+    def _run(**kwargs: str) -> None:
+        """Fire entry point to run the async main function."""
+        asyncio.run(main(**kwargs))
+
+    Fire(_run)
+</file>
+
+<file path="examples/mcp/memory.py">
+"""
+Simple example of using the Memory MCP server:
+https://github.com/modelcontextprotocol/servers/tree/main/src/memory
+This server gives your agent persistent memory using a local Knowledge Graph,
+so when you re-start the chat it will remember what you talked about last time.
+
+
+The server offers several tools, and we can enable ALL of them to be used
+by a Langroid agent.
+
+Run like this (-m model optional; defaults to gpt-4.1-mini):
+
+    uv run examples/mcp/memory.py --m ollama/qwen2.5-coder:32b
+
+"""
+
+from fastmcp.client.transports import NpxStdioTransport
+from fire import Fire
+
+import langroid as lr
+import langroid.language_models as lm
+from langroid.agent.tools.mcp.fastmcp_client import get_tools_async
+from langroid.mytypes import NonToolAction
+
+
+async def main(model: str = ""):
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            # forward to user when LLM doesn't use a tool
+            handle_llm_no_tool=NonToolAction.FORWARD_USER,
+            llm=lm.OpenAIGPTConfig(
+                chat_model=model or "gpt-4.1-mini",
+                max_output_tokens=1000,
+                async_stream_quiet=False,
+            ),
+            system_message="""
+            To be helpful to the user, think about which of your several TOOLs
+            you can use, possibly one after the other, to answer the user's question.
+            """,
+        )
+    )
+
+    transport = NpxStdioTransport(
+        package="@modelcontextprotocol/server-memory",
+        args=["-y"],
+    )
+    tools = await get_tools_async(transport)
+
+    # enable the agent to use all tools
+    agent.enable_message(tools)
+    # make task with interactive=False =>
+    # waits for user only when LLM doesn't use a tool
+    task = lr.Task(agent, interactive=False)
+    await task.run_async(
+        "Based on the TOOLs available to you, greet the user and"
+        "tell them what kinds of help you can provide."
+    )
+
+
+if __name__ == "__main__":
+    Fire(main)
 </file>
 
 <file path="examples/multi-agent-debate/chainlit_utils.py">
@@ -51442,67 +51993,6 @@ class LanceDocChatAgent(DocChatAgent):
         return list(zip(docs, scores))
 </file>
 
-<file path="langroid/agent/tools/mcp/__init__.py">
-from .decorators import mcp_tool
-from .fastmcp_client import (
-    FastMCPClient,
-    get_tool,
-    get_tool_async,
-    get_tools,
-    get_tools_async,
-    get_mcp_tool_async,
-    get_mcp_tools_async,
-)
-
-
-__all__ = [
-    "mcp_tool",
-    "FastMCPClient",
-    "get_tool",
-    "get_tool_async",
-    "get_tools",
-    "get_tools_async",
-    "get_mcp_tool_async",
-    "get_mcp_tools_async",
-]
-</file>
-
-<file path="langroid/agent/tools/mcp/decorators.py">
-from typing import Callable, Type
-
-from langroid.agent.tool_message import ToolMessage
-from langroid.agent.tools.mcp.fastmcp_client import get_tool
-
-
-def mcp_tool(
-    server: str, tool_name: str
-) -> Callable[[Type[ToolMessage]], Type[ToolMessage]]:
-    """Decorator: declare a ToolMessage class bound to a FastMCP tool.
-
-    Usage:
-        @fastmcp_tool("/path/to/server.py", "get_weather")
-        class WeatherTool:
-            def pretty(self) -> str:
-                return f"Temp is {self.temperature}"
-    """
-
-    def decorator(user_cls: Type[ToolMessage]) -> Type[ToolMessage]:
-        # build the “real” ToolMessage subclass for this server/tool
-        RealTool: Type[ToolMessage] = get_tool(server, tool_name)
-
-        # copy user‐defined methods / attributes onto RealTool
-        for name, attr in user_cls.__dict__.items():
-            if name.startswith("__") and name.endswith("__"):
-                continue
-            setattr(RealTool, name, attr)
-
-        # preserve the user’s original name if you like:
-        RealTool.__name__ = user_cls.__name__
-        return RealTool
-
-    return decorator
-</file>
-
 <file path="langroid/agent/batch.py">
 import asyncio
 import copy
@@ -54082,160 +54572,6 @@ replace_and_log() {
 replace_and_log
 </file>
 
-<file path="Makefile">
-.PHONY: setup check lint tests docs nodocs loc
-
-SHELL := /bin/bash
-
-.PHONY: setup update
-
-setup: ## Setup the git pre-commit hooks
-	uv run pre-commit install
-
-update: ## Update the git pre-commit hooks
-	uv run pre-commit autoupdate
-
-.PHONY: type-check
-type-check:
-	@uv run pre-commit install
-	@uv run pre-commit autoupdate
-	@uv run pre-commit run --all-files
-	@echo "Running black..."
-	@uv run black --check .
-	@echo "Running ruff check (without fix)..."
-	@uv run ruff check .
-	@echo "Running mypy...";
-	@uv run mypy -p langroid
-	@echo "All checks passed!"
-
-.PHONY: lint
-lint:
-	uv run black .
-	uv run ruff check . --fix
-	@echo "Auto-fixing issues in examples folder..."
-	@uv run ruff check examples/ --fix-only --no-force-exclude
-
-.PHONY: stubs
-stubs:
-	@echo "Generating Python stubs for the langroid package..."
-	@uv run stubgen -p langroid -o stubs
-	@echo "Stubs generated in the 'stubs' directory"
-
-.PHONY: fix-pydantic
-
-# Entry to replace pydantic imports in specified directories
-fix-pydantic:
-	@echo "Fixing pydantic imports..."
-	@chmod +x scripts/fix-pydantic-imports.sh
-	@./scripts/fix-pydantic-imports.sh
-
-.PHONY: check
-check: fix-pydantic lint type-check
-
-.PHONY: tests
-tests:
-	pytest tests/main --basetemp=/tmp/pytest
-
-
-docs:
-	@# Kill any existing 'mkdocs serve' processes.
-	@pkill -f "mkdocs serve" 2>/dev/null || true
-	@# Build the documentation.
-	mkdocs build
-	@# Serve the documentation in the background.
-	mkdocs serve &
-	@echo "Documentation is being served in the background."
-	@echo "You can access the documentation at http://127.0.0.1:8000/"
-
-nodocs:
-	@# Kill any existing 'mkdocs serve' processes.
-	@pkill -f "mkdocs serve" 2>/dev/null || echo "No 'mkdocs serve' process found."
-	@echo "Stopped serving documentation."
-
-
-loc:
-	@echo "Lines in git-tracked files python files:"
-	@git ls-files | grep '\.py$$' | xargs cat | grep -v '^\s*$$' | wc -l
-
-.PHONY: repomix repomix-no-tests repomix-all
-
-repomix: ## Generate llms.txt and llms-compressed.txt (includes tests)
-	@echo "Generating llms.txt (with tests)..."
-	@git ls-files | repomix --stdin
-	@echo "Generating llms-compressed.txt..."
-	@git ls-files | repomix --stdin --compress -o llms-compressed.txt
-	@echo "Generated llms.txt and llms-compressed.txt"
-
-repomix-no-tests: ## Generate llms-no-tests.txt (excludes tests)
-	@echo "Generating llms-no-tests.txt (without tests)..."
-	@git ls-files | grep -v "^tests/" | repomix --stdin -o llms-no-tests.txt
-	@echo "Generating llms-no-tests-compressed.txt..."
-	@git ls-files | grep -v "^tests/" | repomix --stdin --compress -o llms-no-tests-compressed.txt
-	@echo "Generated llms-no-tests.txt and llms-no-tests-compressed.txt"
-
-repomix-all: repomix repomix-no-tests ## Generate all repomix variants
-
-.PHONY: revert-tag
-revert-tag:
-	@LATEST_TAG=$$(git describe --tags --abbrev=0) && \
-	echo "Deleting tag: $$LATEST_TAG" && \
-	git tag -d $$LATEST_TAG
-
-.PHONY: revert-bump
-revert-bump:
-	@if git log -1 --pretty=%B | grep -q "bump"; then \
-		git reset --hard HEAD~1; \
-		echo "Reverted last commit (bump commit)"; \
-	else \
-		echo "Last commit was not a bump commit"; \
-	fi
-
-.PHONY: revert
-revert: revert-bump revert-tag
-	
-.PHONY: bump-patch
-bump-patch:
-	@cz bump --increment PATCH
-
-.PHONY: bump-minor
-bump-minor:
-	@cz bump --increment MINOR 
-
-.PHONY: bump-major
-bump-major:
-	@cz bump --increment MAJOR 
-
-.PHONY: build
-build:
-	@uv build
-
-.PHONY: push
-push:
-	@git push origin main
-	@git push origin --tags
-
-.PHONY: clean
-clean:
-	-rm -rf dist/*
-
-.PHONY: release
-release:
-	@VERSION=$$(cz version -p | cut -d' ' -f2) && gh release create $${VERSION} dist/*
-
-.PHONY: all-patch
-all-patch: bump-patch clean build push release
-
-.PHONY: all-minor
-all-minor: bump-minor clean build push release
-
-.PHONY: all-major
-all-major: bump-major clean build push release
-
-.PHONY: publish
-publish:
-	uv publish
-</file>
-
 <file path="SECURITY.md">
 # Security Policy
 
@@ -54273,6 +54609,70 @@ Once a security vulnerability is reported, we will work to:
 - Investigate and confirm the issue.
 - Develop a patch or mitigation strategy.
 - Publish the fix and disclose the advisory publicly after the resolution.
+</file>
+
+<file path="ai-instructions/claude-repomix-instructions.md">
+# AI Instructions for Setting Up Repomix
+
+## Task Overview
+Set up [repomix](https://github.com/yamadashy/repomix) to generate LLM-friendly repository exports. This creates text files that can be uploaded to AI models for code analysis.
+
+## Steps to Complete
+
+### 1. Install Repomix
+```bash
+npm install -g repomix
+```
+
+### 2. Create repomix.config.json
+Create a configuration file in the repository root with:
+- **Include patterns**: Source code files (*.py, *.js, *.md, *.yaml, *.yml, *.toml)
+- **Exclude patterns**: Data directories, logs, node_modules, JSON files, generated files
+- **Security check**: Enable to prevent sensitive data inclusion
+
+### 3. Configure Include/Exclude Patterns
+- Include only source code directories and documentation
+- Exclude data/, logs/, build artifacts, dependencies
+- Add `llms*.txt` to exclusions to prevent recursive inclusion
+
+### 4. Test Configuration (Optional)
+```bash
+# Generate file list only for inspection
+repomix --no-files -o file-list.txt
+```
+This allows you to review which files will be included before generating the full output.
+
+### 5. Generate Output Versions
+
+Use the Makefile targets to generate repomix files:
+
+```bash
+# Generate all variants (recommended)
+make repomix-all
+
+# Or generate specific versions:
+make repomix                      # llms.txt and llms-compressed.txt (includes tests)
+make repomix-no-tests             # llms-no-tests.txt and llms-no-tests-compressed.txt
+make repomix-no-tests-no-examples # llms-no-tests-no-examples.txt and compressed version
+```
+
+All commands use `git ls-files` to ensure only git-tracked files are included.
+
+### 6. Verify Results
+- Check file sizes and token counts in repomix output
+- Ensure no sensitive data is included
+- Confirm only relevant source files are packaged
+
+## Expected Outcome
+Six text files optimized for different LLM contexts:
+- `llms.txt`: Full version with tests and examples (870K tokens)
+- `llms-compressed.txt`: Compressed version with tests and examples (513K tokens)
+- `llms-no-tests.txt`: Full version without tests (677K tokens)
+- `llms-no-tests-compressed.txt`: Compressed version without tests (433K tokens)
+- `llms-no-tests-no-examples.txt`: Core library code only (no tests/examples)
+- `llms-no-tests-no-examples-compressed.txt`: Compressed core library code (285K tokens)
+
+The files contain only git-tracked source code with proper exclusions for clean, focused LLM consumption.
 </file>
 
 <file path="ai-notes/handler-parameter-analysis-notes.md">
@@ -60942,63 +61342,6 @@ if __name__ == "__main__":
     app()
 </file>
 
-<file path="examples/mcp/biomcp.py">
-"""
-Simple example of using the BioMCP server.
-
-https://github.com/genomoncology/biomcp
-
-The server offers several tools, and we can enable ALL of them to be used
-by a Langroid agent.
-
-Run like this:
-
-    uv run examples/mcp/biomcp.py --model gpt-4.1-mini
-
-"""
-
-from fastmcp.client.transports import StdioTransport
-from fire import Fire
-
-import langroid as lr
-import langroid.language_models as lm
-from langroid.agent.tools.mcp.fastmcp_client import get_tools_async
-from langroid.mytypes import NonToolAction
-
-
-async def main(model: str = ""):
-    transport = StdioTransport(
-        command="uv", args=["run", "--with", "biomcp-python", "biomcp", "run"]
-    )
-    all_tools = await get_tools_async(transport)
-
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            # forward to user when LLM doesn't use a tool
-            handle_llm_no_tool=NonToolAction.FORWARD_USER,
-            llm=lm.OpenAIGPTConfig(
-                chat_model=model or "gpt-4.1-mini",
-                max_output_tokens=1000,
-                async_stream_quiet=False,
-            ),
-        )
-    )
-
-    # enable the agent to use all tools
-    agent.enable_message(all_tools)
-    # make task with interactive=False =>
-    # waits for user only when LLM doesn't use a tool
-    task = lr.Task(agent, interactive=False)
-    await task.run_async(
-        "Based on the TOOLs available to you, greet the user and"
-        "tell them what kinds of help you can provide."
-    )
-
-
-if __name__ == "__main__":
-    Fire(main)
-</file>
-
 <file path="examples/mcp/chainlit-mcp.py">
 """
 Variant of gitmcp.py that works via the Chainlit UI library,
@@ -61074,380 +61417,6 @@ async def start():
         "Based on the TOOLs available to you, greet the user and"
         "tell them what kinds of help you can provide."
     )
-</file>
-
-<file path="examples/mcp/gitmcp.py">
-"""
-Simple example of using the GitMCP server to "chat" about a GitHub repository.
-
-https://github.com/idosal/git-mcp
-
-The server offers several tools, and we can enable ALL of them to be used
-by a Langroid agent.
-
-Run like this (-m model optional; defaults to gpt-4.1-mini):
-
-    uv run examples/mcp/gitmcp.py -m ollama/qwen2.5-coder:32b
-
-"""
-
-from textwrap import dedent
-from typing import List
-
-from fastmcp.client.transports import SSETransport
-from fire import Fire
-
-import langroid as lr
-import langroid.language_models as lm
-from langroid.agent.tools.mcp.fastmcp_client import get_tools_async
-from langroid.agent.tools.orchestration import SendTool
-from langroid.pydantic_v1 import Field
-
-
-def get_gitmcp_url() -> str:
-    from rich.console import Console
-    from rich.prompt import Prompt
-
-    console = Console()
-    import re
-
-    short_pattern = re.compile(r"^([^/]+)/([^/]+)$")
-    url_pattern = re.compile(
-        r"^(?:https?://)?(?:www\.)?github\.com/([^/]+)/([^/]+)(?:\.git)?/?$"
-    )
-
-    while True:
-        user_input = Prompt.ask(
-            "[bold blue]Enter the GitHub repository (owner/repo or full URL)"
-        ).strip()
-        m = short_pattern.match(user_input)
-        if m:
-            owner, repo = m.groups()
-        else:
-            m = url_pattern.match(user_input)
-            if m:
-                owner, repo = m.groups()
-            else:
-                console.print(
-                    "[red]Invalid format. Please enter 'owner/repo' or a full GitHub URL."
-                )
-                continue
-        break
-
-    github_url = f"https://github.com/{owner}/{repo}"
-    console.print(f"Full GitHub URL set to [green]{github_url}[/]")
-
-    gitmcp_url = f"https://gitmcp.io/{owner}/{repo}"
-    console.print(f"GitMCP URL set to [green]{gitmcp_url}[/]")
-    return gitmcp_url
-
-
-class SendUserTool(SendTool):
-    request: str = "send_user"
-    purpose: str = "Send <content> to user"
-    to: str = "user"
-    content: str = Field(
-        ...,
-        description="""
-        Message to send to user, typically answer to user's request,
-        or a clarification question to the user, if user's task/question
-        is not completely clear.
-        """,
-    )
-
-
-async def main(model: str = ""):
-
-    gitmcp_url = get_gitmcp_url()
-
-    transport = SSETransport(
-        url=gitmcp_url,
-    )
-    all_tools: List[lr.ToolMessage] = await get_tools_async(transport)
-
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            # forward to user when LLM doesn't use a tool
-            handle_llm_no_tool="You FORGOT to use one of your TOOLs!",
-            llm=lm.OpenAIGPTConfig(
-                chat_model=model or "gpt-4.1-mini",
-                max_output_tokens=10_000,
-                async_stream_quiet=False,
-            ),
-            system_message=dedent(
-                f"""
-                Make best use of any of the TOOLs available to you,
-                to answer the user's questions.
-                To communicate with the User, you MUST use
-                the TOOL `{SendUserTool.name()}` - typically this would
-                be to either send the user your answer to their query/request,
-                or to ask the user a clarification question, if the user's request
-                is not completely clear.
-                """
-            ),
-        )
-    )
-
-    # enable the agent to use all tools
-    agent.enable_message(all_tools + [SendUserTool])
-    # configure task to NOT recognize string-based signals like DONE,
-    # since those could occur in the retrieved text!
-    task_cfg = lr.TaskConfig(recognize_string_signals=False)
-    # make task with interactive=False =>
-    # waits for user only when LLM doesn't use a tool
-
-    task = lr.Task(agent, config=task_cfg, interactive=False)
-    await task.run_async(
-        "Based on the TOOLs available to you, greet the user and"
-        "tell them what kinds of help you can provide."
-    )
-
-
-if __name__ == "__main__":
-    Fire(main)
-</file>
-
-<file path="examples/mcp/mcp-fetch.py">
-"""
-Simple example of using the Anthropic Fetch MCP Server to get web-site content.
-
-Fetch MCP Server: https://github.com/modelcontextprotocol/servers/tree/main/src/fetch
-
-Run like this:
-
-    uv run examples/mcp/mcp-fetch.py --model gpt-4.1-mini
-
-Ask questions like:
-
-Summarize the content of this page:
-https://www.anthropic.com/news/model-context-protocol
-"""
-
-from fastmcp.client.transports import UvxStdioTransport
-from fire import Fire
-
-import langroid as lr
-import langroid.language_models as lm
-from langroid.agent.tools.mcp.fastmcp_client import get_tool_async
-from langroid.mytypes import NonToolAction
-
-
-async def main(model: str = ""):
-    transport = UvxStdioTransport(
-        tool_name="mcp-server-fetch",
-    )
-    FetchTool = await get_tool_async(transport, "fetch")
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            # forward to user when LLM doesn't use a tool
-            handle_llm_no_tool=NonToolAction.FORWARD_USER,
-            llm=lm.OpenAIGPTConfig(
-                chat_model=model or "gpt-4.1-mini",
-                max_output_tokens=1000,
-                async_stream_quiet=False,
-            ),
-        )
-    )
-
-    # enable the agent to use the fetch tool
-    agent.enable_message(FetchTool)
-    # make task with interactive=False =>
-    # waits for user only when LLM doesn't use a tool
-    task = lr.Task(agent, interactive=False)
-    await task.run_async()
-
-
-if __name__ == "__main__":
-    Fire(main)
-</file>
-
-<file path="examples/mcp/mcp-file-system.py">
-"""
-Example: Expose local file-system operations via an in-memory FastMCP server.
-
-Run like this:
-
-uv run examples/mcp/mcp-file-system.py --model gpt-4.1-mini
-
-Then ask your agent to list, write, or read files.
-"""
-
-import asyncio
-import os
-
-from fastmcp.server import FastMCP
-from fire import Fire
-
-import langroid as lr
-import langroid.language_models as lm
-from langroid.agent.tools.mcp import get_tool_async, mcp_tool
-from langroid.pydantic_v1 import Field
-
-
-def create_fs_mcp_server() -> FastMCP:
-    """Return a FastMCP server exposing list/read/write file tools."""
-    server = FastMCP("FsServer")
-
-    @server.tool()
-    def list_files(
-        directory: str = Field(..., description="Directory path to list")
-    ) -> list[str]:
-        """List file names in the given directory."""
-        try:
-            return os.listdir(directory)
-        except FileNotFoundError:
-            return []
-
-    @server.tool()
-    def write_file(
-        path: str = Field(..., description="Path to write to"),
-        content: str = Field(..., description="Text content to write"),
-    ) -> bool:
-        """Write text to a file; return True on success."""
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(content)
-        return True
-
-    @server.tool()
-    def read_file(
-        path: str = Field(..., description="Path of a text file to read")
-    ) -> str:
-        """Read and return the content of a text file."""
-        with open(path, "r", encoding="utf-8") as f:
-            return f.read()
-
-    return server
-
-
-# use decorator to create a Langroid ToolMessage with a custom handle_async method
-@mcp_tool(create_fs_mcp_server(), "write_file")
-class WriteFileTool(lr.ToolMessage):
-    """Tool to write text to a file."""
-
-    async def handle_async(self) -> str:
-        """Invoke `write_file` and report the result."""
-        ok = await self.call_tool_async()  # type: ignore
-        return f"Wrote {self.path}: {ok}"
-
-
-# use decorator to create a Langroid ToolMessage with a custom handle_async method
-@mcp_tool(create_fs_mcp_server(), "read_file")
-class ReadFileTool(lr.ToolMessage):
-    """Tool to read the content of a text file."""
-
-    async def handle_async(self) -> str:
-        """Invoke `read_file` and return its contents."""
-        text = await self.call_tool_async()  # type: ignore
-        return text or ""
-
-
-async def main(model: str = "") -> None:
-    """
-    Launch a ChatAgent that can list, write, and read files.
-
-    Args:
-    model: Optional LLM model name (defaults to gpt-4.1-mini).
-    """
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            llm=lm.OpenAIGPTConfig(
-                chat_model=model or "gpt-4.1-mini",
-                max_output_tokens=500,
-                async_stream_quiet=False,
-            ),
-        )
-    )
-
-    # create ListFilesTool using the helper function get_tool_async
-    ListFilesTool = await get_tool_async(create_fs_mcp_server(), "list_files")
-
-    # enable all three tools
-    agent.enable_message([ListFilesTool, WriteFileTool, ReadFileTool])
-
-    # create a non-interactive task
-    task = lr.Task(agent, interactive=False)
-
-    # instruct the agent
-    prompt = """
-    1. List files in the current directory.
-    2. Write a file 'note.txt' containing "Hello, MCP!".
-    3. Read back 'note.txt'.
-    """
-    result = await task.run_async(prompt, turns=3)
-    print(result.content)
-
-
-if __name__ == "__main__":
-
-    def _run(**kwargs: str) -> None:
-        """Fire entry point to run the async main function."""
-        asyncio.run(main(**kwargs))
-
-    Fire(_run)
-</file>
-
-<file path="examples/mcp/memory.py">
-"""
-Simple example of using the Memory MCP server:
-https://github.com/modelcontextprotocol/servers/tree/main/src/memory
-This server gives your agent persistent memory using a local Knowledge Graph,
-so when you re-start the chat it will remember what you talked about last time.
-
-
-The server offers several tools, and we can enable ALL of them to be used
-by a Langroid agent.
-
-Run like this (-m model optional; defaults to gpt-4.1-mini):
-
-    uv run examples/mcp/memory.py --m ollama/qwen2.5-coder:32b
-
-"""
-
-from fastmcp.client.transports import NpxStdioTransport
-from fire import Fire
-
-import langroid as lr
-import langroid.language_models as lm
-from langroid.agent.tools.mcp.fastmcp_client import get_tools_async
-from langroid.mytypes import NonToolAction
-
-
-async def main(model: str = ""):
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            # forward to user when LLM doesn't use a tool
-            handle_llm_no_tool=NonToolAction.FORWARD_USER,
-            llm=lm.OpenAIGPTConfig(
-                chat_model=model or "gpt-4.1-mini",
-                max_output_tokens=1000,
-                async_stream_quiet=False,
-            ),
-            system_message="""
-            To be helpful to the user, think about which of your several TOOLs
-            you can use, possibly one after the other, to answer the user's question.
-            """,
-        )
-    )
-
-    transport = NpxStdioTransport(
-        package="@modelcontextprotocol/server-memory",
-        args=["-y"],
-    )
-    tools = await get_tools_async(transport)
-
-    # enable the agent to use all tools
-    agent.enable_message(tools)
-    # make task with interactive=False =>
-    # waits for user only when LLM doesn't use a tool
-    task = lr.Task(agent, interactive=False)
-    await task.run_async(
-        "Based on the TOOLs available to you, greet the user and"
-        "tell them what kinds of help you can provide."
-    )
-
-
-if __name__ == "__main__":
-    Fire(main)
 </file>
 
 <file path="examples/mcp/openmemory.py">
@@ -67077,6 +67046,366 @@ commands/
 .claude/
 </file>
 
+<file path="docs/notes/mcp-tools.md">
+# Langroid MCP Integration
+
+Langroid provides seamless integration with Model Context Protocol (MCP) servers via 
+two methods, both of which involve creating Langroid `ToolMessage` subclasses
+corresponding to the MCP tools: 
+
+1. Programmatic creation of Langroid tools using `get_tool_async`, 
+   `get_tools_async` from the tool definitions defined on an MCP server.
+2. Declarative creation of Langroid tools using the **`@mcp_tool` decorator**, which allows
+   customizing the tool-handling behavior beyond what is provided by the MCP server.
+
+This integration allows _any_ LLM (that is good enough to do function-calling via prompts) to use any MCP server.
+See the following to understand the integration better:
+
+- example python scripts under [`examples/mcp`](https://github.com/langroid/langroid/tree/main/examples/mcp)
+- [`tests/main/test_mcp_tools.py`](https://github.com/langroid/langroid/blob/main/tests/main/test_mcp_tools.py)
+
+---
+
+## 1. Connecting to an MCP server via transport specification
+
+Before creating Langroid tools, we first need to define and connect to an MCP server
+via a [FastMCP](https://gofastmcp.com/getting-started/welcome) client. 
+There are several ways to connect to a server, depending on how it is defined. 
+Each of these uses a different type of [transport](https://gofastmcp.com/clients/transports).
+
+The typical pattern to use with Langroid is as follows:
+
+- define an MCP server transport
+- create a `ToolMessage` subclass using the `@mcp_tool` decorator or 
+  `get_tool_async()` function, with the transport as the first argument
+
+
+Langroid's MCP integration will work with any of [transports](https://gofastmcp.com/clients/transportsl) 
+supported by FastMCP.
+Below we go over some common ways to define transports and extract tools from the servers.
+
+1. **Local Python script**
+2. **In-memory FastMCP server** - useful for testing and for simple in-memory servers
+   that don't need to be run as a separate process.
+3. **NPX stdio transport**
+4. **UVX stdio transport**
+5. **Generic stdio transport** – launch any CLI‐based MCP server via stdin/stdout
+6. **Network SSE transport** – connect to HTTP/S MCP servers via `SSETransport`
+
+
+All examples below use the async helpers to create Langroid tools (`ToolMessage` subclasses):
+
+```python
+from langroid.agent.tools.mcp import (
+    get_tools_async,
+    get_tool_async,
+)
+```
+
+---
+
+#### Path to a Python Script
+
+Point at your MCP‐server entrypoint, e.g., to the `weather.py` script in the 
+langroid repo (based on the [Anthropic quick-start guide](https://modelcontextprotocol.io/quickstart/server)):
+
+```python
+async def example_script_path() -> None:
+    server = "tests/main/mcp/weather-server-python/weather.py"
+    tools = await get_tools_async(server) # all tools available
+    AlertTool = await get_tool_async(server, "get_alerts") # specific tool
+
+    # instantiate the tool with a specific input
+    msg = AlertTool(state="CA")
+    
+    # Call the tool via handle_async()
+    alerts = await msg.handle_async()
+    print(alerts)
+```
+
+---
+
+#### In-Memory FastMCP Server
+
+Define your server with `FastMCP(...)` and pass the instance:
+
+```python
+from fastmcp.server import FastMCP
+from pydantic import BaseModel, Field
+
+class CounterInput(BaseModel):
+    start: int = Field(...)
+
+def make_server() -> FastMCP:
+    server = FastMCP("CounterServer")
+
+    @server.tool()
+    def increment(data: CounterInput) -> int:
+        """Increment start by 1."""
+        return data.start + 1
+
+    return server
+
+async def example_in_memory() -> None:
+    server = make_server()
+    tools = await get_tools_async(server)
+    IncTool = await get_tool_async(server, "increment")
+
+    result = await IncTool(start=41).handle_async()
+    print(result)  # 42
+```
+
+See the [`mcp-file-system.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/mcp-file-system.py)
+script for a working example of this.
+
+---
+
+#### NPX stdio Transport
+
+Use any npm-installed MCP server via `npx`, e.g., the 
+[Exa web-search MCP server](https://docs.exa.ai/examples/exa-mcp):
+
+```python
+from fastmcp.client.transports import NpxStdioTransport
+
+transport = NpxStdioTransport(
+    package="exa-mcp-server",
+    env_vars={"EXA_API_KEY": "…"},
+)
+
+async def example_npx() -> None:
+    tools = await get_tools_async(transport)
+    SearchTool = await get_tool_async(transport, "web_search_exa")
+
+    results = await SearchTool(
+        query="How does Langroid integrate with MCP?"
+    ).handle_async()
+    print(results)
+```
+
+For a fully working example, see the script [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py).
+
+---
+
+#### UVX stdio Transport
+
+Connect to a UVX-based MCP server, e.g., the [Git MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
+
+```python
+from fastmcp.client.transports import UvxStdioTransport
+
+transport = UvxStdioTransport(tool_name="mcp-server-git")
+
+async def example_uvx() -> None:
+    tools = await get_tools_async(transport)
+    GitStatus = await get_tool_async(transport, "git_status")
+
+    status = await GitStatus(path=".").handle_async()
+    print(status)
+```
+
+--- 
+
+#### Generic stdio Transport
+
+Use `StdioTransport` to run any MCP server as a subprocess over stdio:
+
+```python
+from fastmcp.client.transports import StdioTransport
+from langroid.agent.tools.mcp import get_tools_async, get_tool_async
+
+
+async def example_stdio() -> None:
+    """Example: any CLI‐based MCP server via StdioTransport."""
+    transport: StdioTransport = StdioTransport(
+        command="uv",
+        args=["run", "--with", "biomcp-python", "biomcp", "run"],
+    )
+    tools: list[type] = await get_tools_async(transport)
+    BioTool = await get_tool_async(transport, "tool_name")
+    result: str = await BioTool(param="value").handle_async()
+    print(result)
+```
+
+See the full example in [`examples/mcp/biomcp.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/biomcp.py).
+
+---
+
+#### Network SSE Transport
+
+Use `SSETransport` to connect to a FastMCP server over HTTP/S:
+
+```python
+from fastmcp.client.transports import SSETransport
+from langroid.agent.tools.mcp import (
+    get_tools_async,
+    get_tool_async,
+)
+
+
+async def example_sse() -> None:
+    """Example: connect to an HTTP/S MCP server via SSETransport."""
+    url: str = "https://localhost:8000/sse"
+    transport: SSETransport = SSETransport(
+        url=url, headers={"Authorization": "Bearer TOKEN"}
+    )
+    tools: list[type] = await get_tools_async(transport)
+    ExampleTool = await get_tool_async(transport, "tool_name")
+    result: str = await ExampleTool(param="value").handle_async()
+    print(result)
+```    
+
+---
+
+With these patterns you can list tools, generate Pydantic-backed `ToolMessage` classes,
+and invoke them via `.handle_async()`, all with zero boilerplate client setup. 
+As the `FastMCP` library adds other types of transport (e.g., `StreamableHTTPTransport`),
+the pattern of usage with Langroid will remain the same.
+
+
+---
+
+## 2. Create Langroid Tools declaratively using the `@mcp_tool` decorator
+
+The above examples showed how you can create Langroid tools programmatically using
+the helper functions `get_tool_async()` and `get_tools_async()`,
+with the first argument being the transport to the MCP server. The `@mcp_tool` decorator
+works in the same way: 
+
+- **Arguments to the decorator**
+    1. `server_spec`: path/URL/`FastMCP`/`ClientTransport`, as mentioned above.
+    2. `tool_name`: name of a specific MCP tool
+
+- **Behavior**
+    - Generates a `ToolMessage` subclass with all input fields typed.
+    - Provides a `call_tool_async()` under the hood -- this is the "raw" MCP tool call,
+      returning a string.
+    - If you define your own `handle_async()`, it overrides the default. Typically,
+you would override it to customize either the input or the output of the tool call, or both.
+    - If you don't define your own `handle_async()`, it defaults to just returning the
+      value of the `call_tool_async()` method.
+
+Here is a simple example of using the `@mcp_tool` decorator to create a Langroid tool:
+
+```python
+from fastmcp.server import FastMCP
+from langroid.agent.tools.mcp import mcp_tool
+import langroid as lr
+
+# Define your MCP server (pydantic v2 for schema)
+server = FastMCP("MyServer")
+
+@mcp_tool(server, "greet")
+class GreetTool(lr.ToolMessage):
+    """Say hello to someone."""
+
+    async def handle_async(self) -> str:
+        # Customize post-processing
+        raw = await self.call_tool_async()
+        return f"💬 {raw}"
+```
+
+Using the decorator method allows you to customize the `handle_async` method of the
+tool, or add additional fields to the `ToolMessage`. 
+You may want to customize the input to the tool, or the tool result before it is sent back to 
+the LLM. If you don't override it, the default behavior is to simply return the value of 
+the "raw" MCP tool call `await self.call_tool_async()`. 
+
+```python
+@mcp_tool(server, "calculate")
+class CalcTool(ToolMessage):
+    """Perform complex calculation."""
+
+    async def handle_async(self) -> str:
+        result = await self.call_tool_async()
+        # Add context or emojis, etc.
+        return f"🧮 Result is *{result}*"
+```
+
+---
+
+## 3. Enabling Tools in Your Agent
+
+Once you’ve created a Langroid `ToolMessage` subclass from an MCP server, 
+you can enable it on a `ChatAgent`, just like you normally would. Below is an example of using 
+the [Exa MCP server](https://docs.exa.ai/examples/exa-mcp) to create a 
+Langroid web search tool, enable a `ChatAgent` to use it, and then set up a `Task` to 
+run the agent loop.
+
+First we must define the appropriate `ClientTransport` for the MCP server:
+```python
+# define the transport
+transport = NpxStdioTransport(
+    package="exa-mcp-server",
+    env_vars=dict(EXA_API_KEY=os.getenv("EXA_API_KEY")),
+)
+```
+
+Then we use the `@mcp_tool` decorator to create a `ToolMessage` 
+subclass representing the web search tool. Note that one reason to use the decorator
+to define our tool is so we can specify a custom `handle_async` method that
+controls what is sent to the LLM after the actual raw MCP tool-call
+(the `call_tool_async` method) is made.
+
+```python
+# the second arg specifically refers to the `web_search_exa` tool available
+# on the server defined by the `transport` variable.
+@mcp_tool(transport, "web_search_exa")
+class ExaSearchTool(lr.ToolMessage):
+    async def handle_async(self):
+        result: str = await self.call_tool_async()
+        return f"""
+        Below are the results of the web search:
+        
+        <WebSearchResult>
+        {result}
+        </WebSearchResult>
+        
+        Use these results to answer the user's original question.
+        """
+
+```
+
+If we did not want to override the `handle_async` method, we could simply have
+created the `ExaSearchTool` class programmatically via the `get_tool_async` 
+function as shown above, i.e.:
+
+```python
+from langroid.agent.tools.mcp import get_tool_async
+
+ExaSearchTool = awwait
+get_tool_async(transport, "web_search_exa")
+```
+
+We can now define our main function where we create our `ChatAgent`,
+attach the `ExaSearchTool` to it, define the `Task`, and run the task loop.
+
+```python
+async def main():
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            # forward to user when LLM doesn't use a tool
+            handle_llm_no_tool=NonToolAction.FORWARD_USER,
+            llm=lm.OpenAIGPTConfig(
+                max_output_tokens=1000,
+                # this defaults to True, but we set it to False so we can see output
+                async_stream_quiet=False,
+            ),
+        )
+    )
+
+    # enable the agent to use the web-search tool
+    agent.enable_message(ExaSearchTool)
+    # make task with interactive=False =>
+    # waits for user only when LLM doesn't use a tool
+    task = lr.Task(agent, interactive=False)
+    await task.run_async()
+```
+
+See [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py) for a full 
+working example of this.
+</file>
+
 <file path="examples/basic/planner-workflow-simple.py">
 """
 Illustrates a Planner agent orchestrating a multi-step workflow by using tools that
@@ -70718,364 +71047,166 @@ agent.enable_message([Tool1, Tool2, Tool3])  # Pass list of tool classes
 - Tokens are not needed for public repositories and can cause GitHub rendering issues
 </file>
 
-<file path="docs/notes/mcp-tools.md">
-# Langroid MCP Integration
-
-Langroid provides seamless integration with Model Context Protocol (MCP) servers via 
-two methods, both of which involve creating Langroid `ToolMessage` subclasses
-corresponding to the MCP tools: 
-
-1. Programmatic creation of Langroid tools using `get_tool_async`, 
-   `get_tools_async` from the tool definitions defined on an MCP server.
-2. Declarative creation of Langroid tools using the **`@mcp_tool` decorator**, which allows
-   customizing the tool-handling behavior beyond what is provided by the MCP server.
-
-This integration allows _any_ LLM (that is good enough to do function-calling via prompts) to use any MCP server.
-See the following to understand the integration better:
-
-- example python scripts under [`examples/mcp`](https://github.com/langroid/langroid/tree/main/examples/mcp)
-- [`tests/main/test_mcp_tools.py`](https://github.com/langroid/langroid/blob/main/tests/main/test_mcp_tools.py)
-
----
-
-## 1. Connecting to an MCP server via transport specification
-
-Before creating Langroid tools, we first need to define and connect to an MCP server
-via a [FastMCP](https://gofastmcp.com/getting-started/welcome) client. 
-There are several ways to connect to a server, depending on how it is defined. 
-Each of these uses a different type of [transport](https://gofastmcp.com/clients/transports).
-
-The typical pattern to use with Langroid is as follows:
-
-- define an MCP server transport
-- create a `ToolMessage` subclass using the `@mcp_tool` decorator or 
-  `get_tool_async()` function, with the transport as the first argument
-
-
-Langroid's MCP integration will work with any of [transports](https://gofastmcp.com/clients/transportsl) 
-supported by FastMCP.
-Below we go over some common ways to define transports and extract tools from the servers.
-
-1. **Local Python script**
-2. **In-memory FastMCP server** - useful for testing and for simple in-memory servers
-   that don't need to be run as a separate process.
-3. **NPX stdio transport**
-4. **UVX stdio transport**
-5. **Generic stdio transport** – launch any CLI‐based MCP server via stdin/stdout
-6. **Network SSE transport** – connect to HTTP/S MCP servers via `SSETransport`
-
-
-All examples below use the async helpers to create Langroid tools (`ToolMessage` subclasses):
-
-```python
-from langroid.agent.tools.mcp import (
-    get_tools_async,
-    get_tool_async,
-)
-```
-
----
-
-#### Path to a Python Script
-
-Point at your MCP‐server entrypoint, e.g., to the `weather.py` script in the 
-langroid repo (based on the [Anthropic quick-start guide](https://modelcontextprotocol.io/quickstart/server)):
-
-```python
-async def example_script_path() -> None:
-    server = "tests/main/mcp/weather-server-python/weather.py"
-    tools = await get_tools_async(server) # all tools available
-    AlertTool = await get_tool_async(server, "get_alerts") # specific tool
-
-    # instantiate the tool with a specific input
-    msg = AlertTool(state="CA")
-    
-    # Call the tool via handle_async()
-    alerts = await msg.handle_async()
-    print(alerts)
-```
-
----
-
-#### In-Memory FastMCP Server
-
-Define your server with `FastMCP(...)` and pass the instance:
-
-```python
-from fastmcp.server import FastMCP
-from pydantic import BaseModel, Field
-
-class CounterInput(BaseModel):
-    start: int = Field(...)
-
-def make_server() -> FastMCP:
-    server = FastMCP("CounterServer")
-
-    @server.tool()
-    def increment(data: CounterInput) -> int:
-        """Increment start by 1."""
-        return data.start + 1
-
-    return server
-
-async def example_in_memory() -> None:
-    server = make_server()
-    tools = await get_tools_async(server)
-    IncTool = await get_tool_async(server, "increment")
-
-    result = await IncTool(start=41).handle_async()
-    print(result)  # 42
-```
-
-See the [`mcp-file-system.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/mcp-file-system.py)
-script for a working example of this.
-
----
-
-#### NPX stdio Transport
-
-Use any npm-installed MCP server via `npx`, e.g., the 
-[Exa web-search MCP server](https://docs.exa.ai/examples/exa-mcp):
-
-```python
-from fastmcp.client.transports import NpxStdioTransport
-
-transport = NpxStdioTransport(
-    package="exa-mcp-server",
-    env_vars={"EXA_API_KEY": "…"},
-)
-
-async def example_npx() -> None:
-    tools = await get_tools_async(transport)
-    SearchTool = await get_tool_async(transport, "web_search_exa")
-
-    results = await SearchTool(
-        query="How does Langroid integrate with MCP?"
-    ).handle_async()
-    print(results)
-```
-
-For a fully working example, see the script [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py).
-
----
-
-#### UVX stdio Transport
-
-Connect to a UVX-based MCP server, e.g., the [Git MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
-
-```python
-from fastmcp.client.transports import UvxStdioTransport
-
-transport = UvxStdioTransport(tool_name="mcp-server-git")
-
-async def example_uvx() -> None:
-    tools = await get_tools_async(transport)
-    GitStatus = await get_tool_async(transport, "git_status")
-
-    status = await GitStatus(path=".").handle_async()
-    print(status)
-```
-
---- 
-
-#### Generic stdio Transport
-
-Use `StdioTransport` to run any MCP server as a subprocess over stdio:
-
-```python
-from fastmcp.client.transports import StdioTransport
-from langroid.agent.tools.mcp import get_tools_async, get_tool_async
-
-
-async def example_stdio() -> None:
-    """Example: any CLI‐based MCP server via StdioTransport."""
-    transport: StdioTransport = StdioTransport(
-        command="uv",
-        args=["run", "--with", "biomcp-python", "biomcp", "run"],
-    )
-    tools: list[type] = await get_tools_async(transport)
-    BioTool = await get_tool_async(transport, "tool_name")
-    result: str = await BioTool(param="value").handle_async()
-    print(result)
-```
-
-See the full example in [`examples/mcp/biomcp.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/biomcp.py).
-
----
-
-#### Network SSE Transport
-
-Use `SSETransport` to connect to a FastMCP server over HTTP/S:
-
-```python
-from fastmcp.client.transports import SSETransport
-from langroid.agent.tools.mcp import (
-    get_tools_async,
-    get_tool_async,
-)
-
-
-async def example_sse() -> None:
-    """Example: connect to an HTTP/S MCP server via SSETransport."""
-    url: str = "https://localhost:8000/sse"
-    transport: SSETransport = SSETransport(
-        url=url, headers={"Authorization": "Bearer TOKEN"}
-    )
-    tools: list[type] = await get_tools_async(transport)
-    ExampleTool = await get_tool_async(transport, "tool_name")
-    result: str = await ExampleTool(param="value").handle_async()
-    print(result)
-```    
-
----
-
-With these patterns you can list tools, generate Pydantic-backed `ToolMessage` classes,
-and invoke them via `.handle_async()`, all with zero boilerplate client setup. 
-As the `FastMCP` library adds other types of transport (e.g., `StreamableHTTPTransport`),
-the pattern of usage with Langroid will remain the same.
-
-
----
-
-## 2. Create Langroid Tools declaratively using the `@mcp_tool` decorator
-
-The above examples showed how you can create Langroid tools programmatically using
-the helper functions `get_tool_async()` and `get_tools_async()`,
-with the first argument being the transport to the MCP server. The `@mcp_tool` decorator
-works in the same way: 
-
-- **Arguments to the decorator**
-    1. `server_spec`: path/URL/`FastMCP`/`ClientTransport`, as mentioned above.
-    2. `tool_name`: name of a specific MCP tool
-
-- **Behavior**
-    - Generates a `ToolMessage` subclass with all input fields typed.
-    - Provides a `call_tool_async()` under the hood -- this is the "raw" MCP tool call,
-      returning a string.
-    - If you define your own `handle_async()`, it overrides the default. Typically,
-you would override it to customize either the input or the output of the tool call, or both.
-    - If you don't define your own `handle_async()`, it defaults to just returning the
-      value of the `call_tool_async()` method.
-
-Here is a simple example of using the `@mcp_tool` decorator to create a Langroid tool:
-
-```python
-from fastmcp.server import FastMCP
-from langroid.agent.tools.mcp import mcp_tool
-import langroid as lr
-
-# Define your MCP server (pydantic v2 for schema)
-server = FastMCP("MyServer")
-
-@mcp_tool(server, "greet")
-class GreetTool(lr.ToolMessage):
-    """Say hello to someone."""
-
-    async def handle_async(self) -> str:
-        # Customize post-processing
-        raw = await self.call_tool_async()
-        return f"💬 {raw}"
-```
-
-Using the decorator method allows you to customize the `handle_async` method of the
-tool, or add additional fields to the `ToolMessage`. 
-You may want to customize the input to the tool, or the tool result before it is sent back to 
-the LLM. If you don't override it, the default behavior is to simply return the value of 
-the "raw" MCP tool call `await self.call_tool_async()`. 
-
-```python
-@mcp_tool(server, "calculate")
-class CalcTool(ToolMessage):
-    """Perform complex calculation."""
-
-    async def handle_async(self) -> str:
-        result = await self.call_tool_async()
-        # Add context or emojis, etc.
-        return f"🧮 Result is *{result}*"
-```
-
----
-
-## 3. Enabling Tools in Your Agent
-
-Once you’ve created a Langroid `ToolMessage` subclass from an MCP server, 
-you can enable it on a `ChatAgent`, just like you normally would. Below is an example of using 
-the [Exa MCP server](https://docs.exa.ai/examples/exa-mcp) to create a 
-Langroid web search tool, enable a `ChatAgent` to use it, and then set up a `Task` to 
-run the agent loop.
-
-First we must define the appropriate `ClientTransport` for the MCP server:
-```python
-# define the transport
-transport = NpxStdioTransport(
-    package="exa-mcp-server",
-    env_vars=dict(EXA_API_KEY=os.getenv("EXA_API_KEY")),
-)
-```
-
-Then we use the `@mcp_tool` decorator to create a `ToolMessage` 
-subclass representing the web search tool. Note that one reason to use the decorator
-to define our tool is so we can specify a custom `handle_async` method that
-controls what is sent to the LLM after the actual raw MCP tool-call
-(the `call_tool_async` method) is made.
-
-```python
-# the second arg specifically refers to the `web_search_exa` tool available
-# on the server defined by the `transport` variable.
-@mcp_tool(transport, "web_search_exa")
-class ExaSearchTool(lr.ToolMessage):
-    async def handle_async(self):
-        result: str = await self.call_tool_async()
-        return f"""
-        Below are the results of the web search:
-        
-        <WebSearchResult>
-        {result}
-        </WebSearchResult>
-        
-        Use these results to answer the user's original question.
-        """
-
-```
-
-If we did not want to override the `handle_async` method, we could simply have
-created the `ExaSearchTool` class programmatically via the `get_tool_async` 
-function as shown above, i.e.:
-
-```python
-from langroid.agent.tools.mcp import get_tool_async
-
-ExaSearchTool = awwait
-get_tool_async(transport, "web_search_exa")
-```
-
-We can now define our main function where we create our `ChatAgent`,
-attach the `ExaSearchTool` to it, define the `Task`, and run the task loop.
-
-```python
-async def main():
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            # forward to user when LLM doesn't use a tool
-            handle_llm_no_tool=NonToolAction.FORWARD_USER,
-            llm=lm.OpenAIGPTConfig(
-                max_output_tokens=1000,
-                # this defaults to True, but we set it to False so we can see output
-                async_stream_quiet=False,
-            ),
-        )
-    )
-
-    # enable the agent to use the web-search tool
-    agent.enable_message(ExaSearchTool)
-    # make task with interactive=False =>
-    # waits for user only when LLM doesn't use a tool
-    task = lr.Task(agent, interactive=False)
-    await task.run_async()
-```
-
-See [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py) for a full 
-working example of this.
+<file path="Makefile">
+.PHONY: setup check lint tests docs nodocs loc
+
+SHELL := /bin/bash
+
+.PHONY: setup update
+
+setup: ## Setup the git pre-commit hooks
+	uv run pre-commit install
+
+update: ## Update the git pre-commit hooks
+	uv run pre-commit autoupdate
+
+.PHONY: type-check
+type-check:
+	@uv run pre-commit install
+	@uv run pre-commit autoupdate
+	@uv run pre-commit run --all-files
+	@echo "Running black..."
+	@uv run black --check .
+	@echo "Running ruff check (without fix)..."
+	@uv run ruff check .
+	@echo "Running mypy...";
+	@uv run mypy -p langroid
+	@echo "All checks passed!"
+
+.PHONY: lint
+lint:
+	uv run black .
+	uv run ruff check . --fix
+	@echo "Auto-fixing issues in examples folder..."
+	@uv run ruff check examples/ --fix-only --no-force-exclude
+
+.PHONY: stubs
+stubs:
+	@echo "Generating Python stubs for the langroid package..."
+	@uv run stubgen -p langroid -o stubs
+	@echo "Stubs generated in the 'stubs' directory"
+
+.PHONY: fix-pydantic
+
+# Entry to replace pydantic imports in specified directories
+fix-pydantic:
+	@echo "Fixing pydantic imports..."
+	@chmod +x scripts/fix-pydantic-imports.sh
+	@./scripts/fix-pydantic-imports.sh
+
+
+.PHONY: tests
+tests:
+	pytest tests/main --basetemp=/tmp/pytest
+
+
+docs:
+	@# Kill any existing 'mkdocs serve' processes.
+	@pkill -f "mkdocs serve" 2>/dev/null || true
+	@# Build the documentation.
+	mkdocs build
+	@# Serve the documentation in the background.
+	mkdocs serve &
+	@echo "Documentation is being served in the background."
+	@echo "You can access the documentation at http://127.0.0.1:8000/"
+
+nodocs:
+	@# Kill any existing 'mkdocs serve' processes.
+	@pkill -f "mkdocs serve" 2>/dev/null || echo "No 'mkdocs serve' process found."
+	@echo "Stopped serving documentation."
+
+
+loc:
+	@echo "Lines in git-tracked files python files:"
+	@git ls-files | grep '\.py$$' | xargs cat | grep -v '^\s*$$' | wc -l
+
+.PHONY: repomix repomix-no-tests repomix-all
+
+repomix: ## Generate llms.txt and llms-compressed.txt (includes tests)
+	@echo "Generating llms.txt (with tests)..."
+	@git ls-files | repomix --stdin
+	@echo "Generating llms-compressed.txt..."
+	@git ls-files | repomix --stdin --compress -o llms-compressed.txt
+	@echo "Generated llms.txt and llms-compressed.txt"
+
+repomix-no-tests: ## Generate llms-no-tests.txt (excludes tests)
+	@echo "Generating llms-no-tests.txt (without tests)..."
+	@git ls-files | grep -v "^tests/" | repomix --stdin -o llms-no-tests.txt
+	@echo "Generating llms-no-tests-compressed.txt..."
+	@git ls-files | grep -v "^tests/" | repomix --stdin --compress -o llms-no-tests-compressed.txt
+	@echo "Generated llms-no-tests.txt and llms-no-tests-compressed.txt"
+
+repomix-no-tests-no-examples: ## Generate llms-no-tests-no-examples.txt (excludes tests and examples)
+	@echo "Generating llms-no-tests-no-examples.txt (without tests and examples)..."
+	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin -o llms-no-tests-no-examples.txt
+	@echo "Generating llms-no-tests-no-examples-compressed.txt..."
+	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin --compress -o llms-no-tests-no-examples-compressed.txt
+	@echo "Generated llms-no-tests-no-examples.txt and llms-no-tests-no-examples-compressed.txt"
+
+repomix-all: repomix repomix-no-tests repomix-no-tests-no-examples ## Generate all repomix variants
+
+.PHONY: check
+check: fix-pydantic lint type-check repomix-all
+
+.PHONY: revert-tag
+revert-tag:
+	@LATEST_TAG=$$(git describe --tags --abbrev=0) && \
+	echo "Deleting tag: $$LATEST_TAG" && \
+	git tag -d $$LATEST_TAG
+
+.PHONY: revert-bump
+revert-bump:
+	@if git log -1 --pretty=%B | grep -q "bump"; then \
+		git reset --hard HEAD~1; \
+		echo "Reverted last commit (bump commit)"; \
+	else \
+		echo "Last commit was not a bump commit"; \
+	fi
+
+.PHONY: revert
+revert: revert-bump revert-tag
+	
+.PHONY: bump-patch
+bump-patch:
+	@cz bump --increment PATCH
+
+.PHONY: bump-minor
+bump-minor:
+	@cz bump --increment MINOR 
+
+.PHONY: bump-major
+bump-major:
+	@cz bump --increment MAJOR 
+
+.PHONY: build
+build:
+	@uv build
+
+.PHONY: push
+push:
+	@git push origin main
+	@git push origin --tags
+
+.PHONY: clean
+clean:
+	-rm -rf dist/*
+
+.PHONY: release
+release:
+	@VERSION=$$(cz version -p | cut -d' ' -f2) && gh release create $${VERSION} dist/*
+
+.PHONY: all-patch
+all-patch: bump-patch clean build push release
+
+.PHONY: all-minor
+all-minor: bump-minor clean build push release
+
+.PHONY: all-major
+all-major: bump-major clean build push release
+
+.PHONY: publish
+publish:
+	uv publish
 </file>
 
 <file path="examples/mcp/any-mcp.py">
@@ -72830,6 +72961,593 @@ class DocChatAgent(ChatAgent):
         return None
 </file>
 
+<file path="langroid/agent/tools/mcp/fastmcp_client.py">
+import asyncio
+import datetime
+import logging
+from base64 import b64decode
+from io import BytesIO
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeAlias, cast
+
+from dotenv import load_dotenv
+from fastmcp.client import Client
+from fastmcp.client.roots import (
+    RootsHandler,
+    RootsList,
+)
+from fastmcp.client.sampling import SamplingHandler
+from fastmcp.client.transports import ClientTransport
+from fastmcp.server import FastMCP
+from mcp.client.session import (
+    LoggingFnT,
+    MessageHandlerFnT,
+)
+from mcp.types import (
+    BlobResourceContents,
+    CallToolResult,
+    EmbeddedResource,
+    ImageContent,
+    TextContent,
+    TextResourceContents,
+    Tool,
+)
+
+from langroid.agent.base import Agent
+from langroid.agent.chat_document import ChatDocument
+from langroid.agent.tool_message import ToolMessage
+from langroid.parsing.file_attachment import FileAttachment
+from langroid.pydantic_v1 import AnyUrl, BaseModel, Field, create_model
+
+load_dotenv()  # load environment variables from .env
+
+FastMCPServerSpec: TypeAlias = str | FastMCP[Any] | ClientTransport | AnyUrl
+
+
+class FastMCPClient:
+    """A client for interacting with a FastMCP server.
+
+    Provides async context manager functionality to safely manage resources.
+    """
+
+    logger = logging.getLogger(__name__)
+    _cm: Optional[Client] = None
+    client: Optional[Client] = None
+
+    def __init__(
+        self,
+        server: FastMCPServerSpec,
+        persist_connection: bool = False,
+        forward_images: bool = True,
+        forward_text_resources: bool = False,
+        forward_blob_resources: bool = False,
+        sampling_handler: SamplingHandler | None = None,  # type: ignore
+        roots: RootsList | RootsHandler | None = None,  # type: ignore
+        log_handler: LoggingFnT | None = None,
+        message_handler: MessageHandlerFnT | None = None,
+        read_timeout_seconds: datetime.timedelta | None = None,
+    ) -> None:
+        """Initialize the FastMCPClient.
+
+        Args:
+            server: FastMCP server or path to such a server
+        """
+        self.server = server
+        self.client = None
+        self._cm = None
+        self.sampling_handler = sampling_handler
+        self.roots = roots
+        self.log_handler = log_handler
+        self.message_handler = message_handler
+        self.read_timeout_seconds = read_timeout_seconds
+        self.persist_connection = persist_connection
+        self.forward_text_resources = forward_text_resources
+        self.forward_blob_resources = forward_blob_resources
+        self.forward_images = forward_images
+
+    async def __aenter__(self) -> "FastMCPClient":
+        """Enter the async context manager and connect inner client."""
+        # create inner client context manager
+        self._cm = Client(
+            self.server,
+            sampling_handler=self.sampling_handler,
+            roots=self.roots,
+            log_handler=self.log_handler,
+            message_handler=self.message_handler,
+            timeout=self.read_timeout_seconds,
+        )
+        # actually enter it (opens the session)
+        self.client = await self._cm.__aenter__()  # type: ignore
+        return self
+
+    async def connect(self) -> None:
+        """Open the underlying session."""
+        await self.__aenter__()
+
+    async def close(self) -> None:
+        """Close the underlying session."""
+        await self.__aexit__(None, None, None)
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[Exception]],
+        exc_val: Optional[Exception],
+        exc_tb: Optional[Any],
+    ) -> None:
+        """Exit the async context manager and close inner client."""
+        # exit and close the inner fastmcp.Client
+        if hasattr(self, "_cm"):
+            if self._cm is not None:
+                await self._cm.__aexit__(exc_type, exc_val, exc_tb)  # type: ignore
+        self.client = None
+        self._cm = None
+
+    def __del__(self) -> None:
+        """Warn about unclosed persistent connections."""
+        if self.client is not None and self.persist_connection:
+            import warnings
+
+            warnings.warn(
+                f"FastMCPClient with persist_connection=True was not properly closed. "
+                f"Connection to {self.server} may leak resources. "
+                f"Use 'async with' or call await client.close()",
+                ResourceWarning,
+                stacklevel=2,
+            )
+
+    def _schema_to_field(
+        self, name: str, schema: Dict[str, Any], prefix: str
+    ) -> Tuple[Any, Any]:
+        """Convert a JSON Schema snippet into a (type, Field) tuple.
+
+        Args:
+            name: Name of the field.
+            schema: JSON Schema for this field.
+            prefix: Prefix to use for nested model names.
+
+        Returns:
+            A tuple of (python_type, Field(...)) for create_model.
+        """
+        t = schema.get("type")
+        default = schema.get("default", ...)
+        desc = schema.get("description")
+        # Object → nested BaseModel
+        if t == "object" and "properties" in schema:
+            sub_name = f"{prefix}_{name.capitalize()}"
+            sub_fields: Dict[str, Tuple[type, Any]] = {}
+            for k, sub_s in schema["properties"].items():
+                ftype, fld = self._schema_to_field(sub_name + k, sub_s, sub_name)
+                sub_fields[k] = (ftype, fld)
+            submodel = create_model(  # type: ignore
+                sub_name,
+                __base__=BaseModel,
+                **sub_fields,
+            )
+            return submodel, Field(default=default, description=desc)  # type: ignore
+        # Array → List of items
+        if t == "array" and "items" in schema:
+            item_type, _ = self._schema_to_field(name, schema["items"], prefix)
+            return List[item_type], Field(default=default, description=desc)  # type: ignore
+        # Primitive types
+        if t == "string":
+            return str, Field(default=default, description=desc)
+        if t == "integer":
+            return int, Field(default=default, description=desc)
+        if t == "number":
+            return float, Field(default=default, description=desc)
+        if t == "boolean":
+            return bool, Field(default=default, description=desc)
+        # Fallback or unions
+        if any(key in schema for key in ("oneOf", "anyOf", "allOf")):
+            self.logger.warning("Unsupported union schema in field %s; using Any", name)
+            return Any, Field(default=default, description=desc)
+        # Default fallback
+        return Any, Field(default=default, description=desc)
+
+    async def get_tool_async(self, tool_name: str) -> Type[ToolMessage]:
+        """
+        Create a Langroid ToolMessage subclass from the MCP Tool
+        with the given `tool_name`.
+        """
+        if not self.client:
+            if self.persist_connection:
+                await self.connect()
+                assert self.client
+            else:
+                raise RuntimeError(
+                    "Client not initialized. Use async with FastMCPClient."
+                )
+        target = await self.get_mcp_tool_async(tool_name)
+        if target is None:
+            raise ValueError(f"No tool named {tool_name}")
+        props = target.inputSchema.get("properties", {})
+        fields: Dict[str, Tuple[type, Any]] = {}
+        for fname, schema in props.items():
+            ftype, fld = self._schema_to_field(fname, schema, target.name)
+            fields[fname] = (ftype, fld)
+
+        # Convert target.name to CamelCase and add Tool suffix
+        parts = target.name.replace("-", "_").split("_")
+        camel_case = "".join(part.capitalize() for part in parts)
+        model_name = f"{camel_case}Tool"
+
+        from langroid.agent.tool_message import ToolMessage as _BaseToolMessage
+
+        # IMPORTANT: Avoid clashes with reserved field names in Langroid ToolMessage!
+        # First figure out which field names are reserved
+        reserved = set(_BaseToolMessage.__annotations__.keys())
+        reserved.update(["recipient", "_handler", "name"])
+        renamed: Dict[str, str] = {}
+        new_fields: Dict[str, Tuple[type, Any]] = {}
+        for fname, (ftype, fld) in fields.items():
+            if fname in reserved:
+                new_name = fname + "__"
+                renamed[fname] = new_name
+                new_fields[new_name] = (ftype, fld)
+            else:
+                new_fields[fname] = (ftype, fld)
+        # now replace fields with our renamed‐aware mapping
+        fields = new_fields
+
+        # create Langroid ToolMessage subclass, with expected fields.
+        tool_model = cast(
+            Type[ToolMessage],
+            create_model(  # type: ignore[call-overload]
+                model_name,
+                request=(str, target.name),
+                purpose=(str, target.description or f"Use the tool {target.name}"),
+                __base__=ToolMessage,
+                **fields,
+            ),
+        )
+        # Store ALL client configuration needed to recreate a client
+        client_config = {
+            "server": self.server,
+            "sampling_handler": self.sampling_handler,
+            "roots": self.roots,
+            "log_handler": self.log_handler,
+            "message_handler": self.message_handler,
+            "read_timeout_seconds": self.read_timeout_seconds,
+        }
+
+        tool_model._client_config = client_config  # type: ignore [attr-defined]
+        tool_model._renamed_fields = renamed  # type: ignore[attr-defined]
+
+        # 2) define an arg-free call_tool_async()
+        async def call_tool_async(itself: ToolMessage) -> Any:
+            from langroid.agent.tools.mcp.fastmcp_client import FastMCPClient
+
+            # pack up the payload
+            payload = itself.dict(
+                exclude=itself.Config.schema_extra["exclude"].union(
+                    ["request", "purpose"]
+                ),
+            )
+
+            # restore any renamed fields
+            for orig, new in itself.__class__._renamed_fields.items():  # type: ignore
+                if new in payload:
+                    payload[orig] = payload.pop(new)
+
+            client_cfg = getattr(itself.__class__, "_client_config", None)  # type: ignore
+            if not client_cfg:
+                # Fallback or error - ideally _client_config should always exist
+                raise RuntimeError(f"Client config missing on {itself.__class__}")
+
+            # Connect the client if not yet connected and keep the connection open
+            if self.persist_connection:
+                if not self.client:
+                    await self.connect()
+
+                return await self.call_mcp_tool(itself.request, payload)
+
+            # open a fresh client, call the tool, then close
+            async with FastMCPClient(**client_cfg) as client:  # type: ignore
+                return await client.call_mcp_tool(itself.request, payload)
+
+        tool_model.call_tool_async = call_tool_async  # type: ignore
+
+        if not hasattr(tool_model, "handle_async"):
+            # 3) define handle_async() method with optional agent parameter
+            from typing import Union
+
+            async def handle_async(
+                self: ToolMessage, agent: Optional[Agent] = None
+            ) -> Union[str, Optional[ChatDocument]]:
+                """
+                Auto-generated handler for MCP tool. Returns ChatDocument with files
+                if files are present and agent is provided, otherwise returns text.
+
+                To override: define your own handle_async method with matching signature
+                if you need file handling, or simpler signature if you only need text.
+                """
+                response = await self.call_tool_async()  # type: ignore[attr-defined]
+                if response is None:
+                    return None
+
+                content, files = response
+
+                # If we have files and an agent is provided, return a ChatDocument
+                if files and agent is not None:
+                    return agent.create_agent_response(
+                        content=content,
+                        files=files,
+                    )
+                else:
+                    # Otherwise, just return the text content
+                    return str(content) if content is not None else None
+
+            # add the handle_async() method to the tool model
+            tool_model.handle_async = handle_async  # type: ignore
+
+        return tool_model
+
+    async def get_tools_async(self) -> List[Type[ToolMessage]]:
+        """
+        Get all available tools as Langroid ToolMessage classes,
+        handling nested schemas, with `handle_async` methods
+        """
+        if not self.client:
+            if self.persist_connection:
+                await self.connect()
+                assert self.client
+            else:
+                raise RuntimeError(
+                    "Client not initialized. Use async with FastMCPClient."
+                )
+        resp = await self.client.list_tools()
+        return [await self.get_tool_async(t.name) for t in resp]
+
+    async def get_mcp_tool_async(self, name: str) -> Optional[Tool]:
+        """Find the "original" MCP Tool (i.e. of type mcp.types.Tool) on the server
+         matching `name`, or None if missing. This contains the metadata for the tool:
+         name, description, inputSchema, etc.
+
+        Args:
+            name: Name of the tool to look up.
+
+        Returns:
+            The raw Tool object from the server, or None.
+        """
+        if not self.client:
+            if self.persist_connection:
+                await self.connect()
+                assert self.client
+            else:
+                raise RuntimeError(
+                    "Client not initialized. Use async with FastMCPClient."
+                )
+        resp: List[Tool] = await self.client.list_tools()
+        return next((t for t in resp if t.name == name), None)
+
+    def _convert_tool_result(
+        self,
+        tool_name: str,
+        result: CallToolResult,
+    ) -> Optional[str | tuple[str, list[FileAttachment]]]:
+        if result.isError:
+            # Log more detailed error information
+            error_content = None
+            if result.content and len(result.content) > 0:
+                try:
+                    error_content = [
+                        item.text if hasattr(item, "text") else str(item)
+                        for item in result.content
+                    ]
+                except Exception as e:
+                    error_content = [f"Could not extract error content: {str(e)}"]
+
+            self.logger.error(
+                f"Error calling MCP tool {tool_name}. Details: {error_content}"
+            )
+            return f"ERROR: Tool call failed - {error_content}"
+
+        results_text = [
+            item.text for item in result.content if isinstance(item, TextContent)
+        ]
+        results_file = []
+
+        for item in result.content:
+            if isinstance(item, ImageContent) and self.forward_images:
+                results_file.append(
+                    FileAttachment.from_bytes(
+                        b64decode(item.data),
+                        mime_type=item.mimeType,
+                    )
+                )
+            elif isinstance(item, EmbeddedResource):
+                if (
+                    isinstance(item.resource, TextResourceContents)
+                    and self.forward_text_resources
+                ):
+                    results_text.append(item.resource.text)
+                elif (
+                    isinstance(item.resource, BlobResourceContents)
+                    and self.forward_blob_resources
+                ):
+                    results_file.append(
+                        FileAttachment.from_io(
+                            BytesIO(b64decode(item.resource.blob)),
+                            mime_type=item.resource.mimeType,
+                        )
+                    )
+
+        return "\n".join(results_text), results_file
+
+    async def call_mcp_tool(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> Optional[tuple[str, list[FileAttachment]]]:
+        """Call an MCP tool with the given arguments.
+
+        Args:
+            tool_name: Name of the tool to call.
+            arguments: Arguments to pass to the tool.
+
+        Returns:
+            The result of the tool call.
+        """
+        if not self.client:
+            if self.persist_connection:
+                await self.connect()
+                assert self.client
+            else:
+                raise RuntimeError(
+                    "Client not initialized. Use async with FastMCPClient."
+                )
+        result: CallToolResult = await self.client.session.call_tool(
+            tool_name,
+            arguments,
+        )
+        results = self._convert_tool_result(tool_name, result)
+
+        if isinstance(results, str):
+            return results, []
+
+        return results
+
+
+# ==============================================================================
+# Convenience functions (wrappers around FastMCPClient methods)
+# These are useful for one-off calls without needing to manage the
+# FastMCPClient context explicitly.
+# ==============================================================================
+
+
+async def get_tool_async(
+    server: FastMCPServerSpec,
+    tool_name: str,
+    **client_kwargs: Any,
+) -> Type[ToolMessage]:
+    """Get a single Langroid ToolMessage subclass for a specific MCP tool name (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        tool_name: The name of the tool to retrieve.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A dynamically created Langroid ToolMessage subclass representing the
+        requested tool.
+    """
+    async with FastMCPClient(server, **client_kwargs) as client:
+        return await client.get_tool_async(tool_name)
+
+
+def get_tool(
+    server: FastMCPServerSpec,
+    tool_name: str,
+    **client_kwargs: Any,
+) -> Type[ToolMessage]:
+    """Get a single Langroid ToolMessage subclass
+    for a specific MCP tool name (synchronous).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
+    async `get_tool_async` function using `asyncio.run()`.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        tool_name: The name of the tool to retrieve.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A dynamically created Langroid ToolMessage subclass representing the
+        requested tool.
+    """
+    return asyncio.run(get_tool_async(server, tool_name, **client_kwargs))
+
+
+async def get_tools_async(
+    server: FastMCPServerSpec,
+    **client_kwargs: Any,
+) -> List[Type[ToolMessage]]:
+    """Get all available tools as Langroid ToolMessage subclasses (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A list of dynamically created Langroid ToolMessage subclasses
+        representing all available tools on the server.
+    """
+    async with FastMCPClient(server, **client_kwargs) as client:
+        return await client.get_tools_async()
+
+
+def get_tools(
+    server: FastMCPServerSpec,
+    **client_kwargs: Any,
+) -> List[Type[ToolMessage]]:
+    """Get all available tools as Langroid ToolMessage subclasses (synchronous).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
+    async `get_tools_async` function using `asyncio.run()`.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A list of dynamically created Langroid ToolMessage subclasses
+        representing all available tools on the server.
+    """
+    return asyncio.run(get_tools_async(server, **client_kwargs))
+
+
+async def get_mcp_tool_async(
+    server: FastMCPServerSpec,
+    name: str,
+    **client_kwargs: Any,
+) -> Optional[Tool]:
+    """Get the raw MCP Tool object for a specific tool name (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient to
+    retrieve the tool definition from the server.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        name: The name of the tool to look up.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor.
+
+    Returns:
+        The raw `mcp.types.Tool` object from the server, or `None` if the tool
+        is not found.
+    """
+    async with FastMCPClient(server, **client_kwargs) as client:
+        return await client.get_mcp_tool_async(name)
+
+
+async def get_mcp_tools_async(
+    server: FastMCPServerSpec,
+    **client_kwargs: Any,
+) -> List[Tool]:
+    """Get all available raw MCP Tool objects from the server (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient to
+    retrieve the list of tool definitions from the server.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor.
+
+    Returns:
+        A list of raw `mcp.types.Tool` objects available on the server.
+    """
+    async with FastMCPClient(server, **client_kwargs) as client:
+        if not client.client:
+            raise RuntimeError("Client not initialized. Use async with FastMCPClient.")
+        return await client.client.list_tools()
+</file>
+
 <file path="langroid/agent/tools/task_tool.py">
 """
 TaskTool: A tool that allows agents to delegate a task to a sub-agent with
@@ -72871,10 +73589,13 @@ class TaskTool(ToolMessage):
     system_message: Optional[str] = Field(
         ...,
         description="""
-        Optional system message to configure the sub-agent's general behavior.
+        Optional system message to configure the sub-agent's general behavior and 
+        to specify the task and its context.
             A good system message will have these components:
             - Inform the sub-agent of its role, e.g. "You are a financial analyst."
-            - Clear spec of the task
+            - Clear spec of the task, with sufficient context for the sub-agent to 
+              understand what it needs to do, since the sub-agent does 
+              NOT have access to your conversation history!
             - Any additional general context needed for the task, such as a
               (part of a) document, or data items, etc.
             - Specify when to use certain tools, e.g. 
@@ -72906,9 +73627,10 @@ class TaskTool(ToolMessage):
         A list of tool names to enable for the sub-agent.
         This must be a list of strings referring to the names of tools
         that are known to you. 
-        If you want to enable all tools, you can set this field
-         to a singleton list containing 'ALL'
-        To disable all tools, set it to a singleton list containing 'NONE'
+        If you want to enable all tools, or you do not have any preference
+        on what tools are enabled for the sub-agent, you can set 
+        this field to a singleton list ['ALL']
+        To disable all tools, set it to a singleton list ['NONE']
         """,
     )
     # TODO: ensure valid model name
@@ -72946,11 +73668,20 @@ class TaskTool(ToolMessage):
         # TODO: Maybe we just copy the parent agent's config and override chat_model?
         #   -- but what if parent agent has a MockLMConfig?
         llm_config = lm.OpenAIGPTConfig(
-            chat_model=self.model or "gpt-4.1-mini",  # Default model if not specified
+            chat_model=self.model or lm.OpenAIChatModel.GPT4_1_MINI,
         )
         config = ChatAgentConfig(
             name=agent_name,
             llm=llm_config,
+            handle_llm_no_tool=f"""
+                You forgot to use one of your TOOLs! Remember that you must either:
+                - use a tool, or a sequence of tools, to complete your task, OR
+                - if you are done with your task, use the `{DoneTool.name()}` tool
+                to return the result.
+                
+                As a reminder, this was your task:
+                {self.prompt}
+                """,
             system_message=f"""
                 {self.system_message}
                 
@@ -72971,7 +73702,9 @@ class TaskTool(ToolMessage):
             tool_classes = [
                 agent.llm_tools_map[t]
                 for t in agent.llm_tools_known
-                if t in agent.llm_tools_map and t != self.request
+                if t in agent.llm_tools_map
+                and t != self.request
+                and agent.llm_tools_map[t]._allow_llm_use
                 # Exclude the TaskTool itself!
             ]
         elif self.tools == ["NONE"]:
@@ -72983,6 +73716,7 @@ class TaskTool(ToolMessage):
                 agent.llm_tools_map[tool_name]
                 for tool_name in self.tools
                 if tool_name in agent.llm_tools_map
+                and agent.llm_tools_map[tool_name]._allow_llm_use
             ]
 
         # always enable the DoneTool to signal task completion
@@ -72993,7 +73727,9 @@ class TaskTool(ToolMessage):
 
         return task
 
-    def handle(self, agent: ChatAgent) -> Optional[ChatDocument]:
+    def handle(
+        self, agent: ChatAgent, chat_doc: Optional[ChatDocument] = None
+    ) -> Optional[ChatDocument]:
         """
 
         Handle the TaskTool by creating a sub-agent with specified tools
@@ -73001,26 +73737,66 @@ class TaskTool(ToolMessage):
 
         Args:
             agent: The parent ChatAgent that is handling this tool
+            chat_doc: The ChatDocument containing this tool message
         """
 
         task = self._set_up_task(agent)
-        # Run the task on the prompt, and return the result
-        result = task.run(self.prompt, turns=self.max_iterations or 10)
+
+        # Create a ChatDocument for the prompt with parent pointer
+        prompt_doc = None
+        if chat_doc is not None:
+            from langroid.agent.chat_document import ChatDocMetaData
+
+            prompt_doc = ChatDocument(
+                content=self.prompt,
+                metadata=ChatDocMetaData(
+                    parent_id=chat_doc.id(),
+                    agent_id=agent.id,
+                    sender=chat_doc.metadata.sender,
+                ),
+            )
+            # Set bidirectional parent-child relationship
+            chat_doc.metadata.child_id = prompt_doc.id()
+
+        # Run the task with the ChatDocument or string prompt
+        result = task.run(prompt_doc or self.prompt, turns=self.max_iterations or 10)
         return result
 
-    async def handle_async(self, agent: ChatAgent) -> Optional[ChatDocument]:
+    async def handle_async(
+        self, agent: ChatAgent, chat_doc: Optional[ChatDocument] = None
+    ) -> Optional[ChatDocument]:
         """
         Async method to handle the TaskTool by creating a sub-agent with specified tools
         and running the task non-interactively.
 
         Args:
             agent: The parent ChatAgent that is handling this tool
+            chat_doc: The ChatDocument containing this tool message
         """
         task = self._set_up_task(agent)
-        # Run the task on the prompt, and return the result
+
+        # Create a ChatDocument for the prompt with parent pointer
+        prompt_doc = None
+        if chat_doc is not None:
+            from langroid.agent.chat_document import ChatDocMetaData
+
+            prompt_doc = ChatDocument(
+                content=self.prompt,
+                metadata=ChatDocMetaData(
+                    parent_id=chat_doc.id(),
+                    agent_id=agent.id,
+                    sender=chat_doc.metadata.sender,
+                ),
+            )
+            # Set bidirectional parent-child relationship
+            chat_doc.metadata.child_id = prompt_doc.id()
+
+        # Run the task with the ChatDocument or string prompt
         # TODO eventually allow the various task setup configs,
         #  including termination conditions
-        result = await task.run_async(self.prompt, turns=self.max_iterations or 10)
+        result = await task.run_async(
+            prompt_doc or self.prompt, turns=self.max_iterations or 10
+        )
         return result
 </file>
 
@@ -73642,7 +74418,10 @@ class Task:
             if isinstance(msg, ChatDocument):
                 # carefully deep-copy: fresh metadata.id, register
                 # as new obj in registry
+                original_parent_id = msg.metadata.parent_id
                 self.pending_message = ChatDocument.deepcopy(msg)
+                # Preserve the parent pointer from the original message
+                self.pending_message.metadata.parent_id = original_parent_id
             if self.pending_message is not None and self.caller is not None:
                 # msg may have come from `caller`, so we pretend this is from
                 # the CURRENT task's USER entity
@@ -73650,7 +74429,11 @@ class Task:
                 # update parent, child, agent pointers
                 if msg is not None:
                     msg.metadata.child_id = self.pending_message.metadata.id
-                    self.pending_message.metadata.parent_id = msg.metadata.id
+                    # Only override parent_id if it wasn't already set in the
+                    # original message. This preserves parent chains from TaskTool
+                    if not msg.metadata.parent_id:
+                        self.pending_message.metadata.parent_id = msg.metadata.id
+            if self.pending_message is not None:
                 self.pending_message.metadata.agent_id = self.agent.id
 
         self._show_pending_message_if_debug()
@@ -75277,24 +76060,33 @@ class Task:
     def _get_message_chain(
         self, msg: ChatDocument | None, max_depth: Optional[int] = None
     ) -> List[ChatDocument]:
-        """Get the chain of messages by following parent pointers."""
+        """Get the chain of messages using agent's message history."""
         if max_depth is None:
             # Get max depth needed from all sequences
             max_depth = 50  # default fallback
             if self._parsed_done_sequences:
                 max_depth = max(len(seq.events) for seq in self._parsed_done_sequences)
 
-        chain = []
-        current = msg
-        depth = 0
+        # Get chat document IDs from message history
+        doc_ids = [
+            m.chat_document_id for m in self.agent.message_history if m.chat_document_id
+        ]
 
-        while current is not None and depth < max_depth:
-            chain.append(current)
-            current = current.parent
-            depth += 1
+        # Add current message ID if it exists and is not already the last one
+        if msg:
+            msg_id = msg.id()
+            if not doc_ids or doc_ids[-1] != msg_id:
+                doc_ids.append(msg_id)
 
-        # Reverse to get chronological order (oldest first)
-        return list(reversed(chain))
+        # Take only the last max_depth elements
+        relevant_ids = doc_ids[-max_depth:]
+
+        # Convert IDs to ChatDocuments and filter out None values
+        return [
+            doc
+            for doc_id in relevant_ids
+            if (doc := ChatDocument.from_id(doc_id)) is not None
+        ]
 
     def _matches_event(self, actual: AgentEvent, expected: AgentEvent) -> bool:
         """Check if an actual event matches an expected event pattern."""
@@ -76899,593 +77691,6 @@ if __name__ == "__main__":
     Fire(main)
 </file>
 
-<file path="langroid/agent/tools/mcp/fastmcp_client.py">
-import asyncio
-import datetime
-import logging
-from base64 import b64decode
-from io import BytesIO
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeAlias, cast
-
-from dotenv import load_dotenv
-from fastmcp.client import Client
-from fastmcp.client.roots import (
-    RootsHandler,
-    RootsList,
-)
-from fastmcp.client.sampling import SamplingHandler
-from fastmcp.client.transports import ClientTransport
-from fastmcp.server import FastMCP
-from mcp.client.session import (
-    LoggingFnT,
-    MessageHandlerFnT,
-)
-from mcp.types import (
-    BlobResourceContents,
-    CallToolResult,
-    EmbeddedResource,
-    ImageContent,
-    TextContent,
-    TextResourceContents,
-    Tool,
-)
-
-from langroid.agent.base import Agent
-from langroid.agent.chat_document import ChatDocument
-from langroid.agent.tool_message import ToolMessage
-from langroid.parsing.file_attachment import FileAttachment
-from langroid.pydantic_v1 import AnyUrl, BaseModel, Field, create_model
-
-load_dotenv()  # load environment variables from .env
-
-FastMCPServerSpec: TypeAlias = str | FastMCP[Any] | ClientTransport | AnyUrl
-
-
-class FastMCPClient:
-    """A client for interacting with a FastMCP server.
-
-    Provides async context manager functionality to safely manage resources.
-    """
-
-    logger = logging.getLogger(__name__)
-    _cm: Optional[Client] = None
-    client: Optional[Client] = None
-
-    def __init__(
-        self,
-        server: FastMCPServerSpec,
-        persist_connection: bool = False,
-        forward_images: bool = True,
-        forward_text_resources: bool = False,
-        forward_blob_resources: bool = False,
-        sampling_handler: SamplingHandler | None = None,  # type: ignore
-        roots: RootsList | RootsHandler | None = None,  # type: ignore
-        log_handler: LoggingFnT | None = None,
-        message_handler: MessageHandlerFnT | None = None,
-        read_timeout_seconds: datetime.timedelta | None = None,
-    ) -> None:
-        """Initialize the FastMCPClient.
-
-        Args:
-            server: FastMCP server or path to such a server
-        """
-        self.server = server
-        self.client = None
-        self._cm = None
-        self.sampling_handler = sampling_handler
-        self.roots = roots
-        self.log_handler = log_handler
-        self.message_handler = message_handler
-        self.read_timeout_seconds = read_timeout_seconds
-        self.persist_connection = persist_connection
-        self.forward_text_resources = forward_text_resources
-        self.forward_blob_resources = forward_blob_resources
-        self.forward_images = forward_images
-
-    async def __aenter__(self) -> "FastMCPClient":
-        """Enter the async context manager and connect inner client."""
-        # create inner client context manager
-        self._cm = Client(
-            self.server,
-            sampling_handler=self.sampling_handler,
-            roots=self.roots,
-            log_handler=self.log_handler,
-            message_handler=self.message_handler,
-            timeout=self.read_timeout_seconds,
-        )
-        # actually enter it (opens the session)
-        self.client = await self._cm.__aenter__()  # type: ignore
-        return self
-
-    async def connect(self) -> None:
-        """Open the underlying session."""
-        await self.__aenter__()
-
-    async def close(self) -> None:
-        """Close the underlying session."""
-        await self.__aexit__(None, None, None)
-
-    async def __aexit__(
-        self,
-        exc_type: Optional[type[Exception]],
-        exc_val: Optional[Exception],
-        exc_tb: Optional[Any],
-    ) -> None:
-        """Exit the async context manager and close inner client."""
-        # exit and close the inner fastmcp.Client
-        if hasattr(self, "_cm"):
-            if self._cm is not None:
-                await self._cm.__aexit__(exc_type, exc_val, exc_tb)  # type: ignore
-        self.client = None
-        self._cm = None
-
-    def __del__(self) -> None:
-        """Warn about unclosed persistent connections."""
-        if self.client is not None and self.persist_connection:
-            import warnings
-
-            warnings.warn(
-                f"FastMCPClient with persist_connection=True was not properly closed. "
-                f"Connection to {self.server} may leak resources. "
-                f"Use 'async with' or call await client.close()",
-                ResourceWarning,
-                stacklevel=2,
-            )
-
-    def _schema_to_field(
-        self, name: str, schema: Dict[str, Any], prefix: str
-    ) -> Tuple[Any, Any]:
-        """Convert a JSON Schema snippet into a (type, Field) tuple.
-
-        Args:
-            name: Name of the field.
-            schema: JSON Schema for this field.
-            prefix: Prefix to use for nested model names.
-
-        Returns:
-            A tuple of (python_type, Field(...)) for create_model.
-        """
-        t = schema.get("type")
-        default = schema.get("default", ...)
-        desc = schema.get("description")
-        # Object → nested BaseModel
-        if t == "object" and "properties" in schema:
-            sub_name = f"{prefix}_{name.capitalize()}"
-            sub_fields: Dict[str, Tuple[type, Any]] = {}
-            for k, sub_s in schema["properties"].items():
-                ftype, fld = self._schema_to_field(sub_name + k, sub_s, sub_name)
-                sub_fields[k] = (ftype, fld)
-            submodel = create_model(  # type: ignore
-                sub_name,
-                __base__=BaseModel,
-                **sub_fields,
-            )
-            return submodel, Field(default=default, description=desc)  # type: ignore
-        # Array → List of items
-        if t == "array" and "items" in schema:
-            item_type, _ = self._schema_to_field(name, schema["items"], prefix)
-            return List[item_type], Field(default=default, description=desc)  # type: ignore
-        # Primitive types
-        if t == "string":
-            return str, Field(default=default, description=desc)
-        if t == "integer":
-            return int, Field(default=default, description=desc)
-        if t == "number":
-            return float, Field(default=default, description=desc)
-        if t == "boolean":
-            return bool, Field(default=default, description=desc)
-        # Fallback or unions
-        if any(key in schema for key in ("oneOf", "anyOf", "allOf")):
-            self.logger.warning("Unsupported union schema in field %s; using Any", name)
-            return Any, Field(default=default, description=desc)
-        # Default fallback
-        return Any, Field(default=default, description=desc)
-
-    async def get_tool_async(self, tool_name: str) -> Type[ToolMessage]:
-        """
-        Create a Langroid ToolMessage subclass from the MCP Tool
-        with the given `tool_name`.
-        """
-        if not self.client:
-            if self.persist_connection:
-                await self.connect()
-                assert self.client
-            else:
-                raise RuntimeError(
-                    "Client not initialized. Use async with FastMCPClient."
-                )
-        target = await self.get_mcp_tool_async(tool_name)
-        if target is None:
-            raise ValueError(f"No tool named {tool_name}")
-        props = target.inputSchema.get("properties", {})
-        fields: Dict[str, Tuple[type, Any]] = {}
-        for fname, schema in props.items():
-            ftype, fld = self._schema_to_field(fname, schema, target.name)
-            fields[fname] = (ftype, fld)
-
-        # Convert target.name to CamelCase and add Tool suffix
-        parts = target.name.replace("-", "_").split("_")
-        camel_case = "".join(part.capitalize() for part in parts)
-        model_name = f"{camel_case}Tool"
-
-        from langroid.agent.tool_message import ToolMessage as _BaseToolMessage
-
-        # IMPORTANT: Avoid clashes with reserved field names in Langroid ToolMessage!
-        # First figure out which field names are reserved
-        reserved = set(_BaseToolMessage.__annotations__.keys())
-        reserved.update(["recipient", "_handler", "name"])
-        renamed: Dict[str, str] = {}
-        new_fields: Dict[str, Tuple[type, Any]] = {}
-        for fname, (ftype, fld) in fields.items():
-            if fname in reserved:
-                new_name = fname + "__"
-                renamed[fname] = new_name
-                new_fields[new_name] = (ftype, fld)
-            else:
-                new_fields[fname] = (ftype, fld)
-        # now replace fields with our renamed‐aware mapping
-        fields = new_fields
-
-        # create Langroid ToolMessage subclass, with expected fields.
-        tool_model = cast(
-            Type[ToolMessage],
-            create_model(  # type: ignore[call-overload]
-                model_name,
-                request=(str, target.name),
-                purpose=(str, target.description or f"Use the tool {target.name}"),
-                __base__=ToolMessage,
-                **fields,
-            ),
-        )
-        # Store ALL client configuration needed to recreate a client
-        client_config = {
-            "server": self.server,
-            "sampling_handler": self.sampling_handler,
-            "roots": self.roots,
-            "log_handler": self.log_handler,
-            "message_handler": self.message_handler,
-            "read_timeout_seconds": self.read_timeout_seconds,
-        }
-
-        tool_model._client_config = client_config  # type: ignore [attr-defined]
-        tool_model._renamed_fields = renamed  # type: ignore[attr-defined]
-
-        # 2) define an arg-free call_tool_async()
-        async def call_tool_async(itself: ToolMessage) -> Any:
-            from langroid.agent.tools.mcp.fastmcp_client import FastMCPClient
-
-            # pack up the payload
-            payload = itself.dict(
-                exclude=itself.Config.schema_extra["exclude"].union(
-                    ["request", "purpose"]
-                ),
-            )
-
-            # restore any renamed fields
-            for orig, new in itself.__class__._renamed_fields.items():  # type: ignore
-                if new in payload:
-                    payload[orig] = payload.pop(new)
-
-            client_cfg = getattr(itself.__class__, "_client_config", None)  # type: ignore
-            if not client_cfg:
-                # Fallback or error - ideally _client_config should always exist
-                raise RuntimeError(f"Client config missing on {itself.__class__}")
-
-            # Connect the client if not yet connected and keep the connection open
-            if self.persist_connection:
-                if not self.client:
-                    await self.connect()
-
-                return await self.call_mcp_tool(itself.request, payload)
-
-            # open a fresh client, call the tool, then close
-            async with FastMCPClient(**client_cfg) as client:  # type: ignore
-                return await client.call_mcp_tool(itself.request, payload)
-
-        tool_model.call_tool_async = call_tool_async  # type: ignore
-
-        if not hasattr(tool_model, "handle_async"):
-            # 3) define handle_async() method with optional agent parameter
-            from typing import Union
-
-            async def handle_async(
-                self: ToolMessage, agent: Optional[Agent] = None
-            ) -> Union[str, Optional[ChatDocument]]:
-                """
-                Auto-generated handler for MCP tool. Returns ChatDocument with files
-                if files are present and agent is provided, otherwise returns text.
-
-                To override: define your own handle_async method with matching signature
-                if you need file handling, or simpler signature if you only need text.
-                """
-                response = await self.call_tool_async()  # type: ignore[attr-defined]
-                if response is None:
-                    return None
-
-                content, files = response
-
-                # If we have files and an agent is provided, return a ChatDocument
-                if files and agent is not None:
-                    return agent.create_agent_response(
-                        content=content,
-                        files=files,
-                    )
-                else:
-                    # Otherwise, just return the text content
-                    return str(content) if content is not None else None
-
-            # add the handle_async() method to the tool model
-            tool_model.handle_async = handle_async  # type: ignore
-
-        return tool_model
-
-    async def get_tools_async(self) -> List[Type[ToolMessage]]:
-        """
-        Get all available tools as Langroid ToolMessage classes,
-        handling nested schemas, with `handle_async` methods
-        """
-        if not self.client:
-            if self.persist_connection:
-                await self.connect()
-                assert self.client
-            else:
-                raise RuntimeError(
-                    "Client not initialized. Use async with FastMCPClient."
-                )
-        resp = await self.client.list_tools()
-        return [await self.get_tool_async(t.name) for t in resp]
-
-    async def get_mcp_tool_async(self, name: str) -> Optional[Tool]:
-        """Find the "original" MCP Tool (i.e. of type mcp.types.Tool) on the server
-         matching `name`, or None if missing. This contains the metadata for the tool:
-         name, description, inputSchema, etc.
-
-        Args:
-            name: Name of the tool to look up.
-
-        Returns:
-            The raw Tool object from the server, or None.
-        """
-        if not self.client:
-            if self.persist_connection:
-                await self.connect()
-                assert self.client
-            else:
-                raise RuntimeError(
-                    "Client not initialized. Use async with FastMCPClient."
-                )
-        resp: List[Tool] = await self.client.list_tools()
-        return next((t for t in resp if t.name == name), None)
-
-    def _convert_tool_result(
-        self,
-        tool_name: str,
-        result: CallToolResult,
-    ) -> Optional[str | tuple[str, list[FileAttachment]]]:
-        if result.isError:
-            # Log more detailed error information
-            error_content = None
-            if result.content and len(result.content) > 0:
-                try:
-                    error_content = [
-                        item.text if hasattr(item, "text") else str(item)
-                        for item in result.content
-                    ]
-                except Exception as e:
-                    error_content = [f"Could not extract error content: {str(e)}"]
-
-            self.logger.error(
-                f"Error calling MCP tool {tool_name}. Details: {error_content}"
-            )
-            return f"ERROR: Tool call failed - {error_content}"
-
-        results_text = [
-            item.text for item in result.content if isinstance(item, TextContent)
-        ]
-        results_file = []
-
-        for item in result.content:
-            if isinstance(item, ImageContent) and self.forward_images:
-                results_file.append(
-                    FileAttachment.from_bytes(
-                        b64decode(item.data),
-                        mime_type=item.mimeType,
-                    )
-                )
-            elif isinstance(item, EmbeddedResource):
-                if (
-                    isinstance(item.resource, TextResourceContents)
-                    and self.forward_text_resources
-                ):
-                    results_text.append(item.resource.text)
-                elif (
-                    isinstance(item.resource, BlobResourceContents)
-                    and self.forward_blob_resources
-                ):
-                    results_file.append(
-                        FileAttachment.from_io(
-                            BytesIO(b64decode(item.resource.blob)),
-                            mime_type=item.resource.mimeType,
-                        )
-                    )
-
-        return "\n".join(results_text), results_file
-
-    async def call_mcp_tool(
-        self, tool_name: str, arguments: Dict[str, Any]
-    ) -> Optional[tuple[str, list[FileAttachment]]]:
-        """Call an MCP tool with the given arguments.
-
-        Args:
-            tool_name: Name of the tool to call.
-            arguments: Arguments to pass to the tool.
-
-        Returns:
-            The result of the tool call.
-        """
-        if not self.client:
-            if self.persist_connection:
-                await self.connect()
-                assert self.client
-            else:
-                raise RuntimeError(
-                    "Client not initialized. Use async with FastMCPClient."
-                )
-        result: CallToolResult = await self.client.session.call_tool(
-            tool_name,
-            arguments,
-        )
-        results = self._convert_tool_result(tool_name, result)
-
-        if isinstance(results, str):
-            return results, []
-
-        return results
-
-
-# ==============================================================================
-# Convenience functions (wrappers around FastMCPClient methods)
-# These are useful for one-off calls without needing to manage the
-# FastMCPClient context explicitly.
-# ==============================================================================
-
-
-async def get_tool_async(
-    server: FastMCPServerSpec,
-    tool_name: str,
-    **client_kwargs: Any,
-) -> Type[ToolMessage]:
-    """Get a single Langroid ToolMessage subclass for a specific MCP tool name (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        tool_name: The name of the tool to retrieve.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A dynamically created Langroid ToolMessage subclass representing the
-        requested tool.
-    """
-    async with FastMCPClient(server, **client_kwargs) as client:
-        return await client.get_tool_async(tool_name)
-
-
-def get_tool(
-    server: FastMCPServerSpec,
-    tool_name: str,
-    **client_kwargs: Any,
-) -> Type[ToolMessage]:
-    """Get a single Langroid ToolMessage subclass
-    for a specific MCP tool name (synchronous).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
-    async `get_tool_async` function using `asyncio.run()`.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        tool_name: The name of the tool to retrieve.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A dynamically created Langroid ToolMessage subclass representing the
-        requested tool.
-    """
-    return asyncio.run(get_tool_async(server, tool_name, **client_kwargs))
-
-
-async def get_tools_async(
-    server: FastMCPServerSpec,
-    **client_kwargs: Any,
-) -> List[Type[ToolMessage]]:
-    """Get all available tools as Langroid ToolMessage subclasses (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A list of dynamically created Langroid ToolMessage subclasses
-        representing all available tools on the server.
-    """
-    async with FastMCPClient(server, **client_kwargs) as client:
-        return await client.get_tools_async()
-
-
-def get_tools(
-    server: FastMCPServerSpec,
-    **client_kwargs: Any,
-) -> List[Type[ToolMessage]]:
-    """Get all available tools as Langroid ToolMessage subclasses (synchronous).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
-    async `get_tools_async` function using `asyncio.run()`.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A list of dynamically created Langroid ToolMessage subclasses
-        representing all available tools on the server.
-    """
-    return asyncio.run(get_tools_async(server, **client_kwargs))
-
-
-async def get_mcp_tool_async(
-    server: FastMCPServerSpec,
-    name: str,
-    **client_kwargs: Any,
-) -> Optional[Tool]:
-    """Get the raw MCP Tool object for a specific tool name (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient to
-    retrieve the tool definition from the server.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        name: The name of the tool to look up.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor.
-
-    Returns:
-        The raw `mcp.types.Tool` object from the server, or `None` if the tool
-        is not found.
-    """
-    async with FastMCPClient(server, **client_kwargs) as client:
-        return await client.get_mcp_tool_async(name)
-
-
-async def get_mcp_tools_async(
-    server: FastMCPServerSpec,
-    **client_kwargs: Any,
-) -> List[Tool]:
-    """Get all available raw MCP Tool objects from the server (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient to
-    retrieve the list of tool definitions from the server.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor.
-
-    Returns:
-        A list of raw `mcp.types.Tool` objects available on the server.
-    """
-    async with FastMCPClient(server, **client_kwargs) as client:
-        if not client.client:
-            raise RuntimeError("Client not initialized. Use async with FastMCPClient.")
-        return await client.client.list_tools()
-</file>
-
 <file path="langroid/agent/base.py">
 import asyncio
 import copy
@@ -77626,6 +77831,7 @@ class Agent(ABC):
 
     def __init__(self, config: AgentConfig = AgentConfig()):
         self.config = config
+        self.id = ObjectRegistry.new_id()  # Initialize agent ID
         self.lock = asyncio.Lock()  # for async access to update self.llm.usage_cost
         self.dialog: List[Tuple[str, str]] = []  # seq of LLM (prompt, response) tuples
         self.llm_tools_map: Dict[str, Type[ToolMessage]] = {}
@@ -78174,6 +78380,7 @@ class Agent(ABC):
             results.metadata.tool_ids = (
                 [] if msg is None or isinstance(msg, str) else msg.metadata.tool_ids
             )
+            results.metadata.agent_id = self.id
             return results
         sender_name = self.config.name
         if isinstance(msg, ChatDocument) and msg.function_call is not None:
@@ -78192,6 +78399,7 @@ class Agent(ABC):
             metadata=ChatDocMetaData(
                 source=Entity.AGENT,
                 sender=Entity.AGENT,
+                agent_id=self.id,
                 sender_name=sender_name,
                 oai_tool_id=oai_tool_id,
                 # preserve trail of tool_ids for OpenAI Assistant fn-calls
@@ -78456,6 +78664,7 @@ class Agent(ABC):
             return ChatDocument(
                 content=user_msg,
                 metadata=ChatDocMetaData(
+                    agent_id=self.id,
                     source=source,
                     sender=sender,
                     # preserve trail of tool_ids for OpenAI Assistant fn-calls

--- a/llms.txt
+++ b/llms.txt
@@ -33,7 +33,7 @@ The content is organized as follows:
 <notes>
 - Some files may have been excluded based on .gitignore rules and Repomix's configuration
 - Binary files are not included in this packed representation. Please refer to the Repository Structure section for a complete list of file paths, including binary files
-- Files matching these patterns are excluded: .*/**, !.github, !.github/**, data/**, **/data/**, **/*.csv, logs/**, build/**, dist/**, *.egg-info/**, __pycache__/**, **/*.pyc, .pytest_cache/**, .mypy_cache/**, .ruff_cache/**, venv/**, env/**, .env, **/*.json, llms.txt, llms-compressed.txt, llms-128k.txt, file-list.txt, file-list-updated.txt, examples/data/**, examples/docqa/docs/**, examples/logs/**, tests/cache/**, tests/logs/**, **/*.pkl, **/*.pickle, **/*.db, **/*.sqlite, **/*.log, **/node_modules/**, **/*.min.js, **/*.map, coverage/**, htmlcov/**, .coverage, *.orig, *.tmp, *.bak, *.swp, *.swo, **/docker-compose*.yml, visual_log.sh, **/*_converted.md, **/page_*.md, **/page-*.md, tests/main/dummy-pages/**, tests/main/data/**/*.txt, **/*.pb2.py, **/*.pb2_grpc.py
+- Files matching these patterns are excluded: .*/**, !.github, !.github/**, data/**, **/data/**, **/*.csv, logs/**, build/**, dist/**, *.egg-info/**, __pycache__/**, **/*.pyc, .pytest_cache/**, .mypy_cache/**, .ruff_cache/**, venv/**, env/**, .env, **/*.json, llms.txt, llms-compressed.txt, llms-128k.txt, llms-no-tests.txt, llms-no-tests-compressed.txt, llms-no-tests-no-examples.txt, llms-no-tests-no-examples-compressed.txt, file-list.txt, file-list-updated.txt, examples/data/**, examples/docqa/docs/**, examples/logs/**, tests/cache/**, tests/logs/**, **/*.pkl, **/*.pickle, **/*.db, **/*.sqlite, **/*.log, **/node_modules/**, **/*.min.js, **/*.map, coverage/**, htmlcov/**, .coverage, *.orig, *.tmp, *.bak, *.swp, *.swo, **/docker-compose*.yml, visual_log.sh, **/*_converted.md, **/page_*.md, **/page-*.md, tests/main/dummy-pages/**, tests/main/data/**/*.txt, **/*.pb2.py, **/*.pb2_grpc.py
 - Files matching patterns in .gitignore are excluded
 - Files matching default ignore patterns are excluded
 - Files are sorted by Git change count (files with more changes are at the bottom)
@@ -516,6 +516,7 @@ release-notes/
   v0-56-0-task-tool.md
   v0-56-11-openai-client-caching.md
   v0-56-12-cached-tokens-support.md
+  v0-56-13-done-sequences-parent-chain-fixes.md
   v0-56-2-table-chat-fix.md
   v0-56-4-handler-params.md
   v0-56-6-doc-chat-refactor.md
@@ -15753,6 +15754,67 @@ class RetrieverAgent(DocChatAgent):
             self.vecdb.add_documents(records)
 </file>
 
+<file path="langroid/agent/tools/mcp/__init__.py">
+from .decorators import mcp_tool
+from .fastmcp_client import (
+    FastMCPClient,
+    get_tool,
+    get_tool_async,
+    get_tools,
+    get_tools_async,
+    get_mcp_tool_async,
+    get_mcp_tools_async,
+)
+
+
+__all__ = [
+    "mcp_tool",
+    "FastMCPClient",
+    "get_tool",
+    "get_tool_async",
+    "get_tools",
+    "get_tools_async",
+    "get_mcp_tool_async",
+    "get_mcp_tools_async",
+]
+</file>
+
+<file path="langroid/agent/tools/mcp/decorators.py">
+from typing import Callable, Type
+
+from langroid.agent.tool_message import ToolMessage
+from langroid.agent.tools.mcp.fastmcp_client import get_tool
+
+
+def mcp_tool(
+    server: str, tool_name: str
+) -> Callable[[Type[ToolMessage]], Type[ToolMessage]]:
+    """Decorator: declare a ToolMessage class bound to a FastMCP tool.
+
+    Usage:
+        @fastmcp_tool("/path/to/server.py", "get_weather")
+        class WeatherTool:
+            def pretty(self) -> str:
+                return f"Temp is {self.temperature}"
+    """
+
+    def decorator(user_cls: Type[ToolMessage]) -> Type[ToolMessage]:
+        # build the “real” ToolMessage subclass for this server/tool
+        RealTool: Type[ToolMessage] = get_tool(server, tool_name)
+
+        # copy user‐defined methods / attributes onto RealTool
+        for name, attr in user_cls.__dict__.items():
+            if name.startswith("__") and name.endswith("__"):
+                continue
+            setattr(RealTool, name, attr)
+
+        # preserve the user’s original name if you like:
+        RealTool.__name__ = user_cls.__name__
+        return RealTool
+
+    return decorator
+</file>
+
 <file path="langroid/agent/tools/__init__.py">
 from . import google_search_tool
 from . import recipient_tool
@@ -30561,6 +30623,125 @@ class NonToolAction(str, Enum):
 
     FORWARD_USER = "user"  # forward msg to user
     DONE = "done"  # task done
+</file>
+
+<file path="release-notes/v0-56-13-done-sequences-parent-chain-fixes.md">
+# v0.56.13: DoneSequences Parent Chain and Agent ID Fixes
+
+## Summary
+
+This release fixes critical issues with the DoneSequence implementation, parent pointer chain preservation in TaskTool, and agent ID initialization. These fixes ensure that task termination sequences work correctly with subtasks and that message lineage is properly maintained across agent boundaries.
+
+## Key Fixes
+
+### 1. Agent ID Initialization Fix
+
+**Problem**: The `Agent.id` field was incorrectly returning a `FieldInfo` object instead of an actual ID string because `Agent` is not a Pydantic model but was using Pydantic's `Field` syntax.
+
+**Solution**: Added proper ID initialization in `Agent.__init__()`:
+```python
+self.id = ObjectRegistry.new_id()  # Initialize agent ID
+```
+
+**Impact**: This ensures that `agent_id` is correctly set in `ChatDocument` metadata, which is crucial for tracking which agent owns which messages.
+
+### 2. DoneSequence Message Chain Fix
+
+**Problem**: The `_get_message_chain` method in `Task` was traversing parent pointers to build the message chain. When subtasks are involved, parent pointers can cross agent boundaries, incorrectly including messages from subtask agents in the parent task's chain.
+
+**Solution**: Replaced parent pointer traversal with agent message history:
+```python
+def _get_message_chain(self, msg: ChatDocument | None, max_depth: Optional[int] = None) -> List[ChatDocument]:
+    """Get the chain of messages using agent's message history."""
+    # Get chat document IDs from message history
+    doc_ids = [m.chat_document_id for m in self.agent.message_history 
+               if m.chat_document_id]
+    
+    # Add current message ID if it exists and is not already the last one
+    if msg:
+        msg_id = msg.id()
+        if not doc_ids or doc_ids[-1] != msg_id:
+            doc_ids.append(msg_id)
+    
+    # Take only the last max_depth elements
+    relevant_ids = doc_ids[-max_depth:]
+    
+    # Convert IDs to ChatDocuments
+    return [doc for doc_id in relevant_ids 
+            if (doc := ChatDocument.from_id(doc_id)) is not None]
+```
+
+**Impact**: DoneSequences now correctly check only messages from the current agent, preventing incorrect task termination when subtasks generate matching sequences.
+
+### 3. Parent Pointer Preservation in Task.init()
+
+**Problem**: When `ChatDocument.deepcopy()` is called during `task.init()`, it resets `parent_id` and `child_id` to empty strings, breaking the parent chain. This particularly affected TaskTool when creating subtasks with parent pointers.
+
+**Solution**: Modified `task.init()` to preserve the original parent_id after deepcopy:
+```python
+if isinstance(msg, ChatDocument):
+    original_parent_id = msg.metadata.parent_id
+    self.pending_message = ChatDocument.deepcopy(msg)
+    # Preserve the parent pointer from the original message
+    self.pending_message.metadata.parent_id = original_parent_id
+```
+
+Additionally, added conditional logic to only override parent_id when necessary:
+```python
+if self.pending_message is not None and self.caller is not None:
+    # Only override parent_id if it wasn't already set in the original message
+    if not msg.metadata.parent_id:
+        self.pending_message.metadata.parent_id = msg.metadata.id
+```
+
+**Impact**: Parent chains are now preserved when TaskTool creates subtasks, maintaining proper message lineage.
+
+### 4. TaskTool Parent-Child Relationship
+
+**Problem**: TaskTool was only setting the parent pointer on the prompt ChatDocument but not the corresponding child pointer on the TaskTool message.
+
+**Solution**: Added bidirectional parent-child relationship in TaskTool handlers:
+```python
+if chat_doc is not None:
+    prompt_doc = ChatDocument(
+        content=self.prompt,
+        metadata=ChatDocMetaData(
+            parent_id=chat_doc.id(),
+            agent_id=agent.id,
+            sender=chat_doc.metadata.sender,
+        )
+    )
+    # Set bidirectional parent-child relationship
+    chat_doc.metadata.child_id = prompt_doc.id()
+```
+
+**Impact**: Complete bidirectional parent-child chains are maintained, improving message traceability.
+
+## Tests Added
+
+Added comprehensive test `test_task_init_preserves_parent_id()` in `test_task.py` that verifies:
+- Parent IDs are preserved during ChatDocument deep copying
+- Conditional parent_id override logic works correctly for subtasks
+- Parent chains are maintained in various scenarios
+
+## Breaking Changes
+
+None. All changes are backward compatible bug fixes.
+
+## Migration Guide
+
+No migration needed. The fixes will automatically apply to existing code.
+
+## Technical Details
+
+The core issue was that DoneSequences were incorrectly checking messages across agent boundaries due to parent pointer traversal. Combined with the agent ID initialization bug and parent chain breaks in deepcopy, this caused incorrect task termination behavior. The fixes ensure:
+
+1. Each agent's messages are properly tagged with the agent's ID
+2. DoneSequence checking is confined to the current agent's message history
+3. Parent chains are preserved through TaskTool subtask creation
+4. Bidirectional parent-child relationships are maintained
+
+These changes work together to ensure proper message lineage and task termination behavior in multi-agent systems.
 </file>
 
 <file path="tests/extras/sql/test_automatic_context_extraction.py">
@@ -46679,67 +46860,6 @@ max-line-length = 88
 ignore = W291, W293, E501, E203, W503
 </file>
 
-<file path="ai-instructions/claude-repomix-instructions.md">
-# AI Instructions for Setting Up Repomix
-
-## Task Overview
-Set up [repomix](https://github.com/yamadashy/repomix) to generate LLM-friendly repository exports. This creates text files that can be uploaded to AI models for code analysis.
-
-## Steps to Complete
-
-### 1. Install Repomix
-```bash
-npm install -g repomix
-```
-
-### 2. Create repomix.config.json
-Create a configuration file in the repository root with:
-- **Include patterns**: Source code files (*.py, *.js, *.md, *.yaml, *.yml, *.toml)
-- **Exclude patterns**: Data directories, logs, node_modules, JSON files, generated files
-- **Security check**: Enable to prevent sensitive data inclusion
-
-### 3. Configure Include/Exclude Patterns
-- Include only source code directories and documentation
-- Exclude data/, logs/, build artifacts, dependencies
-- Add `llms*.txt` to exclusions to prevent recursive inclusion
-
-### 4. Test Configuration (Optional)
-```bash
-# Generate file list only for inspection
-repomix --no-files -o file-list.txt
-```
-This allows you to review which files will be included before generating the full output.
-
-### 5. Generate Output Versions
-
-Use the Makefile targets to generate repomix files:
-
-```bash
-# Generate all variants (recommended)
-make repomix-all
-
-# Or generate specific versions:
-make repomix          # llms.txt and llms-compressed.txt (includes tests)
-make repomix-no-tests # llms-no-tests.txt and llms-no-tests-compressed.txt
-```
-
-All commands use `git ls-files` to ensure only git-tracked files are included.
-
-### 6. Verify Results
-- Check file sizes and token counts in repomix output
-- Ensure no sensitive data is included
-- Confirm only relevant source files are packaged
-
-## Expected Outcome
-Four text files optimized for different LLM contexts:
-- `llms.txt`: Full version with tests for comprehensive analysis
-- `llms-compressed.txt`: Compressed version with tests
-- `llms-no-tests.txt`: Full version without tests for focused source code analysis
-- `llms-no-tests-compressed.txt`: Compressed version without tests for smaller contexts
-
-The files contain only git-tracked source code with proper exclusions for clean, focused LLM consumption.
-</file>
-
 <file path="ai-notes/Langroid-repo-docs.md">
 # CLAUDE.md
 
@@ -60874,6 +60994,63 @@ if __name__ == "__main__":
     main()
 </file>
 
+<file path="examples/mcp/biomcp.py">
+"""
+Simple example of using the BioMCP server.
+
+https://github.com/genomoncology/biomcp
+
+The server offers several tools, and we can enable ALL of them to be used
+by a Langroid agent.
+
+Run like this:
+
+    uv run examples/mcp/biomcp.py --model gpt-4.1-mini
+
+"""
+
+from fastmcp.client.transports import StdioTransport
+from fire import Fire
+
+import langroid as lr
+import langroid.language_models as lm
+from langroid.agent.tools.mcp.fastmcp_client import get_tools_async
+from langroid.mytypes import NonToolAction
+
+
+async def main(model: str = ""):
+    transport = StdioTransport(
+        command="uv", args=["run", "--with", "biomcp-python", "biomcp", "run"]
+    )
+    all_tools = await get_tools_async(transport)
+
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            # forward to user when LLM doesn't use a tool
+            handle_llm_no_tool=NonToolAction.FORWARD_USER,
+            llm=lm.OpenAIGPTConfig(
+                chat_model=model or "gpt-4.1-mini",
+                max_output_tokens=1000,
+                async_stream_quiet=False,
+            ),
+        )
+    )
+
+    # enable the agent to use all tools
+    agent.enable_message(all_tools)
+    # make task with interactive=False =>
+    # waits for user only when LLM doesn't use a tool
+    task = lr.Task(agent, interactive=False)
+    await task.run_async(
+        "Based on the TOOLs available to you, greet the user and"
+        "tell them what kinds of help you can provide."
+    )
+
+
+if __name__ == "__main__":
+    Fire(main)
+</file>
+
 <file path="examples/mcp/exa-web-search.py">
 """
 Simple example of using the Exa Web Search MCP Server to
@@ -60957,6 +61134,380 @@ if __name__ == "__main__":
         asyncio.run(main(**kwargs))
 
     Fire(run_main)
+</file>
+
+<file path="examples/mcp/gitmcp.py">
+"""
+Simple example of using the GitMCP server to "chat" about a GitHub repository.
+
+https://github.com/idosal/git-mcp
+
+The server offers several tools, and we can enable ALL of them to be used
+by a Langroid agent.
+
+Run like this (-m model optional; defaults to gpt-4.1-mini):
+
+    uv run examples/mcp/gitmcp.py -m ollama/qwen2.5-coder:32b
+
+"""
+
+from textwrap import dedent
+from typing import List
+
+from fastmcp.client.transports import SSETransport
+from fire import Fire
+
+import langroid as lr
+import langroid.language_models as lm
+from langroid.agent.tools.mcp.fastmcp_client import get_tools_async
+from langroid.agent.tools.orchestration import SendTool
+from langroid.pydantic_v1 import Field
+
+
+def get_gitmcp_url() -> str:
+    from rich.console import Console
+    from rich.prompt import Prompt
+
+    console = Console()
+    import re
+
+    short_pattern = re.compile(r"^([^/]+)/([^/]+)$")
+    url_pattern = re.compile(
+        r"^(?:https?://)?(?:www\.)?github\.com/([^/]+)/([^/]+)(?:\.git)?/?$"
+    )
+
+    while True:
+        user_input = Prompt.ask(
+            "[bold blue]Enter the GitHub repository (owner/repo or full URL)"
+        ).strip()
+        m = short_pattern.match(user_input)
+        if m:
+            owner, repo = m.groups()
+        else:
+            m = url_pattern.match(user_input)
+            if m:
+                owner, repo = m.groups()
+            else:
+                console.print(
+                    "[red]Invalid format. Please enter 'owner/repo' or a full GitHub URL."
+                )
+                continue
+        break
+
+    github_url = f"https://github.com/{owner}/{repo}"
+    console.print(f"Full GitHub URL set to [green]{github_url}[/]")
+
+    gitmcp_url = f"https://gitmcp.io/{owner}/{repo}"
+    console.print(f"GitMCP URL set to [green]{gitmcp_url}[/]")
+    return gitmcp_url
+
+
+class SendUserTool(SendTool):
+    request: str = "send_user"
+    purpose: str = "Send <content> to user"
+    to: str = "user"
+    content: str = Field(
+        ...,
+        description="""
+        Message to send to user, typically answer to user's request,
+        or a clarification question to the user, if user's task/question
+        is not completely clear.
+        """,
+    )
+
+
+async def main(model: str = ""):
+
+    gitmcp_url = get_gitmcp_url()
+
+    transport = SSETransport(
+        url=gitmcp_url,
+    )
+    all_tools: List[lr.ToolMessage] = await get_tools_async(transport)
+
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            # forward to user when LLM doesn't use a tool
+            handle_llm_no_tool="You FORGOT to use one of your TOOLs!",
+            llm=lm.OpenAIGPTConfig(
+                chat_model=model or "gpt-4.1-mini",
+                max_output_tokens=10_000,
+                async_stream_quiet=False,
+            ),
+            system_message=dedent(
+                f"""
+                Make best use of any of the TOOLs available to you,
+                to answer the user's questions.
+                To communicate with the User, you MUST use
+                the TOOL `{SendUserTool.name()}` - typically this would
+                be to either send the user your answer to their query/request,
+                or to ask the user a clarification question, if the user's request
+                is not completely clear.
+                """
+            ),
+        )
+    )
+
+    # enable the agent to use all tools
+    agent.enable_message(all_tools + [SendUserTool])
+    # configure task to NOT recognize string-based signals like DONE,
+    # since those could occur in the retrieved text!
+    task_cfg = lr.TaskConfig(recognize_string_signals=False)
+    # make task with interactive=False =>
+    # waits for user only when LLM doesn't use a tool
+
+    task = lr.Task(agent, config=task_cfg, interactive=False)
+    await task.run_async(
+        "Based on the TOOLs available to you, greet the user and"
+        "tell them what kinds of help you can provide."
+    )
+
+
+if __name__ == "__main__":
+    Fire(main)
+</file>
+
+<file path="examples/mcp/mcp-fetch.py">
+"""
+Simple example of using the Anthropic Fetch MCP Server to get web-site content.
+
+Fetch MCP Server: https://github.com/modelcontextprotocol/servers/tree/main/src/fetch
+
+Run like this:
+
+    uv run examples/mcp/mcp-fetch.py --model gpt-4.1-mini
+
+Ask questions like:
+
+Summarize the content of this page:
+https://www.anthropic.com/news/model-context-protocol
+"""
+
+from fastmcp.client.transports import UvxStdioTransport
+from fire import Fire
+
+import langroid as lr
+import langroid.language_models as lm
+from langroid.agent.tools.mcp.fastmcp_client import get_tool_async
+from langroid.mytypes import NonToolAction
+
+
+async def main(model: str = ""):
+    transport = UvxStdioTransport(
+        tool_name="mcp-server-fetch",
+    )
+    FetchTool = await get_tool_async(transport, "fetch")
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            # forward to user when LLM doesn't use a tool
+            handle_llm_no_tool=NonToolAction.FORWARD_USER,
+            llm=lm.OpenAIGPTConfig(
+                chat_model=model or "gpt-4.1-mini",
+                max_output_tokens=1000,
+                async_stream_quiet=False,
+            ),
+        )
+    )
+
+    # enable the agent to use the fetch tool
+    agent.enable_message(FetchTool)
+    # make task with interactive=False =>
+    # waits for user only when LLM doesn't use a tool
+    task = lr.Task(agent, interactive=False)
+    await task.run_async()
+
+
+if __name__ == "__main__":
+    Fire(main)
+</file>
+
+<file path="examples/mcp/mcp-file-system.py">
+"""
+Example: Expose local file-system operations via an in-memory FastMCP server.
+
+Run like this:
+
+uv run examples/mcp/mcp-file-system.py --model gpt-4.1-mini
+
+Then ask your agent to list, write, or read files.
+"""
+
+import asyncio
+import os
+
+from fastmcp.server import FastMCP
+from fire import Fire
+
+import langroid as lr
+import langroid.language_models as lm
+from langroid.agent.tools.mcp import get_tool_async, mcp_tool
+from langroid.pydantic_v1 import Field
+
+
+def create_fs_mcp_server() -> FastMCP:
+    """Return a FastMCP server exposing list/read/write file tools."""
+    server = FastMCP("FsServer")
+
+    @server.tool()
+    def list_files(
+        directory: str = Field(..., description="Directory path to list")
+    ) -> list[str]:
+        """List file names in the given directory."""
+        try:
+            return os.listdir(directory)
+        except FileNotFoundError:
+            return []
+
+    @server.tool()
+    def write_file(
+        path: str = Field(..., description="Path to write to"),
+        content: str = Field(..., description="Text content to write"),
+    ) -> bool:
+        """Write text to a file; return True on success."""
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+        return True
+
+    @server.tool()
+    def read_file(
+        path: str = Field(..., description="Path of a text file to read")
+    ) -> str:
+        """Read and return the content of a text file."""
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    return server
+
+
+# use decorator to create a Langroid ToolMessage with a custom handle_async method
+@mcp_tool(create_fs_mcp_server(), "write_file")
+class WriteFileTool(lr.ToolMessage):
+    """Tool to write text to a file."""
+
+    async def handle_async(self) -> str:
+        """Invoke `write_file` and report the result."""
+        ok = await self.call_tool_async()  # type: ignore
+        return f"Wrote {self.path}: {ok}"
+
+
+# use decorator to create a Langroid ToolMessage with a custom handle_async method
+@mcp_tool(create_fs_mcp_server(), "read_file")
+class ReadFileTool(lr.ToolMessage):
+    """Tool to read the content of a text file."""
+
+    async def handle_async(self) -> str:
+        """Invoke `read_file` and return its contents."""
+        text = await self.call_tool_async()  # type: ignore
+        return text or ""
+
+
+async def main(model: str = "") -> None:
+    """
+    Launch a ChatAgent that can list, write, and read files.
+
+    Args:
+    model: Optional LLM model name (defaults to gpt-4.1-mini).
+    """
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            llm=lm.OpenAIGPTConfig(
+                chat_model=model or "gpt-4.1-mini",
+                max_output_tokens=500,
+                async_stream_quiet=False,
+            ),
+        )
+    )
+
+    # create ListFilesTool using the helper function get_tool_async
+    ListFilesTool = await get_tool_async(create_fs_mcp_server(), "list_files")
+
+    # enable all three tools
+    agent.enable_message([ListFilesTool, WriteFileTool, ReadFileTool])
+
+    # create a non-interactive task
+    task = lr.Task(agent, interactive=False)
+
+    # instruct the agent
+    prompt = """
+    1. List files in the current directory.
+    2. Write a file 'note.txt' containing "Hello, MCP!".
+    3. Read back 'note.txt'.
+    """
+    result = await task.run_async(prompt, turns=3)
+    print(result.content)
+
+
+if __name__ == "__main__":
+
+    def _run(**kwargs: str) -> None:
+        """Fire entry point to run the async main function."""
+        asyncio.run(main(**kwargs))
+
+    Fire(_run)
+</file>
+
+<file path="examples/mcp/memory.py">
+"""
+Simple example of using the Memory MCP server:
+https://github.com/modelcontextprotocol/servers/tree/main/src/memory
+This server gives your agent persistent memory using a local Knowledge Graph,
+so when you re-start the chat it will remember what you talked about last time.
+
+
+The server offers several tools, and we can enable ALL of them to be used
+by a Langroid agent.
+
+Run like this (-m model optional; defaults to gpt-4.1-mini):
+
+    uv run examples/mcp/memory.py --m ollama/qwen2.5-coder:32b
+
+"""
+
+from fastmcp.client.transports import NpxStdioTransport
+from fire import Fire
+
+import langroid as lr
+import langroid.language_models as lm
+from langroid.agent.tools.mcp.fastmcp_client import get_tools_async
+from langroid.mytypes import NonToolAction
+
+
+async def main(model: str = ""):
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            # forward to user when LLM doesn't use a tool
+            handle_llm_no_tool=NonToolAction.FORWARD_USER,
+            llm=lm.OpenAIGPTConfig(
+                chat_model=model or "gpt-4.1-mini",
+                max_output_tokens=1000,
+                async_stream_quiet=False,
+            ),
+            system_message="""
+            To be helpful to the user, think about which of your several TOOLs
+            you can use, possibly one after the other, to answer the user's question.
+            """,
+        )
+    )
+
+    transport = NpxStdioTransport(
+        package="@modelcontextprotocol/server-memory",
+        args=["-y"],
+    )
+    tools = await get_tools_async(transport)
+
+    # enable the agent to use all tools
+    agent.enable_message(tools)
+    # make task with interactive=False =>
+    # waits for user only when LLM doesn't use a tool
+    task = lr.Task(agent, interactive=False)
+    await task.run_async(
+        "Based on the TOOLs available to you, greet the user and"
+        "tell them what kinds of help you can provide."
+    )
+
+
+if __name__ == "__main__":
+    Fire(main)
 </file>
 
 <file path="examples/multi-agent-debate/chainlit_utils.py">
@@ -67101,67 +67652,6 @@ class LanceDocChatAgent(DocChatAgent):
         docs = self.vecdb._lance_result_to_docs(result)
         scores = [r["score"] for r in result.to_list()]
         return list(zip(docs, scores))
-</file>
-
-<file path="langroid/agent/tools/mcp/__init__.py">
-from .decorators import mcp_tool
-from .fastmcp_client import (
-    FastMCPClient,
-    get_tool,
-    get_tool_async,
-    get_tools,
-    get_tools_async,
-    get_mcp_tool_async,
-    get_mcp_tools_async,
-)
-
-
-__all__ = [
-    "mcp_tool",
-    "FastMCPClient",
-    "get_tool",
-    "get_tool_async",
-    "get_tools",
-    "get_tools_async",
-    "get_mcp_tool_async",
-    "get_mcp_tools_async",
-]
-</file>
-
-<file path="langroid/agent/tools/mcp/decorators.py">
-from typing import Callable, Type
-
-from langroid.agent.tool_message import ToolMessage
-from langroid.agent.tools.mcp.fastmcp_client import get_tool
-
-
-def mcp_tool(
-    server: str, tool_name: str
-) -> Callable[[Type[ToolMessage]], Type[ToolMessage]]:
-    """Decorator: declare a ToolMessage class bound to a FastMCP tool.
-
-    Usage:
-        @fastmcp_tool("/path/to/server.py", "get_weather")
-        class WeatherTool:
-            def pretty(self) -> str:
-                return f"Temp is {self.temperature}"
-    """
-
-    def decorator(user_cls: Type[ToolMessage]) -> Type[ToolMessage]:
-        # build the “real” ToolMessage subclass for this server/tool
-        RealTool: Type[ToolMessage] = get_tool(server, tool_name)
-
-        # copy user‐defined methods / attributes onto RealTool
-        for name, attr in user_cls.__dict__.items():
-            if name.startswith("__") and name.endswith("__"):
-                continue
-            setattr(RealTool, name, attr)
-
-        # preserve the user’s original name if you like:
-        RealTool.__name__ = user_cls.__name__
-        return RealTool
-
-    return decorator
 </file>
 
 <file path="langroid/agent/batch.py">
@@ -74034,160 +74524,6 @@ async def test_handle_both_sync_async():
     assert async_result == "async handled with agent: ChatAgent"
 </file>
 
-<file path="Makefile">
-.PHONY: setup check lint tests docs nodocs loc
-
-SHELL := /bin/bash
-
-.PHONY: setup update
-
-setup: ## Setup the git pre-commit hooks
-	uv run pre-commit install
-
-update: ## Update the git pre-commit hooks
-	uv run pre-commit autoupdate
-
-.PHONY: type-check
-type-check:
-	@uv run pre-commit install
-	@uv run pre-commit autoupdate
-	@uv run pre-commit run --all-files
-	@echo "Running black..."
-	@uv run black --check .
-	@echo "Running ruff check (without fix)..."
-	@uv run ruff check .
-	@echo "Running mypy...";
-	@uv run mypy -p langroid
-	@echo "All checks passed!"
-
-.PHONY: lint
-lint:
-	uv run black .
-	uv run ruff check . --fix
-	@echo "Auto-fixing issues in examples folder..."
-	@uv run ruff check examples/ --fix-only --no-force-exclude
-
-.PHONY: stubs
-stubs:
-	@echo "Generating Python stubs for the langroid package..."
-	@uv run stubgen -p langroid -o stubs
-	@echo "Stubs generated in the 'stubs' directory"
-
-.PHONY: fix-pydantic
-
-# Entry to replace pydantic imports in specified directories
-fix-pydantic:
-	@echo "Fixing pydantic imports..."
-	@chmod +x scripts/fix-pydantic-imports.sh
-	@./scripts/fix-pydantic-imports.sh
-
-.PHONY: check
-check: fix-pydantic lint type-check
-
-.PHONY: tests
-tests:
-	pytest tests/main --basetemp=/tmp/pytest
-
-
-docs:
-	@# Kill any existing 'mkdocs serve' processes.
-	@pkill -f "mkdocs serve" 2>/dev/null || true
-	@# Build the documentation.
-	mkdocs build
-	@# Serve the documentation in the background.
-	mkdocs serve &
-	@echo "Documentation is being served in the background."
-	@echo "You can access the documentation at http://127.0.0.1:8000/"
-
-nodocs:
-	@# Kill any existing 'mkdocs serve' processes.
-	@pkill -f "mkdocs serve" 2>/dev/null || echo "No 'mkdocs serve' process found."
-	@echo "Stopped serving documentation."
-
-
-loc:
-	@echo "Lines in git-tracked files python files:"
-	@git ls-files | grep '\.py$$' | xargs cat | grep -v '^\s*$$' | wc -l
-
-.PHONY: repomix repomix-no-tests repomix-all
-
-repomix: ## Generate llms.txt and llms-compressed.txt (includes tests)
-	@echo "Generating llms.txt (with tests)..."
-	@git ls-files | repomix --stdin
-	@echo "Generating llms-compressed.txt..."
-	@git ls-files | repomix --stdin --compress -o llms-compressed.txt
-	@echo "Generated llms.txt and llms-compressed.txt"
-
-repomix-no-tests: ## Generate llms-no-tests.txt (excludes tests)
-	@echo "Generating llms-no-tests.txt (without tests)..."
-	@git ls-files | grep -v "^tests/" | repomix --stdin -o llms-no-tests.txt
-	@echo "Generating llms-no-tests-compressed.txt..."
-	@git ls-files | grep -v "^tests/" | repomix --stdin --compress -o llms-no-tests-compressed.txt
-	@echo "Generated llms-no-tests.txt and llms-no-tests-compressed.txt"
-
-repomix-all: repomix repomix-no-tests ## Generate all repomix variants
-
-.PHONY: revert-tag
-revert-tag:
-	@LATEST_TAG=$$(git describe --tags --abbrev=0) && \
-	echo "Deleting tag: $$LATEST_TAG" && \
-	git tag -d $$LATEST_TAG
-
-.PHONY: revert-bump
-revert-bump:
-	@if git log -1 --pretty=%B | grep -q "bump"; then \
-		git reset --hard HEAD~1; \
-		echo "Reverted last commit (bump commit)"; \
-	else \
-		echo "Last commit was not a bump commit"; \
-	fi
-
-.PHONY: revert
-revert: revert-bump revert-tag
-	
-.PHONY: bump-patch
-bump-patch:
-	@cz bump --increment PATCH
-
-.PHONY: bump-minor
-bump-minor:
-	@cz bump --increment MINOR 
-
-.PHONY: bump-major
-bump-major:
-	@cz bump --increment MAJOR 
-
-.PHONY: build
-build:
-	@uv build
-
-.PHONY: push
-push:
-	@git push origin main
-	@git push origin --tags
-
-.PHONY: clean
-clean:
-	-rm -rf dist/*
-
-.PHONY: release
-release:
-	@VERSION=$$(cz version -p | cut -d' ' -f2) && gh release create $${VERSION} dist/*
-
-.PHONY: all-patch
-all-patch: bump-patch clean build push release
-
-.PHONY: all-minor
-all-minor: bump-minor clean build push release
-
-.PHONY: all-major
-all-major: bump-major clean build push release
-
-.PHONY: publish
-publish:
-	uv publish
-</file>
-
 <file path="SECURITY.md">
 # Security Policy
 
@@ -74225,6 +74561,70 @@ Once a security vulnerability is reported, we will work to:
 - Investigate and confirm the issue.
 - Develop a patch or mitigation strategy.
 - Publish the fix and disclose the advisory publicly after the resolution.
+</file>
+
+<file path="ai-instructions/claude-repomix-instructions.md">
+# AI Instructions for Setting Up Repomix
+
+## Task Overview
+Set up [repomix](https://github.com/yamadashy/repomix) to generate LLM-friendly repository exports. This creates text files that can be uploaded to AI models for code analysis.
+
+## Steps to Complete
+
+### 1. Install Repomix
+```bash
+npm install -g repomix
+```
+
+### 2. Create repomix.config.json
+Create a configuration file in the repository root with:
+- **Include patterns**: Source code files (*.py, *.js, *.md, *.yaml, *.yml, *.toml)
+- **Exclude patterns**: Data directories, logs, node_modules, JSON files, generated files
+- **Security check**: Enable to prevent sensitive data inclusion
+
+### 3. Configure Include/Exclude Patterns
+- Include only source code directories and documentation
+- Exclude data/, logs/, build artifacts, dependencies
+- Add `llms*.txt` to exclusions to prevent recursive inclusion
+
+### 4. Test Configuration (Optional)
+```bash
+# Generate file list only for inspection
+repomix --no-files -o file-list.txt
+```
+This allows you to review which files will be included before generating the full output.
+
+### 5. Generate Output Versions
+
+Use the Makefile targets to generate repomix files:
+
+```bash
+# Generate all variants (recommended)
+make repomix-all
+
+# Or generate specific versions:
+make repomix                      # llms.txt and llms-compressed.txt (includes tests)
+make repomix-no-tests             # llms-no-tests.txt and llms-no-tests-compressed.txt
+make repomix-no-tests-no-examples # llms-no-tests-no-examples.txt and compressed version
+```
+
+All commands use `git ls-files` to ensure only git-tracked files are included.
+
+### 6. Verify Results
+- Check file sizes and token counts in repomix output
+- Ensure no sensitive data is included
+- Confirm only relevant source files are packaged
+
+## Expected Outcome
+Six text files optimized for different LLM contexts:
+- `llms.txt`: Full version with tests and examples (870K tokens)
+- `llms-compressed.txt`: Compressed version with tests and examples (513K tokens)
+- `llms-no-tests.txt`: Full version without tests (677K tokens)
+- `llms-no-tests-compressed.txt`: Compressed version without tests (433K tokens)
+- `llms-no-tests-no-examples.txt`: Core library code only (no tests/examples)
+- `llms-no-tests-no-examples-compressed.txt`: Compressed core library code (285K tokens)
+
+The files contain only git-tracked source code with proper exclusions for clean, focused LLM consumption.
 </file>
 
 <file path="ai-notes/handler-parameter-analysis-notes.md">
@@ -80894,63 +81294,6 @@ if __name__ == "__main__":
     app()
 </file>
 
-<file path="examples/mcp/biomcp.py">
-"""
-Simple example of using the BioMCP server.
-
-https://github.com/genomoncology/biomcp
-
-The server offers several tools, and we can enable ALL of them to be used
-by a Langroid agent.
-
-Run like this:
-
-    uv run examples/mcp/biomcp.py --model gpt-4.1-mini
-
-"""
-
-from fastmcp.client.transports import StdioTransport
-from fire import Fire
-
-import langroid as lr
-import langroid.language_models as lm
-from langroid.agent.tools.mcp.fastmcp_client import get_tools_async
-from langroid.mytypes import NonToolAction
-
-
-async def main(model: str = ""):
-    transport = StdioTransport(
-        command="uv", args=["run", "--with", "biomcp-python", "biomcp", "run"]
-    )
-    all_tools = await get_tools_async(transport)
-
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            # forward to user when LLM doesn't use a tool
-            handle_llm_no_tool=NonToolAction.FORWARD_USER,
-            llm=lm.OpenAIGPTConfig(
-                chat_model=model or "gpt-4.1-mini",
-                max_output_tokens=1000,
-                async_stream_quiet=False,
-            ),
-        )
-    )
-
-    # enable the agent to use all tools
-    agent.enable_message(all_tools)
-    # make task with interactive=False =>
-    # waits for user only when LLM doesn't use a tool
-    task = lr.Task(agent, interactive=False)
-    await task.run_async(
-        "Based on the TOOLs available to you, greet the user and"
-        "tell them what kinds of help you can provide."
-    )
-
-
-if __name__ == "__main__":
-    Fire(main)
-</file>
-
 <file path="examples/mcp/chainlit-mcp.py">
 """
 Variant of gitmcp.py that works via the Chainlit UI library,
@@ -81026,380 +81369,6 @@ async def start():
         "Based on the TOOLs available to you, greet the user and"
         "tell them what kinds of help you can provide."
     )
-</file>
-
-<file path="examples/mcp/gitmcp.py">
-"""
-Simple example of using the GitMCP server to "chat" about a GitHub repository.
-
-https://github.com/idosal/git-mcp
-
-The server offers several tools, and we can enable ALL of them to be used
-by a Langroid agent.
-
-Run like this (-m model optional; defaults to gpt-4.1-mini):
-
-    uv run examples/mcp/gitmcp.py -m ollama/qwen2.5-coder:32b
-
-"""
-
-from textwrap import dedent
-from typing import List
-
-from fastmcp.client.transports import SSETransport
-from fire import Fire
-
-import langroid as lr
-import langroid.language_models as lm
-from langroid.agent.tools.mcp.fastmcp_client import get_tools_async
-from langroid.agent.tools.orchestration import SendTool
-from langroid.pydantic_v1 import Field
-
-
-def get_gitmcp_url() -> str:
-    from rich.console import Console
-    from rich.prompt import Prompt
-
-    console = Console()
-    import re
-
-    short_pattern = re.compile(r"^([^/]+)/([^/]+)$")
-    url_pattern = re.compile(
-        r"^(?:https?://)?(?:www\.)?github\.com/([^/]+)/([^/]+)(?:\.git)?/?$"
-    )
-
-    while True:
-        user_input = Prompt.ask(
-            "[bold blue]Enter the GitHub repository (owner/repo or full URL)"
-        ).strip()
-        m = short_pattern.match(user_input)
-        if m:
-            owner, repo = m.groups()
-        else:
-            m = url_pattern.match(user_input)
-            if m:
-                owner, repo = m.groups()
-            else:
-                console.print(
-                    "[red]Invalid format. Please enter 'owner/repo' or a full GitHub URL."
-                )
-                continue
-        break
-
-    github_url = f"https://github.com/{owner}/{repo}"
-    console.print(f"Full GitHub URL set to [green]{github_url}[/]")
-
-    gitmcp_url = f"https://gitmcp.io/{owner}/{repo}"
-    console.print(f"GitMCP URL set to [green]{gitmcp_url}[/]")
-    return gitmcp_url
-
-
-class SendUserTool(SendTool):
-    request: str = "send_user"
-    purpose: str = "Send <content> to user"
-    to: str = "user"
-    content: str = Field(
-        ...,
-        description="""
-        Message to send to user, typically answer to user's request,
-        or a clarification question to the user, if user's task/question
-        is not completely clear.
-        """,
-    )
-
-
-async def main(model: str = ""):
-
-    gitmcp_url = get_gitmcp_url()
-
-    transport = SSETransport(
-        url=gitmcp_url,
-    )
-    all_tools: List[lr.ToolMessage] = await get_tools_async(transport)
-
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            # forward to user when LLM doesn't use a tool
-            handle_llm_no_tool="You FORGOT to use one of your TOOLs!",
-            llm=lm.OpenAIGPTConfig(
-                chat_model=model or "gpt-4.1-mini",
-                max_output_tokens=10_000,
-                async_stream_quiet=False,
-            ),
-            system_message=dedent(
-                f"""
-                Make best use of any of the TOOLs available to you,
-                to answer the user's questions.
-                To communicate with the User, you MUST use
-                the TOOL `{SendUserTool.name()}` - typically this would
-                be to either send the user your answer to their query/request,
-                or to ask the user a clarification question, if the user's request
-                is not completely clear.
-                """
-            ),
-        )
-    )
-
-    # enable the agent to use all tools
-    agent.enable_message(all_tools + [SendUserTool])
-    # configure task to NOT recognize string-based signals like DONE,
-    # since those could occur in the retrieved text!
-    task_cfg = lr.TaskConfig(recognize_string_signals=False)
-    # make task with interactive=False =>
-    # waits for user only when LLM doesn't use a tool
-
-    task = lr.Task(agent, config=task_cfg, interactive=False)
-    await task.run_async(
-        "Based on the TOOLs available to you, greet the user and"
-        "tell them what kinds of help you can provide."
-    )
-
-
-if __name__ == "__main__":
-    Fire(main)
-</file>
-
-<file path="examples/mcp/mcp-fetch.py">
-"""
-Simple example of using the Anthropic Fetch MCP Server to get web-site content.
-
-Fetch MCP Server: https://github.com/modelcontextprotocol/servers/tree/main/src/fetch
-
-Run like this:
-
-    uv run examples/mcp/mcp-fetch.py --model gpt-4.1-mini
-
-Ask questions like:
-
-Summarize the content of this page:
-https://www.anthropic.com/news/model-context-protocol
-"""
-
-from fastmcp.client.transports import UvxStdioTransport
-from fire import Fire
-
-import langroid as lr
-import langroid.language_models as lm
-from langroid.agent.tools.mcp.fastmcp_client import get_tool_async
-from langroid.mytypes import NonToolAction
-
-
-async def main(model: str = ""):
-    transport = UvxStdioTransport(
-        tool_name="mcp-server-fetch",
-    )
-    FetchTool = await get_tool_async(transport, "fetch")
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            # forward to user when LLM doesn't use a tool
-            handle_llm_no_tool=NonToolAction.FORWARD_USER,
-            llm=lm.OpenAIGPTConfig(
-                chat_model=model or "gpt-4.1-mini",
-                max_output_tokens=1000,
-                async_stream_quiet=False,
-            ),
-        )
-    )
-
-    # enable the agent to use the fetch tool
-    agent.enable_message(FetchTool)
-    # make task with interactive=False =>
-    # waits for user only when LLM doesn't use a tool
-    task = lr.Task(agent, interactive=False)
-    await task.run_async()
-
-
-if __name__ == "__main__":
-    Fire(main)
-</file>
-
-<file path="examples/mcp/mcp-file-system.py">
-"""
-Example: Expose local file-system operations via an in-memory FastMCP server.
-
-Run like this:
-
-uv run examples/mcp/mcp-file-system.py --model gpt-4.1-mini
-
-Then ask your agent to list, write, or read files.
-"""
-
-import asyncio
-import os
-
-from fastmcp.server import FastMCP
-from fire import Fire
-
-import langroid as lr
-import langroid.language_models as lm
-from langroid.agent.tools.mcp import get_tool_async, mcp_tool
-from langroid.pydantic_v1 import Field
-
-
-def create_fs_mcp_server() -> FastMCP:
-    """Return a FastMCP server exposing list/read/write file tools."""
-    server = FastMCP("FsServer")
-
-    @server.tool()
-    def list_files(
-        directory: str = Field(..., description="Directory path to list")
-    ) -> list[str]:
-        """List file names in the given directory."""
-        try:
-            return os.listdir(directory)
-        except FileNotFoundError:
-            return []
-
-    @server.tool()
-    def write_file(
-        path: str = Field(..., description="Path to write to"),
-        content: str = Field(..., description="Text content to write"),
-    ) -> bool:
-        """Write text to a file; return True on success."""
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(content)
-        return True
-
-    @server.tool()
-    def read_file(
-        path: str = Field(..., description="Path of a text file to read")
-    ) -> str:
-        """Read and return the content of a text file."""
-        with open(path, "r", encoding="utf-8") as f:
-            return f.read()
-
-    return server
-
-
-# use decorator to create a Langroid ToolMessage with a custom handle_async method
-@mcp_tool(create_fs_mcp_server(), "write_file")
-class WriteFileTool(lr.ToolMessage):
-    """Tool to write text to a file."""
-
-    async def handle_async(self) -> str:
-        """Invoke `write_file` and report the result."""
-        ok = await self.call_tool_async()  # type: ignore
-        return f"Wrote {self.path}: {ok}"
-
-
-# use decorator to create a Langroid ToolMessage with a custom handle_async method
-@mcp_tool(create_fs_mcp_server(), "read_file")
-class ReadFileTool(lr.ToolMessage):
-    """Tool to read the content of a text file."""
-
-    async def handle_async(self) -> str:
-        """Invoke `read_file` and return its contents."""
-        text = await self.call_tool_async()  # type: ignore
-        return text or ""
-
-
-async def main(model: str = "") -> None:
-    """
-    Launch a ChatAgent that can list, write, and read files.
-
-    Args:
-    model: Optional LLM model name (defaults to gpt-4.1-mini).
-    """
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            llm=lm.OpenAIGPTConfig(
-                chat_model=model or "gpt-4.1-mini",
-                max_output_tokens=500,
-                async_stream_quiet=False,
-            ),
-        )
-    )
-
-    # create ListFilesTool using the helper function get_tool_async
-    ListFilesTool = await get_tool_async(create_fs_mcp_server(), "list_files")
-
-    # enable all three tools
-    agent.enable_message([ListFilesTool, WriteFileTool, ReadFileTool])
-
-    # create a non-interactive task
-    task = lr.Task(agent, interactive=False)
-
-    # instruct the agent
-    prompt = """
-    1. List files in the current directory.
-    2. Write a file 'note.txt' containing "Hello, MCP!".
-    3. Read back 'note.txt'.
-    """
-    result = await task.run_async(prompt, turns=3)
-    print(result.content)
-
-
-if __name__ == "__main__":
-
-    def _run(**kwargs: str) -> None:
-        """Fire entry point to run the async main function."""
-        asyncio.run(main(**kwargs))
-
-    Fire(_run)
-</file>
-
-<file path="examples/mcp/memory.py">
-"""
-Simple example of using the Memory MCP server:
-https://github.com/modelcontextprotocol/servers/tree/main/src/memory
-This server gives your agent persistent memory using a local Knowledge Graph,
-so when you re-start the chat it will remember what you talked about last time.
-
-
-The server offers several tools, and we can enable ALL of them to be used
-by a Langroid agent.
-
-Run like this (-m model optional; defaults to gpt-4.1-mini):
-
-    uv run examples/mcp/memory.py --m ollama/qwen2.5-coder:32b
-
-"""
-
-from fastmcp.client.transports import NpxStdioTransport
-from fire import Fire
-
-import langroid as lr
-import langroid.language_models as lm
-from langroid.agent.tools.mcp.fastmcp_client import get_tools_async
-from langroid.mytypes import NonToolAction
-
-
-async def main(model: str = ""):
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            # forward to user when LLM doesn't use a tool
-            handle_llm_no_tool=NonToolAction.FORWARD_USER,
-            llm=lm.OpenAIGPTConfig(
-                chat_model=model or "gpt-4.1-mini",
-                max_output_tokens=1000,
-                async_stream_quiet=False,
-            ),
-            system_message="""
-            To be helpful to the user, think about which of your several TOOLs
-            you can use, possibly one after the other, to answer the user's question.
-            """,
-        )
-    )
-
-    transport = NpxStdioTransport(
-        package="@modelcontextprotocol/server-memory",
-        args=["-y"],
-    )
-    tools = await get_tools_async(transport)
-
-    # enable the agent to use all tools
-    agent.enable_message(tools)
-    # make task with interactive=False =>
-    # waits for user only when LLM doesn't use a tool
-    task = lr.Task(agent, interactive=False)
-    await task.run_async(
-        "Based on the TOOLs available to you, greet the user and"
-        "tell them what kinds of help you can provide."
-    )
-
-
-if __name__ == "__main__":
-    Fire(main)
 </file>
 
 <file path="examples/mcp/openmemory.py">
@@ -89214,6 +89183,944 @@ def test_lance_doc_chat_df_direct(test_settings: Settings):
     assert result is not None and len(result.content) > 10
 </file>
 
+<file path="tests/main/test_mcp_tools.py">
+import os
+from typing import List, Optional
+
+import pytest
+from fastmcp import Context, FastMCP
+from fastmcp.client.sampling import (
+    RequestContext,
+    SamplingMessage,
+    SamplingParams,
+)
+from fastmcp.client.transports import NpxStdioTransport, UvxStdioTransport
+from mcp.types import (
+    BlobResourceContents,
+    EmbeddedResource,
+    ImageContent,
+    TextContent,
+    TextResourceContents,
+    Tool,
+)
+
+# note we use pydantic v2 to define MCP server
+from pydantic import BaseModel, Field  # keep - need pydantic v2 for MCP server
+
+import langroid as lr
+import langroid.language_models as lm
+from langroid.agent.tools.mcp import (
+    FastMCPClient,
+    get_mcp_tool_async,
+    get_tool_async,
+    get_tools_async,
+    mcp_tool,
+)
+
+
+class SubItem(BaseModel):
+    """A sub‐item with a value and multiplier."""
+
+    val: int = Field(..., description="Value for sub-item")
+    multiplier: float = Field(1.0, description="Multiplier applied to val")
+
+
+class ComplexData(BaseModel):
+    """Complex data combining two ints and a list of SubItem."""
+
+    a: int = Field(..., description="First integer")
+    b: int = Field(..., description="Second integer")
+    items: List[SubItem] = Field(..., description="List of sub-items")
+
+
+def mcp_server():
+    server = FastMCP("TestServer")
+
+    class Counter:
+        def __init__(self) -> None:
+            self.count: int = 0
+
+        def get_num_beans(self) -> int:
+            """Return current counter."""
+            return self.count
+
+        def add_beans(
+            self,
+            x: int = Field(..., description="Number of beans to add"),
+        ) -> int:
+            """Increment and return new counter."""
+            self.count += x
+            return self.count
+
+    # create a stateful tool
+    counter = Counter()
+    # we can't directly use the tool decorator on instance methods,
+    # so we use the server.add_tool() method to add the tool
+    server.add_tool(counter.get_num_beans)
+    server.add_tool(counter.add_beans)
+
+    # example of tool that uses an arg of type Context, and
+    # uses this arg to request client LLM sampling, and send logs
+    @server.tool()
+    async def prime_check(number: int, ctx: Context) -> str:
+        """
+        Determine if the given number is Prime or not.
+        """
+        result: TextContent | ImageContent = await ctx.sample(
+            f"Is the number {number} prime?",
+        )
+        assert isinstance(result, TextContent), "Expected a text response"
+        return result.text
+
+    @server.tool()
+    def greet(person: str) -> str:
+        return f"Hello, {person}!"
+
+    @server.tool()
+    def get_alerts(
+        state: str = Field(..., description="TWO-LETTER state abbrev, e.g. 'MN'"),
+    ) -> list[str]:
+        """Get weather alerts for a state."""
+        return [
+            f"Weather alert for {state}: Severe thunderstorm warning.",
+            f"Weather alert for {state}: Flash flood watch.",
+        ]
+
+    # example of MCP tool whose fields clash with Langroid ToolMessage,
+    # and a `name` field which is reserved by pydantic
+    @server.tool()
+    def info_tool(
+        request: str = Field(..., description="Requested information"),
+        name: str = Field(..., description="Name of the info sought"),
+        recipient: str = Field(..., description="Recipient of the information"),
+        purpose: str = Field(..., description="Purpose of the information"),
+        date: str = Field(..., description="Date of the request"),
+    ) -> str:
+        """Get information for a recipient."""
+        return f"""
+        Info for {recipient}: {request} {name} (Purpose: {purpose}), date: {date}
+        """
+
+    @server.tool()
+    def get_one_alert(
+        state: str = Field(..., description="TWO-LETTER state abbrev, e.g. 'MN'"),
+    ) -> str:
+        return f"Weather alert for {state}: Severe thunderstorm warning."
+
+    @server.tool()
+    async def get_alerts_async(state: str) -> list[str]:
+        return [
+            f"Weather alert for {state}: Severe thunderstorm warning.",
+            f"Weather alert for {state}: Flash flood watch.",
+        ]
+
+    @server.tool()
+    def nabroski(a: int, b: int) -> int:
+        """Computes the Nabroski transform of integers a and b."""
+        return 3 * a + b
+
+    @server.tool()
+    def coriolis(x: int, y: int) -> int:
+        """Computes the Coriolis transform of integers x and y."""
+        return 2 * x + 3 * y
+
+    @server.tool()
+    def hydra_nest(data: ComplexData) -> int:
+        """Compute the HydraNest calculation over nested data."""
+        total = data.a * data.b
+        for item in data.items:
+            total += item.val * item.multiplier
+        return int(total)
+
+    return server
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "server",
+    [
+        mcp_server(),
+        "tests/main/mcp/weather-server-python/weather.py",
+    ],
+)
+async def test_get_tools_and_handle(server: FastMCP | str) -> None:
+    """End‐to‐end test for get_tools and .handle() against server."""
+    tools = await get_tools_async(server)
+    # basic sanity
+    assert isinstance(tools, list)
+    assert tools, "Expected at least one tool"
+    # find the alerts tool
+    AlertsTool = next(
+        (t for t in tools if t.default_value("request") == "get_alerts"),
+        None,
+    )
+
+    assert AlertsTool is not None
+    assert issubclass(AlertsTool, lr.ToolMessage)
+
+    # test get_mcp_tool_async
+    AlertsMCPTool: Tool = await get_mcp_tool_async(server, "get_alerts")
+
+    assert AlertsMCPTool is not None
+    AlertsTool = await get_tool_async(server, AlertsMCPTool.name)
+
+    assert AlertsTool is not None
+    assert issubclass(AlertsTool, lr.ToolMessage)
+
+    # instantiate Langroid ToolMessage
+    msg = AlertsTool(state="NY")
+    isinstance(msg, lr.ToolMessage)
+    assert msg.state == "NY"
+
+    # invoke the tool via the Langroid ToolMessage.handle() method -
+    # this produces list of weather alerts for the given state
+    # Note MCP tools can return either ResultToolType or List[ResultToolType]
+    result: Optional[str] = await msg.handle_async()
+    print(result)
+    assert isinstance(result, str)
+    assert result is not None
+
+    # make tool from async FastMCP tool
+    AlertsMCPToolAsync = await get_mcp_tool_async(server, "get_alerts_async")
+    assert AlertsMCPToolAsync is not None
+    AlertsToolAsync = await get_tool_async(server, AlertsMCPToolAsync.name)
+
+    assert AlertsToolAsync is not None
+    assert issubclass(AlertsToolAsync, lr.ToolMessage)
+
+    # instantiate Langroid ToolMessage
+    msg = AlertsToolAsync(state="NY")
+    isinstance(msg, lr.ToolMessage)
+    assert msg.state == "NY"
+
+    # invoke the tool via the Langroid ToolMessage.handle_async() method -
+    # this produces list of weather alerts for the given state
+    # Note MCP tools can return either ResultToolType or List[ResultToolType]
+    result: Optional[str] = await msg.handle_async()
+    assert result is not None
+    print(result)
+    assert isinstance(result, str)
+    assert result is not None
+
+    # test making tool with utility functions
+    AlertsTool = await get_tool_async(server, "get_alerts")
+    assert issubclass(AlertsTool, lr.ToolMessage)
+    # instantiate Langroid ToolMessage
+    msg = AlertsTool(state="NY")
+    isinstance(msg, lr.ToolMessage)
+
+
+@pytest.mark.parametrize(
+    "server",
+    [
+        mcp_server(),
+        "tests/main/mcp/weather-server-python/weather.py",
+    ],
+)
+@pytest.mark.asyncio
+async def test_tools_connect_close(server: str | FastMCP) -> None:
+    """Test that we can use connect()... tool-calls ... close()"""
+
+    client = FastMCPClient(server)
+    await client.connect()
+    mcp_tools = await client.client.list_tools()
+    assert all(isinstance(t, Tool) for t in mcp_tools)
+    langroid_tool_classes = await client.get_tools_async()
+    assert all(issubclass(tc, lr.ToolMessage) for tc in langroid_tool_classes)
+
+    AlertsMCPTool = await get_mcp_tool_async(server, "get_alerts")
+
+    AlertsTool = await get_tool_async(server, AlertsMCPTool.name)
+    await client.close()
+
+    assert AlertsTool is not None
+    assert issubclass(AlertsTool, lr.ToolMessage)
+    # instantiate Langroid ToolMessage
+    msg = AlertsTool(state="NY")
+    isinstance(msg, lr.ToolMessage)
+    assert msg.state == "NY"
+
+    result = await msg.handle_async()
+    assert isinstance(result, str)
+
+
+@pytest.mark.asyncio
+async def test_stateful_tool() -> None:
+    # instantiate the server
+    server = mcp_server()
+
+    # get tools from the SAME instance of the server
+    AddBeansTool = await get_tool_async(server, "add_beans")
+    assert issubclass(AddBeansTool, lr.ToolMessage)
+
+    GetNumBeansTool = await get_tool_async(server, "get_num_beans")
+    assert issubclass(GetNumBeansTool, lr.ToolMessage)
+
+    add_beans_msg = AddBeansTool(x=5)
+    assert isinstance(add_beans_msg, lr.ToolMessage)
+
+    result = await add_beans_msg.handle_async()
+    assert isinstance(result, str)
+    assert "5" in result
+
+    get_num_beans_msg = GetNumBeansTool()
+    assert isinstance(get_num_beans_msg, lr.ToolMessage)
+    result = await get_num_beans_msg.handle_async()
+    assert isinstance(result, str)
+    assert "5" in result
+
+
+@pytest.mark.asyncio
+async def test_tool_with_context_and_sampling() -> None:
+    async def sampling_handler(
+        messages: list[SamplingMessage],
+        params: SamplingParams,
+        context: RequestContext,
+    ) -> str:
+        """Handle a sampling request from server"""
+        # simulate an LLM call
+        return "Yes"
+
+    PrimeCheckTool = await get_tool_async(
+        mcp_server(),
+        "prime_check",
+        sampling_handler=sampling_handler,
+    )
+    assert issubclass(PrimeCheckTool, lr.ToolMessage)
+    # assert that "ctx" is NOT a field in the tool
+    assert "ctx" not in PrimeCheckTool.llm_function_schema().parameters["properties"]
+
+    # instantiate Langroid ToolMessage
+    prime_check_msg = PrimeCheckTool(number=7)
+    assert isinstance(prime_check_msg, lr.ToolMessage)
+
+    result = await prime_check_msg.handle_async()
+    assert isinstance(result, str)
+    assert "yes" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_schemas() -> None:
+    """
+    Test that descriptions, field-descriptions of MCP tools are preserved
+    when we translate them to Langroid ToolMessage classes. This is important
+    since the LLM is shown these, and helps with tool-call accuracy.
+    """
+    # make a langroid AlertsTool from the corresponding MCP tool
+    AlertsTool = await get_tool_async(mcp_server(), "get_alerts")
+
+    assert issubclass(AlertsTool, lr.ToolMessage)
+    description = "Get weather alerts for a state."
+    assert AlertsTool.default_value("purpose") == description
+    schema: lm.LLMFunctionSpec = AlertsTool.llm_function_schema()
+    assert schema.description == description
+    assert schema.name == "get_alerts"
+    assert schema.parameters["required"] == ["state"]
+    assert "TWO-LETTER" in schema.parameters["properties"]["state"]["description"]
+
+    InfoTool = await get_tool_async(mcp_server(), "info_tool")
+    assert issubclass(InfoTool, lr.ToolMessage)
+    description = "Get information for a recipient."
+    assert InfoTool.default_value("purpose") == description
+    assert InfoTool.default_value("request") == "info_tool"
+
+    # instantiate InfoTool
+    msg = InfoTool(
+        name__="InfoName",
+        request__="address",
+        recipient__="John Doe",
+        purpose__="to know the address",
+        date="2023-10-01",
+    )
+    assert isinstance(msg, lr.ToolMessage)
+    assert msg.name__ == "InfoName"
+    assert msg.request__ == "address"
+    assert msg.recipient__ == "John Doe"
+    assert msg.purpose__ == "to know the address"
+    assert msg.date == "2023-10-01"
+    # call the tool
+    result = await msg.handle_async()
+    assert isinstance(result, str)
+    assert "address" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_single_output() -> None:
+    """Test that a tool with a single string output works
+    similarly to one that has a list of strings outputs."""
+
+    OneAlertTool = await get_tool_async(mcp_server(), "get_one_alert")
+
+    assert OneAlertTool is not None
+    msg = OneAlertTool(state="NY")
+    assert isinstance(msg, lr.ToolMessage)
+    assert msg.state == "NY"
+    result = await msg.handle_async()
+
+    # we expect a list containing a single str
+    assert isinstance(result, str)
+    assert any(x in result.lower() for x in ["alert", "weather"])
+
+
+@pytest.mark.asyncio
+async def test_agent_mcp_tools() -> None:
+    """Test that a Langroid ChatAgent can use and handle MCP tools."""
+
+    server = mcp_server()
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            llm=lm.OpenAIGPTConfig(
+                max_output_tokens=500,
+                async_stream_quiet=False,
+            ),
+        )
+    )
+
+    NabroskiTool: lr.ToolMessage = await get_tool_async(server, "nabroski")
+
+    agent.enable_message(NabroskiTool)
+
+    response: lr.ChatDocument = await agent.llm_response_async(
+        "What is the Nabroski transform of 3 and 5?"
+    )
+    tools = agent.get_tool_messages(response)
+    assert len(tools) == 1
+    assert isinstance(tools[0], NabroskiTool)
+    result: lr.ChatDocument = await agent.agent_response_async(response)
+    # TODO assert needs to take LLM tool-forgetting into account
+    assert "14" in result.content
+
+    agent.init_state()
+    task = lr.Task(agent, interactive=False)
+    result: lr.ChatDocument = await task.run_async(
+        "What is the Nabroski transform of 3 and 5?",
+        turns=3,
+    )
+    assert "14" in result.content
+
+    # test MCP tool with fields that clash with Langroid ToolMessage
+    InfoTool = await get_tool_async(server, "info_tool")
+    agent.init_state()
+    agent.enable_message(InfoTool)
+    result: lr.ChatDocument = await task.run_async(
+        """
+        Use the TOOL `info_tool` to find the address of the Municipal Building
+        so you can send it to John Doe on 2023-10-01.
+        """,
+        turns=3,
+    )
+    assert "address" in result.content.lower()
+
+
+# Need to define the tools outside async def,
+# since the decorator uses asyncio.run() to wrap around an async fn
+@mcp_tool(mcp_server(), "get_alerts")
+class GetAlertsTool(lr.ToolMessage):
+    """Tool to get weather alerts."""
+
+    async def my_handler(self) -> str:
+        alert = await self.handle_async()
+        return "ALERT: " + alert
+
+
+@mcp_tool(mcp_server(), "nabroski")
+class NabroskiTool(lr.ToolMessage):
+    """Tool to get Nabroski transform."""
+
+    async def my_handler(self) -> str:
+        result = await self.handle_async()
+        return f"FINAL Nabroski transform result: {result}"
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_decorator() -> None:
+    """Test that the mcp_tool decorator works as expected."""
+
+    msg = GetAlertsTool(state="NY")
+    assert isinstance(msg, lr.ToolMessage)
+    assert msg.state == "NY"
+    result = await msg.my_handler()
+    assert isinstance(result, str)
+    assert "ALERT" in result
+
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            llm=lm.OpenAIGPTConfig(
+                max_output_tokens=500,
+                async_stream_quiet=False,
+            ),
+        )
+    )
+    agent.enable_message(GetAlertsTool)
+
+    agent.enable_message(NabroskiTool)
+    task = lr.Task(agent, interactive=False)
+    result = await task.run_async("What is the nabroski transform of 5 and 3?", turns=3)
+    assert "nabroski" in result.content.lower() and "18" in result.content
+
+
+@mcp_tool(mcp_server(), "hydra_nest")
+class HydraNestTool(lr.ToolMessage):
+    """Tool for computing HydraNest calculation."""
+
+    async def my_handler(self) -> str:
+        """Call hydra_nest and format result."""
+        result = await self.handle_async()
+        return f"Computed: {result}"
+
+
+@pytest.mark.asyncio
+async def test_complex_tool_decorator() -> None:
+    """Test that compute_complex via decorator works end‐to‐end."""
+    # build nested input
+    payload = {
+        "data": {
+            "a": 4,
+            "b": 5,
+            "items": [
+                {"val": 2, "multiplier": 1.5},
+                {"val": 3, "multiplier": 2.0},
+            ],
+        }
+    }
+    msg = HydraNestTool(**payload)
+    assert isinstance(msg, lr.ToolMessage)
+    # call handler
+    result = await msg.my_handler()
+    expected = int(4 * 5 + 2 * 1.5 + 3 * 2.0)
+    assert f"{expected}" in result
+
+    # round‐trip via an agent
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            llm=lm.OpenAIGPTConfig(
+                max_output_tokens=1000,
+                async_stream_quiet=False,
+            ),
+        )
+    )
+    agent.enable_message(HydraNestTool)
+    task = lr.Task(agent, interactive=False)
+    prompt = """
+    Compute the HydraNest calculation with a=4, b=5,
+    and a list of items with these val-multiplier pairs:
+        val=2, multiplier=1.5
+        val=3, multiplier=2.0
+    """
+    response = await task.run_async(prompt, turns=3)
+    assert str(expected) in response.content
+
+
+@pytest.mark.parametrize(
+    "prompt,tool_name,expected",
+    [
+        ("What is the Nabroski transform of 3 and 5?", "nabroski", "14"),
+        ("What is the Coriolis transform of 4 and 3?", "coriolis", "17"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_multiple_tools(prompt, tool_name, expected) -> None:
+    """
+    Test one-shot enabling of multiple tools.
+    """
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            llm=lm.OpenAIGPTConfig(
+                max_output_tokens=1000,
+                async_stream_quiet=False,
+            ),
+        )
+    )
+    all_tools = await get_tools_async(mcp_server())
+
+    tool = next(
+        (t for t in all_tools if t.name() == tool_name),
+        None,
+    )
+    agent.enable_message(all_tools)
+
+    # test that agent (LLM) can pick right tool based on prompt
+    prompt = "use one of your TOOLs to answer this: " + prompt
+    response: lr.ChatDocument = await agent.llm_response_async(prompt)
+    tools = agent.get_tool_messages(response)
+    assert len(tools) == 1
+    assert isinstance(tools[0], lr.ToolMessage)
+    assert isinstance(tools[0], tool)
+
+    # test in a task
+    task = lr.Task(agent, interactive=False)
+    result: lr.ChatDocument = await task.run_async(prompt, turns=3)
+    assert expected in result.content
+
+
+@pytest.mark.asyncio
+async def test_npxstdio_transport() -> None:
+    """
+    Test that we can create Langroid ToolMessage from an MCP server
+    via npx stdio transport, for example the `exa-mcp-server`:
+    https://github.com/exa-labs/exa-mcp-server
+    """
+    transport = NpxStdioTransport(
+        package="exa-mcp-server",
+        env_vars=dict(EXA_API_KEY=os.getenv("EXA_API_KEY")),
+    )
+    tools = await get_tools_async(transport)
+    assert isinstance(tools, list)
+    assert tools, "Expected at least one tool"
+    WebSearchTool = await get_tool_async(transport, "web_search_exa")
+
+    assert WebSearchTool is not None
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            llm=lm.OpenAIGPTConfig(
+                max_output_tokens=1000,
+                async_stream_quiet=False,
+            ),
+            system_message="""
+            When asked a question, use the TOOL `web_search_exa` to
+            perform a web search and find the answer.
+            """,
+        )
+    )
+    agent.enable_message(WebSearchTool)
+    # Note: we shouldn't have to explicitly beg the LLM to use the tool here
+    # but I've found that even GPT-4o sometimes fails to use the tool
+    question = """
+    Use the `web_search_exa` TOOL to find out:
+    Who won the Presidential election in Gabon in 2025?
+    """
+    response = await agent.llm_response_async(question)
+
+    tools = agent.get_tool_messages(response)
+    assert len(tools) == 1
+    assert isinstance(tools[0], WebSearchTool)
+
+    task = lr.Task(agent, interactive=False)
+    result: lr.ChatDocument = await task.run_async(question, turns=3)
+    assert "Nguema" in result.content
+
+
+transport = UvxStdioTransport(
+    # `tool_name` is a misleading name -- it really refers to the
+    # MCP server, which offers several tools
+    tool_name="mcp-server-git",
+)
+
+
+@mcp_tool(transport, "git_status")
+class GitStatusTool(lr.ToolMessage):
+    """Tool to get git status."""
+
+    async def handle_async(self) -> str:
+        """
+        When defining a class explicitly with the @mcp_tool decorator,
+        we have the flexibility to define our own `handle_async` method
+        which calls the call_tool_async method, which in turn calls the
+        MCP server's call_tool method.
+        Returns:
+
+        """
+        status = await self.call_tool_async()
+        return "GIT STATUS: " + status
+
+
+@pytest.mark.asyncio
+async def test_uvxstdio_transport() -> None:
+    """
+    Test that we can create Langroid ToolMessage from an MCP server
+    via uvx stdio transport. We use this example `git` MCP server:
+    https://github.com/modelcontextprotocol/servers/tree/main/src/git
+    """
+    tools = await get_tools_async(transport)
+    assert isinstance(tools, list)
+    assert tools, "Expected at least one tool"
+    GitStatusTool = await get_tool_async(transport, "git_status")
+
+    assert GitStatusTool is not None
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            llm=lm.OpenAIGPTConfig(
+                max_output_tokens=1000,
+                async_stream_quiet=False,
+            ),
+        )
+    )
+    agent.enable_message(GitStatusTool)
+    prompt = """
+        Use the `git_status` TOOL to find out the status of the 
+        current git repository at "../langroid"
+        """
+
+    response = await agent.llm_response_async(prompt)
+    tools = agent.get_tool_messages(response)
+    assert len(tools) == 1
+    assert isinstance(tools[0], GitStatusTool)
+
+    task = lr.Task(agent, interactive=False)
+    result: lr.ChatDocument = await task.run_async(prompt, turns=3)
+    assert "langroid" in result.content
+
+    # test GitStatusTool created via @mcp_tool decorator
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            llm=lm.OpenAIGPTConfig(
+                max_output_tokens=1000,
+                async_stream_quiet=False,
+            ),
+        )
+    )
+    agent.enable_message(GitStatusTool)
+    prompt = """
+        Find out the git status of the git repository at "../langroid"
+        """
+
+    response = await agent.llm_response_async(prompt)
+    tools = agent.get_tool_messages(response)
+    assert len(tools) == 1
+    assert isinstance(tools[0], GitStatusTool)
+
+    task = lr.Task(agent, interactive=False)
+    result: lr.ChatDocument = await task.run_async(prompt, turns=3)
+    assert "status" in result.content.lower()
+
+
+@pytest.mark.asyncio
+async def test_npxstdio_transport_memory() -> None:
+    """
+    Test that we can create Langroid ToolMessage from the `memory` MCP server
+    via npx stdio transport:
+    https://github.com/modelcontextprotocol/servers/tree/main/src/memory
+    """
+    transport = NpxStdioTransport(
+        package="@modelcontextprotocol/server-memory",
+        args=["-y"],
+    )
+    tools = await get_tools_async(transport)
+    assert isinstance(tools, list)
+    assert tools, "Expected at least one tool"
+
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            llm=lm.OpenAIGPTConfig(
+                max_output_tokens=1000,
+                async_stream_quiet=False,
+            ),
+            system_message="""
+Follow these steps for each interaction:
+
+1. User Identification:
+   - You should assume that you are interacting with default_user
+   - If you have not identified default_user, proactively try to do so.
+
+2. Memory Retrieval:
+   - Always begin your chat by saying only "Remembering..." and retrieve all 
+       relevant information from your knowledge graph
+   - Always refer to your knowledge graph as your "memory"
+   - Use your TOOLS to retrieve information from your memory when asked
+
+3. Memory
+   - While conversing with the user, be attentive to any new information that falls 
+       into these categories:
+     a) Basic Identity (age, gender, location, job title, education level, etc.)
+     b) Behaviors (interests, habits, etc.)
+     c) Preferences (communication style, preferred language, etc.)
+     d) Goals (goals, targets, aspirations, etc.)
+     e) Relationships (personal and professional relationships up to 3 degrees of 
+         separation)
+
+4. Memory Update:
+   - If any new information was gathered during the interaction, 
+       update your memory as follows:
+     a) Create entities for recurring organizations, people, and significant events
+     b) Connect them to the current entities using relations
+     b) Store facts about them as observations   
+     Use your TOOLS to update your memory.         
+            """,
+        )
+    )
+
+    agent.enable_message(tools)
+    prompt = """
+        Joseph Knecht was a member of the Glass Bead Game Society.
+        He was good friends with the composer Hesse.
+        His mentor was the former teacher of the Glass Bead Game Society, Maestro.
+        Memorize the relevant information using one of the TOOLs:
+        `add_observations`, `create_entities`, `create_relations`
+        """
+    response = await agent.llm_response_async(prompt)
+    tools = agent.get_tool_messages(response)
+    assert len(tools) >= 1
+
+    task = lr.Task(agent, interactive=False, restart=False)
+    prompt = """
+    Who was Joseph Knecht's mentor? Use the `search_nodes` TOOL to find out.
+    """
+    result: lr.ChatDocument = await task.run_async(prompt, turns=3)
+    assert "Maestro" in result.content
+
+
+@pytest.mark.asyncio
+async def test_persist_connection() -> None:
+    """Test that persist_connection keeps the connection open between tool calls."""
+    server = mcp_server()
+
+    # Create client with persist_connection=True
+    async with FastMCPClient(server, persist_connection=True) as client:
+        # First tool call - this should create and keep the connection open
+        tool1 = await client.get_tool_async("add_beans")
+        assert tool1 is not None
+
+        # Check that client connection is established
+        assert client.client is not None
+        initial_client = client.client
+
+        # Second tool call - should reuse the same connection
+        tool2 = await client.get_tool_async("get_num_beans")
+        assert tool2 is not None
+
+        # Verify the same client connection was reused
+        assert client.client is initial_client
+
+        # Call the tools to ensure they work
+        add_msg = tool1(x=5)
+        result1 = await add_msg.handle_async()
+        assert result1 == "5"  # handle_async returns string for backward compatibility
+
+        get_msg = tool2()
+        result2 = await get_msg.handle_async()
+        assert result2 == "5"  # handle_async returns string for backward compatibility
+
+
+@pytest.mark.asyncio
+async def test_handle_async_with_images() -> None:
+    """Test that response_async returns ChatDocument with file attachments."""
+    # Create a mock server that returns image content
+    server = FastMCP("ImageServer")
+
+    @server.tool()
+    async def get_chart() -> List[TextContent | ImageContent]:
+        """Get a chart with image."""
+        return [
+            TextContent(type="text", text="Here is your chart:"),
+            ImageContent(
+                type="image",
+                mimeType="image/png",
+                data="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",  # noqa: E501
+            ),
+        ]
+
+    # Get the tool and test response_async
+    async with FastMCPClient(server, forward_images=True) as client:
+        ChartTool = await client.get_tool_async("get_chart")
+
+        # Create a mock agent
+        agent = lr.ChatAgent(lr.ChatAgentConfig())
+
+        # Test response_async method
+        chart_msg = ChartTool()
+        response = await chart_msg.handle_async(agent)
+
+        # Verify we got a ChatDocument
+        assert isinstance(response, lr.ChatDocument)
+        assert "Here is your chart:" in response.content
+
+        # Verify we have file attachments in the files attribute
+        assert response.files is not None
+        assert len(response.files) == 1
+
+        # Verify the file is an image
+        file = response.files[0]
+        assert file.mime_type == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_forward_text_resources() -> None:
+    """Test that forward_text_resources setting works correctly."""
+    from mcp.types import CallToolResult
+
+    server = FastMCP("TextResourceServer")
+
+    # Test the _convert_tool_result method directly with mocked data
+    async with FastMCPClient(server, forward_text_resources=True) as client:
+        # Create a mock CallToolResult with text and text resource
+        mock_result = CallToolResult(
+            content=[
+                TextContent(type="text", text="Document content:"),
+                EmbeddedResource(
+                    type="resource",
+                    resource=TextResourceContents(
+                        uri="file:///example.txt",
+                        mimeType="text/plain",
+                        text="This is embedded text content from a resource.",
+                    ),
+                ),
+            ],
+            isError=False,
+        )
+
+        # Test with forward_text_resources=True
+        result = client._convert_tool_result("test_tool", mock_result)
+        content, files = result
+
+        # Should include both the main text and the resource text
+        assert "Document content:" in content
+        assert "This is embedded text content from a resource." in content
+
+    # Test with forward_text_resources=False
+    async with FastMCPClient(server, forward_text_resources=False) as client:
+        result = client._convert_tool_result("test_tool", mock_result)
+        content, files = result
+
+        # Should only include the main text, not the resource text
+        assert "Document content:" in content
+        assert "This is embedded text content from a resource." not in content
+
+
+@pytest.mark.asyncio
+async def test_forward_blob_resources() -> None:
+    """Test that forward_blob_resources setting works correctly."""
+    from mcp.types import CallToolResult
+
+    server = FastMCP("BlobResourceServer")
+
+    # Test the _convert_tool_result method directly with mocked data
+    async with FastMCPClient(server, forward_blob_resources=True) as client:
+        # Small PNG data (1x1 blue pixel)
+        png_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAD0lEQVR42mNkYPhfz/ADAAKAA4RkT4UVAAAAAElFTkSuQmCC"  # noqa: E501
+
+        # Create a mock CallToolResult with text and blob resource
+        mock_result = CallToolResult(
+            content=[
+                TextContent(type="text", text="Document with blob:"),
+                EmbeddedResource(
+                    type="resource",
+                    resource=BlobResourceContents(
+                        uri="file:///example.png", mimeType="image/png", blob=png_data
+                    ),
+                ),
+            ],
+            isError=False,
+        )
+
+        # Test with forward_blob_resources=True
+        result = client._convert_tool_result("test_tool", mock_result)
+        content, files = result
+
+        # Should have text content and file attachment
+        assert "Document with blob:" in content
+        assert len(files) == 1
+        assert files[0].mime_type == "image/png"
+
+    # Test with forward_blob_resources=False
+    async with FastMCPClient(server, forward_blob_resources=False) as client:
+        result = client._convert_tool_result("test_tool", mock_result)
+        content, files = result
+
+        # Should only have text content, no file attachments
+        assert "Document with blob:" in content
+        assert len(files) == 0
+</file>
+
 <file path="tests/main/test_rich_file_logger.py">
 from __future__ import annotations
 
@@ -89790,6 +90697,366 @@ dmypy.json
 sessions/
 commands/
 .claude/
+</file>
+
+<file path="docs/notes/mcp-tools.md">
+# Langroid MCP Integration
+
+Langroid provides seamless integration with Model Context Protocol (MCP) servers via 
+two methods, both of which involve creating Langroid `ToolMessage` subclasses
+corresponding to the MCP tools: 
+
+1. Programmatic creation of Langroid tools using `get_tool_async`, 
+   `get_tools_async` from the tool definitions defined on an MCP server.
+2. Declarative creation of Langroid tools using the **`@mcp_tool` decorator**, which allows
+   customizing the tool-handling behavior beyond what is provided by the MCP server.
+
+This integration allows _any_ LLM (that is good enough to do function-calling via prompts) to use any MCP server.
+See the following to understand the integration better:
+
+- example python scripts under [`examples/mcp`](https://github.com/langroid/langroid/tree/main/examples/mcp)
+- [`tests/main/test_mcp_tools.py`](https://github.com/langroid/langroid/blob/main/tests/main/test_mcp_tools.py)
+
+---
+
+## 1. Connecting to an MCP server via transport specification
+
+Before creating Langroid tools, we first need to define and connect to an MCP server
+via a [FastMCP](https://gofastmcp.com/getting-started/welcome) client. 
+There are several ways to connect to a server, depending on how it is defined. 
+Each of these uses a different type of [transport](https://gofastmcp.com/clients/transports).
+
+The typical pattern to use with Langroid is as follows:
+
+- define an MCP server transport
+- create a `ToolMessage` subclass using the `@mcp_tool` decorator or 
+  `get_tool_async()` function, with the transport as the first argument
+
+
+Langroid's MCP integration will work with any of [transports](https://gofastmcp.com/clients/transportsl) 
+supported by FastMCP.
+Below we go over some common ways to define transports and extract tools from the servers.
+
+1. **Local Python script**
+2. **In-memory FastMCP server** - useful for testing and for simple in-memory servers
+   that don't need to be run as a separate process.
+3. **NPX stdio transport**
+4. **UVX stdio transport**
+5. **Generic stdio transport** – launch any CLI‐based MCP server via stdin/stdout
+6. **Network SSE transport** – connect to HTTP/S MCP servers via `SSETransport`
+
+
+All examples below use the async helpers to create Langroid tools (`ToolMessage` subclasses):
+
+```python
+from langroid.agent.tools.mcp import (
+    get_tools_async,
+    get_tool_async,
+)
+```
+
+---
+
+#### Path to a Python Script
+
+Point at your MCP‐server entrypoint, e.g., to the `weather.py` script in the 
+langroid repo (based on the [Anthropic quick-start guide](https://modelcontextprotocol.io/quickstart/server)):
+
+```python
+async def example_script_path() -> None:
+    server = "tests/main/mcp/weather-server-python/weather.py"
+    tools = await get_tools_async(server) # all tools available
+    AlertTool = await get_tool_async(server, "get_alerts") # specific tool
+
+    # instantiate the tool with a specific input
+    msg = AlertTool(state="CA")
+    
+    # Call the tool via handle_async()
+    alerts = await msg.handle_async()
+    print(alerts)
+```
+
+---
+
+#### In-Memory FastMCP Server
+
+Define your server with `FastMCP(...)` and pass the instance:
+
+```python
+from fastmcp.server import FastMCP
+from pydantic import BaseModel, Field
+
+class CounterInput(BaseModel):
+    start: int = Field(...)
+
+def make_server() -> FastMCP:
+    server = FastMCP("CounterServer")
+
+    @server.tool()
+    def increment(data: CounterInput) -> int:
+        """Increment start by 1."""
+        return data.start + 1
+
+    return server
+
+async def example_in_memory() -> None:
+    server = make_server()
+    tools = await get_tools_async(server)
+    IncTool = await get_tool_async(server, "increment")
+
+    result = await IncTool(start=41).handle_async()
+    print(result)  # 42
+```
+
+See the [`mcp-file-system.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/mcp-file-system.py)
+script for a working example of this.
+
+---
+
+#### NPX stdio Transport
+
+Use any npm-installed MCP server via `npx`, e.g., the 
+[Exa web-search MCP server](https://docs.exa.ai/examples/exa-mcp):
+
+```python
+from fastmcp.client.transports import NpxStdioTransport
+
+transport = NpxStdioTransport(
+    package="exa-mcp-server",
+    env_vars={"EXA_API_KEY": "…"},
+)
+
+async def example_npx() -> None:
+    tools = await get_tools_async(transport)
+    SearchTool = await get_tool_async(transport, "web_search_exa")
+
+    results = await SearchTool(
+        query="How does Langroid integrate with MCP?"
+    ).handle_async()
+    print(results)
+```
+
+For a fully working example, see the script [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py).
+
+---
+
+#### UVX stdio Transport
+
+Connect to a UVX-based MCP server, e.g., the [Git MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
+
+```python
+from fastmcp.client.transports import UvxStdioTransport
+
+transport = UvxStdioTransport(tool_name="mcp-server-git")
+
+async def example_uvx() -> None:
+    tools = await get_tools_async(transport)
+    GitStatus = await get_tool_async(transport, "git_status")
+
+    status = await GitStatus(path=".").handle_async()
+    print(status)
+```
+
+--- 
+
+#### Generic stdio Transport
+
+Use `StdioTransport` to run any MCP server as a subprocess over stdio:
+
+```python
+from fastmcp.client.transports import StdioTransport
+from langroid.agent.tools.mcp import get_tools_async, get_tool_async
+
+
+async def example_stdio() -> None:
+    """Example: any CLI‐based MCP server via StdioTransport."""
+    transport: StdioTransport = StdioTransport(
+        command="uv",
+        args=["run", "--with", "biomcp-python", "biomcp", "run"],
+    )
+    tools: list[type] = await get_tools_async(transport)
+    BioTool = await get_tool_async(transport, "tool_name")
+    result: str = await BioTool(param="value").handle_async()
+    print(result)
+```
+
+See the full example in [`examples/mcp/biomcp.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/biomcp.py).
+
+---
+
+#### Network SSE Transport
+
+Use `SSETransport` to connect to a FastMCP server over HTTP/S:
+
+```python
+from fastmcp.client.transports import SSETransport
+from langroid.agent.tools.mcp import (
+    get_tools_async,
+    get_tool_async,
+)
+
+
+async def example_sse() -> None:
+    """Example: connect to an HTTP/S MCP server via SSETransport."""
+    url: str = "https://localhost:8000/sse"
+    transport: SSETransport = SSETransport(
+        url=url, headers={"Authorization": "Bearer TOKEN"}
+    )
+    tools: list[type] = await get_tools_async(transport)
+    ExampleTool = await get_tool_async(transport, "tool_name")
+    result: str = await ExampleTool(param="value").handle_async()
+    print(result)
+```    
+
+---
+
+With these patterns you can list tools, generate Pydantic-backed `ToolMessage` classes,
+and invoke them via `.handle_async()`, all with zero boilerplate client setup. 
+As the `FastMCP` library adds other types of transport (e.g., `StreamableHTTPTransport`),
+the pattern of usage with Langroid will remain the same.
+
+
+---
+
+## 2. Create Langroid Tools declaratively using the `@mcp_tool` decorator
+
+The above examples showed how you can create Langroid tools programmatically using
+the helper functions `get_tool_async()` and `get_tools_async()`,
+with the first argument being the transport to the MCP server. The `@mcp_tool` decorator
+works in the same way: 
+
+- **Arguments to the decorator**
+    1. `server_spec`: path/URL/`FastMCP`/`ClientTransport`, as mentioned above.
+    2. `tool_name`: name of a specific MCP tool
+
+- **Behavior**
+    - Generates a `ToolMessage` subclass with all input fields typed.
+    - Provides a `call_tool_async()` under the hood -- this is the "raw" MCP tool call,
+      returning a string.
+    - If you define your own `handle_async()`, it overrides the default. Typically,
+you would override it to customize either the input or the output of the tool call, or both.
+    - If you don't define your own `handle_async()`, it defaults to just returning the
+      value of the `call_tool_async()` method.
+
+Here is a simple example of using the `@mcp_tool` decorator to create a Langroid tool:
+
+```python
+from fastmcp.server import FastMCP
+from langroid.agent.tools.mcp import mcp_tool
+import langroid as lr
+
+# Define your MCP server (pydantic v2 for schema)
+server = FastMCP("MyServer")
+
+@mcp_tool(server, "greet")
+class GreetTool(lr.ToolMessage):
+    """Say hello to someone."""
+
+    async def handle_async(self) -> str:
+        # Customize post-processing
+        raw = await self.call_tool_async()
+        return f"💬 {raw}"
+```
+
+Using the decorator method allows you to customize the `handle_async` method of the
+tool, or add additional fields to the `ToolMessage`. 
+You may want to customize the input to the tool, or the tool result before it is sent back to 
+the LLM. If you don't override it, the default behavior is to simply return the value of 
+the "raw" MCP tool call `await self.call_tool_async()`. 
+
+```python
+@mcp_tool(server, "calculate")
+class CalcTool(ToolMessage):
+    """Perform complex calculation."""
+
+    async def handle_async(self) -> str:
+        result = await self.call_tool_async()
+        # Add context or emojis, etc.
+        return f"🧮 Result is *{result}*"
+```
+
+---
+
+## 3. Enabling Tools in Your Agent
+
+Once you’ve created a Langroid `ToolMessage` subclass from an MCP server, 
+you can enable it on a `ChatAgent`, just like you normally would. Below is an example of using 
+the [Exa MCP server](https://docs.exa.ai/examples/exa-mcp) to create a 
+Langroid web search tool, enable a `ChatAgent` to use it, and then set up a `Task` to 
+run the agent loop.
+
+First we must define the appropriate `ClientTransport` for the MCP server:
+```python
+# define the transport
+transport = NpxStdioTransport(
+    package="exa-mcp-server",
+    env_vars=dict(EXA_API_KEY=os.getenv("EXA_API_KEY")),
+)
+```
+
+Then we use the `@mcp_tool` decorator to create a `ToolMessage` 
+subclass representing the web search tool. Note that one reason to use the decorator
+to define our tool is so we can specify a custom `handle_async` method that
+controls what is sent to the LLM after the actual raw MCP tool-call
+(the `call_tool_async` method) is made.
+
+```python
+# the second arg specifically refers to the `web_search_exa` tool available
+# on the server defined by the `transport` variable.
+@mcp_tool(transport, "web_search_exa")
+class ExaSearchTool(lr.ToolMessage):
+    async def handle_async(self):
+        result: str = await self.call_tool_async()
+        return f"""
+        Below are the results of the web search:
+        
+        <WebSearchResult>
+        {result}
+        </WebSearchResult>
+        
+        Use these results to answer the user's original question.
+        """
+
+```
+
+If we did not want to override the `handle_async` method, we could simply have
+created the `ExaSearchTool` class programmatically via the `get_tool_async` 
+function as shown above, i.e.:
+
+```python
+from langroid.agent.tools.mcp import get_tool_async
+
+ExaSearchTool = awwait
+get_tool_async(transport, "web_search_exa")
+```
+
+We can now define our main function where we create our `ChatAgent`,
+attach the `ExaSearchTool` to it, define the `Task`, and run the task loop.
+
+```python
+async def main():
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            # forward to user when LLM doesn't use a tool
+            handle_llm_no_tool=NonToolAction.FORWARD_USER,
+            llm=lm.OpenAIGPTConfig(
+                max_output_tokens=1000,
+                # this defaults to True, but we set it to False so we can see output
+                async_stream_quiet=False,
+            ),
+        )
+    )
+
+    # enable the agent to use the web-search tool
+    agent.enable_message(ExaSearchTool)
+    # make task with interactive=False =>
+    # waits for user only when LLM doesn't use a tool
+    task = lr.Task(agent, interactive=False)
+    await task.run_async()
+```
+
+See [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py) for a full 
+working example of this.
 </file>
 
 <file path="examples/basic/planner-workflow-simple.py">
@@ -93134,944 +94401,6 @@ class OpenAIGPT(LanguageModel):
         return self._process_chat_completion_response(cached, response_dict)
 </file>
 
-<file path="tests/main/test_mcp_tools.py">
-import os
-from typing import List, Optional
-
-import pytest
-from fastmcp import Context, FastMCP
-from fastmcp.client.sampling import (
-    RequestContext,
-    SamplingMessage,
-    SamplingParams,
-)
-from fastmcp.client.transports import NpxStdioTransport, UvxStdioTransport
-from mcp.types import (
-    BlobResourceContents,
-    EmbeddedResource,
-    ImageContent,
-    TextContent,
-    TextResourceContents,
-    Tool,
-)
-
-# note we use pydantic v2 to define MCP server
-from pydantic import BaseModel, Field  # keep - need pydantic v2 for MCP server
-
-import langroid as lr
-import langroid.language_models as lm
-from langroid.agent.tools.mcp import (
-    FastMCPClient,
-    get_mcp_tool_async,
-    get_tool_async,
-    get_tools_async,
-    mcp_tool,
-)
-
-
-class SubItem(BaseModel):
-    """A sub‐item with a value and multiplier."""
-
-    val: int = Field(..., description="Value for sub-item")
-    multiplier: float = Field(1.0, description="Multiplier applied to val")
-
-
-class ComplexData(BaseModel):
-    """Complex data combining two ints and a list of SubItem."""
-
-    a: int = Field(..., description="First integer")
-    b: int = Field(..., description="Second integer")
-    items: List[SubItem] = Field(..., description="List of sub-items")
-
-
-def mcp_server():
-    server = FastMCP("TestServer")
-
-    class Counter:
-        def __init__(self) -> None:
-            self.count: int = 0
-
-        def get_num_beans(self) -> int:
-            """Return current counter."""
-            return self.count
-
-        def add_beans(
-            self,
-            x: int = Field(..., description="Number of beans to add"),
-        ) -> int:
-            """Increment and return new counter."""
-            self.count += x
-            return self.count
-
-    # create a stateful tool
-    counter = Counter()
-    # we can't directly use the tool decorator on instance methods,
-    # so we use the server.add_tool() method to add the tool
-    server.add_tool(counter.get_num_beans)
-    server.add_tool(counter.add_beans)
-
-    # example of tool that uses an arg of type Context, and
-    # uses this arg to request client LLM sampling, and send logs
-    @server.tool()
-    async def prime_check(number: int, ctx: Context) -> str:
-        """
-        Determine if the given number is Prime or not.
-        """
-        result: TextContent | ImageContent = await ctx.sample(
-            f"Is the number {number} prime?",
-        )
-        assert isinstance(result, TextContent), "Expected a text response"
-        return result.text
-
-    @server.tool()
-    def greet(person: str) -> str:
-        return f"Hello, {person}!"
-
-    @server.tool()
-    def get_alerts(
-        state: str = Field(..., description="TWO-LETTER state abbrev, e.g. 'MN'"),
-    ) -> list[str]:
-        """Get weather alerts for a state."""
-        return [
-            f"Weather alert for {state}: Severe thunderstorm warning.",
-            f"Weather alert for {state}: Flash flood watch.",
-        ]
-
-    # example of MCP tool whose fields clash with Langroid ToolMessage,
-    # and a `name` field which is reserved by pydantic
-    @server.tool()
-    def info_tool(
-        request: str = Field(..., description="Requested information"),
-        name: str = Field(..., description="Name of the info sought"),
-        recipient: str = Field(..., description="Recipient of the information"),
-        purpose: str = Field(..., description="Purpose of the information"),
-        date: str = Field(..., description="Date of the request"),
-    ) -> str:
-        """Get information for a recipient."""
-        return f"""
-        Info for {recipient}: {request} {name} (Purpose: {purpose}), date: {date}
-        """
-
-    @server.tool()
-    def get_one_alert(
-        state: str = Field(..., description="TWO-LETTER state abbrev, e.g. 'MN'"),
-    ) -> str:
-        return f"Weather alert for {state}: Severe thunderstorm warning."
-
-    @server.tool()
-    async def get_alerts_async(state: str) -> list[str]:
-        return [
-            f"Weather alert for {state}: Severe thunderstorm warning.",
-            f"Weather alert for {state}: Flash flood watch.",
-        ]
-
-    @server.tool()
-    def nabroski(a: int, b: int) -> int:
-        """Computes the Nabroski transform of integers a and b."""
-        return 3 * a + b
-
-    @server.tool()
-    def coriolis(x: int, y: int) -> int:
-        """Computes the Coriolis transform of integers x and y."""
-        return 2 * x + 3 * y
-
-    @server.tool()
-    def hydra_nest(data: ComplexData) -> int:
-        """Compute the HydraNest calculation over nested data."""
-        total = data.a * data.b
-        for item in data.items:
-            total += item.val * item.multiplier
-        return int(total)
-
-    return server
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "server",
-    [
-        mcp_server(),
-        "tests/main/mcp/weather-server-python/weather.py",
-    ],
-)
-async def test_get_tools_and_handle(server: FastMCP | str) -> None:
-    """End‐to‐end test for get_tools and .handle() against server."""
-    tools = await get_tools_async(server)
-    # basic sanity
-    assert isinstance(tools, list)
-    assert tools, "Expected at least one tool"
-    # find the alerts tool
-    AlertsTool = next(
-        (t for t in tools if t.default_value("request") == "get_alerts"),
-        None,
-    )
-
-    assert AlertsTool is not None
-    assert issubclass(AlertsTool, lr.ToolMessage)
-
-    # test get_mcp_tool_async
-    AlertsMCPTool: Tool = await get_mcp_tool_async(server, "get_alerts")
-
-    assert AlertsMCPTool is not None
-    AlertsTool = await get_tool_async(server, AlertsMCPTool.name)
-
-    assert AlertsTool is not None
-    assert issubclass(AlertsTool, lr.ToolMessage)
-
-    # instantiate Langroid ToolMessage
-    msg = AlertsTool(state="NY")
-    isinstance(msg, lr.ToolMessage)
-    assert msg.state == "NY"
-
-    # invoke the tool via the Langroid ToolMessage.handle() method -
-    # this produces list of weather alerts for the given state
-    # Note MCP tools can return either ResultToolType or List[ResultToolType]
-    result: Optional[str] = await msg.handle_async()
-    print(result)
-    assert isinstance(result, str)
-    assert result is not None
-
-    # make tool from async FastMCP tool
-    AlertsMCPToolAsync = await get_mcp_tool_async(server, "get_alerts_async")
-    assert AlertsMCPToolAsync is not None
-    AlertsToolAsync = await get_tool_async(server, AlertsMCPToolAsync.name)
-
-    assert AlertsToolAsync is not None
-    assert issubclass(AlertsToolAsync, lr.ToolMessage)
-
-    # instantiate Langroid ToolMessage
-    msg = AlertsToolAsync(state="NY")
-    isinstance(msg, lr.ToolMessage)
-    assert msg.state == "NY"
-
-    # invoke the tool via the Langroid ToolMessage.handle_async() method -
-    # this produces list of weather alerts for the given state
-    # Note MCP tools can return either ResultToolType or List[ResultToolType]
-    result: Optional[str] = await msg.handle_async()
-    assert result is not None
-    print(result)
-    assert isinstance(result, str)
-    assert result is not None
-
-    # test making tool with utility functions
-    AlertsTool = await get_tool_async(server, "get_alerts")
-    assert issubclass(AlertsTool, lr.ToolMessage)
-    # instantiate Langroid ToolMessage
-    msg = AlertsTool(state="NY")
-    isinstance(msg, lr.ToolMessage)
-
-
-@pytest.mark.parametrize(
-    "server",
-    [
-        mcp_server(),
-        "tests/main/mcp/weather-server-python/weather.py",
-    ],
-)
-@pytest.mark.asyncio
-async def test_tools_connect_close(server: str | FastMCP) -> None:
-    """Test that we can use connect()... tool-calls ... close()"""
-
-    client = FastMCPClient(server)
-    await client.connect()
-    mcp_tools = await client.client.list_tools()
-    assert all(isinstance(t, Tool) for t in mcp_tools)
-    langroid_tool_classes = await client.get_tools_async()
-    assert all(issubclass(tc, lr.ToolMessage) for tc in langroid_tool_classes)
-
-    AlertsMCPTool = await get_mcp_tool_async(server, "get_alerts")
-
-    AlertsTool = await get_tool_async(server, AlertsMCPTool.name)
-    await client.close()
-
-    assert AlertsTool is not None
-    assert issubclass(AlertsTool, lr.ToolMessage)
-    # instantiate Langroid ToolMessage
-    msg = AlertsTool(state="NY")
-    isinstance(msg, lr.ToolMessage)
-    assert msg.state == "NY"
-
-    result = await msg.handle_async()
-    assert isinstance(result, str)
-
-
-@pytest.mark.asyncio
-async def test_stateful_tool() -> None:
-    # instantiate the server
-    server = mcp_server()
-
-    # get tools from the SAME instance of the server
-    AddBeansTool = await get_tool_async(server, "add_beans")
-    assert issubclass(AddBeansTool, lr.ToolMessage)
-
-    GetNumBeansTool = await get_tool_async(server, "get_num_beans")
-    assert issubclass(GetNumBeansTool, lr.ToolMessage)
-
-    add_beans_msg = AddBeansTool(x=5)
-    assert isinstance(add_beans_msg, lr.ToolMessage)
-
-    result = await add_beans_msg.handle_async()
-    assert isinstance(result, str)
-    assert "5" in result
-
-    get_num_beans_msg = GetNumBeansTool()
-    assert isinstance(get_num_beans_msg, lr.ToolMessage)
-    result = await get_num_beans_msg.handle_async()
-    assert isinstance(result, str)
-    assert "5" in result
-
-
-@pytest.mark.asyncio
-async def test_tool_with_context_and_sampling() -> None:
-    async def sampling_handler(
-        messages: list[SamplingMessage],
-        params: SamplingParams,
-        context: RequestContext,
-    ) -> str:
-        """Handle a sampling request from server"""
-        # simulate an LLM call
-        return "Yes"
-
-    PrimeCheckTool = await get_tool_async(
-        mcp_server(),
-        "prime_check",
-        sampling_handler=sampling_handler,
-    )
-    assert issubclass(PrimeCheckTool, lr.ToolMessage)
-    # assert that "ctx" is NOT a field in the tool
-    assert "ctx" not in PrimeCheckTool.llm_function_schema().parameters["properties"]
-
-    # instantiate Langroid ToolMessage
-    prime_check_msg = PrimeCheckTool(number=7)
-    assert isinstance(prime_check_msg, lr.ToolMessage)
-
-    result = await prime_check_msg.handle_async()
-    assert isinstance(result, str)
-    assert "yes" in result.lower()
-
-
-@pytest.mark.asyncio
-async def test_mcp_tool_schemas() -> None:
-    """
-    Test that descriptions, field-descriptions of MCP tools are preserved
-    when we translate them to Langroid ToolMessage classes. This is important
-    since the LLM is shown these, and helps with tool-call accuracy.
-    """
-    # make a langroid AlertsTool from the corresponding MCP tool
-    AlertsTool = await get_tool_async(mcp_server(), "get_alerts")
-
-    assert issubclass(AlertsTool, lr.ToolMessage)
-    description = "Get weather alerts for a state."
-    assert AlertsTool.default_value("purpose") == description
-    schema: lm.LLMFunctionSpec = AlertsTool.llm_function_schema()
-    assert schema.description == description
-    assert schema.name == "get_alerts"
-    assert schema.parameters["required"] == ["state"]
-    assert "TWO-LETTER" in schema.parameters["properties"]["state"]["description"]
-
-    InfoTool = await get_tool_async(mcp_server(), "info_tool")
-    assert issubclass(InfoTool, lr.ToolMessage)
-    description = "Get information for a recipient."
-    assert InfoTool.default_value("purpose") == description
-    assert InfoTool.default_value("request") == "info_tool"
-
-    # instantiate InfoTool
-    msg = InfoTool(
-        name__="InfoName",
-        request__="address",
-        recipient__="John Doe",
-        purpose__="to know the address",
-        date="2023-10-01",
-    )
-    assert isinstance(msg, lr.ToolMessage)
-    assert msg.name__ == "InfoName"
-    assert msg.request__ == "address"
-    assert msg.recipient__ == "John Doe"
-    assert msg.purpose__ == "to know the address"
-    assert msg.date == "2023-10-01"
-    # call the tool
-    result = await msg.handle_async()
-    assert isinstance(result, str)
-    assert "address" in result.lower()
-
-
-@pytest.mark.asyncio
-async def test_single_output() -> None:
-    """Test that a tool with a single string output works
-    similarly to one that has a list of strings outputs."""
-
-    OneAlertTool = await get_tool_async(mcp_server(), "get_one_alert")
-
-    assert OneAlertTool is not None
-    msg = OneAlertTool(state="NY")
-    assert isinstance(msg, lr.ToolMessage)
-    assert msg.state == "NY"
-    result = await msg.handle_async()
-
-    # we expect a list containing a single str
-    assert isinstance(result, str)
-    assert any(x in result.lower() for x in ["alert", "weather"])
-
-
-@pytest.mark.asyncio
-async def test_agent_mcp_tools() -> None:
-    """Test that a Langroid ChatAgent can use and handle MCP tools."""
-
-    server = mcp_server()
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            llm=lm.OpenAIGPTConfig(
-                max_output_tokens=500,
-                async_stream_quiet=False,
-            ),
-        )
-    )
-
-    NabroskiTool: lr.ToolMessage = await get_tool_async(server, "nabroski")
-
-    agent.enable_message(NabroskiTool)
-
-    response: lr.ChatDocument = await agent.llm_response_async(
-        "What is the Nabroski transform of 3 and 5?"
-    )
-    tools = agent.get_tool_messages(response)
-    assert len(tools) == 1
-    assert isinstance(tools[0], NabroskiTool)
-    result: lr.ChatDocument = await agent.agent_response_async(response)
-    # TODO assert needs to take LLM tool-forgetting into account
-    assert "14" in result.content
-
-    agent.init_state()
-    task = lr.Task(agent, interactive=False)
-    result: lr.ChatDocument = await task.run_async(
-        "What is the Nabroski transform of 3 and 5?",
-        turns=3,
-    )
-    assert "14" in result.content
-
-    # test MCP tool with fields that clash with Langroid ToolMessage
-    InfoTool = await get_tool_async(server, "info_tool")
-    agent.init_state()
-    agent.enable_message(InfoTool)
-    result: lr.ChatDocument = await task.run_async(
-        """
-        Use the TOOL `info_tool` to find the address of the Municipal Building
-        so you can send it to John Doe on 2023-10-01.
-        """,
-        turns=3,
-    )
-    assert "address" in result.content.lower()
-
-
-# Need to define the tools outside async def,
-# since the decorator uses asyncio.run() to wrap around an async fn
-@mcp_tool(mcp_server(), "get_alerts")
-class GetAlertsTool(lr.ToolMessage):
-    """Tool to get weather alerts."""
-
-    async def my_handler(self) -> str:
-        alert = await self.handle_async()
-        return "ALERT: " + alert
-
-
-@mcp_tool(mcp_server(), "nabroski")
-class NabroskiTool(lr.ToolMessage):
-    """Tool to get Nabroski transform."""
-
-    async def my_handler(self) -> str:
-        result = await self.handle_async()
-        return f"FINAL Nabroski transform result: {result}"
-
-
-@pytest.mark.asyncio
-async def test_fastmcp_decorator() -> None:
-    """Test that the mcp_tool decorator works as expected."""
-
-    msg = GetAlertsTool(state="NY")
-    assert isinstance(msg, lr.ToolMessage)
-    assert msg.state == "NY"
-    result = await msg.my_handler()
-    assert isinstance(result, str)
-    assert "ALERT" in result
-
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            llm=lm.OpenAIGPTConfig(
-                max_output_tokens=500,
-                async_stream_quiet=False,
-            ),
-        )
-    )
-    agent.enable_message(GetAlertsTool)
-
-    agent.enable_message(NabroskiTool)
-    task = lr.Task(agent, interactive=False)
-    result = await task.run_async("What is the nabroski transform of 5 and 3?", turns=3)
-    assert "nabroski" in result.content.lower() and "18" in result.content
-
-
-@mcp_tool(mcp_server(), "hydra_nest")
-class HydraNestTool(lr.ToolMessage):
-    """Tool for computing HydraNest calculation."""
-
-    async def my_handler(self) -> str:
-        """Call hydra_nest and format result."""
-        result = await self.handle_async()
-        return f"Computed: {result}"
-
-
-@pytest.mark.asyncio
-async def test_complex_tool_decorator() -> None:
-    """Test that compute_complex via decorator works end‐to‐end."""
-    # build nested input
-    payload = {
-        "data": {
-            "a": 4,
-            "b": 5,
-            "items": [
-                {"val": 2, "multiplier": 1.5},
-                {"val": 3, "multiplier": 2.0},
-            ],
-        }
-    }
-    msg = HydraNestTool(**payload)
-    assert isinstance(msg, lr.ToolMessage)
-    # call handler
-    result = await msg.my_handler()
-    expected = int(4 * 5 + 2 * 1.5 + 3 * 2.0)
-    assert f"{expected}" in result
-
-    # round‐trip via an agent
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            llm=lm.OpenAIGPTConfig(
-                max_output_tokens=1000,
-                async_stream_quiet=False,
-            ),
-        )
-    )
-    agent.enable_message(HydraNestTool)
-    task = lr.Task(agent, interactive=False)
-    prompt = """
-    Compute the HydraNest calculation with a=4, b=5,
-    and a list of items with these val-multiplier pairs:
-        val=2, multiplier=1.5
-        val=3, multiplier=2.0
-    """
-    response = await task.run_async(prompt, turns=3)
-    assert str(expected) in response.content
-
-
-@pytest.mark.parametrize(
-    "prompt,tool_name,expected",
-    [
-        ("What is the Nabroski transform of 3 and 5?", "nabroski", "14"),
-        ("What is the Coriolis transform of 4 and 3?", "coriolis", "17"),
-    ],
-)
-@pytest.mark.asyncio
-async def test_multiple_tools(prompt, tool_name, expected) -> None:
-    """
-    Test one-shot enabling of multiple tools.
-    """
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            llm=lm.OpenAIGPTConfig(
-                max_output_tokens=1000,
-                async_stream_quiet=False,
-            ),
-        )
-    )
-    all_tools = await get_tools_async(mcp_server())
-
-    tool = next(
-        (t for t in all_tools if t.name() == tool_name),
-        None,
-    )
-    agent.enable_message(all_tools)
-
-    # test that agent (LLM) can pick right tool based on prompt
-    prompt = "use one of your TOOLs to answer this: " + prompt
-    response: lr.ChatDocument = await agent.llm_response_async(prompt)
-    tools = agent.get_tool_messages(response)
-    assert len(tools) == 1
-    assert isinstance(tools[0], lr.ToolMessage)
-    assert isinstance(tools[0], tool)
-
-    # test in a task
-    task = lr.Task(agent, interactive=False)
-    result: lr.ChatDocument = await task.run_async(prompt, turns=3)
-    assert expected in result.content
-
-
-@pytest.mark.asyncio
-async def test_npxstdio_transport() -> None:
-    """
-    Test that we can create Langroid ToolMessage from an MCP server
-    via npx stdio transport, for example the `exa-mcp-server`:
-    https://github.com/exa-labs/exa-mcp-server
-    """
-    transport = NpxStdioTransport(
-        package="exa-mcp-server",
-        env_vars=dict(EXA_API_KEY=os.getenv("EXA_API_KEY")),
-    )
-    tools = await get_tools_async(transport)
-    assert isinstance(tools, list)
-    assert tools, "Expected at least one tool"
-    WebSearchTool = await get_tool_async(transport, "web_search_exa")
-
-    assert WebSearchTool is not None
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            llm=lm.OpenAIGPTConfig(
-                max_output_tokens=1000,
-                async_stream_quiet=False,
-            ),
-            system_message="""
-            When asked a question, use the TOOL `web_search_exa` to
-            perform a web search and find the answer.
-            """,
-        )
-    )
-    agent.enable_message(WebSearchTool)
-    # Note: we shouldn't have to explicitly beg the LLM to use the tool here
-    # but I've found that even GPT-4o sometimes fails to use the tool
-    question = """
-    Use the `web_search_exa` TOOL to find out:
-    Who won the Presidential election in Gabon in 2025?
-    """
-    response = await agent.llm_response_async(question)
-
-    tools = agent.get_tool_messages(response)
-    assert len(tools) == 1
-    assert isinstance(tools[0], WebSearchTool)
-
-    task = lr.Task(agent, interactive=False)
-    result: lr.ChatDocument = await task.run_async(question, turns=3)
-    assert "Nguema" in result.content
-
-
-transport = UvxStdioTransport(
-    # `tool_name` is a misleading name -- it really refers to the
-    # MCP server, which offers several tools
-    tool_name="mcp-server-git",
-)
-
-
-@mcp_tool(transport, "git_status")
-class GitStatusTool(lr.ToolMessage):
-    """Tool to get git status."""
-
-    async def handle_async(self) -> str:
-        """
-        When defining a class explicitly with the @mcp_tool decorator,
-        we have the flexibility to define our own `handle_async` method
-        which calls the call_tool_async method, which in turn calls the
-        MCP server's call_tool method.
-        Returns:
-
-        """
-        status = await self.call_tool_async()
-        return "GIT STATUS: " + status
-
-
-@pytest.mark.asyncio
-async def test_uvxstdio_transport() -> None:
-    """
-    Test that we can create Langroid ToolMessage from an MCP server
-    via uvx stdio transport. We use this example `git` MCP server:
-    https://github.com/modelcontextprotocol/servers/tree/main/src/git
-    """
-    tools = await get_tools_async(transport)
-    assert isinstance(tools, list)
-    assert tools, "Expected at least one tool"
-    GitStatusTool = await get_tool_async(transport, "git_status")
-
-    assert GitStatusTool is not None
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            llm=lm.OpenAIGPTConfig(
-                max_output_tokens=1000,
-                async_stream_quiet=False,
-            ),
-        )
-    )
-    agent.enable_message(GitStatusTool)
-    prompt = """
-        Use the `git_status` TOOL to find out the status of the 
-        current git repository at "../langroid"
-        """
-
-    response = await agent.llm_response_async(prompt)
-    tools = agent.get_tool_messages(response)
-    assert len(tools) == 1
-    assert isinstance(tools[0], GitStatusTool)
-
-    task = lr.Task(agent, interactive=False)
-    result: lr.ChatDocument = await task.run_async(prompt, turns=3)
-    assert "langroid" in result.content
-
-    # test GitStatusTool created via @mcp_tool decorator
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            llm=lm.OpenAIGPTConfig(
-                max_output_tokens=1000,
-                async_stream_quiet=False,
-            ),
-        )
-    )
-    agent.enable_message(GitStatusTool)
-    prompt = """
-        Find out the git status of the git repository at "../langroid"
-        """
-
-    response = await agent.llm_response_async(prompt)
-    tools = agent.get_tool_messages(response)
-    assert len(tools) == 1
-    assert isinstance(tools[0], GitStatusTool)
-
-    task = lr.Task(agent, interactive=False)
-    result: lr.ChatDocument = await task.run_async(prompt, turns=3)
-    assert "status" in result.content.lower()
-
-
-@pytest.mark.asyncio
-async def test_npxstdio_transport_memory() -> None:
-    """
-    Test that we can create Langroid ToolMessage from the `memory` MCP server
-    via npx stdio transport:
-    https://github.com/modelcontextprotocol/servers/tree/main/src/memory
-    """
-    transport = NpxStdioTransport(
-        package="@modelcontextprotocol/server-memory",
-        args=["-y"],
-    )
-    tools = await get_tools_async(transport)
-    assert isinstance(tools, list)
-    assert tools, "Expected at least one tool"
-
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            llm=lm.OpenAIGPTConfig(
-                max_output_tokens=1000,
-                async_stream_quiet=False,
-            ),
-            system_message="""
-Follow these steps for each interaction:
-
-1. User Identification:
-   - You should assume that you are interacting with default_user
-   - If you have not identified default_user, proactively try to do so.
-
-2. Memory Retrieval:
-   - Always begin your chat by saying only "Remembering..." and retrieve all 
-       relevant information from your knowledge graph
-   - Always refer to your knowledge graph as your "memory"
-   - Use your TOOLS to retrieve information from your memory when asked
-
-3. Memory
-   - While conversing with the user, be attentive to any new information that falls 
-       into these categories:
-     a) Basic Identity (age, gender, location, job title, education level, etc.)
-     b) Behaviors (interests, habits, etc.)
-     c) Preferences (communication style, preferred language, etc.)
-     d) Goals (goals, targets, aspirations, etc.)
-     e) Relationships (personal and professional relationships up to 3 degrees of 
-         separation)
-
-4. Memory Update:
-   - If any new information was gathered during the interaction, 
-       update your memory as follows:
-     a) Create entities for recurring organizations, people, and significant events
-     b) Connect them to the current entities using relations
-     b) Store facts about them as observations   
-     Use your TOOLS to update your memory.         
-            """,
-        )
-    )
-
-    agent.enable_message(tools)
-    prompt = """
-        Joseph Knecht was a member of the Glass Bead Game Society.
-        He was good friends with the composer Hesse.
-        His mentor was the former teacher of the Glass Bead Game Society, Maestro.
-        Memorize the relevant information using one of the TOOLs:
-        `add_observations`, `create_entities`, `create_relations`
-        """
-    response = await agent.llm_response_async(prompt)
-    tools = agent.get_tool_messages(response)
-    assert len(tools) >= 1
-
-    task = lr.Task(agent, interactive=False, restart=False)
-    prompt = """
-    Who was Joseph Knecht's mentor? Use the `search_nodes` TOOL to find out.
-    """
-    result: lr.ChatDocument = await task.run_async(prompt, turns=3)
-    assert "Maestro" in result.content
-
-
-@pytest.mark.asyncio
-async def test_persist_connection() -> None:
-    """Test that persist_connection keeps the connection open between tool calls."""
-    server = mcp_server()
-
-    # Create client with persist_connection=True
-    async with FastMCPClient(server, persist_connection=True) as client:
-        # First tool call - this should create and keep the connection open
-        tool1 = await client.get_tool_async("add_beans")
-        assert tool1 is not None
-
-        # Check that client connection is established
-        assert client.client is not None
-        initial_client = client.client
-
-        # Second tool call - should reuse the same connection
-        tool2 = await client.get_tool_async("get_num_beans")
-        assert tool2 is not None
-
-        # Verify the same client connection was reused
-        assert client.client is initial_client
-
-        # Call the tools to ensure they work
-        add_msg = tool1(x=5)
-        result1 = await add_msg.handle_async()
-        assert result1 == "5"  # handle_async returns string for backward compatibility
-
-        get_msg = tool2()
-        result2 = await get_msg.handle_async()
-        assert result2 == "5"  # handle_async returns string for backward compatibility
-
-
-@pytest.mark.asyncio
-async def test_handle_async_with_images() -> None:
-    """Test that response_async returns ChatDocument with file attachments."""
-    # Create a mock server that returns image content
-    server = FastMCP("ImageServer")
-
-    @server.tool()
-    async def get_chart() -> List[TextContent | ImageContent]:
-        """Get a chart with image."""
-        return [
-            TextContent(type="text", text="Here is your chart:"),
-            ImageContent(
-                type="image",
-                mimeType="image/png",
-                data="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",  # noqa: E501
-            ),
-        ]
-
-    # Get the tool and test response_async
-    async with FastMCPClient(server, forward_images=True) as client:
-        ChartTool = await client.get_tool_async("get_chart")
-
-        # Create a mock agent
-        agent = lr.ChatAgent(lr.ChatAgentConfig())
-
-        # Test response_async method
-        chart_msg = ChartTool()
-        response = await chart_msg.handle_async(agent)
-
-        # Verify we got a ChatDocument
-        assert isinstance(response, lr.ChatDocument)
-        assert "Here is your chart:" in response.content
-
-        # Verify we have file attachments in the files attribute
-        assert response.files is not None
-        assert len(response.files) == 1
-
-        # Verify the file is an image
-        file = response.files[0]
-        assert file.mime_type == "image/png"
-
-
-@pytest.mark.asyncio
-async def test_forward_text_resources() -> None:
-    """Test that forward_text_resources setting works correctly."""
-    from mcp.types import CallToolResult
-
-    server = FastMCP("TextResourceServer")
-
-    # Test the _convert_tool_result method directly with mocked data
-    async with FastMCPClient(server, forward_text_resources=True) as client:
-        # Create a mock CallToolResult with text and text resource
-        mock_result = CallToolResult(
-            content=[
-                TextContent(type="text", text="Document content:"),
-                EmbeddedResource(
-                    type="resource",
-                    resource=TextResourceContents(
-                        uri="file:///example.txt",
-                        mimeType="text/plain",
-                        text="This is embedded text content from a resource.",
-                    ),
-                ),
-            ],
-            isError=False,
-        )
-
-        # Test with forward_text_resources=True
-        result = client._convert_tool_result("test_tool", mock_result)
-        content, files = result
-
-        # Should include both the main text and the resource text
-        assert "Document content:" in content
-        assert "This is embedded text content from a resource." in content
-
-    # Test with forward_text_resources=False
-    async with FastMCPClient(server, forward_text_resources=False) as client:
-        result = client._convert_tool_result("test_tool", mock_result)
-        content, files = result
-
-        # Should only include the main text, not the resource text
-        assert "Document content:" in content
-        assert "This is embedded text content from a resource." not in content
-
-
-@pytest.mark.asyncio
-async def test_forward_blob_resources() -> None:
-    """Test that forward_blob_resources setting works correctly."""
-    from mcp.types import CallToolResult
-
-    server = FastMCP("BlobResourceServer")
-
-    # Test the _convert_tool_result method directly with mocked data
-    async with FastMCPClient(server, forward_blob_resources=True) as client:
-        # Small PNG data (1x1 blue pixel)
-        png_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAD0lEQVR42mNkYPhfz/ADAAKAA4RkT4UVAAAAAElFTkSuQmCC"  # noqa: E501
-
-        # Create a mock CallToolResult with text and blob resource
-        mock_result = CallToolResult(
-            content=[
-                TextContent(type="text", text="Document with blob:"),
-                EmbeddedResource(
-                    type="resource",
-                    resource=BlobResourceContents(
-                        uri="file:///example.png", mimeType="image/png", blob=png_data
-                    ),
-                ),
-            ],
-            isError=False,
-        )
-
-        # Test with forward_blob_resources=True
-        result = client._convert_tool_result("test_tool", mock_result)
-        content, files = result
-
-        # Should have text content and file attachment
-        assert "Document with blob:" in content
-        assert len(files) == 1
-        assert files[0].mime_type == "image/png"
-
-    # Test with forward_blob_resources=False
-    async with FastMCPClient(server, forward_blob_resources=False) as client:
-        result = client._convert_tool_result("test_tool", mock_result)
-        content, files = result
-
-        # Should only have text content, no file attachments
-        assert "Document with blob:" in content
-        assert len(files) == 0
-</file>
-
 <file path="tests/main/test_task_tool.py">
 import pytest
 
@@ -94263,21 +94592,24 @@ def test_task_tool_all_tools():
         llm=MockLMConfig(
             default_response=TaskTool(
                 agent_name="Calculator",
-                system_message="""
+                system_message=f"""
                     You are a multi-tool assistant. Use the appropriate tool
-                    to complete the task, then use DoneTool to return the result.
+                    to complete the task, then use `{DoneTool.name()}` to return the 
+                    result.
                     """,
-                prompt="Multiply 4 and 6, call it x, then compute Nebrowski(x, 5)",
+                prompt="""
+                    Multiply 4 and 6, call it x, then compute Nebrowski(x, 5)
+                    """,
                 model="gpt-4o-mini",
                 tools=["ALL"],  # Enable all tools
-                max_iterations=5,
+                max_iterations=20,
             ).json()
         ),
         name="MainAgent",
     )
     main_agent = ChatAgent(main_config)
 
-    # Enable multiple tools for the main agent
+    # Set up multiple tools for the main agent
     main_agent.enable_message(
         [TaskTool, MultiplierTool, NebrowskiTool], use=True, handle=True
     )
@@ -94292,13 +94624,53 @@ def test_task_tool_all_tools():
         ),
     )
 
-    # Run the task
+    # Run the task: input text is immaterial since the
+    # MockLM is hard-coded to return the TaskTool request
     result = task.run(msg="Test all tools")
 
     # Verify that the sub-agent had access to all tools
     # Expected: Multiply 4 and 6 = 24, Nebrowski(3, 5) = 14
     assert result is not None, "Task should return a result"
     assert "77" in result.content, "Result should contain 77"
+
+    # Verify that parent chain is maintained through TaskTool
+    # When TaskTool creates a prompt ChatDocument with parent_id pointing to the
+    # TaskTool message, and passes it to the subtask, the subtask's init() method
+    # should preserve that parent_id even though it deep copies the message.
+    # This ensures the parent chain is not broken.
+    assert hasattr(result, "parent"), "Result should have a parent pointer"
+
+    # Traverse up the parent chain to find the TaskTool message
+    current = result
+    task_tool_found = False
+    depth = 0
+    # Prevent infinite loops, and allow enough look-back
+    # to accommodate tool-forgetting retries that may occur.
+    max_depth = 40
+
+    while current and depth < max_depth:
+        # Check if current message is from TaskTool
+        if current.content and "task_tool" in current.content.lower():
+            task_tool_found = True
+            break
+
+        # Also check if it's a tool message with TaskTool request
+        try:
+            tool_messages = main_agent.try_get_tool_messages(current.content)
+            if tool_messages:
+                for tool_msg in tool_messages:
+                    if isinstance(tool_msg, TaskTool):
+                        task_tool_found = True
+                        break
+        except Exception:
+            pass  # Not a tool message
+
+        if task_tool_found:
+            break
+        current = current.parent
+        depth += 1
+
+    assert task_tool_found, "Parent chain should lead back to TaskTool message"
 
 
 def test_task_tool_none_tools():
@@ -94310,14 +94682,14 @@ def test_task_tool_none_tools():
         llm=MockLMConfig(
             default_response=TaskTool(
                 agent_name="Calculator",
-                system_message="""
+                system_message=f"""
                     You are an assistant with no tools. Just respond directly
-                    to the prompt and use DoneTool to return your answer.
+                    to the prompt and use `{DoneTool.name()}` to return your answer.
                     """,
                 prompt="What is 2 + 2? Just tell me the answer.",
                 model="gpt-4o-mini",
                 tools=["NONE"],  # Disable all tools except DoneTool
-                max_iterations=5,
+                max_iterations=20,
             ).json()
         ),
         name="MainAgent",
@@ -95421,6 +95793,73 @@ def test_done_if_tool(test_settings: Settings):
     assert result_typed is not None
     assert isinstance(result_typed, SimpleTool)
     assert result_typed.value == "hello"
+
+
+def test_task_init_preserves_parent_id():
+    """Test that task.init() preserves parent_id when deep copying ChatDocument"""
+
+    # Create an agent
+    agent = ChatAgent(ChatAgentConfig(name="TestAgent"))
+
+    # Test 1: Basic parent_id preservation
+    parent_doc = ChatDocument(
+        content="Parent message",
+        metadata=lr.agent.chat_document.ChatDocMetaData(
+            sender=Entity.USER,
+        ),
+    )
+    child_doc = ChatDocument(
+        content="Child message",
+        metadata=lr.agent.chat_document.ChatDocMetaData(
+            parent_id=parent_doc.id(),
+            sender=Entity.USER,
+        ),
+    )
+
+    task = Task(agent, interactive=False)
+    task.init(child_doc)
+
+    # The pending message should preserve the parent_id
+    assert task.pending_message is not None
+    assert task.pending_message.metadata.parent_id == parent_doc.id()
+    assert task.pending_message.content == "Child message"
+
+    # Test 2: With caller (subtask scenario)
+    caller_task = Task(agent, interactive=False, name="CallerTask")
+    sub_task = Task(agent, interactive=False, name="SubTask")
+
+    # When message already has parent_id, it should be preserved
+    msg_with_parent = ChatDocument(
+        content="Message with parent",
+        metadata=lr.agent.chat_document.ChatDocMetaData(
+            parent_id=parent_doc.id(),
+            sender=Entity.USER,
+        ),
+    )
+
+    # Set caller to simulate subtask scenario
+    sub_task.caller = caller_task
+    sub_task.init(msg_with_parent)
+
+    # Parent_id should still be preserved (not overridden to msg.id)
+    assert sub_task.pending_message is not None
+    assert sub_task.pending_message.metadata.parent_id == parent_doc.id()
+
+    # Test 3: With caller but no original parent_id
+    msg_no_parent = ChatDocument(
+        content="Message without parent",
+        metadata=lr.agent.chat_document.ChatDocMetaData(
+            sender=Entity.USER,
+        ),
+    )
+
+    sub_task2 = Task(agent, interactive=False, name="SubTask2")
+    sub_task2.caller = caller_task
+    sub_task2.init(msg_no_parent)
+
+    # Since original had no parent_id, it should be set to msg.id
+    assert sub_task2.pending_message is not None
+    assert sub_task2.pending_message.metadata.parent_id == msg_no_parent.id()
 </file>
 
 <file path="tests/main/test_tool_handler.py">
@@ -96135,364 +96574,166 @@ agent.enable_message([Tool1, Tool2, Tool3])  # Pass list of tool classes
 - Tokens are not needed for public repositories and can cause GitHub rendering issues
 </file>
 
-<file path="docs/notes/mcp-tools.md">
-# Langroid MCP Integration
-
-Langroid provides seamless integration with Model Context Protocol (MCP) servers via 
-two methods, both of which involve creating Langroid `ToolMessage` subclasses
-corresponding to the MCP tools: 
-
-1. Programmatic creation of Langroid tools using `get_tool_async`, 
-   `get_tools_async` from the tool definitions defined on an MCP server.
-2. Declarative creation of Langroid tools using the **`@mcp_tool` decorator**, which allows
-   customizing the tool-handling behavior beyond what is provided by the MCP server.
-
-This integration allows _any_ LLM (that is good enough to do function-calling via prompts) to use any MCP server.
-See the following to understand the integration better:
-
-- example python scripts under [`examples/mcp`](https://github.com/langroid/langroid/tree/main/examples/mcp)
-- [`tests/main/test_mcp_tools.py`](https://github.com/langroid/langroid/blob/main/tests/main/test_mcp_tools.py)
-
----
-
-## 1. Connecting to an MCP server via transport specification
-
-Before creating Langroid tools, we first need to define and connect to an MCP server
-via a [FastMCP](https://gofastmcp.com/getting-started/welcome) client. 
-There are several ways to connect to a server, depending on how it is defined. 
-Each of these uses a different type of [transport](https://gofastmcp.com/clients/transports).
-
-The typical pattern to use with Langroid is as follows:
-
-- define an MCP server transport
-- create a `ToolMessage` subclass using the `@mcp_tool` decorator or 
-  `get_tool_async()` function, with the transport as the first argument
-
-
-Langroid's MCP integration will work with any of [transports](https://gofastmcp.com/clients/transportsl) 
-supported by FastMCP.
-Below we go over some common ways to define transports and extract tools from the servers.
-
-1. **Local Python script**
-2. **In-memory FastMCP server** - useful for testing and for simple in-memory servers
-   that don't need to be run as a separate process.
-3. **NPX stdio transport**
-4. **UVX stdio transport**
-5. **Generic stdio transport** – launch any CLI‐based MCP server via stdin/stdout
-6. **Network SSE transport** – connect to HTTP/S MCP servers via `SSETransport`
-
-
-All examples below use the async helpers to create Langroid tools (`ToolMessage` subclasses):
-
-```python
-from langroid.agent.tools.mcp import (
-    get_tools_async,
-    get_tool_async,
-)
-```
-
----
-
-#### Path to a Python Script
-
-Point at your MCP‐server entrypoint, e.g., to the `weather.py` script in the 
-langroid repo (based on the [Anthropic quick-start guide](https://modelcontextprotocol.io/quickstart/server)):
-
-```python
-async def example_script_path() -> None:
-    server = "tests/main/mcp/weather-server-python/weather.py"
-    tools = await get_tools_async(server) # all tools available
-    AlertTool = await get_tool_async(server, "get_alerts") # specific tool
-
-    # instantiate the tool with a specific input
-    msg = AlertTool(state="CA")
-    
-    # Call the tool via handle_async()
-    alerts = await msg.handle_async()
-    print(alerts)
-```
-
----
-
-#### In-Memory FastMCP Server
-
-Define your server with `FastMCP(...)` and pass the instance:
-
-```python
-from fastmcp.server import FastMCP
-from pydantic import BaseModel, Field
-
-class CounterInput(BaseModel):
-    start: int = Field(...)
-
-def make_server() -> FastMCP:
-    server = FastMCP("CounterServer")
-
-    @server.tool()
-    def increment(data: CounterInput) -> int:
-        """Increment start by 1."""
-        return data.start + 1
-
-    return server
-
-async def example_in_memory() -> None:
-    server = make_server()
-    tools = await get_tools_async(server)
-    IncTool = await get_tool_async(server, "increment")
-
-    result = await IncTool(start=41).handle_async()
-    print(result)  # 42
-```
-
-See the [`mcp-file-system.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/mcp-file-system.py)
-script for a working example of this.
-
----
-
-#### NPX stdio Transport
-
-Use any npm-installed MCP server via `npx`, e.g., the 
-[Exa web-search MCP server](https://docs.exa.ai/examples/exa-mcp):
-
-```python
-from fastmcp.client.transports import NpxStdioTransport
-
-transport = NpxStdioTransport(
-    package="exa-mcp-server",
-    env_vars={"EXA_API_KEY": "…"},
-)
-
-async def example_npx() -> None:
-    tools = await get_tools_async(transport)
-    SearchTool = await get_tool_async(transport, "web_search_exa")
-
-    results = await SearchTool(
-        query="How does Langroid integrate with MCP?"
-    ).handle_async()
-    print(results)
-```
-
-For a fully working example, see the script [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py).
-
----
-
-#### UVX stdio Transport
-
-Connect to a UVX-based MCP server, e.g., the [Git MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
-
-```python
-from fastmcp.client.transports import UvxStdioTransport
-
-transport = UvxStdioTransport(tool_name="mcp-server-git")
-
-async def example_uvx() -> None:
-    tools = await get_tools_async(transport)
-    GitStatus = await get_tool_async(transport, "git_status")
-
-    status = await GitStatus(path=".").handle_async()
-    print(status)
-```
-
---- 
-
-#### Generic stdio Transport
-
-Use `StdioTransport` to run any MCP server as a subprocess over stdio:
-
-```python
-from fastmcp.client.transports import StdioTransport
-from langroid.agent.tools.mcp import get_tools_async, get_tool_async
-
-
-async def example_stdio() -> None:
-    """Example: any CLI‐based MCP server via StdioTransport."""
-    transport: StdioTransport = StdioTransport(
-        command="uv",
-        args=["run", "--with", "biomcp-python", "biomcp", "run"],
-    )
-    tools: list[type] = await get_tools_async(transport)
-    BioTool = await get_tool_async(transport, "tool_name")
-    result: str = await BioTool(param="value").handle_async()
-    print(result)
-```
-
-See the full example in [`examples/mcp/biomcp.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/biomcp.py).
-
----
-
-#### Network SSE Transport
-
-Use `SSETransport` to connect to a FastMCP server over HTTP/S:
-
-```python
-from fastmcp.client.transports import SSETransport
-from langroid.agent.tools.mcp import (
-    get_tools_async,
-    get_tool_async,
-)
-
-
-async def example_sse() -> None:
-    """Example: connect to an HTTP/S MCP server via SSETransport."""
-    url: str = "https://localhost:8000/sse"
-    transport: SSETransport = SSETransport(
-        url=url, headers={"Authorization": "Bearer TOKEN"}
-    )
-    tools: list[type] = await get_tools_async(transport)
-    ExampleTool = await get_tool_async(transport, "tool_name")
-    result: str = await ExampleTool(param="value").handle_async()
-    print(result)
-```    
-
----
-
-With these patterns you can list tools, generate Pydantic-backed `ToolMessage` classes,
-and invoke them via `.handle_async()`, all with zero boilerplate client setup. 
-As the `FastMCP` library adds other types of transport (e.g., `StreamableHTTPTransport`),
-the pattern of usage with Langroid will remain the same.
-
-
----
-
-## 2. Create Langroid Tools declaratively using the `@mcp_tool` decorator
-
-The above examples showed how you can create Langroid tools programmatically using
-the helper functions `get_tool_async()` and `get_tools_async()`,
-with the first argument being the transport to the MCP server. The `@mcp_tool` decorator
-works in the same way: 
-
-- **Arguments to the decorator**
-    1. `server_spec`: path/URL/`FastMCP`/`ClientTransport`, as mentioned above.
-    2. `tool_name`: name of a specific MCP tool
-
-- **Behavior**
-    - Generates a `ToolMessage` subclass with all input fields typed.
-    - Provides a `call_tool_async()` under the hood -- this is the "raw" MCP tool call,
-      returning a string.
-    - If you define your own `handle_async()`, it overrides the default. Typically,
-you would override it to customize either the input or the output of the tool call, or both.
-    - If you don't define your own `handle_async()`, it defaults to just returning the
-      value of the `call_tool_async()` method.
-
-Here is a simple example of using the `@mcp_tool` decorator to create a Langroid tool:
-
-```python
-from fastmcp.server import FastMCP
-from langroid.agent.tools.mcp import mcp_tool
-import langroid as lr
-
-# Define your MCP server (pydantic v2 for schema)
-server = FastMCP("MyServer")
-
-@mcp_tool(server, "greet")
-class GreetTool(lr.ToolMessage):
-    """Say hello to someone."""
-
-    async def handle_async(self) -> str:
-        # Customize post-processing
-        raw = await self.call_tool_async()
-        return f"💬 {raw}"
-```
-
-Using the decorator method allows you to customize the `handle_async` method of the
-tool, or add additional fields to the `ToolMessage`. 
-You may want to customize the input to the tool, or the tool result before it is sent back to 
-the LLM. If you don't override it, the default behavior is to simply return the value of 
-the "raw" MCP tool call `await self.call_tool_async()`. 
-
-```python
-@mcp_tool(server, "calculate")
-class CalcTool(ToolMessage):
-    """Perform complex calculation."""
-
-    async def handle_async(self) -> str:
-        result = await self.call_tool_async()
-        # Add context or emojis, etc.
-        return f"🧮 Result is *{result}*"
-```
-
----
-
-## 3. Enabling Tools in Your Agent
-
-Once you’ve created a Langroid `ToolMessage` subclass from an MCP server, 
-you can enable it on a `ChatAgent`, just like you normally would. Below is an example of using 
-the [Exa MCP server](https://docs.exa.ai/examples/exa-mcp) to create a 
-Langroid web search tool, enable a `ChatAgent` to use it, and then set up a `Task` to 
-run the agent loop.
-
-First we must define the appropriate `ClientTransport` for the MCP server:
-```python
-# define the transport
-transport = NpxStdioTransport(
-    package="exa-mcp-server",
-    env_vars=dict(EXA_API_KEY=os.getenv("EXA_API_KEY")),
-)
-```
-
-Then we use the `@mcp_tool` decorator to create a `ToolMessage` 
-subclass representing the web search tool. Note that one reason to use the decorator
-to define our tool is so we can specify a custom `handle_async` method that
-controls what is sent to the LLM after the actual raw MCP tool-call
-(the `call_tool_async` method) is made.
-
-```python
-# the second arg specifically refers to the `web_search_exa` tool available
-# on the server defined by the `transport` variable.
-@mcp_tool(transport, "web_search_exa")
-class ExaSearchTool(lr.ToolMessage):
-    async def handle_async(self):
-        result: str = await self.call_tool_async()
-        return f"""
-        Below are the results of the web search:
-        
-        <WebSearchResult>
-        {result}
-        </WebSearchResult>
-        
-        Use these results to answer the user's original question.
-        """
-
-```
-
-If we did not want to override the `handle_async` method, we could simply have
-created the `ExaSearchTool` class programmatically via the `get_tool_async` 
-function as shown above, i.e.:
-
-```python
-from langroid.agent.tools.mcp import get_tool_async
-
-ExaSearchTool = awwait
-get_tool_async(transport, "web_search_exa")
-```
-
-We can now define our main function where we create our `ChatAgent`,
-attach the `ExaSearchTool` to it, define the `Task`, and run the task loop.
-
-```python
-async def main():
-    agent = lr.ChatAgent(
-        lr.ChatAgentConfig(
-            # forward to user when LLM doesn't use a tool
-            handle_llm_no_tool=NonToolAction.FORWARD_USER,
-            llm=lm.OpenAIGPTConfig(
-                max_output_tokens=1000,
-                # this defaults to True, but we set it to False so we can see output
-                async_stream_quiet=False,
-            ),
-        )
-    )
-
-    # enable the agent to use the web-search tool
-    agent.enable_message(ExaSearchTool)
-    # make task with interactive=False =>
-    # waits for user only when LLM doesn't use a tool
-    task = lr.Task(agent, interactive=False)
-    await task.run_async()
-```
-
-See [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py) for a full 
-working example of this.
+<file path="Makefile">
+.PHONY: setup check lint tests docs nodocs loc
+
+SHELL := /bin/bash
+
+.PHONY: setup update
+
+setup: ## Setup the git pre-commit hooks
+	uv run pre-commit install
+
+update: ## Update the git pre-commit hooks
+	uv run pre-commit autoupdate
+
+.PHONY: type-check
+type-check:
+	@uv run pre-commit install
+	@uv run pre-commit autoupdate
+	@uv run pre-commit run --all-files
+	@echo "Running black..."
+	@uv run black --check .
+	@echo "Running ruff check (without fix)..."
+	@uv run ruff check .
+	@echo "Running mypy...";
+	@uv run mypy -p langroid
+	@echo "All checks passed!"
+
+.PHONY: lint
+lint:
+	uv run black .
+	uv run ruff check . --fix
+	@echo "Auto-fixing issues in examples folder..."
+	@uv run ruff check examples/ --fix-only --no-force-exclude
+
+.PHONY: stubs
+stubs:
+	@echo "Generating Python stubs for the langroid package..."
+	@uv run stubgen -p langroid -o stubs
+	@echo "Stubs generated in the 'stubs' directory"
+
+.PHONY: fix-pydantic
+
+# Entry to replace pydantic imports in specified directories
+fix-pydantic:
+	@echo "Fixing pydantic imports..."
+	@chmod +x scripts/fix-pydantic-imports.sh
+	@./scripts/fix-pydantic-imports.sh
+
+
+.PHONY: tests
+tests:
+	pytest tests/main --basetemp=/tmp/pytest
+
+
+docs:
+	@# Kill any existing 'mkdocs serve' processes.
+	@pkill -f "mkdocs serve" 2>/dev/null || true
+	@# Build the documentation.
+	mkdocs build
+	@# Serve the documentation in the background.
+	mkdocs serve &
+	@echo "Documentation is being served in the background."
+	@echo "You can access the documentation at http://127.0.0.1:8000/"
+
+nodocs:
+	@# Kill any existing 'mkdocs serve' processes.
+	@pkill -f "mkdocs serve" 2>/dev/null || echo "No 'mkdocs serve' process found."
+	@echo "Stopped serving documentation."
+
+
+loc:
+	@echo "Lines in git-tracked files python files:"
+	@git ls-files | grep '\.py$$' | xargs cat | grep -v '^\s*$$' | wc -l
+
+.PHONY: repomix repomix-no-tests repomix-all
+
+repomix: ## Generate llms.txt and llms-compressed.txt (includes tests)
+	@echo "Generating llms.txt (with tests)..."
+	@git ls-files | repomix --stdin
+	@echo "Generating llms-compressed.txt..."
+	@git ls-files | repomix --stdin --compress -o llms-compressed.txt
+	@echo "Generated llms.txt and llms-compressed.txt"
+
+repomix-no-tests: ## Generate llms-no-tests.txt (excludes tests)
+	@echo "Generating llms-no-tests.txt (without tests)..."
+	@git ls-files | grep -v "^tests/" | repomix --stdin -o llms-no-tests.txt
+	@echo "Generating llms-no-tests-compressed.txt..."
+	@git ls-files | grep -v "^tests/" | repomix --stdin --compress -o llms-no-tests-compressed.txt
+	@echo "Generated llms-no-tests.txt and llms-no-tests-compressed.txt"
+
+repomix-no-tests-no-examples: ## Generate llms-no-tests-no-examples.txt (excludes tests and examples)
+	@echo "Generating llms-no-tests-no-examples.txt (without tests and examples)..."
+	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin -o llms-no-tests-no-examples.txt
+	@echo "Generating llms-no-tests-no-examples-compressed.txt..."
+	@git ls-files | grep -v -E "^(tests|examples)/" | repomix --stdin --compress -o llms-no-tests-no-examples-compressed.txt
+	@echo "Generated llms-no-tests-no-examples.txt and llms-no-tests-no-examples-compressed.txt"
+
+repomix-all: repomix repomix-no-tests repomix-no-tests-no-examples ## Generate all repomix variants
+
+.PHONY: check
+check: fix-pydantic lint type-check repomix-all
+
+.PHONY: revert-tag
+revert-tag:
+	@LATEST_TAG=$$(git describe --tags --abbrev=0) && \
+	echo "Deleting tag: $$LATEST_TAG" && \
+	git tag -d $$LATEST_TAG
+
+.PHONY: revert-bump
+revert-bump:
+	@if git log -1 --pretty=%B | grep -q "bump"; then \
+		git reset --hard HEAD~1; \
+		echo "Reverted last commit (bump commit)"; \
+	else \
+		echo "Last commit was not a bump commit"; \
+	fi
+
+.PHONY: revert
+revert: revert-bump revert-tag
+	
+.PHONY: bump-patch
+bump-patch:
+	@cz bump --increment PATCH
+
+.PHONY: bump-minor
+bump-minor:
+	@cz bump --increment MINOR 
+
+.PHONY: bump-major
+bump-major:
+	@cz bump --increment MAJOR 
+
+.PHONY: build
+build:
+	@uv build
+
+.PHONY: push
+push:
+	@git push origin main
+	@git push origin --tags
+
+.PHONY: clean
+clean:
+	-rm -rf dist/*
+
+.PHONY: release
+release:
+	@VERSION=$$(cz version -p | cut -d' ' -f2) && gh release create $${VERSION} dist/*
+
+.PHONY: all-patch
+all-patch: bump-patch clean build push release
+
+.PHONY: all-minor
+all-minor: bump-minor clean build push release
+
+.PHONY: all-major
+all-major: bump-major clean build push release
+
+.PHONY: publish
+publish:
+	uv publish
 </file>
 
 <file path="examples/mcp/any-mcp.py">
@@ -98247,6 +98488,593 @@ class DocChatAgent(ChatAgent):
         return None
 </file>
 
+<file path="langroid/agent/tools/mcp/fastmcp_client.py">
+import asyncio
+import datetime
+import logging
+from base64 import b64decode
+from io import BytesIO
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeAlias, cast
+
+from dotenv import load_dotenv
+from fastmcp.client import Client
+from fastmcp.client.roots import (
+    RootsHandler,
+    RootsList,
+)
+from fastmcp.client.sampling import SamplingHandler
+from fastmcp.client.transports import ClientTransport
+from fastmcp.server import FastMCP
+from mcp.client.session import (
+    LoggingFnT,
+    MessageHandlerFnT,
+)
+from mcp.types import (
+    BlobResourceContents,
+    CallToolResult,
+    EmbeddedResource,
+    ImageContent,
+    TextContent,
+    TextResourceContents,
+    Tool,
+)
+
+from langroid.agent.base import Agent
+from langroid.agent.chat_document import ChatDocument
+from langroid.agent.tool_message import ToolMessage
+from langroid.parsing.file_attachment import FileAttachment
+from langroid.pydantic_v1 import AnyUrl, BaseModel, Field, create_model
+
+load_dotenv()  # load environment variables from .env
+
+FastMCPServerSpec: TypeAlias = str | FastMCP[Any] | ClientTransport | AnyUrl
+
+
+class FastMCPClient:
+    """A client for interacting with a FastMCP server.
+
+    Provides async context manager functionality to safely manage resources.
+    """
+
+    logger = logging.getLogger(__name__)
+    _cm: Optional[Client] = None
+    client: Optional[Client] = None
+
+    def __init__(
+        self,
+        server: FastMCPServerSpec,
+        persist_connection: bool = False,
+        forward_images: bool = True,
+        forward_text_resources: bool = False,
+        forward_blob_resources: bool = False,
+        sampling_handler: SamplingHandler | None = None,  # type: ignore
+        roots: RootsList | RootsHandler | None = None,  # type: ignore
+        log_handler: LoggingFnT | None = None,
+        message_handler: MessageHandlerFnT | None = None,
+        read_timeout_seconds: datetime.timedelta | None = None,
+    ) -> None:
+        """Initialize the FastMCPClient.
+
+        Args:
+            server: FastMCP server or path to such a server
+        """
+        self.server = server
+        self.client = None
+        self._cm = None
+        self.sampling_handler = sampling_handler
+        self.roots = roots
+        self.log_handler = log_handler
+        self.message_handler = message_handler
+        self.read_timeout_seconds = read_timeout_seconds
+        self.persist_connection = persist_connection
+        self.forward_text_resources = forward_text_resources
+        self.forward_blob_resources = forward_blob_resources
+        self.forward_images = forward_images
+
+    async def __aenter__(self) -> "FastMCPClient":
+        """Enter the async context manager and connect inner client."""
+        # create inner client context manager
+        self._cm = Client(
+            self.server,
+            sampling_handler=self.sampling_handler,
+            roots=self.roots,
+            log_handler=self.log_handler,
+            message_handler=self.message_handler,
+            timeout=self.read_timeout_seconds,
+        )
+        # actually enter it (opens the session)
+        self.client = await self._cm.__aenter__()  # type: ignore
+        return self
+
+    async def connect(self) -> None:
+        """Open the underlying session."""
+        await self.__aenter__()
+
+    async def close(self) -> None:
+        """Close the underlying session."""
+        await self.__aexit__(None, None, None)
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[Exception]],
+        exc_val: Optional[Exception],
+        exc_tb: Optional[Any],
+    ) -> None:
+        """Exit the async context manager and close inner client."""
+        # exit and close the inner fastmcp.Client
+        if hasattr(self, "_cm"):
+            if self._cm is not None:
+                await self._cm.__aexit__(exc_type, exc_val, exc_tb)  # type: ignore
+        self.client = None
+        self._cm = None
+
+    def __del__(self) -> None:
+        """Warn about unclosed persistent connections."""
+        if self.client is not None and self.persist_connection:
+            import warnings
+
+            warnings.warn(
+                f"FastMCPClient with persist_connection=True was not properly closed. "
+                f"Connection to {self.server} may leak resources. "
+                f"Use 'async with' or call await client.close()",
+                ResourceWarning,
+                stacklevel=2,
+            )
+
+    def _schema_to_field(
+        self, name: str, schema: Dict[str, Any], prefix: str
+    ) -> Tuple[Any, Any]:
+        """Convert a JSON Schema snippet into a (type, Field) tuple.
+
+        Args:
+            name: Name of the field.
+            schema: JSON Schema for this field.
+            prefix: Prefix to use for nested model names.
+
+        Returns:
+            A tuple of (python_type, Field(...)) for create_model.
+        """
+        t = schema.get("type")
+        default = schema.get("default", ...)
+        desc = schema.get("description")
+        # Object → nested BaseModel
+        if t == "object" and "properties" in schema:
+            sub_name = f"{prefix}_{name.capitalize()}"
+            sub_fields: Dict[str, Tuple[type, Any]] = {}
+            for k, sub_s in schema["properties"].items():
+                ftype, fld = self._schema_to_field(sub_name + k, sub_s, sub_name)
+                sub_fields[k] = (ftype, fld)
+            submodel = create_model(  # type: ignore
+                sub_name,
+                __base__=BaseModel,
+                **sub_fields,
+            )
+            return submodel, Field(default=default, description=desc)  # type: ignore
+        # Array → List of items
+        if t == "array" and "items" in schema:
+            item_type, _ = self._schema_to_field(name, schema["items"], prefix)
+            return List[item_type], Field(default=default, description=desc)  # type: ignore
+        # Primitive types
+        if t == "string":
+            return str, Field(default=default, description=desc)
+        if t == "integer":
+            return int, Field(default=default, description=desc)
+        if t == "number":
+            return float, Field(default=default, description=desc)
+        if t == "boolean":
+            return bool, Field(default=default, description=desc)
+        # Fallback or unions
+        if any(key in schema for key in ("oneOf", "anyOf", "allOf")):
+            self.logger.warning("Unsupported union schema in field %s; using Any", name)
+            return Any, Field(default=default, description=desc)
+        # Default fallback
+        return Any, Field(default=default, description=desc)
+
+    async def get_tool_async(self, tool_name: str) -> Type[ToolMessage]:
+        """
+        Create a Langroid ToolMessage subclass from the MCP Tool
+        with the given `tool_name`.
+        """
+        if not self.client:
+            if self.persist_connection:
+                await self.connect()
+                assert self.client
+            else:
+                raise RuntimeError(
+                    "Client not initialized. Use async with FastMCPClient."
+                )
+        target = await self.get_mcp_tool_async(tool_name)
+        if target is None:
+            raise ValueError(f"No tool named {tool_name}")
+        props = target.inputSchema.get("properties", {})
+        fields: Dict[str, Tuple[type, Any]] = {}
+        for fname, schema in props.items():
+            ftype, fld = self._schema_to_field(fname, schema, target.name)
+            fields[fname] = (ftype, fld)
+
+        # Convert target.name to CamelCase and add Tool suffix
+        parts = target.name.replace("-", "_").split("_")
+        camel_case = "".join(part.capitalize() for part in parts)
+        model_name = f"{camel_case}Tool"
+
+        from langroid.agent.tool_message import ToolMessage as _BaseToolMessage
+
+        # IMPORTANT: Avoid clashes with reserved field names in Langroid ToolMessage!
+        # First figure out which field names are reserved
+        reserved = set(_BaseToolMessage.__annotations__.keys())
+        reserved.update(["recipient", "_handler", "name"])
+        renamed: Dict[str, str] = {}
+        new_fields: Dict[str, Tuple[type, Any]] = {}
+        for fname, (ftype, fld) in fields.items():
+            if fname in reserved:
+                new_name = fname + "__"
+                renamed[fname] = new_name
+                new_fields[new_name] = (ftype, fld)
+            else:
+                new_fields[fname] = (ftype, fld)
+        # now replace fields with our renamed‐aware mapping
+        fields = new_fields
+
+        # create Langroid ToolMessage subclass, with expected fields.
+        tool_model = cast(
+            Type[ToolMessage],
+            create_model(  # type: ignore[call-overload]
+                model_name,
+                request=(str, target.name),
+                purpose=(str, target.description or f"Use the tool {target.name}"),
+                __base__=ToolMessage,
+                **fields,
+            ),
+        )
+        # Store ALL client configuration needed to recreate a client
+        client_config = {
+            "server": self.server,
+            "sampling_handler": self.sampling_handler,
+            "roots": self.roots,
+            "log_handler": self.log_handler,
+            "message_handler": self.message_handler,
+            "read_timeout_seconds": self.read_timeout_seconds,
+        }
+
+        tool_model._client_config = client_config  # type: ignore [attr-defined]
+        tool_model._renamed_fields = renamed  # type: ignore[attr-defined]
+
+        # 2) define an arg-free call_tool_async()
+        async def call_tool_async(itself: ToolMessage) -> Any:
+            from langroid.agent.tools.mcp.fastmcp_client import FastMCPClient
+
+            # pack up the payload
+            payload = itself.dict(
+                exclude=itself.Config.schema_extra["exclude"].union(
+                    ["request", "purpose"]
+                ),
+            )
+
+            # restore any renamed fields
+            for orig, new in itself.__class__._renamed_fields.items():  # type: ignore
+                if new in payload:
+                    payload[orig] = payload.pop(new)
+
+            client_cfg = getattr(itself.__class__, "_client_config", None)  # type: ignore
+            if not client_cfg:
+                # Fallback or error - ideally _client_config should always exist
+                raise RuntimeError(f"Client config missing on {itself.__class__}")
+
+            # Connect the client if not yet connected and keep the connection open
+            if self.persist_connection:
+                if not self.client:
+                    await self.connect()
+
+                return await self.call_mcp_tool(itself.request, payload)
+
+            # open a fresh client, call the tool, then close
+            async with FastMCPClient(**client_cfg) as client:  # type: ignore
+                return await client.call_mcp_tool(itself.request, payload)
+
+        tool_model.call_tool_async = call_tool_async  # type: ignore
+
+        if not hasattr(tool_model, "handle_async"):
+            # 3) define handle_async() method with optional agent parameter
+            from typing import Union
+
+            async def handle_async(
+                self: ToolMessage, agent: Optional[Agent] = None
+            ) -> Union[str, Optional[ChatDocument]]:
+                """
+                Auto-generated handler for MCP tool. Returns ChatDocument with files
+                if files are present and agent is provided, otherwise returns text.
+
+                To override: define your own handle_async method with matching signature
+                if you need file handling, or simpler signature if you only need text.
+                """
+                response = await self.call_tool_async()  # type: ignore[attr-defined]
+                if response is None:
+                    return None
+
+                content, files = response
+
+                # If we have files and an agent is provided, return a ChatDocument
+                if files and agent is not None:
+                    return agent.create_agent_response(
+                        content=content,
+                        files=files,
+                    )
+                else:
+                    # Otherwise, just return the text content
+                    return str(content) if content is not None else None
+
+            # add the handle_async() method to the tool model
+            tool_model.handle_async = handle_async  # type: ignore
+
+        return tool_model
+
+    async def get_tools_async(self) -> List[Type[ToolMessage]]:
+        """
+        Get all available tools as Langroid ToolMessage classes,
+        handling nested schemas, with `handle_async` methods
+        """
+        if not self.client:
+            if self.persist_connection:
+                await self.connect()
+                assert self.client
+            else:
+                raise RuntimeError(
+                    "Client not initialized. Use async with FastMCPClient."
+                )
+        resp = await self.client.list_tools()
+        return [await self.get_tool_async(t.name) for t in resp]
+
+    async def get_mcp_tool_async(self, name: str) -> Optional[Tool]:
+        """Find the "original" MCP Tool (i.e. of type mcp.types.Tool) on the server
+         matching `name`, or None if missing. This contains the metadata for the tool:
+         name, description, inputSchema, etc.
+
+        Args:
+            name: Name of the tool to look up.
+
+        Returns:
+            The raw Tool object from the server, or None.
+        """
+        if not self.client:
+            if self.persist_connection:
+                await self.connect()
+                assert self.client
+            else:
+                raise RuntimeError(
+                    "Client not initialized. Use async with FastMCPClient."
+                )
+        resp: List[Tool] = await self.client.list_tools()
+        return next((t for t in resp if t.name == name), None)
+
+    def _convert_tool_result(
+        self,
+        tool_name: str,
+        result: CallToolResult,
+    ) -> Optional[str | tuple[str, list[FileAttachment]]]:
+        if result.isError:
+            # Log more detailed error information
+            error_content = None
+            if result.content and len(result.content) > 0:
+                try:
+                    error_content = [
+                        item.text if hasattr(item, "text") else str(item)
+                        for item in result.content
+                    ]
+                except Exception as e:
+                    error_content = [f"Could not extract error content: {str(e)}"]
+
+            self.logger.error(
+                f"Error calling MCP tool {tool_name}. Details: {error_content}"
+            )
+            return f"ERROR: Tool call failed - {error_content}"
+
+        results_text = [
+            item.text for item in result.content if isinstance(item, TextContent)
+        ]
+        results_file = []
+
+        for item in result.content:
+            if isinstance(item, ImageContent) and self.forward_images:
+                results_file.append(
+                    FileAttachment.from_bytes(
+                        b64decode(item.data),
+                        mime_type=item.mimeType,
+                    )
+                )
+            elif isinstance(item, EmbeddedResource):
+                if (
+                    isinstance(item.resource, TextResourceContents)
+                    and self.forward_text_resources
+                ):
+                    results_text.append(item.resource.text)
+                elif (
+                    isinstance(item.resource, BlobResourceContents)
+                    and self.forward_blob_resources
+                ):
+                    results_file.append(
+                        FileAttachment.from_io(
+                            BytesIO(b64decode(item.resource.blob)),
+                            mime_type=item.resource.mimeType,
+                        )
+                    )
+
+        return "\n".join(results_text), results_file
+
+    async def call_mcp_tool(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> Optional[tuple[str, list[FileAttachment]]]:
+        """Call an MCP tool with the given arguments.
+
+        Args:
+            tool_name: Name of the tool to call.
+            arguments: Arguments to pass to the tool.
+
+        Returns:
+            The result of the tool call.
+        """
+        if not self.client:
+            if self.persist_connection:
+                await self.connect()
+                assert self.client
+            else:
+                raise RuntimeError(
+                    "Client not initialized. Use async with FastMCPClient."
+                )
+        result: CallToolResult = await self.client.session.call_tool(
+            tool_name,
+            arguments,
+        )
+        results = self._convert_tool_result(tool_name, result)
+
+        if isinstance(results, str):
+            return results, []
+
+        return results
+
+
+# ==============================================================================
+# Convenience functions (wrappers around FastMCPClient methods)
+# These are useful for one-off calls without needing to manage the
+# FastMCPClient context explicitly.
+# ==============================================================================
+
+
+async def get_tool_async(
+    server: FastMCPServerSpec,
+    tool_name: str,
+    **client_kwargs: Any,
+) -> Type[ToolMessage]:
+    """Get a single Langroid ToolMessage subclass for a specific MCP tool name (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        tool_name: The name of the tool to retrieve.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A dynamically created Langroid ToolMessage subclass representing the
+        requested tool.
+    """
+    async with FastMCPClient(server, **client_kwargs) as client:
+        return await client.get_tool_async(tool_name)
+
+
+def get_tool(
+    server: FastMCPServerSpec,
+    tool_name: str,
+    **client_kwargs: Any,
+) -> Type[ToolMessage]:
+    """Get a single Langroid ToolMessage subclass
+    for a specific MCP tool name (synchronous).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
+    async `get_tool_async` function using `asyncio.run()`.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        tool_name: The name of the tool to retrieve.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A dynamically created Langroid ToolMessage subclass representing the
+        requested tool.
+    """
+    return asyncio.run(get_tool_async(server, tool_name, **client_kwargs))
+
+
+async def get_tools_async(
+    server: FastMCPServerSpec,
+    **client_kwargs: Any,
+) -> List[Type[ToolMessage]]:
+    """Get all available tools as Langroid ToolMessage subclasses (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A list of dynamically created Langroid ToolMessage subclasses
+        representing all available tools on the server.
+    """
+    async with FastMCPClient(server, **client_kwargs) as client:
+        return await client.get_tools_async()
+
+
+def get_tools(
+    server: FastMCPServerSpec,
+    **client_kwargs: Any,
+) -> List[Type[ToolMessage]]:
+    """Get all available tools as Langroid ToolMessage subclasses (synchronous).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
+    async `get_tools_async` function using `asyncio.run()`.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor (e.g., sampling_handler, roots).
+
+    Returns:
+        A list of dynamically created Langroid ToolMessage subclasses
+        representing all available tools on the server.
+    """
+    return asyncio.run(get_tools_async(server, **client_kwargs))
+
+
+async def get_mcp_tool_async(
+    server: FastMCPServerSpec,
+    name: str,
+    **client_kwargs: Any,
+) -> Optional[Tool]:
+    """Get the raw MCP Tool object for a specific tool name (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient to
+    retrieve the tool definition from the server.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        name: The name of the tool to look up.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor.
+
+    Returns:
+        The raw `mcp.types.Tool` object from the server, or `None` if the tool
+        is not found.
+    """
+    async with FastMCPClient(server, **client_kwargs) as client:
+        return await client.get_mcp_tool_async(name)
+
+
+async def get_mcp_tools_async(
+    server: FastMCPServerSpec,
+    **client_kwargs: Any,
+) -> List[Tool]:
+    """Get all available raw MCP Tool objects from the server (async).
+
+    This is a convenience wrapper that creates a temporary FastMCPClient to
+    retrieve the list of tool definitions from the server.
+
+    Args:
+        server: Specification of the FastMCP server to connect to.
+        **client_kwargs: Additional keyword arguments to pass to the
+            FastMCPClient constructor.
+
+    Returns:
+        A list of raw `mcp.types.Tool` objects available on the server.
+    """
+    async with FastMCPClient(server, **client_kwargs) as client:
+        if not client.client:
+            raise RuntimeError("Client not initialized. Use async with FastMCPClient.")
+        return await client.client.list_tools()
+</file>
+
 <file path="langroid/agent/tools/task_tool.py">
 """
 TaskTool: A tool that allows agents to delegate a task to a sub-agent with
@@ -98288,10 +99116,13 @@ class TaskTool(ToolMessage):
     system_message: Optional[str] = Field(
         ...,
         description="""
-        Optional system message to configure the sub-agent's general behavior.
+        Optional system message to configure the sub-agent's general behavior and 
+        to specify the task and its context.
             A good system message will have these components:
             - Inform the sub-agent of its role, e.g. "You are a financial analyst."
-            - Clear spec of the task
+            - Clear spec of the task, with sufficient context for the sub-agent to 
+              understand what it needs to do, since the sub-agent does 
+              NOT have access to your conversation history!
             - Any additional general context needed for the task, such as a
               (part of a) document, or data items, etc.
             - Specify when to use certain tools, e.g. 
@@ -98323,9 +99154,10 @@ class TaskTool(ToolMessage):
         A list of tool names to enable for the sub-agent.
         This must be a list of strings referring to the names of tools
         that are known to you. 
-        If you want to enable all tools, you can set this field
-         to a singleton list containing 'ALL'
-        To disable all tools, set it to a singleton list containing 'NONE'
+        If you want to enable all tools, or you do not have any preference
+        on what tools are enabled for the sub-agent, you can set 
+        this field to a singleton list ['ALL']
+        To disable all tools, set it to a singleton list ['NONE']
         """,
     )
     # TODO: ensure valid model name
@@ -98363,11 +99195,20 @@ class TaskTool(ToolMessage):
         # TODO: Maybe we just copy the parent agent's config and override chat_model?
         #   -- but what if parent agent has a MockLMConfig?
         llm_config = lm.OpenAIGPTConfig(
-            chat_model=self.model or "gpt-4.1-mini",  # Default model if not specified
+            chat_model=self.model or lm.OpenAIChatModel.GPT4_1_MINI,
         )
         config = ChatAgentConfig(
             name=agent_name,
             llm=llm_config,
+            handle_llm_no_tool=f"""
+                You forgot to use one of your TOOLs! Remember that you must either:
+                - use a tool, or a sequence of tools, to complete your task, OR
+                - if you are done with your task, use the `{DoneTool.name()}` tool
+                to return the result.
+                
+                As a reminder, this was your task:
+                {self.prompt}
+                """,
             system_message=f"""
                 {self.system_message}
                 
@@ -98388,7 +99229,9 @@ class TaskTool(ToolMessage):
             tool_classes = [
                 agent.llm_tools_map[t]
                 for t in agent.llm_tools_known
-                if t in agent.llm_tools_map and t != self.request
+                if t in agent.llm_tools_map
+                and t != self.request
+                and agent.llm_tools_map[t]._allow_llm_use
                 # Exclude the TaskTool itself!
             ]
         elif self.tools == ["NONE"]:
@@ -98400,6 +99243,7 @@ class TaskTool(ToolMessage):
                 agent.llm_tools_map[tool_name]
                 for tool_name in self.tools
                 if tool_name in agent.llm_tools_map
+                and agent.llm_tools_map[tool_name]._allow_llm_use
             ]
 
         # always enable the DoneTool to signal task completion
@@ -98410,7 +99254,9 @@ class TaskTool(ToolMessage):
 
         return task
 
-    def handle(self, agent: ChatAgent) -> Optional[ChatDocument]:
+    def handle(
+        self, agent: ChatAgent, chat_doc: Optional[ChatDocument] = None
+    ) -> Optional[ChatDocument]:
         """
 
         Handle the TaskTool by creating a sub-agent with specified tools
@@ -98418,26 +99264,66 @@ class TaskTool(ToolMessage):
 
         Args:
             agent: The parent ChatAgent that is handling this tool
+            chat_doc: The ChatDocument containing this tool message
         """
 
         task = self._set_up_task(agent)
-        # Run the task on the prompt, and return the result
-        result = task.run(self.prompt, turns=self.max_iterations or 10)
+
+        # Create a ChatDocument for the prompt with parent pointer
+        prompt_doc = None
+        if chat_doc is not None:
+            from langroid.agent.chat_document import ChatDocMetaData
+
+            prompt_doc = ChatDocument(
+                content=self.prompt,
+                metadata=ChatDocMetaData(
+                    parent_id=chat_doc.id(),
+                    agent_id=agent.id,
+                    sender=chat_doc.metadata.sender,
+                ),
+            )
+            # Set bidirectional parent-child relationship
+            chat_doc.metadata.child_id = prompt_doc.id()
+
+        # Run the task with the ChatDocument or string prompt
+        result = task.run(prompt_doc or self.prompt, turns=self.max_iterations or 10)
         return result
 
-    async def handle_async(self, agent: ChatAgent) -> Optional[ChatDocument]:
+    async def handle_async(
+        self, agent: ChatAgent, chat_doc: Optional[ChatDocument] = None
+    ) -> Optional[ChatDocument]:
         """
         Async method to handle the TaskTool by creating a sub-agent with specified tools
         and running the task non-interactively.
 
         Args:
             agent: The parent ChatAgent that is handling this tool
+            chat_doc: The ChatDocument containing this tool message
         """
         task = self._set_up_task(agent)
-        # Run the task on the prompt, and return the result
+
+        # Create a ChatDocument for the prompt with parent pointer
+        prompt_doc = None
+        if chat_doc is not None:
+            from langroid.agent.chat_document import ChatDocMetaData
+
+            prompt_doc = ChatDocument(
+                content=self.prompt,
+                metadata=ChatDocMetaData(
+                    parent_id=chat_doc.id(),
+                    agent_id=agent.id,
+                    sender=chat_doc.metadata.sender,
+                ),
+            )
+            # Set bidirectional parent-child relationship
+            chat_doc.metadata.child_id = prompt_doc.id()
+
+        # Run the task with the ChatDocument or string prompt
         # TODO eventually allow the various task setup configs,
         #  including termination conditions
-        result = await task.run_async(self.prompt, turns=self.max_iterations or 10)
+        result = await task.run_async(
+            prompt_doc or self.prompt, turns=self.max_iterations or 10
+        )
         return result
 </file>
 
@@ -99059,7 +99945,10 @@ class Task:
             if isinstance(msg, ChatDocument):
                 # carefully deep-copy: fresh metadata.id, register
                 # as new obj in registry
+                original_parent_id = msg.metadata.parent_id
                 self.pending_message = ChatDocument.deepcopy(msg)
+                # Preserve the parent pointer from the original message
+                self.pending_message.metadata.parent_id = original_parent_id
             if self.pending_message is not None and self.caller is not None:
                 # msg may have come from `caller`, so we pretend this is from
                 # the CURRENT task's USER entity
@@ -99067,7 +99956,11 @@ class Task:
                 # update parent, child, agent pointers
                 if msg is not None:
                     msg.metadata.child_id = self.pending_message.metadata.id
-                    self.pending_message.metadata.parent_id = msg.metadata.id
+                    # Only override parent_id if it wasn't already set in the
+                    # original message. This preserves parent chains from TaskTool
+                    if not msg.metadata.parent_id:
+                        self.pending_message.metadata.parent_id = msg.metadata.id
+            if self.pending_message is not None:
                 self.pending_message.metadata.agent_id = self.agent.id
 
         self._show_pending_message_if_debug()
@@ -100694,24 +101587,33 @@ class Task:
     def _get_message_chain(
         self, msg: ChatDocument | None, max_depth: Optional[int] = None
     ) -> List[ChatDocument]:
-        """Get the chain of messages by following parent pointers."""
+        """Get the chain of messages using agent's message history."""
         if max_depth is None:
             # Get max depth needed from all sequences
             max_depth = 50  # default fallback
             if self._parsed_done_sequences:
                 max_depth = max(len(seq.events) for seq in self._parsed_done_sequences)
 
-        chain = []
-        current = msg
-        depth = 0
+        # Get chat document IDs from message history
+        doc_ids = [
+            m.chat_document_id for m in self.agent.message_history if m.chat_document_id
+        ]
 
-        while current is not None and depth < max_depth:
-            chain.append(current)
-            current = current.parent
-            depth += 1
+        # Add current message ID if it exists and is not already the last one
+        if msg:
+            msg_id = msg.id()
+            if not doc_ids or doc_ids[-1] != msg_id:
+                doc_ids.append(msg_id)
 
-        # Reverse to get chronological order (oldest first)
-        return list(reversed(chain))
+        # Take only the last max_depth elements
+        relevant_ids = doc_ids[-max_depth:]
+
+        # Convert IDs to ChatDocuments and filter out None values
+        return [
+            doc
+            for doc_id in relevant_ids
+            if (doc := ChatDocument.from_id(doc_id)) is not None
+        ]
 
     def _matches_event(self, actual: AgentEvent, expected: AgentEvent) -> bool:
         """Check if an actual event matches an expected event pattern."""
@@ -102316,593 +103218,6 @@ if __name__ == "__main__":
     Fire(main)
 </file>
 
-<file path="langroid/agent/tools/mcp/fastmcp_client.py">
-import asyncio
-import datetime
-import logging
-from base64 import b64decode
-from io import BytesIO
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeAlias, cast
-
-from dotenv import load_dotenv
-from fastmcp.client import Client
-from fastmcp.client.roots import (
-    RootsHandler,
-    RootsList,
-)
-from fastmcp.client.sampling import SamplingHandler
-from fastmcp.client.transports import ClientTransport
-from fastmcp.server import FastMCP
-from mcp.client.session import (
-    LoggingFnT,
-    MessageHandlerFnT,
-)
-from mcp.types import (
-    BlobResourceContents,
-    CallToolResult,
-    EmbeddedResource,
-    ImageContent,
-    TextContent,
-    TextResourceContents,
-    Tool,
-)
-
-from langroid.agent.base import Agent
-from langroid.agent.chat_document import ChatDocument
-from langroid.agent.tool_message import ToolMessage
-from langroid.parsing.file_attachment import FileAttachment
-from langroid.pydantic_v1 import AnyUrl, BaseModel, Field, create_model
-
-load_dotenv()  # load environment variables from .env
-
-FastMCPServerSpec: TypeAlias = str | FastMCP[Any] | ClientTransport | AnyUrl
-
-
-class FastMCPClient:
-    """A client for interacting with a FastMCP server.
-
-    Provides async context manager functionality to safely manage resources.
-    """
-
-    logger = logging.getLogger(__name__)
-    _cm: Optional[Client] = None
-    client: Optional[Client] = None
-
-    def __init__(
-        self,
-        server: FastMCPServerSpec,
-        persist_connection: bool = False,
-        forward_images: bool = True,
-        forward_text_resources: bool = False,
-        forward_blob_resources: bool = False,
-        sampling_handler: SamplingHandler | None = None,  # type: ignore
-        roots: RootsList | RootsHandler | None = None,  # type: ignore
-        log_handler: LoggingFnT | None = None,
-        message_handler: MessageHandlerFnT | None = None,
-        read_timeout_seconds: datetime.timedelta | None = None,
-    ) -> None:
-        """Initialize the FastMCPClient.
-
-        Args:
-            server: FastMCP server or path to such a server
-        """
-        self.server = server
-        self.client = None
-        self._cm = None
-        self.sampling_handler = sampling_handler
-        self.roots = roots
-        self.log_handler = log_handler
-        self.message_handler = message_handler
-        self.read_timeout_seconds = read_timeout_seconds
-        self.persist_connection = persist_connection
-        self.forward_text_resources = forward_text_resources
-        self.forward_blob_resources = forward_blob_resources
-        self.forward_images = forward_images
-
-    async def __aenter__(self) -> "FastMCPClient":
-        """Enter the async context manager and connect inner client."""
-        # create inner client context manager
-        self._cm = Client(
-            self.server,
-            sampling_handler=self.sampling_handler,
-            roots=self.roots,
-            log_handler=self.log_handler,
-            message_handler=self.message_handler,
-            timeout=self.read_timeout_seconds,
-        )
-        # actually enter it (opens the session)
-        self.client = await self._cm.__aenter__()  # type: ignore
-        return self
-
-    async def connect(self) -> None:
-        """Open the underlying session."""
-        await self.__aenter__()
-
-    async def close(self) -> None:
-        """Close the underlying session."""
-        await self.__aexit__(None, None, None)
-
-    async def __aexit__(
-        self,
-        exc_type: Optional[type[Exception]],
-        exc_val: Optional[Exception],
-        exc_tb: Optional[Any],
-    ) -> None:
-        """Exit the async context manager and close inner client."""
-        # exit and close the inner fastmcp.Client
-        if hasattr(self, "_cm"):
-            if self._cm is not None:
-                await self._cm.__aexit__(exc_type, exc_val, exc_tb)  # type: ignore
-        self.client = None
-        self._cm = None
-
-    def __del__(self) -> None:
-        """Warn about unclosed persistent connections."""
-        if self.client is not None and self.persist_connection:
-            import warnings
-
-            warnings.warn(
-                f"FastMCPClient with persist_connection=True was not properly closed. "
-                f"Connection to {self.server} may leak resources. "
-                f"Use 'async with' or call await client.close()",
-                ResourceWarning,
-                stacklevel=2,
-            )
-
-    def _schema_to_field(
-        self, name: str, schema: Dict[str, Any], prefix: str
-    ) -> Tuple[Any, Any]:
-        """Convert a JSON Schema snippet into a (type, Field) tuple.
-
-        Args:
-            name: Name of the field.
-            schema: JSON Schema for this field.
-            prefix: Prefix to use for nested model names.
-
-        Returns:
-            A tuple of (python_type, Field(...)) for create_model.
-        """
-        t = schema.get("type")
-        default = schema.get("default", ...)
-        desc = schema.get("description")
-        # Object → nested BaseModel
-        if t == "object" and "properties" in schema:
-            sub_name = f"{prefix}_{name.capitalize()}"
-            sub_fields: Dict[str, Tuple[type, Any]] = {}
-            for k, sub_s in schema["properties"].items():
-                ftype, fld = self._schema_to_field(sub_name + k, sub_s, sub_name)
-                sub_fields[k] = (ftype, fld)
-            submodel = create_model(  # type: ignore
-                sub_name,
-                __base__=BaseModel,
-                **sub_fields,
-            )
-            return submodel, Field(default=default, description=desc)  # type: ignore
-        # Array → List of items
-        if t == "array" and "items" in schema:
-            item_type, _ = self._schema_to_field(name, schema["items"], prefix)
-            return List[item_type], Field(default=default, description=desc)  # type: ignore
-        # Primitive types
-        if t == "string":
-            return str, Field(default=default, description=desc)
-        if t == "integer":
-            return int, Field(default=default, description=desc)
-        if t == "number":
-            return float, Field(default=default, description=desc)
-        if t == "boolean":
-            return bool, Field(default=default, description=desc)
-        # Fallback or unions
-        if any(key in schema for key in ("oneOf", "anyOf", "allOf")):
-            self.logger.warning("Unsupported union schema in field %s; using Any", name)
-            return Any, Field(default=default, description=desc)
-        # Default fallback
-        return Any, Field(default=default, description=desc)
-
-    async def get_tool_async(self, tool_name: str) -> Type[ToolMessage]:
-        """
-        Create a Langroid ToolMessage subclass from the MCP Tool
-        with the given `tool_name`.
-        """
-        if not self.client:
-            if self.persist_connection:
-                await self.connect()
-                assert self.client
-            else:
-                raise RuntimeError(
-                    "Client not initialized. Use async with FastMCPClient."
-                )
-        target = await self.get_mcp_tool_async(tool_name)
-        if target is None:
-            raise ValueError(f"No tool named {tool_name}")
-        props = target.inputSchema.get("properties", {})
-        fields: Dict[str, Tuple[type, Any]] = {}
-        for fname, schema in props.items():
-            ftype, fld = self._schema_to_field(fname, schema, target.name)
-            fields[fname] = (ftype, fld)
-
-        # Convert target.name to CamelCase and add Tool suffix
-        parts = target.name.replace("-", "_").split("_")
-        camel_case = "".join(part.capitalize() for part in parts)
-        model_name = f"{camel_case}Tool"
-
-        from langroid.agent.tool_message import ToolMessage as _BaseToolMessage
-
-        # IMPORTANT: Avoid clashes with reserved field names in Langroid ToolMessage!
-        # First figure out which field names are reserved
-        reserved = set(_BaseToolMessage.__annotations__.keys())
-        reserved.update(["recipient", "_handler", "name"])
-        renamed: Dict[str, str] = {}
-        new_fields: Dict[str, Tuple[type, Any]] = {}
-        for fname, (ftype, fld) in fields.items():
-            if fname in reserved:
-                new_name = fname + "__"
-                renamed[fname] = new_name
-                new_fields[new_name] = (ftype, fld)
-            else:
-                new_fields[fname] = (ftype, fld)
-        # now replace fields with our renamed‐aware mapping
-        fields = new_fields
-
-        # create Langroid ToolMessage subclass, with expected fields.
-        tool_model = cast(
-            Type[ToolMessage],
-            create_model(  # type: ignore[call-overload]
-                model_name,
-                request=(str, target.name),
-                purpose=(str, target.description or f"Use the tool {target.name}"),
-                __base__=ToolMessage,
-                **fields,
-            ),
-        )
-        # Store ALL client configuration needed to recreate a client
-        client_config = {
-            "server": self.server,
-            "sampling_handler": self.sampling_handler,
-            "roots": self.roots,
-            "log_handler": self.log_handler,
-            "message_handler": self.message_handler,
-            "read_timeout_seconds": self.read_timeout_seconds,
-        }
-
-        tool_model._client_config = client_config  # type: ignore [attr-defined]
-        tool_model._renamed_fields = renamed  # type: ignore[attr-defined]
-
-        # 2) define an arg-free call_tool_async()
-        async def call_tool_async(itself: ToolMessage) -> Any:
-            from langroid.agent.tools.mcp.fastmcp_client import FastMCPClient
-
-            # pack up the payload
-            payload = itself.dict(
-                exclude=itself.Config.schema_extra["exclude"].union(
-                    ["request", "purpose"]
-                ),
-            )
-
-            # restore any renamed fields
-            for orig, new in itself.__class__._renamed_fields.items():  # type: ignore
-                if new in payload:
-                    payload[orig] = payload.pop(new)
-
-            client_cfg = getattr(itself.__class__, "_client_config", None)  # type: ignore
-            if not client_cfg:
-                # Fallback or error - ideally _client_config should always exist
-                raise RuntimeError(f"Client config missing on {itself.__class__}")
-
-            # Connect the client if not yet connected and keep the connection open
-            if self.persist_connection:
-                if not self.client:
-                    await self.connect()
-
-                return await self.call_mcp_tool(itself.request, payload)
-
-            # open a fresh client, call the tool, then close
-            async with FastMCPClient(**client_cfg) as client:  # type: ignore
-                return await client.call_mcp_tool(itself.request, payload)
-
-        tool_model.call_tool_async = call_tool_async  # type: ignore
-
-        if not hasattr(tool_model, "handle_async"):
-            # 3) define handle_async() method with optional agent parameter
-            from typing import Union
-
-            async def handle_async(
-                self: ToolMessage, agent: Optional[Agent] = None
-            ) -> Union[str, Optional[ChatDocument]]:
-                """
-                Auto-generated handler for MCP tool. Returns ChatDocument with files
-                if files are present and agent is provided, otherwise returns text.
-
-                To override: define your own handle_async method with matching signature
-                if you need file handling, or simpler signature if you only need text.
-                """
-                response = await self.call_tool_async()  # type: ignore[attr-defined]
-                if response is None:
-                    return None
-
-                content, files = response
-
-                # If we have files and an agent is provided, return a ChatDocument
-                if files and agent is not None:
-                    return agent.create_agent_response(
-                        content=content,
-                        files=files,
-                    )
-                else:
-                    # Otherwise, just return the text content
-                    return str(content) if content is not None else None
-
-            # add the handle_async() method to the tool model
-            tool_model.handle_async = handle_async  # type: ignore
-
-        return tool_model
-
-    async def get_tools_async(self) -> List[Type[ToolMessage]]:
-        """
-        Get all available tools as Langroid ToolMessage classes,
-        handling nested schemas, with `handle_async` methods
-        """
-        if not self.client:
-            if self.persist_connection:
-                await self.connect()
-                assert self.client
-            else:
-                raise RuntimeError(
-                    "Client not initialized. Use async with FastMCPClient."
-                )
-        resp = await self.client.list_tools()
-        return [await self.get_tool_async(t.name) for t in resp]
-
-    async def get_mcp_tool_async(self, name: str) -> Optional[Tool]:
-        """Find the "original" MCP Tool (i.e. of type mcp.types.Tool) on the server
-         matching `name`, or None if missing. This contains the metadata for the tool:
-         name, description, inputSchema, etc.
-
-        Args:
-            name: Name of the tool to look up.
-
-        Returns:
-            The raw Tool object from the server, or None.
-        """
-        if not self.client:
-            if self.persist_connection:
-                await self.connect()
-                assert self.client
-            else:
-                raise RuntimeError(
-                    "Client not initialized. Use async with FastMCPClient."
-                )
-        resp: List[Tool] = await self.client.list_tools()
-        return next((t for t in resp if t.name == name), None)
-
-    def _convert_tool_result(
-        self,
-        tool_name: str,
-        result: CallToolResult,
-    ) -> Optional[str | tuple[str, list[FileAttachment]]]:
-        if result.isError:
-            # Log more detailed error information
-            error_content = None
-            if result.content and len(result.content) > 0:
-                try:
-                    error_content = [
-                        item.text if hasattr(item, "text") else str(item)
-                        for item in result.content
-                    ]
-                except Exception as e:
-                    error_content = [f"Could not extract error content: {str(e)}"]
-
-            self.logger.error(
-                f"Error calling MCP tool {tool_name}. Details: {error_content}"
-            )
-            return f"ERROR: Tool call failed - {error_content}"
-
-        results_text = [
-            item.text for item in result.content if isinstance(item, TextContent)
-        ]
-        results_file = []
-
-        for item in result.content:
-            if isinstance(item, ImageContent) and self.forward_images:
-                results_file.append(
-                    FileAttachment.from_bytes(
-                        b64decode(item.data),
-                        mime_type=item.mimeType,
-                    )
-                )
-            elif isinstance(item, EmbeddedResource):
-                if (
-                    isinstance(item.resource, TextResourceContents)
-                    and self.forward_text_resources
-                ):
-                    results_text.append(item.resource.text)
-                elif (
-                    isinstance(item.resource, BlobResourceContents)
-                    and self.forward_blob_resources
-                ):
-                    results_file.append(
-                        FileAttachment.from_io(
-                            BytesIO(b64decode(item.resource.blob)),
-                            mime_type=item.resource.mimeType,
-                        )
-                    )
-
-        return "\n".join(results_text), results_file
-
-    async def call_mcp_tool(
-        self, tool_name: str, arguments: Dict[str, Any]
-    ) -> Optional[tuple[str, list[FileAttachment]]]:
-        """Call an MCP tool with the given arguments.
-
-        Args:
-            tool_name: Name of the tool to call.
-            arguments: Arguments to pass to the tool.
-
-        Returns:
-            The result of the tool call.
-        """
-        if not self.client:
-            if self.persist_connection:
-                await self.connect()
-                assert self.client
-            else:
-                raise RuntimeError(
-                    "Client not initialized. Use async with FastMCPClient."
-                )
-        result: CallToolResult = await self.client.session.call_tool(
-            tool_name,
-            arguments,
-        )
-        results = self._convert_tool_result(tool_name, result)
-
-        if isinstance(results, str):
-            return results, []
-
-        return results
-
-
-# ==============================================================================
-# Convenience functions (wrappers around FastMCPClient methods)
-# These are useful for one-off calls without needing to manage the
-# FastMCPClient context explicitly.
-# ==============================================================================
-
-
-async def get_tool_async(
-    server: FastMCPServerSpec,
-    tool_name: str,
-    **client_kwargs: Any,
-) -> Type[ToolMessage]:
-    """Get a single Langroid ToolMessage subclass for a specific MCP tool name (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        tool_name: The name of the tool to retrieve.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A dynamically created Langroid ToolMessage subclass representing the
-        requested tool.
-    """
-    async with FastMCPClient(server, **client_kwargs) as client:
-        return await client.get_tool_async(tool_name)
-
-
-def get_tool(
-    server: FastMCPServerSpec,
-    tool_name: str,
-    **client_kwargs: Any,
-) -> Type[ToolMessage]:
-    """Get a single Langroid ToolMessage subclass
-    for a specific MCP tool name (synchronous).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
-    async `get_tool_async` function using `asyncio.run()`.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        tool_name: The name of the tool to retrieve.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A dynamically created Langroid ToolMessage subclass representing the
-        requested tool.
-    """
-    return asyncio.run(get_tool_async(server, tool_name, **client_kwargs))
-
-
-async def get_tools_async(
-    server: FastMCPServerSpec,
-    **client_kwargs: Any,
-) -> List[Type[ToolMessage]]:
-    """Get all available tools as Langroid ToolMessage subclasses (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A list of dynamically created Langroid ToolMessage subclasses
-        representing all available tools on the server.
-    """
-    async with FastMCPClient(server, **client_kwargs) as client:
-        return await client.get_tools_async()
-
-
-def get_tools(
-    server: FastMCPServerSpec,
-    **client_kwargs: Any,
-) -> List[Type[ToolMessage]]:
-    """Get all available tools as Langroid ToolMessage subclasses (synchronous).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient and runs the
-    async `get_tools_async` function using `asyncio.run()`.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor (e.g., sampling_handler, roots).
-
-    Returns:
-        A list of dynamically created Langroid ToolMessage subclasses
-        representing all available tools on the server.
-    """
-    return asyncio.run(get_tools_async(server, **client_kwargs))
-
-
-async def get_mcp_tool_async(
-    server: FastMCPServerSpec,
-    name: str,
-    **client_kwargs: Any,
-) -> Optional[Tool]:
-    """Get the raw MCP Tool object for a specific tool name (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient to
-    retrieve the tool definition from the server.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        name: The name of the tool to look up.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor.
-
-    Returns:
-        The raw `mcp.types.Tool` object from the server, or `None` if the tool
-        is not found.
-    """
-    async with FastMCPClient(server, **client_kwargs) as client:
-        return await client.get_mcp_tool_async(name)
-
-
-async def get_mcp_tools_async(
-    server: FastMCPServerSpec,
-    **client_kwargs: Any,
-) -> List[Tool]:
-    """Get all available raw MCP Tool objects from the server (async).
-
-    This is a convenience wrapper that creates a temporary FastMCPClient to
-    retrieve the list of tool definitions from the server.
-
-    Args:
-        server: Specification of the FastMCP server to connect to.
-        **client_kwargs: Additional keyword arguments to pass to the
-            FastMCPClient constructor.
-
-    Returns:
-        A list of raw `mcp.types.Tool` objects available on the server.
-    """
-    async with FastMCPClient(server, **client_kwargs) as client:
-        if not client.client:
-            raise RuntimeError("Client not initialized. Use async with FastMCPClient.")
-        return await client.client.list_tools()
-</file>
-
 <file path="langroid/agent/base.py">
 import asyncio
 import copy
@@ -103043,6 +103358,7 @@ class Agent(ABC):
 
     def __init__(self, config: AgentConfig = AgentConfig()):
         self.config = config
+        self.id = ObjectRegistry.new_id()  # Initialize agent ID
         self.lock = asyncio.Lock()  # for async access to update self.llm.usage_cost
         self.dialog: List[Tuple[str, str]] = []  # seq of LLM (prompt, response) tuples
         self.llm_tools_map: Dict[str, Type[ToolMessage]] = {}
@@ -103591,6 +103907,7 @@ class Agent(ABC):
             results.metadata.tool_ids = (
                 [] if msg is None or isinstance(msg, str) else msg.metadata.tool_ids
             )
+            results.metadata.agent_id = self.id
             return results
         sender_name = self.config.name
         if isinstance(msg, ChatDocument) and msg.function_call is not None:
@@ -103609,6 +103926,7 @@ class Agent(ABC):
             metadata=ChatDocMetaData(
                 source=Entity.AGENT,
                 sender=Entity.AGENT,
+                agent_id=self.id,
                 sender_name=sender_name,
                 oai_tool_id=oai_tool_id,
                 # preserve trail of tool_ids for OpenAI Assistant fn-calls
@@ -103873,6 +104191,7 @@ class Agent(ABC):
             return ChatDocument(
                 content=user_msg,
                 metadata=ChatDocMetaData(
+                    agent_id=self.id,
                     source=source,
                     sender=sender,
                     # preserve trail of tool_ids for OpenAI Assistant fn-calls

--- a/release-notes/v0-56-13-done-sequences-parent-chain-fixes.md
+++ b/release-notes/v0-56-13-done-sequences-parent-chain-fixes.md
@@ -1,0 +1,116 @@
+# v0.56.13: DoneSequences Parent Chain and Agent ID Fixes
+
+## Summary
+
+This release fixes critical issues with the DoneSequence implementation, parent pointer chain preservation in TaskTool, and agent ID initialization. These fixes ensure that task termination sequences work correctly with subtasks and that message lineage is properly maintained across agent boundaries.
+
+## Key Fixes
+
+### 1. Agent ID Initialization Fix
+
+**Problem**: The `Agent.id` field was incorrectly returning a `FieldInfo` object instead of an actual ID string because `Agent` is not a Pydantic model but was using Pydantic's `Field` syntax.
+
+**Solution**: Added proper ID initialization in `Agent.__init__()`:
+```python
+self.id = ObjectRegistry.new_id()  # Initialize agent ID
+```
+
+**Impact**: This ensures that `agent_id` is correctly set in `ChatDocument` metadata, which is crucial for tracking which agent owns which messages.
+
+### 2. DoneSequence Message Chain Fix
+
+**Problem**: The `_get_message_chain` method in `Task` was traversing parent pointers to build the message chain. When subtasks are involved, parent pointers can cross agent boundaries, incorrectly including messages from subtask agents in the parent task's chain.
+
+**Solution**: Replaced parent pointer traversal with agent message history:
+```python
+def _get_message_chain(self, msg: ChatDocument | None, max_depth: Optional[int] = None) -> List[ChatDocument]:
+    """Get the chain of messages using agent's message history."""
+    # Get chat document IDs from message history
+    doc_ids = [m.chat_document_id for m in self.agent.message_history 
+               if m.chat_document_id]
+    
+    # Add current message ID if it exists and is not already the last one
+    if msg:
+        msg_id = msg.id()
+        if not doc_ids or doc_ids[-1] != msg_id:
+            doc_ids.append(msg_id)
+    
+    # Take only the last max_depth elements
+    relevant_ids = doc_ids[-max_depth:]
+    
+    # Convert IDs to ChatDocuments
+    return [doc for doc_id in relevant_ids 
+            if (doc := ChatDocument.from_id(doc_id)) is not None]
+```
+
+**Impact**: DoneSequences now correctly check only messages from the current agent, preventing incorrect task termination when subtasks generate matching sequences.
+
+### 3. Parent Pointer Preservation in Task.init()
+
+**Problem**: When `ChatDocument.deepcopy()` is called during `task.init()`, it resets `parent_id` and `child_id` to empty strings, breaking the parent chain. This particularly affected TaskTool when creating subtasks with parent pointers.
+
+**Solution**: Modified `task.init()` to preserve the original parent_id after deepcopy:
+```python
+if isinstance(msg, ChatDocument):
+    original_parent_id = msg.metadata.parent_id
+    self.pending_message = ChatDocument.deepcopy(msg)
+    # Preserve the parent pointer from the original message
+    self.pending_message.metadata.parent_id = original_parent_id
+```
+
+Additionally, added conditional logic to only override parent_id when necessary:
+```python
+if self.pending_message is not None and self.caller is not None:
+    # Only override parent_id if it wasn't already set in the original message
+    if not msg.metadata.parent_id:
+        self.pending_message.metadata.parent_id = msg.metadata.id
+```
+
+**Impact**: Parent chains are now preserved when TaskTool creates subtasks, maintaining proper message lineage.
+
+### 4. TaskTool Parent-Child Relationship
+
+**Problem**: TaskTool was only setting the parent pointer on the prompt ChatDocument but not the corresponding child pointer on the TaskTool message.
+
+**Solution**: Added bidirectional parent-child relationship in TaskTool handlers:
+```python
+if chat_doc is not None:
+    prompt_doc = ChatDocument(
+        content=self.prompt,
+        metadata=ChatDocMetaData(
+            parent_id=chat_doc.id(),
+            agent_id=agent.id,
+            sender=chat_doc.metadata.sender,
+        )
+    )
+    # Set bidirectional parent-child relationship
+    chat_doc.metadata.child_id = prompt_doc.id()
+```
+
+**Impact**: Complete bidirectional parent-child chains are maintained, improving message traceability.
+
+## Tests Added
+
+Added comprehensive test `test_task_init_preserves_parent_id()` in `test_task.py` that verifies:
+- Parent IDs are preserved during ChatDocument deep copying
+- Conditional parent_id override logic works correctly for subtasks
+- Parent chains are maintained in various scenarios
+
+## Breaking Changes
+
+None. All changes are backward compatible bug fixes.
+
+## Migration Guide
+
+No migration needed. The fixes will automatically apply to existing code.
+
+## Technical Details
+
+The core issue was that DoneSequences were incorrectly checking messages across agent boundaries due to parent pointer traversal. Combined with the agent ID initialization bug and parent chain breaks in deepcopy, this caused incorrect task termination behavior. The fixes ensure:
+
+1. Each agent's messages are properly tagged with the agent's ID
+2. DoneSequence checking is confined to the current agent's message history
+3. Parent chains are preserved through TaskTool subtask creation
+4. Bidirectional parent-child relationships are maintained
+
+These changes work together to ensure proper message lineage and task termination behavior in multi-agent systems.

--- a/uv.lock
+++ b/uv.lock
@@ -2790,7 +2790,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2
 
 [[package]]
 name = "langroid"
-version = "0.56.11"
+version = "0.56.12"
 source = { editable = "." }
 dependencies = [
     { name = "adb-cloud-connector" },


### PR DESCRIPTION
## Summary
- Fixed Agent.id returning FieldInfo instead of actual ID value
- Updated DoneSequence to use message history instead of parent pointers
- Enhanced TaskTool to maintain parent-child relationships across subtasks

## Problem

The DoneSequence implementation had a critical bug where `_get_message_chain` would incorrectly include messages from subtask agents when parent pointers crossed agent boundaries. This occurred when TaskTool spawned subtasks, causing premature task termination.

Additionally, Agent.id was returning a Pydantic FieldInfo object instead of the actual ID string, preventing proper agent_id assignment in ChatDocument metadata.

## Solution

### 1. Agent ID Initialization
- Added `self.id = ObjectRegistry.new_id()` in `Agent.__init__`
- Ensures agent_id is properly set in ChatDocument metadata

### 2. DoneSequence Message Chain Fix
- Changed `_get_message_chain` to use agent's message history instead of parent pointer traversal
- Prevents crossing agent boundaries and including subtask messages
- Simplifies implementation by leveraging existing message_history

### 3. TaskTool Parent Chain Preservation  
- Updated `handle()` and `handle_async()` to set bidirectional parent-child relationships
- Creates prompt ChatDocument with parent_id pointing to TaskTool message
- Maintains proper parent chains across subtask boundaries

### 4. Task.init() Deep Copy Fix
- Modified to preserve parent_id when deep copying ChatDocument
- Only overrides parent_id if not already set in original message
- Prevents breaking existing parent chains from TaskTool

## Test plan
- [x] All existing tests pass
- [x] Added test_task_init_preserves_parent_id() to verify parent chain preservation
- [x] Updated test_task_tool_all_tools to verify parent chain through TaskTool
- [x] Ran `make check` - all linting and type checks pass

## Release Notes
See release-notes/v0-56-13-done-sequences-parent-chain-fixes.md for detailed documentation.