### PR TITLE
feat(agent): add portable chat history snapshots

### DIFF
--- a/docs/notes/chat-history-snapshots.md
+++ b/docs/notes/chat-history-snapshots.md
@@ -1,0 +1,39 @@
+# Chat History Snapshots
+
+`ChatAgent` can export and restore its message history as versioned JSON. This
+is useful when a conversation must resume in a later process or move between
+workers without serializing the entire agent.
+
+```python
+from pathlib import Path
+
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+
+history_path = Path(".cache/agent-state/history.json")
+agent = ChatAgent(ChatAgentConfig())
+
+if history_path.exists():
+    agent.import_history(history_path.read_text())
+
+# Run the agent or task, then persist its current history.
+history_path.parent.mkdir(parents=True, exist_ok=True)
+history_path.write_text(agent.export_history())
+```
+
+The snapshot contains a format version and the agent's `LLMMessage` records.
+Binary file attachments are Base64-encoded so the result remains valid JSON.
+Process-local `chat_document_id` values are cleared during export and import.
+
+When imported history includes OpenAI tool calls, the agent rebuilds its call
+lookup and pending-call list. A call remains pending only when the history does
+not contain a matching `tool` result. This allows an interrupted tool workflow
+to resume without treating completed calls as pending.
+
+Import validates the complete snapshot before replacing the current history.
+Malformed JSON, unsupported versions, invalid messages, or invalid Base64 data
+raise `ValueError` and leave the existing conversation unchanged.
+
+Snapshots contain conversation text and attachment contents. Store them with
+the same access controls used for other user data. The previous
+`examples/basic/chat-persist.py` pickle file is intentionally not loaded or
+migrated automatically because unpickling untrusted data can execute code.

