### PR TITLE
feat(mcp): namespace tools from multiple servers

### DIFF
--- a/docs/notes/mcp-tools.md
+++ b/docs/notes/mcp-tools.md
@@ -460,6 +460,30 @@ async with FastMCPClient(server) as client:
     models = [client.tool_model_from_mcp_tool(t) for t in wanted]
 ```
 
+## Namespacing tools from multiple servers
+
+Two MCP servers can expose the same tool name. Enabling both generated tools on
+one `ChatAgent` would otherwise make the later tool replace the earlier entry in
+the agent's tool map. Pass `tool_name_prefix` when loading each server to give
+the Langroid-facing names distinct namespaces:
+
+```python
+weather_tools = await get_tools_async(
+    weather_server,
+    tool_name_prefix="weather",
+)
+inventory_tools = await get_tools_async(
+    inventory_server,
+    tool_name_prefix="inventory",
+)
+
+agent.enable_message(weather_tools + inventory_tools)
+```
+
+If both servers expose `lookup`, the agent sees `weather__lookup` and
+`inventory__lookup`. Each generated tool still invokes `lookup` on the server
+that defined it. Omitting `tool_name_prefix` preserves the existing tool names.
+
 ## Tool parameter type mapping
 
 When an MCP tool is converted into a Langroid `ToolMessage`,

--- a/langroid/agent/tools/mcp/fastmcp_client.py
+++ b/langroid/agent/tools/mcp/fastmcp_client.py
@@ -94,11 +94,15 @@ class FastMCPClient:
         log_handler: LoggingFnT | None = None,
         message_handler: MessageHandlerFnT | None = None,
         read_timeout_seconds: datetime.timedelta | None = None,
+        tool_name_prefix: str | None = None,
     ) -> None:
         """Initialize the FastMCPClient.
 
         Args:
             server: FastMCP server or path to such a server
+            tool_name_prefix: Optional namespace prepended to generated Langroid
+                tool names as ``<prefix>__<server-tool-name>``. Calls to the MCP
+                server continue to use its original tool name.
         """
         self.server = server
         self.client = None
@@ -121,6 +125,7 @@ class FastMCPClient:
         self.forward_text_resources = forward_text_resources
         self.forward_blob_resources = forward_blob_resources
         self.forward_images = forward_images
+        self.tool_name_prefix = tool_name_prefix
 
     async def __aenter__(self) -> "FastMCPClient":
         """Enter the async context manager and connect inner client.
@@ -492,9 +497,14 @@ class FastMCPClient:
         Returns:
             A dynamically created Langroid ToolMessage subclass for `target`.
         """
-        tool_name = getattr(target, "name", None)
-        if not isinstance(tool_name, str) or tool_name == "":
+        mcp_tool_name = getattr(target, "name", None)
+        if not isinstance(mcp_tool_name, str) or mcp_tool_name == "":
             raise ValueError(f"Invalid MCP tool name for tool {target!r}")
+        tool_name = (
+            f"{self.tool_name_prefix}__{mcp_tool_name}"
+            if self.tool_name_prefix
+            else mcp_tool_name
+        )
 
         input_schema = getattr(target, "inputSchema", None)
         schema = input_schema if isinstance(input_schema, dict) else {}
@@ -579,6 +589,7 @@ class FastMCPClient:
 
         tool_model._client_config = client_config  # type: ignore [attr-defined]
         tool_model._renamed_fields = renamed  # type: ignore[attr-defined]
+        tool_model._mcp_tool_name = mcp_tool_name  # type: ignore[attr-defined]
 
         # 2) define an arg-free call_tool_async()
         async def call_tool_async(itself: ToolMessage) -> Any:
@@ -622,11 +633,17 @@ class FastMCPClient:
                 if not self.client:
                     await self.connect()
 
-                return await self.call_mcp_tool(itself.request, payload)
+                return await self.call_mcp_tool(
+                    itself.__class__._mcp_tool_name,  # type: ignore[attr-defined]
+                    payload,
+                )
 
             # open a fresh client, call the tool, then close
             async with FastMCPClient(**client_cfg) as client:  # type: ignore
-                return await client.call_mcp_tool(itself.request, payload)
+                return await client.call_mcp_tool(
+                    itself.__class__._mcp_tool_name,  # type: ignore[attr-defined]
+                    payload,
+                )
 
         tool_model.call_tool_async = call_tool_async  # type: ignore
 

--- a/tests/main/test_mcp_tools.py
+++ b/tests/main/test_mcp_tools.py
@@ -1520,6 +1520,56 @@ def test_tool_model_from_mcp_tool_handles_malformed_enum() -> None:
     assert tool_model(bad_enum=5).bad_enum == 5
 
 
+@pytest.mark.asyncio
+async def test_namespaced_tools_avoid_cross_server_name_collisions() -> None:
+    """Namespaced tools with the same server name remain independently usable."""
+    weather_server = FastMCP("WeatherServer")
+    inventory_server = FastMCP("InventoryServer")
+
+    @weather_server.tool(name="lookup")
+    def weather_lookup(item: str) -> str:
+        return f"weather:{item}"
+
+    @inventory_server.tool(name="lookup")
+    def inventory_lookup(item: str) -> str:
+        return f"inventory:{item}"
+
+    weather_tools = await get_tools_async(
+        weather_server,
+        tool_name_prefix="weather",
+    )
+    inventory_tools = await get_tools_async(
+        inventory_server,
+        tool_name_prefix="inventory",
+    )
+    weather_tool = weather_tools[0]
+    inventory_tool = inventory_tools[0]
+
+    assert weather_tool.default_value("request") == "weather__lookup"
+    assert inventory_tool.default_value("request") == "inventory__lookup"
+
+    agent = lr.ChatAgent(lr.ChatAgentConfig(llm=None))
+    agent.enable_message([weather_tool, inventory_tool])
+    assert set(agent.llm_tools_map) >= {
+        "weather__lookup",
+        "inventory__lookup",
+    }
+
+    weather_result = await weather_tool(item="Paris").handle_async()
+    inventory_result = await inventory_tool(item="sprocket").handle_async()
+    assert weather_result == "weather:Paris"
+    assert inventory_result == "inventory:sprocket"
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_names_remain_unchanged_without_prefix() -> None:
+    """Omitting a namespace preserves the existing public tool name."""
+    tools = await get_tools_async(mcp_server())
+    requests = {tool.default_value("request") for tool in tools}
+
+    assert "get_alerts" in requests
+
+
 def test_tool_model_from_mcp_tool_maps_one_of_to_union() -> None:
     """A oneOf schema should produce a union whose members both validate."""
     from typing import Union, get_args, get_origin


### PR DESCRIPTION
## Summary

- add an optional `tool_name_prefix` when converting MCP server tools into Langroid tools
- expose names such as `weather__lookup` while keeping the protocol-level MCP call name as `lookup`
- cover collisions across two MCP servers and preserve existing names when no prefix is set
- document multi-server namespacing with a concrete example

## Motivation

Different MCP servers can publish the same tool name. Enabling both generated tools on one `ChatAgent` currently causes one entry to replace the other in the agent tool map. This opt-in namespace keeps both tools independently addressable without changing either MCP server contract.

## Validation

- focused offline MCP tests (41 passed, 9 external tests deselected)
- Black checks passed for the changed Python files
- Ruff checks passed for the changed Python files
- Mypy validation passed

## Compatibility

The default remains unchanged. A prefix is applied only when `tool_name_prefix` is provided, and generated handlers continue to call the original server-side tool name.