### PR TITLE
Serialize video attachments as `video_url` content-parts

### DIFF
--- a/docs/notes/file-input.md
+++ b/docs/notes/file-input.md
@@ -58,6 +58,9 @@ Currently the OpenAI-API supports:
 - PDF files (including image-based PDFs)
 - image files and URLs
 
+Video files and URLs are serialized as `video_url` content-parts, and work with
+any chat-completions API that accepts video input.
+
 
 ## Creating Attachments
 

--- a/langroid/parsing/file_attachment.py
+++ b/langroid/parsing/file_attachment.py
@@ -201,6 +201,21 @@ class FileAttachment(BaseModel):
         base64_content = self.to_base64()
         return f"data:{self.mime_type};base64,{base64_content}"
 
+    def _content_url(self) -> str:
+        """URL to send to the API for this attachment.
+
+        Returns:
+            The original URL when it is a full http/https URL that the API can
+            fetch directly, else a base64-encoded data URI of the content.
+        """
+        # If we have a URL and it's a full http/https URL, use it directly
+        if self.url and (
+            self.url.startswith("http://") or self.url.startswith("https://")
+        ):
+            return self.url
+        # Otherwise use base64 data URI
+        return self.to_data_uri()
+
     def to_dict(self, model: str) -> Dict[str, Any]:
         """
         Convert to a dictionary suitable for API requests.
@@ -216,16 +231,7 @@ class FileAttachment(BaseModel):
         ):
             # for gemini models, we use `image_url` for both pdf-files and images
 
-            image_url_dict = {}
-
-            # If we have a URL and it's a full http/https URL, use it directly
-            if self.url and (
-                self.url.startswith("http://") or self.url.startswith("https://")
-            ):
-                image_url_dict["url"] = self.url
-            # Otherwise use base64 data URI
-            else:
-                image_url_dict["url"] = self.to_data_uri()
+            image_url_dict: Dict[str, str] = dict(url=self._content_url())
 
             # Add detail parameter if specified
             if self.detail:
@@ -234,6 +240,14 @@ class FileAttachment(BaseModel):
             return dict(
                 type="image_url",
                 image_url=image_url_dict,
+            )
+        elif self.mime_type.startswith("video/"):
+            # Videos are sent as `video_url` content-parts, mirroring the
+            # `image_url` parts used for images: a generic `file` part is not
+            # recognized as video input by the API.
+            return dict(
+                type="video_url",
+                video_url=dict(url=self._content_url()),
             )
         else:
             # For non-image files

--- a/tests/main/test_file_attachment.py
+++ b/tests/main/test_file_attachment.py
@@ -90,6 +90,54 @@ class TestFileAttachment:
         result = attachment.to_dict("gpt-4.1")
         assert result is not None
 
+    def test_to_dict_image(self):
+        """Images are sent as `image_url` content-parts."""
+        content = b"test content"
+        attachment = FileAttachment.from_bytes(
+            content=content, filename="image.png", mime_type="image/png"
+        )
+
+        result = attachment.to_dict("test-model")
+
+        assert result["type"] == "image_url"
+        assert result["image_url"]["url"] == attachment.to_data_uri()
+
+    def test_to_dict_video(self):
+        """Videos are sent as `video_url` content-parts, not generic file parts."""
+        content = b"test content"
+        attachment = FileAttachment.from_bytes(content=content, filename="clip.mp4")
+
+        assert attachment.mime_type == "video/mp4"
+
+        result = attachment.to_dict("test-model")
+
+        assert result["type"] == "video_url"
+        assert result["video_url"]["url"] == attachment.to_data_uri()
+        assert "file" not in result
+
+    def test_to_dict_video_url_passthrough(self):
+        """A remote video URL is passed through instead of being base64-encoded."""
+        url = "https://example.com/videos/clip.mp4"
+        attachment = FileAttachment.from_path(url)
+
+        assert attachment.mime_type == "video/mp4"
+
+        result = attachment.to_dict("test-model")
+
+        assert result["type"] == "video_url"
+        assert result["video_url"]["url"] == url
+
+    def test_to_dict_non_media_file(self):
+        """Non-image, non-video files keep using generic `file` content-parts."""
+        content = b"test content"
+        attachment = FileAttachment.from_bytes(content=content, filename="doc.pdf")
+
+        result = attachment.to_dict("test-model")
+
+        assert result["type"] == "file"
+        assert result["file"]["filename"] == "doc.pdf"
+        assert result["file"]["file_data"] == attachment.to_data_uri()
+
     def test_mime_type_inference(self):
         """Test MIME type is correctly inferred from filename."""
         content = b"test content"


### PR DESCRIPTION
Reason: Video attachments were serialized as generic `file` content-parts, so chat-completions APIs that accept video input never received them as video.

## Changes

- `langroid/parsing/file_attachment.py`
  - `FileAttachment.to_dict()` now emits a `video_url` content-part for attachments whose MIME type starts with `video/`, mirroring the existing `image_url` part used for `image/*`.
  - As with images, a full `http`/`https` URL is passed through as-is, and otherwise the base64 data URI is used.
  - Extracted that shared "remote URL, else data URI" logic into a small `_content_url()` helper now used by both the image and video branches.
  - Images, PDFs and every other MIME type keep their current serialization: the new branch is only reached when the existing image branch does not match, so no existing payload changes.

- `tests/main/test_file_attachment.py`
  - New unit tests: video bytes produce a `video_url` part carrying the data URI, and a remote video URL is passed through unchanged.
  - Added regression tests pinning the existing `image_url` part for images and the generic `file` part for other files, which were previously only asserted to be non-`None`.

- `docs/notes/file-input.md`
  - Note that video files and URLs are sent as `video_url` content-parts.

## Checks

- `ruff check langroid/parsing/file_attachment.py tests/main/test_file_attachment.py` — all checks passed
- `ruff format --diff` on both changed Python files — already formatted
- Unit tests in `tests/main/test_file_attachment.py` — 13 passed

Model registry entries are out of scope here: the dispatch is keyed only off the attachment MIME type, so it stays model-agnostic and applies to any model whose API accepts video input.
