### PR TITLE
fix: keep identified tool/function results in history even when empty

### DIFF
--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -63,6 +63,28 @@ console = Console()
 logger = logging.getLogger(__name__)
 
 
+def _is_identified_result(message: LLMMessage) -> bool:
+    """Whether a TOOL/FUNCTION result has its identifier and no call payload.
+
+    Such results must survive even with empty content so their calls can be
+    marked complete (issue #1063).
+    """
+    has_identifier = (
+        message.role == Role.TOOL and bool((message.tool_call_id or "").strip())
+    ) or (message.role == Role.FUNCTION and bool((message.name or "").strip()))
+    return has_identifier and message.function_call is None and not message.tool_calls
+
+
+def _llm_message_has_payload(message: LLMMessage) -> bool:
+    """Whether a message has the fields required for a valid history entry."""
+    return (
+        (message.content or "").strip() != ""
+        or message.function_call is not None
+        or bool(message.tool_calls)
+        or _is_identified_result(message)
+    )
+
+
 class ChatAgentConfig(AgentConfig):
     """
     Configuration for ChatAgent
@@ -1345,7 +1367,9 @@ class ChatAgent(Agent):
             llm_msg = self.message_history[idx]
         else:
             llm_msg = copy.deepcopy(self.message_history[idx])
-        if llm_msg.content is None:
+        if llm_msg.content is None or (
+            llm_msg.content == "" and _is_identified_result(llm_msg)
+        ):
             return llm_msg
         orig_content = llm_msg.content
         new_content = (
@@ -1641,15 +1665,15 @@ class ChatAgent(Agent):
                 # either the message is a str, or it is a fresh ChatDocument
                 # different from the last message in the history
                 llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
-                # Keep messages that have text or a function/tool call. A call-only
-                # assistant turn has no content but is still required in history.
-                llm_msgs = [
-                    m
-                    for m in llm_msgs
-                    if (m.content or "").strip() != ""
-                    or m.function_call is not None
-                    or bool(m.tool_calls)
-                ]
+                llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
+                # Canonicalize retained whitespace-only results before token counting.
+                for llm_msg in llm_msgs:
+                    if (
+                        _is_identified_result(llm_msg)
+                        and llm_msg.content is not None
+                        and llm_msg.content.strip() == ""
+                    ):
+                        llm_msg.content = ""
                 if len(llm_msgs) == 0:
                     return [], 0
                 # process tools if any

--- a/tests/main/test_prep_llm_message.py
+++ b/tests/main/test_prep_llm_message.py
@@ -1,8 +1,13 @@
 import json
+from typing import Any
 
 import pytest
 
-from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.agent.chat_agent import (
+    ChatAgent,
+    ChatAgentConfig,
+    _llm_message_has_payload,
+)
 from langroid.agent.chat_document import ChatDocMetaData, ChatDocument
 from langroid.language_models.base import (
     LLMFunctionCall,
@@ -11,6 +16,7 @@ from langroid.language_models.base import (
     OpenAIToolCall,
     Role,
 )
+from langroid.language_models.mock_lm import MockLM, MockLMConfig
 from langroid.language_models.openai_gpt import OpenAIGPTConfig
 from langroid.mytypes import Entity
 from langroid.parsing.file_attachment import FileAttachment
@@ -558,6 +564,92 @@ def test_truncate_tool_only_message_preserves_none(agent):
     assert "content" not in truncated.api_dict(MODEL)
 
 
+@pytest.mark.parametrize(
+    ("role", "identifying_field"),
+    [
+        (Role.TOOL, {"tool_call_id": "call_1"}),
+        (Role.FUNCTION, {"name": "check_weather"}),
+    ],
+)
+def test_truncate_empty_result_preserves_wire_payload(
+    agent: ChatAgent,
+    role: Role,
+    identifying_field: dict[str, str],
+) -> None:
+    """Truncation must preserve a present-but-empty result."""
+    message = LLMMessage(role=role, content="", **identifying_field)
+    agent.message_history.append(message)
+    original_payload = message.api_dict(MODEL)
+
+    truncated = agent.truncate_message(-1)
+
+    assert truncated.content == ""
+    assert truncated.api_dict(MODEL) == original_payload
+
+
+@pytest.mark.parametrize(
+    "payload_field",
+    [
+        {"function_call": LLMFunctionCall(name="check_weather", arguments={})},
+        {"tool_calls": [_tool_call()]},
+    ],
+)
+@pytest.mark.parametrize(
+    ("role", "identifying_field"),
+    [
+        (Role.TOOL, {"tool_call_id": "call_1"}),
+        (Role.FUNCTION, {"name": "check_weather"}),
+    ],
+)
+def test_truncate_blank_identified_result_with_existing_payload(
+    agent: ChatAgent,
+    role: Role,
+    identifying_field: dict[str, str],
+    payload_field: dict[str, Any],
+) -> None:
+    """Blank results already retained by call payloads remain truncatable."""
+    agent.message_history.append(
+        LLMMessage(
+            role=role,
+            content="",
+            **identifying_field,
+            **payload_field,
+        )
+    )
+
+    truncated = agent.truncate_message(-1)
+
+    assert truncated.content == "\n...[Contents truncated!]"
+
+
+@pytest.mark.parametrize("role", [Role.TOOL, Role.FUNCTION])
+def test_truncate_blank_result_without_identifier(
+    agent: ChatAgent,
+    role: Role,
+) -> None:
+    """Malformed blank results remain truncation candidates."""
+    agent.message_history.append(LLMMessage(role=role, content=""))
+
+    truncated = agent.truncate_message(-1)
+
+    assert truncated.content == "\n...[Contents truncated!]"
+
+
+@pytest.mark.parametrize("role", [Role.USER, Role.ASSISTANT])
+def test_truncate_whitespace_message_for_non_result_role(
+    agent: ChatAgent,
+    role: Role,
+) -> None:
+    """Whitespace-only conversation messages remain truncation candidates."""
+    content = " " * 10_000
+    agent.message_history.append(LLMMessage(role=role, content=content))
+
+    truncated = agent.truncate_message(-1)
+
+    assert truncated.content != content
+    assert truncated.content.endswith("...[Contents truncated!]")
+
+
 def test_content_is_none_overrides_populated_content_any():
     """A call-only turn stays content=None even when content_any was populated
     (e.g. by _load_output_format parsing the tool args under a strict
@@ -592,3 +684,306 @@ def test_content_is_none_overrides_stale_text_after_serialization():
     assert msg.content is None
     assert msg.tool_calls == [_tool_call()]
     assert "content" not in msg.api_dict(MODEL)
+
+
+@pytest.mark.parametrize("content", ["", " " * CHAT_CONTEXT_LENGTH])
+def test_prep_keeps_legitimately_empty_tool_result(
+    agent: ChatAgent,
+    content: str,
+) -> None:
+    """A tool result with genuinely empty content (e.g. a tool that succeeds
+    with no output) must stay in history and clear the pending tool call from
+    agent.oai_tool_calls, not get silently dropped (issue #1063). Before the
+    fix, the history filter kept a message only if it had non-empty content, a
+    function_call, or tool_calls -- none of which a TOOL-role result carries,
+    so an empty-content result was dropped and its call_id never reached
+    `done_tools`, leaving the call marked pending forever."""
+    pending_call = _tool_call()
+    agent.message_history.append(
+        LLMMessage(
+            role=Role.ASSISTANT,
+            content=None,
+            tool_calls=[pending_call],
+        )
+    )
+    agent.oai_tool_calls = [pending_call]
+    doc = ChatDocument(
+        content=content,
+        metadata=ChatDocMetaData(
+            sender=Entity.AGENT, source=Entity.AGENT, oai_tool_id="call_1"
+        ),
+    )
+
+    hist, output_len = agent._prep_llm_messages(doc)
+
+    tool_msgs = [m for m in hist if m.role == Role.TOOL]
+    assert len(tool_msgs) == 1
+    assert tool_msgs[0].tool_call_id == "call_1"
+    assert tool_msgs[0].content == ""
+    assert agent.oai_tool_calls == []
+    assert output_len == MAX_OUTPUT_TOKENS
+
+
+def test_prep_keeps_legitimately_empty_function_result(
+    agent: ChatAgent,
+) -> None:
+    """An empty legacy function result must stay in message history."""
+    function_name = "check_weather"
+    function_call = LLMFunctionCall(
+        name=function_name,
+        arguments={"city": "London"},
+    )
+    parent = ChatDocument(
+        content="",
+        content_is_none=True,
+        function_call=function_call,
+        metadata=ChatDocMetaData(sender=Entity.LLM, source=Entity.LLM),
+    )
+    agent.message_history.append(
+        LLMMessage(
+            role=Role.ASSISTANT,
+            content=None,
+            function_call=function_call,
+        )
+    )
+    result = ChatDocument(
+        content="",
+        metadata=ChatDocMetaData(
+            sender=Entity.AGENT,
+            source=Entity.AGENT,
+            parent_id=parent.id(),
+        ),
+    )
+
+    hist, _ = agent._prep_llm_messages(result)
+
+    function_msgs = [m for m in hist if m.role == Role.FUNCTION]
+    assert len(function_msgs) == 1
+    assert function_msgs[0].name == function_name
+
+
+def test_prep_empty_result_completes_only_matching_tool_call(
+    agent: ChatAgent,
+) -> None:
+    """An identified empty result completes only its matching pending call."""
+    first_call = _tool_call()
+    second_call = _tool_call()
+    second_call.id = "call_2"
+    agent.message_history.append(
+        LLMMessage(
+            role=Role.ASSISTANT,
+            content=None,
+            tool_calls=[first_call, second_call],
+        )
+    )
+    agent.oai_tool_calls = [first_call, second_call]
+    result = ChatDocument(
+        content="",
+        metadata=ChatDocMetaData(
+            sender=Entity.AGENT,
+            source=Entity.AGENT,
+            oai_tool_id="call_2",
+        ),
+    )
+
+    hist, _ = agent._prep_llm_messages(result)
+
+    tool_messages = [message for message in hist if message.role == Role.TOOL]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].tool_call_id == "call_2"
+    assert agent.oai_tool_calls == [first_call]
+
+
+class RecordingMockLM(MockLM):
+    """Mock LM that records the messages supplied to its chat method."""
+
+    def __init__(self, config: MockLMConfig) -> None:
+        super().__init__(config)
+        self.received_messages: list[LLMMessage] = []
+
+    def chat(
+        self,
+        messages: str | list[LLMMessage],
+        *args: Any,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Record messages before returning the configured local response."""
+        assert isinstance(messages, list)
+        self.received_messages = messages
+        return super().chat(messages, *args, **kwargs)
+
+
+def test_llm_response_sends_empty_tool_result_to_lm() -> None:
+    """llm_response sends an empty correlated result and returns a document."""
+    llm_config = MockLMConfig(default_response="tool result received")
+    agent = ChatAgent(
+        ChatAgentConfig(
+            system_message="System message",
+            llm=llm_config,
+        )
+    )
+    recording_llm = RecordingMockLM(llm_config)
+    agent.llm = recording_llm
+    agent.init_message_history()
+    pending_call = _tool_call()
+    agent.message_history.append(
+        LLMMessage(
+            role=Role.ASSISTANT,
+            content=None,
+            tool_calls=[pending_call],
+        )
+    )
+    agent.oai_tool_calls = [pending_call]
+    result = ChatDocument(
+        content="",
+        metadata=ChatDocMetaData(
+            sender=Entity.AGENT,
+            source=Entity.AGENT,
+            oai_tool_id="call_1",
+        ),
+    )
+
+    response = agent.llm_response(result)
+
+    assert isinstance(response, ChatDocument)
+    tool_messages = [
+        message
+        for message in recording_llm.received_messages
+        if message.role == Role.TOOL
+    ]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].tool_call_id == "call_1"
+    assert tool_messages[0].content == ""
+
+
+def test_prep_drops_empty_tool_result_without_id(agent: ChatAgent) -> None:
+    """An empty tool result without a correlation ID is malformed."""
+    pending_call = _tool_call()
+    pending_call.id = None
+    agent.oai_tool_calls = [pending_call]
+    doc = ChatDocument(
+        content="",
+        metadata=ChatDocMetaData(sender=Entity.AGENT, source=Entity.AGENT),
+    )
+
+    hist, output_len = agent._prep_llm_messages(doc)
+
+    assert hist == []
+    assert output_len == 0
+    assert agent.oai_tool_calls == [pending_call]
+
+
+def test_prep_drops_empty_function_result_without_name(
+    agent: ChatAgent,
+) -> None:
+    """An empty function result without its function name is malformed."""
+    function_call = LLMFunctionCall.model_construct(
+        name=None,
+        arguments={"city": "London"},
+    )
+    parent = ChatDocument(
+        content="",
+        content_is_none=True,
+        function_call=function_call,
+        metadata=ChatDocMetaData(sender=Entity.LLM, source=Entity.LLM),
+    )
+    result = ChatDocument(
+        content="",
+        metadata=ChatDocMetaData(
+            sender=Entity.AGENT,
+            source=Entity.AGENT,
+            parent_id=parent.id(),
+        ),
+    )
+
+    hist, output_len = agent._prep_llm_messages(result)
+
+    assert hist == []
+    assert output_len == 0
+
+
+@pytest.mark.parametrize("role", [Role.TOOL, Role.FUNCTION])
+@pytest.mark.parametrize(
+    ("field_state", "identifier"),
+    [
+        ("none", None),
+        ("empty", ""),
+        ("space", " "),
+        ("whitespace", "\t\n"),
+    ],
+)
+def test_empty_result_requires_identifying_field(
+    role: Role,
+    field_state: str,
+    identifier: str | None,
+) -> None:
+    """Malformed empty results are not valid history entries."""
+    field = "tool_call_id" if role == Role.TOOL else "name"
+    message = LLMMessage.model_construct(role=role, content="")
+    setattr(message, field, identifier)
+
+    assert not _llm_message_has_payload(message)
+
+
+@pytest.mark.parametrize("role", [Role.TOOL, Role.FUNCTION])
+@pytest.mark.parametrize("identifier", ["", " ", "\t\n"])
+def test_prep_drops_empty_result_with_malformed_identifier(
+    agent: ChatAgent,
+    role: Role,
+    identifier: str,
+) -> None:
+    """Whitespace identifiers cannot complete or remove pending calls."""
+    valid_call = _tool_call()
+    agent.oai_tool_calls = [valid_call]
+    if role == Role.TOOL:
+        malformed_call = _tool_call()
+        malformed_call.id = identifier
+        agent.message_history.append(
+            LLMMessage(
+                role=Role.ASSISTANT,
+                content=None,
+                tool_calls=[malformed_call],
+            )
+        )
+        agent.oai_tool_calls.append(malformed_call)
+        result = ChatDocument(
+            content="",
+            metadata=ChatDocMetaData(
+                sender=Entity.AGENT,
+                source=Entity.AGENT,
+                oai_tool_id=identifier,
+            ),
+        )
+    else:
+        malformed_function = LLMFunctionCall(
+            name=identifier,
+            arguments={"city": "London"},
+        )
+        agent.message_history.append(
+            LLMMessage(
+                role=Role.ASSISTANT,
+                content=None,
+                function_call=malformed_function,
+            )
+        )
+        parent = ChatDocument(
+            content="",
+            content_is_none=True,
+            function_call=malformed_function,
+            metadata=ChatDocMetaData(sender=Entity.LLM, source=Entity.LLM),
+        )
+        result = ChatDocument(
+            content="",
+            metadata=ChatDocMetaData(
+                sender=Entity.AGENT,
+                source=Entity.AGENT,
+                parent_id=parent.id(),
+            ),
+        )
+
+    pending_calls = list(agent.oai_tool_calls)
+    hist, output_len = agent._prep_llm_messages(result)
+
+    assert all(message.role != role for message in hist)
+    assert output_len == 0
+    assert agent.oai_tool_calls == pending_calls


### PR DESCRIPTION
Supersedes #1064 by @AmirF194; fixes #1063. The root-cause analysis in #1064
was correct and this PR builds directly on it.

## The bug

A tool/function *result* message carries neither `function_call` nor
`tool_calls` — those live on the assistant turn that *made* the call, not on
the message answering it. `_prep_llm_messages` filtered incoming messages down
to those with non-empty content, a `function_call`, or `tool_calls`, then
computed `done_tools` from the survivors. So a legitimately-empty tool result
(a tool that succeeds with no output) was dropped before `done_tools` was
computed: its `tool_call_id` never got there, `self.oai_tool_calls` kept the
call pending forever, and when that result was the only message being prepped,
`llm_response()` returned `None` instead of sending the tool response back to
the model.

Reproduced through the public API against `main`:

```
TOOL messages surviving prep : 0 (want 1)
pending oai_tool_calls left  : 1 (want 0)
```

and on this branch:

```
TOOL messages surviving prep : 1 (want 1)
pending oai_tool_calls left  : 0 (want 0)
```

## The fix

Keep a result message when it carries its correlation identifier: a `TOOL`
with a non-blank `tool_call_id`, or a `FUNCTION` with a non-blank `name`, and
no call payload of its own.

The identifier guard is the part that matters. Keeping every empty result by
role alone — `or m.role in (Role.FUNCTION, Role.TOOL)` — would newly retain
malformed messages that `main` dropped and that providers reject with a 400.

Two consequences handled:

- **Truncation.** A retained empty result must not acquire a fabricated
  `...[Contents truncated!]` marker, so `truncate_message` skips exactly the
  newly-retained empty results. Every other role and content shape truncates
  exactly as on `main`.
- **Whitespace-only results.** These are treated as empty and canonicalized to
  `""` at the point of retention. Otherwise a tool returning a large blank
  payload would be charged full token cost while being permanently exempt from
  truncation, which could exhaust the context and raise `ValueError`.

## What this adds beyond #1064

- The legacy `Role.FUNCTION` path, which #1064 described but did not cover or test.
- The identifier guard (see above).
- Restores `assert "content" not in msg.api_dict(MODEL)` in
  `test_content_is_none_overrides_stale_text_after_serialization`, which #1064
  removed — that assertion guards the #1062 Gemini serialization behavior.
- Coverage for malformed and whitespace identifiers, blank results carrying a
  call payload, multiple pending calls with partial completion, truncation
  behavior across roles, and an end-to-end `llm_response()` test for the
  symptom actually reported in #1063.

## Verification

- `tests/main/test_prep_llm_message.py`, `test_openai_gpt_none_content.py`,
  `test_llm_response.py`, `test_object_registry.py`: **82 passed**.
- `black --check .`, `ruff check .`, `mypy -p langroid`: clean.
- `tests/main/test_chat_agent.py` shows 7 failures on this branch and the
  **same 7 on `main`** — all `openai.AuthenticationError` from the absent API
  key in this environment, not regressions.
- Not run: suites requiring live API credentials.