### PR TITLE
extra_content in OpenAIToolCall

### DIFF
--- a/langroid/language_models/base.py
+++ b/langroid/language_models/base.py
@@ -173,6 +173,7 @@ class OpenAIToolCall(BaseModel):
     id: str | None = None
     type: ToolTypes = "function"
     function: LLMFunctionCall | None = None
+    extra_content: Dict[str, Any] | None = None
 
     @staticmethod
     def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall":
@@ -184,7 +185,13 @@ class OpenAIToolCall(BaseModel):
         id = message["id"]
         type = message["type"]
         function = LLMFunctionCall.from_dict(message["function"])
-        return OpenAIToolCall(id=id, type=type, function=function)
+        extra_content = message.get("extra_content")
+        return OpenAIToolCall(
+            id=id,
+            type=type,
+            function=function,
+            extra_content=extra_content
+        )
 
     def __str__(self) -> str:
         if self.function is None:
@@ -332,6 +339,8 @@ class LLMMessage(BaseModel):
                     tc["function"]["arguments"] = json.dumps(
                         tc["function"]["arguments"]
                     )
+                if "extra_content" in tc and tc["extra_content"] is None:
+                    del tc["extra_content"]
         # IMPORTANT! drop fields that are not expected in API call
         dict_no_none.pop("tool_id", None)
         dict_no_none.pop("timestamp", None)


### PR DESCRIPTION
`gemini-3-flash` model uses `extra_content` field in `tool_calls` to include thought signatures.
If we don't include these tools in subsequent "completion" requests, model returns the following error:
```
[{
  "error": {
    "code": 400,
    "message": "Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly, and missing thought_signature may lead to degraded model performance. Additional data, function call `default_api:mcp_everything_echo` , position 2. please refer to https://ai.google.dev/gemini-api/docs/thought-signatures for more details.",
    "status": "INVALID_ARGUMENT"
  }
}]
```
As a result of that, tool calls are effectively not working with `gemini-3-flash` model.

To overcome the problem, I added optional `extra_contents` field to the `OpenAIToolCall` class.
After the fix, tool calls are working as expected.