### PR TITLE
Fix ObjectRegistry leak in Task.init() system message handling

### DIFF
--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -327,8 +327,8 @@ class Task:
         except Exception:
             logger.warning(
                 """
-                Failed to deep-copy Agent config during task creation, 
-                proceeding with original config. Be aware that changes to 
+                Failed to deep-copy Agent config during task creation,
+                proceeding with original config. Be aware that changes to
                 the config may affect other agents using the same config.
                 """
             )
@@ -665,12 +665,13 @@ class Task:
             and self.agent.system_message
         ):
             system_msg = self.agent._create_system_and_tools_message()
-            system_message_chat_doc = ChatDocument.from_LLMMessage(
+            system_message_temp_doc = ChatDocument.from_LLMMessage(
                 system_msg,
                 sender_name=self.name or "system",
             )
             # log the system message
-            self.log_message(Entity.SYSTEM, system_message_chat_doc, mark=True)
+            self.log_message(Entity.SYSTEM, system_message_temp_doc, mark=True)
+            ChatDocument.delete_id(system_message_temp_doc.id())
         self.log_message(Entity.USER, self.pending_message, mark=True)
         return self.pending_message
 
@@ -865,7 +866,7 @@ class Task:
                 raise InfiniteLoopException(
                     """Possible infinite loop detected!
                     You can adjust infinite loop detection (or turn it off)
-                    by changing the params in the TaskConfig passed to the Task 
+                    by changing the params in the TaskConfig passed to the Task
                     constructor; see here:
                     https://langroid.github.io/langroid/reference/agent/task/#langroid.agent.task.TaskConfig
                     """
@@ -898,7 +899,7 @@ class Task:
                         A response adhering to the following JSON schema was expected:
                         {schema}
 
-                        Please resubmit with the correct schema. 
+                        Please resubmit with the correct schema.
                         """
                     )
 
@@ -1065,7 +1066,7 @@ class Task:
                 raise InfiniteLoopException(
                     """Possible infinite loop detected!
                     You can adjust infinite loop detection (or turn it off)
-                    by changing the params in the TaskConfig passed to the Task 
+                    by changing the params in the TaskConfig passed to the Task
                     constructor; see here:
                     https://langroid.github.io/langroid/reference/agent/task/#langroid.agent.task.TaskConfig
                     """
@@ -1098,7 +1099,7 @@ class Task:
                         A response adhering to the following JSON schema was expected:
                         {schema}
 
-                        Please resubmit with the correct schema. 
+                        Please resubmit with the correct schema.
                         """
                     )
 

--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -671,6 +671,8 @@ class Task:
             )
             # log the system message
             self.log_message(Entity.SYSTEM, system_message_temp_doc, mark=True)
+            # ChatDocument.__init__ auto-registers in ObjectRegistry; remove
+            # the temp doc explicitly to avoid leaking it across Task creations.
             ChatDocument.delete_id(system_message_temp_doc.id())
         self.log_message(Entity.USER, self.pending_message, mark=True)
         return self.pending_message

--- a/tests/main/test_chat_agent.py
+++ b/tests/main/test_chat_agent.py
@@ -337,3 +337,40 @@ def test_llm_response_messages_no_registry_leak():
         f"This suggests ChatDocument objects are being created unnecessarily "
         f"(e.g., in callbacks or _render_llm_response) and not cleaned up."
     )
+
+
+def test_task_init_no_registry_leak() -> None:
+    """
+    Regression test for PR #1021: Task.init() builds a temporary ChatDocument
+    purely to feed log_message(Entity.SYSTEM, ...). That doc is auto-registered
+    by ChatDocument.__init__ and was never removed, leaking into the
+    class-level ObjectRegistry on every Task creation. The fix calls
+    ChatDocument.delete_id(...) on the temp doc after logging.
+    """
+    from langroid.language_models.mock_lm import MockLMConfig
+    from langroid.utils.object_registry import ObjectRegistry
+
+    config = ChatAgentConfig(
+        llm=MockLMConfig(default_response="Hello"),
+        system_message="You are a helpful assistant.",
+    )
+    agent = ChatAgent(config)
+
+    initial_count = sum(
+        1 for obj in ObjectRegistry.registry.values() if isinstance(obj, ChatDocument)
+    )
+
+    num_tasks = 5
+    for _ in range(num_tasks):
+        Task(agent, single_round=True).init()
+
+    final_count = sum(
+        1 for obj in ObjectRegistry.registry.values() if isinstance(obj, ChatDocument)
+    )
+
+    new_docs = final_count - initial_count
+    assert new_docs == 0, (
+        f"Expected 0 leaked ChatDocuments after {num_tasks} Task.init() calls, "
+        f"but found {new_docs}. The temporary system-message ChatDocument is "
+        f"being left in ObjectRegistry."
+    )


### PR DESCRIPTION
## Summary
Fix a memory leak where temporary `ChatDocument` objects created during `Task.init()` were being left in the `ObjectRegistry`, accumulating with each Task creation.

## Key Changes
- **langroid/agent/task.py**: Modified `Task.init()` to explicitly delete the temporary system message `ChatDocument` from the `ObjectRegistry` after logging it. The document is auto-registered by `ChatDocument.__init__` but was never cleaned up, causing it to persist in the class-level registry across Task creations.
- **tests/main/test_chat_agent.py**: Added regression test `test_task_init_no_registry_leak()` that verifies no `ChatDocument` objects leak into the `ObjectRegistry` after multiple `Task.init()` calls.
- **Minor formatting**: Fixed trailing whitespace in several error messages and docstrings in `task.py`.

## Implementation Details
The fix involves calling `ChatDocument.delete_id(system_message_temp_doc.id())` immediately after logging the temporary system message document. This ensures the temporary document is removed from the registry while still being available for the logging operation. The variable was also renamed from `system_message_chat_doc` to `system_message_temp_doc` to clarify its temporary nature.

