### PR TITLE
feat: add direct Mistral API support

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,4 +1,5 @@
 OPENAI_API_KEY=your-key-here-without-quotes
+MISTRAL_API_KEY=your-mistral-key-here-without-quotes
 GITHUB_ACCESS_TOKEN=your-personal-access-token-no-quotes
 CACHE_TYPE=redis # or momento
 REDIS_PASSWORD=your-redis-password-no-quotes

--- a/docs/tutorials/non-openai-llms.md
+++ b/docs/tutorials/non-openai-llms.md
@@ -113,6 +113,24 @@ Available models include `MiniMax-M2.7`, `MiniMax-M2.5`, `MiniMax-M2.1`, and
 
 See the [`chat-minimax.py`](https://github.com/langroid/langroid/blob/main/examples/basic/chat-minimax.py) example for a ready-to-run interactive chat script.
 
+## Mistral LLMs
+
+Mistral exposes an OpenAI-compatible chat-completions endpoint, so Langroid can
+use it directly without LiteLLM or an additional client dependency.
+
+Set `MISTRAL_API_KEY` in your `.env` file or shell, then prefix the model name
+with `mistral/`:
+
+```python
+llm_config = lm.OpenAIGPTConfig(
+    chat_model="mistral/mistral-small-latest",
+)
+```
+
+The prefix selects `https://api.mistral.ai/v1` and is removed before the model
+name is sent. You can set `api_base` explicitly when using a compatible proxy
+or regional endpoint.
+
 ## AI Gateways for Multiple LLM Providers
 
 In addition to LiteLLM, Langroid integrates with AI gateways that provide unified access to multiple LLM providers with additional enterprise features:
@@ -207,12 +225,3 @@ When the `--m` option is omitted, the default OpenAI GPT4 model is used.
       parameter in the `OpenAIGPTConfig` object. which you may need to adjust for different models.
       So this option is only meant for quickly testing against different models, and not meant as
       a way to switch between models in a production environment.
-
-
-
-
-
-
-
-
-    

--- a/docs/tutorials/supported-models.md
+++ b/docs/tutorials/supported-models.md
@@ -55,6 +55,7 @@ and which environment variable to set for the API key.
 | Gemini        | `gemini/gemini-2.0-flash`                                | `GEMINI_API_KEY` |
 | DeepSeek      | `deepseek/deepseek-reasoner`                             | `DEEPSEEK_API_KEY` |
 | MiniMax       | `minimax/MiniMax-M2.7`                                   | `MINIMAX_API_KEY` |
+| Mistral       | `mistral/mistral-small-latest`                           | `MISTRAL_API_KEY` |
 | GLHF          | `glhf/hf:Qwen/Qwen2.5-Coder-32B-Instruct`                | `GLHF_API_KEY` |
 | OpenRouter    | `openrouter/deepseek/deepseek-r1-distill-llama-70b:free` | `OPENROUTER_API_KEY` |
 | Ollama        | `ollama/qwen2.5`                                         | `OLLAMA_API_KEY` (usually `ollama`) |

--- a/langroid/language_models/__init__.py
+++ b/langroid/language_models/__init__.py
@@ -20,6 +20,7 @@ from .model_info import (
     AnthropicModel,
     GeminiModel,
     MiniMaxModel,
+    MistralModel,
     OpenAICompletionModel,
 )
 from .openai_gpt import OpenAIGPTConfig, OpenAIGPT, OpenAICallParams
@@ -47,6 +48,7 @@ __all__ = [
     "AnthropicModel",
     "GeminiModel",
     "MiniMaxModel",
+    "MistralModel",
     "OpenAICompletionModel",
     "OpenAIGPTConfig",
     "OpenAIGPT",

--- a/langroid/language_models/model_info.py
+++ b/langroid/language_models/model_info.py
@@ -15,6 +15,7 @@ class ModelProvider(str, Enum):
     DEEPSEEK = "deepseek"
     GOOGLE = "google"
     MINIMAX = "minimax"
+    MISTRAL = "mistral"
     UNKNOWN = "unknown"
 
 
@@ -113,6 +114,13 @@ class MiniMaxModel(ModelName):
     MINIMAX_M2_1 = "MiniMax-M2.1"
     MINIMAX_M2_1_HIGHSPEED = "MiniMax-M2.1-highspeed"
     MINIMAX_M2 = "MiniMax-M2"
+
+
+class MistralModel(ModelName):
+    """Stable aliases for Mistral chat models."""
+
+    MISTRAL_SMALL_LATEST = "mistral-small-latest"
+    MISTRAL_LARGE_LATEST = "mistral-large-latest"
 
 
 class OpenAI_API_ParamInfo(BaseModel):
@@ -762,6 +770,29 @@ MODEL_INFO: Dict[str, ModelInfo] = {
         output_cost_per_million=0.95,
         has_structured_output=True,
         description="MiniMax M2 (204K context)",
+    ),
+    # Mistral aliases
+    MistralModel.MISTRAL_SMALL_LATEST.value: ModelInfo(
+        name=MistralModel.MISTRAL_SMALL_LATEST.value,
+        provider=ModelProvider.MISTRAL,
+        context_length=256_000,
+        max_output_tokens=8192,
+        input_cost_per_million=0.15,
+        cached_cost_per_million=0.015,
+        output_cost_per_million=0.60,
+        has_structured_output=True,
+        description="Mistral Small (latest alias)",
+    ),
+    MistralModel.MISTRAL_LARGE_LATEST.value: ModelInfo(
+        name=MistralModel.MISTRAL_LARGE_LATEST.value,
+        provider=ModelProvider.MISTRAL,
+        context_length=256_000,
+        max_output_tokens=8192,
+        input_cost_per_million=0.50,
+        cached_cost_per_million=0.05,
+        output_cost_per_million=1.50,
+        has_structured_output=True,
+        description="Mistral Large (latest alias)",
     ),
 }
 

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -61,6 +61,7 @@ from langroid.language_models.config import HFPromptFormatterConfig
 from langroid.language_models.model_info import (
     DeepSeekModel,
     MiniMaxModel,
+    MistralModel,
     OpenAI_API_ParamInfo,
 )
 from langroid.language_models.model_info import (
@@ -99,6 +100,7 @@ OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
 GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
 MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+MISTRAL_BASE_URL = "https://api.mistral.ai/v1"
 OLLAMA_API_KEY = "ollama"
 
 VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
@@ -570,6 +572,7 @@ class OpenAIGPT(LanguageModel):
         self.is_gemini = self.is_gemini_model()
         self.is_deepseek = self.is_deepseek_model()
         self.is_minimax = self.is_minimax_model()
+        self.is_mistral = self.is_mistral_model()
         self.is_glhf = self.config.chat_model.startswith("glhf/")
         self.is_openrouter = self.config.chat_model.startswith("openrouter/")
         self.is_langdb = self.config.chat_model.startswith("langdb/")
@@ -674,6 +677,24 @@ class OpenAIGPT(LanguageModel):
                 # and self.info() can find the model in MODEL_INFO.
                 self.supports_strict_tools = True
                 self.supports_json_schema = self.info().has_structured_output
+            elif self.is_mistral:
+                self.config.chat_model = self.config.chat_model.replace("mistral/", "")
+                # Do not inherit OPENAI_API_BASE for a Mistral-prefixed model.
+                # An api_base passed explicitly still supports proxies and
+                # regional endpoints.
+                openai_api_base = os.getenv("OPENAI_API_BASE")
+                explicit_api_base = (
+                    self.config.api_base
+                    if self.config.api_base and self.config.api_base != openai_api_base
+                    else None
+                )
+                self.api_base = explicit_api_base or MISTRAL_BASE_URL
+                if self.api_key == OPENAI_API_KEY:
+                    mistral_key = os.getenv("MISTRAL_API_KEY", "")
+                    if mistral_key:
+                        self.api_key = mistral_key
+                self.supports_strict_tools = False
+                self.supports_json_schema = True
             elif self.is_langdb:
                 self.config.chat_model = self.config.chat_model.replace("langdb/", "")
                 self.api_base = self.config.langdb_params.base_url
@@ -903,6 +924,14 @@ class OpenAIGPT(LanguageModel):
             or self.chat_model_orig.startswith("minimax/")
         )
 
+    def is_mistral_model(self) -> bool:
+        """Are we using Mistral's OpenAI-compatible API?"""
+        mistral_models = [model.value for model in MistralModel]
+        return (
+            self.chat_model_orig in mistral_models
+            or self.chat_model_orig.startswith("mistral/")
+        )
+
     def unsupported_params(self) -> List[str]:
         """
         List of params that are not supported by the current model
@@ -915,6 +944,8 @@ class OpenAIGPT(LanguageModel):
         Map of param name -> new name for specific models.
         Currently main troublemaker is o1* series.
         """
+        if self.is_mistral:
+            return {"max_completion_tokens": "max_tokens"}
         return self.info().rename_params
 
     def chat_context_length(self) -> int:
@@ -2305,7 +2336,11 @@ class OpenAIGPT(LanguageModel):
             max_completion_tokens=max_tokens,
             stream=self.get_stream(),
         )
