### PR TITLE
fix(batch): stop_on_first_result should wait for the first non-None result

### DIFF
--- a/docs/notes/batch-processing.md
+++ b/docs/notes/batch-processing.md
@@ -1,0 +1,91 @@
+# Batch Processing
+
+Langroid can run many tasks or agent methods concurrently over a list of items.
+The helpers in `langroid/agent/batch.py` are `run_batch_tasks`,
+`run_batch_task_gen`, `run_batch_agent_method`, `llm_response_batch`,
+`agent_response_batch`, and `run_batch_function`.
+
+## Basic usage
+
+Given a configured agent, create a task and map each item to its input and each
+task result to the value needed by the caller:
+
+```python
+from langroid.agent.batch import run_batch_tasks
+from langroid.agent.task import Task
+
+task = Task(agent, interactive=False)
+items = ["first question", "second question"]
+
+answers = run_batch_tasks(
+    task,
+    items,
+    input_map=lambda item: item,
+    output_map=lambda result: None if result is None else result.content,
+    sequential=False,
+)
+```
+
+The returned list has the same length and ordering as `items`.
+
+## Stopping at the first valid result
+
+Set `stop_on_first_result=True` for a search-style batch that should return as
+soon as any task produces a valid result. A result is valid when it is non-`None`
+*after* `output_map` runs. The usual idiom is therefore to map unusable output
+to `None`; the batch will keep waiting for another task.
+
+Results retain their original input positions. Entries are `None` for tasks
+that were cancelled or whose output mapped to `None`. If every task finishes
+with a `None`-mapped result, the function returns an all-`None` list after all
+tasks have completed.
+
+For helpers that accept `handle_exceptions`, its value also affects stopping:
+
+- `ExceptionHandling.RETURN_NONE` converts an exception to `None`, so the batch
+  keeps waiting.
+- `ExceptionHandling.RETURN_EXCEPTION` returns the exception object. Because
+  that object is non-`None`, it counts as a stopping result and occupies the
+  failed task's original position.
+- `ExceptionHandling.RAISE`, the default, propagates the exception.
+
+For example, suppose the first search finishes quickly without a usable result,
+the second finds an answer later, and the third is still running:
+
+```python
+items = ["fast miss", "slower match", "long-running search"]
+
+results = run_batch_tasks(
+    search_task,
+    items,
+    input_map=lambda query: query,
+    output_map=lambda result: (
+        result.content if result is not None and is_usable(result) else None
+    ),
+    stop_on_first_result=True,
+    sequential=False,
+)
+
+# The fast miss does not stop the batch. The long search is cancelled.
+assert results == [None, "the valid answer", None]
+```
+
+### Behavior change
+
+In earlier versions, a fast result that mapped to `None` could cancel the
+remaining tasks and return an all-`None` list. This was fixed in
+[GitHub issue #1068](https://github.com/langroid/langroid/issues/1068). Users do
+not need to make any API changes.
+
+## Batching
+
+Set `batch_size` to process fixed-size batches in input order. With
+`stop_on_first_result=True`, once a valid result is found, later batches are
+skipped and their positions are filled with `None`.
+
+Set `sequential=True` to process items one at a time when normal batch
+processing is used. The `stop_on_first_result` path schedules the tasks in the
+current batch concurrently so that it can return whichever valid result
+finishes first.
+
+See `tests/main/test_batch.py` for executable examples and edge-case coverage.

--- a/langroid/agent/batch.py
+++ b/langroid/agent/batch.py
@@ -295,9 +295,12 @@ def run_batch_task_gen(
             map any invalid output to None. We continue until some non-None
             result is obtained.
         stop_on_first_result (bool): whether to stop after the first valid
-            (non-None, after `output_map`) result. Processing continues past
-            None-mapped results. Once a non-None result appears, pending tasks
-            are cancelled and their entries in the returned list are None.
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
         sequential (bool): whether to run sequentially
             (e.g. some APIs such as ooba don't support concurrent requests)
         batch_size (Optional[int]): The number of tasks to run at a time,
@@ -390,9 +393,12 @@ def run_batch_tasks(
         output_map (Callable[[ChatDocument|str], U]): function to map result
             to final result
         stop_on_first_result (bool): whether to stop after the first valid
-            (non-None, after `output_map`) result. Processing continues past
-            None-mapped results. Once a non-None result appears, pending tasks
-            are cancelled and their entries in the returned list are None.
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
         sequential (bool): whether to run sequentially
             (e.g. some APIs such as ooba don't support concurrent requests)
         batch_size (Optional[int]): The number of tasks to run at a time,
@@ -457,9 +463,12 @@ def run_batch_agent_method(
         sequential (bool): whether to run sequentially
             (e.g. some APIs such as ooba don't support concurrent requests)
         stop_on_first_result (bool): whether to stop after the first valid
-            (non-None, after `output_map`) result. Processing continues past
-            None-mapped results. Once a non-None result appears, pending tasks
-            are cancelled and their entries in the returned list are None.
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
         handle_exceptions: How to handle exceptions:
             - RAISE or False: Let exceptions propagate
             - RETURN_NONE or True: Convert exceptions to None in results

--- a/langroid/agent/batch.py
+++ b/langroid/agent/batch.py
@@ -118,21 +118,23 @@ async def _process_batch_async(
             task_indices = {task: i for i, task in enumerate(tasks)}
             results = [None] * len(tasks)
 
-            done, pending = await asyncio.wait(
-                tasks, return_when=asyncio.FIRST_COMPLETED
-            )
+            pending = set(tasks)
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED
+                )
 
-            # Process completed tasks
-            for task in done:
-                index = task_indices[task]
-                try:
-                    result = await task
-                    results[index] = output_map(result)
-                except BaseException as e:
-                    results[index] = handle_error(e)
+                # Process completed tasks
+                for task in done:
+                    index = task_indices[task]
+                    try:
+                        result = await task
+                        results[index] = output_map(result)
+                    except BaseException as e:
+                        results[index] = handle_error(e)
 
-            if any(r is not None for r in results):
-                return results
+                if any(r is not None for r in results):
+                    return results
         finally:
             for task in pending:
                 task.cancel()

--- a/langroid/agent/batch.py
+++ b/langroid/agent/batch.py
@@ -393,11 +393,10 @@ def run_batch_tasks(
         output_map (Callable[[ChatDocument|str], U]): function to map result
             to final result
         stop_on_first_result (bool): whether to stop after the first valid
-            (non-None) result. Successful results are evaluated after
-            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
-            exception object is itself non-None and also stops the batch.
-            Processing continues past None results; once a non-None result
-            appears, pending tasks are cancelled and their entries in the
+            (non-None, after `output_map`) result. Processing continues past
+            None-mapped results; exceptions propagate, since this function
+            always uses the default `RAISE` exception handling. Once a non-None
+            result appears, pending tasks are cancelled and their entries in the
             returned list are None.
         sequential (bool): whether to run sequentially
             (e.g. some APIs such as ooba don't support concurrent requests)

--- a/langroid/agent/batch.py
+++ b/langroid/agent/batch.py
@@ -295,9 +295,9 @@ def run_batch_task_gen(
             map any invalid output to None. We continue until some non-None
             result is obtained.
         stop_on_first_result (bool): whether to stop after the first valid
-            (not-None) result. In this case all other tasks are
-            cancelled, and their corresponding result is None in the
-            returned list.
+            (non-None, after `output_map`) result. Processing continues past
+            None-mapped results. Once a non-None result appears, pending tasks
+            are cancelled and their entries in the returned list are None.
         sequential (bool): whether to run sequentially
             (e.g. some APIs such as ooba don't support concurrent requests)
         batch_size (Optional[int]): The number of tasks to run at a time,
@@ -389,6 +389,10 @@ def run_batch_tasks(
             initial message to process
         output_map (Callable[[ChatDocument|str], U]): function to map result
             to final result
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None, after `output_map`) result. Processing continues past
+            None-mapped results. Once a non-None result appears, pending tasks
+            are cancelled and their entries in the returned list are None.
         sequential (bool): whether to run sequentially
             (e.g. some APIs such as ooba don't support concurrent requests)
         batch_size (Optional[int]): The number of tasks to run at a time,
@@ -453,6 +457,9 @@ def run_batch_agent_method(
         sequential (bool): whether to run sequentially
             (e.g. some APIs such as ooba don't support concurrent requests)
         stop_on_first_result (bool): whether to stop after the first valid
+            (non-None, after `output_map`) result. Processing continues past
+            None-mapped results. Once a non-None result appears, pending tasks
+            are cancelled and their entries in the returned list are None.
         handle_exceptions: How to handle exceptions:
             - RAISE or False: Let exceptions propagate
             - RETURN_NONE or True: Convert exceptions to None in results

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
       - Cross-Encoder Reranking: notes/cross-encoder.md
       - Task Logs: notes/html-logger.md
       - Pydantic v2 Migration: notes/pydantic-v2-migration.md
+      - Batch Processing: notes/batch-processing.md
 
   - Examples:
     - Guide: examples/guide.md

--- a/tests/main/test_batch.py
+++ b/tests/main/test_batch.py
@@ -564,3 +564,41 @@ def test_process_batch_async_stop_on_first_all_none() -> None:
     )
 
     assert results == [None, None]
+
+
+def test_process_batch_async_stop_on_first_skips_exception_result() -> None:
+    """Keep waiting when an exception is converted to no valid result."""
+
+    async def run_batch() -> list[Any]:
+        release_valid = asyncio.Event()
+        never_release = asyncio.Event()
+        invalid_result = object()
+
+        def output_map(result: Any) -> Any:
+            if result is invalid_result:
+                release_valid.set()
+                return None
+            return result
+
+        async def mock_task(input: str, i: int) -> Any:
+            if input == "error":
+                raise ValueError("test error")
+            if input == "invalid":
+                return invalid_result
+            if input == "valid":
+                await release_valid.wait()
+                return "Processed valid"
+            await never_release.wait()
+            raise AssertionError("Unreachable")
+
+        return await _process_batch_async(
+            ["error", "invalid", "valid", "slow"],
+            mock_task,
+            stop_on_first_result=True,
+            handle_exceptions=ExceptionHandling.RETURN_NONE,
+            output_map=output_map,
+        )
+
+    results = asyncio.run(run_batch())
+
+    assert results == [None, None, "Processed valid", None]

--- a/tests/main/test_batch.py
+++ b/tests/main/test_batch.py
@@ -515,39 +515,52 @@ def test_process_batch_async_stop_on_first(stop_on_first_result):
         assert all("Processed" in r for r in results)
 
 
-def test_process_batch_async_stop_on_first_skips_none_result():
+def test_process_batch_async_stop_on_first_skips_none_result() -> None:
     """Keep waiting when the first completed task has no valid result."""
 
     async def run_batch() -> list[Any]:
-        invalid_done = asyncio.Event()
         release_valid = asyncio.Event()
 
-        async def release_after_invalid() -> None:
-            await invalid_done.wait()
-            await asyncio.sleep(0)
-            release_valid.set()
+        def output_map(result: Any) -> Any:
+            if result is None:
+                release_valid.set()
+            return result
 
         async def mock_task(input: str, i: int) -> str | None:
             if input == "invalid":
-                invalid_done.set()
                 return None
             if input == "valid":
                 await release_valid.wait()
                 return "Processed valid"
             await asyncio.Event().wait()
+            raise AssertionError("Unreachable")
 
-        controller = asyncio.create_task(release_after_invalid())
-        await asyncio.sleep(0)
-        try:
-            return await _process_batch_async(
-                ["invalid", "valid", "slow"],
-                mock_task,
-                stop_on_first_result=True,
-                handle_exceptions=ExceptionHandling.RAISE,
-            )
-        finally:
-            await controller
+        return await _process_batch_async(
+            ["invalid", "valid", "slow"],
+            mock_task,
+            stop_on_first_result=True,
+            handle_exceptions=ExceptionHandling.RAISE,
+            output_map=output_map,
+        )
 
     results = asyncio.run(run_batch())
 
     assert results == [None, "Processed valid", None]
+
+
+def test_process_batch_async_stop_on_first_all_none() -> None:
+    """Return after all tasks complete when every mapped result is None."""
+
+    async def mock_task(input: str, i: int) -> None:
+        return None
+
+    results = asyncio.run(
+        _process_batch_async(
+            ["invalid-1", "invalid-2"],
+            mock_task,
+            stop_on_first_result=True,
+            handle_exceptions=ExceptionHandling.RAISE,
+        )
+    )
+
+    assert results == [None, None]

--- a/tests/main/test_batch.py
+++ b/tests/main/test_batch.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -513,3 +513,41 @@ def test_process_batch_async_stop_on_first(stop_on_first_result):
     else:
         assert all(r is not None for r in results)
         assert all("Processed" in r for r in results)
+
+
+def test_process_batch_async_stop_on_first_skips_none_result():
+    """Keep waiting when the first completed task has no valid result."""
+
+    async def run_batch() -> list[Any]:
+        invalid_done = asyncio.Event()
+        release_valid = asyncio.Event()
+
+        async def release_after_invalid() -> None:
+            await invalid_done.wait()
+            await asyncio.sleep(0)
+            release_valid.set()
+
+        async def mock_task(input: str, i: int) -> str | None:
+            if input == "invalid":
+                invalid_done.set()
+                return None
+            if input == "valid":
+                await release_valid.wait()
+                return "Processed valid"
+            await asyncio.Event().wait()
+
+        controller = asyncio.create_task(release_after_invalid())
+        await asyncio.sleep(0)
+        try:
+            return await _process_batch_async(
+                ["invalid", "valid", "slow"],
+                mock_task,
+                stop_on_first_result=True,
+                handle_exceptions=ExceptionHandling.RAISE,
+            )
+        finally:
+            await controller
+
+    results = asyncio.run(run_batch())
+
+    assert results == [None, "Processed valid", None]


### PR DESCRIPTION
Supersedes #1069 by @KXHXK, whose original commit and fix are preserved here
(with authorship). Fixes #1068.

## The bug

`_process_batch_async(..., stop_on_first_result=True)` called
`asyncio.wait(..., FIRST_COMPLETED)` exactly once, then its `finally` block
cancelled every still-pending task — even when every completed task mapped to
`None`. A fast invalid result therefore suppressed a slower valid one, contrary
to the documented behavior of continuing until a non-`None` result is obtained.

## The fix

Wait repeatedly on the remaining task set until a non-`None` mapped result
appears or no tasks remain. Results keep their original input positions, and
only the tasks still pending at that point are cancelled. Exception handling
and cleanup stay on the same paths.

Reproducer from #1068 (`invalid` -> `None` fast, `valid` slower, `slow` long):

- before: `[None, None, None]`
- after: `[None, 'Processed valid', None]`

## Hardening added on top of the original PR

Following an adversarial review (asyncio-correctness, contract/caller-impact,
test-quality, and a contract-free cold-diff lens):

- The regression test is now **deterministic**: the "valid" task is released
  from inside `output_map`, which runs while the first completed round is being
  processed, so it provably cannot land in that first `asyncio.wait` round.
  Both regression tests were confirmed to FAIL against `main`'s implementation.
- Added `test_process_batch_async_stop_on_first_all_none` — an all-`None` batch
  must terminate (return all `None`s) rather than hang.
- Added `test_process_batch_async_stop_on_first_skips_exception_result` — under
  `ExceptionHandling.RETURN_NONE`, a fast task that *raises* must not suppress a
  slower valid result either.
- Documented `stop_on_first_result` semantics precisely in `run_batch_task_gen`,
  `run_batch_tasks` and `run_batch_agent_method`: "valid" means non-`None` after
  `output_map`; processing continues past `None`-mapped results; with
  `ExceptionHandling.RETURN_EXCEPTION` the returned exception object is itself
  non-`None` and stops the batch (noted only on the helpers that actually accept
  `handle_exceptions`).
- New user-facing note `docs/notes/batch-processing.md` (+ mkdocs nav entry)
  covering the batch helpers, `stop_on_first_result`, its interaction with
  `handle_exceptions`, `batch_size`/`sequential`, and the behavior change.

No production-logic change beyond the original PR's loop fix.

## Verification

- `pytest tests/main/test_batch.py -k process_batch_async` -> 11 passed
- `pytest tests/main/test_async_handlers.py` -> 3 passed, 2 skipped
- `black --check`, `ruff check` clean; `mypy langroid/agent/batch.py` shows no
  new errors (only 4 pre-existing ones in a generated `.pyi`, identical on main)
