### PR TITLE
Add Milvus vector store provider

### DIFF
--- a/.github/workflows/pytest-subset.yml
+++ b/.github/workflows/pytest-subset.yml
@@ -78,6 +78,7 @@ jobs:
             --extra hf-embeddings \
             --extra weaviate \
             --extra pinecone \
+            --extra milvus \
             --extra postgres \
             --extra pdf-parsers \
             --extra docx \

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -174,6 +174,7 @@ jobs:
           --extra pymupdf4llm \
           --extra weaviate \
           --extra pinecone \
+          --extra milvus \
           --extra postgres\
           --extra hf-embeddings \
           --extra unstructured \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ You are welcome to take on un-assigned open [issues](https://github.com/langroid
     - [x] Pinecone 
     - [x] PostgresML (pgvector)
     - [x] Weaviate
-    - [ ] Milvus 
+    - [x] Milvus
     - [ ] Marqo 
     
 - Other LLM APIs, e.g.: 

--- a/README.md
+++ b/README.md
@@ -607,8 +607,12 @@ All of the following environment variable settings are optional, and some are on
 to use specific features (as noted below).
 
 - **Qdrant** Vector Store API Key, URL. This is only required if you want to use Qdrant cloud.
-  Alternatively [Chroma](https://docs.trychroma.com/) or [LanceDB](https://lancedb.com/) are also currently supported. 
+  Alternatively [Chroma](https://docs.trychroma.com/), [LanceDB](https://lancedb.com/), or [Milvus](https://milvus.io/) are also currently supported.
   We use the local-storage version of Chroma, so there is no need for an API key.
+- **Milvus** Vector Store URI, token, database name. These are optional.
+  Without them, Milvus uses local storage at `./milvus.db`. Set `MILVUS_URI`
+  for Milvus server or Zilliz Cloud, `MILVUS_TOKEN` for token-based access,
+  and `MILVUS_DB_NAME` for a named database.
 - **Redis** Password, host, port: This is optional, and only needed to cache LLM API responses
   using Redis Cloud. Redis [offers](https://redis.com/try-free/) a free 30MB Redis account
   which is more than sufficient to try out Langroid and even beyond.
@@ -1066,6 +1070,4 @@ Your support will help build Langroid's momentum and community.
 
 - [Prasad Chalasani](https://www.linkedin.com/in/pchalasani/) (IIT BTech/CS, CMU PhD/ML; Independent ML Consultant)
 - [Somesh Jha](https://www.linkedin.com/in/somesh-jha-80208015/) (IIT BTech/CS, CMU PhD/CS; Professor of CS, U Wisc at Madison)
-
-
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ Besides Agents, Langroid also provides simple ways to directly interact with LLM
   Agents with specific skills, wrap them in Tasks, and combine tasks in a flexible way.
 - **LLM Support**: Langroid works with practically any LLM, local/open or remote/proprietary/API-based, via a variety of libraries and providers. See guides to using [local LLMs](tutorials/local-llm-setup.md) and [non-OpenAI LLMs](tutorials/non-openai-llms.md). See [Supported LLMs](tutorials/supported-models.md).
 - **Caching of LLM prompts, responses:** Langroid by default uses [Redis](https://redis.com/try-free/) for caching. 
-- **Vector-stores**: [Qdrant](https://qdrant.tech/), [Chroma](https://www.trychroma.com/) and [LanceDB](https://www.lancedb.com/) are currently supported.
+- **Vector-stores**: [Qdrant](https://qdrant.tech/), [Chroma](https://www.trychroma.com/), [LanceDB](https://www.lancedb.com/), and [Milvus](https://milvus.io/) are currently supported.
   Vector stores allow for Retrieval-Augmented-Generation (RAG).
 - **Grounding and source-citation:** Access to external documents via vector-stores
   allows for grounding and source-citation.

--- a/docs/notes/milvus.md
+++ b/docs/notes/milvus.md
@@ -1,0 +1,96 @@
+# Using Milvus as a Vector Store with Langroid
+
+Langroid supports Milvus through `MilvusDBConfig` and the PyMilvus `MilvusClient`.
+The default configuration uses Milvus Lite at `./milvus.db`, so no separate
+service is required for a local start.
+
+## Installation
+
+Install Langroid with the Milvus extra:
+
+```bash
+uv add "langroid[milvus]"
+```
+
+You can also install it with `pip`:
+
+```bash
+pip install "langroid[milvus]"
+```
+
+## Configuration
+
+By default, `MilvusDBConfig()` connects to Milvus Lite:
+
+```python
+import langroid as lr
+
+vecdb = lr.vector_store.MilvusDBConfig(
+    collection_name="quick_start_chat_agent_docs",
+    replace_collection=True,
+)
+```
+
+To use a local or remote Milvus service, pass `uri` explicitly or set
+`MILVUS_URI`:
+
+```bash
+export MILVUS_URI="http://localhost:19530"
+```
+
+For Zilliz Cloud, set the cloud endpoint and token:
+
+```bash
+export MILVUS_URI="https://your-project.api.region.zillizcloud.com"
+export MILVUS_TOKEN="your-token"
+```
+
+If you use a named Milvus database, set `MILVUS_DB_NAME` or pass `db_name` in
+the config.
+
+## Example
+
+```python
+import langroid as lr
+from langroid.agent.special import DocChatAgent, DocChatAgentConfig
+
+config = DocChatAgentConfig(
+    vecdb=lr.vector_store.MilvusDBConfig(
+        collection_name="quick_start_chat_agent_docs",
+        uri="./milvus.db",
+        replace_collection=True,
+    ),
+    parsing=lr.parsing.parser.ParsingConfig(
+        separators=["\n\n"],
+        splitter=lr.parsing.parser.Splitter.SIMPLE,
+    ),
+    n_similar_chunks=2,
+    n_relevant_chunks=2,
+)
+
+agent = DocChatAgent(config)
+
+documents = [
+    lr.Document(
+        content="Milvus Lite stores vectors in a local file.",
+        metadata=lr.DocMetaData(source="milvus-docs", id="milvus-lite"),
+    ),
+    lr.Document(
+        content="The same config can point to Milvus server or Zilliz Cloud.",
+        metadata=lr.DocMetaData(source="milvus-docs", id="milvus-service"),
+    ),
+]
+
+agent.ingest_docs(documents)
+```
+
+Milvus stores Langroid document metadata in a JSON field and also exposes scalar
+metadata fields for simple filters, for example:
+
+```python
+matches = agent.vecdb.similar_texts_with_scores(
+    "local vector storage",
+    k=2,
+    where='{"source": "milvus-docs"}',
+)
+```

--- a/docs/quick-start/setup.md
+++ b/docs/quick-start/setup.md
@@ -103,8 +103,12 @@ to use specific features (as noted below).
 
 - **Qdrant** Vector Store API Key, URL. This is only required if you want to use Qdrant cloud.
   Langroid uses LanceDB as the default vector store in its `DocChatAgent` class (for RAG).
-  Alternatively [Chroma](https://docs.trychroma.com/) is also currently supported.
+  Alternatively [Chroma](https://docs.trychroma.com/) and [Milvus](https://milvus.io/) are also currently supported.
   We use the local-storage version of Chroma, so there is no need for an API key.
+- **Milvus** Vector Store URI, token, database name. These are optional.
+  Without them, Milvus uses local storage at `./milvus.db`. Set `MILVUS_URI`
+  for Milvus server or Zilliz Cloud, `MILVUS_TOKEN` for token-based access,
+  and `MILVUS_DB_NAME` for a named database.
 - **Redis** Password, host, port: This is optional, and only needed to cache LLM API responses
   using Redis Cloud. Redis [offers](https://redis.com/try-free/) a free 30MB Redis account
   which is more than sufficient to try out Langroid and even beyond.
@@ -169,7 +173,6 @@ provides more information, and you can set each environment variable as follows:
 Now you should be ready to use Langroid!
 As a next step, you may want to see how you can use Langroid to [interact 
 directly with the LLM](llm-interaction.md) (OpenAI GPT models only for now).
-
 
 
 

--- a/examples/docqa/chat.py
+++ b/examples/docqa/chat.py
@@ -165,6 +165,11 @@ def main(
             config.vecdb = lr.vector_store.PostgresDBConfig(
                 embedding=embed_cfg, cloud=True
             )
+        case "milvus" | "milvusdb":
+            config.vecdb = lr.vector_store.MilvusDBConfig(
+                collection_name="doc_chat_milvus",
+                embedding=embed_cfg,
+            )
 
     set_global(
         Settings(

--- a/langroid/vector_store/__init__.py
+++ b/langroid/vector_store/__init__.py
@@ -47,6 +47,14 @@ try:
     PostgresDBConfig
     __all__.extend(["postgres", "PostgresDB", "PostgresDBConfig"])
 
+    from . import milvusdb
+    from .milvusdb import MilvusDB, MilvusDBConfig
+
+    milvusdb
+    MilvusDB
+    MilvusDBConfig
+    __all__.extend(["milvusdb", "MilvusDB", "MilvusDBConfig"])
+
     from . import weaviatedb
     from .weaviatedb import WeaviateDBConfig, WeaviateDB
 

--- a/langroid/vector_store/base.py
+++ b/langroid/vector_store/base.py
@@ -61,6 +61,7 @@ class VectorStore(ABC):
         from langroid.vector_store.chromadb import ChromaDB, ChromaDBConfig
         from langroid.vector_store.lancedb import LanceDB, LanceDBConfig
         from langroid.vector_store.meilisearch import MeiliSearch, MeiliSearchConfig
+        from langroid.vector_store.milvusdb import MilvusDB, MilvusDBConfig
         from langroid.vector_store.pineconedb import PineconeDB, PineconeDBConfig
         from langroid.vector_store.postgres import PostgresDB, PostgresDBConfig
         from langroid.vector_store.qdrantdb import QdrantDB, QdrantDBConfig
@@ -76,6 +77,8 @@ class VectorStore(ABC):
             return MeiliSearch(config)
         elif isinstance(config, PostgresDBConfig):
             return PostgresDB(config)
+        elif isinstance(config, MilvusDBConfig):
+            return MilvusDB(config)
         elif isinstance(config, WeaviateDBConfig):
             return WeaviateDB(config)
         elif isinstance(config, PineconeDBConfig):

--- a/langroid/vector_store/milvusdb.py
+++ b/langroid/vector_store/milvusdb.py
@@ -1,0 +1,416 @@
+import json
+import logging
+import math
+import os
+import re
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from dotenv import load_dotenv
+
+from langroid.embedding_models.base import EmbeddingModelsConfig
+from langroid.embedding_models.models import OpenAIEmbeddingsConfig
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import Document
+from langroid.utils.configuration import settings
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+
+_FIELD_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_STATIC_FIELDS = {"id", "vector", "content", "metadata"}
+_OUTPUT_FIELDS = ["id", "content", "metadata"]
+
+
+class MilvusDBConfig(VectorStoreConfig):
+    collection_name: str | None = "temp"
+    uri: str = ""
+    token: str | None = None
+    db_name: str | None = None
+    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+    metric_type: str = "COSINE"
+    consistency_level: str = "Strong"
+    id_field_max_length: int = 512
+    text_field_max_length: int = 65535
+
+
+class MilvusDB(VectorStore):
+    def __init__(self, config: MilvusDBConfig = MilvusDBConfig()):
+        super().__init__(config)
+        self.config: MilvusDBConfig = config
+        load_dotenv()
+        self.config.uri = self.config.uri or os.getenv("MILVUS_URI", "./milvus.db")
+        self.config.token = self.config.token or os.getenv("MILVUS_TOKEN")
+        self.config.db_name = self.config.db_name or os.getenv("MILVUS_DB_NAME")
+        self.config.metric_type = self.config.metric_type.upper()
+
+        try:
+            from pymilvus import MilvusClient
+        except ImportError as exc:
+            raise LangroidImportError("pymilvus", "milvus") from exc
+
+        client_kwargs: Dict[str, Any] = {
+            "uri": self.config.uri,
+            "timeout": self.config.timeout,
+        }
+        if self.config.token:
+            client_kwargs["token"] = self.config.token
+        if self.config.db_name:
+            client_kwargs["db_name"] = self.config.db_name
+        self.client = MilvusClient(**client_kwargs)
+
+        if self.config.collection_name is not None:
+            self.create_collection(
+                self.config.collection_name,
+                replace=self.config.replace_collection,
+            )
+
+    def close(self) -> None:
+        if hasattr(self.client, "close"):
+            self.client.close()
+
+    def __enter__(self) -> "MilvusDB":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.close()
+
+    def clear_empty_collections(self) -> int:
+        n_deletes = 0
+        for collection_name in self.list_collections(empty=True):
+            if self._row_count(collection_name) == 0:
+                self.delete_collection(collection_name)
+                n_deletes += 1
+        return n_deletes
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        if not really:
+            logger.warning("Not deleting all collections, set really=True to confirm")
+            return 0
+        collection_names = [
+            name
+            for name in self.list_collections(empty=True)
+            if name.startswith(prefix)
+        ]
+        if len(collection_names) == 0:
+            logger.warning(f"No collections found with prefix {prefix}")
+            return 0
+        for collection_name in collection_names:
+            self.delete_collection(collection_name)
+        logger.warning(f"Deleted {len(collection_names)} collections.")
+        return len(collection_names)
+
+    def list_collections(self, empty: bool = False) -> List[str]:
+        collection_names = list(self.client.list_collections())
+        if empty:
+            return collection_names
+        return [
+            collection_name
+            for collection_name in collection_names
+            if self._row_count(collection_name) > 0
+        ]
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        self.config.collection_name = collection_name
+        if self.client.has_collection(collection_name=collection_name):
+            if replace:
+                self.client.drop_collection(collection_name=collection_name)
+            else:
+                self._validate_collection_schema(collection_name)
+                return
+
+        from pymilvus import DataType
+
+        schema = self.client.create_schema(auto_id=False, enable_dynamic_field=True)
+        schema.add_field(
+            field_name="id",
+            datatype=DataType.VARCHAR,
+            is_primary=True,
+            max_length=self.config.id_field_max_length,
+        )
+        schema.add_field(
+            field_name="vector",
+            datatype=DataType.FLOAT_VECTOR,
+            dim=self.embedding_dim,
+        )
+        schema.add_field(
+            field_name="content",
+            datatype=DataType.VARCHAR,
+            max_length=self.config.text_field_max_length,
+        )
+        schema.add_field(field_name="metadata", datatype=DataType.JSON)
+
+        index_params = self.client.prepare_index_params()
+        index_params.add_index(
+            field_name="vector",
+            index_type="AUTOINDEX",
+            metric_type=self.config.metric_type,
+        )
+        self.client.create_collection(
+            collection_name=collection_name,
+            schema=schema,
+            index_params=index_params,
+            consistency_level=self.config.consistency_level,
+        )
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        if len(documents) == 0:
+            return
+        super().maybe_add_ids(documents)
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        if not self.client.has_collection(collection_name=self.config.collection_name):
+            self.create_collection(self.config.collection_name, replace=True)
+
+        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+        batch_size = self.config.batch_size
+        for i in range(0, len(documents), batch_size):
+            rows = [
+                self._document_to_record(doc, embedding)
+                for doc, embedding in zip(
+                    documents[i : i + batch_size],
+                    embedding_vecs[i : i + batch_size],
+                )
+            ]
+            self.client.upsert(collection_name=self.config.collection_name, data=rows)
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        if not self.client.has_collection(collection_name=self.config.collection_name):
+            return []
+
+        docs: List[Document] = []
+        iterator = self.client.query_iterator(
+            collection_name=self.config.collection_name,
+            batch_size=self.config.batch_size,
+            filter=self._where_to_filter(where),
+            output_fields=_OUTPUT_FIELDS,
+        )
+        try:
+            while True:
+                records = iterator.next()
+                if len(records) == 0:
+                    break
+                docs.extend(self._records_to_docs(records))
+        finally:
+            iterator.close()
+        return docs
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        if len(ids) == 0:
+            return []
+        records = self.client.get(
+            collection_name=self.config.collection_name,
+            ids=[str(doc_id) for doc_id in ids],
+            output_fields=_OUTPUT_FIELDS,
+        )
+        id_to_record = {str(record["id"]): record for record in records}
+        ordered_records = [
+            id_to_record[str(doc_id)] for doc_id in ids if str(doc_id) in id_to_record
+        ]
+        return self._records_to_docs(ordered_records)
+
+    def delete_collection(self, collection_name: str) -> None:
+        if self.client.has_collection(collection_name=collection_name):
+            self.client.drop_collection(collection_name=collection_name)
+
+    def similar_texts_with_scores(
+        self,
+        text: str,
+        k: int = 1,
+        where: Optional[str] = None,
+    ) -> List[Tuple[Document, float]]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot search")
+        if not self.client.has_collection(collection_name=self.config.collection_name):
+            return []
+        row_count = self._row_count(self.config.collection_name)
+        if row_count == 0:
+            return []
+
+        embedding = self.embedding_fn([text])[0]
+        results = self.client.search(
+            collection_name=self.config.collection_name,
+            data=[embedding],
+            anns_field="vector",
+            filter=self._where_to_filter(where),
+            limit=min(k, row_count),
+            output_fields=_OUTPUT_FIELDS,
+            search_params={"metric_type": self.config.metric_type},
+        )
+        matches = results[0] if len(results) > 0 else []
+        docs = self._records_to_docs([match["entity"] for match in matches])
+        scores = [
+            self._score_from_distance(float(match["distance"])) for match in matches
+        ]
+        doc_score_pairs = list(zip(docs, scores))
+        if len(doc_score_pairs) == 0:
+            logger.warning(f"No matches found for {text}")
+            return []
+        if settings.debug:
+            logger.info(
+                f"Found {len(doc_score_pairs)} matches, max score: {max(scores)}"
+            )
+        self.show_if_debug(doc_score_pairs)
+        return doc_score_pairs
+
+    def _row_count(self, collection_name: str) -> int:
+        try:
+            stats = self.client.get_collection_stats(collection_name=collection_name)
+            return int(stats.get("row_count", 0))
+        except Exception:
+            logger.warning(f"Error getting collection stats for {collection_name}")
+            return 0
+
+    def _validate_collection_schema(self, collection_name: str) -> None:
+        from pymilvus import DataType
+
+        description = self.client.describe_collection(collection_name=collection_name)
+        fields = {field["name"]: field for field in description.get("fields", [])}
+        missing_fields = _STATIC_FIELDS.difference(fields)
+        if len(missing_fields) > 0:
+            raise ValueError(
+                f"Milvus collection {collection_name} is missing fields: "
+                f"{sorted(missing_fields)}"
+            )
+        if fields["id"]["type"] != DataType.VARCHAR:
+            raise ValueError(f"Milvus collection {collection_name} has invalid id type")
+        if not fields["id"].get("is_primary", False):
+            raise ValueError(
+                f"Milvus collection {collection_name} must use id as primary key"
+            )
+        if fields["vector"]["type"] != DataType.FLOAT_VECTOR:
+            raise ValueError(
+                f"Milvus collection {collection_name} has invalid vector type"
+            )
+        dim = int(fields["vector"].get("params", {}).get("dim", 0))
+        if dim != self.embedding_dim:
+            raise ValueError(
+                f"Milvus collection {collection_name} vector dim {dim} does not "
+                f"match embedding dim {self.embedding_dim}"
+            )
+        if fields["content"]["type"] != DataType.VARCHAR:
+            raise ValueError(
+                f"Milvus collection {collection_name} has invalid content type"
+            )
+        if fields["metadata"]["type"] != DataType.JSON:
+            raise ValueError(
+                f"Milvus collection {collection_name} has invalid metadata type"
+            )
+
+    def _document_to_record(
+        self, doc: Document, embedding: List[float]
+    ) -> Dict[str, Any]:
+        doc_id = str(doc.id())
+        if len(doc_id) > self.config.id_field_max_length:
+            raise ValueError(
+                f"Document id exceeds Milvus max length "
+                f"{self.config.id_field_max_length}: {doc_id}"
+            )
+        if len(doc.content.encode("utf-8")) > self.config.text_field_max_length:
+            raise ValueError(
+                "Document content exceeds Milvus VARCHAR max length "
+                f"{self.config.text_field_max_length}"
+            )
+
+        metadata = doc.metadata.model_dump()
+        metadata["id"] = doc_id
+        return {
+            "id": doc_id,
+            "vector": embedding,
+            "content": doc.content,
+            "metadata": metadata,
+            **self._dynamic_metadata_fields(metadata),
+        }
+
+    @staticmethod
+    def _dynamic_metadata_fields(metadata: Dict[str, Any]) -> Dict[str, Any]:
+        dynamic_fields: Dict[str, Any] = {}
+        for key, value in metadata.items():
+            if key in _STATIC_FIELDS or _FIELD_NAME_RE.match(key) is None:
+                continue
+            if isinstance(value, (str, int, float, bool)):
+                dynamic_fields[key] = value
+        return dynamic_fields
+
+    def _records_to_docs(self, records: Sequence[Dict[str, Any]]) -> List[Document]:
+        docs = []
+        for record in records:
+            metadata = dict(record.get("metadata") or {})
+            metadata["id"] = str(record.get("id", metadata.get("id", "")))
+            docs.append(
+                self.config.document_class(
+                    content=record["content"],
+                    metadata=self.config.metadata_class(**metadata),
+                )
+            )
+        return docs
+
+    def _score_from_distance(self, distance: float) -> float:
+        metric_type = self.config.metric_type.upper()
+        if metric_type == "COSINE":
+            return 1.0 - distance
+        if metric_type == "L2":
+            return -distance
+        return distance
+
+    @classmethod
+    def _where_to_filter(cls, where: Optional[str]) -> str:
+        if where is None or where.strip() == "":
+            return ""
+        where = where.strip()
+        try:
+            parsed = json.loads(where)
+        except json.JSONDecodeError:
+            return where
+        if not isinstance(parsed, dict):
+            raise ValueError("Milvus JSON filters must be objects")
+        expressions = [
+            cls._filter_expression(key, value) for key, value in parsed.items()
+        ]
+        return " and ".join(expressions)
+
+    @classmethod
+    def _filter_expression(cls, field_name: str, value: Any) -> str:
+        cls._validate_filter_field(field_name)
+        if isinstance(value, dict):
+            if set(value.keys()) == {"$eq"}:
+                return f"{field_name} == {cls._format_filter_value(value['$eq'])}"
+            if set(value.keys()) == {"$in"}:
+                return cls._in_filter_expression(field_name, value["$in"])
+            raise ValueError(f"Unsupported Milvus filter operator for {field_name}")
+        if isinstance(value, list):
+            return cls._in_filter_expression(field_name, value)
+        return f"{field_name} == {cls._format_filter_value(value)}"
+
+    @classmethod
+    def _in_filter_expression(cls, field_name: str, values: Any) -> str:
+        if not isinstance(values, list) or len(values) == 0:
+            raise ValueError(
+                f"Milvus filter for {field_name} requires a non-empty list"
+            )
+        formatted_values = ", ".join(
+            cls._format_filter_value(value) for value in values
+        )
+        return f"{field_name} in [{formatted_values}]"
+
+    @staticmethod
+    def _validate_filter_field(field_name: str) -> None:
+        if _FIELD_NAME_RE.match(field_name) is None:
+            raise ValueError(f"Invalid Milvus filter field name: {field_name}")
+
+    @staticmethod
+    def _format_filter_value(value: Any) -> str:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, str):
+            return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+        if isinstance(value, int):
+            return str(value)
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                raise ValueError("Milvus filters do not support NaN or infinity")
+            return repr(value)
+        raise ValueError(f"Unsupported Milvus filter value: {value!r}")

--- a/langroid/vector_store/milvusdb.py
+++ b/langroid/vector_store/milvusdb.py
@@ -48,6 +48,8 @@ class MilvusDB(VectorStore):
         except ImportError as exc:
             raise LangroidImportError("pymilvus", "milvus") from exc
 
+        self._milvus_lite_3_0 = self._uses_milvus_lite_3_0(self.config.uri)
+
         client_kwargs: Dict[str, Any] = {
             "uri": self.config.uri,
             "timeout": self.config.timeout,
@@ -351,10 +353,26 @@ class MilvusDB(VectorStore):
     def _score_from_distance(self, distance: float) -> float:
         metric_type = self.config.metric_type.upper()
         if metric_type == "COSINE":
-            return 1.0 - distance
+            return 1.0 - distance if self._milvus_lite_3_0 else distance
         if metric_type == "L2":
-            return -distance
+            l2_distance = (
+                distance if self._milvus_lite_3_0 else math.sqrt(max(distance, 0.0))
+            )
+            return -l2_distance
         return distance
+
+    @staticmethod
+    def _uses_milvus_lite_3_0(uri: str) -> bool:
+        if "://" in uri:
+            return False
+        try:
+            from milvus_lite import __version__ as milvus_lite_version
+        except ImportError:
+            return False
+        # Lite 3.0 reports COSINE as a distance and L2 as Euclidean distance.
+        # Server, cloud, and newer Lite releases report COSINE similarity and
+        # squared L2 distance. See https://github.com/milvus-io/milvus-lite/issues/343.
+        return milvus_lite_version in {"3.0", "3.0.0"}
 
     @classmethod
     def _where_to_filter(cls, where: Optional[str]) -> str:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
       - Weaviate: notes/weaviate.md
       - Handling LLM Non-Tool Messages: notes/handle-llm-no-tool.md
       - PGVector: notes/pgvector.md
+      - Milvus: notes/milvus.md
       - Pinecone: notes/pinecone.md
       - Tavily Search Tool: notes/tavily_search.md
       - Seltz Search Tool: notes/seltz_search.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ vecdbs = [
     "chromadb<=0.4.23,>=0.4.21",
     "weaviate-client>=4.9.6",
     "pinecone-client>=5.0.1",
+    "pymilvus[milvus-lite]>=3.0.0",
 ]
 
 db = [
@@ -129,6 +130,7 @@ all = [
     "psycopg2-binary>=2.9.10",
     "marker-pdf",
     "seltz>=0.2.0",
+    "pymilvus[milvus-lite]>=3.0.0",
 ]
 
 # More granular groupings
@@ -287,6 +289,9 @@ firecrawl = [
 ]
 crawl4ai = [
     "crawl4ai>=0.6.3",
+]
+milvus = [
+    "pymilvus[milvus-lite]>=3.0.0",
 ]
 
 

--- a/tests/main/test_vector_stores.py
+++ b/tests/main/test_vector_stores.py
@@ -10,14 +10,16 @@ from sqlalchemy.exc import OperationalError
 from langroid.agent.batch import run_batch_tasks
 from langroid.agent.special.doc_chat_agent import DocChatAgent, DocChatAgentConfig
 from langroid.agent.task import Task
+from langroid.embedding_models.base import EmbeddingModel
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
 from langroid.exceptions import LangroidImportError
-from langroid.mytypes import DocMetaData, Document
+from langroid.mytypes import DocMetaData, Document, Embeddings
 from langroid.parsing.parser import Parser, ParsingConfig, Splitter
 from langroid.utils.system import rmdir
 from langroid.vector_store.base import VectorStore
 from langroid.vector_store.lancedb import LanceDB, LanceDBConfig
 from langroid.vector_store.meilisearch import MeiliSearch, MeiliSearchConfig
+from langroid.vector_store.milvusdb import MilvusDB, MilvusDBConfig
 from langroid.vector_store.pineconedb import PineconeDB, PineconeDBConfig
 from langroid.vector_store.postgres import PostgresDB, PostgresDBConfig
 from langroid.vector_store.qdrantdb import QdrantDB, QdrantDBConfig
@@ -53,6 +55,29 @@ stored_docs = [
     MyDoc(content=d, metadata=MyDocMetaData(id=str(i)))
     for i, d in enumerate(vars(phrases).values())
 ]
+
+
+class DeterministicEmbeddingModel(EmbeddingModel):
+    @property
+    def embedding_dims(self) -> int:
+        return 4
+
+    def embedding_fn(self):
+        def embed(texts: List[str]) -> Embeddings:
+            return [self._embed(text) for text in texts]
+
+        return embed
+
+    @staticmethod
+    def _embed(text: str) -> List[float]:
+        text = text.lower()
+        if "alpha" in text:
+            return [1.0, 0.0, 0.0, 0.0]
+        if "beta" in text:
+            return [0.0, 1.0, 0.0, 0.0]
+        if "gamma" in text:
+            return [0.0, 0.0, 1.0, 0.0]
+        return [0.0, 0.0, 0.0, 1.0]
 
 
 @pytest.fixture(scope="function")
@@ -211,6 +236,81 @@ def vecdb(request) -> VectorStore:
         yield pinecone_serverless
         pinecone_serverless.delete_collection(collection_name=cfg.collection_name)
         return
+
+
+@pytest.fixture(scope="function")
+def milvus_vecdb(tmp_path) -> MilvusDB:
+    cfg = MilvusDBConfig(
+        collection_name="test_milvus",
+        uri=str(tmp_path / "milvus.db"),
+        replace_collection=True,
+        embedding_model=DeterministicEmbeddingModel(),
+        batch_size=2,
+    )
+    vecdb = VectorStore.create(cfg)
+    assert isinstance(vecdb, MilvusDB)
+    yield vecdb
+    vecdb.clear_all_collections(really=True, prefix="test_")
+    vecdb.close()
+
+
+def test_milvus_vector_store_lite_add_search_list_delete_clear(
+    milvus_vecdb: MilvusDB,
+):
+    docs = [
+        Document(
+            content="alpha document",
+            metadata=DocMetaData(id="alpha", source="group_a"),
+        ),
+        Document(
+            content="beta document",
+            metadata=DocMetaData(id="beta", source="group_b"),
+        ),
+        Document(
+            content="gamma document",
+            metadata=DocMetaData(id="gamma", source="group_a"),
+        ),
+    ]
+    milvus_vecdb.add_documents(docs)
+
+    assert "test_milvus" in milvus_vecdb.list_collections(empty=True)
+    assert "test_milvus" in milvus_vecdb.list_collections()
+
+    all_docs = milvus_vecdb.get_all_documents()
+    assert {doc.id() for doc in all_docs} == {"alpha", "beta", "gamma"}
+
+    group_a_docs = milvus_vecdb.get_all_documents(json.dumps({"source": "group_a"}))
+    assert {doc.id() for doc in group_a_docs} == {"alpha", "gamma"}
+
+    ordered_docs = milvus_vecdb.get_documents_by_ids(["gamma", "alpha"])
+    assert [doc.id() for doc in ordered_docs] == ["gamma", "alpha"]
+
+    docs_and_scores = milvus_vecdb.similar_texts_with_scores("alpha", k=2)
+    assert docs_and_scores[0][0].content == "alpha document"
+    assert docs_and_scores[0][1] > docs_and_scores[1][1]
+
+    filtered_docs_and_scores = milvus_vecdb.similar_texts_with_scores(
+        "alpha",
+        k=3,
+        where=json.dumps({"source": {"$in": ["group_b"]}}),
+    )
+    assert [doc.id() for doc, _ in filtered_docs_and_scores] == ["beta"]
+
+    empty_collections = [f"test_empty_{i}" for i in range(2)]
+    for collection_name in empty_collections:
+        milvus_vecdb.create_collection(collection_name)
+    assert milvus_vecdb.clear_empty_collections() == len(empty_collections)
+
+    junk_collections = [f"test_junk_{i}" for i in range(3)]
+    for collection_name in junk_collections:
+        milvus_vecdb.create_collection(collection_name)
+    assert milvus_vecdb.clear_all_collections(
+        really=True,
+        prefix="test_junk_",
+    ) == len(junk_collections)
+
+    milvus_vecdb.delete_collection("test_milvus")
+    assert "test_milvus" not in milvus_vecdb.list_collections(empty=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/main/test_vector_stores.py
+++ b/tests/main/test_vector_stores.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 from types import SimpleNamespace
 from typing import List
@@ -71,6 +72,8 @@ class DeterministicEmbeddingModel(EmbeddingModel):
     @staticmethod
     def _embed(text: str) -> List[float]:
         text = text.lower()
+        if "alpha beta" in text:
+            return [0.6, 0.8, 0.0, 0.0]
         if "alpha" in text:
             return [1.0, 0.0, 0.0, 0.0]
         if "beta" in text:
@@ -314,6 +317,62 @@ def test_milvus_vector_store_lite_add_search_list_delete_clear(
 
     milvus_vecdb.delete_collection("test_milvus")
     assert "test_milvus" not in milvus_vecdb.list_collections(empty=True)
+
+
+@pytest.mark.parametrize("metric_type", ["COSINE", "IP", "L2"])
+def test_milvus_vector_store_lite_score_semantics(tmp_path, metric_type: str):
+    cfg = MilvusDBConfig(
+        collection_name=f"test_milvus_scores_{metric_type.lower()}",
+        uri=str(tmp_path / f"milvus_{metric_type.lower()}.db"),
+        metric_type=metric_type,
+        replace_collection=True,
+        embedding_model=DeterministicEmbeddingModel(),
+    )
+    try:
+        vecdb = VectorStore.create(cfg)
+    except LangroidImportError as exc:
+        pytest.skip(f"Milvus not installed: {exc}")
+    assert isinstance(vecdb, MilvusDB)
+    try:
+        vecdb.add_documents(
+            [
+                Document(
+                    content="alpha document",
+                    metadata=DocMetaData(id="alpha"),
+                ),
+                Document(
+                    content="alpha beta document",
+                    metadata=DocMetaData(id="alpha_beta"),
+                ),
+                Document(
+                    content="beta document",
+                    metadata=DocMetaData(id="beta"),
+                ),
+            ]
+        )
+
+        docs_and_scores = vecdb.similar_texts_with_scores("alpha", k=3)
+        ids = [doc.id() for doc, _ in docs_and_scores]
+        scores = [score for _, score in docs_and_scores]
+
+        assert ids == ["alpha", "alpha_beta", "beta"]
+        assert scores == sorted(scores, reverse=True)
+        if metric_type in ["COSINE", "IP"]:
+            assert scores == pytest.approx([1.0, 0.6, 0.0], abs=1e-6)
+        else:
+            assert scores == pytest.approx(
+                [0.0, -math.sqrt(0.8), -math.sqrt(2.0)],
+                abs=1e-6,
+            )
+
+        if metric_type == "COSINE":
+            matches_above_threshold = [
+                doc.id() for doc, score in docs_and_scores if score > 0.7
+            ]
+            assert matches_above_threshold == ["alpha"]
+    finally:
+        vecdb.clear_all_collections(really=True, prefix="test_milvus_scores_")
+        vecdb.close()
 
 
 @pytest.mark.parametrize(

--- a/tests/main/test_vector_stores.py
+++ b/tests/main/test_vector_stores.py
@@ -376,6 +376,30 @@ def test_milvus_vector_store_lite_score_semantics(tmp_path, metric_type: str):
 
 
 @pytest.mark.parametrize(
+    "metric_type,raw_score,lite_3_0,expected_score",
+    [
+        ("COSINE", 0.4, True, 0.6),
+        ("COSINE", 0.6, False, 0.6),
+        ("IP", 0.6, True, 0.6),
+        ("IP", 0.6, False, 0.6),
+        ("L2", math.sqrt(0.8), True, -math.sqrt(0.8)),
+        ("L2", 0.8, False, -math.sqrt(0.8)),
+    ],
+)
+def test_milvus_score_normalization(
+    metric_type: str,
+    raw_score: float,
+    lite_3_0: bool,
+    expected_score: float,
+):
+    vecdb = object.__new__(MilvusDB)
+    vecdb.config = MilvusDBConfig(metric_type=metric_type)
+    vecdb._milvus_lite_3_0 = lite_3_0
+
+    assert vecdb._score_from_distance(raw_score) == pytest.approx(expected_score)
+
+
+@pytest.mark.parametrize(
     "query,results,exceptions",
     [
         ("which city is Belgium's capital?", [phrases.BELGIUM], ["meilisearch"]),

--- a/tests/main/test_vector_stores.py
+++ b/tests/main/test_vector_stores.py
@@ -247,7 +247,10 @@ def milvus_vecdb(tmp_path) -> MilvusDB:
         embedding_model=DeterministicEmbeddingModel(),
         batch_size=2,
     )
-    vecdb = VectorStore.create(cfg)
+    try:
+        vecdb = VectorStore.create(cfg)
+    except LangroidImportError as exc:
+        pytest.skip(f"Milvus not installed: {exc}")
     assert isinstance(vecdb, MilvusDB)
     yield vecdb
     vecdb.clear_all_collections(really=True, prefix="test_")

--- a/uv.lock
+++ b/uv.lock
@@ -1,34 +1,27 @@
 version = 1
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version < '3.11' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version < '3.11' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version >= '3.13' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_version < '0'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 
 [manifest]
@@ -750,7 +743,7 @@ name = "build"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "os_name == 'nt' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin'" },
+    { name = "colorama", marker = "os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux'" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10.2'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
@@ -1122,7 +1115,7 @@ name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows' and sys_platform != 'darwin'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000 }
 wheels = [
@@ -1176,7 +1169,7 @@ name = "colorlog"
 version = "6.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8c/55/ba79756cb90c8d69d599d57785398ac87bba7b19c80e87f4e8a562197c93/colorlog-6.12.0.tar.gz", hash = "sha256:2a7924c1dadf18b22a0eb8b06d1c7b01d5341707ec1641eb6fcc4fde0c3e8e5f", size = 18151 }
 wheels = [
@@ -1494,7 +1487,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "platform_system == 'Linux'" },
+    { name = "cuda-pathfinder", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403 },
@@ -1525,43 +1518,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_system == 'Linux' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_system == 'Linux' and sys_platform == 'win32')" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -1741,7 +1734,7 @@ name = "docker"
 version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
     { name = "urllib3" },
 ]
@@ -1802,7 +1795,7 @@ wheels = [
 [package.optional-dependencies]
 chunking = [
     { name = "semchunk" },
-    { name = "transformers", marker = "platform_system != 'Linux' or sys_platform != 'darwin'" },
+    { name = "transformers" },
     { name = "tree-sitter" },
     { name = "tree-sitter-c" },
     { name = "tree-sitter-javascript" },
@@ -1827,7 +1820,7 @@ dependencies = [
     { name = "torch" },
     { name = "torchvision" },
     { name = "tqdm" },
-    { name = "transformers", marker = "platform_system != 'Linux' or sys_platform != 'darwin'" },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/2b/c0ad433da1210672d6e8e774f1ba601824e0d23153e8cd963521dcf1c28c/docling_ibm_models-3.13.3.tar.gz", hash = "sha256:8c8b55e80b3d20fc74d85ca49a4d064578ef75b9f7251eec42fc9df6af426218", size = 98768 }
 wheels = [
@@ -1842,7 +1835,7 @@ dependencies = [
     { name = "docling-core" },
     { name = "pillow" },
     { name = "pydantic" },
-    { name = "pywin32", marker = "platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/94/33a91dfb849c1c2a645481cbd7b131c92ff6de17e0b01fe584177b1cb82b/docling_parse-7.8.1.tar.gz", hash = "sha256:5bb5ff8e003b9d0a88da9bf1d1f9927c81677dc9dc20815c87ba6e117d1af661", size = 6758311 }
 wheels = [
@@ -2052,6 +2045,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317 },
+]
+
+[[package]]
+name = "faiss-cpu"
+version = "1.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/b0/48c083d01b7b68c463c1d56507147a9d733f791e1c469a77215a872a9fb5/faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45", size = 4768290 },
+    { url = "https://files.pythonhosted.org/packages/ab/34/6b04ef5bae3eada6b5a9457d7875cce041c040d53c890815cbd1e9821c65/faiss_cpu-1.14.3-cp310-abi3-macosx_15_0_x86_64.whl", hash = "sha256:f9d0e84d909194f63f027bbd3c1e35e905e48c9345c2db6e6f24da09a6bc5906", size = 6925734 },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/b451af4b3c6dd18749ecfb58ccb68503b77e49c9aa4a89d950e9d521e058/faiss_cpu-1.14.3-cp310-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d734cfa9ac90b6a5dfed3a27cb706d05f22824703dafc3969b4e2071877a31c", size = 9661210 },
+    { url = "https://files.pythonhosted.org/packages/a0/ed/57335bc18c9e18677587bec9bf070c675b29c8e683e13f4def0440731ca0/faiss_cpu-1.14.3-cp310-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8780b526c06e57aad90a8c4655dfba2ff1b3195bd600ff4499752fc45159c9fc", size = 18506292 },
+    { url = "https://files.pythonhosted.org/packages/e7/d3/c6ca8c44a63b909e78aa8a69e14501c79c89613e62261d58455ea603d710/faiss_cpu-1.14.3-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b28ba083e8c02f2c9be03783402537fd3f00d27e68799c44bf88931500ee12ec", size = 11238800 },
+    { url = "https://files.pythonhosted.org/packages/93/5f/b405692913a301251749cb175cb3f564ed257fdaa80a22c9a36444d0095d/faiss_cpu-1.14.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cdcb90850cb4b7c27d270839b37bcc0dc8d1fb6a62d1e13053e51ac95061ca25", size = 19237637 },
 ]
 
 [[package]]
@@ -3054,7 +3064,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702 }
 wheels = [
@@ -3166,7 +3176,7 @@ name = "ipykernel"
 version = "7.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -3190,7 +3200,7 @@ name = "ipython"
 version = "8.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "decorator" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "jedi" },
@@ -3360,14 +3370,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853 },
     { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160 },
     { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862 },
-    { url = "https://files.pythonhosted.org/packages/06/d3/8e278946d43eeca2585b4dd0834a887cd71136329b837f3a16ed86a8b4b0/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad", size = 304518 },
-    { url = "https://files.pythonhosted.org/packages/72/43/28d4ef495028bf0506a413d4db3f4eb3e7288a382e0f065f306a17bbeb5e/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f", size = 310207 },
-    { url = "https://files.pythonhosted.org/packages/e0/ca/c366b1012da1d640de975d9683acd44e4d150d9068845d0ca2610435253f/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5", size = 342771 },
-    { url = "https://files.pythonhosted.org/packages/16/52/50cc4056fc1ae02e7154704e7ecc89df0afb8300222cfe8a52d3f67e4730/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85", size = 346468 },
-    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106 },
-    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658 },
-    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719 },
-    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885 },
 ]
 
 [[package]]
@@ -3549,9 +3551,9 @@ dependencies = [
     { name = "jaraco-classes" },
     { name = "jaraco-context" },
     { name = "jaraco-functools" },
-    { name = "jeepney", marker = "platform_system != 'Darwin' and sys_platform == 'linux'" },
-    { name = "pywin32-ctypes", marker = "platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
-    { name = "secretstorage", marker = "platform_system != 'Darwin' and sys_platform == 'linux'" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516 }
 wheels = [
@@ -3636,10 +3638,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/bd/877056304626943ff0f1f44c08f584300c199b887cb3176cd7e34f1515f1/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:fc4d3f1fb9ca0ae9f97b095963bc6326f1dbfd3779d6679a1e016b9baaa153d3", size = 2597482 },
     { url = "https://files.pythonhosted.org/packages/75/19/c60626c47bf0f8ac5dcf72c6c98e266d714f2fbbfd50cf6dab5ede3aaa50/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f443b4825c50a51ee68585522ab4a1d1257fac65896f282b4c6763337ac9f5d2", size = 2394328 },
     { url = "https://files.pythonhosted.org/packages/47/84/6a6d5e5bb8273756c27b7d810d47f7ef2f1f9b9fd23c9ee9a3f8c75c9cef/kiwisolver-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:893ff3a711d1b515ba9da14ee090519bad4610ed1962fbe298a434e8c5f8db53", size = 68410 },
-    { url = "https://files.pythonhosted.org/packages/1c/fa/2910df836372d8761bb6eff7d8bdcb1613b5c2e03f260efe7abe34d388a7/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797", size = 130262 },
-    { url = "https://files.pythonhosted.org/packages/0f/41/c5f71f9f00aabcc71fee8b7475e3f64747282580c2fe748961ba29b18385/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203", size = 138036 },
-    { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295 },
-    { url = "https://files.pythonhosted.org/packages/b5/91/53255615acd2a1eaca307ede3c90eb550bae9c94581f8c00081b6b1c8f44/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57", size = 75987 },
     { url = "https://files.pythonhosted.org/packages/17/6f/6fd4f690a40c2582fa34b97d2678f718acf3706b91d270c65ecb455d0a06/kiwisolver-1.5.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:295d9ffe712caa9f8a3081de8d32fc60191b4b51c76f02f951fd8407253528f4", size = 59606 },
     { url = "https://files.pythonhosted.org/packages/82/a0/2355d5e3b338f13ce63f361abb181e3b6ea5fffdb73f739b3e80efa76159/kiwisolver-1.5.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:51e8c4084897de9f05898c2c2a39af6318044ae969d46ff7a34ed3f96274adca", size = 57537 },
     { url = "https://files.pythonhosted.org/packages/c8/b9/1d50e610ecadebe205b71d6728fd224ce0e0ca6aba7b9cbe1da049203ac5/kiwisolver-1.5.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b83af57bdddef03c01a9138034c6ff03181a3028d9a1003b301eb1a55e161a3f", size = 79888 },
@@ -3732,7 +3730,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2
 
 [[package]]
 name = "langroid"
-version = "0.65.14"
+version = "0.65.15"
 source = { editable = "." }
 dependencies = [
     { name = "adb-cloud-connector" },
@@ -3804,6 +3802,7 @@ all = [
     { name = "pgvector" },
     { name = "psycopg2" },
     { name = "psycopg2-binary" },
+    { name = "pymilvus", extra = ["milvus-lite"] },
     { name = "pymupdf" },
     { name = "pymupdf4llm" },
     { name = "pymysql" },
@@ -3917,6 +3916,9 @@ meilisearch = [
 metaphor = [
     { name = "metaphor-python" },
 ]
+milvus = [
+    { name = "pymilvus", extra = ["milvus-lite"] },
+]
 mysql = [
     { name = "pymysql" },
     { name = "sqlglot" },
@@ -3979,6 +3981,7 @@ vecdbs = [
     { name = "lancedb" },
     { name = "pinecone-client" },
     { name = "pyarrow" },
+    { name = "pymilvus", extra = ["milvus-lite"] },
     { name = "tantivy" },
     { name = "weaviate-client" },
 ]
@@ -4116,6 +4119,9 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.0.0,<3.0.0" },
     { name = "pygithub", specifier = ">=1.58.1,<2.0.0" },
     { name = "pygments", specifier = ">=2.15.1,<3.0.0" },
+    { name = "pymilvus", extras = ["milvus-lite"], marker = "extra == 'all'", specifier = ">=3.0.0" },
+    { name = "pymilvus", extras = ["milvus-lite"], marker = "extra == 'milvus'", specifier = ">=3.0.0" },
+    { name = "pymilvus", extras = ["milvus-lite"], marker = "extra == 'vecdbs'", specifier = ">=3.0.0" },
     { name = "pymupdf", marker = "extra == 'all'", specifier = ">=1.23.3,<2.0.0" },
     { name = "pymupdf", marker = "extra == 'doc-chat'", specifier = ">=1.23.3,<2.0.0" },
     { name = "pymupdf", marker = "extra == 'pdf-parsers'", specifier = ">=1.23.3,<2.0.0" },
@@ -4344,8 +4350,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559 }
 wheels = [
@@ -4456,15 +4462,15 @@ name = "magika"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
-    { name = "numpy", marker = "python_full_version < '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
-    { name = "onnxruntime", marker = "python_full_version < '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
+    { name = "click", marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
+    { name = "numpy", marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
+    { name = "onnxruntime", marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/8fdd991142ad3e037179a494b153f463024e5a211ef3ad948b955c26b4de/magika-0.6.2.tar.gz", hash = "sha256:37eb6ae8020f6e68f231bc06052c0a0cbe8e6fa27492db345e8dc867dbceb067", size = 3036634 }
 wheels = [
@@ -4477,30 +4483,24 @@ name = "magika"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version < '3.11' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version < '3.11' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "click", marker = "(python_full_version < '3.13' and platform_system == 'Darwin') or (python_full_version < '3.13' and platform_system == 'Linux') or (python_full_version < '3.13' and sys_platform != 'win32')" },
-    { name = "numpy", marker = "(python_full_version < '3.13' and platform_system == 'Darwin') or (python_full_version < '3.13' and platform_system == 'Linux') or (python_full_version < '3.13' and sys_platform != 'win32')" },
-    { name = "onnxruntime", marker = "(python_full_version < '3.13' and platform_system == 'Darwin') or (python_full_version < '3.13' and platform_system == 'Linux') or (python_full_version < '3.13' and sys_platform != 'win32')" },
-    { name = "python-dotenv", marker = "(python_full_version < '3.13' and platform_system == 'Darwin') or (python_full_version < '3.13' and platform_system == 'Linux') or (python_full_version < '3.13' and sys_platform != 'win32')" },
+    { name = "click", marker = "python_full_version < '3.13' and sys_platform != 'win32'" },
+    { name = "numpy", marker = "python_full_version < '3.13' and sys_platform != 'win32'" },
+    { name = "onnxruntime", marker = "python_full_version < '3.13' and sys_platform != 'win32'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.13' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/f3/3d1dcdd7b9c41d589f5cff252d32ed91cdf86ba84391cfc81d9d8773571d/magika-0.6.3.tar.gz", hash = "sha256:7cc52aa7359af861957043e2bf7265ed4741067251c104532765cd668c0c0cb1", size = 3042784 }
 wheels = [
@@ -4514,13 +4514,11 @@ name = "magika"
 version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version >= '3.13' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "click", marker = "python_full_version >= '3.13'" },
@@ -4642,13 +4640,11 @@ name = "markitdown"
 version = "0.1.0a4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version >= '3.13' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "beautifulsoup4", marker = "python_full_version >= '3.13'" },
@@ -4679,34 +4675,28 @@ name = "markitdown"
 version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version < '3.11' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version < '3.11' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "beautifulsoup4", marker = "python_full_version < '3.13'" },
     { name = "charset-normalizer", marker = "python_full_version < '3.13'" },
     { name = "defusedxml", marker = "python_full_version < '3.13'" },
-    { name = "magika", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
-    { name = "magika", version = "0.6.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and platform_system == 'Darwin') or (python_full_version < '3.13' and platform_system == 'Linux') or (python_full_version < '3.13' and sys_platform != 'win32')" },
+    { name = "magika", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
+    { name = "magika", version = "0.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' and sys_platform != 'win32'" },
     { name = "markdownify", marker = "python_full_version < '3.13'" },
     { name = "requests", marker = "python_full_version < '3.13'" },
 ]
@@ -4905,7 +4895,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
-    { name = "pywin32", marker = "platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
     { name = "starlette" },
     { name = "typing-extensions" },
@@ -4976,6 +4966,22 @@ wheels = [
 ]
 
 [[package]]
+name = "milvus-lite"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "faiss-cpu", marker = "sys_platform != 'win32'" },
+    { name = "grpcio", marker = "sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "sys_platform != 'win32'" },
+    { name = "tomli", marker = "python_full_version < '3.11' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/d0/3edb31f832287557c8a8bb0515aec2c73265512040dcd4fc43d747722d11/milvus_lite-3.1.1.tar.gz", hash = "sha256:0cbf8386a2e99b6464a5eda14cf8e31934b0e287e36c831e293aee614d9efc2e", size = 647172 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/22/51e60aaf1c1c69ca59d24b01a7f4b0703d6d5a5658385e7d3ed0f8a3a8b2/milvus_lite-3.1.1-py3-none-any.whl", hash = "sha256:0f343c9bf1e291d6c2fa615a52a57090ebbaf96b84bfb71f7eb73cd95cd7fc1c", size = 256749 },
+]
+
+[[package]]
 name = "mirakuru"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5005,7 +5011,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "platform_system == 'Windows' and sys_platform != 'darwin'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -5149,7 +5155,7 @@ dependencies = [
     { name = "mkdocs" },
     { name = "properdocs" },
     { name = "requests" },
-    { name = "tzdata", marker = "platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/e8/70055ec6d7105c0f7c84918e0f98180443b5065469b2877aca43067a5709/mkdocs_rss_plugin-1.19.0.tar.gz", hash = "sha256:0b9b7f14688393e5bd7d26a6dc14dfd2b228a8cdfe5b598a6677589b2159d957", size = 573045 }
 wheels = [
@@ -5211,13 +5217,11 @@ name = "ml-dtypes"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version >= '3.13' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", marker = "python_full_version >= '3.13'" },
@@ -5243,27 +5247,21 @@ name = "ml-dtypes"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version < '3.11' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version < '3.11' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", marker = "python_full_version < '3.13'" },
@@ -5367,7 +5365,7 @@ version = "2.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pygments" },
-    { name = "pywin32", marker = "platform_system == 'Windows' and sys_platform != 'darwin'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/93/80ac75c20ce54c785648b4ed363c88f148bf22637e10c9863db4fbe73e74/mpire-2.10.2.tar.gz", hash = "sha256:f66a321e93fadff34585a4bfa05e95bd946cf714b442f51c529038eb45773d97", size = 271270 }
@@ -5804,7 +5802,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_system == 'Linux'" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918 },
@@ -5843,7 +5841,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "platform_system == 'Linux'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296 },
@@ -5855,7 +5853,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "platform_system == 'Linux'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554 },
@@ -5885,9 +5883,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "platform_system == 'Linux'" },
-    { name = "nvidia-cusparse", marker = "platform_system == 'Linux'" },
-    { name = "nvidia-nvjitlink", marker = "platform_system == 'Linux'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760 },
@@ -5899,7 +5897,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "platform_system == 'Linux'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568 },
@@ -5987,13 +5985,11 @@ name = "onnx"
 version = "1.19.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version >= '3.13' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "ml-dtypes", version = "0.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
@@ -6037,27 +6033,21 @@ name = "onnx"
 version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version < '3.11' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version < '3.11' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "ml-dtypes", version = "0.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
@@ -7197,7 +7187,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "platform_system == 'Darwin' or platform_system == 'Linux' or sys_platform != 'win32'" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450 }
 wheels = [
@@ -7478,16 +7468,14 @@ name = "portalocker"
 version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version >= '3.13' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "pywin32", marker = "python_full_version >= '3.13' and platform_system == 'Windows' and sys_platform != 'darwin'" },
+    { name = "pywin32", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ed/d3/c6c64067759e87af98cc668c1cc75171347d0f1577fab7ca3749134e3cd4/portalocker-2.10.1.tar.gz", hash = "sha256:ef1bf844e878ab08aee7e40184156e1151f228f103aa5c6bd0724cc330960f8f", size = 40891 }
 wheels = [
@@ -7499,30 +7487,24 @@ name = "portalocker"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version < '3.11' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version < '3.11' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "pywin32", marker = "python_full_version < '3.13' and platform_system == 'Windows' and sys_platform != 'darwin'" },
+    { name = "pywin32", marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644 }
 wheels = [
@@ -7707,7 +7689,7 @@ version = "1.6.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "platform_system == 'Windows' and sys_platform != 'darwin'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -7787,7 +7769,7 @@ version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "tzdata", marker = "platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799 }
 wheels = [
@@ -8170,14 +8152,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693 },
     { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819 },
     { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411 },
-    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589 },
-    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552 },
-    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984 },
-    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417 },
-    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527 },
-    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024 },
-    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696 },
-    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590 },
     { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782 },
     { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146 },
     { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492 },
@@ -8299,6 +8273,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455 },
+]
+
+[[package]]
+name = "pymilvus"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "grpcio" },
+    { name = "orjson" },
+    { name = "pandas" },
+    { name = "protobuf" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/c1/01647e61f3a82fd881382746b6dde3401d65b88cd4f75bd059901fb2392b/pymilvus-3.0.0-1-py3-none-any.whl", hash = "sha256:57c8e7c87fbbf579f122b4df893949bc78e50bca2988527864891bd544817b05", size = 344817 },
+]
+
+[package.optional-dependencies]
+milvus-lite = [
+    { name = "milvus-lite", marker = "sys_platform != 'win32'" },
 ]
 
 [[package]]
@@ -8532,7 +8529,7 @@ name = "pytest"
 version = "7.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
@@ -8961,13 +8958,11 @@ name = "qdrant-client"
 version = "1.12.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version >= '3.13' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "grpcio", marker = "python_full_version >= '3.13'" },
@@ -8988,27 +8983,21 @@ name = "qdrant-client"
 version = "1.15.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version < '3.11' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version < '3.11' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_system == 'Linux'",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "grpcio", marker = "python_full_version < '3.13'" },
@@ -9614,8 +9603,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(platform_system == 'Linux' and sys_platform == 'darwin') or (platform_system == 'Linux' and sys_platform == 'win32') or (platform_system != 'Darwin' and sys_platform != 'darwin' and sys_platform != 'win32')" },
-    { name = "jeepney", marker = "(platform_system == 'Linux' and sys_platform == 'darwin') or (platform_system == 'Linux' and sys_platform == 'win32') or (platform_system != 'Darwin' and sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "cryptography", marker = "sys_platform == 'linux'" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884 }
 wheels = [
@@ -10255,19 +10244,19 @@ name = "torch"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "platform_system == 'Linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "platform_system == 'Linux'" },
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cudnn-cu13", marker = "platform_system == 'Linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "platform_system == 'Linux'" },
-    { name = "nvidia-nccl-cu13", marker = "platform_system == 'Linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "platform_system == 'Linux'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
     { name = "setuptools" },
     { name = "sympy" },
-    { name = "triton", marker = "platform_system == 'Linux'" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
@@ -10339,7 +10328,7 @@ name = "tqdm"
 version = "4.69.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows' and sys_platform != 'darwin'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/84/da0e5038228fa34dfd77c5026b173ed035d2a3ba31f1077590c013de2bff/tqdm-4.69.1.tar.gz", hash = "sha256:2be21080a0ce17e902c2f1baeb6a74bf551b67bbdfa4bc0109fad471d0b4cb0d", size = 793046 }
 wheels = [
@@ -10752,7 +10741,7 @@ name = "tzlocal"
 version = "5.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "platform_system == 'Windows' and sys_platform != 'darwin'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/5b/879b2f932adfa7a053c360d50bc896c977fa6426109185f7c12ebdd0cb9d/tzlocal-5.4.4.tar.gz", hash = "sha256:8dbb8660838688a7b6ba4fed31d18dedf842afb4d47ca050d6d891c2c15f3be4", size = 31170 }
 wheels = [


### PR DESCRIPTION
## Summary
- Add `MilvusDBConfig` and `MilvusDB` using PyMilvus `MilvusClient`, with Milvus Lite as the default `./milvus.db` backend.
- Support `MILVUS_URI`, `MILVUS_TOKEN`, and `MILVUS_DB_NAME`, plus optional `uri`, `token`, and `db_name` config fields.
- Wire the vector store factory, exports, optional extras, docs, and the docqa chat example.
- Add focused Milvus Lite coverage for add, search, filtering, listing, delete, and clear behavior.

## Testing
- `uvx ruff check langroid/vector_store/milvusdb.py tests/main/test_vector_stores.py`
- `uvx black --check langroid/vector_store/milvusdb.py tests/main/test_vector_stores.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --python 3.11 --extra milvus --with sqlalchemy pytest -q tests/main/test_vector_stores.py -k milvus`

Closes #693
