### PR TITLE
adjust shape of show_llm_response / finish_llm_stream callbacks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.14.6
+  rev: v0.14.11
   hooks:
     - id: ruff

--- a/langroid/agent/callbacks/chainlit.py
+++ b/langroid/agent/callbacks/chainlit.py
@@ -356,7 +356,7 @@ class ChainlitAgentCallbacks:
             run_sync(self.stream.remove())  # type: ignore
         else:
             run_sync(self.stream.update())  # type: ignore
-        stream_id = self.stream.id if content else None
+        stream_id = self.stream.id if tools_content or content else None
         step = cl.Message(
             content=textwrap.dedent(tools_content or content) or NO_ANSWER,
             id=stream_id,

--- a/langroid/agent/callbacks/chainlit.py
+++ b/langroid/agent/callbacks/chainlit.py
@@ -302,7 +302,7 @@ class ChainlitAgentCallbacks:
         logger.info(
             f"""
             Starting LLM stream for {self.agent.config.name}
-            id = {self.stream.id} 
+            id = {self.stream.id}
             under parent {self._get_parent_id()}
         """
         )
@@ -328,7 +328,7 @@ class ChainlitAgentCallbacks:
         logger.info(
             f"""
             Starting LLM stream for {self.agent.config.name}
-            id = {self.stream.id} 
+            id = {self.stream.id}
             under parent {self._get_parent_id()}
             """
         )
@@ -346,7 +346,9 @@ class ChainlitAgentCallbacks:
         if self.stream is not None:
             run_sync(self.stream.remove())  # type: ignore
 
-    def finish_llm_stream(self, content: str, is_tool: bool = False) -> None:
+    def finish_llm_stream(
+        self, content: str, tools_content: str = "", is_tool: bool = False
+    ) -> None:
         """Update the stream, and display entire response in the right language."""
         if self.agent.llm is None or self.stream is None:
             raise ValueError("LLM or stream not initialized")
@@ -356,7 +358,7 @@ class ChainlitAgentCallbacks:
             run_sync(self.stream.update())  # type: ignore
         stream_id = self.stream.id if content else None
         step = cl.Message(
-            content=textwrap.dedent(content) or NO_ANSWER,
+            content=textwrap.dedent(tools_content or content) or NO_ANSWER,
             id=stream_id,
             author=self._entity_name("llm", tool=is_tool),
             type="assistant_message",
@@ -366,7 +368,7 @@ class ChainlitAgentCallbacks:
         logger.info(
             f"""
             Finish STREAM LLM response for {self.agent.config.name}
-            id = {step.id} 
+            id = {step.id}
             under parent {self._get_parent_id()}
             """
         )
@@ -375,13 +377,14 @@ class ChainlitAgentCallbacks:
     def show_llm_response(
         self,
         content: str,
+        tools_content: str = "",
         is_tool: bool = False,
         cached: bool = False,
         language: str | None = None,
     ) -> None:
         """Show non-streaming LLM response."""
         step = cl.Message(
-            content=textwrap.dedent(content) or NO_ANSWER,
+            content=textwrap.dedent(tools_content or content) or NO_ANSWER,
             id=self.curr_step.id if self.curr_step is not None else None,
             author=self._entity_name("llm", tool=is_tool, cached=cached),
             type="assistant_message",
@@ -393,7 +396,7 @@ class ChainlitAgentCallbacks:
         logger.info(
             f"""
             Showing NON-STREAM LLM response for {self.agent.config.name}
-            id = {step.id} 
+            id = {step.id}
             under parent {self._get_parent_id()}
             """
         )
@@ -433,7 +436,7 @@ class ChainlitAgentCallbacks:
         logger.info(
             f"""
             Showing AGENT response for {self.agent.config.name}
-            id = {step.id} 
+            id = {step.id}
             under parent {self._get_parent_id()}
             """
         )
@@ -456,7 +459,7 @@ class ChainlitAgentCallbacks:
         logger.info(
             f"""
             Showing START response for {self.agent.config.name} ({entity})
-            id = {step.id} 
+            id = {step.id}
             under parent {self._get_parent_id()}
             """
         )

--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -1860,7 +1860,8 @@ class ChatAgent(Agent):
             )
         if self.llm.get_stream():
             self.callbacks.finish_llm_stream(
-                content=str(response),
+                content=response.message,
+                tools_content=response.tools_content(),
                 is_tool=self.has_tool_message_attempt(
                     ChatDocument.from_LLMResponse(response, displayed=True),
                 ),
@@ -1917,7 +1918,8 @@ class ChatAgent(Agent):
         )
         if self.llm.get_stream():
             self.callbacks.finish_llm_stream(
-                content=str(response),
+                content=response.message,
+                tools_content=response.tools_content(),
                 is_tool=self.has_tool_message_attempt(
                     ChatDocument.from_LLMResponse(response, displayed=True),
                 ),
@@ -1968,7 +1970,8 @@ class ChatAgent(Agent):
             if not settings.quiet:
                 print(cached + "[green]" + escape(str(response)))
             self.callbacks.show_llm_response(
-                content=str(response),
+                content=response.message,
+                tools_content=response.tools_content(),
                 is_tool=self.has_tool_message_attempt(chat_doc),
                 cached=is_cached,
             )
@@ -1986,6 +1989,7 @@ class ChatAgent(Agent):
                 print("[grey37]SOURCES:\n" + escape(citation) + "[/grey37]")
             self.callbacks.show_llm_response(
                 content=str(citation),
+                tools_content="",
                 is_tool=False,
                 cached=False,
                 language="text",

--- a/langroid/language_models/base.py
+++ b/langroid/language_models/base.py
@@ -368,6 +368,14 @@ class LLMResponse(BaseModel):
         else:
             return self.message
 
+    def tools_content(self) -> str:
+        if self.function_call is not None:
+            return str(self.function_call)
+        elif self.oai_tool_calls:
+            return "\n".join(str(tc) for tc in self.oai_tool_calls)
+        else:
+            return ""
+
     def to_LLMMessage(self) -> LLMMessage:
         """Convert LLM response to an LLMMessage, to be included in the
         message-list sent to the API.


### PR DESCRIPTION
### Problem description

`show_llm_response` and `finish_llm_stream` callbacks currently include `content=str(response)` which mixes text `message` generated by model with serialization of `functions / tools`. While this may be fine for a simple `chainlit` integration, this is not "good enough" for applications that use these callbacks to handle model responses. For example, I use these callbacks in my application to convert the text generated by model to voice - and if model generates some invalid function / tools call, `content` gets populated with JSON string, while `is_tool` is False - and I'm "playing" to user JSON string - definitely not an expected behavior...

### Proposed solution

Change shape of `show_llm_response` and `finish_llm_stream` to include separate `content` and `tools_content` parameters.
The former is always populated with `response.message`. The later is populated with serialization of `functions / tools` if such exist; or empty string otherwise.

This gives enough information for applications that need to know THE EXACT information that was present in the LLM response. While still keeping `chainlit` integration logic very straightforward - see the diff in `chainlit.py` file.