### PR TITLE
perf(mcp): build all MCP tools with a single list_tools() round-trip

### DIFF
--- a/langroid/agent/tools/mcp/fastmcp_client.py
+++ b/langroid/agent/tools/mcp/fastmcp_client.py
@@ -321,6 +321,24 @@ class FastMCPClient:
         target = await self.get_mcp_tool_async(tool_name)
         if target is None:
             raise ValueError(f"No tool named {tool_name}")
+        return self.tool_model_from_mcp_tool(target)
+
+    def tool_model_from_mcp_tool(self, target: Tool) -> Type[ToolMessage]:
+        """
+        Build a Langroid ToolMessage subclass from an already-fetched MCP
+        `Tool` object.
+
+        This is a pure, synchronous, network-free conversion: it performs no
+        ``list_tools()`` round-trip. Pair it with a single ``list_tools()`` call
+        to build many tools without re-listing the server once per tool
+        (see :meth:`get_tools_async`).
+
+        Args:
+            target: The raw ``mcp.types.Tool`` (name, description, inputSchema).
+
+        Returns:
+            A dynamically created Langroid ToolMessage subclass for `target`.
+        """
         props = target.inputSchema.get("properties", {})
         # Get the list of required fields from JSON Schema
         required_fields = set(target.inputSchema.get("required", []))
@@ -476,7 +494,7 @@ class FastMCPClient:
                     "Client not initialized. Use async with FastMCPClient."
                 )
         resp = await self.client.list_tools()
-        return [await self.get_tool_async(t.name) for t in resp]
+        return [self.tool_model_from_mcp_tool(t) for t in resp]
 
     async def get_mcp_tool_async(self, name: str) -> Optional[Tool]:
         """Find the "original" MCP Tool (i.e. of type mcp.types.Tool) on the server

--- a/tests/main/test_mcp_tools.py
+++ b/tests/main/test_mcp_tools.py
@@ -1299,3 +1299,81 @@ async def test_optional_fields_exclude_none_in_payload() -> None:
     assert captured_payload["pattern"] == "test"
     assert "path" not in captured_payload  # Should be excluded because it's None
     assert "case_insensitive" not in captured_payload  # Should be excluded
+
+
+def _make_list_tools_counter(monkeypatch: pytest.MonkeyPatch) -> Callable[[], int]:
+    """Patch fastmcp's Client.list_tools to count real tools/list round-trips.
+
+    fastmcp's ``Client.list_tools()`` is uncached: every call issues a live
+    ``tools/list`` request over the transport. Counting invocations therefore
+    measures the actual number of server round-trips.
+
+    Returns a zero-arg callable returning the current count.
+    """
+    from fastmcp.client import Client
+
+    original_list_tools = Client.list_tools
+    count = 0
+
+    async def counting_list_tools(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal count
+        count += 1
+        return await original_list_tools(self, *args, **kwargs)
+
+    monkeypatch.setattr(Client, "list_tools", counting_list_tools)
+    return lambda: count
+
+
+@pytest.mark.asyncio
+async def test_get_tools_async_single_list_tools_roundtrip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Benchmark/regression: building ALL tools via get_tools_async must issue
+    exactly ONE ``tools/list`` round-trip, regardless of the number of tools.
+
+    Before the fix, get_tools_async did ``1 + N`` round-trips: one initial
+    ``list_tools()`` plus one re-list per tool inside
+    ``get_tool_async -> get_mcp_tool_async``. This test fails on that old
+    behavior (observed count == 1 + N) and passes on the de-duplicated path.
+    """
+    server = mcp_server()
+    get_count = _make_list_tools_counter(monkeypatch)
+
+    tools = await get_tools_async(server)
+
+    n = len(tools)
+    assert n > 1, "Test server should expose several tools"
+    assert get_count() == 1, (
+        f"Expected exactly 1 list_tools() round-trip to build {n} tools, "
+        f"but observed {get_count()} (pre-fix behavior would be {1 + n})."
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_model_from_mcp_tool_no_extra_roundtrips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public sync builder ``tool_model_from_mcp_tool`` must add zero
+    round-trips: a filtered subset can be built from a single ``list_tools()``
+    snapshot. This is the O(1) path for allow-list / subset consumers.
+    """
+    server = mcp_server()
+    get_count = _make_list_tools_counter(monkeypatch)
+
+    allowed = {"greet", "nabroski"}
+    async with FastMCPClient(server) as client:
+        assert client.client is not None
+        server_tools = await client.client.list_tools()  # the ONLY round-trip
+        subset = [
+            client.tool_model_from_mcp_tool(t)
+            for t in server_tools
+            if t.name in allowed
+        ]
+
+    assert get_count() == 1, (
+        f"Building a {len(subset)}-tool subset should need 1 list_tools() "
+        f"call, but observed {get_count()}."
+    )
+    assert {t.default_value("request") for t in subset} == allowed
+    for t in subset:
+        assert issubclass(t, lr.ToolMessage)


### PR DESCRIPTION
FastMCPClient.get_tools_async() issued 1 + N tools/list round-trips to build N tools: one initial list_tools(), then one more inside get_tool_async -> get_mcp_tool_async for every tool, each re-fetching the entire tool list only to pick one entry by name. Because fastmcp's Client.list_tools() is uncached, every call is a real round-trip, so tool init was O(N) network calls -- the bulk of init latency on slow/remote servers with many tools.

Split the network fetch from the (pure, synchronous, network-free) schema-to-ToolMessage conversion:

- Add public FastMCPClient.tool_model_from_mcp_tool(target): builds a ToolMessage subclass from an already-fetched mcp.types.Tool with no round-trip. Exposing it lets subset/allow-list consumers convert a filtered list_tools() snapshot without re-listing once per tool.
- get_tool_async() fetches the target, then delegates to the builder (single-tool path keeps its unavoidable 1-list floor).
- get_tools_async() lists once and maps the builder over the result, taking it from 1 + N to 1 round-trip.

Behavior is preserved: same Tool objects, same generated models, no public signature changes. It also removes the latent inconsistency of re-listing a server whose tool list could change between the N calls.

Add tests that count real list_tools() round-trips: get_tools_async must issue exactly one regardless of tool count, and the public builder must add zero round-trips when building a filtered subset from one snapshot.