### PR TITLE
add timestamp to client cache

### DIFF
--- a/langroid/language_models/client_cache.py
+++ b/langroid/language_models/client_cache.py
@@ -2,18 +2,22 @@
 Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
 """
 
+import asyncio
 import atexit
 import hashlib
+import inspect
+import time
 import weakref
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, Optional, Tuple, Union, cast
 
 from cerebras.cloud.sdk import AsyncCerebras, Cerebras
 from groq import AsyncGroq, Groq
 from httpx import Timeout
 from openai import AsyncOpenAI, OpenAI
 
-# Cache for client instances, keyed by hashed configuration parameters
-_client_cache: Dict[str, Any] = {}
+# Cache for client instances, keyed by hashed configuration parameters.
+# Value is a tuple of (client instance, last_used_monotonic_seconds).
+_client_cache: Dict[str, Tuple[Any, float]] = {}
 
 # Keep track of clients for cleanup
 _all_clients: weakref.WeakSet[Any] = weakref.WeakSet()
@@ -41,6 +45,39 @@ def _get_cache_key(client_type: str, **kwargs: Any) -> str:
     hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
 
     return hashed_key
+
+
+def _close_client(client: Any) -> None:
+    """Best-effort close for sync and async clients."""
+    close_method = getattr(client, "close", None)
+    if not callable(close_method):
+        return
+
+    try:
+        result = close_method()
+    except Exception:
+        return
+
+    if inspect.isawaitable(result):
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(result)
+        except RuntimeError:
+            try:
+                asyncio.run(result)
+            except Exception:
+                pass
+
+
+def _get_cached_client(cache_key: str) -> Optional[Any]:
+    """Get cached client and refresh its last-used timestamp."""
+    entry = _client_cache.get(cache_key)
+    if entry is None:
+        return None
+
+    client, _ = entry
+    _client_cache[cache_key] = (client, time.monotonic())
+    return client
 
 
 def get_openai_client(
@@ -106,8 +143,9 @@ def get_openai_client(
         http_client_config=http_client_config,  # Include config in cache key
     )
 
-    if cache_key in _client_cache:
-        return cast(OpenAI, _client_cache[cache_key])
+    cached_client = _get_cached_client(cache_key)
+    if cached_client is not None:
+        return cast(OpenAI, cached_client)
 
     client = OpenAI(
         api_key=api_key,
@@ -118,7 +156,7 @@ def get_openai_client(
         http_client=created_http_client,  # Use the client created from config
     )
 
-    _client_cache[cache_key] = client
+    _client_cache[cache_key] = (client, time.monotonic())
     _all_clients.add(client)
     return client
 
@@ -186,8 +224,9 @@ def get_async_openai_client(
         http_client_config=http_client_config,  # Include config in cache key
     )
 
-    if cache_key in _client_cache:
-        return cast(AsyncOpenAI, _client_cache[cache_key])
+    cached_client = _get_cached_client(cache_key)
+    if cached_client is not None:
+        return cast(AsyncOpenAI, cached_client)
 
     client = AsyncOpenAI(
         api_key=api_key,
@@ -198,7 +237,7 @@ def get_async_openai_client(
         http_client=created_http_client,  # Use the client created from config
     )
 
-    _client_cache[cache_key] = client
+    _client_cache[cache_key] = (client, time.monotonic())
     _all_clients.add(client)
     return client
 
@@ -215,11 +254,12 @@ def get_groq_client(api_key: str) -> Groq:
     """
     cache_key = _get_cache_key("groq", api_key=api_key)
 
-    if cache_key in _client_cache:
-        return cast(Groq, _client_cache[cache_key])
+    cached_client = _get_cached_client(cache_key)
+    if cached_client is not None:
+        return cast(Groq, cached_client)
 
     client = Groq(api_key=api_key)
-    _client_cache[cache_key] = client
+    _client_cache[cache_key] = (client, time.monotonic())
     _all_clients.add(client)
     return client
 
@@ -236,11 +276,12 @@ def get_async_groq_client(api_key: str) -> AsyncGroq:
     """
     cache_key = _get_cache_key("async_groq", api_key=api_key)
 
-    if cache_key in _client_cache:
-        return cast(AsyncGroq, _client_cache[cache_key])
+    cached_client = _get_cached_client(cache_key)
+    if cached_client is not None:
+        return cast(AsyncGroq, cached_client)
 
     client = AsyncGroq(api_key=api_key)
-    _client_cache[cache_key] = client
+    _client_cache[cache_key] = (client, time.monotonic())
     _all_clients.add(client)
     return client
 
@@ -257,11 +298,12 @@ def get_cerebras_client(api_key: str) -> Cerebras:
     """
     cache_key = _get_cache_key("cerebras", api_key=api_key)
 
