### PR TITLE
docs: add Tuning Engines gateway example

### DIFF
--- a/docs/tutorials/non-openai-llms.md
+++ b/docs/tutorials/non-openai-llms.md
@@ -8,7 +8,7 @@ OpenAI-compatible endpoints. See the [Local LLM Setup](https://langroid.github.i
 - There are tools like [LiteLLM](https://github.com/BerriAI/litellm/tree/main/litellm) 
   that provide an OpenAI-like API for _hundreds_ of non-OpenAI LLM providers 
 (e.g. Anthropic's Claude, Google's Gemini).
-- AI gateways like [LangDB](https://langdb.ai/), [Portkey](https://portkey.ai), and [OpenRouter](https://openrouter.ai/) provide unified access to multiple LLM providers with additional features like cost control, observability, caching, and fallback strategies.
+- AI gateways like [LangDB](https://langdb.ai/), [Portkey](https://portkey.ai), [OpenRouter](https://openrouter.ai/), and [Tuning Engines](https://app.tuningengines.com/docs/inference-api) provide unified access to multiple LLM providers with additional features like cost control, observability, governance, caching, and fallback strategies.
   
 Below we show how you can use these various options with Langroid.
 
@@ -147,6 +147,36 @@ To use OpenRouter with Langroid:
 
 For more details, see the [Local LLM Setup guide](local-llm-setup.md#local-llms-available-on-openrouter).
 
+### Tuning Engines
+
+[Tuning Engines](https://app.tuningengines.com/docs/inference-api) provides an
+OpenAI-compatible API for teams that want Langroid agents to run through a
+governed control plane. Langroid continues to own the agent behavior, tools, and
+conversation flow, while Tuning Engines can centralize tenant model access,
+policy checks, audit logs, traces, usage, and cost reporting.
+
+To use Tuning Engines with Langroid:
+
+- Create a Tuning Engines inference key and enable the model alias you want to use.
+- Set the key in your environment:
+
+```bash
+export TUNING_ENGINES_API_KEY=sk-te-your-inference-key
+```
+
+- Configure Langroid with the OpenAI-compatible endpoint:
+
+```python
+import os
+import langroid.language_models as lm
+
+llm_config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4o",
+    api_base="https://api.tuningengines.com/v1",
+    api_key=os.environ["TUNING_ENGINES_API_KEY"],
+)
+```
+
 ## Working with the created `OpenAIGPTConfig` object
 
 From here you can proceed as usual, creating instances of `OpenAIGPT`,
@@ -214,5 +244,3 @@ When the `--m` option is omitted, the default OpenAI GPT4 model is used.
 
 
 
-
-    

--- a/docs/tutorials/supported-models.md
+++ b/docs/tutorials/supported-models.md
@@ -57,6 +57,7 @@ and which environment variable to set for the API key.
 | MiniMax       | `minimax/MiniMax-M2.7`                                   | `MINIMAX_API_KEY` |
 | GLHF          | `glhf/hf:Qwen/Qwen2.5-Coder-32B-Instruct`                | `GLHF_API_KEY` |
 | OpenRouter    | `openrouter/deepseek/deepseek-r1-distill-llama-70b:free` | `OPENROUTER_API_KEY` |
+| Tuning Engines | `gpt-4o` with `api_base="https://api.tuningengines.com/v1"` | `TUNING_ENGINES_API_KEY` |
 | Ollama        | `ollama/qwen2.5`                                         | `OLLAMA_API_KEY` (usually `ollama`) |
 | VLLM          | `vllm/mistral-7b-instruct`                               | `VLLM_API_KEY` |
 | LlamaCPP      | `llamacpp/localhost:8080`                                | `LLAMA_API_KEY` |


### PR DESCRIPTION
## Summary
- add Tuning Engines to the existing AI gateway discussion
- show Langroid configuration with api_base set to the Tuning Engines OpenAI-compatible endpoint
- add the setup to the supported models table

## Why
We are an AI infrastructure team using Langroid with Tuning Engines. The docs already explain gateway options such as LangDB, Portkey, and OpenRouter; this adds a copy-paste path for teams that want Langroid to keep owning agent behavior/tools while Tuning Engines handles governed model access, policy checks, traces, and usage/cost reporting. It would mean a lot to us if this is useful for your users, and I am happy to adjust the wording or placement.

## Validation
- git diff --check