### PR TITLE
feat(mcp): map JSON-Schema enum/const → Literal and anyOf/oneOf → Union for tool params

### DIFF
--- a/langroid/agent/tool_message.py
+++ b/langroid/agent/tool_message.py
@@ -364,9 +364,13 @@ class ToolMessage(ABC, BaseModel):
                     f"the required parameters with correct types"
                 )
 
-        # Handle nested ToolMessage fields
-        if "definitions" in parameters:
-            for v in parameters["definitions"].values():
+        # Handle nested ToolMessage fields.
+        # NOTE: Pydantic v1 emitted nested-model schemas under "definitions";
+        # v2's model_json_schema() emits them under "$defs". This must track the
+        # v2 key or the cleanup below silently no-ops (leaking purpose/id/exclude
+        # and an unconstrained request into the nested schema sent to the LLM).
+        if "$defs" in parameters:
+            for v in parameters["$defs"].values():
                 if "exclude" in v:
                     v.pop("exclude")
 

--- a/langroid/agent/tools/mcp/fastmcp_client.py
+++ b/langroid/agent/tools/mcp/fastmcp_client.py
@@ -66,6 +66,10 @@ FastMCPServerSpec: TypeAlias = (
     FastMCPServerConcrete | Callable[[], FastMCPServerConcrete]
 )
 
+# Sentinel marking a $defs entry that is currently being resolved into a model,
+# used to break reference cycles when converting JSON-Schema $ref nodes.
+_REF_IN_PROGRESS = object()
+
 
 class FastMCPClient:
     """A client for interacting with a FastMCP server.
@@ -250,7 +254,13 @@ class FastMCPClient:
             )
 
     def _schema_to_field(
-        self, name: str, schema: Any, prefix: str, is_required: bool = True
+        self,
+        name: str,
+        schema: Any,
+        prefix: str,
+        is_required: bool = True,
+        defs: Optional[Dict[str, Any]] = None,
+        ref_cache: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, Any]:
         """Convert a JSON Schema snippet into a (type, Field) tuple.
 
@@ -259,10 +269,22 @@ class FastMCPClient:
             schema: JSON Schema for this field.
             prefix: Prefix to use for nested model names.
             is_required: Whether this field is required (from JSON Schema "required").
