### PR TITLE
adhere to llama.cpp's /embedding endpoint data format

### DIFF
--- a/langroid/embedding_models/models.py
+++ b/langroid/embedding_models/models.py
@@ -463,7 +463,7 @@ class LlamaCppServerEmbeddings(EmbeddingModel):
         response = requests.post(self.embedding_url, json=data)
 
         if response.status_code == 200:
-            embeddings = response.json()["embedding"]
+            embeddings = response.json()[0]["embedding"][0]
             if not (
                 isinstance(embeddings, list) and isinstance(embeddings[0], (int, float))
             ):


### PR DESCRIPTION
Llama.cpp's /embedding endpoint supports a batch mode to process more than one embedding at once. Hence, an array of embedding objects is returned. To support llama.cpp's /embedding properly, this has to be taken into account.