### PR TITLE
fix: normalize Gemini model names with multi-suffix/date variants

### DIFF
--- a/langroid/language_models/model_info.py
+++ b/langroid/language_models/model_info.py
@@ -819,19 +819,51 @@ def _normalize_model_names(models: List[str | ModelName]) -> List[str]:
 
 
 def _normalize_gemini_model_name(model: str) -> str | None:
+    """Normalize a Gemini model name to its canonical form.
+
+    Handles dated variants (e.g. ``gemini-2.0-flash-thinking-exp-01-21``),
+    preview/exp/experimental/latest suffixes, and combinations thereof.
+    """
+    import re
+
     base_model = model.rsplit("/", 1)[-1]
     if base_model in GEMINI_CANONICAL_MODEL_NAMES:
         return base_model
     if not base_model.startswith("gemini-"):
         return None
 
-    # Try stripping known suffixes to find a canonical name.
+    # Pattern for trailing date components like "-01-21" or "-06-17".
+    _DATE_RE = re.compile(r"-\d{2}-\d{2}$")
+
+    def _strip_date(name: str) -> str:
+        return _DATE_RE.sub("", name)
+
+    # Step 1: strip a trailing date suffix alone (handles variants of canonical
+    # names that already contain "-exp", e.g. "gemini-2.0-flash-thinking-exp").
+    date_stripped = _strip_date(base_model)
+    if date_stripped != base_model and date_stripped in GEMINI_CANONICAL_MODEL_NAMES:
+        return date_stripped
+
+    # Step 2: strip a known keyword suffix, then optionally a trailing date.
     # Use split (not endswith) for "-preview" so dated variants like
     # "gemini-2.5-flash-lite-preview-06-17" are handled correctly.
     for suffix in ("-preview", "-exp", "-experimental", "-latest"):
         stripped = base_model.split(suffix, maxsplit=1)[0]
-        if stripped != base_model and stripped in GEMINI_CANONICAL_MODEL_NAMES:
+        if stripped == base_model:
+            continue
+        if stripped in GEMINI_CANONICAL_MODEL_NAMES:
             return stripped
+        # After removing the keyword suffix, there may still be a trailing date
+        # (e.g. "gemini-2.0-pro-exp-03-07" → strip "-exp" → "gemini-2.0-pro"
+        # with trailing "-03-07" already gone via split; but cover the symmetric
+        # case where the date precedes the keyword suffix is unusual — keep for
+        # forward-compatibility).
+        date_stripped2 = _strip_date(stripped)
+        if (
+            date_stripped2 != stripped
+            and date_stripped2 in GEMINI_CANONICAL_MODEL_NAMES
+        ):
+            return date_stripped2
     return None
 
 

