### PR TITLE
remove traceback from OpenAI API error logs

### DIFF
--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -1644,6 +1644,9 @@ class OpenAIGPT(LanguageModel):
 
         try:
             return self._generate(prompt, max_tokens)
+        except openai.APIError as e:
+            logging.error(f"API error in OpenAIGPT.generate: {e}")
+            raise e
         except Exception as e:
             # log and re-raise exception
             logging.error(friendly_error(e, "Error in OpenAIGPT.generate: "))
@@ -1725,6 +1728,9 @@ class OpenAIGPT(LanguageModel):
 
         try:
             return await self._agenerate(prompt, max_tokens)
+        except openai.APIError as e:
+            logging.error(f"API error in OpenAIGPT.agenerate: {e}")
+            raise e
         except Exception as e:
             # log and re-raise exception
             logging.error(friendly_error(e, "Error in OpenAIGPT.agenerate: "))
@@ -1837,6 +1843,9 @@ class OpenAIGPT(LanguageModel):
                 function_call,
                 response_format,
             )
+        except openai.APIError as e:
+            logging.error(f"API error in OpenAIGPT.chat: {e}")
+            raise e
         except Exception as e:
             # log and re-raise exception
             logging.error(friendly_error(e, "Error in OpenAIGPT.chat: "))
@@ -1891,6 +1900,9 @@ class OpenAIGPT(LanguageModel):
                 response_format,
             )
             return result
+        except openai.APIError as e:
+            logging.error(f"API error in OpenAIGPT.achat: {e}")
+            raise e
         except Exception as e:
             # log and re-raise exception
             logging.error(friendly_error(e, "Error in OpenAIGPT.achat: "))


### PR DESCRIPTION
Current code logs traceback for every exception that happens in OpenAI SDK.
For API errors - e.g. Authentication or BadRequest errors - this is not very useful, as the error is coming from the OpenAI servers and has nothing to do with langroid/SDK code - so we are just flooding logs with unneeded tracebacks.
To overcome the problem I added special handling for `openai.APIError` in corresponding `OpenAIGPT` class methods.