### PR TITLE
fix: avoid constructing httpx transports on client cache hits

### DIFF
--- a/langroid/language_models/client_cache.py
+++ b/langroid/language_models/client_cache.py
@@ -130,13 +130,12 @@ def get_openai_client(
         if http_client_config is not None:
             try:
                 from httpx import Client
-
-                created_http_client = Client(**http_client_config)
             except ImportError:
                 raise ValueError(
                     "httpx is required to use http_client_config. "
                     "Install it with: pip install httpx"
                 )
+            created_http_client = Client(**http_client_config)
 
         client = OpenAI(
             api_key=api_key,
@@ -210,13 +209,12 @@ def get_async_openai_client(
         if http_client_config is not None:
             try:
                 from httpx import AsyncClient
-
-                created_http_client = AsyncClient(**http_client_config)
             except ImportError:
                 raise ValueError(
                     "httpx is required to use http_client_config. "
                     "Install it with: pip install httpx"
                 )
+            created_http_client = AsyncClient(**http_client_config)
 
         client = AsyncOpenAI(
             api_key=api_key,

--- a/langroid/language_models/client_cache.py
+++ b/langroid/language_models/client_cache.py
@@ -111,19 +111,6 @@ def get_openai_client(
         _all_clients.add(client)
         return client
 
-    # If http_client_config is provided, create client from config and cache
-    created_http_client = None
-    if http_client_config is not None:
-        try:
-            from httpx import Client
-
-            created_http_client = Client(**http_client_config)
-        except ImportError:
-            raise ValueError(
-                "httpx is required to use http_client_config. "
-                "Install it with: pip install httpx"
-            )
-
     cache_key = _get_cache_key(
         "openai",
         api_key=api_key,
@@ -138,6 +125,18 @@ def get_openai_client(
         cached_client = _get_cached_client(cache_key)
         if cached_client is not None:
             return cast(OpenAI, cached_client)
+
+        created_http_client = None
+        if http_client_config is not None:
+            try:
+                from httpx import Client
+
+                created_http_client = Client(**http_client_config)
+            except ImportError:
+                raise ValueError(
+                    "httpx is required to use http_client_config. "
+                    "Install it with: pip install httpx"
+                )
 
         client = OpenAI(
             api_key=api_key,
@@ -192,19 +191,6 @@ def get_async_openai_client(
         _all_clients.add(client)
         return client
 
-    # If http_client_config is provided, create async client from config and cache
-    created_http_client = None
-    if http_client_config is not None:
-        try:
-            from httpx import AsyncClient
-
-            created_http_client = AsyncClient(**http_client_config)
-        except ImportError:
-            raise ValueError(
-                "httpx is required to use http_client_config. "
-                "Install it with: pip install httpx"
-            )
-
     cache_key = _get_cache_key(
         "async_openai",
         api_key=api_key,
@@ -219,6 +205,18 @@ def get_async_openai_client(
         cached_client = _get_cached_client(cache_key)
         if cached_client is not None:
             return cast(AsyncOpenAI, cached_client)
+
+        created_http_client = None
+        if http_client_config is not None:
+            try:
+                from httpx import AsyncClient
+
+                created_http_client = AsyncClient(**http_client_config)
+            except ImportError:
+                raise ValueError(
+                    "httpx is required to use http_client_config. "
+                    "Install it with: pip install httpx"
+                )
 
         client = AsyncOpenAI(
             api_key=api_key,

--- a/tests/main/test_openai_gpt_client_cache.py
+++ b/tests/main/test_openai_gpt_client_cache.py
@@ -2,7 +2,14 @@
 Tests for OpenAIGPT client caching functionality.
 """
 
+import sys
+import threading
+import time
+from typing import Any
+
+import httpx
 import pytest
+from openai import AsyncOpenAI, OpenAI
 
 import langroid.language_models.client_cache as client_cache_module
 from langroid.language_models.client_cache import (
@@ -112,6 +119,300 @@ class TestOpenAIGPTClientCache:
 
         client3 = get_openai_client(api_key="test-key-refresh")
         assert client3 is client1
+
+    def test_openai_client_cache_hit_does_not_create_extra_httpx_client(
+        self, monkeypatch
+    ):
+        """Test cache hits avoid allocating a new sync transport for config."""
+        created_clients: list[httpx.Client] = []
+        real_client = httpx.Client
+
+        class TrackingClient(real_client):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created_clients.append(self)
+
+        monkeypatch.setattr(httpx, "Client", TrackingClient)
+
+        client1 = get_openai_client(
+            api_key="test-key-http-client-config",
+            http_client_config={"timeout": 1.0},
+        )
+        client2 = get_openai_client(
+            api_key="test-key-http-client-config",
+            http_client_config={"timeout": 1.0},
+        )
+
+        assert client1 is client2
+        assert len(created_clients) == 1
+
+    def test_async_openai_client_cache_hit_does_not_create_extra_httpx_client(
+        self, monkeypatch
+    ):
+        """Test cache hits avoid allocating a new async transport for config."""
+        created_clients: list[httpx.AsyncClient] = []
+        real_async_client = httpx.AsyncClient
+
+        class TrackingAsyncClient(real_async_client):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created_clients.append(self)
+
+        monkeypatch.setattr(httpx, "AsyncClient", TrackingAsyncClient)
+
+        client1 = get_async_openai_client(
+            api_key="test-key-async-http-client-config",
+            http_client_config={"timeout": 1.0},
+        )
+        client2 = get_async_openai_client(
+            api_key="test-key-async-http-client-config",
+            http_client_config={"timeout": 1.0},
+        )
+
+        assert client1 is client2
+        assert len(created_clients) == 1
+
+    @pytest.mark.parametrize(
+        "getter,httpx_attr,openai_cls,api_key",
+        [
+            (get_openai_client, "Client", OpenAI, "test-key-race-sync"),
+            (
+                get_async_openai_client,
+                "AsyncClient",
+                AsyncOpenAI,
+                "test-key-race-async",
+            ),
+        ],
+        ids=["sync", "async"],
+    )
+    def test_concurrent_misses_construct_httpx_client_once(
+        self, monkeypatch, getter, httpx_attr, openai_cls, api_key
+    ):
+        """Racing identical misses build exactly one transport per entry.
+
+        Miss construction is serialized under the cache lock, so threads
+        racing on the same argument tuple must share a single client and
+        construct at most one httpx transport.
+        """
+        created_http_clients: list[Any] = []
+        real_http_client_cls = getattr(httpx, httpx_attr)
+        n_threads = 8
+        barrier = threading.Barrier(n_threads)
+
+        class BlockingTrackingHttpClient(real_http_client_cls):
+            def __init__(self, *args, **kwargs):
+                created_http_clients.append(self)
+                # Stay inside the constructor briefly so unserialized
+                # construction by racing threads would be detected.
+                time.sleep(0.15)
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(httpx, httpx_attr, BlockingTrackingHttpClient)
+
+        results: list[Any] = []
+        errors: list[BaseException] = []
+
+        def get_client():
+            try:
+                barrier.wait(timeout=10)
+                results.append(
+                    getter(
+                        api_key=api_key,
+                        http_client_config={"timeout": 1.0},
+                    )
+                )
+            except BaseException as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=get_client, daemon=True) for _ in range(n_threads)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=30)
+
+        assert all(not thread.is_alive() for thread in threads)
+        assert errors == []
+        assert len(results) == n_threads
+        assert all(client is results[0] for client in results)
+        assert isinstance(results[0], openai_cls)
+        assert len(created_http_clients) == 1
+
+    @pytest.mark.parametrize(
+        "getter,httpx_attr,openai_cls,api_key",
+        [
+            (get_openai_client, "Client", OpenAI, "test-key-flaky-sync"),
+            (
+                get_async_openai_client,
+                "AsyncClient",
+                AsyncOpenAI,
+                "test-key-flaky-async",
+            ),
+        ],
+        ids=["sync", "async"],
+    )
+    def test_httpx_construction_failure_propagates_and_is_not_cached(
+        self, monkeypatch, getter, httpx_attr, openai_cls, api_key
+    ):
+        """Failed transport construction propagates and caches nothing.
+
+        The construction error must reach the caller, the cache lock must
+        be released, and no failed/partial client may be cached: a retry
+        with identical arguments constructs a fresh client.
+        """
+        construction_calls: list[Any] = []
+        real_http_client_cls = getattr(httpx, httpx_attr)
+
+        class FlakyHttpClient(real_http_client_cls):
+            def __init__(self, *args, **kwargs):
+                construction_calls.append(self)
+                if len(construction_calls) == 1:
+                    raise RuntimeError("transport construction failed")
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(httpx, httpx_attr, FlakyHttpClient)
+
+        def call_getter():
+            return getter(
+                api_key=api_key,
+                http_client_config={"timeout": 1.0},
+            )
+
+        with pytest.raises(RuntimeError, match="transport construction failed"):
+            call_getter()
+        assert len(construction_calls) == 1
+
+        # Retry on another thread: it must not deadlock on a leaked cache
+        # lock (an RLock re-acquired from this thread would mask a leak),
+        # and it must not observe a cached failed/partial client.
+        retry_results: list[Any] = []
+        retry_errors: list[BaseException] = []
+
+        def retry():
+            try:
+                retry_results.append(call_getter())
+            except BaseException as exc:
+                retry_errors.append(exc)
+
+        thread = threading.Thread(target=retry, daemon=True)
+        thread.start()
+        thread.join(timeout=10)
+
+        assert not thread.is_alive(), "cache lock was not released"
+        assert retry_errors == []
+        assert len(retry_results) == 1
+        client = retry_results[0]
+        assert isinstance(client, openai_cls)
+        assert len(construction_calls) == 2
+
+        # A further identical call is a plain cache hit: same client,
+        # and no additional transport construction.
+        assert call_getter() is client
+        assert len(construction_calls) == 2
+
+    @pytest.mark.parametrize(
+        "getter,openai_cls,api_key",
+        [
+            (get_openai_client, OpenAI, "test-key-no-httpx-sync"),
+            (
+                get_async_openai_client,
+                AsyncOpenAI,
+                "test-key-no-httpx-async",
+            ),
+        ],
+        ids=["sync", "async"],
+    )
+    def test_missing_httpx_raises_value_error_and_is_not_cached(
+        self, getter, openai_cls, api_key
+    ):
+        """Unimportable httpx plus http_client_config raises ValueError.
+
+        When ``from httpx import Client`` / ``from httpx import
+        AsyncClient`` fails with ImportError, the getter must raise the
+        documented ValueError, cache nothing, and construct/cache
+        normally once httpx is importable again.
+        """
+
+        def call_getter():
+            return getter(
+                api_key=api_key,
+                http_client_config={"timeout": 1.0},
+            )
+
+        real_httpx = sys.modules["httpx"]
+        # Simulate an environment without httpx: a None entry in
+        # sys.modules makes ``from httpx import ...`` raise ImportError.
+        sys.modules["httpx"] = None  # type: ignore[assignment]
+        try:
+            with pytest.raises(ValueError) as excinfo:
+                call_getter()
+        finally:
+            sys.modules["httpx"] = real_httpx
+
+        assert str(excinfo.value) == (
+            "httpx is required to use http_client_config. "
+            "Install it with: pip install httpx"
+        )
+        # The ValueError must come from the ImportError branch.
+        assert isinstance(excinfo.value.__context__, ImportError)
+        # The failed call must not leave a cache entry behind.
+        assert len(client_cache_module._client_cache) == 0
+
+        # With httpx importable again, the identical call constructs
+        # and caches a client normally.
+        client = call_getter()
+        assert isinstance(client, openai_cls)
+        assert len(client_cache_module._client_cache) == 1
+        assert call_getter() is client
+
+    @pytest.mark.parametrize(
+        "getter,httpx_attr,api_key",
+        [
+            (get_openai_client, "Client", "test-key-configs-sync"),
+            (
+                get_async_openai_client,
+                "AsyncClient",
+                "test-key-configs-async",
+            ),
+        ],
+        ids=["sync", "async"],
+    )
+    def test_distinct_http_client_configs_get_distinct_clients(
+        self, monkeypatch, getter, httpx_attr, api_key
+    ):
+        """Same API key but different http_client_config: no client reuse.
+
+        http_client_config is part of the cache key, so each distinct
+        config must get its own client and its own httpx transport.
+        """
+        created_http_clients: list[Any] = []
+        real_http_client_cls = getattr(httpx, httpx_attr)
+
+        class TrackingHttpClient(real_http_client_cls):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created_http_clients.append(self)
+
+        monkeypatch.setattr(httpx, httpx_attr, TrackingHttpClient)
+
+        client1 = getter(
+            api_key=api_key,
+            http_client_config={"timeout": 1.0},
+        )
+        client2 = getter(
+            api_key=api_key,
+            http_client_config={"timeout": 2.0},
+        )
+
+        assert client1 is not client2
+        assert len(created_http_clients) == 2
+
+        # Each distinct config keeps its own cache entry: repeat calls
+        # are hits and construct no further transports.
+        assert getter(api_key=api_key, http_client_config={"timeout": 1.0}) is client1
+        assert getter(api_key=api_key, http_client_config={"timeout": 2.0}) is client2
+        assert len(created_http_clients) == 2
 
     def test_prune_cache_negative_max_age_raises(self):
         """Test that negative max_age_seconds raises ValueError."""

--- a/tests/main/test_openai_gpt_client_cache.py
+++ b/tests/main/test_openai_gpt_client_cache.py
@@ -312,6 +312,40 @@ class TestOpenAIGPTClientCache:
         assert len(construction_calls) == 2
 
     @pytest.mark.parametrize(
+        "getter,httpx_attr,api_key",
+        [
+            (get_openai_client, "Client", "test-key-import-error-sync"),
+            (
+                get_async_openai_client,
+                "AsyncClient",
+                "test-key-import-error-async",
+            ),
+        ],
+        ids=["sync", "async"],
+    )
+    def test_httpx_constructor_import_error_propagates_and_is_not_cached(
+        self, monkeypatch, getter, httpx_attr, api_key
+    ):
+        """Constructor ImportError propagates unchanged and caches nothing."""
+        constructor_error = ImportError("optional transport dependency is missing")
+        real_http_client_cls = getattr(httpx, httpx_attr)
+
+        class FailingHttpClient(real_http_client_cls):
+            def __init__(self, *args, **kwargs):
+                raise constructor_error
+
+        monkeypatch.setattr(httpx, httpx_attr, FailingHttpClient)
+
+        with pytest.raises(ImportError) as excinfo:
+            getter(
+                api_key=api_key,
+                http_client_config={"timeout": 1.0},
+            )
+
+        assert excinfo.value is constructor_error
+        assert len(client_cache_module._client_cache) == 0
+
+    @pytest.mark.parametrize(
         "getter,openai_cls,api_key",
         [
             (get_openai_client, OpenAI, "test-key-no-httpx-sync"),


### PR DESCRIPTION
## Summary

Takes over and extends #1018 by @shaun0927, and also supersedes the
independently-submitted #1067 by @Sanjays2402. Fixes #1017.

`get_openai_client` / `get_async_openai_client` built the httpx
`Client` / `AsyncClient` from `http_client_config` **before** the cache lookup,
so every cache hit allocated a transport that was immediately discarded. The
transport is now constructed only on a cache **miss**, inside the cache lock.

Two commits:

1. **`fix: avoid constructing httpx transports on client cache hits`** — the
   fix itself (sync + async), plus regression tests.
2. **`fix: narrow httpx ImportError handling to the import itself`** — the
   `try` block wrapped both the `from httpx import Client` and the constructor
   call, so an `ImportError` raised by httpx's own constructor (e.g. a
   `socks://` proxy without `socksio` installed) was misreported as
   "httpx is required to use http_client_config". The `except ImportError` now
   covers only the import; constructor errors propagate unchanged.

## Beyond #1018 and #1067

Both of those change the same few lines; this PR adds the test coverage and the
error-reporting fix:

- sync **and** async cache-hit regression tests (transport constructed exactly
  once across two identical calls);
- concurrent cache misses construct the transport exactly once;
- failed transport construction propagates, releases the cache lock, and caches
  nothing — a retry (on another thread, so a leaked `RLock` can't be masked)
  succeeds;
- unimportable httpx still raises the documented `ValueError`, caches nothing,
  and recovers once httpx is importable again;
- constructor-raised `ImportError` propagates as `ImportError`, not `ValueError`;
- distinct `http_client_config` values get distinct clients and distinct
  transports.

## Scope

Exactly two files: `langroid/language_models/client_cache.py` (+24/−26) and
`tests/main/test_openai_gpt_client_cache.py` (+335). The earlier revision of
this branch also carried regenerated `llms*.txt` and lockfile churn; that has
been dropped and the branch rebased onto current `main`.

## Testing

`uv run pytest -q tests/main/test_openai_gpt_client_cache.py` → **30 passed**.
`black --check`, `ruff check`, and `mypy` on the changed files are clean.

Supersedes #1018 (thanks @shaun0927) and #1067 (thanks @Sanjays2402).
