### PR TITLE
add reasoning parameter to show_llm_response / finish_llm_stream callbacks

### DIFF
--- a/langroid/agent/callbacks/chainlit.py
+++ b/langroid/agent/callbacks/chainlit.py
@@ -347,7 +347,11 @@ class ChainlitAgentCallbacks:
             run_sync(self.stream.remove())  # type: ignore
 
     def finish_llm_stream(
-        self, content: str, tools_content: str = "", is_tool: bool = False
+        self,
+        content: str,
+        tools_content: str = "",
+        is_tool: bool = False,
+        reasoning: str = "",
     ) -> None:
         """Update the stream, and display entire response in the right language."""
         if self.agent.llm is None or self.stream is None:
@@ -379,6 +383,7 @@ class ChainlitAgentCallbacks:
         content: str,
         tools_content: str = "",
         is_tool: bool = False,
+        reasoning: str = "",
         cached: bool = False,
         language: str | None = None,
     ) -> None:

--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -1900,6 +1900,7 @@ class ChatAgent(Agent):
                 content=response.message,
                 tools_content=response.tools_content(),
                 is_tool=self.has_tool_message_attempt(temp_doc),
+                reasoning=response.reasoning,
             )
             ObjectRegistry.remove(temp_doc.id())
         self.llm.config.streamer = noop_fn
@@ -1968,6 +1969,7 @@ class ChatAgent(Agent):
                 content=response.message,
                 tools_content=response.tools_content(),
                 is_tool=self.has_tool_message_attempt(temp_doc),
+                reasoning=response.reasoning,
             )
             ObjectRegistry.remove(temp_doc.id())
         self.llm.config.streamer_async = async_noop_fn
@@ -2035,6 +2037,7 @@ class ChatAgent(Agent):
                 content=content,
                 tools_content=tools_content,
                 is_tool=self.has_tool_message_attempt(chat_doc),
+                reasoning=response.reasoning,
                 cached=is_cached,
             )
             # Clean up temp ChatDocument to avoid polluting ObjectRegistry


### PR DESCRIPTION
Add `reasoning` parameter to `show_llm_response` / `finish_llm_stream` callbacks, so that they can properly display COT