### PR TITLE
support reasoning_effort parameter for OpenAI thinking models

### DIFF
--- a/langroid/language_models/model_info.py
+++ b/langroid/language_models/model_info.py
@@ -90,6 +90,11 @@ class OpenAI_API_ParamInfo(BaseModel):
     params: Dict[str, List[str]] = dict(
         reasoning_effort=[
             OpenAIChatModel.O3_MINI.value,
+            OpenAIChatModel.O3.value,
+            OpenAIChatModel.O4_MINI.value,
+            OpenAIChatModel.GPT5.value,
+            OpenAIChatModel.GPT5_MINI.value,
+            OpenAIChatModel.GPT5_NANO.value,
             GeminiModel.GEMINI_2_5_PRO.value,
             GeminiModel.GEMINI_2_5_FLASH.value,
             GeminiModel.GEMINI_2_5_FLASH_LITE.value,


### PR DESCRIPTION
`reasoning_effort` parameter is used to control thinking level of various OpenAI models.
However current implementation "whitelists" it only for `o3-mini` model - and not, for example, for `gpt-5` models.
This PR fixes the issue.