-    if cache_key in _client_cache:
-        return cast(Cerebras, _client_cache[cache_key])
+    cached_client = _get_cached_client(cache_key)
+    if cached_client is not None:
+        return cast(Cerebras, cached_client)
 
     client = Cerebras(api_key=api_key)
-    _client_cache[cache_key] = client
+    _client_cache[cache_key] = (client, time.monotonic())
     _all_clients.add(client)
     return client
 
@@ -278,13 +320,43 @@ def get_async_cerebras_client(api_key: str) -> AsyncCerebras:
     """
     cache_key = _get_cache_key("async_cerebras", api_key=api_key)
 
-    if cache_key in _client_cache:
-        return cast(AsyncCerebras, _client_cache[cache_key])
+    cached_client = _get_cached_client(cache_key)
+    if cached_client is not None:
+        return cast(AsyncCerebras, cached_client)
 
     client = AsyncCerebras(api_key=api_key)
-    _client_cache[cache_key] = client
+    _client_cache[cache_key] = (client, time.monotonic())
     _all_clients.add(client)
     return client
+
+
+def prune_cache(max_age_seconds: float) -> int:
+    """
+    Clear cache entries older than the specified age.
+
+    Args:
+        max_age_seconds: Maximum age (in seconds) for cache entries to keep.
+            Entries older than this value are removed.
+
+    Returns:
+        Number of cache entries removed.
+    """
+    if max_age_seconds < 0:
+        raise ValueError("max_age_seconds must be non-negative")
+
+    now = time.monotonic()
+    stale_entries = [
+        (key, client)
+        for key, (client, last_used_at) in _client_cache.items()
+        if now - last_used_at > max_age_seconds
+    ]
+
+    for key, client in stale_entries:
+        _close_client(client)
+        _all_clients.discard(client)
+        _client_cache.pop(key, None)
+
+    return len(stale_entries)
 
 
 def _cleanup_clients() -> None:
@@ -292,21 +364,8 @@ def _cleanup_clients() -> None:
     Cleanup function to close all cached clients on exit.
     Called automatically via atexit.
     """
-    import inspect
-
     for client in list(_all_clients):
-        if hasattr(client, "close") and callable(client.close):
-            try:
-                # Check if close is a coroutine function (async)
-                if inspect.iscoroutinefunction(client.close):
-                    # For async clients, we can't await in atexit
-                    # They will be cleaned up by the OS
-                    pass
-                else:
-                    # Sync clients can be closed directly
-                    client.close()
-            except Exception:
-                pass  # Ignore errors during cleanup
+        _close_client(client)
 
 
 # Register cleanup function to run on exit

--- a/langroid/language_models/client_cache.py
+++ b/langroid/language_models/client_cache.py
@@ -4,7 +4,6 @@ Client caching/singleton pattern for LLM clients to prevent connection pool exha
 
 import atexit
 import hashlib
-import inspect
 import time
 import weakref
 from typing import Any, Dict, Optional, Tuple, Union, cast
@@ -323,32 +322,15 @@ def prune_cache(max_age_seconds: float) -> int:
 
     now = time.monotonic()
     stale_entries = [
-        (key, client)
-        for key, (client, last_used_at) in _client_cache.items()
+        key
+        for key, (_, last_used_at) in _client_cache.items()
         if now - last_used_at > max_age_seconds
     ]
 
-    for key, client in stale_entries:
-        if not _client_has_sync_close_method(client):
-            # Remove from tracking if we can't close it
-            _all_clients.discard(client)
+    for key in stale_entries:
         _client_cache.pop(key, None)
 
     return len(stale_entries)
-
-
-def _client_has_sync_close_method(client: Any) -> bool:
-    """Check if the client has a synchronous close method."""
-    if hasattr(client, "close") and callable(client.close):
-        try:
-            # Check if close is a coroutine function (async)
-            if inspect.iscoroutinefunction(client.close):
-                return False
-            else:
-                return True
-        except Exception:
-            pass  # Ignore errors during cleanup
-    return False
 
 
 def _cleanup_clients() -> None:
