### PR TITLE
replace deprecated parseString

### DIFF
--- a/langroid/parsing/agent_chats.py
+++ b/langroid/parsing/agent_chats.py
@@ -32,7 +32,7 @@ def parse_message(msg: str) -> Tuple[str, str]:
     parser = to_field + message
 
     try:
-        parsed = parser.parseString(msg)
+        parsed = parser.parse_string(msg)
         return parsed.name, parsed.text
     except ParseException:
         return "", msg


### PR DESCRIPTION
replace deprecated `parser.parseString` with `parse_string`