### PR TITLE
fix unsupported parameters check

### DIFF
--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -808,16 +808,6 @@ class OpenAIGPT(LanguageModel):
         List of params that are not supported by the current model
         """
         unsupported = set(self.info().unsupported_params)
-        # Only apply allowlist restrictions for known models.
-        # Unknown/custom models are allowed to use all params by default.
-        is_known_model = self.info().name != "unknown"
-        if is_known_model:
-            for param, model_list in OpenAI_API_ParamInfo().params.items():
-                if (
-                    self.config.chat_model not in model_list
-                    and self.chat_model_orig not in model_list
-                ):
-                    unsupported.add(param)
         return list(unsupported)
 
     def rename_params(self) -> Dict[str, str]:


### PR DESCRIPTION
I know that we already discussed this in the past - but unfortunately the "known models" hack that you implemented is not good enough. Good example are Gemini models in Vertex AI - in order to use them I need to set `llm_cfg.chat_model` to "gemini/google/gemini-2.5-flash". And this breaks the "is_known_model" logic, because:
* `self.config.chat_model == "google/chat_model"`
* `self.chat_model_orig == "gemini/google/gemini-2.5-flash"`
* `self.info()` finds the model info - because it looks up for one of the following names as fallback: `("gemini/google/gemini-2.5-flash", "google/gemini-2.5-flash", "gemini-2.5-flash")`
* but `self.config.chat_model` is NOT in `OpenAI_API_ParamInfo()` - hence it assumes that `reasoning_effort` is not supported - which is WRONG

Bottom line - IMO giving user API through which he passes parameters, but then silently dropping them based on some internal logic - is a bad idea - and we better remove it. )))