@@ -356,13 +338,21 @@ def _cleanup_clients() -> None:
     Cleanup function to close all cached clients on exit.
     Called automatically via atexit.
     """
+    import inspect
+
     for client in list(_all_clients):
-        # Sync clients can be closed directly
-        # For async clients, we can't await in atexit
-        # They will be cleaned up by the OS
-        if _client_has_sync_close_method(client):
-            # Sync clients can be closed directly
-            client.close()
+        if hasattr(client, "close") and callable(client.close):
+            try:
+                # Check if close is a coroutine function (async)
+                if inspect.iscoroutinefunction(client.close):
+                    # For async clients, we can't await in atexit
+                    # They will be cleaned up by the OS
+                    pass
+                else:
+                    # Sync clients can be closed directly
+                    client.close()
+            except Exception:
+                pass  # Ignore errors during cleanup
 
 
 # Register cleanup function to run on exit

--- a/langroid/language_models/client_cache.py
+++ b/langroid/language_models/client_cache.py
@@ -4,6 +4,7 @@ Client caching/singleton pattern for LLM clients to prevent connection pool exha
 
 import atexit
 import hashlib
+import threading
 import time
 import weakref
 from typing import Any, Dict, Optional, Tuple, Union, cast
@@ -16,6 +17,7 @@ from openai import AsyncOpenAI, OpenAI
 # Cache for client instances, keyed by hashed configuration parameters.
 # Value is a tuple of (client instance, last_used_monotonic_seconds).
 _client_cache: Dict[str, Tuple[Any, float]] = {}
+_client_cache_lock = threading.RLock()
 
 # Keep track of clients for cleanup
 _all_clients: weakref.WeakSet[Any] = weakref.WeakSet()
@@ -47,13 +49,14 @@ def _get_cache_key(client_type: str, **kwargs: Any) -> str:
 
 def _get_cached_client(cache_key: str) -> Optional[Any]:
     """Get cached client and refresh its last-used timestamp."""
-    entry = _client_cache.get(cache_key)
-    if entry is None:
-        return None
+    with _client_cache_lock:
+        entry = _client_cache.get(cache_key)
+        if entry is None:
+            return None
 
-    client, _ = entry
-    _client_cache[cache_key] = (client, time.monotonic())
-    return client
+        client, _ = entry
+        _client_cache[cache_key] = (client, time.monotonic())
+        return client
 
 
 def get_openai_client(
@@ -132,7 +135,8 @@ def get_openai_client(
         http_client=created_http_client,  # Use the client created from config
     )
 
-    _client_cache[cache_key] = (client, time.monotonic())
+    with _client_cache_lock:
+        _client_cache[cache_key] = (client, time.monotonic())
     _all_clients.add(client)
     return client
 
@@ -213,7 +217,8 @@ def get_async_openai_client(
         http_client=created_http_client,  # Use the client created from config
     )
 
-    _client_cache[cache_key] = (client, time.monotonic())
+    with _client_cache_lock:
+        _client_cache[cache_key] = (client, time.monotonic())
     _all_clients.add(client)
     return client
 
@@ -235,7 +240,8 @@ def get_groq_client(api_key: str) -> Groq:
         return cast(Groq, cached_client)
 
     client = Groq(api_key=api_key)
-    _client_cache[cache_key] = (client, time.monotonic())
+    with _client_cache_lock:
+        _client_cache[cache_key] = (client, time.monotonic())
     _all_clients.add(client)
     return client
 
@@ -257,7 +263,8 @@ def get_async_groq_client(api_key: str) -> AsyncGroq:
         return cast(AsyncGroq, cached_client)
 
     client = AsyncGroq(api_key=api_key)
-    _client_cache[cache_key] = (client, time.monotonic())
+    with _client_cache_lock:
+        _client_cache[cache_key] = (client, time.monotonic())
     _all_clients.add(client)
     return client
 
@@ -279,7 +286,8 @@ def get_cerebras_client(api_key: str) -> Cerebras:
         return cast(Cerebras, cached_client)
 
     client = Cerebras(api_key=api_key)
-    _client_cache[cache_key] = (client, time.monotonic())
+    with _client_cache_lock:
+        _client_cache[cache_key] = (client, time.monotonic())
     _all_clients.add(client)
     return client
 
@@ -301,7 +309,8 @@ def get_async_cerebras_client(api_key: str) -> AsyncCerebras:
         return cast(AsyncCerebras, cached_client)
 
     client = AsyncCerebras(api_key=api_key)
-    _client_cache[cache_key] = (client, time.monotonic())
+    with _client_cache_lock:
+        _client_cache[cache_key] = (client, time.monotonic())
     _all_clients.add(client)
     return client
 
@@ -321,14 +330,15 @@ def prune_cache(max_age_seconds: float) -> int:
         raise ValueError("max_age_seconds must be non-negative")
 
     now = time.monotonic()
-    stale_entries = [
-        key
-        for key, (_, last_used_at) in _client_cache.items()
-        if now - last_used_at > max_age_seconds
-    ]
+    with _client_cache_lock:
+        stale_entries = [
+            key
+            for key, (_, last_used_at) in _client_cache.items()
+            if now - last_used_at > max_age_seconds
+        ]
 
-    for key in stale_entries:
-        _client_cache.pop(key, None)
+        for key in stale_entries:
+            _client_cache.pop(key, None)
 
     return len(stale_entries)
 
@@ -362,4 +372,5 @@ atexit.register(_cleanup_clients)
 # For testing purposes
 def _clear_cache() -> None:
     """Clear the client cache. Only for testing."""
-    _client_cache.clear()
+    with _client_cache_lock:
+        _client_cache.clear()

--- a/langroid/language_models/client_cache.py
+++ b/langroid/language_models/client_cache.py
@@ -2,7 +2,6 @@
 Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
 """
 
