### PR TITLE
feat: add Requesty as an LLM provider

### DIFF
--- a/docs/tutorials/non-openai-llms.md
+++ b/docs/tutorials/non-openai-llms.md
@@ -147,6 +147,16 @@ To use OpenRouter with Langroid:
 
 For more details, see the [Local LLM Setup guide](local-llm-setup.md#local-llms-available-on-openrouter).
 
+### Requesty
+
+[Requesty](https://requesty.ai/) is an OpenAI-compatible LLM router that provides unified access to multiple LLM providers through a single API, using `provider/model` naming.
+
+To use Requesty with Langroid:
+- Set up your `REQUESTY_API_KEY` environment variable
+- Set `chat_model="requesty/<provider>/<model_name>"` in the `OpenAIGPTConfig` (e.g., `"requesty/openai/gpt-4o-mini"`)
+
+For more details, see the [Requesty documentation](https://docs.requesty.ai/).
+
 ## Working with the created `OpenAIGPTConfig` object
 
 From here you can proceed as usual, creating instances of `OpenAIGPT`,

--- a/docs/tutorials/supported-models.md
+++ b/docs/tutorials/supported-models.md
@@ -57,6 +57,7 @@ and which environment variable to set for the API key.
 | MiniMax       | `minimax/MiniMax-M2.7`                                   | `MINIMAX_API_KEY` |
 | GLHF          | `glhf/hf:Qwen/Qwen2.5-Coder-32B-Instruct`                | `GLHF_API_KEY` |
 | OpenRouter    | `openrouter/deepseek/deepseek-r1-distill-llama-70b:free` | `OPENROUTER_API_KEY` |
+| Requesty      | `requesty/openai/gpt-4o-mini`                            | `REQUESTY_API_KEY` |
 | Ollama        | `ollama/qwen2.5`                                         | `OLLAMA_API_KEY` (usually `ollama`) |
 | VLLM          | `vllm/mistral-7b-instruct`                               | `VLLM_API_KEY` |
 | LlamaCPP      | `llamacpp/localhost:8080`                                | `LLAMA_API_KEY` |

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -95,6 +95,7 @@ else:
 
 DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+REQUESTY_BASE_URL = "https://router.requesty.ai/v1"
 GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
 GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
 MINIMAX_BASE_URL = "https://api.minimax.io/v1"
@@ -553,6 +554,7 @@ class OpenAIGPT(LanguageModel):
         self.is_minimax = self.is_minimax_model()
         self.is_glhf = self.config.chat_model.startswith("glhf/")
         self.is_openrouter = self.config.chat_model.startswith("openrouter/")
+        self.is_requesty = self.config.chat_model.startswith("requesty/")
         self.is_langdb = self.config.chat_model.startswith("langdb/")
         self.is_portkey = self.config.chat_model.startswith("portkey/")
         self.is_litellm_proxy = self.config.chat_model.startswith("litellm-proxy/")
@@ -619,6 +621,11 @@ class OpenAIGPT(LanguageModel):
                 if self.api_key == OPENAI_API_KEY:
                     self.api_key = os.getenv("OPENROUTER_API_KEY", DUMMY_API_KEY)
                 self.api_base = OPENROUTER_BASE_URL
+            elif self.is_requesty:
+                self.config.chat_model = self.config.chat_model.replace("requesty/", "")
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("REQUESTY_API_KEY", DUMMY_API_KEY)
+                self.api_base = REQUESTY_BASE_URL
             elif self.is_deepseek:
                 self.config.chat_model = self.config.chat_model.replace("deepseek/", "")
                 self.api_base = DEEPSEEK_BASE_URL

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -625,7 +625,16 @@ class OpenAIGPT(LanguageModel):
                 self.config.chat_model = self.config.chat_model.replace("requesty/", "")
                 if self.api_key == OPENAI_API_KEY:
                     self.api_key = os.getenv("REQUESTY_API_KEY", DUMMY_API_KEY)
-                self.api_base = REQUESTY_BASE_URL
+                # Honor caller-supplied base URL (e.g. Requesty's EU endpoint
+                # router.eu.requesty.ai/v1, or an internal proxy) instead of
+                # always forcing the default.
+                openai_api_base = os.getenv("OPENAI_API_BASE")
+                explicit_api_base = (
+                    self.config.api_base
+                    if self.config.api_base and self.config.api_base != openai_api_base
+                    else None
+                )
+                self.api_base = explicit_api_base or REQUESTY_BASE_URL
             elif self.is_deepseek:
                 self.config.chat_model = self.config.chat_model.replace("deepseek/", "")
                 self.api_base = DEEPSEEK_BASE_URL


### PR DESCRIPTION
## Add Requesty as an LLM provider

This PR adds [Requesty](https://requesty.ai/) as an LLM provider, mirroring the existing OpenRouter provider-prefix integration. Requesty is an OpenAI-compatible LLM router that uses `provider/model` naming, so the integration follows the same prefix pattern as OpenRouter (`openrouter/`).

### Usage

```python
from langroid.language_models import OpenAIGPTConfig, OpenAIGPT

# set REQUESTY_API_KEY in your environment
llm_config = OpenAIGPTConfig(chat_model="requesty/openai/gpt-4o-mini")
llm = OpenAIGPT(llm_config)
```

When `chat_model` starts with `requesty/`, the prefix is stripped, the API key is read from `REQUESTY_API_KEY` (falling back to a dummy key), and `api_base` is set to `https://router.requesty.ai/v1`.

### Changes
- `langroid/language_models/openai_gpt.py`: add `REQUESTY_BASE_URL`, `self.is_requesty` flag, and an `elif self.is_requesty:` branch mirroring the OpenRouter branch exactly.
- `docs/tutorials/supported-models.md`: add a Requesty row to the supported-models table.
- `docs/tutorials/non-openai-llms.md`: add a Requesty section mirroring the OpenRouter one.

### Verification
- `make check` passes (black, ruff, mypy: "All checks passed!" / "Success: no issues found").
- Construction check confirms the prefix handling:
  ```
  OpenAIGPT(OpenAIGPTConfig(chat_model="requesty/openai/gpt-4o-mini"))
  -> api_base = https://router.requesty.ai/v1, chat_model = openai/gpt-4o-mini
  ```

---

Disclosure: I work at Requesty. Happy to adjust the wording/placement or close this if it's out of scope.