--- a/tests/main/test_model_info.py
+++ b/tests/main/test_model_info.py
@@ -1,0 +1,68 @@
+"""Tests for langroid.language_models.model_info helpers."""
+
+import pytest
+
+from langroid.language_models.model_info import (
+    GeminiModel,
+    _normalize_gemini_model_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_gemini_model_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model, expected",
+    [
+        # ---- canonical names are returned unchanged ----
+        ("gemini-2.5-flash", "gemini-2.5-flash"),
+        ("gemini-2.5-pro", "gemini-2.5-pro"),
+        ("gemini-2.0-flash", "gemini-2.0-flash"),
+        ("gemini-1.5-pro", "gemini-1.5-pro"),
+        # canonical name that already ends with "-exp"
+        (
+            GeminiModel.GEMINI_2_FLASH_THINKING.value,
+            GeminiModel.GEMINI_2_FLASH_THINKING.value,
+        ),
+        # ---- provider-prefixed variants ----
+        ("google/gemini-2.5-flash", "gemini-2.5-flash"),
+        ("vertex_ai/gemini-2.5-pro", "gemini-2.5-pro"),
+        # ---- simple keyword suffixes ----
+        ("gemini-2.5-flash-preview", "gemini-2.5-flash"),
+        ("gemini-2.5-pro-preview", "gemini-2.5-pro"),
+        ("gemini-2.5-flash-latest", "gemini-2.5-flash"),
+        ("gemini-2.5-flash-experimental", "gemini-2.5-flash"),
+        # ---- dated preview variants (keyword + date) ----
+        ("gemini-2.5-flash-preview-05-20", "gemini-2.5-flash"),
+        ("gemini-2.5-flash-lite-preview-06-17", "gemini-2.5-flash-lite"),
+        ("gemini-2.5-pro-preview-03-25", "gemini-2.5-pro"),
+        # ---- date-only suffix on a canonical name that contains "-exp" ----
+        # "gemini-2.0-flash-thinking-exp" is canonical; "-01-21" is the date variant
+        (
+            "gemini-2.0-flash-thinking-exp-01-21",
+            GeminiModel.GEMINI_2_FLASH_THINKING.value,
+        ),
+        (
+            "gemini-2.0-flash-thinking-exp-12-31",
+            GeminiModel.GEMINI_2_FLASH_THINKING.value,
+        ),
+        # ---- non-Gemini models return None ----
+        ("gpt-4o", None),
+        ("claude-3-opus-latest", None),
+        # ---- completely unknown Gemini variant returns None ----
+        ("gemini-99-ultra", None),
+    ],
+)
+def test_normalize_gemini_model_name(model: str, expected: str | None) -> None:
+    assert _normalize_gemini_model_name(model) == expected
+
+
+def test_normalize_gemini_all_canonical_names_are_stable() -> None:
+    """Every canonical GeminiModel value must normalize to itself."""
+    for member in GeminiModel:
+        result = _normalize_gemini_model_name(member.value)
+        assert (
+            result == member.value
+        ), f"Canonical name {member.value!r} normalized to {result!r}"


### PR DESCRIPTION
## Summary

Fixes #995.

`_normalize_gemini_model_name` failed to normalize Gemini model variants whose name contains a date suffix appended *after* a keyword like `-exp` — for example `gemini-2.0-flash-thinking-exp-01-21`. The canonical name for this model is `gemini-2.0-flash-thinking-exp`, so stripping a keyword suffix alone (the previous logic) would give `gemini-2.0-flash-thinking`, which is not in `GEMINI_CANONICAL_MODEL_NAMES`.

### Root cause

The suffix-stripping loop tried each keyword (`-preview`, `-exp`, `-experimental`, `-latest`) and returned the stripped form only if it was a canonical name. It did not handle the case where a trailing `MM-DD` date component sits *after* the keyword.

### Fix

Two-pass normalization is applied after the initial direct-match check:

1. **Date-only pass** — strip a trailing `-MM-DD` component and check canonical. This handles variants of canonical names that already end with `-exp` (e.g. `gemini-2.0-flash-thinking-exp-01-21` → `gemini-2.0-flash-thinking-exp` ✓).
2. **Keyword + optional date pass** — existing keyword-stripping logic, extended to also try stripping a trailing date from the keyword-stripped result (for forward-compatibility with patterns where the date precedes the keyword suffix).

### Tests

`tests/main/test_model_info.py` (new file) covers:
- All canonical `GeminiModel` values normalize to themselves
- Provider-prefixed variants (`google/`, `vertex_ai/`)
- Simple keyword suffixes (`-preview`, `-latest`, `-experimental`)
- Dated preview variants (`gemini-2.5-flash-lite-preview-06-17` → `gemini-2.5-flash-lite`)
- Date-only suffix on canonical names containing `-exp` (`gemini-2.0-flash-thinking-exp-01-21` → `gemini-2.0-flash-thinking-exp`)
- Non-Gemini and completely unknown Gemini variants return `None`

## Test plan

- [x] `pytest tests/main/test_model_info.py` — 20 tests, all pass
- [x] `black` formatting applied
