### PR TITLE
fix crash in response processing from gemini-3-flash model

### DIFF
--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -2179,10 +2179,11 @@ class OpenAIGPT(LanguageModel):
             }
         }
         """
-        if response.get("choices") is None:
-            message = {}
+        choices = response.get("choices")
+        if isinstance(choices, list) and len(choices) > 0:
+            message = choices[0].get("message", {})
         else:
-            message = response["choices"][0].get("message", {})
+            message = {}
         if message is None:
             message = {}
         content = message.get("content", "")


### PR DESCRIPTION
`gemini-3-flash` model sometimes generates empty `choices` array in response - which crashes current `_process_chat_completion_response` implementation.

```
Traceback (most recent call last):
  File "/app/lr_agent.py", line 884, in _llm_response_async
    return await super().llm_response_async(message)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/langroid/agent/chat_agent.py", line 1520, in llm_response_async
    response = await self.llm_response_messages_async(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/lr_agent.py", line 1566, in llm_response_messages_async
    response = await self.llm.achat(
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/langroid/language_models/openai_gpt.py", line 1897, in achat
    raise e
  File "/usr/local/lib/python3.12/site-packages/langroid/language_models/openai_gpt.py", line 1884, in achat
    result = await self._achat(
             ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/langroid/language_models/openai_gpt.py", line 2332, in _achat
    return self._process_chat_completion_response(cached, response_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/langroid/language_models/openai_gpt.py", line 2185, in _process_chat_completion_response
    message = response["choices"][0].get("message", {})
              ~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

I implemented a simple fix to prevent the crash.