### PR TITLE
fix: avoid constructing unused httpx client on cache hit

### DIFF
--- a/langroid/language_models/client_cache.py
+++ b/langroid/language_models/client_cache.py
@@ -111,19 +111,6 @@ def get_openai_client(
         _all_clients.add(client)
         return client
 
-    # If http_client_config is provided, create client from config and cache
-    created_http_client = None
-    if http_client_config is not None:
-        try:
-            from httpx import Client
-
-            created_http_client = Client(**http_client_config)
-        except ImportError:
-            raise ValueError(
-                "httpx is required to use http_client_config. "
-                "Install it with: pip install httpx"
-            )
-
     cache_key = _get_cache_key(
         "openai",
         api_key=api_key,
@@ -138,6 +125,20 @@ def get_openai_client(
         cached_client = _get_cached_client(cache_key)
         if cached_client is not None:
             return cast(OpenAI, cached_client)
+
+        # Only create the transport on a cache miss, so cache hits do not
+        # allocate an httpx client that is never used.
+        created_http_client = None
+        if http_client_config is not None:
+            try:
+                from httpx import Client
+
+                created_http_client = Client(**http_client_config)
+            except ImportError:
+                raise ValueError(
+                    "httpx is required to use http_client_config. "
+                    "Install it with: pip install httpx"
+                )
 
         client = OpenAI(
             api_key=api_key,
@@ -192,19 +193,6 @@ def get_async_openai_client(
         _all_clients.add(client)
         return client
 
-    # If http_client_config is provided, create async client from config and cache
-    created_http_client = None
-    if http_client_config is not None:
-        try:
-            from httpx import AsyncClient
-
-            created_http_client = AsyncClient(**http_client_config)
-        except ImportError:
-            raise ValueError(
-                "httpx is required to use http_client_config. "
-                "Install it with: pip install httpx"
-            )
-
     cache_key = _get_cache_key(
         "async_openai",
         api_key=api_key,
@@ -219,6 +207,20 @@ def get_async_openai_client(
         cached_client = _get_cached_client(cache_key)
         if cached_client is not None:
             return cast(AsyncOpenAI, cached_client)
+
+        # Only create the transport on a cache miss, so cache hits do not
+        # allocate an httpx client that is never used.
+        created_http_client = None
+        if http_client_config is not None:
+            try:
+                from httpx import AsyncClient
+
+                created_http_client = AsyncClient(**http_client_config)
+            except ImportError:
+                raise ValueError(
+                    "httpx is required to use http_client_config. "
+                    "Install it with: pip install httpx"
+                )
 
         client = AsyncOpenAI(
             api_key=api_key,

--- a/tests/main/test_openai_gpt_client_cache.py
+++ b/tests/main/test_openai_gpt_client_cache.py
@@ -42,6 +42,54 @@ class TestOpenAIGPTClientCache:
         client2 = get_openai_client(api_key="key2")
         assert client1 is not client2
 
+    def test_cache_hit_does_not_create_extra_httpx_client(self, monkeypatch):
+        """A cache hit must not construct an unused httpx.Client."""
+        import httpx
+
+        created = []
+        real_client = httpx.Client
+
+        class TrackingClient(real_client):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created.append(self)
+
+        monkeypatch.setattr(httpx, "Client", TrackingClient)
+
+        client1 = get_openai_client(
+            api_key="test-key-httpx", http_client_config={"timeout": 1.0}
+        )
+        client2 = get_openai_client(
+            api_key="test-key-httpx", http_client_config={"timeout": 1.0}
+        )
+
+        assert client1 is client2
+        assert len(created) == 1
+
+    def test_async_cache_hit_does_not_create_extra_httpx_client(self, monkeypatch):
+        """A cache hit must not construct an unused httpx.AsyncClient."""
+        import httpx
+
+        created = []
+        real_client = httpx.AsyncClient
+
+        class TrackingAsyncClient(real_client):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created.append(self)
+
+        monkeypatch.setattr(httpx, "AsyncClient", TrackingAsyncClient)
+
+        client1 = get_async_openai_client(
+            api_key="test-key-httpx-async", http_client_config={"timeout": 1.0}
+        )
+        client2 = get_async_openai_client(
+            api_key="test-key-httpx-async", http_client_config={"timeout": 1.0}
+        )
+
+        assert client1 is client2
+        assert len(created) == 1
+
     def test_async_openai_client_singleton(self):
         """Test that same config returns same AsyncOpenAI client instance."""
         api_key = "test-key-async"


### PR DESCRIPTION
Closes #1017

When `http_client_config` is passed, the httpx transport was built *before* the cache lookup, so every cache hit allocated an `httpx.Client`/`AsyncClient` that was immediately discarded. Moving the construction inside the cache-miss branch fixes it for both `get_openai_client` and `get_async_openai_client`.

Regression tests count httpx client constructions across two identical calls: 2 before the fix, 1 after.
