### PR TITLE
feat: add Dakera vector store backend

### DIFF
--- a/.github/workflows/pytest-subset.yml
+++ b/.github/workflows/pytest-subset.yml
@@ -78,6 +78,7 @@ jobs:
             --extra hf-embeddings \
             --extra weaviate \
             --extra pinecone \
+            --extra dakera \
             --extra postgres \
             --extra pdf-parsers \
             --extra docx \

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -174,6 +174,7 @@ jobs:
           --extra pymupdf4llm \
           --extra weaviate \
           --extra pinecone \
+          --extra dakera \
           --extra postgres\
           --extra hf-embeddings \
           --extra unstructured \

--- a/docs/notes/dakera.md
+++ b/docs/notes/dakera.md
@@ -1,0 +1,138 @@
+---
+
+# **Using Dakera as a Vector Store with Langroid**
+
+---
+
+[Dakera](https://dakera.ai) is a self-hosted memory server that provides persistent,
+decay-weighted vector recall. Langroid can use a Dakera *namespace* as a vector store via
+`DakeraDBConfig`; embeddings are supplied by Langroid's configured embedding model while
+Dakera handles storage and similarity search.
+
+---
+
+## **1. Run Dakera**
+
+Dakera is self-hosted. The canonical way to run it is the
+[`dakera-deploy`](https://github.com/dakera-ai/dakera-deploy) docker-compose stack, which
+starts the Dakera server (default port `3000`) together with the object store it depends on:
+
+```bash
+git clone https://github.com/dakera-ai/dakera-deploy
+cd dakera-deploy
+docker compose up -d
+```
+
+Then set the following environment variables (e.g. in your `.env` file):
+
+```env
+DAKERA_API_KEY=dk-...
+# Optional; defaults to http://localhost:3000
+DAKERA_URL=http://localhost:3000
+```
+
+---
+
+## **2. Use Dakera with Langroid**
+
+### **Installation**
+
+If you are using uv or pip for package management, install Langroid with the `dakera` extra:
+
+```
+uv add langroid[dakera]   # or: pip install langroid[dakera]
+```
+
+### **Code Example**
+
+```python
+import langroid as lr
+from langroid.agent.special import DocChatAgent, DocChatAgentConfig
+from langroid.embedding_models import OpenAIEmbeddingsConfig
+
+# Configure OpenAI embeddings
+embed_cfg = OpenAIEmbeddingsConfig(
+    model_type="openai",
+)
+
+# Configure the DocChatAgent with Dakera
+config = DocChatAgentConfig(
+    llm=lr.language_models.OpenAIGPTConfig(
+        chat_model=lr.language_models.OpenAIChatModel.GPT4o
+    ),
+    vecdb=lr.vector_store.DakeraDBConfig(
+        collection_name="quick_start_chat_agent_docs",
+        replace_collection=True,
+        embedding=embed_cfg,
+    ),
+    parsing=lr.parsing.parser.ParsingConfig(
+        separators=["\n\n"],
+        splitter=lr.parsing.parser.Splitter.SIMPLE,
+    ),
+    n_similar_chunks=2,
+    n_relevant_chunks=2,
+)
+
+# Create the agent
+agent = DocChatAgent(config)
+```
+
+`DakeraDBConfig` also accepts `url` and `api_key` (overriding the env vars) and a `metric`
+(`cosine`, `euclidean` or `dot_product`). The namespace dimension is inferred automatically
+from the configured embedding model.
+
+---
+
+## **3. Create and Ingest Documents**
+
+Define documents with their content and metadata for ingestion into the vector store.
+
+### **Code Example**
+
+```python
+documents = [
+    lr.Document(
+        content="""
+            In the year 2050, GPT10 was released.
+
+            In 2057, paperclips were seen all over the world.
+
+            Global warming was solved in 2060.
+
+            In 2061, the world was taken over by paperclips.
+
+            In 2045, the Tour de France was still going on.
+            They were still using bicycles.
+
+            There was one more ice age in 2040.
+        """,
+        metadata=lr.DocMetaData(source="wikipedia-2063", id="dkfjkladfjalk"),
+    ),
+    lr.Document(
+        content="""
+            We are living in an alternate universe
+            where Germany has occupied the USA, and the capital of USA is Berlin.
+
+            Charlie Chaplin was a great comedian.
+            In 2050, all Asian countries merged into Indonesia.
+        """,
+        metadata=lr.DocMetaData(source="Almanac", id="lkdajfdkla"),
+    ),
+]
+```
+
+### **Ingest Documents**
+
+```python
+agent.ingest_docs(documents)
+```
+
+---
+
+## **4. Get an answer from the LLM**
+
+```python
+answer = agent.llm_response("When will the new ice age begin?")
+```
+
+---

--- a/langroid/vector_store/__init__.py
+++ b/langroid/vector_store/__init__.py
@@ -62,7 +62,13 @@ try:
     PineconeDB
     PineconeDBConfig
     __all__.extend(["pineconedb", "PineconeDB", "PineconeDBConfig"])
+except ImportError:
+    pass
 
+
+# Kept in its own try/except so installing only the `dakera` extra is enough to
+# import it, independent of the other optional backends above.
+try:
     from . import dakera
     from .dakera import DakeraDB, DakeraDBConfig
 

--- a/langroid/vector_store/__init__.py
+++ b/langroid/vector_store/__init__.py
@@ -62,5 +62,13 @@ try:
     PineconeDB
     PineconeDBConfig
     __all__.extend(["pineconedb", "PineconeDB", "PineconeDBConfig"])
+
+    from . import dakera
+    from .dakera import DakeraDB, DakeraDBConfig
+
+    dakera
+    DakeraDB
+    DakeraDBConfig
+    __all__.extend(["dakera", "DakeraDB", "DakeraDBConfig"])
 except ImportError:
     pass

--- a/langroid/vector_store/base.py
+++ b/langroid/vector_store/base.py
@@ -59,6 +59,7 @@ class VectorStore(ABC):
     @staticmethod
     def create(config: VectorStoreConfig) -> Optional["VectorStore"]:
         from langroid.vector_store.chromadb import ChromaDB, ChromaDBConfig
+        from langroid.vector_store.dakera import DakeraDB, DakeraDBConfig
         from langroid.vector_store.lancedb import LanceDB, LanceDBConfig
         from langroid.vector_store.meilisearch import MeiliSearch, MeiliSearchConfig
         from langroid.vector_store.pineconedb import PineconeDB, PineconeDBConfig
@@ -80,6 +81,8 @@ class VectorStore(ABC):
             return WeaviateDB(config)
         elif isinstance(config, PineconeDBConfig):
             return PineconeDB(config)
+        elif isinstance(config, DakeraDBConfig):
+            return DakeraDB(config)
 
         else:
             logger.warning(

--- a/langroid/vector_store/dakera.py
+++ b/langroid/vector_store/dakera.py
@@ -1,0 +1,299 @@
+import json
+import logging
+import os
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+from dotenv import load_dotenv
+
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import Document
+from langroid.utils.configuration import settings
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+
+
+has_dakera: bool = True
+try:
+    from dakera import DakeraClient, DistanceMetric, NotFoundError, Vector
+except ImportError:
+    if not TYPE_CHECKING:
+        DakeraClient = Any
+        DistanceMetric = Any
+        Vector = Any
+
+        class NotFoundError(Exception):  # type: ignore
+            """Fallback when the ``dakera`` package is not installed."""
+
+        has_dakera = False
+
+
+# Distance metrics accepted in the config, mapped to the Dakera SDK enum.
+_METRIC_ALIASES = ("cosine", "euclidean", "dot_product")
+
+
+class DakeraDBConfig(VectorStoreConfig):
+    collection_name: str | None = "temp"
+    url: str = "http://localhost:3000"
+    api_key: str = ""  # falls back to the DAKERA_API_KEY env var
+    metric: str = "cosine"
+    # Upper bound on the number of documents returned by `get_all_documents`,
+    # which Dakera serves via a similarity query with a placeholder vector.
+    max_all_documents: int = 10_000
+
+
+class DakeraDB(VectorStore):
+    """VectorStore backed by a self-hosted Dakera memory server.
+
+    Dakera stores each document as a vector inside a *namespace* (the langroid
+    "collection"). Embeddings are supplied by langroid's configured embedding
+    model; Dakera handles storage and dense similarity search over the raw
+    vector-namespace API.
+    """
+
+    def __init__(self, config: DakeraDBConfig = DakeraDBConfig()):
+        super().__init__(config)
+        if not has_dakera:
+            raise LangroidImportError("dakera", "dakera")
+        self.config: DakeraDBConfig = config
+        load_dotenv()
+        key = config.api_key or os.getenv("DAKERA_API_KEY", "")
+        url = config.url or os.getenv("DAKERA_URL", "http://localhost:3000")
+        if not key:
+            raise ValueError(
+                "DAKERA_API_KEY not set, could not instantiate Dakera client"
+            )
+        self.client = DakeraClient(base_url=url, api_key=key)
+
+        if config.collection_name:
+            self.create_collection(
+                collection_name=config.collection_name,
+                replace=config.replace_collection,
+            )
+
+    def _distance(self) -> "DistanceMetric":
+        metric = self.config.metric
+        if metric not in _METRIC_ALIASES:
+            metric = "cosine"
+        return DistanceMetric(metric)
+
+    def clear_empty_collections(self) -> int:
+        namespaces = self.client.list_namespaces()
+        n_deletes = 0
+        for ns in namespaces:
+            if ns.vector_count == 0:
+                self.delete_collection(collection_name=ns.name)
+                n_deletes += 1
+        return n_deletes
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """
+        Returns:
+            Number of Dakera namespaces that were deleted.
+
+        Args:
+            really: whether to really delete all matching namespaces.
+            prefix: only namespaces whose name starts with this prefix are deleted.
+        """
+        if not really:
+            logger.warning("Not deleting all collections, set really=True to confirm")
+            return 0
+        namespaces = [
+            ns for ns in self.client.list_namespaces() if ns.name.startswith(prefix)
+        ]
+        if len(namespaces) == 0:
+            logger.warning(f"No collections found with prefix {prefix}")
+            return 0
+        for ns in namespaces:
+            self.delete_collection(collection_name=ns.name)
+        logger.warning(f"Deleted {len(namespaces)} namespaces with prefix {prefix}")
+        return len(namespaces)
+
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """
+        Returns:
+            Names of Dakera namespaces.
+
+        Args:
+            empty: if True, include namespaces with no vectors.
+        """
+        namespaces = self.client.list_namespaces()
+        if empty:
+            return [ns.name for ns in namespaces]
+        return [ns.name for ns in namespaces if ns.vector_count > 0]
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        """
+        Create a namespace, optionally replacing an existing non-empty one.
+
+        Args:
+            collection_name: name of the namespace to create.
+            replace: whether to replace an existing non-empty namespace.
+        """
+        self.config.collection_name = collection_name
+        existing = {ns.name: ns for ns in self.client.list_namespaces()}
+        if collection_name in existing:
+            if existing[collection_name].vector_count > 0:
+                logger.warning(f"Non-empty collection {collection_name} already exists")
+                if not replace:
+                    logger.warning("Not replacing collection")
+                    return
+                logger.warning("Recreating fresh collection")
+            self.delete_collection(collection_name=collection_name)
+
+        self.client.configure_namespace(
+            collection_name,
+            dimension=self.embedding_dim,
+            distance=self._distance(),
+        )
+
+    def delete_collection(self, collection_name: str) -> None:
+        logger.info(f"Attempting to delete {collection_name}")
+        try:
+            self.client.delete_namespace(collection_name)
+        except NotFoundError:
+            logger.debug(f"Namespace {collection_name} not found, nothing to delete")
+
+    def _to_vectors(self, documents: Sequence[Document]) -> List[Any]:
+        document_dicts = [doc.model_dump() for doc in documents]
+        document_ids = [doc.id() for doc in documents]
+        embedding_vectors = self.embedding_fn([doc.content for doc in documents])
+        return [
+            Vector(
+                id=document_id,
+                values=list(embedding_vector),
+                metadata={
+                    **document_dict["metadata"],
+                    **{
+                        key: value
+                        for key, value in document_dict.items()
+                        if key != "metadata"
+                    },
+                },
+            )
+            for document_dict, document_id, embedding_vector in zip(
+                document_dicts, document_ids, embedding_vectors
+            )
+        ]
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        if len(documents) == 0:
+            logger.warning("Empty list of documents passed into add_documents")
+            return
+
+        super().maybe_add_ids(documents)
+        vectors = self._to_vectors(documents)
+
+        if self.config.collection_name not in self.list_collections(empty=True):
+            self.create_collection(
+                collection_name=self.config.collection_name, replace=True
+            )
+
+        batch_size = self.config.batch_size
+        for i in range(0, len(vectors), batch_size):
+            self.client.upsert(
+                self.config.collection_name, vectors=vectors[i : i + batch_size]
+            )
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        """
+        Returns:
+            All documents in the current collection, up to
+            ``config.max_all_documents``.
+
+        Args:
+            where: optional Dakera metadata filter as a JSON string.
+        """
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+
+        filter_ = json.loads(where) if where else None
+        placeholder = [0.0] * self.embedding_dim
+        result = self.client.query(
+            self.config.collection_name,
+            vector=placeholder,
+            top_k=self.config.max_all_documents,
+            filter=filter_,
+            include_metadata=True,
+        )
+        docs = [self._transform(match.metadata or {}) for match in result.results]
+        if len(docs) == self.config.max_all_documents:
+            logger.warning(
+                f"get_all_documents hit the max_all_documents limit of "
+                f"{self.config.max_all_documents}; more documents may exist."
+            )
+        return docs
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        """
+        Returns:
+            Documents reconstructed from the metadata stored in Dakera, in the
+            same order as ``ids`` (missing ids are skipped).
+
+        Args:
+            ids: vector ids to fetch.
+        """
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        if not ids:
+            return []
+        vectors = self.client.fetch(
+            self.config.collection_name,
+            ids=ids,
+            include_values=False,
+            include_metadata=True,
+        )
+        id_mapping = {vector.id: vector for vector in vectors}
+        return [
+            self._transform(id_mapping[_id].metadata or {})
+            for _id in ids
+            if _id in id_mapping
+        ]
+
+    def similar_texts_with_scores(
+        self,
+        text: str,
+        k: int = 1,
+        where: Optional[str] = None,
+        neighbors: int = 0,
+    ) -> List[Tuple[Document, float]]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot search")
+        if k < 1:
+            raise ValueError(f"k for Dakera vector search must be >= 1, got {k}")
+
+        filter_ = json.loads(where) if where else None
+        query_vector = self.embedding_fn([text])[0]
+        result = self.client.query(
+            self.config.collection_name,
+            vector=list(query_vector),
+            top_k=k,
+            filter=filter_,
+            include_metadata=True,
+            distance_metric=self._distance(),
+        )
+        doc_score_pairs = [
+            (self._transform(match.metadata or {}), match.score)
+            for match in result.results
+        ]
+        if settings.debug and doc_score_pairs:
+            max_score = max(pair[1] for pair in doc_score_pairs)
+            logger.info(f"Found {len(doc_score_pairs)} matches, max score: {max_score}")
+        self.show_if_debug(doc_score_pairs)
+        return doc_score_pairs
+
+    def _transform(self, metadata_dict: Dict[str, Any]) -> Document:
+        """Reconstruct a Document from the metadata stored alongside its vector."""
+        return self.config.document_class(
+            **{**metadata_dict, "metadata": {**metadata_dict}}
+        )

--- a/langroid/vector_store/dakera.py
+++ b/langroid/vector_store/dakera.py
@@ -42,7 +42,8 @@ _METRIC_ALIASES = ("cosine", "euclidean", "dot_product")
 
 class DakeraDBConfig(VectorStoreConfig):
     collection_name: str | None = "temp"
-    url: str = "http://localhost:3000"
+    # Empty by default so DAKERA_URL is honored; falls back to localhost:3000.
+    url: str = ""
     api_key: str = ""  # falls back to the DAKERA_API_KEY env var
     metric: str = "cosine"
     # Upper bound on the number of documents returned by `get_all_documents`,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
       - Handling LLM Non-Tool Messages: notes/handle-llm-no-tool.md
       - PGVector: notes/pgvector.md
       - Pinecone: notes/pinecone.md
+      - Dakera: notes/dakera.md
       - Tavily Search Tool: notes/tavily_search.md
       - Seltz Search Tool: notes/seltz_search.md
       - Twitter Search via Xquik MCP: notes/twitter-search.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ vecdbs = [
     "chromadb<=0.4.23,>=0.4.21",
     "weaviate-client>=4.9.6",
     "pinecone-client>=5.0.1",
+    "dakera>=0.12.8",
 ]
 
 db = [
@@ -278,6 +279,9 @@ doc-parsers = [
 
 pinecone = [
     "pinecone-client>=5.0.1"
+]
+dakera = [
+    "dakera>=0.12.8"
 ]
 asyncio = [
     "asyncio>=3.4.3",

--- a/tests/main/test_dakera.py
+++ b/tests/main/test_dakera.py
@@ -1,0 +1,185 @@
+"""
+Unit tests for the Dakera vector store, using a mocked Dakera client and a fake
+embedding function so they run without a live server or embedding API.
+
+Integration coverage (against a real Dakera server) is provided by the
+parametrized suite in ``tests/main/test_vector_stores.py`` when a server and
+``DAKERA_API_KEY`` are available.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("dakera")
+
+from dakera import DistanceMetric, Vector  # noqa: E402
+
+from langroid.mytypes import DocMetaData, Document  # noqa: E402
+from langroid.vector_store.dakera import DakeraDB, DakeraDBConfig  # noqa: E402
+
+CLIENT_PATH = "langroid.vector_store.dakera.DakeraClient"
+EMB_CREATE_PATH = "langroid.vector_store.base.EmbeddingModel.create"
+
+
+class _FakeEmbeddingModel:
+    """Deterministic 3-dim embeddings, no network."""
+
+    def embedding_fn(self):
+        return lambda texts: [[0.1, 0.2, 0.3] for _ in texts]
+
+
+def _make_db(mock_client_cls, collection_name="test-coll"):
+    client = mock_client_cls.return_value
+    client.list_namespaces.return_value = []
+    with patch(EMB_CREATE_PATH, return_value=_FakeEmbeddingModel()):
+        db = DakeraDB(
+            DakeraDBConfig(collection_name=collection_name, api_key="dk-fake")
+        )
+    return db, client
+
+
+@patch(CLIENT_PATH)
+def test_init_configures_namespace(mock_client_cls):
+    db, client = _make_db(mock_client_cls)
+    mock_client_cls.assert_called_once_with(
+        base_url="http://localhost:3000", api_key="dk-fake"
+    )
+    # embedding_dim is inferred from the fake embedding function (len == 3).
+    client.configure_namespace.assert_called_once()
+    kwargs = client.configure_namespace.call_args.kwargs
+    assert kwargs["dimension"] == 3
+    assert kwargs["distance"] == DistanceMetric.COSINE
+
+
+def test_init_requires_api_key(monkeypatch):
+    monkeypatch.delenv("DAKERA_API_KEY", raising=False)
+    with patch(CLIENT_PATH), patch(EMB_CREATE_PATH, return_value=_FakeEmbeddingModel()):
+        with pytest.raises(ValueError, match="DAKERA_API_KEY"):
+            DakeraDB(DakeraDBConfig(collection_name=None, api_key=""))
+
+
+@patch(CLIENT_PATH)
+def test_add_documents_and_roundtrip_via_query(mock_client_cls):
+    db, client = _make_db(mock_client_cls)
+    # Collection already exists (non-empty check in add_documents).
+    client.list_namespaces.return_value = [
+        SimpleNamespace(name="test-coll", vector_count=0)
+    ]
+
+    docs = [
+        Document(content="hello world", metadata=DocMetaData()),
+        Document(content="goodbye", metadata=DocMetaData()),
+    ]
+    db.add_documents(docs)
+
+    client.upsert.assert_called_once()
+    ns_arg = client.upsert.call_args.args[0]
+    vectors = client.upsert.call_args.kwargs["vectors"]
+    assert ns_arg == "test-coll"
+    assert len(vectors) == 2
+    assert vectors[0].values == [0.1, 0.2, 0.3]
+    assert vectors[0].metadata["content"] == "hello world"
+
+    # Round-trip: feed the stored metadata back through a query and confirm the
+    # Document is reconstructed with the same content and score.
+    stored_meta = vectors[0].metadata
+    client.query.return_value = SimpleNamespace(
+        results=[SimpleNamespace(id="x", score=0.88, values=None, metadata=stored_meta)]
+    )
+    pairs = db.similar_texts_with_scores("hello", k=3)
+    assert client.query.call_args.kwargs["top_k"] == 3
+    assert client.query.call_args.kwargs["distance_metric"] == DistanceMetric.COSINE
+    assert len(pairs) == 1
+    doc, score = pairs[0]
+    assert doc.content == "hello world"
+    assert score == 0.88
+
+
+@patch(CLIENT_PATH)
+def test_get_documents_by_ids_preserves_order(mock_client_cls):
+    db, client = _make_db(mock_client_cls)
+    client.list_namespaces.return_value = [
+        SimpleNamespace(name="test-coll", vector_count=0)
+    ]
+    db.add_documents([Document(content="alpha", metadata=DocMetaData())])
+    stored_meta = client.upsert.call_args.kwargs["vectors"][0].metadata
+
+    client.fetch.return_value = [
+        Vector(id="b", values=[0.0, 0.0, 0.0], metadata=stored_meta),
+        Vector(id="a", values=[0.0, 0.0, 0.0], metadata=stored_meta),
+    ]
+    docs = db.get_documents_by_ids(["a", "b", "missing"])
+    # Order follows the requested ids; missing ids are skipped.
+    assert [d.content for d in docs] == ["alpha", "alpha"]
+    assert client.fetch.call_args.args[0] == "test-coll"
+
+
+@patch(CLIENT_PATH)
+def test_get_documents_by_ids_empty(mock_client_cls):
+    db, client = _make_db(mock_client_cls)
+    assert db.get_documents_by_ids([]) == []
+    client.fetch.assert_not_called()
+
+
+@patch(CLIENT_PATH)
+def test_list_collections_filters_empty(mock_client_cls):
+    db, client = _make_db(mock_client_cls)
+    client.list_namespaces.return_value = [
+        SimpleNamespace(name="a", vector_count=2),
+        SimpleNamespace(name="b", vector_count=0),
+    ]
+    assert db.list_collections(empty=False) == ["a"]
+    assert set(db.list_collections(empty=True)) == {"a", "b"}
+
+
+@patch(CLIENT_PATH)
+def test_clear_empty_collections(mock_client_cls):
+    db, client = _make_db(mock_client_cls)
+    client.list_namespaces.return_value = [
+        SimpleNamespace(name="a", vector_count=2),
+        SimpleNamespace(name="b", vector_count=0),
+        SimpleNamespace(name="c", vector_count=0),
+    ]
+    assert db.clear_empty_collections() == 2
+    deleted = {c.args[0] for c in client.delete_namespace.call_args_list}
+    assert deleted == {"b", "c"}
+
+
+@patch(CLIENT_PATH)
+def test_clear_all_collections_requires_really(mock_client_cls):
+    db, client = _make_db(mock_client_cls)
+    assert db.clear_all_collections(really=False) == 0
+    client.delete_namespace.assert_not_called()
+
+
+@patch(CLIENT_PATH)
+def test_clear_all_collections_with_prefix(mock_client_cls):
+    db, client = _make_db(mock_client_cls)
+    client.list_namespaces.return_value = [
+        SimpleNamespace(name="keep-1", vector_count=1),
+        SimpleNamespace(name="drop-1", vector_count=1),
+        SimpleNamespace(name="drop-2", vector_count=0),
+    ]
+    assert db.clear_all_collections(really=True, prefix="drop-") == 2
+    deleted = {c.args[0] for c in client.delete_namespace.call_args_list}
+    assert deleted == {"drop-1", "drop-2"}
+
+
+@patch(CLIENT_PATH)
+def test_similar_texts_rejects_bad_k(mock_client_cls):
+    db, _ = _make_db(mock_client_cls)
+    with pytest.raises(ValueError, match="must be >= 1"):
+        db.similar_texts_with_scores("q", k=0)
+
+
+@patch(CLIENT_PATH)
+def test_metric_defaults_to_cosine_for_unknown(mock_client_cls):
+    client = mock_client_cls.return_value
+    client.list_namespaces.return_value = []
+    with patch(EMB_CREATE_PATH, return_value=_FakeEmbeddingModel()):
+        db = DakeraDB(
+            DakeraDBConfig(collection_name="c", api_key="dk-fake", metric="manhattan")
+        )
+    assert db._distance() == DistanceMetric.COSINE

--- a/tests/main/test_dakera.py
+++ b/tests/main/test_dakera.py
@@ -53,6 +53,16 @@ def test_init_configures_namespace(mock_client_cls):
     assert kwargs["distance"] == DistanceMetric.COSINE
 
 
+@patch(CLIENT_PATH)
+def test_url_honors_env_var(mock_client_cls, monkeypatch):
+    monkeypatch.setenv("DAKERA_URL", "http://env-host:9999")
+    _make_db(mock_client_cls)
+    # With the default (empty) config url, DAKERA_URL is used.
+    mock_client_cls.assert_called_once_with(
+        base_url="http://env-host:9999", api_key="dk-fake"
+    )
+
+
 def test_init_requires_api_key(monkeypatch):
     monkeypatch.delenv("DAKERA_API_KEY", raising=False)
     with patch(CLIENT_PATH), patch(EMB_CREATE_PATH, return_value=_FakeEmbeddingModel()):


### PR DESCRIPTION
## Summary

Adds **`DakeraDB`**, a `VectorStore` backend backed by a self-hosted [Dakera](https://dakera.ai) memory server. Dakera stores each document as a vector inside a *namespace* (langroid's "collection") and serves dense similarity search; embeddings are supplied by langroid's configured embedding model, so this backend mirrors the existing cloud vector stores (closest sibling: `PineconeDB`).

## What's included

- **`langroid/vector_store/dakera.py`** — `DakeraDB` + `DakeraDBConfig`, implementing the full `VectorStore` interface: `create_collection`, `delete_collection`, `list_collections`, `clear_empty_collections`, `clear_all_collections`, `add_documents`, `similar_texts_with_scores`, `get_all_documents`, `get_documents_by_ids`. It drives Dakera's vector-namespace API (`list_namespaces` / `configure_namespace` / `delete_namespace` / `upsert` / `query` / `fetch`). The client is imported lazily behind a `has_dakera` guard, matching the other optional backends.
- **Registration** — added to `vector_store/__init__.py` and the `VectorStore.create()` factory (`DakeraDBConfig` dispatch).
- **Packaging** — new `dakera` optional-dependency extra (also added to `vecdbs`); `--extra dakera` added to the `pytest` and `pytest-subset` CI workflows so the tests run.
- **Tests** — `tests/main/test_dakera.py`: mocked-client unit tests (no live server or embedding API needed) covering namespace configuration, add/query round-trip through the real serialization path, `get_documents_by_ids` ordering, collection listing/clearing, and metric handling.

## Testing

Validated locally against `langroid` (editable, core) + `dakera 0.12.8`:

- `pytest tests/main/test_dakera.py` → **11 passed**
- `black --check` and `ruff check` → clean on the new files
- `mypy` → clean on `langroid/vector_store/dakera.py`

Integration testing against a live server: run a Dakera server via the [`dakera-deploy`](https://github.com/dakera-ai/dakera-deploy) docker-compose stack and set `DAKERA_API_KEY` (and optionally `DAKERA_URL`).

## Note on `uv.lock`

I intentionally did **not** commit a regenerated `uv.lock`. Locking with a current `uv` rewrites environment markers repo-wide (`platform_system == 'Linux'` → `sys_platform == 'linux'`, etc.), producing hundreds of lines of churn unrelated to this change. CI's `uv sync` resolves the new `dakera` extra at install time. Happy to commit a lock update generated with your pinned `uv` version if you'd prefer.
