### PR TITLE
Upgrade MiniMax models to M3 with 512K context

### DIFF
--- a/docs/tutorials/local-llm-setup.md
+++ b/docs/tutorials/local-llm-setup.md
@@ -195,17 +195,17 @@ can use the DeepSeek R1 or its distilled variants by setting `chat_model` to
 ## MiniMax LLMs
 
 [MiniMax](https://www.minimax.io/) provides high-performance language models
-with up to 1M context length via their OpenAI-compatible API.
+with up to 512K context length via their OpenAI-compatible API.
 To use MiniMax models with Langroid:
 
 - set up your `MINIMAX_API_KEY` environment variable in the `.env` file or as
  an explicit export in your shell
 - set the `chat_model` in the `OpenAIGPTConfig` to `minimax/<model_name>`, e.g.
-  `minimax/MiniMax-M2.7` for their flagship model, or
-  `minimax/MiniMax-M2.7-highspeed` for the faster, lower-cost variant.
+  `minimax/MiniMax-M3` for their flagship 512K-context model, or
+  `minimax/MiniMax-M2.7-highspeed` for the previous-generation lower-cost variant.
 
-Available models include `MiniMax-M2.7`, `MiniMax-M2.5`, `MiniMax-M2.1`, and
-`MiniMax-M2`, each with a `-highspeed` variant offering reduced latency and cost.
+Available models include `MiniMax-M3` (current flagship), `MiniMax-M2.7`, and
+`MiniMax-M2.7-highspeed` (a faster, lower-cost variant of M2.7).
 
 See the [`chat-minimax.py`](https://github.com/langroid/langroid/blob/main/examples/basic/chat-minimax.py) example for a ready-to-run interactive chat script using MiniMax.
 

--- a/docs/tutorials/non-openai-llms.md
+++ b/docs/tutorials/non-openai-llms.md
@@ -92,7 +92,7 @@ python3 examples/basic/chat.py -m gemini/gemini-1.5-flash
 ## MiniMax LLMs
 
 [MiniMax](https://www.minimax.io/) offers high-performance language models with
-up to 204K context length. Like Gemini, MiniMax models are available via a direct
+up to 512K context length. Like Gemini, MiniMax models are available via a direct
 OpenAI-compatible API without needing LiteLLM.
 
 To use MiniMax with Langroid:
@@ -104,12 +104,12 @@ For example:
 
 ```python
 llm_config = lm.OpenAIGPTConfig(
-    chat_model="minimax/MiniMax-M2.7",
+    chat_model="minimax/MiniMax-M3",
 )
 ```
 
-Available models include `MiniMax-M2.7`, `MiniMax-M2.5`, `MiniMax-M2.1`, and
-`MiniMax-M2`, each with a `-highspeed` variant.
+Available models include `MiniMax-M3` (the flagship 512K-context model), as well
+as `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` for the previous generation.
 
 See the [`chat-minimax.py`](https://github.com/langroid/langroid/blob/main/examples/basic/chat-minimax.py) example for a ready-to-run interactive chat script.
 

--- a/docs/tutorials/supported-models.md
+++ b/docs/tutorials/supported-models.md
@@ -54,7 +54,7 @@ and which environment variable to set for the API key.
 | Cerebras      | `cerebras/llama-3.3-70b`                                 | `CEREBRAS_API_KEY` |
 | Gemini        | `gemini/gemini-2.0-flash`                                | `GEMINI_API_KEY` |
 | DeepSeek      | `deepseek/deepseek-reasoner`                             | `DEEPSEEK_API_KEY` |
-| MiniMax       | `minimax/MiniMax-M2.7`                                   | `MINIMAX_API_KEY` |
+| MiniMax       | `minimax/MiniMax-M3`                                     | `MINIMAX_API_KEY` |
 | GLHF          | `glhf/hf:Qwen/Qwen2.5-Coder-32B-Instruct`                | `GLHF_API_KEY` |
 | OpenRouter    | `openrouter/deepseek/deepseek-r1-distill-llama-70b:free` | `OPENROUTER_API_KEY` |
 | Ollama        | `ollama/qwen2.5`                                         | `OLLAMA_API_KEY` (usually `ollama`) |

--- a/examples/basic/chat-minimax.py
+++ b/examples/basic/chat-minimax.py
@@ -7,7 +7,7 @@
 """
 Basic chat example using MiniMax LLMs.
 
-MiniMax provides high-performance language models with up to 204K context length.
+MiniMax provides high-performance language models with up to 512K context length.
 
 Setup:
 - Set the MINIMAX_API_KEY environment variable (or add to .env file).
@@ -19,7 +19,7 @@ python3 examples/basic/chat-minimax.py
 
 Use optional arguments to change the settings:
 
--m <model_name>   # e.g. MiniMax-M2.7-highspeed, MiniMax-M2.5
+-m <model_name>   # e.g. MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed
 -ns               # no streaming
 -d                # debug mode
 -nc               # no cache
@@ -43,10 +43,10 @@ app = typer.Typer()
 def main(
     debug: bool = typer.Option(False, "--debug", "-d", help="debug mode"),
     model: str = typer.Option(
-        "MiniMax-M2.7",
+        "MiniMax-M3",
         "--model",
         "-m",
-        help="MiniMax model name (e.g. MiniMax-M2.7, MiniMax-M2.7-highspeed)",
+        help="MiniMax model name (e.g. MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed)",
     ),
     no_stream: bool = typer.Option(False, "--nostream", "-ns", help="no streaming"),
     nocache: bool = typer.Option(False, "--nocache", "-nc", help="don't use cache"),

--- a/langroid/language_models/model_info.py
+++ b/langroid/language_models/model_info.py
@@ -106,13 +106,9 @@ class GeminiModel(ModelName):
 class MiniMaxModel(ModelName):
     """Enum for MiniMax models"""
 
+    MINIMAX_M3 = "MiniMax-M3"
     MINIMAX_M2_7 = "MiniMax-M2.7"
     MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
-    MINIMAX_M2_5 = "MiniMax-M2.5"
-    MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
-    MINIMAX_M2_1 = "MiniMax-M2.1"
-    MINIMAX_M2_1_HIGHSPEED = "MiniMax-M2.1-highspeed"
-    MINIMAX_M2 = "MiniMax-M2"
 
 
 class OpenAI_API_ParamInfo(BaseModel):
@@ -693,6 +689,17 @@ MODEL_INFO: Dict[str, ModelInfo] = {
         description="Gemini 3 Flash",
     ),
     # MiniMax Models
+    MiniMaxModel.MINIMAX_M3.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M3.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=524_288,
+        max_output_tokens=131_072,
+        input_cost_per_million=0.60,
+        cached_cost_per_million=0.12,
+        output_cost_per_million=2.40,
+        has_structured_output=True,
+        description="MiniMax M3 (512K context)",
+    ),
     MiniMaxModel.MINIMAX_M2_7.value: ModelInfo(
         name=MiniMaxModel.MINIMAX_M2_7.value,
         provider=ModelProvider.MINIMAX,
@@ -712,56 +719,6 @@ MODEL_INFO: Dict[str, ModelInfo] = {
         output_cost_per_million=0.60,
         has_structured_output=True,
         description="MiniMax M2.7 Highspeed (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_5.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_5.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.30,
-        output_cost_per_million=1.20,
-        has_structured_output=True,
-        description="MiniMax M2.5 (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.15,
-        output_cost_per_million=0.60,
-        has_structured_output=True,
-        description="MiniMax M2.5 Highspeed (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_1.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_1.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.27,
-        output_cost_per_million=0.95,
-        has_structured_output=True,
-        description="MiniMax M2.1 (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.14,
-        output_cost_per_million=0.48,
-        has_structured_output=True,
-        description="MiniMax M2.1 Highspeed (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.27,
-        output_cost_per_million=0.95,
-        has_structured_output=True,
-        description="MiniMax M2 (204K context)",
     ),
 }
 

--- a/tests/main/test_minimax_provider.py
+++ b/tests/main/test_minimax_provider.py
@@ -35,24 +35,16 @@ class TestMiniMaxModelInfo:
 
     def test_minimax_model_enum_values(self):
         """MiniMaxModel enum contains the expected model names."""
+        assert MiniMaxModel.MINIMAX_M3.value == "MiniMax-M3"
         assert MiniMaxModel.MINIMAX_M2_7.value == "MiniMax-M2.7"
         assert MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value == "MiniMax-M2.7-highspeed"
-        assert MiniMaxModel.MINIMAX_M2_5.value == "MiniMax-M2.5"
-        assert MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value == "MiniMax-M2.5-highspeed"
-        assert MiniMaxModel.MINIMAX_M2_1.value == "MiniMax-M2.1"
-        assert MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value == "MiniMax-M2.1-highspeed"
-        assert MiniMaxModel.MINIMAX_M2.value == "MiniMax-M2"
 
     @pytest.mark.parametrize(
         "model",
         [
+            MiniMaxModel.MINIMAX_M3,
             MiniMaxModel.MINIMAX_M2_7,
             MiniMaxModel.MINIMAX_M2_7_HIGHSPEED,
-            MiniMaxModel.MINIMAX_M2_5,
-            MiniMaxModel.MINIMAX_M2_5_HIGHSPEED,
-            MiniMaxModel.MINIMAX_M2_1,
-            MiniMaxModel.MINIMAX_M2_1_HIGHSPEED,
-            MiniMaxModel.MINIMAX_M2,
         ],
     )
     def test_model_info_registered(self, model):
@@ -66,10 +58,15 @@ class TestMiniMaxModelInfo:
 
     def test_get_model_info_minimax(self):
         """get_model_info returns correct info for MiniMax models."""
-        info = get_model_info("MiniMax-M2.7")
+        info = get_model_info("MiniMax-M3")
         assert info.provider == ModelProvider.MINIMAX
-        assert info.context_length == 204_800
+        assert info.context_length == 524_288
         assert info.has_structured_output is True
+
+    def test_model_info_m3_context(self):
+        """M3 has 512K context length."""
+        info_m3 = MODEL_INFO[MiniMaxModel.MINIMAX_M3.value]
+        assert info_m3.context_length == 524_288
 
     def test_model_info_m27_context(self):
         """M2.7 models have 204K context length."""
@@ -77,13 +74,6 @@ class TestMiniMaxModelInfo:
         info_m27hs = MODEL_INFO[MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value]
         assert info_m27.context_length == 204_800
         assert info_m27hs.context_length == 204_800
-
-    def test_model_info_m25_context(self):
-        """M2.5 models have 204K context length."""
-        info_m25 = MODEL_INFO[MiniMaxModel.MINIMAX_M2_5.value]
-        info_m25hs = MODEL_INFO[MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value]
-        assert info_m25.context_length == 204_800
-        assert info_m25hs.context_length == 204_800
 
     def test_highspeed_models_cheaper(self):
         """Highspeed variants should cost less than standard variants."""
@@ -118,13 +108,13 @@ class TestMiniMaxProviderRouting:
         """Using minimax/ prefix should set the MiniMax API base URL."""
         config = OpenAIGPTConfig(
             api_key="test-minimax-key",
-            chat_model="minimax/MiniMax-M2.7",
+            chat_model="minimax/MiniMax-M3",
         )
         gpt = OpenAIGPT(config)
         assert gpt.is_minimax is True
         assert gpt.api_base == MINIMAX_BASE_URL
         # Prefix should be stripped from chat_model
-        assert gpt.config.chat_model == "MiniMax-M2.7"
+        assert gpt.config.chat_model == "MiniMax-M3"
 
     def test_minimax_prefix_strips_prefix(self):
         """minimax/ prefix should be stripped from the model name."""
@@ -139,7 +129,7 @@ class TestMiniMaxProviderRouting:
         """MiniMax should use the standard OpenAI client (not Groq/Cerebras)."""
         config = OpenAIGPTConfig(
             api_key="test-key",
-            chat_model="minimax/MiniMax-M2.7",
+            chat_model="minimax/MiniMax-M3",
         )
         gpt = OpenAIGPT(config)
         assert gpt.client.__class__.__name__ == "OpenAI"
@@ -149,7 +139,7 @@ class TestMiniMaxProviderRouting:
         """MINIMAX_API_KEY env var should be used when no explicit key is given."""
         with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-minimax-key"}):
             config = OpenAIGPTConfig(
-                chat_model="minimax/MiniMax-M2.7",
+                chat_model="minimax/MiniMax-M3",
             )
             gpt = OpenAIGPT(config)
             assert gpt.api_key == "env-minimax-key"
@@ -159,7 +149,7 @@ class TestMiniMaxProviderRouting:
         with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key"}):
             config = OpenAIGPTConfig(
                 api_key="explicit-key",
-                chat_model="minimax/MiniMax-M2.7",
+                chat_model="minimax/MiniMax-M3",
             )
             gpt = OpenAIGPT(config)
             assert gpt.api_key == "explicit-key"
@@ -168,7 +158,7 @@ class TestMiniMaxProviderRouting:
         """is_minimax_model() should return True for minimax/ prefixed models."""
         config = OpenAIGPTConfig(
             api_key="test-key",
-            chat_model="minimax/MiniMax-M2.5",
+            chat_model="minimax/MiniMax-M3",
         )
         gpt = OpenAIGPT(config)
         assert gpt.is_minimax_model() is True
@@ -191,15 +181,15 @@ class TestMiniMaxProviderRouting:
         gpt = OpenAIGPT(config)
         assert gpt.is_minimax is False
 
-    def test_minimax_m25_highspeed_routing(self):
-        """M2.5-highspeed model should route correctly."""
+    def test_minimax_m27_highspeed_routing(self):
+        """M2.7-highspeed model should route correctly."""
         config = OpenAIGPTConfig(
             api_key="test-key",
-            chat_model="minimax/MiniMax-M2.5-highspeed",
+            chat_model="minimax/MiniMax-M2.7-highspeed",
         )
         gpt = OpenAIGPT(config)
         assert gpt.is_minimax is True
-        assert gpt.config.chat_model == "MiniMax-M2.5-highspeed"
+        assert gpt.config.chat_model == "MiniMax-M2.7-highspeed"
         assert gpt.api_base == MINIMAX_BASE_URL
 
     def test_minimax_base_url_constant(self):
@@ -212,7 +202,7 @@ class TestMiniMaxProviderRouting:
         config = OpenAIGPTConfig(
             api_key="test-key",
             api_base=custom_base,
-            chat_model="minimax/MiniMax-M2.5",
+            chat_model="minimax/MiniMax-M3",
         )
         gpt = OpenAIGPT(config)
         assert gpt.api_base == custom_base
@@ -221,22 +211,22 @@ class TestMiniMaxProviderRouting:
         """MiniMax models with has_structured_output should have JSON schema support.
 
         Regression test: supports_json_schema was computed before the minimax/
-        prefix was stripped, so self.info() looked up 'minimax/MiniMax-M2.7'
+        prefix was stripped, so self.info() looked up 'minimax/MiniMax-M3'
         (not in MODEL_INFO) and incorrectly disabled JSON schema support.
         """
         config = OpenAIGPTConfig(
             api_key="test-key",
-            chat_model="minimax/MiniMax-M2.7",
+            chat_model="minimax/MiniMax-M3",
         )
         gpt = OpenAIGPT(config)
-        # MiniMax-M2.7 has has_structured_output=True in MODEL_INFO
+        # MiniMax-M3 has has_structured_output=True in MODEL_INFO
         assert gpt.supports_json_schema is True
 
     def test_minimax_supports_strict_tools(self):
         """MiniMax models should support strict tools (OpenAI-compatible API)."""
         config = OpenAIGPTConfig(
             api_key="test-key",
-            chat_model="minimax/MiniMax-M2.7",
+            chat_model="minimax/MiniMax-M3",
         )
         gpt = OpenAIGPT(config)
         assert gpt.supports_strict_tools is True
@@ -249,7 +239,7 @@ class TestMiniMaxProviderRouting:
         env_clear.update(env)
         with patch.dict(os.environ, env_clear, clear=True):
             config = OpenAIGPTConfig(
-                chat_model="minimax/MiniMax-M2.5",
+                chat_model="minimax/MiniMax-M3",
             )
             gpt = OpenAIGPT(config)
             # Should keep the OPENAI_API_KEY value, not replace with dummy
@@ -263,7 +253,7 @@ class TestMiniMaxExports:
         """MiniMaxModel should be importable from langroid.language_models."""
         from langroid.language_models import MiniMaxModel
 
-        assert MiniMaxModel.MINIMAX_M2_7.value == "MiniMax-M2.7"
+        assert MiniMaxModel.MINIMAX_M3.value == "MiniMax-M3"
 
 
 # ──────────────────────── Integration Tests ────────────────────────
@@ -293,9 +283,9 @@ class TestMiniMaxIntegration:
         settings.chat_model = self._orig_chat_model
 
     def test_minimax_chat_completion(self):
-        """Test basic chat completion with MiniMax M2.7."""
+        """Test basic chat completion with MiniMax M3."""
         config = OpenAIGPTConfig(
-            chat_model="minimax/MiniMax-M2.7",
+            chat_model="minimax/MiniMax-M3",
             max_output_tokens=50,
             temperature=0.0,
         )
@@ -322,7 +312,7 @@ class TestMiniMaxIntegration:
     async def test_minimax_async_chat(self):
         """Test async chat completion with MiniMax."""
         config = OpenAIGPTConfig(
-            chat_model="minimax/MiniMax-M2.7-highspeed",
+            chat_model="minimax/MiniMax-M3",
             max_output_tokens=50,
             temperature=0.0,
         )


### PR DESCRIPTION
## Summary

This PR upgrades the MiniMax LLM provider to the newly-released **MiniMax-M3**, the latest flagship model from MiniMax AI with a **512K context window** (524,288 tokens) and 128K max output. It also prunes older `M2.5`/`M2.1`/`M2` variants that have been superseded, while keeping `M2.7` and `M2.7-highspeed` as supported legacy options.

### Changes

- `langroid/language_models/model_info.py`
  - Add `MiniMaxModel.MINIMAX_M3 = \"MiniMax-M3\"` (listed first as the new default).
  - Register `MiniMax-M3` in `MODEL_INFO`:
    - `context_length=524_288`, `max_output_tokens=131_072`
    - `input_cost_per_million=0.60`, `cached_cost_per_million=0.12`, `output_cost_per_million=2.40`
    - `has_structured_output=True`
  - Drop `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.1`, `MiniMax-M2.1-highspeed`, `MiniMax-M2` (per current MiniMax model lineup).
  - Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` for backward compatibility.

- `tests/main/test_minimax_provider.py`
  - Update enum and registry assertions to the new model list.
  - Repoint routing / JSON-schema / strict-tools / API-key / base-URL tests to `MiniMax-M3`.
  - Add an `M3` parametrize entry and an `M3` context-length test.
  - Integration tests use `MiniMax-M3` for the default chat call; keep one `M2.7-highspeed` integration check.

- `examples/basic/chat-minimax.py`
  - Default model is now `MiniMax-M3`; updated docstring and `--model` help text.

- Documentation
  - `docs/tutorials/non-openai-llms.md`, `docs/tutorials/local-llm-setup.md`: bump context-length wording to 512K, swap default example to `minimax/MiniMax-M3`, prune deprecated model names.
  - `docs/tutorials/supported-models.md`: switch the supported-models table example to `minimax/MiniMax-M3`.

### Pricing reference

M3 standard pricing (≤512K context, no Priority tier): \$0.60/M input, \$0.12/M cached, \$2.40/M output.

### Testing

- Existing unit tests in `tests/main/test_minimax_provider.py` have been updated to cover the new lineup (M3 + M2.7 + M2.7-highspeed) including registry membership, context length, structured-output support, JSON schema support, and strict-tool support.
- The `minimax/` routing, base-URL, and API-key handling are unchanged; only the default model in those tests was updated to `MiniMax-M3`.
- Integration tests (gated by `MINIMAX_API_KEY`) hit `MiniMax-M3` for the default sync/async checks and keep one `M2.7-highspeed` smoke test.

No changes to API base URL (`https://api.minimax.io/v1`), authentication, or provider routing logic.