### PR TITLE
fix(pgvector): quote index/table identifiers in raw DDL (collection names with '-')

### DIFF
--- a/langroid/vector_store/postgres.py
+++ b/langroid/vector_store/postgres.py
@@ -36,6 +36,16 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier (table/index name) for use in raw DDL, so a name
+    containing characters that are invalid in an unquoted identifier -- e.g.
+    the ``-`` in a pytest-xdist worker suffix like ``mycollection-gw1`` -- does
+    not produce a syntax error. Embedded double-quotes are escaped per the SQL
+    standard.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
 class PostgresDBConfig(VectorStoreConfig):
     collection_name: str = "embeddings"
     cloud: bool = False
@@ -146,8 +156,8 @@ class PostgresDB(VectorStore):
                 connection.execute(text("COMMIT"))
                 create_index_query = text(
                     f"""
-                    CREATE INDEX CONCURRENTLY IF NOT EXISTS {index_name}
-                    ON {self.config.collection_name}
+                    CREATE INDEX CONCURRENTLY IF NOT EXISTS {_quote_ident(index_name)}
+                    ON {_quote_ident(self.config.collection_name)}
                     USING hnsw (embedding vector_cosine_ops)
                     WITH (
                         m = {self.config.hnsw_m},
@@ -223,7 +233,9 @@ class PostgresDB(VectorStore):
         with self.engine.connect() as connection:
             connection.execute(text("COMMIT"))
             index_name = f"hnsw_index_{collection_name}_embedding"
-            drop_index_query = text(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}")
+            drop_index_query = text(
+                f"DROP INDEX CONCURRENTLY IF EXISTS {_quote_ident(index_name)}"
+            )
             connection.execute(drop_index_query)
 
             # 3. Now, drop the table using SQLAlchemy


### PR DESCRIPTION
## Problem

`PostgresDB` builds its HNSW index DDL with **unquoted** identifiers:

```python
index_name = f"hnsw_index_{collection_name}_embedding"
CREATE INDEX CONCURRENTLY IF NOT EXISTS {index_name} ON {collection_name} ...
DROP INDEX CONCURRENTLY IF EXISTS {index_name}
```

If the collection name contains a character invalid in an unquoted SQL
identifier — e.g. the `-` in a pytest-xdist worker suffix like
`mycollection-gw1` — Postgres raises `syntax error at or near "-"`. This
fails `test_vector_stores.py::test_vector_stores_overlapping_matches[postgres]`
under parallel CI, and would break any real collection whose name contains a
`-` (or other special char / mixed case).

## Fix

Quote the index and table identifiers with a small `_quote_ident` helper
(standard SQL double-quoting, embedded quotes escaped). Quoting an
all-lowercase identifier is equivalent to leaving it unquoted, so existing
lowercase collection names are unaffected; the `index_exists` lookup already
uses the literal name and stays consistent.

Lint clean (`mypy -p langroid`, black, ruff). Full verification needs a
Postgres+pgvector instance — CI covers it (this is the test that was failing).
