### PR TITLE
Add MiniMax as first-class LLM provider

### DIFF
--- a/docs/tutorials/supported-models.md
+++ b/docs/tutorials/supported-models.md
@@ -54,6 +54,7 @@ and which environment variable to set for the API key.
 | Cerebras      | `cerebras/llama-3.3-70b`                                 | `CEREBRAS_API_KEY` |
 | Gemini        | `gemini/gemini-2.0-flash`                                | `GEMINI_API_KEY` |
 | DeepSeek      | `deepseek/deepseek-reasoner`                             | `DEEPSEEK_API_KEY` |
+| MiniMax       | `minimax/MiniMax-M2.7`                                   | `MINIMAX_API_KEY` |
 | GLHF          | `glhf/hf:Qwen/Qwen2.5-Coder-32B-Instruct`                | `GLHF_API_KEY` |
 | OpenRouter    | `openrouter/deepseek/deepseek-r1-distill-llama-70b:free` | `OPENROUTER_API_KEY` |
 | Ollama        | `ollama/qwen2.5`                                         | `OLLAMA_API_KEY` (usually `ollama`) |

--- a/langroid/language_models/__init__.py
+++ b/langroid/language_models/__init__.py
@@ -19,6 +19,7 @@ from .model_info import (
     OpenAIChatModel,
     AnthropicModel,
     GeminiModel,
+    MiniMaxModel,
     OpenAICompletionModel,
 )
 from .openai_gpt import OpenAIGPTConfig, OpenAIGPT, OpenAICallParams
