### PR TITLE
Handle longer markdown code fences

### DIFF
--- a/langroid/parsing/md_parser.py
+++ b/langroid/parsing/md_parser.py
@@ -83,11 +83,15 @@ def parse_markdown_headings(md_text: str) -> List[Node]:
             marker = fence_match.group(1)  # e.g. "```" or "~~~~"
             if not in_code_fence:
                 in_code_fence = True
-                fence_marker = marker[:3]  # store triple backtick or triple tilde
+                fence_marker = marker
             else:
-                # only close if the fence_marker matches
-                # E.g. if we opened with ```, we close only on ```
-                if fence_marker and marker.startswith(fence_marker):
+                # only close if marker uses the same character and is at least
+                # as long as the opening marker.
+                if (
+                    fence_marker
+                    and marker[0] == fence_marker[0]
+                    and len(marker) >= len(fence_marker)
+                ):
                     in_code_fence = False
                     fence_marker = None
 

--- a/tests/main/test_md_parser.py
+++ b/tests/main/test_md_parser.py
@@ -198,6 +198,27 @@ print("Hello, world!")
     assert 'print("Hello, world!")' in code_block.content
 
 
+def test_longer_code_fence_not_closed_by_shorter_fence():
+    md = """# Real Header
+
+````python
+```text
+# Not a Header
+```
+````
+
+## Real Subheader
+Real content.
+"""
+    tree = parse_markdown_headings(md)
+
+    assert len(tree) == 1
+    child_headings = [
+        child.content for child in tree[0].children if child.content.startswith("#")
+    ]
+    assert child_headings == ["## Real Subheader"]
+
+
 def test_multiple_same_level_headers():
     md = """# Header A
 Paragraph A.


### PR DESCRIPTION
## What changed

This updates markdown heading parsing so a fenced code block opened with a longer fence, such as four backticks, is only closed by a fence using the same marker character and at least the same length.

## Why

Markdown allows longer fences when the code block itself contains shorter fences. With the previous `marker[:3]` tracking, this input was closed too early:

````markdown
````python
```text
# Not a Header
```
````
````

That made `# Not a Header` look like a real document heading and changed the parsed hierarchy.

## Validation

- `PYTHONUTF8=1 uv run pytest tests/main/test_md_parser.py::test_longer_code_fence_not_closed_by_shorter_fence -q`
- `PYTHONUTF8=1 uv run pytest tests/main/test_md_parser.py -q`
- `PYTHONUTF8=1 uv run ruff check langroid/parsing/md_parser.py tests/main/test_md_parser.py`
- `git diff --check -- langroid/parsing/md_parser.py tests/main/test_md_parser.py`