-import asyncio
 import atexit
 import hashlib
 import inspect
@@ -45,28 +44,6 @@ def _get_cache_key(client_type: str, **kwargs: Any) -> str:
     hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
 
     return hashed_key
-
-
-def _close_client(client: Any) -> None:
-    """Best-effort close for sync and async clients."""
-    close_method = getattr(client, "close", None)
-    if not callable(close_method):
-        return
-
-    try:
-        result = close_method()
-    except Exception:
-        return
-
-    if inspect.isawaitable(result):
-        try:
-            loop = asyncio.get_running_loop()
-            loop.create_task(result)
-        except RuntimeError:
-            try:
-                asyncio.run(result)
-            except Exception:
-                pass
 
 
 def _get_cached_client(cache_key: str) -> Optional[Any]:
@@ -352,11 +329,26 @@ def prune_cache(max_age_seconds: float) -> int:
     ]
 
     for key, client in stale_entries:
-        _close_client(client)
-        _all_clients.discard(client)
+        if not _client_has_sync_close_method(client):
+            # Remove from tracking if we can't close it
+            _all_clients.discard(client)
         _client_cache.pop(key, None)
 
     return len(stale_entries)
+
+
+def _client_has_sync_close_method(client: Any) -> bool:
+    """Check if the client has a synchronous close method."""
+    if hasattr(client, "close") and callable(client.close):
+        try:
+            # Check if close is a coroutine function (async)
+            if inspect.iscoroutinefunction(client.close):
+                return False
+            else:
+                return True
+        except Exception:
+            pass  # Ignore errors during cleanup
+    return False
 
 
 def _cleanup_clients() -> None:
