### PR TITLE
improve tool parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.14.6
+  rev: v0.14.10
   hooks:
     - id: ruff

--- a/langroid/agent/chat_document.py
+++ b/langroid/agent/chat_document.py
@@ -130,7 +130,8 @@ class ChatDocument(Document):
     tool_messages: List[ToolMessage] = []
     # all known tools in the msg that are in an agent's llm_tools_known list,
     # even if non-used/handled
-    all_tool_messages: List[ToolMessage] = []
+    # (the list is populated by Agent.has_tool_message_attempt())
+    all_tool_messages: Optional[List[ToolMessage]] = None
 
     metadata: ChatDocMetaData
     attachment: None | ChatDocAttachment = None


### PR DESCRIPTION
Two improvements in tool parsing logic inside `Agent.get_tool_messages()`:

- `msg.all_tool_messages` is used for indication that we already parsed specific message regardless of whether tool calls exist in it or not
  - we set it to None in `__init__` and then change it to `List` - either empty or with some tools upon the first call to `get_tool_messages`
  - this prevents continuous parsing attempts for the same message, as different parts call, for example, to `has_tool_message_attempt()`

- new configuration parameter `search_for_tools_everywhere` in `ChatAgentConfig`
  - it's set to `False` for backwards compatibility
  - when set to `True` - tools will be searched only in the parts of the message that match agent configuration
    - this prevents unneeded (and potentially dangerous) parsing of message content for OpenAI models that use Tools or Function APIs