### PR TITLE
perf(mcp): single list_tools() round-trip for tool init (+ hardening, tests, docs)

### DIFF
--- a/docs/notes/mcp-tools.md
+++ b/docs/notes/mcp-tools.md
@@ -434,3 +434,28 @@ async def main():
 ```
 
 See [`exa-web-search.py`](https://github.com/langroid/langroid/blob/main/examples/mcp/exa-web-search.py) for a full working example of this. 
+
+---
+
+## Efficient bulk tool creation
+
+`FastMCPClient.get_tools_async()` builds all Langroid tool classes with a single
+`list_tools()` round-trip. Previously it used `1 + N` calls: one list plus one
+re-list per tool, which slowed tool-init on slow or remote MCP servers exposing
+many tools.
+
+The public, synchronous, network-free helper
+`FastMCPClient.tool_model_from_mcp_tool(target)` converts an already-fetched
+`mcp.types.Tool` into a Langroid `ToolMessage` subclass with no round-trip. Use
+it to build an allow-listed subset from a single `list_tools()` snapshot without
+re-listing the server per tool.
+
+```python
+from langroid.agent.tools.mcp.fastmcp_client import FastMCPClient
+
+
+async with FastMCPClient(server) as client:
+    tools = await client.client.list_tools()
+    wanted = [t for t in tools if t.name in {"search", "fetch"}]
+    models = [client.tool_model_from_mcp_tool(t) for t in wanted]
+```

--- a/langroid/agent/tools/mcp/fastmcp_client.py
+++ b/langroid/agent/tools/mcp/fastmcp_client.py
@@ -238,7 +238,7 @@ class FastMCPClient:
             )
 
     def _schema_to_field(
-        self, name: str, schema: Dict[str, Any], prefix: str, is_required: bool = True
+        self, name: str, schema: Any, prefix: str, is_required: bool = True
     ) -> Tuple[Any, Any]:
         """Convert a JSON Schema snippet into a (type, Field) tuple.
 
@@ -251,6 +251,10 @@ class FastMCPClient:
         Returns:
             A tuple of (python_type, Field(...)) for create_model.
         """
+        if not isinstance(schema, dict):
+            default = ... if is_required else None
+            return Any, Field(default=default)
+
         t = schema.get("type")
         # Use schema default if present, otherwise:
         # ... for required fields, None for optional fields
@@ -263,9 +267,17 @@ class FastMCPClient:
         if t == "object" and "properties" in schema:
             sub_name = f"{prefix}_{name.capitalize()}"
             sub_fields: Dict[str, Tuple[type, Any]] = {}
+            nested_properties = schema.get("properties")
+            if not isinstance(nested_properties, dict):
+                nested_properties = {}
             # Get required fields for this nested object
-            nested_required = set(schema.get("required", []))
-            for k, sub_s in schema["properties"].items():
+            nested_required_list = schema.get("required", [])
+            if not isinstance(nested_required_list, list):
+                nested_required_list = []
+            nested_required = {
+                name for name in nested_required_list if isinstance(name, str)
+            }
+            for k, sub_s in nested_properties.items():
                 ftype, fld = self._schema_to_field(
                     sub_name + k, sub_s, sub_name, is_required=k in nested_required
                 )
@@ -280,7 +292,8 @@ class FastMCPClient:
             return model_type, Field(default=default, description=desc)  # type: ignore
         # Array → List of items
         if t == "array" and "items" in schema:
-            item_type, _ = self._schema_to_field(name, schema["items"], prefix)
+            items_schema = schema.get("items")
+            item_type, _ = self._schema_to_field(name, items_schema, prefix)
             array_type = List[item_type]  # type: ignore
             if not is_required:
                 array_type = Optional[array_type]  # type: ignore
@@ -339,18 +352,31 @@ class FastMCPClient:
         Returns:
             A dynamically created Langroid ToolMessage subclass for `target`.
         """
-        props = target.inputSchema.get("properties", {})
+        tool_name = getattr(target, "name", None)
+        if not isinstance(tool_name, str) or tool_name == "":
+            raise ValueError(f"Invalid MCP tool name for tool {target!r}")
+
+        input_schema = getattr(target, "inputSchema", None)
+        schema = input_schema if isinstance(input_schema, dict) else {}
+        props = schema.get("properties") or {}
+        if not isinstance(props, dict):
+            props = {}
         # Get the list of required fields from JSON Schema
-        required_fields = set(target.inputSchema.get("required", []))
+        required_fields = schema.get("required") or []
+        if not isinstance(required_fields, list):
+            required_fields = []
+        required_field_names = {
+            name for name in required_fields if isinstance(name, str)
+        }
         fields: Dict[str, Tuple[type, Any]] = {}
         for fname, schema in props.items():
             ftype, fld = self._schema_to_field(
-                fname, schema, target.name, is_required=fname in required_fields
+                fname, schema, tool_name, is_required=fname in required_field_names
             )
             fields[fname] = (ftype, fld)
 
         # Convert target.name to CamelCase and add Tool suffix
-        parts = target.name.replace("-", "_").split("_")
+        parts = tool_name.replace("-", "_").split("_")
         camel_case = "".join(part.capitalize() for part in parts)
         model_name = f"{camel_case}Tool"
 
@@ -377,8 +403,11 @@ class FastMCPClient:
             Type[ToolMessage],
             create_model(  # type: ignore[call-overload]
                 model_name,
-                request=(str, target.name),
-                purpose=(str, target.description or f"Use the tool {target.name}"),
+                request=(str, tool_name),
+                purpose=(
+                    str,
+                    getattr(target, "description", None) or f"Use the tool {tool_name}",
+                ),
                 __base__=ToolMessage,
                 **fields,
             ),
@@ -427,7 +456,9 @@ class FastMCPClient:
                 if new in payload:
                     payload[orig] = payload.pop(new)
 
-            client_cfg = getattr(itself.__class__, "_client_config", None)  # type: ignore
+            client_cfg = getattr(  # type: ignore
+                itself.__class__, "_client_config", None
+            )
             if not client_cfg:
                 # Fallback or error - ideally _client_config should always exist
                 raise RuntimeError(f"Client config missing on {itself.__class__}")

--- a/langroid/agent/tools/mcp/fastmcp_client.py
+++ b/langroid/agent/tools/mcp/fastmcp_client.py
@@ -321,6 +321,24 @@ class FastMCPClient:
         target = await self.get_mcp_tool_async(tool_name)
         if target is None:
             raise ValueError(f"No tool named {tool_name}")
+        return self.tool_model_from_mcp_tool(target)
+
+    def tool_model_from_mcp_tool(self, target: Tool) -> Type[ToolMessage]:
+        """
+        Build a Langroid ToolMessage subclass from an already-fetched MCP
+        `Tool` object.
+
+        This is a pure, synchronous, network-free conversion: it performs no
+        ``list_tools()`` round-trip. Pair it with a single ``list_tools()`` call
+        to build many tools without re-listing the server once per tool
+        (see :meth:`get_tools_async`).
+
+        Args:
+            target: The raw ``mcp.types.Tool`` (name, description, inputSchema).
+
+        Returns:
+            A dynamically created Langroid ToolMessage subclass for `target`.
+        """
         props = target.inputSchema.get("properties", {})
         # Get the list of required fields from JSON Schema
         required_fields = set(target.inputSchema.get("required", []))
@@ -476,7 +494,7 @@ class FastMCPClient:
                     "Client not initialized. Use async with FastMCPClient."
                 )
         resp = await self.client.list_tools()
-        return [await self.get_tool_async(t.name) for t in resp]
+        return [self.tool_model_from_mcp_tool(t) for t in resp]
 
     async def get_mcp_tool_async(self, name: str) -> Optional[Tool]:
         """Find the "original" MCP Tool (i.e. of type mcp.types.Tool) on the server

--- a/tests/main/test_mcp_tools.py
+++ b/tests/main/test_mcp_tools.py
@@ -1299,3 +1299,81 @@ async def test_optional_fields_exclude_none_in_payload() -> None:
     assert captured_payload["pattern"] == "test"
     assert "path" not in captured_payload  # Should be excluded because it's None
     assert "case_insensitive" not in captured_payload  # Should be excluded
+
+
+def _make_list_tools_counter(monkeypatch: pytest.MonkeyPatch) -> Callable[[], int]:
+    """Patch fastmcp's Client.list_tools to count real tools/list round-trips.
+
+    fastmcp's ``Client.list_tools()`` is uncached: every call issues a live
+    ``tools/list`` request over the transport. Counting invocations therefore
+    measures the actual number of server round-trips.
+
+    Returns a zero-arg callable returning the current count.
+    """
+    from fastmcp.client import Client
+
+    original_list_tools = Client.list_tools
+    count = 0
+
+    async def counting_list_tools(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal count
+        count += 1
+        return await original_list_tools(self, *args, **kwargs)
+
+    monkeypatch.setattr(Client, "list_tools", counting_list_tools)
+    return lambda: count
+
+
+@pytest.mark.asyncio
+async def test_get_tools_async_single_list_tools_roundtrip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Benchmark/regression: building ALL tools via get_tools_async must issue
+    exactly ONE ``tools/list`` round-trip, regardless of the number of tools.
+
+    Before the fix, get_tools_async did ``1 + N`` round-trips: one initial
+    ``list_tools()`` plus one re-list per tool inside
+    ``get_tool_async -> get_mcp_tool_async``. This test fails on that old
+    behavior (observed count == 1 + N) and passes on the de-duplicated path.
+    """
+    server = mcp_server()
+    get_count = _make_list_tools_counter(monkeypatch)
+
+    tools = await get_tools_async(server)
+
+    n = len(tools)
+    assert n > 1, "Test server should expose several tools"
+    assert get_count() == 1, (
+        f"Expected exactly 1 list_tools() round-trip to build {n} tools, "
+        f"but observed {get_count()} (pre-fix behavior would be {1 + n})."
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_model_from_mcp_tool_no_extra_roundtrips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public sync builder ``tool_model_from_mcp_tool`` must add zero
+    round-trips: a filtered subset can be built from a single ``list_tools()``
+    snapshot. This is the O(1) path for allow-list / subset consumers.
+    """
+    server = mcp_server()
+    get_count = _make_list_tools_counter(monkeypatch)
+
+    allowed = {"greet", "nabroski"}
+    async with FastMCPClient(server) as client:
+        assert client.client is not None
+        server_tools = await client.client.list_tools()  # the ONLY round-trip
+        subset = [
+            client.tool_model_from_mcp_tool(t)
+            for t in server_tools
+            if t.name in allowed
+        ]
+
+    assert get_count() == 1, (
+        f"Building a {len(subset)}-tool subset should need 1 list_tools() "
+        f"call, but observed {get_count()}."
+    )
+    assert {t.default_value("request") for t in subset} == allowed
+    for t in subset:
+        assert issubclass(t, lr.ToolMessage)

--- a/tests/main/test_mcp_tools.py
+++ b/tests/main/test_mcp_tools.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import shutil
-from typing import Callable, List, Optional
+from typing import Any, Callable, List, Optional, Type
 
 import pytest
 from anyio import ClosedResourceError
@@ -1315,13 +1315,33 @@ def _make_list_tools_counter(monkeypatch: pytest.MonkeyPatch) -> Callable[[], in
     original_list_tools = Client.list_tools
     count = 0
 
-    async def counting_list_tools(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+    async def counting_list_tools(self: Any, *args: Any, **kwargs: Any) -> Any:
         nonlocal count
         count += 1
         return await original_list_tools(self, *args, **kwargs)
 
     monkeypatch.setattr(Client, "list_tools", counting_list_tools)
     return lambda: count
+
+
+def _tool_model_signature(model: Type[lr.ToolMessage]) -> dict[str, Any]:
+    """Capture behaviorally relevant generated ToolMessage model details."""
+    fields = [
+        (
+            name,
+            repr(field.annotation),
+            repr(field.default),
+            field.is_required(),
+            field.description,
+        )
+        for name, field in model.model_fields.items()
+    ]
+    return {
+        "model_name": model.__name__,
+        "request": model.default_value("request"),
+        "fields": fields,
+        "renamed_fields": getattr(model, "_renamed_fields", {}),
+    }
 
 
 @pytest.mark.asyncio
@@ -1377,3 +1397,176 @@ async def test_tool_model_from_mcp_tool_no_extra_roundtrips(
     assert {t.default_value("request") for t in subset} == allowed
     for t in subset:
         assert issubclass(t, lr.ToolMessage)
+
+
+@pytest.mark.asyncio
+async def test_get_tools_async_matches_per_tool_model_generation() -> None:
+    """Bulk and per-tool MCP conversion must generate equivalent models."""
+    server = mcp_server()
+
+    bulk_tools = await get_tools_async(server)
+
+    async with FastMCPClient(server) as client:
+        assert client.client is not None
+        server_tools = await client.client.list_tools()
+        per_tools = [await client.get_tool_async(t.name) for t in server_tools]
+        per_tool_by_name = {tool.default_value("request"): tool for tool in per_tools}
+
+    assert [tool.default_value("request") for tool in bulk_tools] == [
+        t.name for t in server_tools
+    ]
+    assert len(per_tool_by_name) == len(server_tools)
+    for bulk_tool in bulk_tools:
+        request = bulk_tool.default_value("request")
+        assert _tool_model_signature(bulk_tool) == _tool_model_signature(
+            per_tool_by_name[request]
+        )
+
+
+def test_tool_model_from_mcp_tool_handles_missing_or_invalid_schema() -> None:
+    """Schema-less or malformed schemas should behave like empty schemas."""
+    client = FastMCPClient(mcp_server())
+
+    for input_schema in [None, [], "not-a-schema", {"properties": None}]:
+        tool = Tool.model_construct(
+            name="schema_less",
+            description="Schema-less tool",
+            inputSchema=input_schema,
+        )
+
+        tool_model = client.tool_model_from_mcp_tool(tool)
+
+        assert tool_model.default_value("request") == "schema_less"
+        assert tool_model.default_value("purpose") == "Schema-less tool"
+        assert list(tool_model.model_fields) == ["request", "purpose", "id"]
+
+    omitted_schema_tool = Tool.model_construct(
+        name="omitted_schema",
+        description="Omitted schema tool",
+    )
+
+    tool_model = client.tool_model_from_mcp_tool(omitted_schema_tool)
+
+    assert tool_model.default_value("request") == "omitted_schema"
+    assert tool_model.default_value("purpose") == "Omitted schema tool"
+    assert list(tool_model.model_fields) == ["request", "purpose", "id"]
+
+
+def test_tool_model_from_mcp_tool_handles_omitted_description() -> None:
+    """Missing descriptions should use the default generated purpose."""
+    client = FastMCPClient(mcp_server())
+    tool = Tool.model_construct(
+        name="missing_description",
+        inputSchema={},
+    )
+
+    tool_model = client.tool_model_from_mcp_tool(tool)
+
+    assert tool_model.default_value("request") == "missing_description"
+    assert tool_model.default_value("purpose") == "Use the tool missing_description"
+    assert list(tool_model.model_fields) == ["request", "purpose", "id"]
+
+
+def test_tool_model_from_mcp_tool_rejects_invalid_names() -> None:
+    """Missing or empty MCP tool names should fail with a clear error."""
+    client = FastMCPClient(mcp_server())
+
+    for tool_name in [None, ""]:
+        tool = Tool.model_construct(
+            name=tool_name,
+            description="Bad name",
+            inputSchema={},
+        )
+
+        with pytest.raises(ValueError, match="Invalid MCP tool name"):
+            client.tool_model_from_mcp_tool(tool)
+
+    omitted_name_tool = Tool.model_construct(
+        description="Bad name",
+        inputSchema={},
+    )
+
+    with pytest.raises(ValueError, match="Invalid MCP tool name"):
+        client.tool_model_from_mcp_tool(omitted_name_tool)
+
+
+def test_tool_model_from_mcp_tool_handles_malformed_property_schemas() -> None:
+    """Malformed field schemas should degrade to permissive fields."""
+    client = FastMCPClient(mcp_server())
+    tool = Tool.model_construct(
+        name="malformed_properties",
+        description="Malformed properties",
+        inputSchema={
+            "properties": {
+                "null_field": None,
+                "list_field": [],
+                "object_field": {
+                    "type": "object",
+                    "properties": None,
+                    "required": None,
+                },
+                "array_field": {
+                    "type": "array",
+                    "items": None,
+                },
+                "nested_field": {
+                    "type": "object",
+                    "properties": {
+                        "child": None,
+                        "other": {
+                            "type": "string",
+                        },
+                    },
+                    "required": [{}, "child"],
+                },
+            },
+            "required": [{}, "null_field"],
+        },
+    )
+
+    tool_model = client.tool_model_from_mcp_tool(tool)
+
+    assert tool_model.default_value("request") == "malformed_properties"
+    assert list(tool_model.model_fields) == [
+        "request",
+        "purpose",
+        "id",
+        "null_field",
+        "list_field",
+        "object_field",
+        "array_field",
+        "nested_field",
+    ]
+    payload = tool_model(
+        null_field="anything",
+        list_field=123,
+        object_field={},
+        array_field=[object()],
+        nested_field={"child": object()},
+    )
+    assert payload.null_field == "anything"
+    assert payload.list_field == 123
+    assert payload.object_field.model_dump() == {}
+    assert payload.array_field
+    assert payload.nested_field.child is not None
+
+
+@pytest.mark.asyncio
+async def test_get_tools_async_rejects_invalid_tool_name() -> None:
+    """The optimized bulk path should report invalid tool names clearly."""
+    bad_tool = Tool.model_construct(
+        name=None,
+        description="Bad name",
+        inputSchema={},
+    )
+
+    async with FastMCPClient(mcp_server()) as client:
+        assert client.client is not None
+
+        async def list_tools() -> list[Tool]:
+            return [bad_tool]
+
+        client.client.list_tools = list_tools  # type: ignore[method-assign]
+
+        with pytest.raises(ValueError, match="Invalid MCP tool name"):
+            await client.get_tools_async()


### PR DESCRIPTION
Supersedes #1053 by @alexagr — takes over that PR with added robustness, tests,
and docs. Alex's original perf work and commit are preserved and credited on
this branch.

## What this does

`FastMCPClient.get_tools_async()` previously issued `1 + N` `tools/list`
round-trips to build N tools: one initial `list_tools()`, then one more re-list
per tool inside `get_tool_async → get_mcp_tool_async` (which fetched the whole
list only to pick one entry by name). Since fastmcp's `Client.list_tools()` is
uncached, every call is a real round-trip, so tool init was O(N) network
calls — the bulk of init latency on slow/remote servers with many tools.

The network fetch is split from the pure, synchronous, network-free
schema→`ToolMessage` conversion:

- New public `FastMCPClient.tool_model_from_mcp_tool(target)` builds a
  `ToolMessage` subclass from an already-fetched `mcp.types.Tool` with **no**
  round-trip. Allow-list / subset consumers can convert a filtered
  `list_tools()` snapshot without re-listing the server once per tool.
- `get_tool_async()` fetches the target `Tool`, then delegates to the builder.
- `get_tools_async()` lists **once** and maps the builder over the result →
  **1 round-trip total** (was `1 + N`).

Behavior for well-formed tools is unchanged: same `Tool` objects, same
generated models, no public signature changes.

## Added in this takeover (on top of @alexagr's original commit)

- **Robustness.** `tool_model_from_mcp_tool()` and `_schema_to_field()` now
  tolerate malformed or missing MCP `Tool` metadata that the previous inline
  code dereferenced unguarded: a null / non-`dict` `inputSchema`, missing
  `name` / `inputSchema` / `description` attributes, null nested
  `properties` / `items`, and non-string `required` entries. An invalid tool
  name raises a clear `ValueError`; malformed schemas degrade to permissive
  fields instead of raising `AttributeError` / `TypeError` and failing the
  whole bulk `get_tools_async()` path. (These were pre-existing latent crashes
  in the inline code; hardening them matters more now that the conversion is a
  public method reachable via the bulk path.)
- **Tests** (`tests/main/test_mcp_tools.py`):

    - round-trip counters proving `get_tools_async` issues exactly **one**
      `list_tools()` regardless of tool count (fails on the old `1 + N` path);
    - the public builder adds **zero** round-trips when building a filtered
      subset from a single snapshot;
    - a behavior-**equivalence** test that `get_tools_async` yields the same
      models (names, fields, defaults, renamed fields, order) as calling
      `get_tool_async(name)` per tool — the guarantee the refactor must
      preserve;
    - malformed-schema and invalid-name coverage.

- **Docs.** A note in `docs/notes/mcp-tools.md` on the single-round-trip bulk
  build and the public `tool_model_from_mcp_tool` helper.
- Regenerated `llms*.txt`.

## Testing

`pytest tests/main/test_mcp_tools.py` → **31 passed, 1 xpassed**. `black`,
`ruff`, and `mypy` are clean on the changed source.
