### PR TITLE
compress message history by dropping "turns" from it

### DIFF
--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -1684,7 +1684,7 @@ class ChatAgent(Agent):
 
                     # Find the end of this turn: last message before next USER
                     next_user_idx = -1
-                    for i in range(first_user_idx + 1, last_user_idx):
+                    for i in range(first_user_idx + 1, last_user_idx + 1):
                         if hist[i].role == Role.USER:
                             next_user_idx = i
                             break


### PR DESCRIPTION
Current message history compression logic in `_prep_llm_message()` is not really working for multi-turn "voice agent" conversations with models that have short context length (e.g. `llama-3-8b` model that has 8192 context length). We try to truncate message content - but for typical "voice agent" scenario both USER utterances and ASSISTANT responses are relatively short - so there's not much to truncate (if at all).

This PR updates this logic to simply drop old "user turns" from the conversation history.
This strategy loosely matches behavior of modern real-time / speech-to-speech models (e.g. `gemini-2.5-flash-native-audio`) and ensures that conversation may typically keep going forever.