--- a/examples/basic/chat-persist.py
+++ b/examples/basic/chat-persist.py
@@ -23,7 +23,6 @@ https://langroid.github.io/langroid/tutorials/local-llm-setup/
 """
 
 import logging
-import pickle
 from pathlib import Path
 
 import typer
@@ -82,27 +81,12 @@ def main(
         timeout=45,
     )
 
-    # check if history.pkl exists under STATE_CACHE_DIR, and if it does, load it
-    # into agent.message_history
-    hist_path = Path(STATE_CACHE_DIR) / "history.pkl"
-    hist_found = False
-    try:
-        if hist_path.exists():
-            # read the history from the cache
-            with open(str(hist_path), "rb") as f:
-                msg_history = pickle.load(f)
-            n_msgs = len(msg_history)
-            logger.info(f"Loaded {n_msgs} messages from cache")
-            hist_found = True
-        else:
-            sys_msg = Prompt.ask(
-                "[blue]Tell me who I am. Hit Enter for default, or type your own\n",
-                default=sys_msg,
-            )
-
-    except Exception:
-        logger.warning("Failed to load message history from cache")
-        pass
+    hist_path = Path(STATE_CACHE_DIR) / "history.json"
+    if not hist_path.exists():
+        sys_msg = Prompt.ask(
+            "[blue]Tell me who I am. Hit Enter for default, or type your own\n",
+            default=sys_msg,
+        )
 
     config = ChatAgentConfig(
         system_message=sys_msg,
@@ -110,9 +94,12 @@ def main(
     )
     agent = ChatAgent(config)
 
-    if hist_found:
-        # overrides sys_msg set in config
-        agent.message_history = msg_history
+    if hist_path.exists():
+        try:
+            agent.import_history(hist_path.read_text())
+            logger.info(f"Loaded {len(agent.message_history)} messages from cache")
+        except (OSError, ValueError):
+            logger.warning("Failed to load message history from cache")
 
     # use restart=False so the state is not cleared out at start,
     # which allows continuing the conversation.
@@ -129,8 +116,7 @@ def main(
     # Create STATE_CACHE_DIR if it doesn't exist
     Path(STATE_CACHE_DIR).mkdir(parents=True, exist_ok=True)
     # Save the conversation state to hist_path
-    with open(str(hist_path), "wb") as f:
-        pickle.dump(agent.message_history, f)
+    hist_path.write_text(agent.export_history())
     logger.info(f"Saved {len(agent.message_history)} messages to cache")
 
 

--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -1,3 +1,4 @@
+import base64
 import copy
 import inspect
 import json
@@ -52,6 +53,7 @@ from langroid.language_models.base import (
 )
 from langroid.language_models.openai_gpt import OpenAIGPT
 from langroid.mytypes import Entity, NonToolAction
+from langroid.parsing.file_attachment import FileAttachment
 from langroid.utils.configuration import settings
 from langroid.utils.object_registry import ObjectRegistry
 from langroid.utils.output import status
@@ -477,6 +479,89 @@ class ChatAgent(Agent):
                 LLMMessage(role=Role.ASSISTANT, content=response),
             ]
         )
+
+    def export_history(self) -> str:
+        """Export message history as a portable, versioned JSON snapshot.
+
+        Returns:
+            A JSON string containing the current message history.
+        """
+        messages: List[Dict[str, Any]] = []
+        for message in self.message_history:
+            data = message.model_dump(mode="json", exclude={"files"})
+            data["chat_document_id"] = ""
+            data["files"] = [
+                {
+                    "content_base64": base64.b64encode(file.content).decode("ascii"),
+                    "filename": file.filename,
+                    "mime_type": file.mime_type,
+                    "url": file.url,
+                    "detail": file.detail,
+                }
+                for file in message.files
+            ]
+            messages.append(data)
+        return json.dumps({"version": 1, "messages": messages}, ensure_ascii=False)
+
+    def import_history(self, snapshot: str) -> None:
+        """Restore message history from :meth:`export_history` output.
+
+        Args:
+            snapshot: Versioned JSON snapshot to restore.
+
+        Raises:
+            ValueError: If the snapshot is malformed or has an unknown version.
+        """
+        try:
+            payload = json.loads(snapshot)
+            if not isinstance(payload, dict) or payload.get("version") != 1:
+                raise ValueError("unsupported version")
+            raw_messages = payload.get("messages")
+            if not isinstance(raw_messages, list):
+                raise ValueError("messages must be a list")
+
+            messages: List[LLMMessage] = []
+            for raw_message in raw_messages:
+                if not isinstance(raw_message, dict):
+                    raise ValueError("message must be an object")
+                message_data = dict(raw_message)
+                raw_files = message_data.get("files", [])
+                if not isinstance(raw_files, list):
+                    raise ValueError("files must be a list")
+                files = []
+                for raw_file in raw_files:
+                    if not isinstance(raw_file, dict):
+                        raise ValueError("file must be an object")
+                    file_data = dict(raw_file)
+                    content = base64.b64decode(
+                        file_data.pop("content_base64"),
+                        validate=True,
+                    )
+                    files.append(FileAttachment(content=content, **file_data))
+                message_data["files"] = files
+                message_data["chat_document_id"] = ""
+                messages.append(LLMMessage.model_validate(message_data))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid history snapshot: {exc}") from exc
+
+        all_calls = {
+            call.id: call
+            for message in messages
+            for call in (message.tool_calls or [])
+            if call.id is not None
+        }
+        completed_call_ids = {
+            message.tool_call_id
+            for message in messages
+            if message.role == Role.TOOL and message.tool_call_id is not None
+        }
+        self.message_history = messages
+        self.oai_tool_id2call = all_calls
+        self.oai_tool_calls = [
+            call
+            for call_id, call in all_calls.items()
+            if call_id not in completed_call_ids
+        ]
 
     def tool_format_rules(self) -> str:
         """

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
       - Structured Output: notes/structured-output.md
       - Tool Handlers: notes/tool-message-handler.md
       - Task Termination: notes/task-termination.md
+      - Chat History Snapshots: notes/chat-history-snapshots.md
       - Message Routing: notes/message-routing.md
       - Llama.cpp Embeddings: notes/llama-cpp-embeddings.md
       - Azure OpenAI models: notes/azure-openai-models.md