-        if self.get_stream() and "groq" not in self.chat_model_orig:
+        if (
+            self.get_stream()
+            and "groq" not in self.chat_model_orig
+            and not self.is_mistral
+        ):
             # groq fails when we include stream_options in the request
             args.update(
                 dict(

--- a/langroid/language_models/openai_gpt.py
+++ b/langroid/language_models/openai_gpt.py
@@ -25,7 +25,7 @@ from cerebras.cloud.sdk import AsyncCerebras, Cerebras
 from groq import AsyncGroq, Groq
 from httpx import Timeout
 from openai import AsyncOpenAI, OpenAI
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from rich import print
 from rich.markup import escape
@@ -307,9 +307,11 @@ class OpenAIGPTConfig(LLMConfig):
     )
     http_verify_ssl: bool = True  # Simple flag for SSL verification
     http_client_config: Optional[Dict[str, Any]] = None  # Config dict for httpx.Client
+    _explicit_api_base: str | None = PrivateAttr(default=None)
 
     def __init__(self, **kwargs) -> None:  # type: ignore
-        local_model = "api_base" in kwargs and kwargs["api_base"] is not None
+        explicit_api_base = kwargs.get("api_base") if "api_base" in kwargs else None
+        local_model = explicit_api_base is not None
 
         chat_model = kwargs.get("chat_model", "")
         local_prefixes = ["local/", "litellm/", "ollama/", "vllm/", "llamacpp/"]
@@ -332,6 +334,7 @@ class OpenAIGPTConfig(LLMConfig):
             kwargs["run_on_first_use"] = with_warning
 
         super().__init__(**kwargs)
+        self._explicit_api_base = explicit_api_base
 
     model_config = SettingsConfigDict(env_prefix="OPENAI_")
 
@@ -682,12 +685,15 @@ class OpenAIGPT(LanguageModel):
                 # Do not inherit OPENAI_API_BASE for a Mistral-prefixed model.
                 # An api_base passed explicitly still supports proxies and
                 # regional endpoints.
-                openai_api_base = os.getenv("OPENAI_API_BASE")
-                explicit_api_base = (
-                    self.config.api_base
-                    if self.config.api_base and self.config.api_base != openai_api_base
-                    else None
-                )
+                explicit_api_base = self.config._explicit_api_base
+                if explicit_api_base is None:
+                    openai_api_base = os.getenv("OPENAI_API_BASE")
+                    explicit_api_base = (
+                        self.config.api_base
+                        if self.config.api_base
+                        and self.config.api_base != openai_api_base
+                        else None
+                    )
                 self.api_base = explicit_api_base or MISTRAL_BASE_URL
                 if self.api_key == OPENAI_API_KEY:
                     mistral_key = os.getenv("MISTRAL_API_KEY", "")
@@ -945,7 +951,10 @@ class OpenAIGPT(LanguageModel):
         Currently main troublemaker is o1* series.
         """
         if self.is_mistral:
-            return {"max_completion_tokens": "max_tokens"}
+            return {
+                "max_completion_tokens": "max_tokens",
+                "seed": "random_seed",
+            }
         return self.info().rename_params
 
     def chat_context_length(self) -> int:
@@ -2393,6 +2402,13 @@ class OpenAIGPT(LanguageModel):
         for old_param, new_param in param_rename_map.items():
             if old_param in args:
                 args[new_param] = args.pop(old_param)
+
+        # The OpenAI SDK does not expose Mistral's ``random_seed`` keyword,
+        # so pass it through the supported provider-extension body.
+        if self.is_mistral and "random_seed" in args:
+            extra_body = dict(args.get("extra_body") or {})
+            extra_body["random_seed"] = args.pop("random_seed")
+            args["extra_body"] = extra_body
 
         # finally, get rid of extra_body params exclusive to certain models
         # Only apply allowlist restrictions for known models.

--- a/tests/main/test_mistral_provider.py
+++ b/tests/main/test_mistral_provider.py
@@ -1,0 +1,195 @@
+"""Tests for direct Mistral API routing through the OpenAI client."""
+
+import json
+import os
+from typing import Any, Dict, Generator, List, Tuple
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from langroid.language_models.model_info import (
+    MODEL_INFO,
+    MistralModel,
+    ModelProvider,
+    get_model_info,
+)
+from langroid.language_models.openai_gpt import (
+    MISTRAL_BASE_URL,
+    OpenAIGPT,
+    OpenAIGPTConfig,
+)
+from langroid.utils.configuration import settings
+
+CHAT_COMPLETION_JSON: Dict[str, Any] = {
+    "id": "chatcmpl-mistral-test",
+    "object": "chat.completion",
+    "created": 0,
+    "model": "mistral-small-latest",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "mock-response"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+}
+
+
+def _mock_clients(
+    requests: List[Tuple[str, Dict[str, Any]]],
+) -> Tuple[httpx.Client, httpx.AsyncClient]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append((str(request.url), json.loads(request.content)))
+        return httpx.Response(200, json=CHAT_COMPLETION_JSON)
+
+    transport = httpx.MockTransport(handler)
+    return httpx.Client(transport=transport), httpx.AsyncClient(transport=transport)
+
+
+def _make_llm(requests: List[Tuple[str, Dict[str, Any]]]) -> OpenAIGPT:
+    return OpenAIGPT(
+        OpenAIGPTConfig(
+            api_key="test-mistral-key",
+            chat_model="mistral/mistral-small-latest",
+            stream=False,
+            cache_config=None,
+            use_cached_client=False,
+            http_client_factory=lambda: _mock_clients(requests),
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_global_model() -> Generator[None, None, None]:
+    original = settings.chat_model
+    settings.chat_model = ""
+    try:
+        yield
+    finally:
+        settings.chat_model = original
+
+
+def test_mistral_prefix_configures_provider() -> None:
+    llm = OpenAIGPT(
+        OpenAIGPTConfig(
+            api_key="test-key",
+            chat_model="mistral/mistral-large-latest",
+        )
+    )
+
+    assert llm.is_mistral is True
+    assert llm.config.chat_model == "mistral-large-latest"
+    assert llm.api_base == MISTRAL_BASE_URL
+    assert llm.supports_json_schema is True
+    assert llm.supports_strict_tools is False
+
+
+def test_mistral_model_info_and_export() -> None:
+    from langroid.language_models import MistralModel as ExportedMistralModel
+
+    assert ExportedMistralModel is MistralModel
+    assert MistralModel.MISTRAL_SMALL_LATEST.value in MODEL_INFO
+    info = get_model_info(MistralModel.MISTRAL_SMALL_LATEST)
+    assert info.provider == ModelProvider.MISTRAL
+    assert info.context_length == 256_000
+    assert info.has_structured_output is True
+
+
+def test_bare_mistral_alias_uses_mistral_provider() -> None:
+    llm = OpenAIGPT(
+        OpenAIGPTConfig(
+            api_key="test-key",
+            chat_model=MistralModel.MISTRAL_LARGE_LATEST,
+        )
+    )
+
+    assert llm.is_mistral is True
+    assert llm.api_base == MISTRAL_BASE_URL
+
+
+def test_mistral_uses_environment_key() -> None:
+    with patch.dict(
+        os.environ,
+        {"MISTRAL_API_KEY": " env-mistral-key\n"},
+        clear=False,
+    ):
+        llm = OpenAIGPT(OpenAIGPTConfig(chat_model="mistral/mistral-small-latest"))
+
+    assert llm.api_key == "env-mistral-key"
+
+
+def test_mistral_explicit_key_and_base_take_precedence() -> None:
+    with patch.dict(os.environ, {"MISTRAL_API_KEY": "env-key"}, clear=False):
+        llm = OpenAIGPT(
+            OpenAIGPTConfig(
+                api_key="explicit-key",
+                api_base="https://mistral-proxy.example/v1",
+                chat_model="mistral/custom-model",
+            )
+        )
+
+    assert llm.api_key == "explicit-key"
+    assert llm.api_base == "https://mistral-proxy.example/v1"
+
+
+def test_openai_api_base_does_not_leak_into_mistral() -> None:
+    with patch.dict(
+        os.environ,
+        {"OPENAI_API_BASE": "http://localhost:8000/v1"},
+        clear=False,
+    ):
+        llm = OpenAIGPT(
+            OpenAIGPTConfig(
+                api_key="test-key",
+                chat_model="mistral/mistral-small-latest",
+            )
+        )
+
+    assert llm.api_base == MISTRAL_BASE_URL
+
+
+def test_mistral_stream_params_match_provider_api() -> None:
+    llm = OpenAIGPT(
+        OpenAIGPTConfig(
+            api_key="test-key",
+            chat_model="mistral/mistral-small-latest",
+            stream=True,
+        )
+    )
+
+    original_stream = settings.stream
+    settings.stream = True
+    try:
+        args = llm._prep_chat_completion("hello", max_tokens=5)
+    finally:
+        settings.stream = original_stream
+
+    assert args["stream"] is True
+    assert args["max_tokens"] == 5
+    assert "max_completion_tokens" not in args
+    assert "stream_options" not in args
+
+
+def test_sync_chat_uses_mistral_endpoint_and_model() -> None:
+    requests: List[Tuple[str, Dict[str, Any]]] = []
+    response = _make_llm(requests).chat("hello", max_tokens=5)
+
+    assert response.message == "mock-response"
+    assert requests[0][0] == f"{MISTRAL_BASE_URL}/chat/completions"
+    assert requests[0][1]["model"] == "mistral-small-latest"
+    assert requests[0][1]["max_tokens"] == 5
+    assert "max_completion_tokens" not in requests[0][1]
+
+
+@pytest.mark.asyncio
+async def test_async_chat_uses_mistral_endpoint_and_model() -> None:
+    requests: List[Tuple[str, Dict[str, Any]]] = []
+    response = await _make_llm(requests).achat("hello", max_tokens=5)
+
+    assert response.message == "mock-response"
+    assert requests[0][0] == f"{MISTRAL_BASE_URL}/chat/completions"
+    assert requests[0][1]["model"] == "mistral-small-latest"
+    assert requests[0][1]["max_tokens"] == 5
+    assert "max_completion_tokens" not in requests[0][1]

--- a/tests/main/test_mistral_provider.py
+++ b/tests/main/test_mistral_provider.py
@@ -16,6 +16,7 @@ from langroid.language_models.model_info import (
 )
 from langroid.language_models.openai_gpt import (
     MISTRAL_BASE_URL,
+    OpenAICallParams,
     OpenAIGPT,
     OpenAIGPTConfig,
 )
@@ -53,6 +54,7 @@ def _make_llm(requests: List[Tuple[str, Dict[str, Any]]]) -> OpenAIGPT:
         OpenAIGPTConfig(
             api_key="test-mistral-key",
             chat_model="mistral/mistral-small-latest",
+            params=OpenAICallParams(seed=7),
             stream=False,
             cache_config=None,
             use_cached_client=False,
@@ -150,11 +152,26 @@ def test_openai_api_base_does_not_leak_into_mistral() -> None:
     assert llm.api_base == MISTRAL_BASE_URL
 
 
+def test_explicit_base_matching_openai_environment_is_preserved() -> None:
+    proxy_url = "https://mistral-proxy.example/v1"
+    with patch.dict(os.environ, {"OPENAI_API_BASE": proxy_url}, clear=False):
+        llm = OpenAIGPT(
+            OpenAIGPTConfig(
+                api_key="proxy-key",
+                api_base=proxy_url,
+                chat_model="mistral/custom-model",
+            )
+        )
+
+    assert llm.api_base == proxy_url
+
+
 def test_mistral_stream_params_match_provider_api() -> None:
     llm = OpenAIGPT(
         OpenAIGPTConfig(
             api_key="test-key",
             chat_model="mistral/mistral-small-latest",
+            params=OpenAICallParams(seed=7),
             stream=True,
         )
     )
@@ -169,6 +186,8 @@ def test_mistral_stream_params_match_provider_api() -> None:
     assert args["stream"] is True
     assert args["max_tokens"] == 5
     assert "max_completion_tokens" not in args
+    assert args["extra_body"]["random_seed"] == 7
+    assert "seed" not in args
     assert "stream_options" not in args
 
 
@@ -181,6 +200,8 @@ def test_sync_chat_uses_mistral_endpoint_and_model() -> None:
     assert requests[0][1]["model"] == "mistral-small-latest"
     assert requests[0][1]["max_tokens"] == 5
     assert "max_completion_tokens" not in requests[0][1]
+    assert requests[0][1]["random_seed"] == 7
+    assert "seed" not in requests[0][1]
 
 
 @pytest.mark.asyncio
@@ -193,3 +214,5 @@ async def test_async_chat_uses_mistral_endpoint_and_model() -> None:
     assert requests[0][1]["model"] == "mistral-small-latest"
     assert requests[0][1]["max_tokens"] == 5
     assert "max_completion_tokens" not in requests[0][1]
+    assert requests[0][1]["random_seed"] == 7
+    assert "seed" not in requests[0][1]


### PR DESCRIPTION
## Summary

Fixes #384.

- route `mistral/<model>` and the documented latest aliases directly to Mistral's OpenAI-compatible API
- read `MISTRAL_API_KEY`, honor an explicit API base/key, and avoid leaking `OPENAI_API_BASE` into Mistral clients
- translate `max_completion_tokens` to Mistral's `max_tokens` and omit unsupported `stream_options`
- add current Small/Large model metadata, setup docs, and focused regression coverage

## Verification

- Docker, Python 3.11: Mistral provider and generic request/message preparation tests: **61 passed**
- Docker, Python 3.11: Mistral/MiniMax/Gemini provider-routing tests: **45 passed, 3 skipped** (the skips require a live MiniMax key)
- sync and async Mistral requests are exercised through `httpx.MockTransport`; no live Mistral credentials are required
- `ruff check`: passed
- `black --check`: passed
- `git diff --check`: passed

API behavior was checked against the [Mistral chat-completions API](https://docs.mistral.ai/api/endpoint/chat) and [known limitations](https://docs.mistral.ai/resources/known-limitations).
## Review follow-up

Addressed both automated review findings in `e2090c97`:

- explicit Mistral proxy bases remain explicit even when equal to `OPENAI_API_BASE`
- `seed` is translated to Mistral `random_seed` through the OpenAI SDK extension body

Additional Docker verification (Python 3.11):

- Mistral provider tests: **10 passed**
- Mistral + generic message preparation: **62 passed**
- Mistral/MiniMax/Gemini no-key routing: **39 passed, 3 skipped** (live MiniMax credentials)
- Ruff, Black, and `git diff --check`: passed