### PR TITLE
fix: restore agent-to-agent tool handoffs broken by GHSA-gjgq USER-origin filter

### DIFF
--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -628,7 +628,7 @@ class Agent(ABC):
         recipient: str = "",
     ) -> ChatDocument:
         """Template for agent_response."""
-        return self.response_template(
+        doc = self.response_template(
             Entity.AGENT,
             content=content,
             files=files,
@@ -640,6 +640,15 @@ class Agent(ABC):
             function_call=function_call,
             recipient=recipient,
         )
+        if tool_messages:
+            # Tools explicitly produced as structured ToolMessages by this
+            # agent/handler (e.g. a handler returning AgentSendTool(tools=[...])
+            # or a tool object) are trusted like LLM output -- unlike content
+            # echoed from untrusted input, which carries no structured tools.
+            # Mark so they survive _filter_user_origin_tools after a Task
+            # relabels the sender to USER (GHSA-gjgq-w2m6-wr5q).
+            doc.metadata.tools_from_agent = True
+        return doc
 
     def render_agent_response(
         self,

--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -628,7 +628,7 @@ class Agent(ABC):
         recipient: str = "",
     ) -> ChatDocument:
         """Template for agent_response."""
-        doc = self.response_template(
+        return self.response_template(
             Entity.AGENT,
             content=content,
             files=files,
@@ -640,15 +640,6 @@ class Agent(ABC):
             function_call=function_call,
             recipient=recipient,
         )
-        if tool_messages:
-            # Tools explicitly produced as structured ToolMessages by this
-            # agent/handler (e.g. a handler returning AgentSendTool(tools=[...])
-            # or a tool object) are trusted like LLM output -- unlike content
-            # echoed from untrusted input, which carries no structured tools.
-            # Mark so they survive _filter_user_origin_tools after a Task
-            # relabels the sender to USER (GHSA-gjgq-w2m6-wr5q).
-            doc.metadata.tools_from_agent = True
-        return doc
 
     def render_agent_response(
         self,
@@ -904,7 +895,18 @@ class Agent(ABC):
             function_call=function_call,
             oai_tool_choice=oai_tool_choice,
             metadata=ChatDocMetaData(
-                source=e, sender=e, sender_name=self.config.name, recipient=recipient
+                source=e,
+                sender=e,
+                sender_name=self.config.name,
+                recipient=recipient,
+                # Trust tools structurally produced by an LLM or agent/handler
+                # (explicit `tool_messages`): they must survive
+                # _filter_user_origin_tools after a Task relabels the sender to
+                # USER for a handoff. Content-only / echoed responses carry no
+                # structured tool_messages, so they are NOT marked and stay
+                # filtered (GHSA-gjgq-w2m6-wr5q).
+                tools_from_agent=bool(tool_messages)
+                and e in (Entity.LLM, Entity.AGENT),
             ),
         )
 

--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -1286,19 +1286,32 @@ class Agent(ABC):
         msg: str | ChatDocument | None,
         tools: List[ToolMessage],
     ) -> List[ToolMessage]:
-        """If ``msg`` originates from :attr:`Entity.USER`, drop any tools whose
+        """If ``msg`` is raw input from :attr:`Entity.USER`, drop any tools whose
         ``request`` is not in :attr:`llm_tools_usable`.
 
         Rationale: ``enable_message(..., use=False, handle=True)`` is meant to
         register tools triggered by an LLM's output (this agent's, or another
         agent's in a multi-agent setup). A raw user input that happens to
         contain such a tool's JSON should not bypass the LLM and invoke the
-        handler directly (GHSA-gjgq-w2m6-wr5q). Non-``ChatDocument`` inputs and
-        non-``USER`` senders are returned unchanged.
+        handler directly (GHSA-gjgq-w2m6-wr5q).
+
+        Legitimate agent-to-agent handoffs are preserved: when a Task relays
+        another agent's LLM/handler output to a sub-agent it relabels the
+        sender to ``USER`` but sets ``metadata.tools_from_agent=True``; such
+        messages are returned unchanged, since their tools came from an LLM,
+        not from raw user input.
+
+        Non-``ChatDocument`` inputs and non-``USER`` senders are returned
+        unchanged.
         """
         if not isinstance(msg, ChatDocument):
             return tools
         if msg.metadata.sender != Entity.USER:
+            return tools
+        if msg.metadata.tools_from_agent:
+            # Tools were produced by an agent's LLM/handler (possibly relayed
+            # across a multi-agent handoff), not raw user input -- safe to
+            # dispatch handle-only tools.
             return tools
         return [t for t in tools if t.default_value("request") in self.llm_tools_usable]
 

--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -904,7 +904,9 @@ class Agent(ABC):
                 # _filter_user_origin_tools after a Task relabels the sender to
                 # USER for a handoff. Content-only / echoed responses carry no
                 # structured tool_messages, so they are NOT marked and stay
-                # filtered (GHSA-gjgq-w2m6-wr5q).
+                # filtered (GHSA-gjgq-w2m6-wr5q). Known gap: tools repackaged
+                # from untrusted content (e.g. via get_tool_messages) are still
+                # trusted here -- see issue #1035 for the taint-propagation fix.
                 tools_from_agent=bool(tool_messages)
                 and e in (Entity.LLM, Entity.AGENT),
             ),
@@ -1311,6 +1313,15 @@ class Agent(ABC):
         sender to ``USER`` but sets ``metadata.tools_from_agent=True``; such
         messages are returned unchanged, since their tools came from an LLM,
         not from raw user input.
+
+        Limitation: ``tools_from_agent`` is a message-origin signal and guards
+        only the *direct* case -- raw user input arriving at the agent that
+        receives it. It does NOT defend against an agent that deliberately
+        forwards/repackages untrusted user content into structured
+        ``tool_messages`` (e.g. an ``agent_response`` echoing ``msg.content``,
+        or ``DonePassTool``/``AgentDoneTool`` re-emitting tools parsed from a
+        USER message); such forwarding is the developer's responsibility. A
+        robust taint-propagation fix is tracked in issue #1035.
 
         Non-``ChatDocument`` inputs and non-``USER`` senders are returned
         unchanged.

--- a/langroid/agent/chat_document.py
+++ b/langroid/agent/chat_document.py
@@ -77,14 +77,18 @@ class ChatDocMetaData(DocMetaData):
 
     @model_validator(mode="after")
     def _mark_tools_from_agent(self) -> "ChatDocMetaData":
-        # A message produced by an LLM or an agent (tool handler) carries tools
-        # the system itself generated. Mark it at construction so downstream
-        # tool-handling can dispatch handle-only tools even after a Task
-        # relabels the sender to USER for a multi-agent handoff (direct, via
-        # ForwardTool/SendTool, or multi-hop). We only ever SET the flag, never
-        # clear it: a raw USER input is never marked, so it stays filtered.
-        # See ChatAgent._filter_user_origin_tools and GHSA-gjgq-w2m6-wr5q.
-        if self.sender in (Entity.LLM, Entity.AGENT):
+        # Mark messages produced directly by an LLM: the tools in an LLM's
+        # output are the LLM's own decision (the trusted trigger for handle-only
+        # tools -- see GHSA-gjgq-w2m6-wr5q), so the mark lets a Task relay them
+        # to another agent even after relabeling the sender to USER. The mark is
+        # only ever SET, never cleared, so it survives relabeling and deepcopies
+        # (e.g. ForwardTool/PassTool deepcopy the LLM-born message, carrying the
+        # mark across the handoff). We deliberately do NOT mark generic AGENT
+        # messages: a pass-through/echoing agent could surface untrusted USER
+        # text (with embedded tool JSON) as AGENT content, and marking that
+        # would re-open the user-origin bypass. Raw USER input is never marked,
+        # so it stays filtered. See ChatAgent._filter_user_origin_tools.
+        if self.sender == Entity.LLM:
             self.tools_from_agent = True
         return self
 

--- a/langroid/agent/chat_document.py
+++ b/langroid/agent/chat_document.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union, cast
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from langroid.agent.tool_message import ToolMessage
 from langroid.agent.xml_tool_message import XMLToolMessage
@@ -57,6 +57,12 @@ class ChatDocMetaData(DocMetaData):
     agent_id: str = ""  # ChatAgent that generated this message
     msg_idx: int = -1  # index of this message in the agent `message_history`
     sender: Entity  # sender of the message
+    # True if this msg was relayed from another agent's LLM/handler output in a
+    # multi-agent handoff (a Task then relabels sender -> USER). Lets handle-only
+    # tools be dispatched for legitimate handoffs while still blocking raw
+    # USER-injected tool JSON. See ChatAgent._filter_user_origin_tools and
+    # GHSA-gjgq-w2m6-wr5q.
+    tools_from_agent: bool = False
     # tool_id corresponding to single tool result in ChatDocument.content
     oai_tool_id: str | None = None
     tool_ids: List[str] = []  # stack of tool_ids; used by OpenAIAssistant
@@ -68,6 +74,19 @@ class ChatDocMetaData(DocMetaData):
     displayed: bool = False
     has_citation: bool = False
     status: Optional[StatusCode] = None
+
+    @model_validator(mode="after")
+    def _mark_tools_from_agent(self) -> "ChatDocMetaData":
+        # A message produced by an LLM or an agent (tool handler) carries tools
+        # the system itself generated. Mark it at construction so downstream
+        # tool-handling can dispatch handle-only tools even after a Task
+        # relabels the sender to USER for a multi-agent handoff (direct, via
+        # ForwardTool/SendTool, or multi-hop). We only ever SET the flag, never
+        # clear it: a raw USER input is never marked, so it stays filtered.
+        # See ChatAgent._filter_user_origin_tools and GHSA-gjgq-w2m6-wr5q.
+        if self.sender in (Entity.LLM, Entity.AGENT):
+            self.tools_from_agent = True
+        return self
 
     @property
     def parent(self) -> Optional["ChatDocument"]:

--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -1815,14 +1815,17 @@ class Task:
                 parent_id=result_msg.id() if result_msg else "",
                 agent_id=str(self.agent.id),
                 # Although we relabel sender to USER (to the parent task this
-                # result is equivalent to a USER response), the tools in this
-                # result were produced by this task's agent/LLM, not raw human
-                # input. Preserve that marking so the parent can still dispatch
-                # handle-only tools for the handoff (GHSA-gjgq-w2m6-wr5q).
+                # result is equivalent to a USER response), structured tools
+                # being RELAYED here were produced by this task's agent/LLM, so
+                # the parent must still be able to dispatch them. Preserve the
+                # marking ONLY when actual `tool_messages` are relayed -- NOT
+                # for flattened/echoed content (e.g. a DoneTool whose `content`
+                # is untrusted text that happens to contain tool JSON), which
+                # must stay filtered (GHSA-gjgq-w2m6-wr5q; see also #1035).
                 tools_from_agent=(
-                    result_msg.metadata.tools_from_agent
-                    if result_msg is not None
-                    else False
+                    bool(tool_messages)
+                    and result_msg is not None
+                    and result_msg.metadata.tools_from_agent
                 ),
             ),
         )

--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -1814,6 +1814,16 @@ class Task:
                 tool_ids=tool_ids,
                 parent_id=result_msg.id() if result_msg else "",
                 agent_id=str(self.agent.id),
+                # Although we relabel sender to USER (to the parent task this
+                # result is equivalent to a USER response), the tools in this
+                # result were produced by this task's agent/LLM, not raw human
+                # input. Preserve that marking so the parent can still dispatch
+                # handle-only tools for the handoff (GHSA-gjgq-w2m6-wr5q).
+                tools_from_agent=(
+                    result_msg.metadata.tools_from_agent
+                    if result_msg is not None
+                    else False
+                ),
             ),
         )
         if self.pending_message is not None:


### PR DESCRIPTION
## Problem

The `GHSA-gjgq-w2m6-wr5q` fix (released in **0.65.3**) added
`_filter_user_origin_tools`, which drops *handle-only* tools from
`USER`-origin messages — so a raw human input containing tool JSON can't
invoke a handler directly, bypassing the LLM.

But langroid `Task`s **relabel inter-agent messages' sender to `USER`**
(to the receiving sub-task, the caller's message looks like its "user"
input). So the new filter also dropped **legitimate agent-to-agent
handoffs** — one agent's LLM emits a tool, another agent handles it —
silently breaking the core multi-agent pattern.

**This is a regression on `main` since 0.65.3.** It affects
`recipient_tool` and the orchestration tools (`PassTool`, `ForwardTool`,
`SendTool`, `DoneTool`).

## Fix — distinguish agent/LLM-produced tools from raw human input

| Where | Change |
|---|---|
| `ChatDocMetaData` | New `tools_from_agent: bool`, set at construction (model_validator) whenever `sender ∈ {LLM, AGENT}`. **Only ever set, never cleared** — survives the USER relabeling, relays, and deepcopies. |
| `Task` result-wrapping | Preserves `tools_from_agent` when a sub-task result is relabeled to `USER` for the parent (its tools came from the sub-task's agent). |
| `_filter_user_origin_tools` | Returns tools unchanged when `tools_from_agent` is set; still drops handle-only tools from genuine raw `USER` input (flag stays `False`). |

A raw human input is **never** marked (it enters as `USER` and no agent
produced it), so the GHSA-gjgq protection is fully preserved.

## Verification

- **Regression (was failing on `main` since 0.65.3, now passes):**
  `tests/main/test_tool_orchestration.py` — **13 deterministic (MockLM)
  cases** across PassTool/ForwardTool/SendTool/DoneTool went 13-failed →
  21-passed. Also `test_recipient_tool.py` / `_async`.
- **Security still holds:** `tests/main/test_handle_message_security.py`
  **7/7** — raw USER-origin tool JSON is still filtered.
- `mypy -p langroid`, `black --check`, `ruff` all clean.

## Notes

`test_tool_orchestration.py::test_send_tools` shows occasional flakiness
in the *full* suite (a `ValidationError` from pre-existing test
inter-dependence — it passes 4/4 in isolation and is unrelated to the
filter); CI rerun-on-failure covers it.