--- a/tests/main/test_chat_agent_history_snapshot.py
+++ b/tests/main/test_chat_agent_history_snapshot.py
@@ -1,0 +1,115 @@
+"""Tests for portable ChatAgent message-history snapshots."""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.language_models.base import (
+    LLMFunctionCall,
+    LLMMessage,
+    OpenAIToolCall,
+    Role,
+)
+from langroid.parsing.file_attachment import FileAttachment
+
+
+def _tool_call(call_id: str, city: str) -> OpenAIToolCall:
+    """Build a deterministic tool call for snapshot tests."""
+    return OpenAIToolCall(
+        id=call_id,
+        type="function",
+        function=LLMFunctionCall(
+            name="weather",
+            arguments={"city": city},
+        ),
+    )
+
+
+def test_history_snapshot_round_trips_messages_and_binary_files() -> None:
+    """JSON snapshots preserve message fields and arbitrary attachment bytes."""
+    agent = ChatAgent(ChatAgentConfig(llm=None))
+    timestamp = datetime(2026, 8, 18, 10, 30, tzinfo=timezone.utc)
+    agent.message_history = [
+        LLMMessage(
+            role=Role.USER,
+            content="inspect this",
+            timestamp=timestamp,
+            chat_document_id="process-local-id",
+            files=[
+                FileAttachment(
+                    content=b"\x00\xffbinary",
+                    filename="sample.bin",
+                    mime_type="application/octet-stream",
+                )
+            ],
+        )
+    ]
+
+    snapshot = agent.export_history()
+    restored = ChatAgent(ChatAgentConfig(llm=None))
+    restored.import_history(snapshot)
+
+    payload = json.loads(snapshot)
+    assert payload["version"] == 1
+    assert payload["messages"][0]["files"][0]["content_base64"] == "AP9iaW5hcnk="
+    assert agent.message_history[0].chat_document_id == "process-local-id"
+    message = restored.message_history[0]
+    assert message.role == Role.USER
+    assert message.content == "inspect this"
+    assert message.timestamp == timestamp
+    assert message.chat_document_id == ""
+    assert message.files[0].content == b"\x00\xffbinary"
+    assert message.files[0].filename == "sample.bin"
+
+
+def test_history_snapshot_rebuilds_pending_tool_calls() -> None:
+    """Import derives unresolved calls from calls minus matching tool results."""
+    completed = _tool_call("call-complete", "Paris")
+    pending = _tool_call("call-pending", "Tokyo")
+    source = ChatAgent(ChatAgentConfig(llm=None))
+    source.message_history = [
+        LLMMessage(
+            role=Role.ASSISTANT,
+            content=None,
+            tool_calls=[completed, pending],
+        ),
+        LLMMessage(
+            role=Role.TOOL,
+            content="sunny",
+            tool_call_id="call-complete",
+        ),
+    ]
+
+    restored = ChatAgent(ChatAgentConfig(llm=None))
+    restored.import_history(source.export_history())
+
+    assert [call.id for call in restored.oai_tool_calls] == ["call-pending"]
+    assert set(restored.oai_tool_id2call) == {
+        "call-complete",
+        "call-pending",
+    }
+
+
+@pytest.mark.parametrize(
+    "snapshot",
+    [
+        '{"version": 2, "messages": []}',
+        '{"version": 1, "messages": "not-a-list"}',
+        (
+            '{"version": 1, "messages": [{"role": "user", '
+            '"files": [{"content_base64": "%%%"}]}]}'
+        ),
+    ],
+)
+def test_invalid_history_snapshot_is_rejected_atomically(snapshot: str) -> None:
+    """Invalid snapshots raise without replacing the current conversation."""
+    agent = ChatAgent(ChatAgentConfig(llm=None))
+    original = LLMMessage(role=Role.SYSTEM, content="keep me")
+    agent.message_history = [original]
+
+    with pytest.raises(ValueError, match="history snapshot"):
+        agent.import_history(snapshot)
+
+    assert agent.message_history == [original]


### PR DESCRIPTION
## Summary

- add versioned JSON export/import APIs for `ChatAgent` message history
- preserve binary attachments with Base64 encoding while clearing process-local document IDs
- rebuild pending OpenAI tool-call state from restored assistant calls and completed tool results
- update the persistence example to use JSON instead of unsafe pickle deserialization
- document portability, validation, and data-protection boundaries

## Motivation

Long-running agent workflows often need to pause, move between workers, or resume after a process restart. Serializing the complete agent object is implementation-specific and pickle-based persistence is unsafe for untrusted files. This change provides a narrow, portable history snapshot that carries the conversation state required by `ChatAgent`.

## Validation

- `pytest -q tests/main/test_chat_agent_history_snapshot.py tests/main/test_prep_llm_message.py` (57 passed)
- `black --check langroid/agent/chat_agent.py tests/main/test_chat_agent_history_snapshot.py examples/basic/chat-persist.py`
- `ruff check langroid/agent/chat_agent.py tests/main/test_chat_agent_history_snapshot.py examples/basic/chat-persist.py`
- `mypy -p langroid` (132 source files)
- `python -m py_compile examples/basic/chat-persist.py`
- `mkdocs build`

## Compatibility and security

The snapshot format starts at version 1. Existing `history.pkl` files are intentionally not loaded or migrated automatically because unpickling untrusted data can execute code. Snapshots include conversation and attachment contents and must be protected as user data.