### PR TITLE
fix: carry LLM "no content" faithfully as None (fixes Gemini 3.x tool calls)

### DIFF
--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -1186,7 +1186,7 @@ class Agent(ABC):
             # streaming was enabled, AND we did not find a cached response.
             # If we are here, it means the response has not yet been displayed.
             cached = f"[red]{self.indent}(cached)[/red]" if response.cached else ""
-            print(cached + "[green]" + escape(response.message))
+            print(cached + "[green]" + escape(response.message or ""))
         async with self.lock:
             self.update_token_usage(
                 response,
@@ -1261,7 +1261,7 @@ class Agent(ABC):
             # If we are here, it means the response has not yet been displayed.
             cached = "[red](cached)[/red]" if response.cached else ""
             console.print(f"[green]{self.indent}", end="")
-            print(cached + "[green]" + escape(response.message))
+            print(cached + "[green]" + escape(response.message or ""))
         self.update_token_usage(
             response,
             prompt,
@@ -2206,7 +2206,7 @@ class Agent(ABC):
         else:
             return sum(
                 [
-                    self.parser.num_tokens(m.content)
+                    self.parser.num_tokens(m.content or "")
                     + self.parser.num_tokens(str(m.function_call or ""))
                     for m in prompt
                 ]
@@ -2290,7 +2290,7 @@ class Agent(ABC):
             cost = 0.0
             if not response.cached:
                 prompt_tokens = self.num_tokens(prompt)
-                completion_tokens = self.num_tokens(response.message)
+                completion_tokens = self.num_tokens(response.message or "")
                 if response.function_call is not None:
                     completion_tokens += self.num_tokens(str(response.function_call))
                 cost = self.compute_token_cost(prompt_tokens, 0, completion_tokens)

--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -1345,7 +1345,7 @@ class ChatAgent(Agent):
             llm_msg = self.message_history[idx]
         else:
             llm_msg = copy.deepcopy(self.message_history[idx])
-        orig_content = llm_msg.content
+        orig_content = llm_msg.content or ""
         new_content = (
             self.parser.truncate_tokens(orig_content, tokens)
             if self.parser is not None
@@ -1640,8 +1640,9 @@ class ChatAgent(Agent):
                 # different from the last message in the history
                 llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
                 # LLM only responds to the content, so only those msgs with
-                # non-empty content should be kept
-                llm_msgs = [m for m in llm_msgs if m.content.strip() != ""]
+                # non-empty content should be kept (content may be None, i.e.
+                # "no content", e.g. an assistant turn that is only a tool call)
+                llm_msgs = [m for m in llm_msgs if (m.content or "").strip() != ""]
                 if len(llm_msgs) == 0:
                     return [], 0
                 # process tools if any
@@ -1999,7 +2000,7 @@ class ChatAgent(Agent):
             self._call_callback_with_reasoning(
                 "finish_llm_stream",
                 reasoning=response.reasoning,
-                content=response.message,
+                content=response.message or "",
                 tools_content=response.tools_content(),
                 is_tool=self.has_tool_message_attempt(temp_doc),
             )
@@ -2069,7 +2070,7 @@ class ChatAgent(Agent):
             self._call_callback_with_reasoning(
                 "finish_llm_stream",
                 reasoning=response.reasoning,
-                content=response.message,
+                content=response.message or "",
                 tools_content=response.tools_content(),
                 is_tool=self.has_tool_message_attempt(temp_doc),
             )
@@ -2167,7 +2168,7 @@ class ChatAgent(Agent):
             if not settings.quiet:
                 print(cached + "[green]" + escape(str(response)))
             if isinstance(response, LLMResponse):
-                content = response.message
+                content = response.message or ""
                 tools_content = response.tools_content()
             else:
                 content = response.content
@@ -2331,9 +2332,9 @@ class ChatAgent(Agent):
                 "before calling _message_num_tokens()."
             )
 
-        return self.parser.num_tokens(message.content) + self._attachment_num_tokens(
-            message
-        )
+        return self.parser.num_tokens(
+            message.content or ""
+        ) + self._attachment_num_tokens(message)
 
     def _attachment_num_tokens(self, message: LLMMessage) -> int:
         """

--- a/langroid/agent/chat_document.py
+++ b/langroid/agent/chat_document.py
@@ -151,6 +151,12 @@ class ChatDocument(Document):
 
     reasoning: str = ""  # reasoning produced by a reasoning LLM
     content_any: Any = None  # to hold arbitrary data returned by responders
+    # True when the underlying LLM response had NO content (only a tool/function
+    # call), as opposed to content == "" (present but empty). `content` itself
+    # stays a mandatory str (""), so this flag is what carries "missing" through
+    # to to_LLMMessage(), which reproduces it as LLMMessage.content = None.
+    # (content_any cannot serve this role — it defaults to None on every doc.)
+    content_is_none: bool = False
     # Original LLM response text including inline thought signatures
     # (e.g. <thinking>...</thinking>). Only populated when reasoning was
     # extracted from inline tags in the message text. Used by to_LLMMessage()
@@ -345,10 +351,13 @@ class ChatDocument(Document):
         Returns:
             ChatDocument: ChatDocument representation of this LLMResponse.
         """
+        # Capture "no content" from the source response (None, not "") before
+        # recipient parsing can turn it into "".
+        content_is_none = response.message is None
         recipient, message = response.get_recipient_and_message(
             recognize_recipient_in_content
         )
-        message = message.strip()
+        message = message.strip() if message is not None else ""
         if message in ["''", '""']:
             message = ""
         if response.function_call is not None:
@@ -359,6 +368,7 @@ class ChatDocument(Document):
                 ChatDocument._clean_fn_call(oai_tc.function)
         return ChatDocument(
             content=message,
+            content_is_none=content_is_none,
             reasoning=response.reasoning,
             content_with_reasoning=response.message_with_reasoning,
             content_any=message,
@@ -423,6 +433,7 @@ class ChatDocument(Document):
 
         return ChatDocument(
             content=message.content or "",
+            content_is_none=message.content is None,
             content_any=message.content,
             files=message.files,
             function_call=message.function_call,
@@ -466,7 +477,7 @@ class ChatDocument(Document):
         # content_with_reasoning is only set when inline tags were
         # actually extracted, so this won't interfere with models that
         # provide reasoning via a separate API field.
-        content = (
+        content: Optional[str] = (
             message.content_with_reasoning
             or message.content
             or to_string(message.content_any)
@@ -488,8 +499,17 @@ class ChatDocument(Document):
             # same reasoning as for function-call above
             content += " " + "\n\n".join(str(tc) for tc in oai_tool_calls)
             oai_tool_calls = None
-        # some LLM APIs (e.g. gemini) don't like empty msg
-        content = content or " "
+        # Faithfully carry the response shape: if the underlying LLM response
+        # had NO content (content_is_none), reproduce that as None ("missing"),
+        # distinct from a present-but-empty "". content_any is NOT used as the
+        # signal here — it defaults to None on every ChatDocument. How a missing
+        # content is rendered on the wire is left to LLMMessage.api_dict (it
+        # drops None, and pads a lone space only when a message would otherwise
+        # be completely empty). This is what lets an assistant tool-call turn
+        # omit `content`: Gemini 3.x rejects an assistant turn that has BOTH a
+        # tool/function call and (even whitespace) text content.
+        if message.content_is_none and not content:
+            content = None
         sender_name = message.metadata.sender_name
         tool_ids = message.metadata.tool_ids
         tool_id = tool_ids[-1] if len(tool_ids) > 0 else ""

--- a/langroid/agent/chat_document.py
+++ b/langroid/agent/chat_document.py
@@ -480,7 +480,10 @@ class ChatDocument(Document):
         content: Optional[str] = (
             message.content_with_reasoning
             or message.content
-            or to_string(message.content_any)
+            # content_any may hold parsed structured output (e.g. tool-call
+            # args loaded under a strict output_format), which is NOT message
+            # text — never let it stand in for content on a call-only turn.
+            or ("" if message.content_is_none else to_string(message.content_any))
             or ""
         )
         fun_call = message.function_call
@@ -501,13 +504,16 @@ class ChatDocument(Document):
             oai_tool_calls = None
         # Faithfully carry the response shape: if the underlying LLM response
         # had NO content (content_is_none), reproduce that as None ("missing"),
-        # distinct from a present-but-empty "". content_any is NOT used as the
-        # signal here — it defaults to None on every ChatDocument. How a missing
-        # content is rendered on the wire is left to LLMMessage.api_dict (it
-        # drops None, and pads a lone space only when a message would otherwise
-        # be completely empty). This is what lets an assistant tool-call turn
-        # omit `content`: Gemini 3.x rejects an assistant turn that has BOTH a
-        # tool/function call and (even whitespace) text content.
+        # distinct from a present-but-empty "". content_is_none is the signal
+        # (content_any can't be — it defaults to None on every ChatDocument,
+        # and may carry parsed structured output rather than text; see above).
+        # `not content` still lets a USER-sender fold a function/tool call into
+        # content above. How a missing content is rendered on the wire is left
+        # to LLMMessage.api_dict (it drops None, and pads a lone space only when
+        # a message would otherwise be completely empty). This is what lets an
+        # assistant tool-call turn omit `content`: Gemini 3.x rejects an
+        # assistant turn that has BOTH a tool/function call and (even
+        # whitespace) text content.
         if message.content_is_none and not content:
             content = None
         sender_name = message.metadata.sender_name

--- a/langroid/agent/openai_assistant.py
+++ b/langroid/agent/openai_assistant.py
@@ -803,7 +803,7 @@ class OpenAIAssistant(ChatAgent):
                 self.cached_tool_ids += [response.tool_id]
             response_str = str(response.function_call)
         else:
-            response_str = response.message
+            response_str = response.message or ""
         cache_str = "[red](cached)[/red]" if cached else ""
         if not settings.quiet:
             if not cached and self._get_code_logs_str():

--- a/langroid/language_models/base.py
+++ b/langroid/language_models/base.py
@@ -283,7 +283,10 @@ class LLMMessage(BaseModel):
     name: Optional[str] = None
     tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
     tool_id: str = ""  # used by OpenAIAssistant
-    content: str
+    # None means "no content" (the model returned only a tool/function call).
+    # This is distinct from "" and is dropped from the API payload by api_dict;
+    # see api_dict for how a fully-empty message is handled per-API.
+    content: Optional[str] = None
     files: List[FileAttachment] = []
     function_call: Optional[LLMFunctionCall] = None
     tool_calls: Optional[List[OpenAIToolCall]] = None
@@ -312,7 +315,7 @@ class LLMMessage(BaseModel):
             d["content"] = [
                 dict(
                     type="text",
-                    text=self.content,
+                    text=self.content or "",
                 )
             ] + [f.to_dict(model) for f in self.files]
 
@@ -320,9 +323,10 @@ class LLMMessage(BaseModel):
         # in case has_system_role is False
         if not has_system_role and "role" in d and d["role"] == "system":
             d["role"] = "user"
-            if "content" in d:
+            if d.get("content"):
                 d["content"] = "[ADDITIONAL SYSTEM MESSAGE:]\n\n" + d["content"]
-        # drop None values since API doesn't accept them
+        # drop None values since API doesn't accept them (this omits `content`
+        # entirely when it is None, i.e. "no content")
         dict_no_none = {k: v for k, v in d.items() if v is not None}
         if "name" in dict_no_none and dict_no_none["name"] == "":
             # OpenAI API does not like empty name
@@ -346,6 +350,15 @@ class LLMMessage(BaseModel):
                         )
                 if "extra_content" in tc and tc["extra_content"] is None:
                     del tc["extra_content"]
+        # A message with empty content (None was dropped above, or "") AND no
+        # tool/function call would be an entirely empty message, which some APIs
+        # (e.g. Gemini) reject; fall back to a single space in that case only.
+        # When there IS a tool/function call, empty content is fine (and Gemini
+        # 3.x in fact REQUIRES it — it rejects an assistant turn that carries
+        # both a call and non-empty text content).
+        has_call = "tool_calls" in dict_no_none or "function_call" in dict_no_none
+        if not has_call and not dict_no_none.get("content"):
+            dict_no_none["content"] = " "
         # IMPORTANT! drop fields that are not expected in API call
         dict_no_none.pop("tool_id", None)
         dict_no_none.pop("timestamp", None)
@@ -356,7 +369,7 @@ class LLMMessage(BaseModel):
         if self.function_call is not None:
             content = "FUNC: " + json.dumps(self.function_call)
         else:
-            content = self.content
+            content = self.content or ""
         name_str = f" ({self.name})" if self.name else ""
         return f"{self.role} {name_str}: {content}"
 
@@ -366,7 +379,11 @@ class LLMResponse(BaseModel):
     Class representing response from LLM.
     """
 
-    message: str
+    # None means the model returned NO content (e.g. only a tool/function
+    # call), which is distinct from an empty string "". Preserving this
+    # distinction lets the message be faithfully reproduced downstream
+    # (see ChatDocument.content_is_none and LLMMessage.content).
+    message: Optional[str] = None
     reasoning: str = ""  # optional reasoning text from reasoning models
     # Original message text including inline thought signatures (e.g.
     # <thinking>...</thinking>). Only set when reasoning was extracted
@@ -387,7 +404,7 @@ class LLMResponse(BaseModel):
         elif self.oai_tool_calls:
             return "\n".join(str(tc) for tc in self.oai_tool_calls)
         else:
-            return self.message
+            return self.message or ""
 
     def tools_content(self) -> str:
         if self.function_call is not None:
@@ -567,7 +584,7 @@ class LanguageModel(ABC):
         if len(messages) == 0 or messages[0].role != Role.SYSTEM:
             logger.warning("No system msg, creating dummy system prompt")
             messages.insert(0, LLMMessage(content=DUMMY_SYS_PROMPT, role=Role.SYSTEM))
-        system_prompt = messages[0].content
+        system_prompt = messages[0].content or ""
 
         # now we have messages = [Sys,...]
         if len(messages) == 1:
@@ -591,8 +608,8 @@ class LanguageModel(ABC):
 
         # now we have messages = [Sys, user, ..., user]
         # so we omit the first and last elements and make pairs of user-asst messages
-        conversation = [m.content for m in messages[1:-1]]
-        user_prompt = messages[-1].content
+        conversation = [m.content or "" for m in messages[1:-1]]
+        user_prompt = messages[-1].content or ""
         pairs = LanguageModel.user_assistant_pairs(conversation)
         return system_prompt, pairs, user_prompt
 
@@ -822,13 +839,17 @@ class LanguageModel(ABC):
         """.strip()
 
         show_if_debug(prompt, "FOLLOWUP->STANDALONE-PROMPT= ")
-        standalone = self.chat(
-            messages=[
-                LLMMessage(role=Role.SYSTEM, content=prompt),
-                LLMMessage(role=Role.USER, content=follow_up_question),
-            ],
-            max_tokens=1024,
-        ).message.strip()
+        standalone = (
+            self.chat(
+                messages=[
+                    LLMMessage(role=Role.SYSTEM, content=prompt),
+                    LLMMessage(role=Role.USER, content=follow_up_question),
+                ],
+                max_tokens=1024,
+            ).message
+            or ""
+        )
+        standalone = standalone.strip()
 
         show_if_debug(prompt, "FOLLOWUP->STANDALONE-RESPONSE= ")
         return standalone

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -1863,9 +1863,9 @@ class OpenAIGPT(LanguageModel):
         if not isinstance(response, dict):
             response = response.model_dump()
         if "message" in response["choices"][0]:
-            msg = response["choices"][0]["message"]["content"].strip()
+            msg = (response["choices"][0]["message"]["content"] or "").strip()
         else:
-            msg = response["choices"][0]["text"].strip()
+            msg = (response["choices"][0]["text"] or "").strip()
         return LLMResponse(message=msg, cached=cached)
 
     async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
@@ -1945,9 +1945,9 @@ class OpenAIGPT(LanguageModel):
         if not isinstance(response, dict):
             response = response.model_dump()
         if "message" in response["choices"][0]:
-            msg = response["choices"][0]["message"]["content"].strip()
+            msg = (response["choices"][0]["message"]["content"] or "").strip()
         else:
-            msg = response["choices"][0]["text"].strip()
+            msg = (response["choices"][0]["text"] or "").strip()
         return LLMResponse(message=msg, cached=cached)
 
     def chat(
@@ -2398,7 +2398,10 @@ class OpenAIGPT(LanguageModel):
                     )
                     msg = msg + "\n" + json.dumps(tool_call_dict)
         return LLMResponse(
-            message=msg.strip() if msg is not None else "",
+            # None (no content, e.g. a tool-call-only response) is preserved as
+            # None rather than coerced to "", so the distinction survives
+            # downstream (see LLMMessage.content / ChatDocument.content_is_none).
+            message=msg.strip() if msg is not None else None,
             reasoning=reasoning.strip() if reasoning is not None else "",
             message_with_reasoning=message_with_reasoning,
             function_call=fun_call,

--- a/tests/main/test_prep_llm_message.py
+++ b/tests/main/test_prep_llm_message.py
@@ -4,7 +4,13 @@ import pytest
 
 from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
 from langroid.agent.chat_document import ChatDocMetaData, ChatDocument
-from langroid.language_models.base import LLMMessage, Role
+from langroid.language_models.base import (
+    LLMFunctionCall,
+    LLMMessage,
+    LLMResponse,
+    OpenAIToolCall,
+    Role,
+)
 from langroid.language_models.openai_gpt import OpenAIGPTConfig
 from langroid.mytypes import Entity
 from langroid.parsing.file_attachment import FileAttachment
@@ -381,3 +387,83 @@ def test_drop_turns_accounts_for_buffer():
     # History should have been compressed
     assert hist[0].role == Role.SYSTEM
     assert hist[-1].role == Role.USER
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for "missing" (None) vs "empty" ("") message content.
+#
+# Gemini 3.x rejects (400 INVALID_ARGUMENT) an assistant turn that carries BOTH
+# a tool/function call AND non-empty text content. Langroid used to pad empty
+# content with a single space (" "), which tripped this on every tool-result
+# turn. Content is now carried faithfully: a response with no content becomes
+# LLMMessage.content=None (dropped from the wire), distinct from "".
+# ---------------------------------------------------------------------------
+
+MODEL = "gpt-4o"
+
+
+def _tool_call():
+    return OpenAIToolCall(
+        id="call_1",
+        type="function",
+        function=LLMFunctionCall(name="check_weather", arguments={"city": "London"}),
+    )
+
+
+def test_api_dict_omits_content_for_tool_call_message():
+    """An assistant tool-call turn with no content omits `content` on the wire
+    (never emits " ", which Gemini 3.x rejects alongside a tool call)."""
+    d = LLMMessage(
+        role=Role.ASSISTANT, content=None, tool_calls=[_tool_call()]
+    ).api_dict(MODEL)
+    assert "content" not in d
+    assert "tool_calls" in d
+
+
+def test_api_dict_pads_empty_message_without_tools():
+    """A message with empty content (None or "") and no tool/function call must
+    still send something, since some APIs (e.g. Gemini) reject an empty msg."""
+    assert LLMMessage(role=Role.USER, content=None).api_dict(MODEL)["content"] == " "
+    assert LLMMessage(role=Role.USER, content="").api_dict(MODEL)["content"] == " "
+
+
+def test_api_dict_keeps_real_content():
+    d = LLMMessage(role=Role.USER, content="hello").api_dict(MODEL)
+    assert d["content"] == "hello"
+
+
+def test_missing_content_is_none_end_to_end():
+    """A tool-only LLM response (message=None) is carried faithfully as
+    content_is_none -> LLMMessage.content=None -> omitted from api_dict."""
+    resp = LLMResponse(message=None, oai_tool_calls=[_tool_call()])
+    doc = ChatDocument.from_LLMResponse(resp)
+    assert doc.content == ""  # ChatDocument.content stays a mandatory str
+    assert doc.content_is_none is True
+
+    msg = ChatDocument.to_LLMMessage(doc)[0]
+    assert msg.role == Role.ASSISTANT
+    assert msg.content is None
+    assert msg.tool_calls is not None
+    assert "content" not in msg.api_dict(MODEL)
+
+
+def test_empty_content_stays_empty_not_none():
+    """A present-but-empty response (message="") is distinct from missing:
+    it must NOT be coerced to None."""
+    resp = LLMResponse(message="", oai_tool_calls=[_tool_call()])
+    doc = ChatDocument.from_LLMResponse(resp)
+    assert doc.content_is_none is False
+
+    msg = ChatDocument.to_LLMMessage(doc)[0]
+    assert msg.content == ""
+
+
+def test_none_content_round_trips_through_chatdocument():
+    """LLMMessage.content=None survives an LLMMessage -> ChatDocument ->
+    LLMMessage round-trip (history is rebuilt this way)."""
+    original = LLMMessage(role=Role.ASSISTANT, content=None, tool_calls=[_tool_call()])
+    doc = ChatDocument.from_LLMMessage(original)
+    assert doc.content_is_none is True
+
+    rebuilt = ChatDocument.to_LLMMessage(doc)[0]
+    assert rebuilt.content is None

--- a/tests/main/test_prep_llm_message.py
+++ b/tests/main/test_prep_llm_message.py
@@ -467,3 +467,21 @@ def test_none_content_round_trips_through_chatdocument():
 
     rebuilt = ChatDocument.to_LLMMessage(doc)[0]
     assert rebuilt.content is None
+
+
+def test_content_is_none_overrides_populated_content_any():
+    """A call-only turn stays content=None even when content_any was populated
+    (e.g. by _load_output_format parsing the tool args under a strict
+    output_format). Otherwise the serialized args would be sent as assistant
+    text alongside tool_calls, which is the Gemini 3.x rejection this avoids."""
+    doc = ChatDocument(
+        content="",
+        content_is_none=True,
+        # parsed structured output (tool args), NOT message text:
+        content_any={"city": "London"},
+        oai_tool_calls=[_tool_call()],
+        metadata=ChatDocMetaData(sender=Entity.LLM, source=Entity.LLM),
+    )
+    msg = ChatDocument.to_LLMMessage(doc)[0]
+    assert msg.content is None
+    assert "content" not in msg.api_dict(MODEL)


### PR DESCRIPTION
### Overview

This PR fixes `langroid` behavior for new Gemini 3.5 Flash Lite and Gemini 3.6 Flash models on Vertex AI (Gemini Enterprise Agents Platform).

Before the change any tool call response triggered 400 error from the API - see [this post](https://discuss.ai.google.dev/t/tool-calling-doesnt-work-for-new-gemini-3-6-flash-and-gemini-3-5-flash-lite-models-on-vertex-ai-enterprise-agents-platform-via-openai-compatibility-api/175801/2) for details. The root cause was coercion of LLM response with missing content field into a LLM message with content == " ".

I tried to minimize the "blast radius" - and therefore kept `ChatDocument.content` as a mandatory string, and instead introduced a new `content_is_none` attribute that "carries the signal" along the LLMResponse > ChatDocument > LLMMessage parsing "pipeline".

I explicitly verified the change against both new Gemini models in my Vertex AI account.
Old code produced 400 error. New code produced a valid response.

### Detailed changes description

An assistant turn that is only a tool/function call has no text content. ChatDocument.to_LLMMessage padded such empty content with a single space (" ") "because some LLM APIs don't like an empty msg", so every stored tool-call turn carried content=" ". Gemini 3.x (e.g. gemini-3.5-flash-lite, gemini-3.6-flash) rejects an assistant turn that has BOTH a tool/function call AND non-empty text content with 400 INVALID_ARGUMENT, breaking every conversation on the turn that sends a tool result back to the model.

Carry the response shape faithfully instead of fabricating content:

- LLMResponse.message is now Optional[str]; a tool-only response keeps message=None (distinct from "") rather than being coerced to "".
- ChatDocument gains an explicit `content_is_none` flag (content itself stays a mandatory str). content_any cannot serve this role since it defaults to None on every ChatDocument.
- ChatDocument.to_LLMMessage reproduces "no content" as LLMMessage.content=None (now Optional[str]) instead of " ".
- LLMMessage.api_dict drops None content from the payload, and pads a lone space only when a message would otherwise be entirely empty (no content AND no tool/function call) - the case older Gemini rejects.

This distinguishes "missing" (None, omitted on the wire) from "present-but-empty" ("") end to end. None-safety guards added for the LLMMessage.content / LLMResponse.message consumers (token counting, truncation, display callbacks). Regression tests added.