### PR TITLE
fix(batch): wait for first non-None result

### DIFF
--- a/langroid/agent/batch.py
+++ b/langroid/agent/batch.py
@@ -118,21 +118,23 @@ async def _process_batch_async(
             task_indices = {task: i for i, task in enumerate(tasks)}
             results = [None] * len(tasks)
 
-            done, pending = await asyncio.wait(
-                tasks, return_when=asyncio.FIRST_COMPLETED
-            )
+            pending = set(tasks)
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED
+                )
 
-            # Process completed tasks
-            for task in done:
-                index = task_indices[task]
-                try:
-                    result = await task
-                    results[index] = output_map(result)
-                except BaseException as e:
-                    results[index] = handle_error(e)
+                # Process completed tasks
+                for task in done:
+                    index = task_indices[task]
+                    try:
+                        result = await task
+                        results[index] = output_map(result)
+                    except BaseException as e:
+                        results[index] = handle_error(e)
 
-            if any(r is not None for r in results):
-                return results
+                if any(r is not None for r in results):
+                    return results
         finally:
             for task in pending:
                 task.cancel()

--- a/tests/main/test_batch.py
+++ b/tests/main/test_batch.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -513,3 +513,41 @@ def test_process_batch_async_stop_on_first(stop_on_first_result):
     else:
         assert all(r is not None for r in results)
         assert all("Processed" in r for r in results)
+
+
+def test_process_batch_async_stop_on_first_skips_none_result():
+    """Keep waiting when the first completed task has no valid result."""
+
+    async def run_batch() -> list[Any]:
+        invalid_done = asyncio.Event()
+        release_valid = asyncio.Event()
+
+        async def release_after_invalid() -> None:
+            await invalid_done.wait()
+            await asyncio.sleep(0)
+            release_valid.set()
+
+        async def mock_task(input: str, i: int) -> str | None:
+            if input == "invalid":
+                invalid_done.set()
+                return None
+            if input == "valid":
+                await release_valid.wait()
+                return "Processed valid"
+            await asyncio.Event().wait()
+
+        controller = asyncio.create_task(release_after_invalid())
+        await asyncio.sleep(0)
+        try:
+            return await _process_batch_async(
+                ["invalid", "valid", "slow"],
+                mock_task,
+                stop_on_first_result=True,
+                handle_exceptions=ExceptionHandling.RAISE,
+            )
+        finally:
+            await controller
+
+    results = asyncio.run(run_batch())
+
+    assert results == [None, "Processed valid", None]


### PR DESCRIPTION
## Summary

- keep waiting when the first completed batch task maps to `None`
- stop once a non-`None` result is available, preserving its original input position
- cancel only the tasks that are still pending at that point
- add a deterministic event-based regression test

## Root cause

The `stop_on_first_result` branch called `asyncio.wait(..., FIRST_COMPLETED)` only once. Its `finally` block then cancelled every pending task even when all completed tasks had produced `None`, contrary to the documented behavior of continuing until a valid result is obtained.

The branch now waits repeatedly on the remaining task set. Existing exception handling and cleanup stay in the same paths.

Fixes #1068

## Validation

- `pytest tests/main/test_batch.py -k "process_batch_async" -q` (`9 passed`)
- `ruff check langroid/agent/batch.py tests/main/test_batch.py`
- `git diff --check`