### PR TITLE
feat(task): add cooperative wall-clock budgets

### DIFF
--- a/docs/notes/task-termination.md
+++ b/docs/notes/task-termination.md
@@ -40,6 +40,20 @@ In Langroid, a `Task` wraps an `Agent` and manages the conversation flow. Contro
 result = task.run("Start conversation", turns=5)
 ```
 
+### Wall-clock budget
+
+Long-running agent workflows can also stop after a wall-clock budget:
+
+```python
+result = task.run("Start research", max_time=30.0)
+```
+
+The synchronous and asynchronous run loops check this cooperative limit after
+each completed step. They do not interrupt an in-flight LLM or tool call, so
+agent and tool state cannot be left half-updated. When the budget is exhausted,
+the returned `ChatDocument` has `metadata.status == StatusCode.TIMEOUT`. A
+non-positive `max_time` keeps the existing unlimited behavior.
+
 ### 2. Single Round Mode
 ```python
 # Task completes after one exchange

--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -8,6 +8,7 @@ import threading
 from collections import Counter, OrderedDict, deque
 from enum import Enum
 from pathlib import Path
+from time import monotonic
 from types import SimpleNamespace
 from typing import (
     Any,
@@ -770,6 +771,7 @@ class Task:
         max_tokens: int = 0,
         session_id: str = "",
         allow_restart: bool = True,
+        max_time: float = 0,
     ) -> Optional[ChatDocument]: ...  # noqa
 
     @overload
@@ -783,6 +785,7 @@ class Task:
         max_tokens: int = 0,
         session_id: str = "",
         allow_restart: bool = True,
+        max_time: float = 0,
         return_type: Type[T],
     ) -> Optional[T]: ...  # noqa
 
@@ -796,6 +799,7 @@ class Task:
         session_id: str = "",
         allow_restart: bool = True,
         return_type: Optional[Type[T]] = None,
+        max_time: float = 0,
     ) -> Optional[ChatDocument | T]:
         """Synchronous version of `run_async()`.
         See `run_async()` for details."""
@@ -814,6 +818,7 @@ class Task:
         self.n_no_answer_alternations = 0
         self.max_cost = max_cost
         self.max_tokens = max_tokens
+        started_at = monotonic() if max_time > 0 else None
         self.session_id = session_id
         self._set_alive()
         self._init_message_counter()
@@ -851,6 +856,9 @@ class Task:
             if done:
                 if self._level == 0 and not settings.quiet:
                     print("[magenta]Bye, hope this was useful!")
+                break
+            if started_at is not None and monotonic() - started_at >= max_time:
+                status = StatusCode.TIMEOUT
                 break
             i += 1
             max_turns = (
@@ -938,6 +946,7 @@ class Task:
         max_tokens: int = 0,
         session_id: str = "",
         allow_restart: bool = True,
+        max_time: float = 0,
     ) -> Optional[ChatDocument]: ...  # noqa
 
     @overload
@@ -951,6 +960,7 @@ class Task:
         max_tokens: int = 0,
         session_id: str = "",
         allow_restart: bool = True,
+        max_time: float = 0,
         return_type: Type[T],
     ) -> Optional[T]: ...  # noqa
 
@@ -964,6 +974,7 @@ class Task:
         session_id: str = "",
         allow_restart: bool = True,
         return_type: Optional[Type[T]] = None,
