### PR TITLE
fix: distribute context overflow evenly instead of clamping to 30 tokens

### DIFF
--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -1738,8 +1738,16 @@ class ChatAgent(Agent):
                         _n_remaining = (
                             last_msg_idx_to_compress - msg_idx_to_compress + 1
                         )
-                        _msg_tokens = self._message_num_tokens(
-                            hist[msg_idx_to_compress]
+                        # Use only the *content* token count — not the full
+                        # _message_num_tokens which includes attachments.
+                        # truncate_message only trims message.content, so
+                        # including attachment tokens would inflate _msg_tokens
+                        # and make _keep_tokens too large, preventing convergence
+                        # for messages that carry file attachments.
+                        _msg_tokens = (
+                            self.parser.num_tokens(hist[msg_idx_to_compress].content)
+                            if self.parser is not None
+                            else len(hist[msg_idx_to_compress].content) // 4
                         )
                         _reduction = math.ceil(_current_excess / _n_remaining)
                         # Account for the warning string that truncate_message

--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -2,6 +2,7 @@ import copy
 import inspect
 import json
 import logging
+import math
 import textwrap
 from contextlib import ExitStack
 from inspect import isclass
@@ -1475,7 +1476,9 @@ class ChatAgent(Agent):
         response.metadata.tool_ids = (
             []
             if isinstance(message, str)
-            else message.metadata.tool_ids if message is not None else []
+            else message.metadata.tool_ids
+            if message is not None
+            else []
         )
 
         return response
@@ -1563,7 +1566,9 @@ class ChatAgent(Agent):
         response.metadata.tool_ids = (
             []
             if isinstance(message, str)
-            else message.metadata.tool_ids if message is not None else []
+            else message.metadata.tool_ids
+            if message is not None
+            else []
         )
 
         return response
@@ -1697,12 +1702,12 @@ class ChatAgent(Agent):
                         - 1
                     )
                     n_truncated = 0
-                    while (
-                        self.chat_num_tokens(hist)
-                        > self.llm.chat_context_length()
+                    _target_tokens = (
+                        self.llm.chat_context_length()
                         - self.config.llm.min_output_tokens
                         - CHAT_HISTORY_BUFFER
-                    ):
+                    )
+                    while self.chat_num_tokens(hist) > _target_tokens:
                         if msg_idx_to_compress > last_msg_idx_to_compress:
                             # We want to preserve the first message (typically
                             # system msg) and last message (user msg).