@@ -45,6 +46,7 @@ __all__ = [
     "OpenAIChatModel",
     "AnthropicModel",
     "GeminiModel",
+    "MiniMaxModel",
     "OpenAICompletionModel",
     "OpenAIGPTConfig",
     "OpenAIGPT",

--- a/langroid/language_models/model_info.py
+++ b/langroid/language_models/model_info.py
@@ -14,6 +14,7 @@ class ModelProvider(str, Enum):
     ANTHROPIC = "anthropic"
     DEEPSEEK = "deepseek"
     GOOGLE = "google"
+    MINIMAX = "minimax"
     UNKNOWN = "unknown"
 
 
@@ -100,6 +101,15 @@ class GeminiModel(ModelName):
     GEMINI_2_5_PRO = "gemini-2.5-pro"
     GEMINI_3_FLASH = "gemini-3-flash"
     GEMINI_3_PRO = "gemini-3-pro"
+
+
+class MiniMaxModel(ModelName):
+    """Enum for MiniMax models"""
+
+    MINIMAX_M2_7 = "MiniMax-M2.7"
+    MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
+    MINIMAX_M2_5 = "MiniMax-M2.5"
+    MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
 
 
 class OpenAI_API_ParamInfo(BaseModel):
@@ -678,6 +688,47 @@ MODEL_INFO: Dict[str, ModelInfo] = {
         cached_cost_per_million=0.05,
         output_cost_per_million=3.00,
         description="Gemini 3 Flash",
+    ),
+    # MiniMax Models
+    MiniMaxModel.MINIMAX_M2_7.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_7.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=1_000_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=1.10,
+        output_cost_per_million=4.40,
+        has_structured_output=True,
+        description="MiniMax M2.7 (1M context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=1_000_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=0.55,
+        output_cost_per_million=2.20,
+        has_structured_output=True,
+        description="MiniMax M2.7 Highspeed (1M context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_5.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_5.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=1.10,
+        output_cost_per_million=4.40,
+        has_structured_output=True,
+        description="MiniMax M2.5 (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=0.55,
+        output_cost_per_million=2.20,
+        has_structured_output=True,
+        description="MiniMax M2.5 Highspeed (204K context)",
     ),
 }
 

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -59,6 +59,7 @@ from langroid.language_models.client_cache import (
 from langroid.language_models.config import HFPromptFormatterConfig
 from langroid.language_models.model_info import (
     DeepSeekModel,
+    MiniMaxModel,
     OpenAI_API_ParamInfo,
 )
 from langroid.language_models.model_info import (
@@ -96,6 +97,7 @@ DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
 GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
 OLLAMA_API_KEY = "ollama"
 
 VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
@@ -548,6 +550,7 @@ class OpenAIGPT(LanguageModel):
         self.is_cerebras = self.config.chat_model.startswith("cerebras/")
         self.is_gemini = self.is_gemini_model()
         self.is_deepseek = self.is_deepseek_model()
+        self.is_minimax = self.is_minimax_model()
         self.is_glhf = self.config.chat_model.startswith("glhf/")
         self.is_openrouter = self.config.chat_model.startswith("openrouter/")
         self.is_langdb = self.config.chat_model.startswith("langdb/")
@@ -621,6 +624,11 @@ class OpenAIGPT(LanguageModel):
                 self.api_base = DEEPSEEK_BASE_URL
                 if self.api_key == OPENAI_API_KEY:
                     self.api_key = os.getenv("DEEPSEEK_API_KEY", DUMMY_API_KEY)
+            elif self.is_minimax:
+                self.config.chat_model = self.config.chat_model.replace("minimax/", "")
+                self.api_base = MINIMAX_BASE_URL
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("MINIMAX_API_KEY", DUMMY_API_KEY)
             elif self.is_langdb:
                 self.config.chat_model = self.config.chat_model.replace("langdb/", "")
                 self.api_base = self.config.langdb_params.base_url
@@ -823,6 +831,14 @@ class OpenAIGPT(LanguageModel):
         return (
             self.chat_model_orig in deepseek_models
             or self.chat_model_orig.startswith("deepseek/")
+        )
+
+    def is_minimax_model(self) -> bool:
+        """Are we using the MiniMax OpenAI-compatible API?"""
+        minimax_models = [e.value for e in MiniMaxModel]
+        return (
+            self.chat_model_orig in minimax_models
+            or self.chat_model_orig.startswith("minimax/")
         )
 
     def unsupported_params(self) -> List[str]:

--- a/tests/main/test_minimax_provider.py
+++ b/tests/main/test_minimax_provider.py
@@ -1,0 +1,279 @@
+"""
+Tests for MiniMax LLM provider support.
+
+Unit tests run without network access. Integration tests require MINIMAX_API_KEY.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from langroid.language_models.model_info import (
+    MODEL_INFO,
+    MiniMaxModel,
+    ModelInfo,
+    ModelProvider,
+    get_model_info,
+)
+from langroid.language_models.openai_gpt import (
+    MINIMAX_BASE_URL,
+    OpenAIGPT,
+    OpenAIGPTConfig,
+)
+
+
+# ──────────────────────── Unit Tests ────────────────────────
+
+
+class TestMiniMaxModelInfo:
+    """Unit tests for MiniMax model info registry."""
+
+    def test_minimax_provider_enum(self):
+        """MINIMAX is a valid ModelProvider enum member."""
+        assert ModelProvider.MINIMAX == "minimax"
+        assert ModelProvider.MINIMAX.value == "minimax"
+
+    def test_minimax_model_enum_values(self):
+        """MiniMaxModel enum contains the expected model names."""
+        assert MiniMaxModel.MINIMAX_M2_7.value == "MiniMax-M2.7"
+        assert MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value == "MiniMax-M2.7-highspeed"
+        assert MiniMaxModel.MINIMAX_M2_5.value == "MiniMax-M2.5"
+        assert MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value == "MiniMax-M2.5-highspeed"
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            MiniMaxModel.MINIMAX_M2_7,
+            MiniMaxModel.MINIMAX_M2_7_HIGHSPEED,
+            MiniMaxModel.MINIMAX_M2_5,
+            MiniMaxModel.MINIMAX_M2_5_HIGHSPEED,
+        ],
+    )
+    def test_model_info_registered(self, model):
+        """Each MiniMax model has a ModelInfo entry in the registry."""
+        assert model.value in MODEL_INFO
+        info = MODEL_INFO[model.value]
+        assert isinstance(info, ModelInfo)
+        assert info.provider == ModelProvider.MINIMAX
+        assert info.context_length > 0
+        assert info.max_output_tokens > 0
+
+    def test_get_model_info_minimax(self):
+        """get_model_info returns correct info for MiniMax models."""
+        info = get_model_info("MiniMax-M2.7")
+        assert info.provider == ModelProvider.MINIMAX
+        assert info.context_length == 1_000_000
+        assert info.has_structured_output is True
+
+    def test_model_info_m27_context(self):
+        """M2.7 models have 1M context length."""
+        info_m27 = MODEL_INFO[MiniMaxModel.MINIMAX_M2_7.value]
+        info_m27hs = MODEL_INFO[MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value]
+        assert info_m27.context_length == 1_000_000
+        assert info_m27hs.context_length == 1_000_000
+
+    def test_model_info_m25_context(self):
+        """M2.5 models have 204K context length."""
+        info_m25 = MODEL_INFO[MiniMaxModel.MINIMAX_M2_5.value]
+        info_m25hs = MODEL_INFO[MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value]
+        assert info_m25.context_length == 204_000
+        assert info_m25hs.context_length == 204_000
+
+    def test_highspeed_models_cheaper(self):
+        """Highspeed variants should cost less than standard variants."""
+        m27 = MODEL_INFO[MiniMaxModel.MINIMAX_M2_7.value]
+        m27hs = MODEL_INFO[MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value]
+        assert m27hs.input_cost_per_million < m27.input_cost_per_million
+        assert m27hs.output_cost_per_million < m27.output_cost_per_million
+
+
+class TestMiniMaxProviderRouting:
+    """Unit tests for MiniMax provider routing in OpenAIGPT."""
+
+    def setup_method(self):
+        """Clear OPENAI_API_KEY and settings.chat_model to avoid interference."""
+        from langroid.utils.configuration import settings
+
+        self._orig_key = os.environ.get("OPENAI_API_KEY")
+        if self._orig_key:
+            del os.environ["OPENAI_API_KEY"]
+        self._orig_chat_model = settings.chat_model
+        settings.chat_model = ""
+
+    def teardown_method(self):
+        """Restore OPENAI_API_KEY and settings.chat_model."""
+        from langroid.utils.configuration import settings
+
+        if self._orig_key:
+            os.environ["OPENAI_API_KEY"] = self._orig_key
+        settings.chat_model = self._orig_chat_model
+
+    def test_minimax_prefix_sets_base_url(self):
+        """Using minimax/ prefix should set the MiniMax API base URL."""
+        config = OpenAIGPTConfig(
+            api_key="test-minimax-key",
+            chat_model="minimax/MiniMax-M2.7",
+        )
+        gpt = OpenAIGPT(config)
+        assert gpt.is_minimax is True
+        assert gpt.api_base == MINIMAX_BASE_URL
+        # Prefix should be stripped from chat_model
+        assert gpt.config.chat_model == "MiniMax-M2.7"
+
+    def test_minimax_prefix_strips_prefix(self):
+        """minimax/ prefix should be stripped from the model name."""
+        config = OpenAIGPTConfig(
+            api_key="test-key",
+            chat_model="minimax/MiniMax-M2.7-highspeed",
+        )
+        gpt = OpenAIGPT(config)
+        assert gpt.config.chat_model == "MiniMax-M2.7-highspeed"
+
+    def test_minimax_uses_openai_client(self):
+        """MiniMax should use the standard OpenAI client (not Groq/Cerebras)."""
+        config = OpenAIGPTConfig(
+            api_key="test-key",
+            chat_model="minimax/MiniMax-M2.7",
+        )
+        gpt = OpenAIGPT(config)
+        assert gpt.client.__class__.__name__ == "OpenAI"
+        assert gpt.async_client.__class__.__name__ == "AsyncOpenAI"
+
+    def test_minimax_api_key_from_env(self):
+        """MINIMAX_API_KEY env var should be used when no explicit key is given."""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-minimax-key"}):
+            config = OpenAIGPTConfig(
+                chat_model="minimax/MiniMax-M2.7",
+            )
+            gpt = OpenAIGPT(config)
+            assert gpt.api_key == "env-minimax-key"
+
+    def test_minimax_explicit_api_key_takes_precedence(self):
+        """Explicit api_key in config should override env var."""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key"}):
+            config = OpenAIGPTConfig(
+                api_key="explicit-key",
+                chat_model="minimax/MiniMax-M2.7",
+            )
+            gpt = OpenAIGPT(config)
+            assert gpt.api_key == "explicit-key"
+
+    def test_is_minimax_model_with_prefix(self):
+        """is_minimax_model() should return True for minimax/ prefixed models."""
+        config = OpenAIGPTConfig(
+            api_key="test-key",
+            chat_model="minimax/MiniMax-M2.5",
+        )
+        gpt = OpenAIGPT(config)
+        assert gpt.is_minimax_model() is True
+
+    def test_is_minimax_model_with_enum(self):
+        """is_minimax_model() should return True for MiniMaxModel enum values."""
+        config = OpenAIGPTConfig(
+            api_key="test-key",
+            chat_model="minimax/MiniMax-M2.7",
+        )
+        gpt = OpenAIGPT(config)
+        assert gpt.is_minimax_model() is True
+
+    def test_is_not_minimax_model(self):
+        """is_minimax_model() should return False for non-MiniMax models."""
+        config = OpenAIGPTConfig(
+            api_key="test-key",
+            chat_model="gpt-4o",
+        )
+        gpt = OpenAIGPT(config)
+        assert gpt.is_minimax is False
+
+    def test_minimax_m25_highspeed_routing(self):
+        """M2.5-highspeed model should route correctly."""
+        config = OpenAIGPTConfig(
+            api_key="test-key",
+            chat_model="minimax/MiniMax-M2.5-highspeed",
+        )
+        gpt = OpenAIGPT(config)
+        assert gpt.is_minimax is True
+        assert gpt.config.chat_model == "MiniMax-M2.5-highspeed"
+        assert gpt.api_base == MINIMAX_BASE_URL
+
+    def test_minimax_base_url_constant(self):
+        """MINIMAX_BASE_URL should point to the correct endpoint."""
+        assert MINIMAX_BASE_URL == "https://api.minimax.io/v1"
+
+
+class TestMiniMaxExports:
+    """Unit tests for MiniMax exports in __init__.py."""
+
+    def test_minimax_model_importable(self):
+        """MiniMaxModel should be importable from langroid.language_models."""
+        from langroid.language_models import MiniMaxModel
+
+        assert MiniMaxModel.MINIMAX_M2_7.value == "MiniMax-M2.7"
+
+
+# ──────────────────────── Integration Tests ────────────────────────
+
+
+@pytest.mark.integration
+class TestMiniMaxIntegration:
+    """Integration tests requiring MINIMAX_API_KEY env var."""
+
+    @pytest.fixture(autouse=True)
+    def check_api_key(self):
+        """Skip integration tests if MINIMAX_API_KEY is not set."""
+        if not os.environ.get("MINIMAX_API_KEY"):
+            pytest.skip("MINIMAX_API_KEY not set")
+
+    def setup_method(self):
+        """Clear settings.chat_model to avoid global override."""
+        from langroid.utils.configuration import settings
+
+        self._orig_chat_model = settings.chat_model
+        settings.chat_model = ""
+
+    def teardown_method(self):
+        """Restore settings.chat_model."""
+        from langroid.utils.configuration import settings
+
+        settings.chat_model = self._orig_chat_model
+
+    def test_minimax_chat_completion(self):
+        """Test basic chat completion with MiniMax M2.7."""
+        config = OpenAIGPTConfig(
+            chat_model="minimax/MiniMax-M2.7",
+            max_output_tokens=50,
+            temperature=0.0,
+        )
+        gpt = OpenAIGPT(config)
+        response = gpt.chat("What is 2+2? Reply with just the number.")
+        assert response is not None
+        assert response.message is not None
+        assert "4" in response.message
+
+    def test_minimax_highspeed_chat(self):
+        """Test chat completion with MiniMax M2.7-highspeed."""
+        config = OpenAIGPTConfig(
+            chat_model="minimax/MiniMax-M2.7-highspeed",
+            max_output_tokens=50,
+            temperature=0.0,
+        )
+        gpt = OpenAIGPT(config)
+        response = gpt.chat("Say hello in exactly one word.")
+        assert response is not None
+        assert response.message is not None
+        assert len(response.message.strip()) > 0
+
+    @pytest.mark.asyncio
+    async def test_minimax_async_chat(self):
+        """Test async chat completion with MiniMax."""
+        config = OpenAIGPTConfig(
+            chat_model="minimax/MiniMax-M2.7-highspeed",
+            max_output_tokens=50,
+            temperature=0.0,
+        )
+        gpt = OpenAIGPT(config)
+        response = await gpt.achat("What is 3+3? Reply with just the number.")
+        assert response is not None
+        assert response.message is not None
+        assert "6" in response.message


### PR DESCRIPTION
## Summary

Add [MiniMax AI](https://www.minimaxi.com) as a built-in LLM provider, following the existing pattern for DeepSeek, Gemini, Groq, Cerebras, etc.

- Add `MINIMAX` to `ModelProvider` enum and `MiniMaxModel` enum with M2.7, M2.7-highspeed, M2.5, M2.5-highspeed models
- Add `minimax/` prefix routing in `OpenAIGPT.__init__()` with `MINIMAX_API_KEY` auto-detection and `MINIMAX_BASE_URL`
- Add `is_minimax_model()` detection method
- Register model info (context length up to 1M tokens, pricing, structured output support)
- Export `MiniMaxModel` from `langroid.language_models`
- Add MiniMax to the supported-models docs table
- Add 24 tests (21 unit + 3 integration)

## Usage

```python
import langroid.language_models as lm

config = lm.OpenAIGPTConfig(
    chat_model="minimax/MiniMax-M2.7",  # or MiniMax-M2.7-highspeed
)
agent_config = lr.ChatAgentConfig(llm=config)
agent = lr.ChatAgent(agent_config)
```

Set `MINIMAX_API_KEY` in your environment. MiniMax uses an OpenAI-compatible API at `https://api.minimax.io/v1`.

## Models

| Model | Context | Description |
|-------|---------|-------------|
| `MiniMax-M2.7` | 1M tokens | Latest flagship model |
| `MiniMax-M2.7-highspeed` | 1M tokens | Faster, lower cost variant |
| `MiniMax-M2.5` | 204K tokens | Previous generation |
| `MiniMax-M2.5-highspeed` | 204K tokens | Previous gen, faster variant |

## Test plan

- [x] 21 unit tests pass (model info registry, provider routing, prefix stripping, API key detection, exports)
- [x] 3 integration tests pass with live MiniMax API (sync chat, async chat, highspeed model)
- [ ] Verify no regressions in existing provider tests

## Files changed (5 files, 349 additions)

- `langroid/language_models/model_info.py` — MiniMaxModel enum + ModelInfo entries
- `langroid/language_models/openai_gpt.py` — minimax/ prefix routing + is_minimax_model()
- `langroid/language_models/__init__.py` — Export MiniMaxModel
- `docs/tutorials/supported-models.md` — Add MiniMax to provider table
- `tests/main/test_minimax_provider.py` — 24 tests (21 unit + 3 integration)