### PR TITLE
configuration for content based routing of LLM responses

### DIFF
--- a/langroid/agent/chat_document.py
+++ b/langroid/agent/chat_document.py
@@ -294,6 +294,7 @@ class ChatDocument(Document):
     def from_LLMResponse(
         response: LLMResponse,
         displayed: bool = False,
+        content_based_routing: bool = True,
     ) -> "ChatDocument":
         """
         Convert LLMResponse to ChatDocument.
@@ -303,7 +304,7 @@ class ChatDocument(Document):
         Returns:
             ChatDocument: ChatDocument representation of this LLMResponse.
         """
-        recipient, message = response.get_recipient_and_message()
+        recipient, message = response.get_recipient_and_message(content_based_routing)
         message = message.strip()
         if message in ["''", '""']:
             message = ""

--- a/langroid/language_models/base.py
+++ b/langroid/language_models/base.py
@@ -398,6 +398,7 @@ class LLMResponse(BaseModel):
 
     def get_recipient_and_message(
         self,
+        content_based_routing: bool = True,
     ) -> Tuple[str, str]:
         """
         If `message` or `function_call` of an LLM response contains an explicit
@@ -434,6 +435,9 @@ class LLMResponse(BaseModel):
                         )  # type: ignore
                         if recipient is not None and recipient != "":
                             return recipient, ""
+
+        if not content_based_routing:
+            return "", msg
 
         # It's not a function or tool call, so continue looking to see
         # if a recipient is specified in the message.


### PR DESCRIPTION
Add `content_based_routing` attribute to `ChatAgentConfig` that controls whether we look for "routing instructions" - e.g. "TO: destination" in textual part of LLM response. For scenarios where we use proper orchestration tools, such parsing can be unneeded and even dangerous - as user may trick LLM into generating these pre-defined strings and thus affecting task orchestration logic.