### PR TITLE
Though signatures in message history

### DIFF
--- a/langroid/agent/chat_document.py
+++ b/langroid/agent/chat_document.py
@@ -120,7 +120,7 @@ class ChatDocument(Document):
 
     reasoning: str = ""  # reasoning produced by a reasoning LLM
     content_any: Any = None  # to hold arbitrary data returned by responders
-    content_with_reasoning: Optional[str] = None # original content including reasoning
+    content_with_reasoning: Optional[str] = None  # original content including reasoning
     files: List[FileAttachment] = []  # list of file attachments
     oai_tool_calls: Optional[List[OpenAIToolCall]] = None
     oai_tool_id2result: Optional[OrderedDict[str, str]] = None
@@ -415,8 +415,12 @@ class ChatDocument(Document):
         sender_role = Role.USER
         if isinstance(message, str):
             message = ChatDocument.from_str(message)
-        content = message.content_with_reasoning or \
-            message.content or to_string(message.content_any) or ""
+        content = (
+            message.content_with_reasoning
+            or message.content
+            or to_string(message.content_any)
+            or ""
+        )
         fun_call = message.function_call
         oai_tool_calls = message.oai_tool_calls
         if message.metadata.sender == Entity.USER and fun_call is not None:

--- a/langroid/agent/chat_document.py
+++ b/langroid/agent/chat_document.py
@@ -120,6 +120,7 @@ class ChatDocument(Document):
 
     reasoning: str = ""  # reasoning produced by a reasoning LLM
     content_any: Any = None  # to hold arbitrary data returned by responders
+    content_with_reasoning: Optional[str] = None # original content including reasoning
     files: List[FileAttachment] = []  # list of file attachments
     oai_tool_calls: Optional[List[OpenAIToolCall]] = None
     oai_tool_id2result: Optional[OrderedDict[str, str]] = None
@@ -316,6 +317,7 @@ class ChatDocument(Document):
         return ChatDocument(
             content=message,
             reasoning=response.reasoning,
+            content_with_reasoning=response.message_with_reasoning,
             content_any=message,
             oai_tool_calls=response.oai_tool_calls,
             function_call=response.function_call,
@@ -413,7 +415,8 @@ class ChatDocument(Document):
         sender_role = Role.USER
         if isinstance(message, str):
             message = ChatDocument.from_str(message)
-        content = message.content or to_string(message.content_any) or ""
+        content = message.content_with_reasoning or \
+            message.content or to_string(message.content_any) or ""
         fun_call = message.function_call
         oai_tool_calls = message.oai_tool_calls
         if message.metadata.sender == Entity.USER and fun_call is not None:

--- a/langroid/language_models/base.py
+++ b/langroid/language_models/base.py
@@ -354,8 +354,8 @@ class LLMResponse(BaseModel):
 
     message: str
     reasoning: str = ""  # optional reasoning text from reasoning models
-    message_with_reasoning: Optional[str] = None # if we extracted reasoning
-                         # from the message text, store original message here
+    # if we extract reasoning from the message text, store original message here
+    message_with_reasoning: Optional[str] = None
     # TODO tool_id needs to generalize to multi-tool calls
     tool_id: str = ""  # used by OpenAIAssistant
     oai_tool_calls: Optional[List[OpenAIToolCall]] = None

--- a/langroid/language_models/base.py
+++ b/langroid/language_models/base.py
@@ -354,6 +354,8 @@ class LLMResponse(BaseModel):
 
     message: str
     reasoning: str = ""  # optional reasoning text from reasoning models
+    message_with_reasoning: Optional[str] = None # if we extracted reasoning
+                         # from the message text, store original message here
     # TODO tool_id needs to generalize to multi-tool calls
     tool_id: str = ""  # used by OpenAIAssistant
     oai_tool_calls: Optional[List[OpenAIToolCall]] = None

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -1532,6 +1532,7 @@ class OpenAIGPT(LanguageModel):
             LLMResponse(
                 message=completion,
                 reasoning=reasoning,
+                message_with_reasoning=completion if reasoning else None,
                 cached=False,
                 # don't allow empty list [] here
                 oai_tool_calls=tool_calls or None if len(tool_deltas) > 0 else None,


### PR DESCRIPTION
Many reasoning LLMs include "thought signatures" in textual response, for example:
- Amazon Nova and Nova 2 models (when configured for extended thinking via `reasoning_effort`)
- Gemini 3 Flash (with `thought_tag_marker` configured via `extra_body`)

Typical response from Gemini 3 Flash looks like this:
```
<thinking>
**Assessing My Capacities**

I've been mapping out the appropriate response to the user's question, aiming for brevity and clarity. The core is a succinct outline of my abilities, like answering questions and giving info. I'm keeping the tone polite, and also mentally noting when I should consider using the `transfer_call` feature.
</thinking>

I can answer your questions, provide information, and help with various tasks. I also have the ability to transfer your call to a specialist if you need further assistance.
```

Keeping "thought signatures" in message context is crucial for maintaining model's ability to reason / make function calls as the conversation progresses across turns.

Current `langroid` implementation extracts `message` and `reasoning` from the actual LLM response - using `get_reasoning_final()` - and populates corresponding fields in `LLMResponse` instance. These two fields get copied into the `ChatDocument` - in `from_LLMResponse` method. But conversion to `LLMMessage` - in `to_LLMMessage` method - uses only `content`. This essentially means that "though signatures" get lost and never "make it" into the message history.

My solution is fairly straightforward:
* add `message_with_reasoning` field to `LLMResponse` and populate it with **original** text received from the LLM if we "parse" it into "message" and "reasoning"
* add similar `content_with_reasoning` field to `ChatDocument` and copy to it data from `LLMResponse` - in `from_LLMResponse` method
* finally, use `content_with_reasoning` - if present - when constructing the `LLMMessage` - in `to_LLMMessage` method

It adds minimal amount of memory - as `message_with_reasoning` stays `None`, unless we **actually** modify original LLM response. All existing APIs of `LLMResponse` and `ChatDocument` remain unchanged. And we keep original LLM response - with "thought signatures" - in message history.
