### PR TITLE
fix(sql): reject writes nested below a SELECT top-level node

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -90,6 +90,12 @@ We aim to acknowledge in-scope reports within 7 days.
   precedence over this category.
 - **A code path that skips a documented safety gate entirely** — that is, a
   *missing call* to a validator, not a *bypass* of one.
+- **A statement the `allowed_statement_types` allowlist misclassifies.** The
+  allowlist is a different kind of control from the denylists above: it decides
+  what a statement *does* over a closed set of statement kinds, so a query that
+  performs a write the allowlist did not authorize — for example by nesting it
+  where the classifier does not look — is a bounded, fixable defect and is in
+  scope.
 - Vulnerable dependencies with a demonstrated impact on Langroid.
 
 ### Out of scope
@@ -98,8 +104,8 @@ The following will be closed without a fix, an advisory, or a CVE request:
 
 - New bypasses of the SQL, Cypher, or AQL denylists: previously unlisted
   functions, alternate quoting or escaping forms (backticks, Unicode escapes,
-  schema qualification), dialect-specific syntax, or statement shapes such as
-  writable CTEs. See "What is, and is not, a security boundary" above.
+  schema qualification), or dialect-specific syntax. See "What is, and is not,
+  a security boundary" above.
 - Sandbox escapes from the pandas `eval()` path when `full_eval=True`,
   including object-graph traversal via dunder attributes. `full_eval=True`
   disables the AST validator by design.

--- a/langroid/agent/special/sql/sql_chat_agent.py
+++ b/langroid/agent/special/sql/sql_chat_agent.py
@@ -231,6 +231,11 @@ def _nested_write_kinds(stmt: Any, kind_map: Dict[Any, str]) -> Set[str]:
         stmt: A parsed sqlglot statement.
         kind_map: Mapping of sqlglot expression type to statement-kind name.
 
+    Only independently executable nested statements count. A ``MERGE``'s
+    ``WHEN ... THEN UPDATE/INSERT/DELETE`` actions parse as child write nodes
+    but are part of the merge itself, so an operator who allows ``MERGE`` must
+    not also be forced to allow standalone ``UPDATE``/``INSERT``/``DELETE``.
+
     Returns:
         The set of kind names written by nested nodes, plus ``"CREATE"`` for
         the ``SELECT ... INTO`` form. Empty for an ordinary read-only query.
@@ -245,10 +250,20 @@ def _nested_write_kinds(stmt: Any, kind_map: Dict[Any, str]) -> Set[str]:
         sqlglot_exp.Alter,
         sqlglot_exp.TruncateTable,
     )
+
+    def _is_merge_action(node: Any) -> bool:
+        """Whether `node` is a MERGE ``WHEN`` action rather than a statement."""
+        ancestor = node.parent
+        while ancestor is not None:
+            if isinstance(ancestor, sqlglot_exp.When):
+                return True
+            ancestor = ancestor.parent
+        return False
+
     kinds = {
         kind_map[type(node)]
         for node in stmt.find_all(*write_types)
-        if node is not stmt and type(node) in kind_map
+        if node is not stmt and type(node) in kind_map and not _is_merge_action(node)
     }
     # `SELECT ... INTO tbl` carries no nested Create node; it is flagged by the
     # `into` arg on the Select itself.

--- a/langroid/agent/special/sql/sql_chat_agent.py
+++ b/langroid/agent/special/sql/sql_chat_agent.py
@@ -214,6 +214,28 @@ def _called_function_names(stmt: Any) -> Iterator[str]:
             yield name
 
 
