### PR TITLE
fix: keep tool/function-result messages in history even when empty

### DIFF
--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -1641,14 +1641,20 @@ class ChatAgent(Agent):
                 # either the message is a str, or it is a fresh ChatDocument
                 # different from the last message in the history
                 llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
-                # Keep messages that have text or a function/tool call. A call-only
-                # assistant turn has no content but is still required in history.
+                # Keep messages that have text, a function/tool call, or ARE a
+                # function/tool call result. A call-only assistant turn has no
+                # content but is still required in history, and so is a
+                # legitimately-empty tool/function result: neither carries
+                # function_call/tool_calls (those live on the assistant turn
+                # that made the call), so dropping it here would silently
+                # un-answer the pending call it responds to (issue #1063).
                 llm_msgs = [
                     m
                     for m in llm_msgs
                     if (m.content or "").strip() != ""
                     or m.function_call is not None
                     or bool(m.tool_calls)
+                    or m.role in (Role.FUNCTION, Role.TOOL)
                 ]
                 if len(llm_msgs) == 0:
                     return [], 0

--- a/tests/main/test_prep_llm_message.py
+++ b/tests/main/test_prep_llm_message.py
@@ -591,4 +591,27 @@ def test_content_is_none_overrides_stale_text_after_serialization():
 
     assert msg.content is None
     assert msg.tool_calls == [_tool_call()]
-    assert "content" not in msg.api_dict(MODEL)
+
+
+def test_prep_keeps_legitimately_empty_tool_result(agent: ChatAgent) -> None:
+    """A tool result with genuinely empty content (e.g. a tool that succeeds
+    with no output) must stay in history and clear the pending tool call from
+    agent.oai_tool_calls, not get silently dropped (issue #1063). Before the
+    fix, the history filter kept a message only if it had non-empty content, a
+    function_call, or tool_calls -- none of which a TOOL-role result carries,
+    so an empty-content result was dropped and its call_id never reached
+    `done_tools`, leaving the call marked pending forever."""
+    agent.oai_tool_calls = [_tool_call()]
+    doc = ChatDocument(
+        content="",
+        metadata=ChatDocMetaData(
+            sender=Entity.AGENT, source=Entity.AGENT, oai_tool_id="call_1"
+        ),
+    )
+
+    hist, _ = agent._prep_llm_messages(doc)
+
+    tool_msgs = [m for m in hist if m.role == Role.TOOL]
+    assert len(tool_msgs) == 1
+    assert tool_msgs[0].tool_call_id == "call_1"
+    assert agent.oai_tool_calls == []


### PR DESCRIPTION
## Root cause

`_prep_llm_messages` (`langroid/agent/chat_agent.py:1646-1652`) filters the
messages built from an incoming turn to those with non-empty content, a
`function_call`, or `tool_calls`, then computes `done_tools` (the pending
tool-call ids being answered) from whatever survives that filter.

A tool/function-result message never carries `function_call` or
`tool_calls`: those live on the assistant turn that made the call, not on
the message answering it. So a legitimately-empty tool result (a tool that
succeeds with no output) fails all three conditions and is dropped before
`done_tools` is computed. Its `tool_call_id` never reaches `done_tools`, so
`self.oai_tool_calls` keeps treating that call as pending. When the result
was the only message being prepped, `llm_msgs` ends up empty and
`llm_response()` returns `None` instead of sending the tool response back
to the model.

## Fix

Keep a message when its role is `FUNCTION` or `TOOL`, alongside the
existing content/function_call/tool_calls checks, matching the same
"still required in history" reasoning the comment above it already states
for call-only assistant turns.

## Verification

Ran in a clean `python:3.11` Docker container this session, on this
branch (`uv sync`, then pytest). `python -c 'import
langroid.agent.chat_agent as m; print(m.__file__)'` resolved to the
in-repo copy, confirming provenance.

- Added `test_prep_keeps_legitimately_empty_tool_result`
  (`tests/main/test_prep_llm_message.py`): sets a single pending tool call,
  preps an empty-content tool-result `ChatDocument` answering it, and
  asserts the `TOOL` message survives in history and
  `agent.oai_tool_calls` clears. Fails on main (0 tool messages survive,
  `AssertionError: 0 == 1`), passes with the fix. Confirmed both ways by
  toggling the source change with the test left in place.
- Full `tests/main/test_prep_llm_message.py`: 22 passed.
- `tests/main/test_openai_gpt_none_content.py` and
  `tests/main/test_llm_response.py` (touch the same content/tool-call
  handling, run offline): 22 passed.
- Repo's PR-blocking Lint gate (confirmed from #1062's checks: `lint
  (3.11)`, `lint (3.13)`), run locally on the changed files: `black
  --check`, `ruff check`, `mypy -p langroid` all clean.

Not verified: the broader test suite gated behind `ready_for_review` (the
`Pytest` workflow) and any test requiring an OpenAI API key, since those
need live credentials this session does not have.

Fixes #1063
