### PR TITLE
add gpt-5.1-chat and gpt-5.2-chat models info

### DIFF
--- a/langroid/language_models/model_info.py
+++ b/langroid/language_models/model_info.py
@@ -43,8 +43,10 @@ class OpenAIChatModel(ModelName):
     GPT5_1 = "gpt-5.1"
     GPT5_1_CODEX = "gpt-5.1-codex"
     GPT5_1_CODEX_MINI = "gpt-5.1-codex-mini"
+    GPT5_1_CHAT = "gpt-5.1-chat"
     GPT5_2 = "gpt-5.2"
     GPT5_2_PRO = "gpt-5.2-pro"
+    GPT5_2_CHAT = "gpt-5.2-chat"
     GPT_OSS_120b = "gpt-oss-120b"
     GPT_OSS_20b = "gpt-oss-20b"
 
@@ -419,6 +421,18 @@ MODEL_INFO: Dict[str, ModelInfo] = {
         unsupported_params=["temperature"],
         description="GPT-5.1 Codex Mini",
     ),
+    OpenAIChatModel.GPT5_1_CHAT.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_1_CHAT.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.125,
+        output_cost_per_million=10.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.1 Chat",
+    ),
     OpenAIChatModel.GPT5_2.value: ModelInfo(
         name=OpenAIChatModel.GPT5_2.value,
         provider=ModelProvider.OPENAI,
@@ -442,6 +456,18 @@ MODEL_INFO: Dict[str, ModelInfo] = {
         has_structured_output=True,
         unsupported_params=["temperature"],
         description="GPT-5.2 Pro",
+    ),
+    OpenAIChatModel.GPT5_2_CHAT.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_2_CHAT.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=1.75,
+        cached_cost_per_million=0.175,
+        output_cost_per_million=14.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.2 Chat",
     ),
     OpenAIChatModel.GPT_OSS_120b.value: ModelInfo(
         name=OpenAIChatModel.GPT_OSS_120b.value,


### PR DESCRIPTION
Add model information for `gpt-5.1-chat` and `gpt-5.2-chat` models.

These are non-thinking models - optimized for low-latency use-cases.
They also have smaller context and max output tokens compared to "regular" `gpt-5.1` / `gpt-5.2` models.
