### PR TITLE
support Vertex AI for Gemini models

### DIFF
--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -590,7 +590,7 @@ class OpenAIGPT(LanguageModel):
                 self.config.chat_model = self.config.chat_model.replace("gemini/", "")
                 if self.api_key == OPENAI_API_KEY:
                     self.api_key = os.getenv("GEMINI_API_KEY", DUMMY_API_KEY)
-                if self.config.api_base is not None:
+                if self.config.api_base:
                     self.api_base = self.config.api_base
                 else:
                     self.api_base = GEMINI_BASE_URL

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -590,7 +590,10 @@ class OpenAIGPT(LanguageModel):
                 self.config.chat_model = self.config.chat_model.replace("gemini/", "")
                 if self.api_key == OPENAI_API_KEY:
                     self.api_key = os.getenv("GEMINI_API_KEY", DUMMY_API_KEY)
-                self.api_base = GEMINI_BASE_URL
+                if self.config.api_base is not None:
+                    self.api_base = self.config.api_base
+                else:
+                    self.api_base = GEMINI_BASE_URL
             elif self.is_glhf:
                 self.config.chat_model = self.config.chat_model.replace("glhf/", "")
                 if self.api_key == OPENAI_API_KEY:


### PR DESCRIPTION
Google Vertex AI uses project-specific URLs for OpenAI Compatibility layer (which is different from fixed URL used by Google API) - see https://docs.cloud.google.com/vertex-ai/generative-ai/docs/start/openai for details.

This simple PR adds support for Vertex AI by allowing specification of `api_base` via `OpenAIGPTConfig` for Gemini models.