### PR TITLE
A few small fixes in base Langroid code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.14.6
+  rev: v0.14.10
   hooks:
     - id: ruff

--- a/langroid/cachedb/redis_cachedb.py
+++ b/langroid/cachedb/redis_cachedb.py
@@ -39,7 +39,7 @@ class RedisCache(CacheDB):
             self.pool = fakeredis.FakeStrictRedis()  # type: ignore
         else:
             redis_password = os.getenv("REDIS_PASSWORD")
-            redis_host = os.getenv("REDIS_HOST")
+            redis_host = os.getenv("REDIS_HOST") or None
             redis_port = os.getenv("REDIS_PORT")
             if None in [redis_password, redis_host, redis_port]:
                 if not RedisCache._warned_password:

--- a/langroid/language_models/base.py
+++ b/langroid/language_models/base.py
@@ -54,6 +54,7 @@ class StreamEventType(Enum):
     FUNC_ARGS = 3
     TOOL_NAME = 4
     TOOL_ARGS = 5
+    REASONING = 6
 
 
 class RetryParams(BaseSettings):

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -270,7 +270,7 @@ class OpenAIGPTConfig(LLMConfig):
     )
     # these can be any model name that is served at an OpenAI-compatible API end point
     chat_model: str = default_openai_chat_model
-    chat_model_orig: str = default_openai_chat_model
+    chat_model_orig: Optional[str] = None
     completion_model: str = default_openai_completion_model
     run_on_first_use: Callable[[], None] = noop
     parallel_tool_calls: Optional[bool] = None
@@ -427,7 +427,7 @@ class OpenAIGPT(LanguageModel):
         # save original model name such as `provider/model` before
         # we strip out the `provider` - we retain the original in
         # case some params are specific to a provider.
-        self.chat_model_orig = self.config.chat_model
+        self.chat_model_orig = self.config.chat_model_orig or self.config.chat_model
 
         # Run the first time the model is used
         self.run_on_first_use = cache(self.config.run_on_first_use)

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -970,7 +970,7 @@ class OpenAIGPT(LanguageModel):
             if not silent:
                 sys.stdout.write(Colors().GREEN_DIM + event_reasoning)
                 sys.stdout.flush()
-            self.config.streamer(event_reasoning, StreamEventType.TEXT)
+            self.config.streamer(event_reasoning, StreamEventType.REASONING)
         if event_fn_name:
             function_name = event_fn_name
             has_function = True
@@ -1101,7 +1101,7 @@ class OpenAIGPT(LanguageModel):
             if not silent:
                 sys.stdout.write(Colors().GREEN + event_reasoning)
                 sys.stdout.flush()
-            await self.config.streamer_async(event_reasoning, StreamEventType.TEXT)
+            await self.config.streamer_async(event_reasoning, StreamEventType.REASONING)
         if event_fn_name:
             function_name = event_fn_name
             has_function = True


### PR DESCRIPTION
A few small tweaks in Langroid code:

### [reasoning stream event type](https://github.com/langroid/langroid/commit/6cc550f3e193319e8366bf5a12e51f1ccc3a8770) ###

We should be using different event type for TEXT and REASONING items in streaming callbacks.

### [fix fakeredis detection in Windows bash](https://github.com/langroid/langroid/commit/8f95284e6e2c7e1e6c8aa835be67b212e48a65e2) ###

In Windows bash `os.getenv()` returns empty string for non-existing variables. Hence we used to mistakenly try to create "real" **redis** client even when no REDIS_XYZ environment variables are set.

### [if LLMConfig.chat_model_orig is set, use it to initialize LanguageModel,chat_model_orig](https://github.com/langroid/langroid/commit/aa2b0ea8062cdb0a387d83b6cf3584ee36782965)

Azure OpenAI have introduced new [API v1](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/api-version-lifecycle?view=foundry-classic&tabs=python) in October 2025. This API allows developers to use standard OpenAI clients (instead of Azure-specific ones) as follows:
```
import os
from openai import OpenAI

client = OpenAI(
    api_key=os.getenv("AZURE_OPENAI_API_KEY"),
    base_url="https://YOUR-RESOURCE-NAME.openai.azure.com/openai/v1/"
)

response = client.responses.create(   
  model="gpt-4.1-nano", # Replace with your model deployment name 
  input="This is a test.",
)
```

In Langroid terms this means that we can use `OpenAIGPT()` class instead of `AzureGPT()`, for example as follows:
```
llm_cfg = OpenAIGPTConfig(
    chat_model=deployment_name,
    api_base=api_base + 'openai/v1/',
    api_key=api_key
)

llm = LanguageModel.create(llm_cfg)
```

There is one problem with the above code though - since `chat_model` is set to deployment name - we no longer reliably find `ModelInfo()` in `LanguageModel.get_info()`.

To overcome this problem, the following simple fix is implemented:

- change `OpenAIGPTConfig.chat_model_orig` to `Optional[str]` and set it to `None` by default
- if `OpenAIGPTConfig.chat_model_orig` is set, use it to populate the Language Model's `chat_model_orig`.

After the fix the following code FULLY works for Azure OpenAI models:
```
llm_cfg = OpenAIGPTConfig(
    chat_model=deployment_name,
    chat_model_orig=model_name,
    api_base=api_base + 'openai/v1/',
    api_key=api_key
)

llm = LanguageModel.create(llm_cfg)
```