+            defs: The tool schema's ``$defs`` registry, used to resolve ``$ref``
+                nodes into nested models. fastmcp emits pydantic-model params
+                (and their nested/union/array members) as a local ``$ref`` into
+                ``$defs``.
+            ref_cache: Per-tool cache mapping a ``$defs`` name to its already
+                built type, so shared models are reused and reference cycles can
+                be detected (a name mapped to ``_REF_IN_PROGRESS`` is currently
+                being resolved).
 
         Returns:
             A tuple of (python_type, Field(...)) for create_model.
         """
+        if defs is None:
+            defs = {}
+        if ref_cache is None:
+            ref_cache = {}
         if not isinstance(schema, dict):
             default = ... if is_required else None
             return Any, Field(default=default)
@@ -275,6 +297,37 @@ class FastMCPClient:
         else:
             default = ... if is_required else None
         desc = schema.get("description")
+        # $ref → resolve against $defs and build a nested model. fastmcp emits
+        # pydantic-model params (and nested/union/array members) as a local
+        # ``$ref`` like "#/$defs/Address"; without resolution these degrade to
+        # the permissive `Any` fallback below. A ref to an unknown def, or one
+        # hit while that same def is still being resolved (a cycle), falls back
+        # to `Any`. Resolved types are cached per tool so shared defs are built
+        # once and reused.
+        ref = schema.get("$ref")
+        if isinstance(ref, str):
+            def_name = ref.rsplit("/", 1)[-1]
+            if def_name in ref_cache:
+                cached = ref_cache[def_name]
+                if cached is _REF_IN_PROGRESS:
+                    return Any, Field(default=default, description=desc)
+                ref_type = cached if is_required else Optional[cached]
+                return ref_type, Field(default=default, description=desc)
+            resolved = defs.get(def_name)
+            if not isinstance(resolved, dict):
+                return Any, Field(default=default, description=desc)
+            ref_cache[def_name] = _REF_IN_PROGRESS
+            built, _ = self._schema_to_field(
+                def_name,
+                resolved,
+                prefix,
+                is_required=True,
+                defs=defs,
+                ref_cache=ref_cache,
+            )
+            ref_cache[def_name] = built
+            ref_type = built if is_required else Optional[built]
+            return ref_type, Field(default=default, description=desc)
         # Enum / const → Literal, but only for Literal-compatible scalar values
         # (str/int/bool/None). This takes precedence over the plain `type`
         # branches so the allowed values are preserved for validation and echoed
@@ -312,7 +365,12 @@ class FastMCPClient:
             }
             for k, sub_s in nested_properties.items():
                 ftype, fld = self._schema_to_field(
-                    sub_name + k, sub_s, sub_name, is_required=k in nested_required
+                    sub_name + k,
+                    sub_s,
+                    sub_name,
+                    is_required=k in nested_required,
+                    defs=defs,
+                    ref_cache=ref_cache,
                 )
                 sub_fields[k] = (ftype, fld)
             submodel = create_model(  # type: ignore
@@ -326,7 +384,9 @@ class FastMCPClient:
         # Array → List of items
         if t == "array" and "items" in schema:
             items_schema = schema.get("items")
-            item_type, _ = self._schema_to_field(name, items_schema, prefix)
+            item_type, _ = self._schema_to_field(
+                name, items_schema, prefix, defs=defs, ref_cache=ref_cache
+            )
             array_type = List[item_type]  # type: ignore
             if not is_required:
                 array_type = Optional[array_type]  # type: ignore
@@ -357,7 +417,14 @@ class FastMCPClient:
             has_null = len(non_null) != len(sub_schemas)
             if non_null:
                 member_types = tuple(
-                    self._schema_to_field(name, s, prefix, is_required=True)[0]
+                    self._schema_to_field(
+                        name,
+                        s,
+                        prefix,
+                        is_required=True,
+                        defs=defs,
+                        ref_cache=ref_cache,
+                    )[0]
                     for s in non_null
                 )
                 union_type = Union[member_types]  # type: ignore
@@ -370,7 +437,12 @@ class FastMCPClient:
         all_of = schema.get("allOf")
         if isinstance(all_of, list) and len(all_of) == 1:
             inner_type, _ = self._schema_to_field(
-                name, all_of[0], prefix, is_required=is_required
+                name,
+                all_of[0],
+                prefix,
+                is_required=is_required,
+                defs=defs,
+                ref_cache=ref_cache,
             )
             return inner_type, Field(default=default, description=desc)
         if all_of:
@@ -423,6 +495,15 @@ class FastMCPClient:
         props = schema.get("properties") or {}
         if not isinstance(props, dict):
             props = {}
+        # Registry of shared subschemas ($defs), used to resolve $ref nodes such
+        # as pydantic-model params. Captured before the loop below shadows
+        # `schema` with each property's schema.
+        defs = schema.get("$defs")
+        if not isinstance(defs, dict):
+            defs = {}
+        # Cache of resolved $ref types, shared across all properties so a def
+        # referenced by several params is built once and reused.
+        ref_cache: Dict[str, Any] = {}
         # Get the list of required fields from JSON Schema
         required_fields = schema.get("required") or []
         if not isinstance(required_fields, list):
@@ -433,7 +514,12 @@ class FastMCPClient:
         fields: Dict[str, Tuple[type, Any]] = {}
         for fname, schema in props.items():
             ftype, fld = self._schema_to_field(
-                fname, schema, tool_name, is_required=fname in required_field_names
+                fname,
+                schema,
+                tool_name,
+                is_required=fname in required_field_names,
+                defs=defs,
+                ref_cache=ref_cache,
             )
             fields[fname] = (ftype, fld)
 

--- a/langroid/agent/tools/mcp/fastmcp_client.py
+++ b/langroid/agent/tools/mcp/fastmcp_client.py
@@ -284,8 +284,13 @@ class FastMCPClient:
         enum_values = schema.get(
             "enum", [schema["const"]] if "const" in schema else None
         )
-        if enum_values and all(
-            isinstance(v, (str, int, bool)) or v is None for v in enum_values
+        # `enum` must be a list per JSON Schema; guard against malformed
+        # metadata (e.g. a bare scalar) so it degrades to type-based handling
+        # instead of raising when we iterate.
+        if (
+            isinstance(enum_values, list)
+            and enum_values
+            and all(isinstance(v, (str, int, bool)) or v is None for v in enum_values)
         ):
             literal_type = Literal[tuple(enum_values)]  # type: ignore[valid-type]
             if not is_required:

--- a/langroid/agent/tools/mcp/fastmcp_client.py
+++ b/langroid/agent/tools/mcp/fastmcp_client.py
@@ -15,6 +15,7 @@ from typing import (
     Tuple,
     Type,
     TypeAlias,
+    Union,
     cast,
 )
 
@@ -338,10 +339,39 @@ class FastMCPClient:
         if t == "boolean":
             bool_type = bool if is_required else Optional[bool]
             return bool_type, Field(default=default, description=desc)
-        # Fallback or unions
-        if any(key in schema for key in ("oneOf", "anyOf", "allOf")):
-            self.logger.warning("Unsupported union schema in field %s; using Any", name)
+        # anyOf / oneOf → Union (typing has no XOR, so oneOf also maps to
+        # Union). A `{"type": "null"}` branch — or an optional field — makes the
+        # result Optional. Each branch is converted recursively.
+        sub_schemas = schema.get("anyOf") or schema.get("oneOf")
+        if isinstance(sub_schemas, list) and sub_schemas:
+            non_null = [
+                s
+                for s in sub_schemas
+                if not (isinstance(s, dict) and s.get("type") == "null")
+            ]
+            has_null = len(non_null) != len(sub_schemas)
+            if non_null:
+                member_types = tuple(
+                    self._schema_to_field(name, s, prefix, is_required=True)[0]
+                    for s in non_null
+                )
+                union_type = Union[member_types]  # type: ignore
+                if has_null or not is_required:
+                    union_type = Optional[union_type]  # type: ignore
+                return union_type, Field(default=default, description=desc)
+
+        # allOf: a single subschema is just that schema; a multi-schema
+        # intersection has no clean typing analogue, so fall back to Any.
+        all_of = schema.get("allOf")
+        if isinstance(all_of, list) and len(all_of) == 1:
+            inner_type, _ = self._schema_to_field(
+                name, all_of[0], prefix, is_required=is_required
+            )
+            return inner_type, Field(default=default, description=desc)
+        if all_of:
+            self.logger.warning("Unsupported allOf schema in field %s; using Any", name)
             return Any, Field(default=default, description=desc)
+
         # Default fallback
         return Any, Field(default=default, description=desc)
 

--- a/langroid/agent/tools/mcp/fastmcp_client.py
+++ b/langroid/agent/tools/mcp/fastmcp_client.py
@@ -5,7 +5,18 @@ import logging
 import os
 from base64 import b64decode
 from io import BytesIO
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeAlias, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    TypeAlias,
+    cast,
+)
 
 from dotenv import load_dotenv
 from fastmcp.client import Client
@@ -263,6 +274,22 @@ class FastMCPClient:
         else:
             default = ... if is_required else None
         desc = schema.get("description")
+        # Enum / const → Literal, but only for Literal-compatible scalar values
+        # (str/int/bool/None). This takes precedence over the plain `type`
+        # branches so the allowed values are preserved for validation and echoed
+        # back into the model's JSON schema (which the LLM sees). JSON-Schema
+        # enums may also hold floats or objects, which Literal rejects; those
+        # fall through to the type-based handling below.
+        enum_values = schema.get(
+            "enum", [schema["const"]] if "const" in schema else None
+        )
+        if enum_values and all(
+            isinstance(v, (str, int, bool)) or v is None for v in enum_values
+        ):
+            literal_type = Literal[tuple(enum_values)]  # type: ignore[valid-type]
+            if not is_required:
+                literal_type = Optional[literal_type]  # type: ignore[assignment]
+            return literal_type, Field(default=default, description=desc)
         # Object → nested BaseModel
         if t == "object" and "properties" in schema:
             sub_name = f"{prefix}_{name.capitalize()}"

--- a/tests/main/test_mcp_tools.py
+++ b/tests/main/test_mcp_tools.py
@@ -1758,3 +1758,138 @@ async def test_literal_union_convert_to_openai_tool_spec() -> None:
         "string",
     }
     assert set(strict["required"]) == {"color", "quantity", "size", "request"}
+
+
+@pytest.mark.asyncio
+async def test_nested_model_param_resolves_ref() -> None:
+    """A pydantic-model tool param is emitted by fastmcp as a ``$ref`` into
+    ``$defs``. The converter resolves it into a nested model (instead of
+    degrading to ``Any``), so nested data validates and the constraint is
+    echoed into the LLM-facing schema as ``$defs``/``$ref``.
+    """
+    from pydantic import ValidationError
+
+    class Geo(BaseModel):
+        lat: float
+        lon: float
+
+    class Address(BaseModel):
+        street: str
+        zip_code: int
+        geo: Optional[Geo] = None
+
+    server = FastMCP("NestedServer")
+
+    @server.tool()
+    def set_address(address: Address) -> str:
+        """Set an address."""
+        return address.street
+
+    AddrTool = await get_tool_async(server, "set_address")
+
+    # The `address` field is a real nested model, not Any.
+    addr_type = AddrTool.model_fields["address"].annotation
+    assert isinstance(addr_type, type) and issubclass(addr_type, BaseModel)
+
+    # Nested (incl. doubly-nested Geo) data validates and coerces into models.
+    msg = AddrTool(
+        address={"street": "Main", "zip_code": 12345, "geo": {"lat": 1.0, "lon": 2.0}}
+    )
+    assert msg.address.street == "Main"
+    assert msg.address.geo is not None and msg.address.geo.lat == 1.0
+
+    # A missing required nested field is rejected by validation.
+    with pytest.raises(ValidationError):
+        AddrTool(address={"street": "Main"})  # zip_code missing
+
+    # The LLM-facing tool schema resolves the model via $defs/$ref, not Any.
+    params = AddrTool.llm_function_schema(request=True).parameters
+    assert "$ref" in params["properties"]["address"]
+    ref_name = params["properties"]["address"]["$ref"].split("/")[-1]
+    assert ref_name in params["$defs"]
+
+
+@pytest.mark.asyncio
+async def test_union_and_list_of_model_params_resolve_refs() -> None:
+    """``$ref`` nodes inside ``anyOf`` (union of models) and ``items`` (list of
+    models) are resolved into nested models too.
+    """
+    from typing import Union, get_args, get_origin
+
+    class Address(BaseModel):
+        street: str
+        zip_code: int
+
+    class POBox(BaseModel):
+        box: int
+
+    server = FastMCP("UnionModelServer")
+
+    @server.tool()
+    def deliver(loc: Union[Address, POBox]) -> str:
+        """Deliver to one of two location kinds."""
+        return "ok"
+
+    @server.tool()
+    def deliver_many(addrs: List[Address]) -> str:
+        """Deliver to many addresses."""
+        return "ok"
+
+    # Union[Address, POBox] -> Union of two nested models
+    DeliverTool = await get_tool_async(server, "deliver")
+    loc_ann = DeliverTool.model_fields["loc"].annotation
+    assert get_origin(loc_ann) is Union
+    members = get_args(loc_ann)
+    assert all(isinstance(m, type) and issubclass(m, BaseModel) for m in members)
+    assert DeliverTool(loc={"box": 7}).loc.box == 7
+    assert DeliverTool(loc={"street": "Main", "zip_code": 1}).loc.street == "Main"
+
+    # List[Address] -> List of a nested model
+    ManyTool = await get_tool_async(server, "deliver_many")
+    addrs_ann = ManyTool.model_fields["addrs"].annotation
+    assert get_origin(addrs_ann) is list
+    (item_type,) = get_args(addrs_ann)
+    assert isinstance(item_type, type) and issubclass(item_type, BaseModel)
+    msg = ManyTool(
+        addrs=[{"street": "A", "zip_code": 1}, {"street": "B", "zip_code": 2}]
+    )
+    assert [a.street for a in msg.addrs] == ["A", "B"]
+
+
+def test_self_referential_model_param_breaks_ref_cycle() -> None:
+    """A ``$defs`` entry that references itself must not recurse forever: the
+    cyclic edge degrades to ``Any`` while the rest of the model is built. Uses
+    a hand-built schema so the cycle is exercised deterministically.
+    """
+    client = FastMCPClient(mcp_server())
+    tool = Tool.model_construct(
+        name="walk",
+        description="Walk a tree.",
+        inputSchema={
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "val": {"type": "integer"},
+                        # self-reference: must not loop forever
+                        "child": {"$ref": "#/$defs/Node"},
+                    },
+                    "required": ["val"],
+                }
+            },
+            "properties": {"root": {"$ref": "#/$defs/Node"}},
+            "required": ["root"],
+            "type": "object",
+        },
+    )
+
+    tool_model = client.tool_model_from_mcp_tool(tool)
+
+    root_type = tool_model.model_fields["root"].annotation
+    assert isinstance(root_type, type) and issubclass(root_type, BaseModel)
+    # Non-cyclic field is preserved with its real type.
+    assert root_type.model_fields["val"].annotation is int
+    # Nested data still validates; the cyclic `child` edge is permissive (Any).
+    inst = tool_model(root={"val": 1, "child": {"val": 2}})
+    assert inst.root.val == 1
+    assert inst.root.child == {"val": 2}

--- a/tests/main/test_mcp_tools.py
+++ b/tests/main/test_mcp_tools.py
@@ -1490,6 +1490,32 @@ def test_tool_model_from_mcp_tool_rejects_invalid_names() -> None:
         client.tool_model_from_mcp_tool(omitted_name_tool)
 
 
+def test_tool_model_from_mcp_tool_handles_malformed_enum() -> None:
+    """A non-list ``enum`` (malformed metadata, since JSON Schema requires an
+    array) must degrade to type-based handling instead of raising when we
+    iterate it — consistent with the converter's other defensive fallbacks.
+    """
+    client = FastMCPClient(mcp_server())
+    tool = Tool.model_construct(
+        name="malformed_enum",
+        description="Malformed enum",
+        inputSchema={
+            "properties": {
+                # `enum` is a bare scalar, not a list: must not raise.
+                "bad_enum": {"type": "integer", "enum": 1},
+            },
+            "required": ["bad_enum"],
+        },
+    )
+
+    tool_model = client.tool_model_from_mcp_tool(tool)
+
+    assert tool_model.default_value("request") == "malformed_enum"
+    assert "bad_enum" in tool_model.model_fields
+    # Falls through to the "integer" type branch, so an int still validates.
+    assert tool_model(bad_enum=5).bad_enum == 5
+
+
 def test_tool_model_from_mcp_tool_handles_malformed_property_schemas() -> None:
     """Malformed field schemas should degrade to permissive fields."""
     client = FastMCPClient(mcp_server())

--- a/tests/main/test_mcp_tools.py
+++ b/tests/main/test_mcp_tools.py
@@ -1570,3 +1570,44 @@ async def test_get_tools_async_rejects_invalid_tool_name() -> None:
 
         with pytest.raises(ValueError, match="Invalid MCP tool name"):
             await client.get_tools_async()
+
+
+@pytest.mark.asyncio
+async def test_enum_field_becomes_literal() -> None:
+    """A JSON-Schema ``enum`` field maps to ``typing.Literal``: the generated
+    ToolMessage validates only the allowed values and echoes them back in its
+    schema. A ``Literal`` param on the server is emitted by fastmcp as an
+    ``enum`` in the tool's inputSchema, which the converter turns back into a
+    ``Literal``.
+    """
+    from typing import Literal, get_args, get_origin
+
+    from pydantic import ValidationError
+
+    server = FastMCP("EnumServer")
+
+    @server.tool()
+    def set_unit(
+        unit: Literal["celsius", "fahrenheit"],
+    ) -> str:
+        """Set the temperature unit."""
+        return unit
+
+    UnitTool = await get_tool_async(server, "set_unit")
+
+    # The generated field must be a Literal with exactly the allowed values.
+    annotation = UnitTool.model_fields["unit"].annotation
+    assert get_origin(annotation) is Literal
+    assert set(get_args(annotation)) == {"celsius", "fahrenheit"}
+
+    # Allowed value validates and round-trips.
+    msg = UnitTool(unit="celsius")
+    assert msg.unit == "celsius"
+
+    # Disallowed value is rejected by pydantic validation.
+    with pytest.raises(ValidationError):
+        UnitTool(unit="kelvin")
+
+    # The constraint is echoed into the LLM-facing JSON schema.
+    unit_schema = UnitTool.model_json_schema()["properties"]["unit"]
+    assert set(unit_schema.get("enum", [])) == {"celsius", "fahrenheit"}

--- a/tests/main/test_mcp_tools.py
+++ b/tests/main/test_mcp_tools.py
@@ -1611,3 +1611,40 @@ async def test_enum_field_becomes_literal() -> None:
     # The constraint is echoed into the LLM-facing JSON schema.
     unit_schema = UnitTool.model_json_schema()["properties"]["unit"]
     assert set(unit_schema.get("enum", [])) == {"celsius", "fahrenheit"}
+
+
+@pytest.mark.asyncio
+async def test_anyof_maps_to_union_and_optional() -> None:
+    """A JSON-Schema ``anyOf`` maps to ``typing.Union``; an ``anyOf`` that
+    includes ``{"type": "null"}`` (or an optional field) becomes ``Optional``.
+    fastmcp emits ``int | str`` and ``Optional[int]`` params as ``anyOf``.
+    """
+    from typing import Union, get_args, get_origin
+
+    server = FastMCP("UnionServer")
+
+    @server.tool()
+    def choose(value: int | str) -> str:
+        """Echo an int-or-str value."""
+        return str(value)
+
+    @server.tool()
+    def maybe(count: Optional[int] = None) -> str:
+        """Echo an optional count."""
+        return "none" if count is None else str(count)
+
+    # int | str  ->  Union[int, str]
+    ChooseTool = await get_tool_async(server, "choose")
+    choose_ann = ChooseTool.model_fields["value"].annotation
+    assert get_origin(choose_ann) is Union
+    assert set(get_args(choose_ann)) == {int, str}
+    assert ChooseTool(value=5).value == 5
+    assert ChooseTool(value="hi").value == "hi"
+
+    # Optional[int] (anyOf including null)  ->  Union[int, None]
+    MaybeTool = await get_tool_async(server, "maybe")
+    maybe_ann = MaybeTool.model_fields["count"].annotation
+    assert get_origin(maybe_ann) is Union
+    assert set(get_args(maybe_ann)) == {int, type(None)}
+    assert MaybeTool().count is None
+    assert MaybeTool(count=3).count == 3

--- a/tests/main/test_mcp_tools.py
+++ b/tests/main/test_mcp_tools.py
@@ -1674,3 +1674,87 @@ async def test_anyof_maps_to_union_and_optional() -> None:
     assert set(get_args(maybe_ann)) == {int, type(None)}
     assert MaybeTool().count is None
     assert MaybeTool(count=3).count == 3
+
+
+@pytest.mark.asyncio
+async def test_literal_union_convert_to_openai_tool_spec() -> None:
+    """End-to-end: a tool whose params map to ``Literal``/``Union`` must convert
+    cleanly into the OpenAI-facing tool definition.
+
+    The other schema tests stop at pydantic's raw ``model_json_schema()``; this
+    one exercises the layers that actually build the schema sent to the LLM:
+    langroid's ``ToolMessage.llm_function_schema()`` and the strict
+    structured-outputs transform ``format_schema_for_strict()``. Those rebuild
+    ``required``, strip ``title``/``additionalProperties``, and rewrite
+    ``oneOf``/``allOf`` -> ``anyOf``, so ``enum``/``anyOf`` must survive intact.
+    """
+    import copy
+    from typing import Literal
+
+    from langroid.agent.tool_message import format_schema_for_strict
+
+    server = FastMCP("ToolSpecServer")
+
+    @server.tool()
+    def configure(
+        color: Literal["red", "green", "blue"],
+        quantity: int | str,
+        size: Optional[Literal["S", "M", "L"]] = None,
+    ) -> str:
+        """Configure things."""
+        return "ok"
+
+    ConfigureTool = await get_tool_async(server, "configure")
+
+    # --- non-strict: the default OpenAI function/tool definition ---
+    params = ConfigureTool.llm_function_schema(request=True).parameters
+    props = params["properties"]
+
+    # Literal -> enum preserved
+    assert set(props["color"]["enum"]) == {"red", "green", "blue"}
+
+    # Union[int, str] -> anyOf preserved, with both branches
+    assert {b.get("type") for b in props["quantity"]["anyOf"]} == {
+        "integer",
+        "string",
+    }
+
+    # Optional[Literal] -> anyOf including a null branch, with the enum retained
+    size_branches = props["size"]["anyOf"]
+    assert {"type": "null"} in size_branches
+    assert any(set(b.get("enum", [])) == {"S", "M", "L"} for b in size_branches)
+
+    # required: mandatory params + request, but NOT the optional `size`
+    assert set(params["required"]) == {"color", "quantity", "request"}
+
+    # --- strict mode: must yield a valid structured-outputs schema ---
+    strict = copy.deepcopy(params)
+    format_schema_for_strict(strict)
+
+    # every object is closed (additionalProperties=False) and fully required,
+    # and OpenAI strict mode forbids oneOf/allOf (both rewritten to anyOf).
+    def assert_strict(node: Any) -> None:
+        if isinstance(node, dict):
+            if node.get("type") == "object":
+                assert node.get("additionalProperties") is False
+                assert set(node.get("required", [])) == set(
+                    node.get("properties", {}).keys()
+                )
+            assert "oneOf" not in node
+            assert "allOf" not in node
+            for v in node.values():
+                assert_strict(v)
+        elif isinstance(node, list):
+            for v in node:
+                assert_strict(v)
+
+    assert_strict(strict)
+
+    # enum/anyOf survive the strict transform, and ALL props (incl. the
+    # now-required `size`) are marked required.
+    assert set(strict["properties"]["color"]["enum"]) == {"red", "green", "blue"}
+    assert {b.get("type") for b in strict["properties"]["quantity"]["anyOf"]} == {
+        "integer",
+        "string",
+    }
+    assert set(strict["required"]) == {"color", "quantity", "size", "request"}

--- a/tests/main/test_tool_messages.py
+++ b/tests/main/test_tool_messages.py
@@ -2184,3 +2184,42 @@ def test_multi_agent_tool_caching(test_settings: Settings):
     tools_from_b_cached = agent_b.get_tool_messages(chat_doc, all_tools=True)
     assert len(tools_from_b_cached) == 1
     assert tools_from_b_cached[0].request == "tool_b"
+
+
+def test_nested_tool_message_schema_is_cleaned() -> None:
+    """A ToolMessage nested inside another ToolMessage lands in the schema's
+    ``$defs``, and must get the same cleanup the top-level tool gets: internal
+    fields (``purpose``, ``id``) and the ``exclude`` marker removed, and
+    ``request`` pinned to its constant via an ``enum``.
+
+    Regression guard for the Pydantic v1->v2 migration: v1 emitted nested-model
+    schemas under ``definitions`` while v2 uses ``$defs``. If the cleanup keys
+    off the wrong name it silently no-ops, leaking those internal fields (and an
+    unconstrained ``request``) into the schema sent to the LLM.
+    """
+
+    class Inner(ToolMessage):
+        request: str = "inner_tool"
+        purpose: str = "the inner purpose"
+        x: int
+
+    class Outer(ToolMessage):
+        request: str = "outer_tool"
+        purpose: str = "the outer purpose"
+        inner: Inner
+
+    params = Outer.llm_function_schema(request=True).parameters
+    assert "$defs" in params
+    inner_schema = params["$defs"]["Inner"]
+
+    # internal markers/fields must not leak to the LLM
+    assert "exclude" not in inner_schema
+    assert "purpose" not in inner_schema["properties"]
+    assert "id" not in inner_schema["properties"]
+
+    # `request` is pinned to its constant and required
+    assert inner_schema["properties"]["request"] == {
+        "type": "string",
+        "enum": ["inner_tool"],
+    }
+    assert "request" in inner_schema["required"]


### PR DESCRIPTION
## Summary

`FastMCPClient._schema_to_field` turns each MCP tool parameter's JSON Schema into a pydantic field type. Two common constructs were being dropped, so the generated `ToolMessage` lost type information both for validation and in the schema the LLM sees:

- **`enum` / `const`** fell through to the base scalar type (`{"type": "string", "enum": [...]}` → plain `str`).
- **`anyOf` / `oneOf` / `allOf`** collapsed to `Any` with a warning — including the very common `anyOf: [T, {"type": "null"}]` that fastmcp emits for `Optional[...]` params.

This maps them to precise Python types.

## Changes (all in `_schema_to_field`)

**`enum` / `const` → `typing.Literal`** (before the `type` branches):

```python
enum_values = schema.get("enum", [schema["const"]] if "const" in schema else None)
if enum_values and all(isinstance(v, (str, int, bool)) or v is None for v in enum_values):
    literal_type = Literal[tuple(enum_values)]
    if not is_required:
        literal_type = Optional[literal_type]
    return literal_type, Field(default=default, description=desc)
```
Guarded to `Literal`-compatible scalars (`str`/`int`/`bool`/`None`); enums with floats or objects fall through to existing handling.

**`anyOf` / `oneOf` → `typing.Union`** (replacing the old `Any` fallback), converting each branch recursively; a `{"type": "null"}` branch — or an optional field — yields `Optional`:

```python
sub_schemas = schema.get("anyOf") or schema.get("oneOf")
if isinstance(sub_schemas, list) and sub_schemas:
    non_null = [s for s in sub_schemas if not (isinstance(s, dict) and s.get("type") == "null")]
    has_null = len(non_null) != len(sub_schemas)
    if non_null:
        member_types = tuple(self._schema_to_field(name, s, prefix, is_required=True)[0] for s in non_null)
        union_type = Union[member_types]
        if has_null or not is_required:
            union_type = Optional[union_type]
        return union_type, Field(default=default, description=desc)
```

**`allOf`**: a single subschema is converted directly; multi-schema intersections keep the `Any` fallback (no clean typing analogue). `oneOf` maps to `Union` too — typing has no exclusive-or.

## Why it matters

- **Validation**: out-of-set enum values and wrong-type union values now raise `ValidationError` instead of being silently accepted.
- **Better LLM grounding**: pydantic re-emits `enum`, `anyOf`, and nullability in `model_json_schema()`, so the model receives exact parameter types instead of "string"/"any".

## Testing

- `test_enum_field_becomes_literal`: a `Literal["celsius","fahrenheit"]` param (emitted as a schema `enum`) → `Literal` field; validates `"celsius"`, rejects `"kelvin"`, re-emits the `enum` in `model_json_schema()`.
- `test_anyof_maps_to_union_and_optional`: `int | str` → `Union[int, str]` (both validate); `Optional[int]` → `Union[int, None]` (accepts `None` and `int`).