@@ -1723,11 +1728,36 @@ class ChatAgent(Agent):
                             """
                             )
                         n_truncated += 1
+                        # Compute how many tokens this message should be reduced to.
+                        # Distribute the total excess evenly across the remaining
+                        # compressible messages so that each message retains as much
+                        # content as possible rather than being collapsed to a fixed
+                        # minimum of 30 tokens.
+                        _truncation_warning = "... [Contents truncated!]"
+                        _current_excess = self.chat_num_tokens(hist) - _target_tokens
+                        _n_remaining = (
+                            last_msg_idx_to_compress - msg_idx_to_compress + 1
+                        )
+                        _msg_tokens = self._message_num_tokens(
+                            hist[msg_idx_to_compress]
+                        )
+                        _reduction = math.ceil(_current_excess / _n_remaining)
+                        # Account for the warning string that truncate_message
+                        # appends ("\n" + warning) so the final message token
+                        # count does not exceed the intended target.
+                        _warning_tokens = (
+                            self.parser.num_tokens("\n" + _truncation_warning)
+                            if self.parser is not None
+                            else len(_truncation_warning) // 4
+                        )
+                        _keep_tokens = max(
+                            30, _msg_tokens - _reduction - _warning_tokens
+                        )
                         # compress the msg at idx `msg_idx_to_compress`
                         hist[msg_idx_to_compress] = self.truncate_message(
                             msg_idx_to_compress,
-                            tokens=30,
-                            warning="... [Contents truncated!]",
+                            tokens=_keep_tokens,
+                            warning=_truncation_warning,
                         )
                         msg_idx_to_compress += 1
 
@@ -1975,9 +2005,13 @@ class ChatAgent(Agent):
                 stack.enter_context(cm)
             if self.llm.get_stream() and not settings.quiet:
                 console.print(f"[green]{self.indent}", end="")
-            functions, fun_call, tools, force_tool, output_format = (
-                self._function_args()
-            )
+            (
+                functions,
+                fun_call,
+                tools,
+                force_tool,
+                output_format,
+            ) = self._function_args()
             assert self.llm is not None
             response = self.llm.chat(
                 messages,

--- a/tests/main/test_context_truncation.py
+++ b/tests/main/test_context_truncation.py
@@ -1,0 +1,188 @@
+"""
+Tests for the smart context-overflow truncation in ChatAgent._prep_llm_messages.
+
+Issue #838: Previously every overflowing message was blindly truncated to
+a fixed 30-token minimum.  The fix computes the actual number of tokens each
+message needs to be reduced by so that the history fits within the context
+window, preserving as much content as possible.
+"""
+
+import math
+
+import pytest
+
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.language_models.base import LLMMessage, Role
+from langroid.language_models.mock_lm import MockLMConfig
+from langroid.parsing.parser import Parser, ParsingConfig
+from langroid.utils.configuration import Settings, set_global
+
+# CHAT_HISTORY_BUFFER from chat_agent.py (300 tokens).
+# Tests must account for it: budget = context_length - min_output - 300.
+_CHAT_HISTORY_BUFFER = 300
+_MIN_OUTPUT = 64  # matches LLMConfig.min_output_tokens default
+
+
+def _make_agent(
+    context_length: int,
+    max_output_tokens: int = 4096,
+    min_output_tokens: int = _MIN_OUTPUT,
+) -> ChatAgent:
+    """Return a ChatAgent backed by MockLM with a bounded context window."""
+    cfg = ChatAgentConfig(
+        name="TruncAgent",
+        llm=MockLMConfig(
+            chat_context_length=context_length,
+            max_output_tokens=max_output_tokens,
+            min_output_tokens=min_output_tokens,
+            default_response="ok",
+        ),
+        context_overflow_strategy="truncate",
+    )
+    agent = ChatAgent(cfg)
+    agent.parser = Parser(ParsingConfig())
+    return agent
+
+
+def _fill_history(agent: ChatAgent, n_msgs: int, words_each: int) -> None:
+    """Populate agent.message_history with alternating user/assistant messages."""
+    agent.message_history = [
+        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant.")
+    ]
+    for i in range(n_msgs):
+        role = Role.USER if i % 2 == 0 else Role.ASSISTANT
+        content = ("word " * words_each).strip()
+        agent.message_history.append(LLMMessage(role=role, content=content))
+
+
+def _budget(context_length: int, min_output: int = _MIN_OUTPUT) -> int:
+    return context_length - min_output - _CHAT_HISTORY_BUFFER
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_truncation_fits_within_context(test_settings: Settings) -> None:
+    """After truncation the history must fit within the context budget."""
+    set_global(test_settings)
+    # Use a context window large enough for the buffer but small enough to need
+    # truncation: budget = 1500 - 64 - 300 = 1136 tokens.
+    context_length = 1500
+    # 6 messages × 300 words ≈ 1800 tokens → well over budget
+    agent = _make_agent(context_length, max_output_tokens=context_length)
+    _fill_history(agent, n_msgs=6, words_each=300)
+
+    total_before = agent.chat_num_tokens()
+    assert total_before > _budget(context_length), (
+        f"precondition: history ({total_before}) must exceed budget "
+        f"({_budget(context_length)})"
+    )
+
+    hist, _ = agent._prep_llm_messages(truncate=True)
+
+    assert hist, "expected a non-empty message list after truncation"
+    total_after = agent.chat_num_tokens(hist)
+    budget = _budget(context_length)
+    assert (
+        total_after <= budget
+    ), f"History still too long: {total_after} tokens (budget={budget})"
+
+
+def test_smart_truncation_keeps_more_than_30_tokens(test_settings: Settings) -> None:
+    """
+    When the total overflow is small, smart truncation should leave each
+    message with well more than 30 tokens rather than collapsing it.
+    """
+    set_global(test_settings)
+    # budget = 2000 - 64 - 300 = 1636 tokens.
+    # 4 messages × 200 words ≈ 800 tokens + system ≈ 810 total.
+    # Forcing max_output_tokens = context so reduced output < min_output:
+    #   reduced_output = 2000 - 810 - 300 = 890 > min_output → output-only reduction.
+    # To reach the message-truncation path we need total + min_output > context.
+    # With context=900: budget = 900 - 64 - 300 = 536.
+    # 4 msgs × 200 words ≈ 800 → need to remove ~264 tokens across 3 compressible msgs
+    # → reduction ≈ 88 per msg; keep ≈ 112 tokens each — well above 30.
+    context_length = 900
+    agent = _make_agent(context_length, max_output_tokens=context_length)
+    _fill_history(agent, n_msgs=4, words_each=200)
+
+    total_before = agent.chat_num_tokens()
+    assert total_before > _budget(context_length), (
+        f"precondition: history ({total_before}) must exceed budget "
+        f"({_budget(context_length)})"
+    )
+
+    hist, _ = agent._prep_llm_messages(truncate=True)
+
+    assert hist, "expected non-empty message list after truncation"
+    # Check that the first compressible message (index 1) retained > 30 tokens.
+    msg_tokens = agent.parser.num_tokens(hist[1].content)
+    assert msg_tokens > 30, (
+        f"Smart truncation should retain more than 30 tokens per message "
+        f"when overflow is moderate; got {msg_tokens}"
+    )
+
+
+def test_truncation_preserves_system_and_last_message(test_settings: Settings) -> None:
+    """The system message and the last user message must never be modified."""
+    set_global(test_settings)
+    context_length = 1500
+    agent = _make_agent(context_length, max_output_tokens=context_length)
+    _fill_history(agent, n_msgs=6, words_each=300)
+
+    system_content = agent.message_history[0].content
+    last_content = agent.message_history[-1].content
+
+    hist, _ = agent._prep_llm_messages(truncate=True)
+
+    assert hist, "expected non-empty message list"
+    assert (
+        hist[0].content == system_content
+    ), "System message (index 0) must not be truncated"
+    assert hist[-1].content == last_content, "Last message must not be truncated"
+
+
+def test_truncation_raises_when_impossible(test_settings: Settings) -> None:
+    """ValueError must be raised when the context cannot be made to fit."""
+    set_global(test_settings)
+    # budget = 500 - 490 - 300 = -290 (impossible).
+    # The loop will exhaust all compressible messages and raise.
+    agent = _make_agent(
+        context_length=500, max_output_tokens=500, min_output_tokens=490
+    )
+    _fill_history(agent, n_msgs=4, words_each=50)
+
+    with pytest.raises(ValueError, match="(?s)run out.*of msgs"):
+        agent._prep_llm_messages(truncate=True)
+
+
+def test_truncate_message_smart_target(test_settings: Settings) -> None:
+    """
+    Unit-test the per-message token target computation: given an excess and a
+    number of remaining compressible messages, each message should be reduced
+    by ceil(excess / n_remaining) tokens (but not below 30).
+    """
+    set_global(test_settings)
+    agent = _make_agent(context_length=10_000)
+    _fill_history(agent, n_msgs=4, words_each=200)
+
+    msg_idx = 1
+    original_tokens = agent._message_num_tokens(agent.message_history[msg_idx])
+
+    # Simulate: 300 tokens of excess to spread across 3 remaining messages.
+    excess = 300
+    n_remaining = 3
+    reduction = math.ceil(excess / n_remaining)  # 100
+    keep = max(30, original_tokens - reduction)
+
+    truncated = agent.truncate_message(msg_idx, tokens=keep, inplace=False)
+    actual_tokens = agent.parser.num_tokens(truncated.content)
+
+    assert (
+        actual_tokens <= keep + 5
+    ), (  # small tolerance for tiktoken approximation
+        f"Truncated message has {actual_tokens} tokens, expected ≤ {keep + 5}"
+    )
+    assert actual_tokens >= 20, "Truncated message should not be empty"


### PR DESCRIPTION
## Summary

Fixes #838.

When chat history overflows the model context window and reducing `max_output_tokens` is insufficient, `_prep_llm_messages` falls back to truncating older messages. Previously every truncated message was collapsed to a hard minimum of **30 tokens** regardless of how much content actually needed to be removed. This destroyed most message content even when only a small trim was required.

### Root cause

The truncation loop called `truncate_message(..., tokens=30)` unconditionally — a conservative floor that made no use of how much excess actually needed to be eliminated.

### Fix

Each loop iteration now:

1. Recomputes the **current excess** (`chat_num_tokens(hist) - target`).
2. Counts the **remaining compressible messages** (`last_msg_idx - current_idx + 1`).
3. Distributes the excess evenly: `reduction = ceil(excess / n_remaining)`.
4. Targets `max(30, msg_tokens - reduction - warning_tokens)` tokens for the current message, where `warning_tokens` accounts for the `"... [Contents truncated!]"` string appended by `truncate_message` (without this adjustment the loop could fail to converge).

The repeated target-token expression is also hoisted into a local variable `_target_tokens` to avoid redundant computation.

### Behaviour change

| Scenario | Before | After |
|---|---|---|
| 10-token overflow across 4 messages | Each msg → 30 tokens | Each msg reduced by ~3 tokens |
| 1 000-token overflow across 4 messages | Each msg → 30 tokens | Each msg reduced by ~250 tokens |
| Overflow impossible to recover | `ValueError` | `ValueError` (unchanged) |

### Tests

`tests/main/test_context_truncation.py` (new file) covers:

- History fits within context budget after truncation
- Smart truncation retains more than 30 tokens when overflow is moderate
- System message and last user message are never modified
- `ValueError` is raised when the context cannot be made to fit
- Per-message token target computation (unit test of `truncate_message` with smart target)

## Test plan

- [x] `pytest tests/main/test_context_truncation.py` — 5 tests, all pass
- [x] `black` formatting applied