+def _creates_table(into: Any) -> bool:
+    """Whether a Select's ``into`` arg names a table rather than a variable.
+
+    ``SELECT ... INTO tbl`` creates and populates a table, but MySQL's
+    ``SELECT ... INTO @var`` merely assigns a user variable and writes nothing.
+    sqlglot models the latter as a ``Table`` wrapping a ``Parameter``, so the
+    target's inner node distinguishes them.
+
+    Args:
+        into: The ``into`` arg of a sqlglot ``Select``, or None.
+
+    Returns:
+        True if the target names a table.
+    """
+    if into is None:
+        return False
+    target = into.this
+    if target is None:
+        return False
+    return not isinstance(getattr(target, "this", None), sqlglot_exp.Parameter)
+
+
 def _nested_write_kinds(stmt: Any, kind_map: Dict[Any, str]) -> Set[str]:
     """Statement kinds that `stmt` performs *below* its top-level node.
 
@@ -266,8 +288,13 @@ def _nested_write_kinds(stmt: Any, kind_map: Dict[Any, str]) -> Set[str]:
         if node is not stmt and type(node) in kind_map and not _is_merge_action(node)
     }
     # `SELECT ... INTO tbl` carries no nested Create node; it is flagged by the
-    # `into` arg on the Select itself.
-    if isinstance(stmt, sqlglot_exp.Select) and stmt.args.get("into") is not None:
+    # `into` arg on a Select. Check every Select, not just the top-level one:
+    # under a set operation (`SELECT ... INTO t UNION ALL SELECT ...`) the top
+    # node is a Union and the `into` sits on a branch.
+    selects = list(stmt.find_all(sqlglot_exp.Select))
+    if isinstance(stmt, sqlglot_exp.Select):
+        selects.append(stmt)
+    if any(_creates_table(sel.args.get("into")) for sel in selects):
         kinds.add("CREATE")
     return kinds
 

--- a/langroid/agent/special/sql/sql_chat_agent.py
+++ b/langroid/agent/special/sql/sql_chat_agent.py
@@ -273,19 +273,21 @@ def _nested_write_kinds(stmt: Any, kind_map: Dict[Any, str]) -> Set[str]:
         sqlglot_exp.TruncateTable,
     )
 
-    def _is_merge_action(node: Any) -> bool:
-        """Whether `node` is a MERGE ``WHEN`` action rather than a statement."""
-        ancestor = node.parent
-        while ancestor is not None:
-            if isinstance(ancestor, sqlglot_exp.When):
-                return True
-            ancestor = ancestor.parent
-        return False
+    # Exempt only the node that *is* a ``WHEN ... THEN`` action, by identity.
+    # Exempting everything beneath a ``When`` would also hide a write nested in
+    # the WHEN *condition* -- e.g.
+    # ``WHEN MATCHED AND EXISTS (WITH x AS (DELETE ...) SELECT * FROM x) THEN
+    # UPDATE ...`` -- or one buried inside the action's own subqueries.
+    merge_actions = {
+        id(when.args["then"])
+        for when in stmt.find_all(sqlglot_exp.When)
+        if when.args.get("then") is not None
+    }
 
     kinds = {
         kind_map[type(node)]
         for node in stmt.find_all(*write_types)
-        if node is not stmt and type(node) in kind_map and not _is_merge_action(node)
+        if node is not stmt and type(node) in kind_map and id(node) not in merge_actions
     }
     # `SELECT ... INTO tbl` carries no nested Create node; it is flagged by the
     # `into` arg on a Select. Check every Select, not just the top-level one:

--- a/langroid/agent/special/sql/sql_chat_agent.py
+++ b/langroid/agent/special/sql/sql_chat_agent.py
@@ -17,6 +17,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Union,
 )
@@ -211,6 +212,49 @@ def _called_function_names(stmt: Any) -> Iterator[str]:
         name = name.rsplit(".", 1)[-1].strip().lower()
         if name:
             yield name
+
+
+def _nested_write_kinds(stmt: Any, kind_map: Dict[Any, str]) -> Set[str]:
+    """Statement kinds that `stmt` performs *below* its top-level node.
+
+    A statement's top-level node does not determine what it writes. Both
+
+    - ``WITH x AS (DELETE FROM t RETURNING *) SELECT * FROM x`` (a
+      data-modifying CTE), and
+    - ``SELECT * INTO new_tbl FROM t`` (which creates and populates a table)
+
+    parse with a ``Select`` top node, so classifying on that node alone reports
+    "SELECT" while the engine still performs the write
+    (GHSA-3gpx-vwr3-xvwx / GHSA-wc83-4cvx-p8xc).
+
+    Args:
+        stmt: A parsed sqlglot statement.
+        kind_map: Mapping of sqlglot expression type to statement-kind name.
+
+    Returns:
+        The set of kind names written by nested nodes, plus ``"CREATE"`` for
+        the ``SELECT ... INTO`` form. Empty for an ordinary read-only query.
+    """
+    write_types = (
+        sqlglot_exp.Insert,
+        sqlglot_exp.Update,
+        sqlglot_exp.Delete,
+        sqlglot_exp.Merge,
+        sqlglot_exp.Create,
+        sqlglot_exp.Drop,
+        sqlglot_exp.Alter,
+        sqlglot_exp.TruncateTable,
+    )
+    kinds = {
+        kind_map[type(node)]
+        for node in stmt.find_all(*write_types)
+        if node is not stmt and type(node) in kind_map
+    }
+    # `SELECT ... INTO tbl` carries no nested Create node; it is flagged by the
+    # `into` arg on the Select itself.
+    if isinstance(stmt, sqlglot_exp.Select) and stmt.args.get("into") is not None:
+        kinds.add("CREATE")
+    return kinds
 
 
 # Default set of SQL statement types the agent is allowed to execute when
@@ -683,6 +727,29 @@ class SQLChatAgent(ChatAgent):
                     f"the operator to extend `allowed_statement_types` "
                     f"(or set `allow_dangerous_operations=True`) on the "
                     f"SQLChatAgent config."
+                )
+            # The top-level node alone does not determine what a statement
+            # writes. A data-modifying CTE
+            # (``WITH x AS (DELETE ... RETURNING *) SELECT ...``) and
+            # ``SELECT ... INTO tbl`` both parse with a ``Select`` top node, so
+            # the check above classifies them as SELECT while the engine still
+            # performs the write (GHSA-3gpx-vwr3-xvwx / GHSA-wc83-4cvx-p8xc).
+            nested = _nested_write_kinds(stmt, kind_map)
+            disallowed = sorted(nested - allowed)
+            if disallowed:
+                logger.warning(
+                    f"SQLChatAgent rejected {kind} statement embedding "
+                    f"{disallowed} (allowed: {sorted(allowed)}): {query!r}"
+                )
+                return (
+                    f"Query REJECTED for safety: although this parses as a "
+                    f"{kind} statement, it embeds {disallowed}, which is not "
+                    f"in the allowed list {sorted(allowed)} -- the database "
+                    f"would still perform that write. Rewrite the query "
+                    f"without the embedded statement, or ask the operator to "
+                    f"extend `allowed_statement_types` (or set "
+                    f"`allow_dangerous_operations=True`) on the SQLChatAgent "
+                    f"config."
                 )
             # AST-side dangerous-function check: catches calls that evaded
             # `_DANGEROUS_SQL_PATTERNS` via quoted identifiers, inline comments,

--- a/tests/main/sql_chat/test_sql_chat_security.py
+++ b/tests/main/sql_chat/test_sql_chat_security.py
@@ -16,9 +16,13 @@ try:
 except ImportError as e:
     raise LangroidImportError(extra="sql", error=str(e))
 
+import sqlglot
+from sqlglot import expressions as sqlglot_exp
+
 from langroid.agent.special.sql.sql_chat_agent import (
     SQLChatAgent,
     SQLChatAgentConfig,
+    _nested_write_kinds,
 )
 from langroid.agent.special.sql.utils.tools import RunQueryTool
 
@@ -387,3 +391,67 @@ def test_merge_nested_in_cte_is_still_caught(session):
     rejection = agent._validate_query(query)
     assert rejection is not None
     assert "REJECTED" in rejection
+
+
+# ---------------------------------------------------------------------------
+# `_nested_write_kinds` unit tests. The agent fixture is SQLite-backed, so
+# dialect-specific parse shapes are exercised against the helper directly with
+# an explicit dialect rather than through a fake agent.
+# ---------------------------------------------------------------------------
+
+_KIND_MAP = {
+    sqlglot_exp.Select: "SELECT",
+    sqlglot_exp.Insert: "INSERT",
+    sqlglot_exp.Update: "UPDATE",
+    sqlglot_exp.Delete: "DELETE",
+    sqlglot_exp.Merge: "MERGE",
+    sqlglot_exp.Create: "CREATE",
+    sqlglot_exp.Drop: "DROP",
+    sqlglot_exp.Alter: "ALTER",
+    sqlglot_exp.TruncateTable: "TRUNCATE",
+    sqlglot_exp.Command: "COMMAND",
+}
+
+
+def _kinds(query: str, dialect: str) -> set:
+    return _nested_write_kinds(sqlglot.parse(query, read=dialect)[0], _KIND_MAP)
+
+
+@pytest.mark.parametrize(
+    "dialect, query, expected",
+    [
+        # MySQL `SELECT ... INTO @var` assigns a user variable and writes
+        # nothing; sqlglot models it as Table(this=Parameter(...)). Treating it
+        # as a table creation would reject a legitimate read under the
+        # SELECT-only default.
+        ("mysql", "SELECT name INTO @x FROM items", set()),
+        # A real table target still counts.
+        ("postgres", "SELECT * INTO evil FROM items", {"CREATE"}),
+        ("tsql", "SELECT * INTO evil FROM items", {"CREATE"}),
+        # `into` on a branch of a set operation: the top node is a Union, so
+        # checking only the top-level Select would miss the table creation.
+        (
+            "tsql",
+            "SELECT 1 AS x INTO new_t UNION ALL SELECT 2",
+            {"CREATE"},
+        ),
+        # Ordinary reads.
+        ("postgres", "SELECT * FROM items", set()),
+        ("postgres", "WITH x AS (SELECT 1) SELECT * FROM x", set()),
+        # Nested DML under a CTE.
+        (
+            "postgres",
+            "WITH x AS (DELETE FROM items RETURNING *) SELECT * FROM x",
+            {"DELETE"},
+        ),
+        # MERGE actions belong to the merge, not to the allowlist.
+        (
+            "postgres",
+            "MERGE INTO a USING b ON a.id = b.id "
+            "WHEN MATCHED THEN UPDATE SET a.n = b.n",
+            set(),
+        ),
+    ],
+)
+def test_nested_write_kinds_across_dialects(dialect, query, expected):
+    assert _kinds(query, dialect) == expected

--- a/tests/main/sql_chat/test_sql_chat_security.py
+++ b/tests/main/sql_chat/test_sql_chat_security.py
@@ -284,3 +284,68 @@ def test_ast_dangerous_function_bypasses_blocked(session, query):
 def test_ast_check_does_not_overmatch_benign_functions(session, query):
     agent = _make_agent(session)
     assert agent._validate_query(query) is None
+
+
+# ---------------------------------------------------------------------------
+# Nested writes: the top-level parse node does not determine what a statement
+# writes (GHSA-3gpx-vwr3-xvwx / GHSA-wc83-4cvx-p8xc).
+# ---------------------------------------------------------------------------
+
+
+NESTED_WRITE_QUERIES = [
+    # Data-modifying CTEs: top node parses as Select, the CTE still executes.
+    "WITH x AS (DELETE FROM items RETURNING *) SELECT count(*) FROM x",
+    "WITH x AS (UPDATE items SET name='b' RETURNING *) SELECT * FROM x",
+    "WITH x AS (INSERT INTO items VALUES (2,'b') RETURNING *) SELECT * FROM x",
+    # Nested a level deeper, to be sure the walk is recursive.
+    "WITH a AS (WITH b AS (DELETE FROM items RETURNING *) SELECT * FROM b)"
+    " SELECT * FROM a",
+    # SELECT ... INTO creates and populates a table; no nested Create node,
+    # it is carried on the Select's `into` arg.
+    "SELECT * INTO evil FROM items",
+]
+
+
+@pytest.mark.parametrize("query", NESTED_WRITE_QUERIES)
+def test_nested_writes_blocked_under_select_only_default(session, query):
+    agent = _make_agent(session)
+    rejection = agent._validate_query(query)
+    assert rejection is not None, f"nested write slipped through: {query}"
+    assert "REJECTED" in rejection
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT * FROM items",
+        "SELECT count(*) FROM items WHERE name = 'a'",
+        # A read-only CTE must still be allowed -- the check keys on the
+        # embedded statement type, not on the presence of a WITH clause.
+        "WITH x AS (SELECT * FROM items) SELECT count(*) FROM x",
+        "WITH a AS (SELECT 1 AS n), b AS (SELECT n FROM a) SELECT * FROM b",
+    ],
+)
+def test_read_only_queries_still_allowed(session, query):
+    agent = _make_agent(session)
+    assert agent._validate_query(query) is None
+
+
+def test_nested_write_allowed_when_operator_extends_allowlist(session):
+    """The gate keys on `allowed_statement_types`, not on nesting itself."""
+    agent = _make_agent(
+        session,
+        allowed_statement_types=["SELECT", "DELETE"],
+    )
+    query = "WITH x AS (DELETE FROM items RETURNING *) SELECT count(*) FROM x"
+    assert agent._validate_query(query) is None
+    # An embedded INSERT is still not in the extended allowlist.
+    insert_q = (
+        "WITH x AS (INSERT INTO items VALUES (2,'b') RETURNING *) SELECT * FROM x"
+    )
+    assert agent._validate_query(insert_q) is not None
+
+
+def test_nested_write_bypass_when_dangerous_ops_allowed(session):
+    agent = _make_agent(session, allow_dangerous_operations=True)
+    query = "WITH x AS (DELETE FROM items RETURNING *) SELECT count(*) FROM x"
+    assert agent._validate_query(query) is None

--- a/tests/main/sql_chat/test_sql_chat_security.py
+++ b/tests/main/sql_chat/test_sql_chat_security.py
@@ -451,6 +451,24 @@ def _kinds(query: str, dialect: str) -> set:
             "WHEN MATCHED THEN UPDATE SET a.n = b.n",
             set(),
         ),
+        # ...but only the WHEN ... THEN action itself is exempt. A write in the
+        # WHEN *condition* is a separate statement and must still be reported,
+        # otherwise the exemption becomes a smuggling route.
+        (
+            "postgres",
+            "MERGE INTO a USING b ON a.id = b.id "
+            "WHEN MATCHED AND EXISTS ("
+            "WITH x AS (DELETE FROM c RETURNING *) SELECT * FROM x"
+            ") THEN UPDATE SET a.n = b.n",
+            {"DELETE"},
+        ),
+        # A MERGE nested inside a CTE is still reported, as MERGE.
+        (
+            "postgres",
+            "WITH x AS (MERGE INTO a USING b ON a.id = b.id "
+            "WHEN MATCHED THEN UPDATE SET a.n = b.n RETURNING *) SELECT * FROM x",
+            {"MERGE"},
+        ),
     ],
 )
 def test_nested_write_kinds_across_dialects(dialect, query, expected):

--- a/tests/main/sql_chat/test_sql_chat_security.py
+++ b/tests/main/sql_chat/test_sql_chat_security.py
@@ -349,3 +349,41 @@ def test_nested_write_bypass_when_dangerous_ops_allowed(session):
     agent = _make_agent(session, allow_dangerous_operations=True)
     query = "WITH x AS (DELETE FROM items RETURNING *) SELECT count(*) FROM x"
     assert agent._validate_query(query) is None
+
+
+MERGE_QUERY = (
+    "MERGE INTO items t USING items s ON t.id = s.id "
+    "WHEN MATCHED THEN UPDATE SET name = s.name "
+    "WHEN NOT MATCHED THEN INSERT (id, name) VALUES (s.id, s.name)"
+)
+
+
+def test_merge_actions_are_not_treated_as_nested_statements(session):
+    """A MERGE's WHEN actions belong to the merge, not to the allowlist.
+
+    sqlglot parses `WHEN MATCHED THEN UPDATE/INSERT/DELETE` as child write
+    nodes. Counting them as nested statements would force an operator who
+    allows MERGE to also allow standalone UPDATE/INSERT/DELETE.
+    """
+    agent = _make_agent(session, allowed_statement_types=["MERGE"])
+    assert agent._validate_query(MERGE_QUERY) is None
+
+
+def test_merge_still_blocked_when_not_allowlisted(session):
+    agent = _make_agent(session)  # SELECT-only default
+    rejection = agent._validate_query(MERGE_QUERY)
+    assert rejection is not None
+    assert "REJECTED" in rejection
+
+
+def test_merge_nested_in_cte_is_still_caught(session):
+    """Only the top-level MERGE's own actions are exempt."""
+    agent = _make_agent(session)
+    query = (
+        "WITH x AS (MERGE INTO items t USING items s ON t.id = s.id "
+        "WHEN MATCHED THEN UPDATE SET name = s.name RETURNING *) "
+        "SELECT * FROM x"
+    )
+    rejection = agent._validate_query(query)
+    assert rejection is not None
+    assert "REJECTED" in rejection


