### PR TITLE
fix: avoid constructing extra httpx transports on client cache hits

### DIFF
--- a/langroid/language_models/client_cache.py
+++ b/langroid/language_models/client_cache.py
@@ -111,19 +111,6 @@ def get_openai_client(
         _all_clients.add(client)
         return client
 
-    # If http_client_config is provided, create client from config and cache
-    created_http_client = None
-    if http_client_config is not None:
-        try:
-            from httpx import Client
-
-            created_http_client = Client(**http_client_config)
-        except ImportError:
-            raise ValueError(
-                "httpx is required to use http_client_config. "
-                "Install it with: pip install httpx"
-            )
-
     cache_key = _get_cache_key(
         "openai",
         api_key=api_key,
@@ -138,6 +125,18 @@ def get_openai_client(
         cached_client = _get_cached_client(cache_key)
         if cached_client is not None:
             return cast(OpenAI, cached_client)
+
+        created_http_client = None
+        if http_client_config is not None:
+            try:
+                from httpx import Client
+
+                created_http_client = Client(**http_client_config)
+            except ImportError:
+                raise ValueError(
+                    "httpx is required to use http_client_config. "
+                    "Install it with: pip install httpx"
+                )
 
         client = OpenAI(
             api_key=api_key,
@@ -192,19 +191,6 @@ def get_async_openai_client(
         _all_clients.add(client)
         return client
 
-    # If http_client_config is provided, create async client from config and cache
-    created_http_client = None
-    if http_client_config is not None:
-        try:
-            from httpx import AsyncClient
-
-            created_http_client = AsyncClient(**http_client_config)
-        except ImportError:
-            raise ValueError(
-                "httpx is required to use http_client_config. "
-                "Install it with: pip install httpx"
-            )
-
     cache_key = _get_cache_key(
         "async_openai",
         api_key=api_key,
@@ -219,6 +205,18 @@ def get_async_openai_client(
         cached_client = _get_cached_client(cache_key)
         if cached_client is not None:
             return cast(AsyncOpenAI, cached_client)
+
+        created_http_client = None
+        if http_client_config is not None:
+            try:
+                from httpx import AsyncClient
+
+                created_http_client = AsyncClient(**http_client_config)
+            except ImportError:
+                raise ValueError(
+                    "httpx is required to use http_client_config. "
+                    "Install it with: pip install httpx"
+                )
 
         client = AsyncOpenAI(
             api_key=api_key,

--- a/tests/main/test_openai_gpt_client_cache.py
+++ b/tests/main/test_openai_gpt_client_cache.py
@@ -2,6 +2,7 @@
 Tests for OpenAIGPT client caching functionality.
 """
 
+import httpx
 import pytest
 
 import langroid.language_models.client_cache as client_cache_module
@@ -112,6 +113,58 @@ class TestOpenAIGPTClientCache:
 
         client3 = get_openai_client(api_key="test-key-refresh")
         assert client3 is client1
+
+    def test_openai_client_cache_hit_does_not_create_extra_httpx_client(
+        self, monkeypatch
+    ):
+        """Test cache hits avoid allocating a new sync transport for config."""
+        created_clients: list[httpx.Client] = []
+        real_client = httpx.Client
+
+        class TrackingClient(real_client):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created_clients.append(self)
+
+        monkeypatch.setattr(httpx, "Client", TrackingClient)
+
+        client1 = get_openai_client(
+            api_key="test-key-http-client-config",
+            http_client_config={"timeout": 1.0},
+        )
+        client2 = get_openai_client(
+            api_key="test-key-http-client-config",
+            http_client_config={"timeout": 1.0},
+        )
+
+        assert client1 is client2
+        assert len(created_clients) == 1
+
+    def test_async_openai_client_cache_hit_does_not_create_extra_httpx_client(
+        self, monkeypatch
+    ):
+        """Test cache hits avoid allocating a new async transport for config."""
+        created_clients: list[httpx.AsyncClient] = []
+        real_async_client = httpx.AsyncClient
+
+        class TrackingAsyncClient(real_async_client):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created_clients.append(self)
+
+        monkeypatch.setattr(httpx, "AsyncClient", TrackingAsyncClient)
+
+        client1 = get_async_openai_client(
+            api_key="test-key-async-http-client-config",
+            http_client_config={"timeout": 1.0},
+        )
+        client2 = get_async_openai_client(
+            api_key="test-key-async-http-client-config",
+            http_client_config={"timeout": 1.0},
+        )
+
+        assert client1 is client2
+        assert len(created_clients) == 1
 
     def test_prune_cache_negative_max_age_raises(self):
         """Test that negative max_age_seconds raises ValueError."""


### PR DESCRIPTION
Fixes #1017

## Summary

Avoid constructing extra `httpx` transports when `http_client_config` is used
with a cache hit in `client_cache.py`.

## Problem

`get_openai_client(..., http_client_config=...)` and
`get_async_openai_client(..., http_client_config=...)` were creating a fresh
`httpx.Client` / `httpx.AsyncClient` before checking the cache.

When the cache already contained a matching OpenAI client, Langroid returned the
cached client but the newly created transport was never used. That means every
cache hit for the same config could allocate an extra transport object.

This is at odds with the cache's goal of reducing resource churn.

## Fix

- compute the cache key first
- check the cache under the existing lock
- only construct `httpx.Client` / `httpx.AsyncClient` after confirming a cache miss

This keeps the existing cache and `prune_cache()` semantics unchanged while
removing the wasted transport allocation.

## Tests

Added regression coverage for both sync and async paths:
- `test_openai_client_cache_hit_does_not_create_extra_httpx_client`
- `test_async_openai_client_cache_hit_does_not_create_extra_httpx_client`

Local validation:
- `ruff check langroid/language_models/client_cache.py tests/main/test_openai_gpt_client_cache.py`
- `pytest -q tests/main/test_openai_gpt_client_cache.py -k 'not concurrent_async_achat' -q`
