### PR TITLE
fix: route google/-prefixed Gemini models to the Gemini API

### DIFF
--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -96,6 +96,8 @@ else:
 DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+# Provider prefixes that route to the Gemini OpenAI-compatible API.
+GEMINI_MODEL_PREFIXES = ("gemini/", "google/")
 GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
 MINIMAX_BASE_URL = "https://api.minimax.io/v1"
 OLLAMA_API_KEY = "ollama"
@@ -592,7 +594,12 @@ class OpenAIGPT(LanguageModel):
                     self.api_key = self.config.litellm_proxy.api_key or self.api_key
                 self.api_base = self.config.litellm_proxy.api_base or self.api_base
             elif self.is_gemini:
-                self.config.chat_model = self.config.chat_model.replace("gemini/", "")
+                for prefix in GEMINI_MODEL_PREFIXES:
+                    if self.config.chat_model.startswith(prefix):
+                        self.config.chat_model = self.config.chat_model.replace(
+                            prefix, "", 1
+                        )
+                        break
                 if self.api_key == OPENAI_API_KEY:
                     self.api_key = os.getenv("GEMINI_API_KEY", DUMMY_API_KEY)
                 # Use GEMINI_API_BASE env var if set (e.g. for Vertex AI),
@@ -845,7 +852,7 @@ class OpenAIGPT(LanguageModel):
 
     def is_gemini_model(self) -> bool:
         """Are we using the gemini OpenAI-compatible API?"""
-        return self.chat_model_orig.startswith("gemini/")
+        return self.chat_model_orig.startswith(GEMINI_MODEL_PREFIXES)
 
     def is_deepseek_model(self) -> bool:
         deepseek_models = [e.value for e in DeepSeekModel]

--- a/tests/main/test_llm.py
+++ b/tests/main/test_llm.py
@@ -608,6 +608,30 @@ def test_gemini_api_base():
             os.environ["GEMINI_API_BASE"] = saved_gemini_api_base
 
 
+def test_gemini_google_prefix():
+    """`google/`-prefixed Gemini models route to the Gemini API (issue #995)."""
+    from langroid.language_models.openai_gpt import GEMINI_BASE_URL
+
+    original_chat_model = settings.chat_model
+    settings.chat_model = ""
+
+    saved_openai_api_base = os.environ.pop("OPENAI_API_BASE", None)
+    saved_gemini_api_base = os.environ.pop("GEMINI_API_BASE", None)
+
+    try:
+        for chat_model in ("gemini/gemini-2.0-flash", "google/gemini-2.0-flash"):
+            llm = lm.OpenAIGPT(lm.OpenAIGPTConfig(chat_model=chat_model))
+            assert llm.is_gemini
+            assert llm.config.chat_model == "gemini-2.0-flash"
+            assert llm.api_base == GEMINI_BASE_URL
+    finally:
+        settings.chat_model = original_chat_model
+        if saved_openai_api_base is not None:
+            os.environ["OPENAI_API_BASE"] = saved_openai_api_base
+        if saved_gemini_api_base is not None:
+            os.environ["GEMINI_API_BASE"] = saved_gemini_api_base
+
+
 def test_followup_standalone():
     """Test that followup_to_standalone works."""
 


### PR DESCRIPTION
Closes #995

`is_gemini_model()` matched only the `gemini/` prefix, so `google/gemini-3-flash-preview` was not detected as Gemini — `api_base` stayed unset and `GEMINI_API_KEY` was never applied — even though `get_model_info()` already normalizes `google/`-prefixed names to their canonical Gemini entry. That inconsistency is what the issue's follow-up comment reports.

Both prefixes now match via a shared `GEMINI_MODEL_PREFIXES` constant, and whichever prefix was used is stripped when deriving the provider-side model name.

Regression test `test_gemini_google_prefix` asserts both prefixes give `is_gemini`, the stripped model name, and `GEMINI_BASE_URL`; it fails on `main` (`assert llm.is_gemini` -> False) and passes with the fix.
