### PR TITLE
fix empty tool arguments handling

### DIFF
--- a/langroid/language_models/base.py
+++ b/langroid/language_models/base.py
@@ -333,9 +333,12 @@ class LLMMessage(BaseModel):
             for tc in dict_no_none["tool_calls"]:
                 if "arguments" in tc["function"]:
                     # arguments must be a string
-                    tc["function"]["arguments"] = json.dumps(
-                        tc["function"]["arguments"]
-                    )
+                    if tc["function"]["arguments"] is None:
+                        tc["function"]["arguments"] = "{}"
+                    else:
+                        tc["function"]["arguments"] = json.dumps(
+                            tc["function"]["arguments"]
+                        )
                 if "extra_content" in tc and tc["extra_content"] is None:
                     del tc["extra_content"]
         # IMPORTANT! drop fields that are not expected in API call


### PR DESCRIPTION
**Problem description**
When we provide model with tool that has no arguments - model generates tool call with arguments set to `{}`.
This gets converted to `LLMFunctionCall` with `arguments` set to `None`.
When we convert this back to text - in `OpenAIGPT::_prep_chat_completion` - we end up with the following text:
```
'tool_calls': [
    {
        'id': 'function-call-2793809230105892082',
        'type': 'function',
        'function': {
            'name': 'get_conversation_data',
            'arguments': 'null'
        }
    }
]
```
Note that `{}` string gets replaced by `null`.

Most models don't care - but Gemini models of VertexAI do, and generate an API error:
```
[{'error': {'code': 400, 'message': 'Expected a valid JSON object in the request', 'status': 'INVALID_ARGUMENT'}}].
```

**Solution**
Small fix in `api_dict()` method to convert `None` argument value to `{}`
