### PR TITLE
make `max_tokens` and `temperature` in OpenAICallParams optional

### DIFF
--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -203,8 +203,8 @@ class OpenAICallParams(BaseModel):
     https://platform.openai.com/docs/api-reference/chat
     """
 
-    max_tokens: int = 1024
-    temperature: float = 0.2
+    max_tokens: int | None = None
+    temperature: float | None = None
     frequency_penalty: float | None = None  # between -2 and 2
     presence_penalty: float | None = None  # between -2 and 2
     response_format: Dict[str, str] | None = None


### PR DESCRIPTION
**Change description**

Make `max_tokens` and `temperature` parameters in `OpenAICallParams` optional.

**Rationale**

`OpenAICallParams` are intended to be used for configuring additional LLM parameters. For example I'm using them to configure `reasoning_effort` for Gemini 2.5 models. However if `OpenAICallParams` contains numeric values for `max_tokens` and `temperature`, as they currently do by default, these values will override corresponding values from model's `config` element - see `OpenAIGPT._openai_api_call_params()`. This IMO is pretty counter-intuitive and rather limiting - as this means that I need to duplicate values from `llm.config` into the `llm.params`.
