### PR TITLE
support creation of async httpx client by http_client_factory

### DIFF
--- a/docs/notes/openai-http-client.md
+++ b/docs/notes/openai-http-client.md
@@ -64,13 +64,13 @@ def create_custom_client():
         },
         timeout=30.0
     )
-    
+
     # Add custom event hooks for logging
     def log_request(request):
         print(f"API Request: {request.method} {request.url}")
-    
+
     client.event_hooks = {"request": [log_request]}
-    
+
     return client
 
 config = lm.OpenAIGPTConfig(
@@ -79,6 +79,27 @@ config = lm.OpenAIGPTConfig(
 )
 
 llm = lm.OpenAIGPT(config)
+```
+
+If you are using `async` methods, return `Tuple(Client, AsyncClient)` from your factory:
+
+```python
+from httpx import AsyncClient, Client
+
+def create_custom_client():
+    """Factory function to create a custom sync and async HTTP clients."""
+    client_args = {
+        "verify": "/path/to/corporate-ca-bundle.pem",
+        "proxies": {
+            "http": "http://proxy.corp.com:8080",
+            "https": "http://proxy.corp.com:8080",
+        },
+        "timeout": 30.0,
+    }
+    client = Client(**client_args)
+    async_client = AsyncClient(**client_args)
+
+    return client, async_client
 ```
 
 **Note**: Custom factories bypass client caching. Each `OpenAIGPT` instance creates a new client.
@@ -112,17 +133,17 @@ config = lm.OpenAIGPTConfig(
 ```python
 def debug_client_factory():
     from httpx import Client
-    
+
     client = Client(verify=False)
-    
+
     def log_response(response):
         print(f"Status: {response.status_code}")
         print(f"Headers: {response.headers}")
-    
+
     client.event_hooks = {
         "response": [log_response]
     }
-    
+
     return client
 
 config = lm.OpenAIGPTConfig(

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -670,9 +670,12 @@ class OpenAIGPT(LanguageModel):
             if self.config.http_client_factory is not None:
                 # Use the factory to create http_client (not cacheable)
                 http_client = self.config.http_client_factory()
-                # Don't set async_http_client from sync client - create separately
-                # This avoids type mismatch issues
-                async_http_client = None
+                if isinstance(http_client, (list, tuple)):
+                    http_client, async_http_client = http_client
+                else:
+                    # set async_http_client to None - so that it will
+                    # be created later
+                    async_http_client = None
             elif self.config.http_client_config is not None:
                 # Use config dict (cacheable)
                 http_client_config_used = self.config.http_client_config


### PR DESCRIPTION
**Problem description**

Current implementation of `http_client_factory` in `OpenAIGPT` supports only returning sync client - thus making it useless for scenarios where async APIs are used.

**Solution**

Support two shapes for `http_client_factory` return:
* single sync client - for backwards compatibility
* tuple of `(sync_client, async_client)` - for scenarios where async client is needed