+        max_time: float = 0,
     ) -> Optional[ChatDocument | T]:
         """
         Loop over `step()` until task is considered done or `turns` is reached.
@@ -984,6 +995,8 @@ class Task:
             caller (Task|None): the calling task, if any
             max_cost (float): max cost allowed for the task (default 0 -> no limit)
             max_tokens (int): max tokens allowed for the task (default 0 -> no limit)
+            max_time (float): max wall-clock seconds for the task. The limit is
+                checked after each completed step (default 0 -> no limit).
             session_id (str): session id for the task
             allow_restart (bool): whether to allow restarting the task
             return_type (Optional[Type[T]]): desired final result type
@@ -1012,6 +1025,7 @@ class Task:
         self.n_no_answer_alternations = 0
         self.max_cost = max_cost
         self.max_tokens = max_tokens
+        started_at = monotonic() if max_time > 0 else None
         self.session_id = session_id
         self._set_alive()
         self._init_message_counter()
@@ -1051,6 +1065,9 @@ class Task:
             if done:
                 if self._level == 0 and not settings.quiet:
                     print("[magenta]Bye, hope this was useful!")
+                break
+            if started_at is not None and monotonic() - started_at >= max_time:
+                status = StatusCode.TIMEOUT
                 break
             i += 1
             max_turns = (

--- a/tests/main/test_task_time_budget.py
+++ b/tests/main/test_task_time_budget.py
@@ -1,0 +1,69 @@
+"""Tests for cooperative wall-clock limits in Task run loops."""
+
+from collections.abc import Iterator
+
+import pytest
+
+import langroid as lr
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.agent.chat_document import ChatDocument
+from langroid.language_models.mock_lm import MockLMConfig
+
+
+def _clock(values: list[float]) -> Iterator[float]:
+    """Yield deterministic monotonic-clock readings."""
+    yield from values
+
+
+def _looping_agent() -> ChatAgent:
+    """Build an offline agent that keeps producing valid responses."""
+    return ChatAgent(
+        ChatAgentConfig(
+            llm=MockLMConfig(response_fn=lambda _: "continue"),
+        )
+    )
+
+
+def test_run_stops_at_wall_clock_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sync loop reports TIMEOUT after a completed step exhausts its budget."""
+    readings = _clock([0.0, 1.0])
+    monkeypatch.setattr("langroid.agent.task.monotonic", lambda: next(readings))
+    task = lr.Task(_looping_agent(), interactive=False)
+
+    result = task.run("start", turns=10, max_time=0.5)
+
+    assert isinstance(result, ChatDocument)
+    assert result.metadata.status == lr.StatusCode.TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_run_async_stops_at_wall_clock_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The async loop applies the same cooperative time budget as sync."""
+    readings = _clock([0.0, 1.0])
+    monkeypatch.setattr("langroid.agent.task.monotonic", lambda: next(readings))
+    task = lr.Task(_looping_agent(), interactive=False)
+
+    result = await task.run_async("start", turns=10, max_time=0.5)
+
+    assert isinstance(result, ChatDocument)
+    assert result.metadata.status == lr.StatusCode.TIMEOUT
+
+
+def test_zero_wall_clock_budget_keeps_existing_unlimited_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A zero budget remains the backwards-compatible unlimited default."""
+    monkeypatch.setattr(
+        "langroid.agent.task.monotonic",
+        lambda: pytest.fail("unlimited runs must not read the budget clock"),
+    )
+    task = lr.Task(_looping_agent(), interactive=False)
+
+    result = task.run("start", turns=1, max_time=0)
+
+    assert isinstance(result, ChatDocument)
+    assert result.metadata.status == lr.StatusCode.FIXED_TURNS


### PR DESCRIPTION
## Summary

- add an optional `max_time` wall-clock budget to synchronous and asynchronous `Task` run loops
- use a monotonic clock and return `StatusCode.TIMEOUT` once the budget is exhausted
- check the limit only after a completed step so in-flight LLM and tool calls are not interrupted
- document the cooperative timeout semantics and unlimited default

## Motivation

Agent tasks can already stop on turn, token, and cost limits, but callers cannot bound total elapsed time through the run API. A small cooperative wall-clock budget gives orchestrators a predictable termination signal while preserving completed-step state.

## Validation

- focused offline Task tests (28 passed)
- Black checks passed for the changed Python files
- Ruff checks passed for the changed Python files
- Mypy validation passed

## Compatibility

`max_time` is appended after existing implementation parameters to preserve positional callers. Zero and negative values retain the existing unlimited behavior. The budget does not cancel an in-flight model or tool request.