### PR DESCRIPTION
Fixes GHSA-3gpx-vwr3-xvwx (and the earlier, identical GHSA-wc83-4cvx-p8xc).

## The bug

`SQLChatAgent._validate_query` classified a statement by `isinstance` on the
**top-level** parse node only. Two shapes perform writes without a write node
at the top:

- a data-modifying CTE — `WITH x AS (DELETE FROM t RETURNING *) SELECT * FROM x`
- `SELECT ... INTO tbl`, which creates and populates a table

Both parse with a `Select` top node, so both were classified `SELECT`, passed
the default SELECT-only allowlist, and were executed and committed while the
database performed the write. Verified against sqlglot:

```
writable CTE   top=Select  nested_writes=['Delete']
SELECT INTO    top=Select  into=True
```

This defeats the specific guarantee the allowlist exists to provide — that the
default config is safe even when the agent's DB role can write. It needs only
ordinary write privileges, not superuser, so it is a strictly lower bar than
CVE-2026-25879.

## The fix

New `_nested_write_kinds()` walks the parsed statement for
`Insert`/`Update`/`Delete`/`Merge`/`Create`/`Drop`/`Alter`/`TruncateTable`
nodes below the top level, and separately flags the `SELECT ... INTO` form
(carried on the `Select`'s `into` arg, not as a nested `Create`). Any nested
kind outside `allowed_statement_types` is rejected with a message that names
what it found.

Deliberately **not** a denylist patch. Statement kinds are a closed set, so
walking the tree closes the whole class rather than naming one more construct —
which is why this is worth fixing where the function-denylist reports are not.

Behavior preserved:

- read-only CTEs still pass (the check keys on the embedded statement type, not
  on `WITH`)
- an operator who extends `allowed_statement_types` still gets exactly the
  writes they authorized, nested or not
- `allow_dangerous_operations=True` still bypasses everything

## Scope correction in SECURITY.md

I previously listed "statement shapes such as writable CTEs" as out of scope
and closed GHSA-wc83-4cvx-p8xc on that basis. That was wrong: it grouped a
bounded classification bug in the **allowlist** with the unbounded **denylist**
problem. The allowlist decides what a statement *does* over a closed set of
kinds, so a misclassification there is fixable and in scope. SECURITY.md now
says so explicitly, and the writable-CTE exclusion is removed.

## Tests

10 new cases in `tests/main/sql_chat/test_sql_chat_security.py`: three CTE
write forms, a doubly-nested CTE, `SELECT ... INTO`, read-only CTEs that must
still pass, the extended-allowlist path, and the `allow_dangerous_operations`
bypass.

**6 of them fail against unfixed source**; all 70 tests in the file pass with
the fix. black, ruff, and `mypy -p langroid` clean.

Two failures in `test_sql_chat_agent.py::test_sql_schema_tools` are pre-existing
LLM-dependent flakes — they fail with the fix stashed too, on a different
parametrization each run.

## Credit

Reported by [@manus-use](https://github.com/manus-use) (GHSA-3gpx-vwr3-xvwx),
and earlier by [@LHMisme420](https://github.com/LHMisme420)
(GHSA-wc83-4cvx-p8xc).