@@ -365,7 +357,12 @@ def _cleanup_clients() -> None:
     Called automatically via atexit.
     """
     for client in list(_all_clients):
-        _close_client(client)
+        # Sync clients can be closed directly
+        # For async clients, we can't await in atexit
+        # They will be cleaned up by the OS
+        if _client_has_sync_close_method(client):
+            # Sync clients can be closed directly
+            client.close()
 
 
 # Register cleanup function to run on exit

--- a/tests/main/test_openai_gpt_client_cache.py
+++ b/tests/main/test_openai_gpt_client_cache.py
@@ -113,32 +113,6 @@ class TestOpenAIGPTClientCache:
         client3 = get_openai_client(api_key="test-key-refresh")
         assert client3 is client1
 
-    def test_prune_cache_closes_and_unregisters_stale_clients(
-        self, monkeypatch
-    ):
-        """Test stale entries are closed and removed from _all_clients."""
-        fake_now = [4000.0]
-
-        monkeypatch.setattr(client_cache_module.time, "monotonic", lambda: fake_now[0])
-
-        class DummyClient:
-            def __init__(self):
-                self.closed = False
-
-            def close(self):
-                self.closed = True
-
-        dummy = DummyClient()
-        client_cache_module._client_cache["dummy"] = (dummy, 3980.0)
-        client_cache_module._all_clients.add(dummy)
-
-        removed = prune_cache(5.0)
-
-        assert removed == 1
-        assert dummy.closed is True
-        assert "dummy" not in client_cache_module._client_cache
-        assert dummy not in client_cache_module._all_clients
-
     def test_mixed_client_types(self):
         """Test that different client types are cached separately."""
         api_key = "same-key-for-all"

--- a/tests/main/test_openai_gpt_client_cache.py
+++ b/tests/main/test_openai_gpt_client_cache.py
@@ -4,12 +4,14 @@ Tests for OpenAIGPT client caching functionality.
 
 import pytest
 
+import langroid.language_models.client_cache as client_cache_module
 from langroid.language_models.client_cache import (
     _clear_cache,
     get_async_openai_client,
     get_cerebras_client,
     get_groq_client,
     get_openai_client,
+    prune_cache,
 )
 from langroid.language_models.openai_gpt import OpenAIGPT, OpenAIGPTConfig
 
@@ -57,6 +59,85 @@ class TestOpenAIGPTClientCache:
         client2 = get_groq_client(api_key=api_key)
 
         assert client1 is client2
+
+    def test_prune_cache_removes_stale_entries(self, monkeypatch):
+        """Test eviction of cache entries older than the specified max age."""
+        fake_now = [1000.0]
+
+        monkeypatch.setattr(client_cache_module.time, "monotonic", lambda: fake_now[0])
+
+        client1 = get_openai_client(api_key="test-key-stale")
+        fake_now[0] += 20.0
+
+        removed = prune_cache(5.0)
+
+        assert removed == 1
+
+        client2 = get_openai_client(api_key="test-key-stale")
+        assert client1 is not client2
+
+    def test_prune_cache_keeps_fresh_entries(self, monkeypatch):
+        """Test fresh cache entries are retained when below max age."""
+        fake_now = [2000.0]
+
+        monkeypatch.setattr(client_cache_module.time, "monotonic", lambda: fake_now[0])
+
+        client1 = get_openai_client(api_key="test-key-fresh")
+        fake_now[0] += 1.0
+
+        removed = prune_cache(5.0)
+
+        assert removed == 0
+
+        client2 = get_openai_client(api_key="test-key-fresh")
+        assert client1 is client2
+
+    def test_cache_age_refreshes_on_use(self, monkeypatch):
+        """Test cache entry last-used timestamp is refreshed on cache hits."""
+        fake_now = [3000.0]
+
+        monkeypatch.setattr(client_cache_module.time, "monotonic", lambda: fake_now[0])
+
+        client1 = get_openai_client(api_key="test-key-refresh")
+
+        # Use client again from cache; this should refresh last-used time.
+        fake_now[0] += 3.0
+        client2 = get_openai_client(api_key="test-key-refresh")
+        assert client1 is client2
+
+        # At this point age since last use is only 3s, so it should not be evicted.
+        fake_now[0] += 3.0
+        removed = prune_cache(5.0)
+        assert removed == 0
+
+        client3 = get_openai_client(api_key="test-key-refresh")
+        assert client3 is client1
+
+    def test_prune_cache_closes_and_unregisters_stale_clients(
+        self, monkeypatch
+    ):
+        """Test stale entries are closed and removed from _all_clients."""
+        fake_now = [4000.0]
+
+        monkeypatch.setattr(client_cache_module.time, "monotonic", lambda: fake_now[0])
+
+        class DummyClient:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        dummy = DummyClient()
+        client_cache_module._client_cache["dummy"] = (dummy, 3980.0)
+        client_cache_module._all_clients.add(dummy)
+
+        removed = prune_cache(5.0)
+
+        assert removed == 1
+        assert dummy.closed is True
+        assert "dummy" not in client_cache_module._client_cache
+        assert dummy not in client_cache_module._all_clients
 
     def test_mixed_client_types(self):
         """Test that different client types are cached separately."""


### PR DESCRIPTION
### Problem

Current OpenAI clients cache implementation in `client_cache.py` stores entries in cache forever.
This makes it not very useful for dynamic environments that run for a long time and use multiple per-customer credentials to instantiate OpenAI clients.

### Solution

- Add timestamp to the cache entries.
- Update timestamp value on "cache hit" - so that it reflects "last use time" for specific entry.
- Add `prune_clients` method that performs age-based eviction of cache entries.