### PR TITLE
fix: warn once when FileAttachment payloads add to context preflight (#996)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.16.0
+  rev: v0.16.4
   hooks:
     - id: ruff

--- a/docs/notes/attachment-token-preflight.md
+++ b/docs/notes/attachment-token-preflight.md
@@ -1,0 +1,46 @@
+# Attachment Token Preflight
+
+Before each LLM call, Langroid runs a local context-length preflight: it counts
+the tokens in the pending message history (`ChatAgent.chat_num_tokens()`) and,
+if needed, reduces the requested output length, truncates old messages, or
+drops old turns so the request fits the model's context window.
+
+Historically this preflight counted only each message's text `content`, ignoring
+`LLMMessage.files` (`FileAttachment` objects). But attachments ARE serialized
+into the actual API request — for Gemini and other OpenAI-compatible paths,
+`FileAttachment.to_dict()` turns an attached PDF or image into a `data:` URI
+containing the full base64 payload. A ~1.9 MB PDF becomes roughly 2.6 million
+base64 characters, so the local check could pass while the real payload was far
+larger (issue #996).
+
+## Behavior
+
+The preflight now includes an estimate for each attachment on `USER` messages:
+
+- Each attachment is serialized exactly as it would be for the API request
+  (`FileAttachment.to_dict(model)`), and the resulting JSON is tokenized with
+  the agent's parser, the same way message text is counted.
+- Attachments that are NOT inlined — e.g. a `FileAttachment` carrying an
+  `http(s)` URL, which is sent as the URL itself rather than base64 bytes —
+  contribute only the tokens of their small serialized form, not the size of
+  the remote file.
+- Messages with no attachments are counted exactly as before; token accounting
+  is unchanged for attachment-free histories.
+
+When attachments contribute to the count for an agent, a warning is logged once
+(per agent, not per message) noting that the count is an estimate.
+
+## How conservative is the estimate?
+
+The estimate measures the serialized request payload (base64 data URI plus the
+surrounding JSON), tokenized like ordinary text. Provider-side accounting may
+differ in either direction:
+
+- Providers that bill inlined files as text-like payload will be close to this
+  estimate.
+- Providers that convert files to their own internal representation (e.g.
+  per-page or per-image token charges) may count fewer or more tokens.
+
+The goal is to keep the local preflight from drastically *under*-estimating the
+request size when large files are attached, so context-window overflows are
+caught locally instead of surfacing as provider-side errors.

--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -243,6 +243,8 @@ class ChatAgent(Agent):
         self.config: ChatAgentConfig = config
         self.config._set_fn_or_tools()
         self.message_history: List[LLMMessage] = []
+        # emit the attachment-token-estimate warning at most once per agent
+        self._attachment_tokens_warned: bool = False
         self.init_state()
         # An agent's "task" is defined by a system msg and an optional user msg;
         # These are "priming" messages that kick off the agent's conversation.
@@ -2680,7 +2682,7 @@ class ChatAgent(Agent):
             return 0
 
         model = self._chat_model_name_for_attachments()
-        return sum(
+        n_tokens = sum(
             self.parser.num_tokens(
                 json.dumps(
                     attachment.to_dict(model),
@@ -2690,6 +2692,15 @@ class ChatAgent(Agent):
             )
             for attachment in message.files
         )
+        if n_tokens > 0 and not self._attachment_tokens_warned:
+            self._attachment_tokens_warned = True
+            logger.warning(
+                "File attachment payloads are included in context-length "
+                "token accounting; this count is an estimate based on the "
+                "serialized (e.g. base64 data-URI) form of each attachment, "
+                "and may differ from the provider's own accounting."
+            )
+        return n_tokens
 
     def _chat_model_name_for_attachments(self) -> str:
         """Return the model name used for attachment serialization."""

--- a/llms-compressed.txt
+++ b/llms-compressed.txt
@@ -109,6 +109,7 @@ docs/
     pure-lambda-non-circular.png
   notes/
     async-streaming.md
+    attachment-token-preflight.md
     azure-openai-models.md
     batch-processing.md
     chat-history-snapshots.md
@@ -685,6 +686,7 @@ tests/
     test_arangodb_chat_agent.py
     test_arangodb.py
     test_async_handlers.py
+    test_attachment_token_accounting.py
     test_azure_openai.py
     test_batch_tasks_typed.py
     test_batch.py
@@ -45322,6 +45324,55 @@ the LLM will try its best to interpret what you want, and offer choices when con
     - Illustrates function-calling/tools and code-generation
 </file>
 
+<file path="docs/notes/attachment-token-preflight.md">
+# Attachment Token Preflight
+
+Before each LLM call, Langroid runs a local context-length preflight: it counts
+the tokens in the pending message history (`ChatAgent.chat_num_tokens()`) and,
+if needed, reduces the requested output length, truncates old messages, or
+drops old turns so the request fits the model's context window.
+
+Historically this preflight counted only each message's text `content`, ignoring
+`LLMMessage.files` (`FileAttachment` objects). But attachments ARE serialized
+into the actual API request — for Gemini and other OpenAI-compatible paths,
+`FileAttachment.to_dict()` turns an attached PDF or image into a `data:` URI
+containing the full base64 payload. A ~1.9 MB PDF becomes roughly 2.6 million
+base64 characters, so the local check could pass while the real payload was far
+larger (issue #996).
+
+## Behavior
+
+The preflight now includes an estimate for each attachment on `USER` messages:
+
+- Each attachment is serialized exactly as it would be for the API request
+  (`FileAttachment.to_dict(model)`), and the resulting JSON is tokenized with
+  the agent's parser, the same way message text is counted.
+- Attachments that are NOT inlined — e.g. a `FileAttachment` carrying an
+  `http(s)` URL, which is sent as the URL itself rather than base64 bytes —
+  contribute only the tokens of their small serialized form, not the size of
+  the remote file.
+- Messages with no attachments are counted exactly as before; token accounting
+  is unchanged for attachment-free histories.
+
+When attachments contribute to the count for an agent, a warning is logged once
+(per agent, not per message) noting that the count is an estimate.
+
+## How conservative is the estimate?
+
+The estimate measures the serialized request payload (base64 data URI plus the
+surrounding JSON), tokenized like ordinary text. Provider-side accounting may
+differ in either direction:
+
+- Providers that bill inlined files as text-like payload will be close to this
+  estimate.
+- Providers that convert files to their own internal representation (e.g.
+  per-page or per-image token charges) may count fewer or more tokens.
+
+The goal is to keep the local preflight from drastically *under*-estimating the
+request size when large files are attached, so context-window overflows are
+caught locally instead of surfacing as provider-side errors.
+</file>
+
 <file path="docs/notes/batch-processing.md">
 # Batch Processing
 
@@ -53728,6 +53779,52 @@ def test_strip_literals_and_comments() -> None
 # real clause text is preserved
 </file>
 
+<file path="tests/main/test_attachment_token_accounting.py">
+"""Tests for attachment-aware context-preflight token accounting (issue #996).
+
+The accounting itself (attachment payloads counted via their serialized
+API form) is covered in `test_prep_llm_message.py`; here we test the
+one-time warning emitted when attachments contribute to the token count,
+and that accounting without attachments is unchanged.
+"""
+⋮----
+LOGGER_NAME = "langroid.agent.chat_agent"
+⋮----
+@pytest.fixture
+def agent() -> ChatAgent
+⋮----
+"""ChatAgent with a char-count parser; no live LLM needed."""
+config = ChatAgentConfig(
+agent = ChatAgent(config)
+⋮----
+class MockParser
+⋮----
+def num_tokens(self, text: str) -> int
+⋮----
+agent.parser = MockParser()  # type: ignore[assignment]
+⋮----
+def _user_msg_with_attachment() -> LLMMessage
+⋮----
+attachment = FileAttachment.from_bytes(
+⋮----
+def _attachment_warnings(caplog: LogCaptureFixture) -> List[logging.LogRecord]
+⋮----
+"""Warning fires once per agent, even across repeated token counts."""
+msg = _user_msg_with_attachment()
+⋮----
+warnings = _attachment_warnings(caplog)
+⋮----
+"""No attachments: no warning, and counting is content-only as before."""
+msg = LLMMessage(role=Role.USER, content="Just text")
+⋮----
+n_tokens = agent.chat_num_tokens([msg])
+⋮----
+"""Attachments on non-user messages are not serialized inline, so they
+    neither count nor warn."""
+attachment = FileAttachment.from_bytes(content=b"x" * 100, filename="f.pdf")
+msg = LLMMessage(
+</file>
+
 <file path="tests/main/test_batch.py">
 def process_int(x: str) -> str
 ⋮----
@@ -59575,6 +59672,580 @@ excludes = excludes.union({"request"})
 schema = generate_simple_schema(
 </file>
 
+<file path="langroid/language_models/base.py">
+logger = logging.getLogger(__name__)
+⋮----
+def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
+⋮----
+async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
+⋮----
+FunctionCallTypes = Literal["none", "auto"]
+ToolChoiceTypes = Literal["none", "auto", "required"]
+ToolTypes = Literal["function"]
+⋮----
+DEFAULT_CONTEXT_LENGTH = 16_000
+⋮----
+class StreamEventType(Enum)
+⋮----
+TEXT = 1
+FUNC_NAME = 2
+FUNC_ARGS = 3
+TOOL_NAME = 4
+TOOL_ARGS = 5
+REASONING = 6
+⋮----
+class RetryParams(BaseSettings)
+⋮----
+max_retries: int = 5
+initial_delay: float = 1.0
+exponential_base: float = 1.3
+jitter: bool = True
+⋮----
+class LLMConfig(BaseSettings)
+⋮----
+"""
+    Common configuration for all language models.
+    """
+⋮----
+type: str = "openai"
+streamer: Optional[Callable[[Any], None]] = noop_fn
+streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
+api_base: str | None = None
+formatter: None | str = None
+# specify None if you want to use the full max output tokens of the model
+max_output_tokens: int | None = 8192
+timeout: int = 20  # timeout for API requests
+chat_model: str = ""
+completion_model: str = ""
+temperature: float = 0.0
+chat_context_length: int | None = None
+async_stream_quiet: bool = False  # suppress streaming output in async mode?
+completion_context_length: int | None = None
+# if input length + max_output_tokens > context length of model,
+# we will try shortening requested output
+min_output_tokens: int = 64
+use_completion_for_chat: bool = False  # use completion model for chat?
+# use chat model for completion? For OpenAI models, this MUST be set to True!
+use_chat_for_completion: bool = True
+stream: bool = True  # stream output from API?
+# TODO: we could have a `stream_reasoning` flag here to control whether to show
+# reasoning output from reasoning models
+cache_config: None | CacheDBConfig = RedisCacheConfig()
+thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
+retry_params: RetryParams = RetryParams()
+⋮----
+@property
+    def model_max_output_tokens(self) -> int
+⋮----
+# Build fallback names by progressively stripping provider prefixes
+# (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
+# succeeds even before OpenAIGPT.__init__ strips the prefix.
+parts = self.chat_model.split("/")
+fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
+⋮----
+class LLMFunctionCall(BaseModel)
+⋮----
+"""
+    Structure of LLM response indicating it "wants" to call a function.
+    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
+    """
+⋮----
+name: str  # name of function to call
+arguments: Optional[Dict[str, Any]] = None
+⋮----
+@staticmethod
+    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall"
+⋮----
+"""
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+fun_call = LLMFunctionCall(name=message["name"])
+fun_args_str = message["arguments"]
+# sometimes may be malformed with invalid indents,
+# so we try to be safe by removing newlines.
+⋮----
+fun_args_str = fun_args_str.replace("\n", "").strip()
+dict_or_list = parse_imperfect_json(fun_args_str)
+⋮----
+fun_args = dict_or_list
+⋮----
+fun_args = None
+⋮----
+def __str__(self) -> str
+⋮----
+class LLMFunctionSpec(BaseModel)
+⋮----
+"""
+    Description of a function available for the LLM to use.
+    To be used when calling the LLM `chat()` method with the `functions` parameter.
+    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
+    """
+⋮----
+name: str
+description: str
+parameters: Dict[str, Any]
+⋮----
+class OpenAIToolCall(BaseModel)
+⋮----
+"""
+    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
+    See https://platform.openai.com/docs/api-reference/chat/create
+
+    Attributes:
+        id: The id of the tool call.
+        type: The type of the tool call;
+            only "function" is currently possible (7/26/24).
+        function: The function call.
+    """
+⋮----
+id: str | None = None
+type: ToolTypes = "function"
+function: LLMFunctionCall | None = None
+extra_content: Dict[str, Any] | None = None
+⋮----
+@staticmethod
+    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall"
+⋮----
+id = message["id"]
+type = message["type"]
+function = LLMFunctionCall.from_dict(message["function"])
+extra_content = message.get("extra_content")
+⋮----
+class OpenAIToolSpec(BaseModel)
+⋮----
+type: ToolTypes
+strict: Optional[bool] = None
+function: LLMFunctionSpec
+⋮----
+class OpenAIJsonSchemaSpec(BaseModel)
+⋮----
+def to_dict(self) -> Dict[str, Any]
+⋮----
+json_schema: Dict[str, Any] = {
+⋮----
+class LLMTokenUsage(BaseModel)
+⋮----
+"""
+    Usage of tokens by an LLM.
+    """
+⋮----
+prompt_tokens: int = 0
+cached_tokens: int = 0
+completion_tokens: int = 0
+cost: float = 0.0
+calls: int = 0  # how many API calls - not used as of 2025-04-04
+⋮----
+def reset(self) -> None
+⋮----
+@property
+    def total_tokens(self) -> int
+⋮----
+class Role(str, Enum)
+⋮----
+"""
+    Possible roles for a message in a chat.
+    """
+⋮----
+USER = "user"
+SYSTEM = "system"
+ASSISTANT = "assistant"
+FUNCTION = "function"
+TOOL = "tool"
+⋮----
+class LLMMessage(BaseModel)
+⋮----
+"""
+    Class representing an entry in the msg-history sent to the LLM API.
+    It could be one of these:
+    - a user message
+    - an LLM ("Assistant") response
+    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
+    - a result or results from executing a fn or tool-call(s)
+    """
+⋮----
+role: Role
+name: Optional[str] = None
+tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
+tool_id: str = ""  # used by OpenAIAssistant
+# None means "no content" (the model returned only a tool/function call).
+# This is distinct from "" and is dropped from the API payload by api_dict;
+# see api_dict for how a fully-empty message is handled per-API.
+content: Optional[str] = None
+files: List[FileAttachment] = []
+function_call: Optional[LLMFunctionCall] = None
+tool_calls: Optional[List[OpenAIToolCall]] = None
+timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+# link to corresponding chat document, for provenance/rewind purposes
+chat_document_id: str = ""
+⋮----
+def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]
+⋮----
+"""
+        Convert to dictionary for API request, keeping ONLY
+        the fields that are expected in an API call!
+        E.g., DROP the tool_id, since it is only for use in the Assistant API,
+            not the completion API.
+
+        Args:
+            has_system_role: whether the message has a system role (if not,
+                set to "user" role)
+        Returns:
+            dict: dictionary representation of LLM message
+        """
+d = self.model_dump()
+files: List[FileAttachment] = d.pop("files")
+⋮----
+# In there are files, then content is an array of
+# different content-parts
+⋮----
+# if there is a key k = "role" with value "system", change to "user"
+# in case has_system_role is False
+⋮----
+# drop None values since API doesn't accept them (this omits `content`
+# entirely when it is None, i.e. "no content")
+dict_no_none = {k: v for k, v in d.items() if v is not None}
+⋮----
+# OpenAI API does not like empty name
+⋮----
+# arguments must be a string
+⋮----
+# convert tool calls to API format
+⋮----
+# An empty tool-call list is not a call and conveys no useful API
+# information. Omitting it also lets the empty-message fallback
+# below produce a valid message.
+⋮----
+# A message with empty content (None was dropped above, or "") AND no
+# tool/function call would be an entirely empty message, which some APIs
+# (e.g. Gemini) reject; fall back to a single space in that case only.
+# When there IS a tool/function call, empty content is fine (and Gemini
+# 3.x in fact REQUIRES it — it rejects an assistant turn that carries
+# both a call and non-empty text content).
+has_call = bool(dict_no_none.get("tool_calls")) or (
+⋮----
+# IMPORTANT! drop fields that are not expected in API call
+⋮----
+content = "FUNC: " + json.dumps(self.function_call)
+⋮----
+content = self.content or ""
+name_str = f" ({self.name})" if self.name else ""
+⋮----
+class LLMResponse(BaseModel)
+⋮----
+"""
+    Class representing response from LLM.
+    """
+⋮----
+# None means the model returned NO content (e.g. only a tool/function
+# call), which is distinct from an empty string "". Preserving this
+# distinction lets the message be faithfully reproduced downstream
+# (see ChatDocument.content_is_none and LLMMessage.content).
+message: Optional[str] = None
+reasoning: str = ""  # optional reasoning text from reasoning models
+# Original message text including inline thought signatures (e.g.
+# <thinking>...</thinking>). Only set when reasoning was extracted
+# from the message text via get_reasoning_final(); NOT set when
+# reasoning comes from a separate API field (e.g. reasoning_content),
+# since in that case the message text never contained thought tags.
+message_with_reasoning: Optional[str] = None
+# TODO tool_id needs to generalize to multi-tool calls
+⋮----
+oai_tool_calls: Optional[List[OpenAIToolCall]] = None
+⋮----
+usage: Optional[LLMTokenUsage] = None
+cached: bool = False
+⋮----
+def tools_content(self) -> str
+⋮----
+def to_LLMMessage(self) -> LLMMessage
+⋮----
+"""Convert LLM response to an LLMMessage, to be included in the
+        message-list sent to the API.
+        This is currently NOT used in any significant way in the library, and is only
+        provided as a utility to construct a message list for the API when directly
+        working with an LLM object.
+
+        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
+        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
+        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
+        """
+⋮----
+"""
+        If `message` or `function_call` of an LLM response contains an explicit
+        recipient name, return this recipient name and `message` stripped
+        of the recipient name if specified.
+
+        Two cases:
+        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
+        (b) `message` is empty and function_call/tool_call with explicit `recipient`
+
+        Args:
+            recognize_recipient_in_content (bool): When True (default), parses
+                message text for ``TO[<recipient>]:<content>`` patterns and
+                top-level JSON ``{"recipient": "..."}`` fields. When False,
+                only function_call/tool_call ``recipient`` fields are checked.
+
+        Returns:
+            (str): name of recipient, which may be empty string if no recipient
+            (str): content of message
+
+        """
+⋮----
+# in this case we ignore message, since all information is in function_call
+msg = ""
+args = self.function_call.arguments
+recipient = ""
+⋮----
+recipient = args.get("recipient", "")
+⋮----
+msg = self.message or ""
+⋮----
+# get the first tool that has a recipient field, if any
+⋮----
+recipient = tc.function.arguments.get(
+⋮----
+)  # type: ignore
+⋮----
+# It's not a function or tool call, so continue looking to see
+# if a recipient is specified in the message.
+⋮----
+# First check if message contains "TO: <recipient> <content>"
+⋮----
+# check if there is a top level json that specifies 'recipient',
+# and retain the entire message as content.
+⋮----
+recipient_name = top_level_json_field(msg, "recipient") if msg else ""
+content = msg
+⋮----
+# Define an abstract base class for language models
+class LanguageModel(ABC)
+⋮----
+"""
+    Abstract base class for language models.
+    """
+⋮----
+# usage cost by model, accumulates here
+usage_cost_dict: Dict[str, LLMTokenUsage] = {}
+⋮----
+def __init__(self, config: LLMConfig = LLMConfig())
+⋮----
+@staticmethod
+    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]
+⋮----
+"""
+        Create a language model.
+        Args:
+            config: configuration for language model
+        Returns: instance of language model
+        """
+⋮----
+openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
+⋮----
+openai = AzureGPT
+⋮----
+openai = OpenAIGPT
+cls = dict(
+return cls(config)  # type: ignore
+⋮----
+@staticmethod
+    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]
+⋮----
+"""
+        Given an even-length sequence of strings, split into a sequence of pairs
+
+        Args:
+            lst (List[str]): sequence of strings
+
+        Returns:
+            List[Tuple[str,str]]: sequence of pairs of strings
+        """
+evens = lst[::2]
+odds = lst[1::2]
+⋮----
+"""
+        From the chat history, extract system prompt, user-assistant turns, and
+        final user msg.
+
+        Args:
+            messages (List[LLMMessage]): List of messages in the chat history
+
+        Returns:
+            Tuple[str, List[Tuple[str,str]], str]:
+                system prompt, user-assistant turns, final user msg
+
+        """
+# Handle various degenerate cases
+messages = [m for m in messages]  # copy
+DUMMY_SYS_PROMPT = "You are a helpful assistant."
+DUMMY_USER_PROMPT = "Follow the instructions above."
+⋮----
+system_prompt = messages[0].content or ""
+⋮----
+# now we have messages = [Sys,...]
+⋮----
+# now we have messages = [Sys, msg, ...]
+⋮----
+# now we have messages = [Sys, user, ...]
+⋮----
+# now we have messages = [Sys, user, ..., user]
+# so we omit the first and last elements and make pairs of user-asst messages
+conversation = [m.content or "" for m in messages[1:-1]]
+user_prompt = messages[-1].content or ""
+pairs = LanguageModel.user_assistant_pairs(conversation)
+⋮----
+@abstractmethod
+    def set_stream(self, stream: bool) -> bool
+⋮----
+"""Enable or disable streaming output from API.
+        Return previous value of stream."""
+⋮----
+@abstractmethod
+    def get_stream(self) -> bool
+⋮----
+"""Get streaming status"""
+⋮----
+@abstractmethod
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+@abstractmethod
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+"""
+        Get chat-completion response from LLM.
+
+        Args:
+            messages: message-history to send to the LLM
+            max_tokens: max tokens to generate
+            tools: tools available for the LLM to use in its response
+            tool_choice: tool call mode, one of "none", "auto", "required",
+                or a dict specifying a specific tool.
+            functions: functions available for LLM to call (deprecated)
+            function_call: function calling mode, "auto", "none", or a specific fn
+                    (deprecated)
+        """
+⋮----
+"""Async version of `chat`. See `chat` for details."""
+⋮----
+def __call__(self, prompt: str, max_tokens: int) -> LLMResponse
+⋮----
+@staticmethod
+    def _fallback_model_names(model: str) -> List[str]
+⋮----
+parts = model.split("/")
+fallbacks = []
+⋮----
+def info(self) -> ModelInfo
+⋮----
+"""Info of relevant chat model"""
+orig_model = (
+⋮----
+def completion_info(self) -> ModelInfo
+⋮----
+"""Info of relevant completion model"""
+⋮----
+def supports_functions_or_tools(self) -> bool
+⋮----
+"""
+        Does this Model's API support "native" tool-calling, i.e.
+        can we call the API with arguments that contain a list of available tools,
+        and their schemas?
+        Note that, given the plethora of LLM provider APIs this determination is
+        imperfect at best, and leans towards returning True.
+        When the API calls fails with an error indicating tools are not supported,
+        then users are encouraged to use the Langroid-based prompt-based
+        ToolMessage mechanism, which works with ANY LLM. To enable this,
+        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
+        """
+⋮----
+def chat_context_length(self) -> int
+⋮----
+def completion_context_length(self) -> int
+⋮----
+def chat_cost(self) -> Tuple[float, float, float]
+⋮----
+"""
+        Return the cost per 1000 tokens for chat completions.
+
+        Returns:
+            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
+                per 1000 tokens
+        """
+⋮----
+def reset_usage_cost(self) -> None
+⋮----
+counter = self.usage_cost_dict[mdl]
+⋮----
+"""
+        Update usage cost for this LLM.
+        Args:
+            chat (bool): whether to update for chat or completion model
+            prompts (int): number of tokens used for prompts
+            completions (int): number of tokens used for completions
+            cost (float): total token cost in USD
+        """
+mdl = self.config.chat_model if chat else self.config.completion_model
+⋮----
+@classmethod
+    def usage_cost_summary(cls) -> str
+⋮----
+s = ""
+⋮----
+@classmethod
+    def tot_tokens_cost(cls) -> Tuple[int, float]
+⋮----
+"""
+        Return total tokens used and total cost across all models.
+        """
+total_tokens = 0
+total_cost = 0.0
+⋮----
+def get_reasoning_final(self, message: str) -> Tuple[str, str]
+⋮----
+"""Extract "reasoning" and "final answer" from an LLM response, if the
+        reasoning is found within configured delimiters, like <think>, </think>.
+        E.g.,
+        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
+
+        Args:
+            message (str): message from LLM
+
+        Returns:
+            Tuple[str, str]: reasoning, final answer
+        """
+⋮----
+parts = message.split(start)
+⋮----
+"""
+        Given a chat history and a question, convert it to a standalone question.
+        Args:
+            chat_history: list of tuples of (question, answer)
+            query: follow-up question
+
+        Returns: standalone version of the question
+        """
+history = collate_chat_history(chat_history)
+⋮----
+prompt = f"""
+⋮----
+follow_up_question = f"""
+⋮----
+standalone = (
+standalone = standalone.strip()
+⋮----
+class StreamingIfAllowed
+⋮----
+"""Context to temporarily enable or disable streaming, if allowed globally via
+    `settings.stream`"""
+⋮----
+def __init__(self, llm: LanguageModel, stream: bool = True)
+⋮----
+def __enter__(self) -> None
+⋮----
+def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
+</file>
+
 <file path="langroid/parsing/parser.py">
 logger = logging.getLogger(__name__)
 ⋮----
@@ -61986,999 +62657,6 @@ def _mutual_loop(base: Path) -> None
     ``Path.resolve()`` raises ``RuntimeError`` -- not ``OSError`` -- on a
     symlink loop, which otherwise propagates out of the walk and kills the run.
     """
-</file>
-
-<file path="tests/main/test_tool_messages.py">
-class CountryCapitalMessage(ToolMessage)
-⋮----
-request: str = "country_capital"
-purpose: str = "To check whether <city> is the capital of <country>."
-country: str = "France"
-city: str = "Paris"
-⋮----
-@classmethod
-    def examples(cls) -> List["CountryCapitalMessage"]
-⋮----
-# illustrating two types of examples
-⋮----
-class FileExistsMessage(ToolMessage)
-⋮----
-request: str = "file_exists"
-purpose: str = """
-filename: str = Field(..., description="File name to check existence of")
-recurse: bool = Field(..., description="Whether to recurse into subdirectories")
-⋮----
-@classmethod
-    def examples(cls) -> List["FileExistsMessage"]
-⋮----
-class PythonVersionMessage(ToolMessage)
-⋮----
-request: str = "python_version"
-_handler: str = "tool_handler"
-purpose: str = "To check which version of Python is needed."
-⋮----
-@classmethod
-    def examples(cls) -> List["PythonVersionMessage"]
-⋮----
-class PresidentInfo(BaseModel)
-⋮----
-name: str = Field(..., description="Name of the president")
-elected: bool = Field(..., description="Whether the president is elected")
-⋮----
-class CountryInfo(BaseModel)
-⋮----
-name: str = Field(..., description="Name of the country")
-capital: str = Field(..., description="Capital city of the country")
-president: PresidentInfo = Field(..., description="President of the country")
-⋮----
-class CountryPresidentTool(ToolMessage)
-⋮----
-request: str = "country_president"
-purpose: str = "To present info on a country and its president."
-⋮----
-country_info: CountryInfo = Field(
-country_type: Literal["island", "landlocked", "coastal"] = Field(
-⋮----
-def handle(self) -> str
-⋮----
-# Return a simple sentence with all the info.
-⋮----
-DEFAULT_PY_VERSION = "3.9"
-⋮----
-class MessageHandlingAgent(ChatAgent)
-⋮----
-def file_exists(self, message: FileExistsMessage) -> str
-⋮----
-def tool_handler(self, message: ToolMessage) -> str
-⋮----
-def country_capital(self, message: CountryCapitalMessage) -> str
-⋮----
-cfg = ChatAgentConfig(
-agent = MessageHandlingAgent(cfg)
-⋮----
-# Define the range of values each variable can have
-use_vals = [True, False]
-handle_vals = [True, False]
-force_vals = [True, False]
-message_classes = [None, FileExistsMessage, PythonVersionMessage]
-⋮----
-# Get the cartesian product
-cartesian_product = list(
-⋮----
-def test_tool_message_name()
-⋮----
-usable_tools = agent.llm_tools_usable
-tools = agent._get_tool_list(msg_class)
-⋮----
-@pytest.mark.parametrize("msg_class", [None, FileExistsMessage, PythonVersionMessage])
-def test_disable_message_handling(msg_class: Optional[ToolMessage])
-⋮----
-usable_tools = agent.llm_tools_usable.copy()
-⋮----
-@pytest.mark.parametrize("msg_class", [None, FileExistsMessage, PythonVersionMessage])
-def test_disable_message_use(msg_class: Optional[ToolMessage])
-⋮----
-# check that disabling tool-use works as expected:
-# Tools part of sys msg should be updated, and
-# LLM should not be able to use this tool
-⋮----
-response = agent.llm_response_forget("Is there a README.md file?")
-⋮----
-@pytest.mark.parametrize("msg_cls", [PythonVersionMessage, FileExistsMessage])
-def test_usage_instruction(msg_cls: ToolMessage)
-⋮----
-usage = msg_cls.usage_examples()
-jsons = extract_top_level_json(usage)
-⋮----
-NONE_MSG = "nothing to see here"
-⋮----
-FILE_EXISTS_MSG = """
-⋮----
-PYTHON_VERSION_MSG = """
-⋮----
-def test_agent_handle_message()
-⋮----
-"""
-    Test whether messages are handled correctly, and that
-    message enabling/disabling works as expected.
-    """
-⋮----
-BAD_FILE_EXISTS_MSG = """
-⋮----
-@pytest.mark.parametrize("as_string", [False, True])
-def test_handle_bad_tool_message(as_string: bool)
-⋮----
-"""
-    Test that a correct tool name with bad/missing args is
-            handled correctly, i.e. the agent returns a clear
-            error message to the LLM so it can try to fix it.
-
-    as_string: whether to pass the bad tool message as a string or as an LLM msg
-    """
-⋮----
-# set up a prior LLM-originated msg, to mock a scenario
-# where the last msg was from LLM, prior to calling
-# handle_message with the bad tool message -- we are trying to
-# test that the error is raised correctly in this case
-⋮----
-result = agent.handle_message(BAD_FILE_EXISTS_MSG)
-⋮----
-bad_tool_from_llm = agent.create_llm_response(BAD_FILE_EXISTS_MSG)
-result = agent.handle_message(bad_tool_from_llm)
-⋮----
-[True],  # ONLY test tools-api since OpenAI has deprecated functions-api
-⋮----
-CountryPresidentTool,  # test nested tool
-⋮----
-"""
-    Test whether LLM is able to GENERATE message (tool) in required format, and the
-    agent handles the message correctly.
-    Args:
-        test_settings: test settings from conftest.py
-        use_functions_api: whether to use LLM's functions api or not
-            (i.e. use the langroid ToolMessage tools instead).
-        message_class: the message class (i.e. tool/function) to test
-        prompt: the prompt to use to induce the LLM to use the tool
-        result: the expected result from agent handling the tool-message
-    """
-⋮----
-llm_msg = agent.llm_response_forget(prompt)
-tool_name = message_class.name()
-⋮----
-tools = agent.get_tool_messages(llm_msg)
-⋮----
-agent_result = agent.handle_message(llm_msg).content
-⋮----
-def test_llm_non_tool(test_settings: Settings)
-⋮----
-"""Having no tools enabled should result in a None handle_message result"""
-⋮----
-llm_msg = agent.llm_response_forget(
-agent_result = agent.handle_message(llm_msg)
-⋮----
-# Test that malformed tool messages results in proper err msg
-class NumPair(BaseModel)
-⋮----
-xval: int
-yval: int
-⋮----
-class NabroskiTool(ToolMessage)
-⋮----
-request: str = "nabroski"
-purpose: str = "to request computing the Nabroski transform of <num_pair>"
-num_pair: NumPair
-⋮----
-class CoriolisTool(ToolMessage)
-⋮----
-"""Tool for testing handling of optional arguments, with default values."""
-⋮----
-request: str = "coriolis"
-purpose: str = "to request computing the Coriolis transform of <cats> and <cows>"
-cats: int
-cows: int = 5
-⋮----
-# same as NabroskiTool result
-⋮----
-wrong_nabroski_tool = """
-⋮----
-agent = ChatAgent(cfg)
-⋮----
-response = agent.agent_response(wrong_nabroski_tool)
-⋮----
-bad_tool_from_llm = agent.create_llm_response(wrong_nabroski_tool)
-response = agent.agent_response(bad_tool_from_llm)
-# We expect an error msg containing certain specific field names
-⋮----
-class FruitPair(BaseModel)
-⋮----
-pears: int
-apples: int
-⋮----
-class EulerTool(ToolMessage)
-⋮----
-request: str = "euler"
-purpose: str = "to request computing the Euler transform of <fruit_pair>"
-fruit_pair: FruitPair
-⋮----
-class BoilerTool(ToolMessage)
-⋮----
-request: str = "boiler"
-purpose: str = "to request computing the Boiler transform of <fruit_pair>"
-⋮----
-class SumTool(ToolMessage)
-⋮----
-request: str = "sum"
-purpose: str = "to request computing the sum of <x> and <y>"
-x: int
-y: int
-⋮----
-class GaussTool(ToolMessage)
-⋮----
-request: str = "gauss"
-purpose: str = "to request computing the Gauss transform of (<x>, <y>)"
-⋮----
-class CoinFlipTool(ToolMessage)
-⋮----
-request: str = "coin_flip"
-purpose: str = "to request a random coin flip"
-⋮----
-def handle(self) -> Literal["Heads", "Tails"]
-⋮----
-heads = random.random() > 0.5
-⋮----
-gauss_request = """{"xval": 1, "yval": 3}"""
-boiler_or_euler_request = """{"fruit_pair": {"pears": 1, "apples": 3}}"""
-euler_request = """{"request": "euler", "fruit_pair": {"pears": 1, "apples": 3}}"""
-additional_args_request = """{"xval": 1, "yval": 3, "zval": 4}"""
-additional_args_request_specified = """
-no_args_request = """{}"""
-no_args_request_specified = """{"request": "coin_flip"}"""
-⋮----
-# Boiler is the only option prior to enabling EulerTool handling
-⋮----
-# Enable handling EulerTool, this makes nabrowski_or_euler_request ambiguous
-⋮----
-# Gauss is the only option
-⋮----
-# Explicit requests are forwarded to the correct handler
-⋮----
-# We cannot infer the correct tool if there exist multiple matches
-⋮----
-# We do not infer tools where the request has additional arguments
-⋮----
-# But additional args are acceptable when the tool is specified
-⋮----
-# We do not infer tools with no args
-⋮----
-# Request must be specified
-⋮----
-"""Test that agent.llm_response does not respond to tool messages."""
-⋮----
-nabroski_tool = NabroskiTool(num_pair=NumPair(xval=1, yval=2)).to_json()
-response = agent.llm_response(nabroski_tool)
-⋮----
-"""Test tool handling without running task, i.e. directly using
-    agent.llm_response and agent.agent_response methods."""
-⋮----
-response = agent.llm_response("What is Nabroski of 1 and 2?")
-⋮----
-result = agent.agent_response(response)
-⋮----
-"""Test that ToolMessage where some args are optional (i.e. have default values)
-    works well, i.e. LLM is able to generate all args if needed, including optionals."""
-⋮----
-response = agent.llm_response("What is the Coriolis transform of 1, 2?")
-⋮----
-tool = agent.get_tool_messages(response)[0]
-⋮----
-"""
-    Test "full life cycle" of tool, when using Task.run().
-
-    1. invoke LLM api with tool-spec
-    2. LLM generates tool
-    3. ChatAgent.agent_response handles tool, result added to ChatAgent msg history
-    5. invoke LLM api with tool result
-    """
-⋮----
-llm_config = OpenAIGPTConfig(max_output_tokens=3_000, timeout=120)
-⋮----
-task = Task(agent, interactive=False)
-⋮----
-request = tool.default_value("request")
-result = task.run(f"What is the {request} transform of 3 and 5?")
-⋮----
-# First test without task; using individual methods
-# ---
-⋮----
-result = task.run(
-# Nabroski: 3*3 + 5 = 14
-# Gauss: (1+2)*2 = 6
-⋮----
-"""
-    Test tool_choice for OpenAI-like LLM APIs.
-    """
-⋮----
-use_tools=False,  # langroid tools
-use_functions_api=True,  # openai tools/fns
-use_tools_api=True,  # openai tools/fns
-⋮----
-chat_doc = agent.create_user_response("What is the sum of 3 and 5?")
-⋮----
-response = agent.llm_response_forget(chat_doc)
-⋮----
-# expect either SumTool or direct result without tool
-⋮----
-chat_doc = agent.create_user_response("What is the double of 5?")
-⋮----
-response = agent.llm_response("What is the nabroski of 3 and 5?")
-⋮----
-def test_tool_handlers_and_results(result_type: str, tool_handler: str)
-⋮----
-"""Test various types of ToolMessage handlers, and check that they can
-    return arbitrary result types"""
-⋮----
-class SpecialResult(BaseModel)
-⋮----
-"""To illustrating returning an arbitrary Pydantic object as a result"""
-⋮----
-answer: int
-details: str = "nothing"
-⋮----
-def result_fn(x: int) -> Any
-⋮----
-# return tool, to be handled by sub-task
-⋮----
-special=SpecialResult(answer=x + 5),  # explicitly declared
-# arbitrary new fields that were not declared in the class...
-⋮----
-# ... does not need to be a Pydantic object
-⋮----
-# pass on to parent, to handle with UberTool,
-# which is NOT enabled for this agent
-⋮----
-class UberTool(ToolMessage)
-⋮----
-request: str = "uber_tool"
-purpose: str = "to request the 'uber' transform of a  number <x>"
-⋮----
-def handle(self) -> Any
-⋮----
-class CoolToolWithHandle(ToolMessage)
-⋮----
-request: str = "cool_tool"
-purpose: str = "to request the 'cool' transform of a  number <x>"
-⋮----
-class MyAgent(ChatAgent)
-⋮----
-def init_state(self) -> None
-⋮----
-"""Handle non-tool LLM response"""
-⋮----
-x = int(msg.content)
-⋮----
-class CoolToolWithResponse(ToolMessage)
-⋮----
-"""To test that `response` handler works as expected,
-        and is able to read and modify agent state.
-        """
-⋮----
-def response(self, agent: MyAgent) -> Any
-⋮----
-class CoolToolWithResponseDoc(ToolMessage)
-⋮----
-"""
-        To test that `response` handler works as expected,
-        is able to read and modify agent state, and
-        when using a `chat_doc` argument, and is able to read values from it.
-        """
-⋮----
-def response(self, agent: MyAgent, chat_doc: ChatDocument) -> Any
-⋮----
-tool_class = CoolToolWithHandle
-⋮----
-tool_class = CoolToolWithResponse
-⋮----
-tool_class = CoolToolWithResponseDoc
-⋮----
-tool_class = None
-⋮----
-agent = MyAgent(
-⋮----
-# no need for a real LLM, use a mock
-⋮----
-# mock LLM generating a CoolTool variant
-⋮----
-tool_result = result_type in ["final_tool", "agent_done", "tool", "result_tool"]
-task = Task(
-⋮----
-# need to specify task done when result is not FinalResultTool
-⋮----
-result = task.run("3")
-⋮----
-# CoolTool handler returns a non-tool result containing 8, and
-# we terminate task on agent_response, via done_if_response,
-# so the result.content == 8
-⋮----
-# CoolTool handler/response returns a ResultTool containing answer == 8
-tool = result.tool_messages[0]
-⋮----
-# When CoolTool handler returns a ToolMessage,
-# test that it is handled correctly by sub-task or a parent.
-⋮----
-another_agent = ChatAgent(
-⋮----
-llm=MockLMConfig(response_fn=lambda x: x),  # pass thru
-⋮----
-another_task = Task(another_agent, interactive=False)
-⋮----
-result = another_task.run("3")
-⋮----
-# task's CoolTool handler returns FinalResultTool
-# which short-circuits parent task and returns as a tool
-# in tool_messages list of the final result
-⋮----
-# inner task's CoolTool handler returns a DoneTool containing
-# UberTool, which is handled by the parent "another_agent"
-# which returns a FinalResultTool containing answer == 8
-⋮----
-# Now disable parent agent's handling of UberTool
-⋮----
-# another_task = Task(another_agent, interactive=False)
-# another_task.add_sub_task(task)
-⋮----
-# parent task is unable to handle UberTool, so will stall and return None
-⋮----
-# inner Task CoolTool handler returns UberTool (with NO done signal),
-# which it is unable to handle, so stalls and returns None,
-# and so does parent another_task
-⋮----
-# Now reverse it: make another_task a sub-task of task, and
-# test handling UberTool returned by task handler, by sub-task another_task
-⋮----
-# task = Task(agent, interactive=False)
-⋮----
-# subtask stalls, parent stalls, returns None
-⋮----
-"""
-    Test that an LLM can directly or indirectly trigger task-end, and return a Tool as
-    result. There are 3 ways:
-    - case llm_tool == "final_tool":
-        LLM returns a Tool (llm_tool == "final_tool") derived from FinalResultTool,
-        with field(s) containing a structured Pydantic object -- in this case the task
-        ends immediately without any agent response handling the tool
-    - case llm_tool == "pair":
-        LLM returns a PairTool, which is handled by the agent, which returns either
-        - AgentDoneTool, with `tools` field set to [self], or
-        - FinalResultTool, with `result` field set to the PairTool
-    """
-⋮----
-class Pair(BaseModel)
-⋮----
-a: int
-b: int
-⋮----
-class PairTool(ToolMessage)
-⋮----
-"""Handle the LLM-generated tool, signal done or final-result and
-        return it as the result."""
-⋮----
-request: str = "pair_tool"
-purpose: str = "to return a <pair> of numbers"
-pair: Pair
-⋮----
-# field name can be anything; `result` is just an example.
-⋮----
-class FinalResultPairTool(FinalResultTool)
-⋮----
-request: str = "final_result_pair_tool"
-purpose: str = "Present final result <pair>"
-⋮----
-_allow_llm_use: bool = True
-⋮----
-final_result_pair_tool_name = FinalResultPairTool.default_value("request")
-⋮----
-"""Mock human user input: they start with 0, then increment by 1"""
-last_num = self.numbers[-1] if self.numbers else 0
-new_num = last_num + 1
-⋮----
-pair_tool_name = PairTool.default_value("request")
-⋮----
-# LLM generates just PairTool , to be handled by its tool handler
-system_message = f"""
-⋮----
-# we are mocking user response, so need to set only_user_quits_root=False
-# so that the done signal (AgentDoneTool or FinalResultTool) actually end the task.
-task = Task(agent, interactive=True, only_user_quits_root=False)
-result = task.run()
-⋮----
-def test_final_result_tool()
-⋮----
-"""Test that FinalResultTool can be returned by agent_response"""
-⋮----
-def agent_response(self, msg: str | ChatDocument) -> Any
-⋮----
-task = Task(agent, interactive=False)[ToolMessage]
-⋮----
-@pytest.mark.parametrize("tool", ["none", "a", "aa", "b"])
-def test_agent_respond_only_tools(tool: str)
-⋮----
-"""
-    Test that we can have an agent that only responds to certain tools,
-    and no plain-text msgs, by setting ChatAgentConfig.respond_only_tools=True.
-    """
-⋮----
-class ATool(ToolMessage)
-⋮----
-request: str = "a_tool"
-purpose: str = "to present a number <num>"
-num: int
-⋮----
-def handle(self) -> FinalResultTool
-⋮----
-class AATool(ToolMessage)
-⋮----
-request: str = "aa_tool"
-⋮----
-class BTool(ToolMessage)
-⋮----
-request: str = "b_tool"
-⋮----
-tool_class = ATool
-⋮----
-tool_class = AATool
-⋮----
-tool_class = BTool
-⋮----
-main_agent = ChatAgent(
-⋮----
-alice_agent = ChatAgent(
-⋮----
-# class BobAgent(ChatAgent):
-#     def handle_message_fallback(self, msg: str | ChatDocument) -> Any:
-#         if isinstance(msg, str) or len(msg.tool_messages) == 0:
-#             return AgentDoneTool(content="")
-⋮----
-bob_agent = ChatAgent(
-⋮----
-class FallbackAgent(ChatAgent)
-⋮----
-fallback_agent = FallbackAgent(
-fallback_task = Task(fallback_agent, interactive=False)
-⋮----
-main_task = Task(main_agent, interactive=False)[ToolMessage]
-alice_task = Task(alice_agent, interactive=False)
-bob_task = Task(bob_agent, interactive=False)
-⋮----
-tool = main_task.run(3)
-⋮----
-# Note: when Main generates a tool, task orchestrator will not allow
-# Alice to respond at all when the tool is not handled by Alice,
-# and similarly for Bob (this uses agent.has_only_unhandled_tools()).
-# However when main generates a non-tool string,
-# we want to ensure that the above handle_message_fallback methods
-# effectively return a null msg (and not get into a stalled loop inside the agent),
-# and is finally handled by the FallbackAgent
-⋮----
-"""
-    Test that structured fallback correctly recovers
-    from failed tool calls.
-    """
-⋮----
-def simulate_failed_call(attempt: str | ChatDocument) -> str
-⋮----
-agent = ChatAgent(
-⋮----
-# Inserting this since OpenAI API strictly requires a
-# Role.TOOL msg immediately after an Assistant Tool call,
-# before the next Assistant msg.
-⋮----
-# Simulates bad tool attempt by the LLM
-⋮----
-response = agent.llm_response(
-⋮----
-result = agent.handle_message(response)
-⋮----
-def to_attempt(attempt: LLMFunctionCall) -> str | ChatDocument
-⋮----
-# The name of the function is incorrect:
-# The LLM should correct the request to "nabroski" in recovery
-⋮----
-# Strict fallback disables the default arguments, but the LLM
-# should infer from context. In addition, the name of the
-# function is incorrect (the LLM should infer "coriolis" in
-# recovery) and the JSON output is malformed
-⋮----
-# Note here we intentionally use "catss" as the arg to ensure that
-# the tool-name inference doesn't work (see `maybe_parse` agent/base.py,
-# there's a mechanism that infers the intended tool if the arguments are
-# unambiguously for a specific tool) -- here since we use `catss` that
-# mechanism fails, and we can do this test properly to focus on structured
-# recovery. But `catss' is sufficiently similar to 'cats' that the
-# intent-based recovery should work.
-⋮----
-# The LLM should correct the request to "coriolis" in recovery
-# The LLM should infer the default argument from context
-⋮----
-# The LLM should infer "euler" in recovery
-⋮----
-"""
-    Test that strict tool and structured output errors
-    are handled gracefully and are disabled if errors
-    are caused.
-    """
-⋮----
-class BrokenStrictSchemaAgent(ChatAgent)
-⋮----
-"""
-            Implements a broken version of the correct _function_args()
-            that ensures that the generated schemas are incompatible
-            with OpenAI's strict decoding implementation.
-
-            Specifically, removes the schema edits performed by
-            `format_schema_for_strict()` (e.g. setting "additionalProperties"
-            to False on all objects in the JSON schema).
-            """
-⋮----
-# remove schema edits for strict
-⋮----
-name = t.function.name
-⋮----
-spec = self.output_format.llm_function_schema(
-⋮----
-output_format = OpenAIJsonSchemaSpec(
-⋮----
-param_spec = self.output_format.model_json_schema()
-⋮----
-agent = BrokenStrictSchemaAgent(
-⋮----
-openai_tools = use_fn_api and use_tools_api
-⋮----
-# Strict tools are automatically enabled only when
-# parallel tool calls are disabled
-⋮----
-response = agent.llm_response_forget(
-⋮----
-structured_agent = agent[NabroskiTool]
-response = structured_agent.llm_response_forget(
-⋮----
-"""
-    Test that validation errors triggered in strict result in disabled strict output.
-    """
-⋮----
-def int_schema(request: str) -> dict[str, Any]
-⋮----
-class WrongSchemaAgent(ChatAgent)
-⋮----
-"""
-            Implements a broken version of the correct _function_args()
-            that replaces the output and all tool schemas with an
-            incorrect schema. Simulates mismatched schemas due to
-            schema edits.
-            """
-⋮----
-agent = WrongSchemaAgent(
-⋮----
-class IntTool(ToolMessage)
-⋮----
-request: str = "int_tool"
-purpose: str = "To return an integer value"
-⋮----
-def handle(self)
-⋮----
-class StrTool(ToolMessage)
-⋮----
-request: str = "str_tool"
-purpose: str = "To return an string value"
-text: str
-⋮----
-strict_openai_tools = use_fn_api and use_tools_api and not parallel_tool_calls
-⋮----
-strict_agent = agent[IntTool]
-⋮----
-strict_agent = agent[StrTool]
-⋮----
-def test_reduce_raw_tool_result()
-⋮----
-BIG_RESULT = "hello " * 50
-⋮----
-class MyTool(ToolMessage)
-⋮----
-request: str = "my_tool"
-⋮----
-_max_result_tokens: int = 10
-_max_retained_tokens: int = 2
-⋮----
-"""
-            Mock user_response method for testing
-            """
-txt = msg if isinstance(msg, str) else msg.content
-map = dict([("hello", "50"), ("3", "5")])
-response = map.get(txt)
-# return the increment of input number
-⋮----
-# create dummy agent first, just to get small_result with truncation
-agent = MyAgent(ChatAgentConfig())
-# Handle ModelPrivateAttr for _max_result_tokens
-max_result_tokens = MyTool._max_result_tokens
-⋮----
-max_result_tokens = max_result_tokens.default
-small_result = agent._maybe_truncate_result(BIG_RESULT, max_result_tokens)
-⋮----
-# now create the actual agent
-⋮----
-result = task.run("1")
-"""
-    msg history:
-    
-    sys_msg
-    user: 1 -> 
-    LLM: MyTool(1) ->
-    agent: BIG_RESULT -> truncated to 10 tokens, as `small_result`
-    LLM: hello ->
-    user: 50 -> 
-    LLM: Done (Finished)
-    """
-⋮----
-tool_result = agent.message_history[3].content
-# Handle ModelPrivateAttr for _max_retained_tokens
-max_retained = MyTool._max_retained_tokens
-⋮----
-max_retained = max_retained.default
-⋮----
-def test_valid_structured_recovery()
-⋮----
-"""
-    Test that structured recovery is not triggered inappropriately
-    when agent response contains a JSON-like string.
-    """
-⋮----
-# with no tool enabled
-⋮----
-result = task.run("3", turns=4)
-# response-sequence: agent, llm, agent, llm -> done
-⋮----
-# with a tool enabled
-⋮----
-def test_handle_llm_no_tool(handle_no_tool: Any)
-⋮----
-"""Verify that ChatAgentConfig.handle_llm_no_tool works as expected"""
-⋮----
-def mock_llm_response(x: str) -> str
-⋮----
-config = ChatAgentConfig(
-agent = ChatAgent(config)
-⋮----
-task = Task(agent, interactive=False, default_human_response="q")
-⋮----
-# task gets stuck and returns None
-⋮----
-# LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> User(4) -> q
-⋮----
-# LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> Done(4)
-⋮----
-# LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> LLM(DONE)
-⋮----
-# LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> ResultTool(4)
-⋮----
-# LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> AgentDoneTool(4) -> 4
-⋮----
-# LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> DonePass
-⋮----
-class GetTimeTool(ToolMessage)
-⋮----
-purpose: str = "Get current time"
-request: str = "get_time"
-⋮----
-def response(self, agent: ChatAgent) -> ChatDocument
-⋮----
-"""
-    Test that structured fallback only occurs on messages
-    sent by the LLM.
-    """
-was_tool_error = False
-⋮----
-class TrackToolError(ChatAgent)
-⋮----
-was_tool_error = True
-⋮----
-agent = TrackToolError(
-⋮----
-content = json.dumps(
-⋮----
-user_message = agent.create_user_response(content=content, recipient=Entity.LLM)
-⋮----
-agent_message = agent.create_agent_response(content=content, recipient=Entity.LLM)
-⋮----
-@pytest.mark.parametrize("use_fn_api", [False, True])
-def test_tool_handler_invoking_llm(use_fn_api: bool)
-⋮----
-"""
-    Check that if a tool handler directly invokes llm_response,
-    it works as expected, especially with OpenAI Tools API
-    """
-⋮----
-def nabroski(self, msg: NabroskiTool)
-⋮----
-ans = self.llm_response("What is 3+4?")
-⋮----
-task = Task(agent, interactive=False, single_round=False)
-⋮----
-def test_enable_message_validates_arguments(test_settings: Settings)
-⋮----
-"""Test that enable_message raises TypeError when tool classes are passed
-    as separate arguments instead of as a list."""
-⋮----
-class Tool1(ToolMessage)
-⋮----
-request: str = "tool1"
-purpose: str = "First tool"
-⋮----
-class Tool2(ToolMessage)
-⋮----
-request: str = "tool2"
-purpose: str = "Second tool"
-⋮----
-class Tool3(ToolMessage)
-⋮----
-request: str = "tool3"
-purpose: str = "Third tool"
-⋮----
-# This should raise TypeError because Tool2 is passed as 'use' parameter
-⋮----
-agent.enable_message(Tool1, Tool2)  # type: ignore
-⋮----
-# This should raise TypeError because Tool3 is passed as 'handle' parameter
-⋮----
-agent.enable_message(Tool1, True, Tool3)  # type: ignore
-⋮----
-# This should work correctly - passing tools as a list
-⋮----
-def test_enable_message_rejects_distinct_classes_with_same_request() -> None
-⋮----
-"""Different tool classes cannot silently replace the same request name."""
-⋮----
-class FirstCollisionTool(ToolMessage)
-⋮----
-request: str = "shared_request"
-⋮----
-class SecondCollisionTool(ToolMessage)
-⋮----
-class DerivedCollisionTool(FirstCollisionTool)
-⋮----
-purpose: str = "Derived tool"
-⋮----
-agent = ChatAgent(ChatAgentConfig(llm=None))
-⋮----
-message = str(exc_info.value)
-⋮----
-derived_agent = ChatAgent(ChatAgentConfig(llm=None))
-⋮----
-recipient_wrapper = FirstCollisionTool.require_recipient()
-⋮----
-class DerivedRecipientCollisionTool(recipient_wrapper):  # type: ignore
-⋮----
-purpose: str = "Derived recipient tool"
-⋮----
-recipient_agent = ChatAgent(ChatAgentConfig(llm=None))
-⋮----
-def test_enable_message_rejects_recipient_wrapper_subclass_origin() -> None
-⋮----
-"""Recipient wrapping must preserve a subclass as a distinct tool origin."""
-⋮----
-class OriginalTool(ToolMessage)
-⋮----
-request: str = "recipient_collision"
-purpose: str = "Original tool"
-⋮----
-recipient_wrapper = OriginalTool.require_recipient()
-⋮----
-class RecipientWrapperSubclass(recipient_wrapper):  # type: ignore
-⋮----
-purpose: str = "Distinct recipient-wrapper subclass"
-⋮----
-def test_any_tool_reenable_is_idempotent() -> None
-⋮----
-"""Regenerated strict-recovery AnyTool must re-register without error.
-
-    `_get_any_tool_message()` builds a fresh class per call (its tool-union
-    varies with enabled tools), so two generations of "tool_or_function" are
-    distinct classes; the same-name registration guard must treat them as the
-    same logical tool (regression: SQLChatAgent strict recovery raised
-    "already registered to AnyTool; cannot register AnyTool").
-    """
-⋮----
-class ToolA(ToolMessage)
-⋮----
-request: str = "any_tool_idem_a"
-purpose: str = "Tool A"
-⋮----
-class ToolB(ToolMessage)
-⋮----
-request: str = "any_tool_idem_b"
-purpose: str = "Tool B"
-⋮----
-any_tool_1 = agent._get_any_tool_message()
-⋮----
-# enabling another tool changes the union => a distinct AnyTool class
-⋮----
-any_tool_2 = agent._get_any_tool_message()
-⋮----
-agent.enable_message(any_tool_2, use=False, handle=True)  # must not raise
-⋮----
-def test_multi_agent_tool_caching(test_settings: Settings)
-⋮----
-"""
-    Test that tool message caching is agent-specific.
-
-    When Agent A parses a ChatDocument and caches tool messages,
-    Agent B (with different tools) should NOT use A's cached results
-    and should re-parse the message with its own tool registry.
-    """
-⋮----
-# Define two different tools
-⋮----
-request: str = "tool_a"
-purpose: str = "Tool for Agent A"
-value: str = "a"
-⋮----
-request: str = "tool_b"
-purpose: str = "Tool for Agent B"
-value: str = "b"
-⋮----
-# Create two agents with different tool registries
-agent_a = ChatAgent(
-⋮----
-agent_b = ChatAgent(
-⋮----
-# Create a ChatDocument containing ToolB (which only AgentB knows about)
-tool_b_json = json.dumps({"request": "tool_b", "value": "test_value"})
-chat_doc = ChatDocument(
-⋮----
-# Agent A parses - should find no tools it handles (ToolB is unknown to A)
-tools_from_a = agent_a.get_tool_messages(chat_doc, all_tools=True)
-⋮----
-# Verify cache was set by Agent A
-⋮----
-# Agent B parses the SAME ChatDocument - should re-parse and find ToolB
-# because the cache was set by a different agent
-tools_from_b = agent_b.get_tool_messages(chat_doc, all_tools=True)
-⋮----
-# Verify cache was updated by Agent B
-⋮----
-# Agent B parsing again should use the cache (same agent)
-tools_from_b_cached = agent_b.get_tool_messages(chat_doc, all_tools=True)
-⋮----
-def test_nested_tool_message_schema_is_cleaned() -> None
-⋮----
-"""A ToolMessage nested inside another ToolMessage lands in the schema's
-    ``$defs``, and must get the same cleanup the top-level tool gets: internal
-    fields (``purpose``, ``id``) and the ``exclude`` marker removed, and
-    ``request`` pinned to its constant via an ``enum``.
-
-    Regression guard for the Pydantic v1->v2 migration: v1 emitted nested-model
-    schemas under ``definitions`` while v2 uses ``$defs``. If the cleanup keys
-    off the wrong name it silently no-ops, leaking those internal fields (and an
-    unconstrained ``request``) into the schema sent to the LLM.
-    """
-⋮----
-class Inner(ToolMessage)
-⋮----
-request: str = "inner_tool"
-purpose: str = "the inner purpose"
-⋮----
-class Outer(ToolMessage)
-⋮----
-request: str = "outer_tool"
-purpose: str = "the outer purpose"
-inner: Inner
-⋮----
-params = Outer.llm_function_schema(request=True).parameters
-⋮----
-inner_schema = params["$defs"]["Inner"]
-⋮----
-# internal markers/fields must not leak to the LLM
-⋮----
-# `request` is pinned to its constant and required
 </file>
 
 <file path="tests/main/test_vector_stores.py">
@@ -67154,580 +66832,6 @@ sender_role = Role.ASSISTANT
 tool_id=tool_id,  # for OpenAI Assistant
 </file>
 
-<file path="langroid/language_models/base.py">
-logger = logging.getLogger(__name__)
-⋮----
-def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
-⋮----
-async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
-⋮----
-FunctionCallTypes = Literal["none", "auto"]
-ToolChoiceTypes = Literal["none", "auto", "required"]
-ToolTypes = Literal["function"]
-⋮----
-DEFAULT_CONTEXT_LENGTH = 16_000
-⋮----
-class StreamEventType(Enum)
-⋮----
-TEXT = 1
-FUNC_NAME = 2
-FUNC_ARGS = 3
-TOOL_NAME = 4
-TOOL_ARGS = 5
-REASONING = 6
-⋮----
-class RetryParams(BaseSettings)
-⋮----
-max_retries: int = 5
-initial_delay: float = 1.0
-exponential_base: float = 1.3
-jitter: bool = True
-⋮----
-class LLMConfig(BaseSettings)
-⋮----
-"""
-    Common configuration for all language models.
-    """
-⋮----
-type: str = "openai"
-streamer: Optional[Callable[[Any], None]] = noop_fn
-streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
-api_base: str | None = None
-formatter: None | str = None
-# specify None if you want to use the full max output tokens of the model
-max_output_tokens: int | None = 8192
-timeout: int = 20  # timeout for API requests
-chat_model: str = ""
-completion_model: str = ""
-temperature: float = 0.0
-chat_context_length: int | None = None
-async_stream_quiet: bool = False  # suppress streaming output in async mode?
-completion_context_length: int | None = None
-# if input length + max_output_tokens > context length of model,
-# we will try shortening requested output
-min_output_tokens: int = 64
-use_completion_for_chat: bool = False  # use completion model for chat?
-# use chat model for completion? For OpenAI models, this MUST be set to True!
-use_chat_for_completion: bool = True
-stream: bool = True  # stream output from API?
-# TODO: we could have a `stream_reasoning` flag here to control whether to show
-# reasoning output from reasoning models
-cache_config: None | CacheDBConfig = RedisCacheConfig()
-thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
-retry_params: RetryParams = RetryParams()
-⋮----
-@property
-    def model_max_output_tokens(self) -> int
-⋮----
-# Build fallback names by progressively stripping provider prefixes
-# (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
-# succeeds even before OpenAIGPT.__init__ strips the prefix.
-parts = self.chat_model.split("/")
-fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
-⋮----
-class LLMFunctionCall(BaseModel)
-⋮----
-"""
-    Structure of LLM response indicating it "wants" to call a function.
-    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
-    """
-⋮----
-name: str  # name of function to call
-arguments: Optional[Dict[str, Any]] = None
-⋮----
-@staticmethod
-    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall"
-⋮----
-"""
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-fun_call = LLMFunctionCall(name=message["name"])
-fun_args_str = message["arguments"]
-# sometimes may be malformed with invalid indents,
-# so we try to be safe by removing newlines.
-⋮----
-fun_args_str = fun_args_str.replace("\n", "").strip()
-dict_or_list = parse_imperfect_json(fun_args_str)
-⋮----
-fun_args = dict_or_list
-⋮----
-fun_args = None
-⋮----
-def __str__(self) -> str
-⋮----
-class LLMFunctionSpec(BaseModel)
-⋮----
-"""
-    Description of a function available for the LLM to use.
-    To be used when calling the LLM `chat()` method with the `functions` parameter.
-    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
-    """
-⋮----
-name: str
-description: str
-parameters: Dict[str, Any]
-⋮----
-class OpenAIToolCall(BaseModel)
-⋮----
-"""
-    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
-    See https://platform.openai.com/docs/api-reference/chat/create
-
-    Attributes:
-        id: The id of the tool call.
-        type: The type of the tool call;
-            only "function" is currently possible (7/26/24).
-        function: The function call.
-    """
-⋮----
-id: str | None = None
-type: ToolTypes = "function"
-function: LLMFunctionCall | None = None
-extra_content: Dict[str, Any] | None = None
-⋮----
-@staticmethod
-    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall"
-⋮----
-id = message["id"]
-type = message["type"]
-function = LLMFunctionCall.from_dict(message["function"])
-extra_content = message.get("extra_content")
-⋮----
-class OpenAIToolSpec(BaseModel)
-⋮----
-type: ToolTypes
-strict: Optional[bool] = None
-function: LLMFunctionSpec
-⋮----
-class OpenAIJsonSchemaSpec(BaseModel)
-⋮----
-def to_dict(self) -> Dict[str, Any]
-⋮----
-json_schema: Dict[str, Any] = {
-⋮----
-class LLMTokenUsage(BaseModel)
-⋮----
-"""
-    Usage of tokens by an LLM.
-    """
-⋮----
-prompt_tokens: int = 0
-cached_tokens: int = 0
-completion_tokens: int = 0
-cost: float = 0.0
-calls: int = 0  # how many API calls - not used as of 2025-04-04
-⋮----
-def reset(self) -> None
-⋮----
-@property
-    def total_tokens(self) -> int
-⋮----
-class Role(str, Enum)
-⋮----
-"""
-    Possible roles for a message in a chat.
-    """
-⋮----
-USER = "user"
-SYSTEM = "system"
-ASSISTANT = "assistant"
-FUNCTION = "function"
-TOOL = "tool"
-⋮----
-class LLMMessage(BaseModel)
-⋮----
-"""
-    Class representing an entry in the msg-history sent to the LLM API.
-    It could be one of these:
-    - a user message
-    - an LLM ("Assistant") response
-    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
-    - a result or results from executing a fn or tool-call(s)
-    """
-⋮----
-role: Role
-name: Optional[str] = None
-tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
-tool_id: str = ""  # used by OpenAIAssistant
-# None means "no content" (the model returned only a tool/function call).
-# This is distinct from "" and is dropped from the API payload by api_dict;
-# see api_dict for how a fully-empty message is handled per-API.
-content: Optional[str] = None
-files: List[FileAttachment] = []
-function_call: Optional[LLMFunctionCall] = None
-tool_calls: Optional[List[OpenAIToolCall]] = None
-timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-# link to corresponding chat document, for provenance/rewind purposes
-chat_document_id: str = ""
-⋮----
-def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]
-⋮----
-"""
-        Convert to dictionary for API request, keeping ONLY
-        the fields that are expected in an API call!
-        E.g., DROP the tool_id, since it is only for use in the Assistant API,
-            not the completion API.
-
-        Args:
-            has_system_role: whether the message has a system role (if not,
-                set to "user" role)
-        Returns:
-            dict: dictionary representation of LLM message
-        """
-d = self.model_dump()
-files: List[FileAttachment] = d.pop("files")
-⋮----
-# In there are files, then content is an array of
-# different content-parts
-⋮----
-# if there is a key k = "role" with value "system", change to "user"
-# in case has_system_role is False
-⋮----
-# drop None values since API doesn't accept them (this omits `content`
-# entirely when it is None, i.e. "no content")
-dict_no_none = {k: v for k, v in d.items() if v is not None}
-⋮----
-# OpenAI API does not like empty name
-⋮----
-# arguments must be a string
-⋮----
-# convert tool calls to API format
-⋮----
-# An empty tool-call list is not a call and conveys no useful API
-# information. Omitting it also lets the empty-message fallback
-# below produce a valid message.
-⋮----
-# A message with empty content (None was dropped above, or "") AND no
-# tool/function call would be an entirely empty message, which some APIs
-# (e.g. Gemini) reject; fall back to a single space in that case only.
-# When there IS a tool/function call, empty content is fine (and Gemini
-# 3.x in fact REQUIRES it — it rejects an assistant turn that carries
-# both a call and non-empty text content).
-has_call = bool(dict_no_none.get("tool_calls")) or (
-⋮----
-# IMPORTANT! drop fields that are not expected in API call
-⋮----
-content = "FUNC: " + json.dumps(self.function_call)
-⋮----
-content = self.content or ""
-name_str = f" ({self.name})" if self.name else ""
-⋮----
-class LLMResponse(BaseModel)
-⋮----
-"""
-    Class representing response from LLM.
-    """
-⋮----
-# None means the model returned NO content (e.g. only a tool/function
-# call), which is distinct from an empty string "". Preserving this
-# distinction lets the message be faithfully reproduced downstream
-# (see ChatDocument.content_is_none and LLMMessage.content).
-message: Optional[str] = None
-reasoning: str = ""  # optional reasoning text from reasoning models
-# Original message text including inline thought signatures (e.g.
-# <thinking>...</thinking>). Only set when reasoning was extracted
-# from the message text via get_reasoning_final(); NOT set when
-# reasoning comes from a separate API field (e.g. reasoning_content),
-# since in that case the message text never contained thought tags.
-message_with_reasoning: Optional[str] = None
-# TODO tool_id needs to generalize to multi-tool calls
-⋮----
-oai_tool_calls: Optional[List[OpenAIToolCall]] = None
-⋮----
-usage: Optional[LLMTokenUsage] = None
-cached: bool = False
-⋮----
-def tools_content(self) -> str
-⋮----
-def to_LLMMessage(self) -> LLMMessage
-⋮----
-"""Convert LLM response to an LLMMessage, to be included in the
-        message-list sent to the API.
-        This is currently NOT used in any significant way in the library, and is only
-        provided as a utility to construct a message list for the API when directly
-        working with an LLM object.
-
-        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
-        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
-        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
-        """
-⋮----
-"""
-        If `message` or `function_call` of an LLM response contains an explicit
-        recipient name, return this recipient name and `message` stripped
-        of the recipient name if specified.
-
-        Two cases:
-        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
-        (b) `message` is empty and function_call/tool_call with explicit `recipient`
-
-        Args:
-            recognize_recipient_in_content (bool): When True (default), parses
-                message text for ``TO[<recipient>]:<content>`` patterns and
-                top-level JSON ``{"recipient": "..."}`` fields. When False,
-                only function_call/tool_call ``recipient`` fields are checked.
-
-        Returns:
-            (str): name of recipient, which may be empty string if no recipient
-            (str): content of message
-
-        """
-⋮----
-# in this case we ignore message, since all information is in function_call
-msg = ""
-args = self.function_call.arguments
-recipient = ""
-⋮----
-recipient = args.get("recipient", "")
-⋮----
-msg = self.message or ""
-⋮----
-# get the first tool that has a recipient field, if any
-⋮----
-recipient = tc.function.arguments.get(
-⋮----
-)  # type: ignore
-⋮----
-# It's not a function or tool call, so continue looking to see
-# if a recipient is specified in the message.
-⋮----
-# First check if message contains "TO: <recipient> <content>"
-⋮----
-# check if there is a top level json that specifies 'recipient',
-# and retain the entire message as content.
-⋮----
-recipient_name = top_level_json_field(msg, "recipient") if msg else ""
-content = msg
-⋮----
-# Define an abstract base class for language models
-class LanguageModel(ABC)
-⋮----
-"""
-    Abstract base class for language models.
-    """
-⋮----
-# usage cost by model, accumulates here
-usage_cost_dict: Dict[str, LLMTokenUsage] = {}
-⋮----
-def __init__(self, config: LLMConfig = LLMConfig())
-⋮----
-@staticmethod
-    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]
-⋮----
-"""
-        Create a language model.
-        Args:
-            config: configuration for language model
-        Returns: instance of language model
-        """
-⋮----
-openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
-⋮----
-openai = AzureGPT
-⋮----
-openai = OpenAIGPT
-cls = dict(
-return cls(config)  # type: ignore
-⋮----
-@staticmethod
-    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]
-⋮----
-"""
-        Given an even-length sequence of strings, split into a sequence of pairs
-
-        Args:
-            lst (List[str]): sequence of strings
-
-        Returns:
-            List[Tuple[str,str]]: sequence of pairs of strings
-        """
-evens = lst[::2]
-odds = lst[1::2]
-⋮----
-"""
-        From the chat history, extract system prompt, user-assistant turns, and
-        final user msg.
-
-        Args:
-            messages (List[LLMMessage]): List of messages in the chat history
-
-        Returns:
-            Tuple[str, List[Tuple[str,str]], str]:
-                system prompt, user-assistant turns, final user msg
-
-        """
-# Handle various degenerate cases
-messages = [m for m in messages]  # copy
-DUMMY_SYS_PROMPT = "You are a helpful assistant."
-DUMMY_USER_PROMPT = "Follow the instructions above."
-⋮----
-system_prompt = messages[0].content or ""
-⋮----
-# now we have messages = [Sys,...]
-⋮----
-# now we have messages = [Sys, msg, ...]
-⋮----
-# now we have messages = [Sys, user, ...]
-⋮----
-# now we have messages = [Sys, user, ..., user]
-# so we omit the first and last elements and make pairs of user-asst messages
-conversation = [m.content or "" for m in messages[1:-1]]
-user_prompt = messages[-1].content or ""
-pairs = LanguageModel.user_assistant_pairs(conversation)
-⋮----
-@abstractmethod
-    def set_stream(self, stream: bool) -> bool
-⋮----
-"""Enable or disable streaming output from API.
-        Return previous value of stream."""
-⋮----
-@abstractmethod
-    def get_stream(self) -> bool
-⋮----
-"""Get streaming status"""
-⋮----
-@abstractmethod
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-@abstractmethod
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-"""
-        Get chat-completion response from LLM.
-
-        Args:
-            messages: message-history to send to the LLM
-            max_tokens: max tokens to generate
-            tools: tools available for the LLM to use in its response
-            tool_choice: tool call mode, one of "none", "auto", "required",
-                or a dict specifying a specific tool.
-            functions: functions available for LLM to call (deprecated)
-            function_call: function calling mode, "auto", "none", or a specific fn
-                    (deprecated)
-        """
-⋮----
-"""Async version of `chat`. See `chat` for details."""
-⋮----
-def __call__(self, prompt: str, max_tokens: int) -> LLMResponse
-⋮----
-@staticmethod
-    def _fallback_model_names(model: str) -> List[str]
-⋮----
-parts = model.split("/")
-fallbacks = []
-⋮----
-def info(self) -> ModelInfo
-⋮----
-"""Info of relevant chat model"""
-orig_model = (
-⋮----
-def completion_info(self) -> ModelInfo
-⋮----
-"""Info of relevant completion model"""
-⋮----
-def supports_functions_or_tools(self) -> bool
-⋮----
-"""
-        Does this Model's API support "native" tool-calling, i.e.
-        can we call the API with arguments that contain a list of available tools,
-        and their schemas?
-        Note that, given the plethora of LLM provider APIs this determination is
-        imperfect at best, and leans towards returning True.
-        When the API calls fails with an error indicating tools are not supported,
-        then users are encouraged to use the Langroid-based prompt-based
-        ToolMessage mechanism, which works with ANY LLM. To enable this,
-        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
-        """
-⋮----
-def chat_context_length(self) -> int
-⋮----
-def completion_context_length(self) -> int
-⋮----
-def chat_cost(self) -> Tuple[float, float, float]
-⋮----
-"""
-        Return the cost per 1000 tokens for chat completions.
-
-        Returns:
-            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
-                per 1000 tokens
-        """
-⋮----
-def reset_usage_cost(self) -> None
-⋮----
-counter = self.usage_cost_dict[mdl]
-⋮----
-"""
-        Update usage cost for this LLM.
-        Args:
-            chat (bool): whether to update for chat or completion model
-            prompts (int): number of tokens used for prompts
-            completions (int): number of tokens used for completions
-            cost (float): total token cost in USD
-        """
-mdl = self.config.chat_model if chat else self.config.completion_model
-⋮----
-@classmethod
-    def usage_cost_summary(cls) -> str
-⋮----
-s = ""
-⋮----
-@classmethod
-    def tot_tokens_cost(cls) -> Tuple[int, float]
-⋮----
-"""
-        Return total tokens used and total cost across all models.
-        """
-total_tokens = 0
-total_cost = 0.0
-⋮----
-def get_reasoning_final(self, message: str) -> Tuple[str, str]
-⋮----
-"""Extract "reasoning" and "final answer" from an LLM response, if the
-        reasoning is found within configured delimiters, like <think>, </think>.
-        E.g.,
-        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
-
-        Args:
-            message (str): message from LLM
-
-        Returns:
-            Tuple[str, str]: reasoning, final answer
-        """
-⋮----
-parts = message.split(start)
-⋮----
-"""
-        Given a chat history and a question, convert it to a standalone question.
-        Args:
-            chat_history: list of tuples of (question, answer)
-            query: follow-up question
-
-        Returns: standalone version of the question
-        """
-history = collate_chat_history(chat_history)
-⋮----
-prompt = f"""
-⋮----
-follow_up_question = f"""
-⋮----
-standalone = (
-standalone = standalone.strip()
-⋮----
-class StreamingIfAllowed
-⋮----
-"""Context to temporarily enable or disable streaming, if allowed globally via
-    `settings.stream`"""
-⋮----
-def __init__(self, llm: LanguageModel, stream: bool = True)
-⋮----
-def __enter__(self) -> None
-⋮----
-def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
-</file>
-
 <file path="langroid/language_models/client_cache.py">
 """
 Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
@@ -69952,6 +69056,999 @@ root_type = tool_model.model_fields["root"].annotation
 ⋮----
 # Nested data still validates; the cyclic `child` edge is permissive (Any).
 inst = tool_model(root={"val": 1, "child": {"val": 2}})
+</file>
+
+<file path="tests/main/test_tool_messages.py">
+class CountryCapitalMessage(ToolMessage)
+⋮----
+request: str = "country_capital"
+purpose: str = "To check whether <city> is the capital of <country>."
+country: str = "France"
+city: str = "Paris"
+⋮----
+@classmethod
+    def examples(cls) -> List["CountryCapitalMessage"]
+⋮----
+# illustrating two types of examples
+⋮----
+class FileExistsMessage(ToolMessage)
+⋮----
+request: str = "file_exists"
+purpose: str = """
+filename: str = Field(..., description="File name to check existence of")
+recurse: bool = Field(..., description="Whether to recurse into subdirectories")
+⋮----
+@classmethod
+    def examples(cls) -> List["FileExistsMessage"]
+⋮----
+class PythonVersionMessage(ToolMessage)
+⋮----
+request: str = "python_version"
+_handler: str = "tool_handler"
+purpose: str = "To check which version of Python is needed."
+⋮----
+@classmethod
+    def examples(cls) -> List["PythonVersionMessage"]
+⋮----
+class PresidentInfo(BaseModel)
+⋮----
+name: str = Field(..., description="Name of the president")
+elected: bool = Field(..., description="Whether the president is elected")
+⋮----
+class CountryInfo(BaseModel)
+⋮----
+name: str = Field(..., description="Name of the country")
+capital: str = Field(..., description="Capital city of the country")
+president: PresidentInfo = Field(..., description="President of the country")
+⋮----
+class CountryPresidentTool(ToolMessage)
+⋮----
+request: str = "country_president"
+purpose: str = "To present info on a country and its president."
+⋮----
+country_info: CountryInfo = Field(
+country_type: Literal["island", "landlocked", "coastal"] = Field(
+⋮----
+def handle(self) -> str
+⋮----
+# Return a simple sentence with all the info.
+⋮----
+DEFAULT_PY_VERSION = "3.9"
+⋮----
+class MessageHandlingAgent(ChatAgent)
+⋮----
+def file_exists(self, message: FileExistsMessage) -> str
+⋮----
+def tool_handler(self, message: ToolMessage) -> str
+⋮----
+def country_capital(self, message: CountryCapitalMessage) -> str
+⋮----
+cfg = ChatAgentConfig(
+agent = MessageHandlingAgent(cfg)
+⋮----
+# Define the range of values each variable can have
+use_vals = [True, False]
+handle_vals = [True, False]
+force_vals = [True, False]
+message_classes = [None, FileExistsMessage, PythonVersionMessage]
+⋮----
+# Get the cartesian product
+cartesian_product = list(
+⋮----
+def test_tool_message_name()
+⋮----
+usable_tools = agent.llm_tools_usable
+tools = agent._get_tool_list(msg_class)
+⋮----
+@pytest.mark.parametrize("msg_class", [None, FileExistsMessage, PythonVersionMessage])
+def test_disable_message_handling(msg_class: Optional[ToolMessage])
+⋮----
+usable_tools = agent.llm_tools_usable.copy()
+⋮----
+@pytest.mark.parametrize("msg_class", [None, FileExistsMessage, PythonVersionMessage])
+def test_disable_message_use(msg_class: Optional[ToolMessage])
+⋮----
+# check that disabling tool-use works as expected:
+# Tools part of sys msg should be updated, and
+# LLM should not be able to use this tool
+⋮----
+response = agent.llm_response_forget("Is there a README.md file?")
+⋮----
+@pytest.mark.parametrize("msg_cls", [PythonVersionMessage, FileExistsMessage])
+def test_usage_instruction(msg_cls: ToolMessage)
+⋮----
+usage = msg_cls.usage_examples()
+jsons = extract_top_level_json(usage)
+⋮----
+NONE_MSG = "nothing to see here"
+⋮----
+FILE_EXISTS_MSG = """
+⋮----
+PYTHON_VERSION_MSG = """
+⋮----
+def test_agent_handle_message()
+⋮----
+"""
+    Test whether messages are handled correctly, and that
+    message enabling/disabling works as expected.
+    """
+⋮----
+BAD_FILE_EXISTS_MSG = """
+⋮----
+@pytest.mark.parametrize("as_string", [False, True])
+def test_handle_bad_tool_message(as_string: bool)
+⋮----
+"""
+    Test that a correct tool name with bad/missing args is
+            handled correctly, i.e. the agent returns a clear
+            error message to the LLM so it can try to fix it.
+
+    as_string: whether to pass the bad tool message as a string or as an LLM msg
+    """
+⋮----
+# set up a prior LLM-originated msg, to mock a scenario
+# where the last msg was from LLM, prior to calling
+# handle_message with the bad tool message -- we are trying to
+# test that the error is raised correctly in this case
+⋮----
+result = agent.handle_message(BAD_FILE_EXISTS_MSG)
+⋮----
+bad_tool_from_llm = agent.create_llm_response(BAD_FILE_EXISTS_MSG)
+result = agent.handle_message(bad_tool_from_llm)
+⋮----
+[True],  # ONLY test tools-api since OpenAI has deprecated functions-api
+⋮----
+CountryPresidentTool,  # test nested tool
+⋮----
+"""
+    Test whether LLM is able to GENERATE message (tool) in required format, and the
+    agent handles the message correctly.
+    Args:
+        test_settings: test settings from conftest.py
+        use_functions_api: whether to use LLM's functions api or not
+            (i.e. use the langroid ToolMessage tools instead).
+        message_class: the message class (i.e. tool/function) to test
+        prompt: the prompt to use to induce the LLM to use the tool
+        result: the expected result from agent handling the tool-message
+    """
+⋮----
+llm_msg = agent.llm_response_forget(prompt)
+tool_name = message_class.name()
+⋮----
+tools = agent.get_tool_messages(llm_msg)
+⋮----
+agent_result = agent.handle_message(llm_msg).content
+⋮----
+def test_llm_non_tool(test_settings: Settings)
+⋮----
+"""Having no tools enabled should result in a None handle_message result"""
+⋮----
+llm_msg = agent.llm_response_forget(
+agent_result = agent.handle_message(llm_msg)
+⋮----
+# Test that malformed tool messages results in proper err msg
+class NumPair(BaseModel)
+⋮----
+xval: int
+yval: int
+⋮----
+class NabroskiTool(ToolMessage)
+⋮----
+request: str = "nabroski"
+purpose: str = "to request computing the Nabroski transform of <num_pair>"
+num_pair: NumPair
+⋮----
+class CoriolisTool(ToolMessage)
+⋮----
+"""Tool for testing handling of optional arguments, with default values."""
+⋮----
+request: str = "coriolis"
+purpose: str = "to request computing the Coriolis transform of <cats> and <cows>"
+cats: int
+cows: int = 5
+⋮----
+# same as NabroskiTool result
+⋮----
+wrong_nabroski_tool = """
+⋮----
+agent = ChatAgent(cfg)
+⋮----
+response = agent.agent_response(wrong_nabroski_tool)
+⋮----
+bad_tool_from_llm = agent.create_llm_response(wrong_nabroski_tool)
+response = agent.agent_response(bad_tool_from_llm)
+# We expect an error msg containing certain specific field names
+⋮----
+class FruitPair(BaseModel)
+⋮----
+pears: int
+apples: int
+⋮----
+class EulerTool(ToolMessage)
+⋮----
+request: str = "euler"
+purpose: str = "to request computing the Euler transform of <fruit_pair>"
+fruit_pair: FruitPair
+⋮----
+class BoilerTool(ToolMessage)
+⋮----
+request: str = "boiler"
+purpose: str = "to request computing the Boiler transform of <fruit_pair>"
+⋮----
+class SumTool(ToolMessage)
+⋮----
+request: str = "sum"
+purpose: str = "to request computing the sum of <x> and <y>"
+x: int
+y: int
+⋮----
+class GaussTool(ToolMessage)
+⋮----
+request: str = "gauss"
+purpose: str = "to request computing the Gauss transform of (<x>, <y>)"
+⋮----
+class CoinFlipTool(ToolMessage)
+⋮----
+request: str = "coin_flip"
+purpose: str = "to request a random coin flip"
+⋮----
+def handle(self) -> Literal["Heads", "Tails"]
+⋮----
+heads = random.random() > 0.5
+⋮----
+gauss_request = """{"xval": 1, "yval": 3}"""
+boiler_or_euler_request = """{"fruit_pair": {"pears": 1, "apples": 3}}"""
+euler_request = """{"request": "euler", "fruit_pair": {"pears": 1, "apples": 3}}"""
+additional_args_request = """{"xval": 1, "yval": 3, "zval": 4}"""
+additional_args_request_specified = """
+no_args_request = """{}"""
+no_args_request_specified = """{"request": "coin_flip"}"""
+⋮----
+# Boiler is the only option prior to enabling EulerTool handling
+⋮----
+# Enable handling EulerTool, this makes nabrowski_or_euler_request ambiguous
+⋮----
+# Gauss is the only option
+⋮----
+# Explicit requests are forwarded to the correct handler
+⋮----
+# We cannot infer the correct tool if there exist multiple matches
+⋮----
+# We do not infer tools where the request has additional arguments
+⋮----
+# But additional args are acceptable when the tool is specified
+⋮----
+# We do not infer tools with no args
+⋮----
+# Request must be specified
+⋮----
+"""Test that agent.llm_response does not respond to tool messages."""
+⋮----
+nabroski_tool = NabroskiTool(num_pair=NumPair(xval=1, yval=2)).to_json()
+response = agent.llm_response(nabroski_tool)
+⋮----
+"""Test tool handling without running task, i.e. directly using
+    agent.llm_response and agent.agent_response methods."""
+⋮----
+response = agent.llm_response("What is Nabroski of 1 and 2?")
+⋮----
+result = agent.agent_response(response)
+⋮----
+"""Test that ToolMessage where some args are optional (i.e. have default values)
+    works well, i.e. LLM is able to generate all args if needed, including optionals."""
+⋮----
+response = agent.llm_response("What is the Coriolis transform of 1, 2?")
+⋮----
+tool = agent.get_tool_messages(response)[0]
+⋮----
+"""
+    Test "full life cycle" of tool, when using Task.run().
+
+    1. invoke LLM api with tool-spec
+    2. LLM generates tool
+    3. ChatAgent.agent_response handles tool, result added to ChatAgent msg history
+    5. invoke LLM api with tool result
+    """
+⋮----
+llm_config = OpenAIGPTConfig(max_output_tokens=3_000, timeout=120)
+⋮----
+task = Task(agent, interactive=False)
+⋮----
+request = tool.default_value("request")
+result = task.run(f"What is the {request} transform of 3 and 5?")
+⋮----
+# First test without task; using individual methods
+# ---
+⋮----
+result = task.run(
+# Nabroski: 3*3 + 5 = 14
+# Gauss: (1+2)*2 = 6
+⋮----
+"""
+    Test tool_choice for OpenAI-like LLM APIs.
+    """
+⋮----
+use_tools=False,  # langroid tools
+use_functions_api=True,  # openai tools/fns
+use_tools_api=True,  # openai tools/fns
+⋮----
+chat_doc = agent.create_user_response("What is the sum of 3 and 5?")
+⋮----
+response = agent.llm_response_forget(chat_doc)
+⋮----
+# expect either SumTool or direct result without tool
+⋮----
+chat_doc = agent.create_user_response("What is the double of 5?")
+⋮----
+response = agent.llm_response("What is the nabroski of 3 and 5?")
+⋮----
+def test_tool_handlers_and_results(result_type: str, tool_handler: str)
+⋮----
+"""Test various types of ToolMessage handlers, and check that they can
+    return arbitrary result types"""
+⋮----
+class SpecialResult(BaseModel)
+⋮----
+"""To illustrating returning an arbitrary Pydantic object as a result"""
+⋮----
+answer: int
+details: str = "nothing"
+⋮----
+def result_fn(x: int) -> Any
+⋮----
+# return tool, to be handled by sub-task
+⋮----
+special=SpecialResult(answer=x + 5),  # explicitly declared
+# arbitrary new fields that were not declared in the class...
+⋮----
+# ... does not need to be a Pydantic object
+⋮----
+# pass on to parent, to handle with UberTool,
+# which is NOT enabled for this agent
+⋮----
+class UberTool(ToolMessage)
+⋮----
+request: str = "uber_tool"
+purpose: str = "to request the 'uber' transform of a  number <x>"
+⋮----
+def handle(self) -> Any
+⋮----
+class CoolToolWithHandle(ToolMessage)
+⋮----
+request: str = "cool_tool"
+purpose: str = "to request the 'cool' transform of a  number <x>"
+⋮----
+class MyAgent(ChatAgent)
+⋮----
+def init_state(self) -> None
+⋮----
+"""Handle non-tool LLM response"""
+⋮----
+x = int(msg.content)
+⋮----
+class CoolToolWithResponse(ToolMessage)
+⋮----
+"""To test that `response` handler works as expected,
+        and is able to read and modify agent state.
+        """
+⋮----
+def response(self, agent: MyAgent) -> Any
+⋮----
+class CoolToolWithResponseDoc(ToolMessage)
+⋮----
+"""
+        To test that `response` handler works as expected,
+        is able to read and modify agent state, and
+        when using a `chat_doc` argument, and is able to read values from it.
+        """
+⋮----
+def response(self, agent: MyAgent, chat_doc: ChatDocument) -> Any
+⋮----
+tool_class = CoolToolWithHandle
+⋮----
+tool_class = CoolToolWithResponse
+⋮----
+tool_class = CoolToolWithResponseDoc
+⋮----
+tool_class = None
+⋮----
+agent = MyAgent(
+⋮----
+# no need for a real LLM, use a mock
+⋮----
+# mock LLM generating a CoolTool variant
+⋮----
+tool_result = result_type in ["final_tool", "agent_done", "tool", "result_tool"]
+task = Task(
+⋮----
+# need to specify task done when result is not FinalResultTool
+⋮----
+result = task.run("3")
+⋮----
+# CoolTool handler returns a non-tool result containing 8, and
+# we terminate task on agent_response, via done_if_response,
+# so the result.content == 8
+⋮----
+# CoolTool handler/response returns a ResultTool containing answer == 8
+tool = result.tool_messages[0]
+⋮----
+# When CoolTool handler returns a ToolMessage,
+# test that it is handled correctly by sub-task or a parent.
+⋮----
+another_agent = ChatAgent(
+⋮----
+llm=MockLMConfig(response_fn=lambda x: x),  # pass thru
+⋮----
+another_task = Task(another_agent, interactive=False)
+⋮----
+result = another_task.run("3")
+⋮----
+# task's CoolTool handler returns FinalResultTool
+# which short-circuits parent task and returns as a tool
+# in tool_messages list of the final result
+⋮----
+# inner task's CoolTool handler returns a DoneTool containing
+# UberTool, which is handled by the parent "another_agent"
+# which returns a FinalResultTool containing answer == 8
+⋮----
+# Now disable parent agent's handling of UberTool
+⋮----
+# another_task = Task(another_agent, interactive=False)
+# another_task.add_sub_task(task)
+⋮----
+# parent task is unable to handle UberTool, so will stall and return None
+⋮----
+# inner Task CoolTool handler returns UberTool (with NO done signal),
+# which it is unable to handle, so stalls and returns None,
+# and so does parent another_task
+⋮----
+# Now reverse it: make another_task a sub-task of task, and
+# test handling UberTool returned by task handler, by sub-task another_task
+⋮----
+# task = Task(agent, interactive=False)
+⋮----
+# subtask stalls, parent stalls, returns None
+⋮----
+"""
+    Test that an LLM can directly or indirectly trigger task-end, and return a Tool as
+    result. There are 3 ways:
+    - case llm_tool == "final_tool":
+        LLM returns a Tool (llm_tool == "final_tool") derived from FinalResultTool,
+        with field(s) containing a structured Pydantic object -- in this case the task
+        ends immediately without any agent response handling the tool
+    - case llm_tool == "pair":
+        LLM returns a PairTool, which is handled by the agent, which returns either
+        - AgentDoneTool, with `tools` field set to [self], or
+        - FinalResultTool, with `result` field set to the PairTool
+    """
+⋮----
+class Pair(BaseModel)
+⋮----
+a: int
+b: int
+⋮----
+class PairTool(ToolMessage)
+⋮----
+"""Handle the LLM-generated tool, signal done or final-result and
+        return it as the result."""
+⋮----
+request: str = "pair_tool"
+purpose: str = "to return a <pair> of numbers"
+pair: Pair
+⋮----
+# field name can be anything; `result` is just an example.
+⋮----
+class FinalResultPairTool(FinalResultTool)
+⋮----
+request: str = "final_result_pair_tool"
+purpose: str = "Present final result <pair>"
+⋮----
+_allow_llm_use: bool = True
+⋮----
+final_result_pair_tool_name = FinalResultPairTool.default_value("request")
+⋮----
+"""Mock human user input: they start with 0, then increment by 1"""
+last_num = self.numbers[-1] if self.numbers else 0
+new_num = last_num + 1
+⋮----
+pair_tool_name = PairTool.default_value("request")
+⋮----
+# LLM generates just PairTool , to be handled by its tool handler
+system_message = f"""
+⋮----
+# we are mocking user response, so need to set only_user_quits_root=False
+# so that the done signal (AgentDoneTool or FinalResultTool) actually end the task.
+task = Task(agent, interactive=True, only_user_quits_root=False)
+result = task.run()
+⋮----
+def test_final_result_tool()
+⋮----
+"""Test that FinalResultTool can be returned by agent_response"""
+⋮----
+def agent_response(self, msg: str | ChatDocument) -> Any
+⋮----
+task = Task(agent, interactive=False)[ToolMessage]
+⋮----
+@pytest.mark.parametrize("tool", ["none", "a", "aa", "b"])
+def test_agent_respond_only_tools(tool: str)
+⋮----
+"""
+    Test that we can have an agent that only responds to certain tools,
+    and no plain-text msgs, by setting ChatAgentConfig.respond_only_tools=True.
+    """
+⋮----
+class ATool(ToolMessage)
+⋮----
+request: str = "a_tool"
+purpose: str = "to present a number <num>"
+num: int
+⋮----
+def handle(self) -> FinalResultTool
+⋮----
+class AATool(ToolMessage)
+⋮----
+request: str = "aa_tool"
+⋮----
+class BTool(ToolMessage)
+⋮----
+request: str = "b_tool"
+⋮----
+tool_class = ATool
+⋮----
+tool_class = AATool
+⋮----
+tool_class = BTool
+⋮----
+main_agent = ChatAgent(
+⋮----
+alice_agent = ChatAgent(
+⋮----
+# class BobAgent(ChatAgent):
+#     def handle_message_fallback(self, msg: str | ChatDocument) -> Any:
+#         if isinstance(msg, str) or len(msg.tool_messages) == 0:
+#             return AgentDoneTool(content="")
+⋮----
+bob_agent = ChatAgent(
+⋮----
+class FallbackAgent(ChatAgent)
+⋮----
+fallback_agent = FallbackAgent(
+fallback_task = Task(fallback_agent, interactive=False)
+⋮----
+main_task = Task(main_agent, interactive=False)[ToolMessage]
+alice_task = Task(alice_agent, interactive=False)
+bob_task = Task(bob_agent, interactive=False)
+⋮----
+tool = main_task.run(3)
+⋮----
+# Note: when Main generates a tool, task orchestrator will not allow
+# Alice to respond at all when the tool is not handled by Alice,
+# and similarly for Bob (this uses agent.has_only_unhandled_tools()).
+# However when main generates a non-tool string,
+# we want to ensure that the above handle_message_fallback methods
+# effectively return a null msg (and not get into a stalled loop inside the agent),
+# and is finally handled by the FallbackAgent
+⋮----
+"""
+    Test that structured fallback correctly recovers
+    from failed tool calls.
+    """
+⋮----
+def simulate_failed_call(attempt: str | ChatDocument) -> str
+⋮----
+agent = ChatAgent(
+⋮----
+# Inserting this since OpenAI API strictly requires a
+# Role.TOOL msg immediately after an Assistant Tool call,
+# before the next Assistant msg.
+⋮----
+# Simulates bad tool attempt by the LLM
+⋮----
+response = agent.llm_response(
+⋮----
+result = agent.handle_message(response)
+⋮----
+def to_attempt(attempt: LLMFunctionCall) -> str | ChatDocument
+⋮----
+# The name of the function is incorrect:
+# The LLM should correct the request to "nabroski" in recovery
+⋮----
+# Strict fallback disables the default arguments, but the LLM
+# should infer from context. In addition, the name of the
+# function is incorrect (the LLM should infer "coriolis" in
+# recovery) and the JSON output is malformed
+⋮----
+# Note here we intentionally use "catss" as the arg to ensure that
+# the tool-name inference doesn't work (see `maybe_parse` agent/base.py,
+# there's a mechanism that infers the intended tool if the arguments are
+# unambiguously for a specific tool) -- here since we use `catss` that
+# mechanism fails, and we can do this test properly to focus on structured
+# recovery. But `catss' is sufficiently similar to 'cats' that the
+# intent-based recovery should work.
+⋮----
+# The LLM should correct the request to "coriolis" in recovery
+# The LLM should infer the default argument from context
+⋮----
+# The LLM should infer "euler" in recovery
+⋮----
+"""
+    Test that strict tool and structured output errors
+    are handled gracefully and are disabled if errors
+    are caused.
+    """
+⋮----
+class BrokenStrictSchemaAgent(ChatAgent)
+⋮----
+"""
+            Implements a broken version of the correct _function_args()
+            that ensures that the generated schemas are incompatible
+            with OpenAI's strict decoding implementation.
+
+            Specifically, removes the schema edits performed by
+            `format_schema_for_strict()` (e.g. setting "additionalProperties"
+            to False on all objects in the JSON schema).
+            """
+⋮----
+# remove schema edits for strict
+⋮----
+name = t.function.name
+⋮----
+spec = self.output_format.llm_function_schema(
+⋮----
+output_format = OpenAIJsonSchemaSpec(
+⋮----
+param_spec = self.output_format.model_json_schema()
+⋮----
+agent = BrokenStrictSchemaAgent(
+⋮----
+openai_tools = use_fn_api and use_tools_api
+⋮----
+# Strict tools are automatically enabled only when
+# parallel tool calls are disabled
+⋮----
+response = agent.llm_response_forget(
+⋮----
+structured_agent = agent[NabroskiTool]
+response = structured_agent.llm_response_forget(
+⋮----
+"""
+    Test that validation errors triggered in strict result in disabled strict output.
+    """
+⋮----
+def int_schema(request: str) -> dict[str, Any]
+⋮----
+class WrongSchemaAgent(ChatAgent)
+⋮----
+"""
+            Implements a broken version of the correct _function_args()
+            that replaces the output and all tool schemas with an
+            incorrect schema. Simulates mismatched schemas due to
+            schema edits.
+            """
+⋮----
+agent = WrongSchemaAgent(
+⋮----
+class IntTool(ToolMessage)
+⋮----
+request: str = "int_tool"
+purpose: str = "To return an integer value"
+⋮----
+def handle(self)
+⋮----
+class StrTool(ToolMessage)
+⋮----
+request: str = "str_tool"
+purpose: str = "To return an string value"
+text: str
+⋮----
+strict_openai_tools = use_fn_api and use_tools_api and not parallel_tool_calls
+⋮----
+strict_agent = agent[IntTool]
+⋮----
+strict_agent = agent[StrTool]
+⋮----
+def test_reduce_raw_tool_result()
+⋮----
+BIG_RESULT = "hello " * 50
+⋮----
+class MyTool(ToolMessage)
+⋮----
+request: str = "my_tool"
+⋮----
+_max_result_tokens: int = 10
+_max_retained_tokens: int = 2
+⋮----
+"""
+            Mock user_response method for testing
+            """
+txt = msg if isinstance(msg, str) else msg.content
+map = dict([("hello", "50"), ("3", "5")])
+response = map.get(txt)
+# return the increment of input number
+⋮----
+# create dummy agent first, just to get small_result with truncation
+agent = MyAgent(ChatAgentConfig())
+# Handle ModelPrivateAttr for _max_result_tokens
+max_result_tokens = MyTool._max_result_tokens
+⋮----
+max_result_tokens = max_result_tokens.default
+small_result = agent._maybe_truncate_result(BIG_RESULT, max_result_tokens)
+⋮----
+# now create the actual agent
+⋮----
+result = task.run("1")
+"""
+    msg history:
+    
+    sys_msg
+    user: 1 -> 
+    LLM: MyTool(1) ->
+    agent: BIG_RESULT -> truncated to 10 tokens, as `small_result`
+    LLM: hello ->
+    user: 50 -> 
+    LLM: Done (Finished)
+    """
+⋮----
+tool_result = agent.message_history[3].content
+# Handle ModelPrivateAttr for _max_retained_tokens
+max_retained = MyTool._max_retained_tokens
+⋮----
+max_retained = max_retained.default
+⋮----
+def test_valid_structured_recovery()
+⋮----
+"""
+    Test that structured recovery is not triggered inappropriately
+    when agent response contains a JSON-like string.
+    """
+⋮----
+# with no tool enabled
+⋮----
+result = task.run("3", turns=4)
+# response-sequence: agent, llm, agent, llm -> done
+⋮----
+# with a tool enabled
+⋮----
+def test_handle_llm_no_tool(handle_no_tool: Any)
+⋮----
+"""Verify that ChatAgentConfig.handle_llm_no_tool works as expected"""
+⋮----
+def mock_llm_response(x: str) -> str
+⋮----
+config = ChatAgentConfig(
+agent = ChatAgent(config)
+⋮----
+task = Task(agent, interactive=False, default_human_response="q")
+⋮----
+# task gets stuck and returns None
+⋮----
+# LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> User(4) -> q
+⋮----
+# LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> Done(4)
+⋮----
+# LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> LLM(DONE)
+⋮----
+# LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> ResultTool(4)
+⋮----
+# LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> AgentDoneTool(4) -> 4
+⋮----
+# LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> DonePass
+⋮----
+class GetTimeTool(ToolMessage)
+⋮----
+purpose: str = "Get current time"
+request: str = "get_time"
+⋮----
+def response(self, agent: ChatAgent) -> ChatDocument
+⋮----
+"""
+    Test that structured fallback only occurs on messages
+    sent by the LLM.
+    """
+was_tool_error = False
+⋮----
+class TrackToolError(ChatAgent)
+⋮----
+was_tool_error = True
+⋮----
+agent = TrackToolError(
+⋮----
+content = json.dumps(
+⋮----
+user_message = agent.create_user_response(content=content, recipient=Entity.LLM)
+⋮----
+agent_message = agent.create_agent_response(content=content, recipient=Entity.LLM)
+⋮----
+@pytest.mark.parametrize("use_fn_api", [False, True])
+def test_tool_handler_invoking_llm(use_fn_api: bool)
+⋮----
+"""
+    Check that if a tool handler directly invokes llm_response,
+    it works as expected, especially with OpenAI Tools API
+    """
+⋮----
+def nabroski(self, msg: NabroskiTool)
+⋮----
+ans = self.llm_response("What is 3+4?")
+⋮----
+task = Task(agent, interactive=False, single_round=False)
+⋮----
+def test_enable_message_validates_arguments(test_settings: Settings)
+⋮----
+"""Test that enable_message raises TypeError when tool classes are passed
+    as separate arguments instead of as a list."""
+⋮----
+class Tool1(ToolMessage)
+⋮----
+request: str = "tool1"
+purpose: str = "First tool"
+⋮----
+class Tool2(ToolMessage)
+⋮----
+request: str = "tool2"
+purpose: str = "Second tool"
+⋮----
+class Tool3(ToolMessage)
+⋮----
+request: str = "tool3"
+purpose: str = "Third tool"
+⋮----
+# This should raise TypeError because Tool2 is passed as 'use' parameter
+⋮----
+agent.enable_message(Tool1, Tool2)  # type: ignore
+⋮----
+# This should raise TypeError because Tool3 is passed as 'handle' parameter
+⋮----
+agent.enable_message(Tool1, True, Tool3)  # type: ignore
+⋮----
+# This should work correctly - passing tools as a list
+⋮----
+def test_enable_message_rejects_distinct_classes_with_same_request() -> None
+⋮----
+"""Different tool classes cannot silently replace the same request name."""
+⋮----
+class FirstCollisionTool(ToolMessage)
+⋮----
+request: str = "shared_request"
+⋮----
+class SecondCollisionTool(ToolMessage)
+⋮----
+class DerivedCollisionTool(FirstCollisionTool)
+⋮----
+purpose: str = "Derived tool"
+⋮----
+agent = ChatAgent(ChatAgentConfig(llm=None))
+⋮----
+message = str(exc_info.value)
+⋮----
+derived_agent = ChatAgent(ChatAgentConfig(llm=None))
+⋮----
+recipient_wrapper = FirstCollisionTool.require_recipient()
+⋮----
+class DerivedRecipientCollisionTool(recipient_wrapper):  # type: ignore
+⋮----
+purpose: str = "Derived recipient tool"
+⋮----
+recipient_agent = ChatAgent(ChatAgentConfig(llm=None))
+⋮----
+def test_enable_message_rejects_recipient_wrapper_subclass_origin() -> None
+⋮----
+"""Recipient wrapping must preserve a subclass as a distinct tool origin."""
+⋮----
+class OriginalTool(ToolMessage)
+⋮----
+request: str = "recipient_collision"
+purpose: str = "Original tool"
+⋮----
+recipient_wrapper = OriginalTool.require_recipient()
+⋮----
+class RecipientWrapperSubclass(recipient_wrapper):  # type: ignore
+⋮----
+purpose: str = "Distinct recipient-wrapper subclass"
+⋮----
+def test_any_tool_reenable_is_idempotent() -> None
+⋮----
+"""Regenerated strict-recovery AnyTool must re-register without error.
+
+    `_get_any_tool_message()` builds a fresh class per call (its tool-union
+    varies with enabled tools), so two generations of "tool_or_function" are
+    distinct classes; the same-name registration guard must treat them as the
+    same logical tool (regression: SQLChatAgent strict recovery raised
+    "already registered to AnyTool; cannot register AnyTool").
+    """
+⋮----
+class ToolA(ToolMessage)
+⋮----
+request: str = "any_tool_idem_a"
+purpose: str = "Tool A"
+⋮----
+class ToolB(ToolMessage)
+⋮----
+request: str = "any_tool_idem_b"
+purpose: str = "Tool B"
+⋮----
+any_tool_1 = agent._get_any_tool_message()
+⋮----
+# enabling another tool changes the union => a distinct AnyTool class
+⋮----
+any_tool_2 = agent._get_any_tool_message()
+⋮----
+agent.enable_message(any_tool_2, use=False, handle=True)  # must not raise
+⋮----
+def test_multi_agent_tool_caching(test_settings: Settings)
+⋮----
+"""
+    Test that tool message caching is agent-specific.
+
+    When Agent A parses a ChatDocument and caches tool messages,
+    Agent B (with different tools) should NOT use A's cached results
+    and should re-parse the message with its own tool registry.
+    """
+⋮----
+# Define two different tools
+⋮----
+request: str = "tool_a"
+purpose: str = "Tool for Agent A"
+value: str = "a"
+⋮----
+request: str = "tool_b"
+purpose: str = "Tool for Agent B"
+value: str = "b"
+⋮----
+# Create two agents with different tool registries
+agent_a = ChatAgent(
+⋮----
+agent_b = ChatAgent(
+⋮----
+# Create a ChatDocument containing ToolB (which only AgentB knows about)
+tool_b_json = json.dumps({"request": "tool_b", "value": "test_value"})
+chat_doc = ChatDocument(
+⋮----
+# Agent A parses - should find no tools it handles (ToolB is unknown to A)
+tools_from_a = agent_a.get_tool_messages(chat_doc, all_tools=True)
+⋮----
+# Verify cache was set by Agent A
+⋮----
+# Agent B parses the SAME ChatDocument - should re-parse and find ToolB
+# because the cache was set by a different agent
+tools_from_b = agent_b.get_tool_messages(chat_doc, all_tools=True)
+⋮----
+# Verify cache was updated by Agent B
+⋮----
+# Agent B parsing again should use the cache (same agent)
+tools_from_b_cached = agent_b.get_tool_messages(chat_doc, all_tools=True)
+⋮----
+def test_nested_tool_message_schema_is_cleaned() -> None
+⋮----
+"""A ToolMessage nested inside another ToolMessage lands in the schema's
+    ``$defs``, and must get the same cleanup the top-level tool gets: internal
+    fields (``purpose``, ``id``) and the ``exclude`` marker removed, and
+    ``request`` pinned to its constant via an ``enum``.
+
+    Regression guard for the Pydantic v1->v2 migration: v1 emitted nested-model
+    schemas under ``definitions`` while v2 uses ``$defs``. If the cleanup keys
+    off the wrong name it silently no-ops, leaking those internal fields (and an
+    unconstrained ``request``) into the schema sent to the LLM.
+    """
+⋮----
+class Inner(ToolMessage)
+⋮----
+request: str = "inner_tool"
+purpose: str = "the inner purpose"
+⋮----
+class Outer(ToolMessage)
+⋮----
+request: str = "outer_tool"
+purpose: str = "the outer purpose"
+inner: Inner
+⋮----
+params = Outer.llm_function_schema(request=True).parameters
+⋮----
+inner_schema = params["$defs"]["Inner"]
+⋮----
+# internal markers/fields must not leak to the LLM
+⋮----
+# `request` is pinned to its constant and required
 </file>
 
 <file path="SECURITY.md">
@@ -73839,1646 +73936,6 @@ model_names = tuple(_model_name(model) for model in models)
 def _model_name(model: str | ModelName) -> str
 </file>
 
-<file path="tests/main/test_llm.py">
-# allow streaming globally, but can be turned off by individual models
-⋮----
-@pytest.mark.parametrize("use_cache", [True, False])
-def test_openai_gpt(test_settings: Settings, streaming, country, capital, use_cache)
-⋮----
-test_settings.cache = False  # cache response but don't retrieve from cache
-⋮----
-cfg = OpenAIGPTConfig(
-⋮----
-stream=streaming,  # use streaming output if enabled globally
-⋮----
-mdl = OpenAIGPT(config=cfg)
-question = "What is the capital of " + country + "?"
-# chat mode via `generate`,
-# i.e. use same call as for completion, but the setting below
-# actually calls `chat` under the hood
-⋮----
-# check that "generate" works when "use_chat_for_completion" is True
-response = mdl.generate(prompt=question, max_tokens=800)
-⋮----
-# actual chat mode
-messages = [
-response = mdl.chat(messages=messages, max_tokens=500)
-⋮----
-# should be from cache this time, Provided config.cache_config is not None
-⋮----
-# pass intentional bad msg to test error handling
-⋮----
-_ = mdl.chat(messages=messages, max_tokens=500)
-⋮----
-def _test_context_length_error(test_settings: Settings, mode: str, max_tokens: int)
-⋮----
-"""
-    Test disabled, see TODO below.
-    Also it takes too long since we are trying to test
-    that it raises the expected error when the context length is exceeded.
-    Args:
-        test_settings: from conftest.py
-        mode: "completion" or "chat"
-        max_tokens: number of tokens to generate
-    """
-⋮----
-parser = Parser(config=ParsingConfig())
-llm = OpenAIGPT(config=cfg)
-context_length = (
-⋮----
-toks_per_sentence = int(parser.num_tokens(generate_random_sentences(1000)) / 1000)
-max_sentences = int(context_length * 1.5 / toks_per_sentence)
-big_message = generate_random_sentences(max_sentences + 1)
-big_message_tokens = parser.num_tokens(big_message)
-⋮----
-response = None
-# TODO need to figure out what error type to expect here
-⋮----
-response = llm.chat(big_message, max_tokens=max_tokens)
-⋮----
-response = llm.generate(prompt=big_message, max_tokens=max_tokens)
-⋮----
-@pytest.mark.parametrize("ctx", [16_000, None])
-def test_llm_config_context_length(mdl: str, ctx: int | None)
-⋮----
-llm_config = lm.OpenAIGPTConfig(
-⋮----
-chat_context_length=ctx,  # even if wrong, use if explicitly set
-⋮----
-mdl = lm.OpenAIGPT(config=llm_config)
-⋮----
-alias_llm = lm.OpenAIGPT(config=lm.OpenAIGPTConfig(chat_model=alias_model))
-canonical_llm = lm.OpenAIGPT(config=lm.OpenAIGPTConfig(chat_model=canonical_model))
-⋮----
-def test_get_model_info_warns_on_unknown_models() -> None
-⋮----
-model_name = "gemini/gemini-999-unknown-preview"
-# Ensure this model hasn't been warned about in a prior test so the
-# warning actually fires.  The cache key is a tuple of the full model
-# strings passed to _warn_unknown_model (i.e. with the provider prefix).
-⋮----
-handler = logging.handlers.MemoryHandler(capacity=100)
-logger = logging.getLogger("langroid.language_models.model_info")
-⋮----
-# Call twice: every lookup of an unknown model must return the
-# fallback-default ModelInfo, but the warning must fire only once
-# (deduped via WARNED_UNKNOWN_MODELS).
-first_info = get_model_info(model_name)
-second_info = get_model_info(model_name)
-⋮----
-messages = [record.getMessage() for record in handler.buffer]
-matching = [
-⋮----
-def test_model_selection(test_settings: Settings)
-⋮----
-defaultOpenAIChatModel = lr.language_models.openai_gpt.default_openai_chat_model
-⋮----
-def get_response(llm)
-⋮----
-def simulate_response(llm)
-⋮----
-# Default is GPT4o; we should not generate the warning in this case
-⋮----
-llm = OpenAIGPT(config=OpenAIGPTConfig(chat_model=OpenAIChatModel.GPT3_5_TURBO))
-⋮----
-llm = OpenAIGPT(config=OpenAIGPTConfig())
-⋮----
-# Default is GPT3.5 (simulate GPT 4 inaccessible)
-⋮----
-# No warnings generated if we specify the model explicitly
-⋮----
-# No warnings generated if we are using a local model
-llm = OpenAIGPT(config=OpenAIGPTConfig(api_base="localhost:8000"))
-⋮----
-llm = OpenAIGPT(config=OpenAIGPTConfig(chat_model="local/localhost:8000"))
-⋮----
-llm = OpenAIGPT(config=OpenAIGPTConfig(chat_model="litellm/ollama/llama"))
-⋮----
-# We should warn on the first usage of a model with auto-selected GPT-3.5
-⋮----
-# We should not warn on subsequent uses and models with auto-selected GPT-3.5
-⋮----
-def test_keys()
-⋮----
-# Do not override the explicit settings below
-⋮----
-providers = [
-key_dict = {p: f"{p.upper()}_API_KEY" for p in providers}
-⋮----
-config = lm.OpenAIGPTConfig(
-⋮----
-llm = lm.OpenAIGPT(config)
-⋮----
-rand_key = str(random.randint(0, 10**9))
-⋮----
-def test_llm_langdb(model: str)
-⋮----
-"""Test that LLM access via LangDB works."""
-# override any chat model passed via --m arg to pytest cmd
-⋮----
-llm_config_langdb = lm.OpenAIGPTConfig(
-llm = lm.OpenAIGPT(config=llm_config_langdb)
-result = llm.chat("what is 3+4?")
-⋮----
-def test_llm_openrouter(model: str)
-⋮----
-llm = lm.OpenAIGPT(config=llm_config)
-⋮----
-def test_llm_portkey(model: str)
-⋮----
-"""Test that LLM access via Portkey works."""
-⋮----
-# Skip if PORTKEY_API_KEY is not set
-⋮----
-# Extract provider from model string
-provider = model.split("/")[1] if "/" in model else ""
-provider_key_var = f"{provider.upper()}_API_KEY"
-⋮----
-# Skip if provider API key is not set
-⋮----
-llm_config_portkey = lm.OpenAIGPTConfig(
-llm = lm.OpenAIGPT(config=llm_config_portkey)
-result = llm.chat("what is 3+4 equal to?")
-⋮----
-def test_portkey_params()
-⋮----
-"""Test that PortkeyParams are correctly configured."""
-⋮----
-# Test with explicit parameters
-params = PortkeyParams(
-⋮----
-headers = params.get_headers()
-⋮----
-# Test model string parsing
-⋮----
-# Test fallback parsing
-⋮----
-# Test provider API key retrieval
-⋮----
-key = params.get_provider_api_key("test_provider")
-⋮----
-def test_portkey_integration()
-⋮----
-"""Test that Portkey integration is properly configured in OpenAIGPT."""
-⋮----
-# Save the current chat model setting
-original_chat_model = settings.chat_model
-⋮----
-# Clear any global chat model override
-⋮----
-# Test basic portkey model configuration
-⋮----
-# Check that model was parsed correctly
-⋮----
-# Check headers are set correctly
-⋮----
-# Restore original chat model setting
-⋮----
-def test_gemini_api_base()
-⋮----
-"""Test that Gemini api_base is configurable for Vertex AI support."""
-⋮----
-# Save and clear env vars that could interfere
-saved_openai_api_base = os.environ.pop("OPENAI_API_BASE", None)
-saved_gemini_api_base = os.environ.pop("GEMINI_API_BASE", None)
-⋮----
-# Default: api_base should be GEMINI_BASE_URL
-⋮----
-# Custom api_base: should override default (e.g. Vertex AI endpoint)
-vertex_url = "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project/locations/us-central1/endpoints/openapi"
-⋮----
-# Empty string api_base: should fall back to default
-⋮----
-# None api_base: should fall back to default
-⋮----
-# OPENAI_API_BASE env var should NOT leak into Gemini api_base
-⋮----
-# GEMINI_API_BASE env var should be used (e.g. Vertex AI)
-⋮----
-# GEMINI_API_BASE should take priority over OPENAI_API_BASE
-⋮----
-# Restore original env vars
-⋮----
-def test_gemini_google_prefix(monkeypatch)
-⋮----
-"""`google/`-prefixed Gemini models route to the Gemini API (issue #995)."""
-⋮----
-llm = lm.OpenAIGPT(lm.OpenAIGPTConfig(chat_model=chat_model))
-⋮----
-def test_gemini_ignores_last_case_variant_openai_api_base(monkeypatch)
-⋮----
-"""Gemini routing follows pydantic's last-wins env case normalization."""
-⋮----
-llm = lm.OpenAIGPT(lm.OpenAIGPTConfig(chat_model="google/gemini-2.0-flash"))
-⋮----
-def test_non_gemini_google_model_is_not_rerouted(monkeypatch, chat_model)
-⋮----
-"""Non-Gemini Google models retain caller routing and credentials."""
-⋮----
-caller_api_key = "caller-api-key"
-⋮----
-llm = lm.OpenAIGPT(
-⋮----
-"""Gemini aliases retain an explicitly configured API base."""
-⋮----
-expected_model = (
-⋮----
-def test_gemini_model_copy_preserves_explicit_api_base(monkeypatch, chat_model)
-⋮----
-"""Gemini configs copied with an API base retain the caller endpoint."""
-⋮----
-custom_base = "https://caller.example/v1"
-config = lm.OpenAIGPTConfig(chat_model=chat_model).model_copy(
-⋮----
-def test_gemini_assignment_preserves_explicit_api_base(monkeypatch, chat_model)
-⋮----
-"""Gemini configs assigned an API base retain the caller endpoint."""
-⋮----
-config = lm.OpenAIGPTConfig(chat_model=chat_model)
-⋮----
-def test_gemini_dynamic_config_preserves_api_base(monkeypatch)
-⋮----
-"""Dynamically prefixed Gemini settings retain their API base."""
-⋮----
-vertex_config = lm.OpenAIGPTConfig.create("vertex")
-⋮----
-llm = lm.OpenAIGPT(vertex_config(chat_model="google/gemini-2.0-flash"))
-⋮----
-def test_followup_standalone()
-⋮----
-"""Test that followup_to_standalone works."""
-⋮----
-llm = OpenAIGPT(OpenAIGPTConfig())
-dialog = [
-followup = "What about 11?"
-response = llm.followup_to_standalone(dialog, followup)
-⋮----
-def test_llm_pdf_attachment()
-⋮----
-"""Test sending a PDF file attachment to the LLM."""
-⋮----
-# Path to the test PDF file
-pdf_path = Path("tests/main/data/dummy.pdf")
-⋮----
-# Create a FileAttachment from the PDF file
-attachment = FileAttachment.from_path(pdf_path)
-⋮----
-# Verify the attachment properties
-⋮----
-# Create messages with the attachment
-⋮----
-# Set up the LLM with a suitable model that supports PDFs
-llm = OpenAIGPT(OpenAIGPTConfig(max_output_tokens=1000))
-⋮----
-# Get response from the LLM
-response = llm.chat(messages=messages)
-⋮----
-# follow-up question
-⋮----
-def test_llm_multi_pdf_attachments()
-⋮----
-# multiple attachments
-pdf_path2 = Path("tests/main/data/sample-test.pdf")
-⋮----
-attachment2 = FileAttachment.from_path(pdf_path2)
-⋮----
-def test_llm_pdf_bytes_and_split()
-⋮----
-"""Test sending PDF files to LLM as bytes and split into pages."""
-⋮----
-# Test creating attachment from bytes
-⋮----
-pdf_bytes = f.read()
-⋮----
-attachment_from_bytes = FileAttachment.from_bytes(
-⋮----
-llm = OpenAIGPT(OpenAIGPTConfig(max_output_tokens=100))
-⋮----
-# Test creating attachment from file-like object
-pdf_io = io.BytesIO(pdf_bytes)
-attachment_from_io = FileAttachment.from_io(
-⋮----
-# Test splitting PDF into pages and sending individual pages
-⋮----
-doc = fitz.open(pdf_path)
-page_attachments = []
-⋮----
-# Extract page as PDF
-page_pdf = io.BytesIO()
-page_doc = fitz.open()
-⋮----
-# Create attachment for this page
-page_attachment = FileAttachment.from_io(
-⋮----
-# Send just the first page
-⋮----
-# Test with multiple pages as separate attachments
-⋮----
-def test_llm_image_input(path: str)
-⋮----
-attachment = FileAttachment.from_path(path, detail="low")
-⋮----
-llm = OpenAIGPT(OpenAIGPTConfig(max_output_tokens=500))
-⋮----
-def test_litellm_model_key()
-⋮----
-"""
-    Test that passing in explicit api_key works with `litellm/*` models
-    """
-model = "litellm/anthropic/claude-3-5-haiku-latest"
-# disable any chat model passed via --m arg to pytest cmd
-⋮----
-class CustomOpenAIGPTConfig(lm.OpenAIGPTConfig)
-⋮----
-"""OpenAI config that doesn't auto-load from environment variables."""
-⋮----
-# Disable environment prefix to prevent auto-loading
-model_config = SettingsConfigDict(env_prefix="")
-⋮----
-llm_config = CustomOpenAIGPTConfig(
-⋮----
-response = llm.chat("What is 3+4?")
-</file>
-
-<file path="langroid/agent/chat_agent.py">
-console = Console()
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-# Stable origin sentinel for the dynamically generated strict-recovery AnyTool
-# class ("tool_or_function"): a fresh class is built per call (its tool-union
-# type varies), so re-registration must be recognized as the same logical tool.
-_ANY_TOOL_MESSAGE_ORIGIN: Any = object()
-⋮----
-# Safety margin (in tokens) subtracted from the model context length when
-# shrinking chat history and/or the requested output length to fit, in case
-# our token-count estimates are off.
-CHAT_HISTORY_BUFFER = 300
-⋮----
-def _reject_json_constant(constant: str) -> None
-⋮----
-"""Reject JavaScript numeric constants that are not valid JSON."""
-⋮----
-def _parse_json_float(value: str) -> float
-⋮----
-"""Parse a JSON float while rejecting exponent overflow."""
-parsed = float(value)
-⋮----
-def _is_identified_result(message: LLMMessage) -> bool
-⋮----
-"""Whether a TOOL/FUNCTION result has its identifier and no call payload.
-
-    Such results must survive even with empty content so their calls can be
-    marked complete (issue #1063).
-    """
-has_identifier = (
-⋮----
-def _llm_message_has_payload(message: LLMMessage) -> bool
-⋮----
-"""Whether a message has the fields required for a valid history entry."""
-⋮----
-class ChatAgentConfig(AgentConfig)
-⋮----
-"""
-    Configuration for ChatAgent
-
-    Attributes:
-        system_message: system message to include in message sequence
-             (typically defines role and task of agent).
-             Used only if `task` is not specified in the constructor.
-        user_message: user message to include in message sequence.
-             Used only if `task` is not specified in the constructor.
-        use_tools: whether to use our own ToolMessages mechanism
-        handle_llm_no_tool (Any): desired agent_response when
-            LLM generates non-tool msg.
-        use_functions_api: whether to use functions/tools native to the LLM API
-                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
-        use_tools_api: When `use_functions_api` is True, if this is also True,
-            the OpenAI tool-call API is used, rather than the older/deprecated
-            function-call API. However the tool-call API has some tricky aspects,
-            hence we set this to False by default.
-        strict_recovery: whether to enable strict schema recovery when there
-            is a tool-generation error.
-        enable_orchestration_tool_handling: whether to enable handling of orchestration
-            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
-        output_format: When supported by the LLM (certain OpenAI LLMs
-            and local LLMs served by providers such as vLLM), ensures
-            that the output is a JSON matching the corresponding
-            schema via grammar-based decoding
-        handle_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for handling".
-        use_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for use" (by LLM) and
-            instructions on using T are added to the system message.
-        instructions_output_format: Controls whether we generate instructions for
-            `output_format` in the system message.
-        use_tools_on_output_format: Controls whether to automatically switch
-            to the Langroid-native tools mechanism when `output_format` is set.
-            Note that LLMs may generate tool calls which do not belong to
-            `output_format` even when strict JSON mode is enabled, so this should be
-            enabled when such tool calls are not desired.
-        output_format_include_defaults: Whether to include fields with default arguments
-            in the output schema
-        full_citations: Whether to show source reference citation + content for each
-            citation, or just the main reference citation.
-        search_for_tools_everywhere: Whether to search for tools everywhere,
-            or only in specific LLM response elements based on use_tools /
-            use_functions_api / use_tools_api config settings.
-        recognize_recipient_in_content: Whether to parse LLM response text content
-            for recipient routing patterns, specifically:
-            - ``TO[<recipient>]:<content>`` addressing format, and
-            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
-            When False, only structured routing via function_call/tool_call
-            ``recipient`` fields is recognized. Default is True.
-            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
-            which controls Task-level signals like DONE, PASS, and SEND_TO.
-            To fully disable all text-based routing, set both to False.
-        context_overflow_strategy: Strategy for handling context overflow when
-            message history exceeds model context length. Options:
-            - "truncate": Truncate content of early messages (preserves all messages
-              but with shortened content). This maintains the message sequence.
-            - "drop_turns": Drop complete conversation turns (USER + all responses
-              until next USER). More aggressive but cleaner for voice agents.
-            Default is "truncate" for backward compatibility.
-    """
-⋮----
-system_message: str = "You are a helpful assistant."
-user_message: Optional[str] = None
-handle_llm_no_tool: Any = None
-use_tools: bool = True
-use_functions_api: bool = False
-use_tools_api: bool = True
-strict_recovery: bool = True
-enable_orchestration_tool_handling: bool = True
-output_format: Optional[type] = None
-handle_output_format: bool = True
-use_output_format: bool = True
-instructions_output_format: bool = True
-output_format_include_defaults: bool = True
-use_tools_on_output_format: bool = True
-full_citations: bool = True  # show source + content for each citation?
-search_for_tools_everywhere: bool = True
-recognize_recipient_in_content: bool = True
-context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
-⋮----
-def _set_fn_or_tools(self) -> None
-⋮----
-"""
-        Enable Langroid Tool or OpenAI-like fn-calling,
-        depending on config settings.
-        """
-⋮----
-class ChatAgent(Agent)
-⋮----
-"""
-    Chat Agent interacting with external env
-    (could be human, or external tools).
-    The agent (the LLM actually) is provided with an optional "Task Spec",
-    which is a sequence of `LLMMessage`s. These are used to initialize
-    the `task_messages` of the agent.
-    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
-    The `Agent` class mainly exists to hold various common methods and attributes.
-    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
-    `llm_response` method uses "chat mode" API (i.e. one that takes a
-    message sequence rather than a single message),
-    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
-    that takes a single message).
-    """
-⋮----
-"""
-        Chat-mode agent initialized with task spec as the initial message sequence
-        Args:
-            config: settings for the agent
-
-        """
-⋮----
-# An agent's "task" is defined by a system msg and an optional user msg;
-# These are "priming" messages that kick off the agent's conversation.
-⋮----
-# if task contains a system msg, we override the config system msg
-⋮----
-# if task contains a user msg, we override the config user msg
-⋮----
-# system-level instructions for using tools/functions:
-# We maintain these as tools/functions are enabled/disabled,
-# and whenever an LLM response is sought, these are used to
-# recreate the system message (via `_create_system_and_tools_message`)
-# each time, so it reflects the current set of enabled tools/functions.
-# (a) these are general instructions on using certain tools/functions,
-#   if they are specified in a ToolMessage class as a classmethod `instructions`
-⋮----
-# (b) these are only for the builtin in Langroid TOOLS mechanism:
-⋮----
-# This variable is not None and equals a `ToolMessage` T, if and only if:
-# (a) T has been set as the output_format of this agent, AND
-# (b) T has been "enabled for use" ONLY for enforcing this output format, AND
-# (c) T has NOT been explicitly "enabled for use" by this Agent.
-⋮----
-# As above but deals with "enabled for handling" instead of "enabled for use".
-⋮----
-# instructions specifically related to enforcing `output_format`
-⋮----
-# controls whether to disable strict schemas for this agent if
-# strict mode causes exception
-⋮----
-# Tracks whether any strict tool is enabled; used to determine whether to set
-# `self.disable_strict` on an exception
-⋮----
-# Tracks the set of tools on which we force-disable strict decoding
-⋮----
-# search for tools according to the agent configuration
-⋮----
-# Only enable HANDLING by `agent_response`, NOT LLM generation of these.
-# This is useful where tool-handlers or agent_response generate these
-# tools, and need to be handled.
-# We don't want enable orch tool GENERATION by default, since that
-# might clutter-up the LLM system message unnecessarily.
-⋮----
-def init_state(self) -> None
-⋮----
-"""
-        Initialize the state of the agent. Just conversation state here,
-        but subclasses can override this to initialize other state.
-        """
-⋮----
-@staticmethod
-    def from_id(id: str) -> "ChatAgent"
-⋮----
-"""
-        Get an agent from its ID
-        Args:
-            agent_id (str): ID of the agent
-        Returns:
-            ChatAgent: The agent with the given ID
-        """
-⋮----
-def clone(self, i: int = 0) -> "ChatAgent"
-⋮----
-"""Create i'th clone of this agent, ensuring tool use/handling is cloned.
-        Important: We assume all member variables are in the __init__ method here
-        and in the Agent class.
-        TODO: We are attempting to clone an agent after its state has been
-        changed in possibly many ways. Below is an imperfect solution. Caution advised.
-        Revisit later.
-        """
-agent_cls = type(self)
-# Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
-# instead of deepcopy which loses subclass information
-config_copy = self.config.model_copy(deep=True)
-⋮----
-new_agent = agent_cls(config_copy)
-⋮----
-# Ensure each clone gets its own vecdb client when supported.
-⋮----
-def _clone_extra_state(self, new_agent: "ChatAgent") -> None
-⋮----
-"""Hook for subclasses to copy additional state into clones."""
-⋮----
-def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool
-⋮----
-"""Should we enable strict mode for a given tool?"""
-⋮----
-tool_class = self.llm_tools_map[tool]
-⋮----
-tool_class = tool
-name = tool_class.default_value("request")
-⋮----
-strict: Optional[bool] = tool_class.default_value("strict")
-⋮----
-strict = self._strict_tools_available()
-⋮----
-def _fn_call_available(self) -> bool
-⋮----
-"""Does this agent's LLM support function calling?"""
-⋮----
-def _strict_tools_available(self) -> bool
-⋮----
-"""Does this agent's LLM support strict tools?"""
-⋮----
-def _json_schema_available(self) -> bool
-⋮----
-"""Does this agent's LLM support strict JSON schema output format?"""
-⋮----
-def set_system_message(self, msg: str) -> None
-⋮----
-# if there is message history, update the system message in it
-⋮----
-def set_user_message(self, msg: str) -> None
-⋮----
-@property
-    def task_messages(self) -> List[LLMMessage]
-⋮----
-"""
-        The task messages are the initial messages that define the task
-        of the agent. There will be at least a system message plus possibly a user msg.
-        Returns:
-            List[LLMMessage]: the task messages
-        """
-msgs = [self._create_system_and_tools_message()]
-⋮----
-def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None
-⋮----
-id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
-⋮----
-# dropping tool result, so ADD the corresponding tool-call back
-# to the list of pending calls!
-id = msg.tool_call_id
-⋮----
-# dropping a msg with tool-calls, so DROP these from pending list
-# as well as from id -> call map
-⋮----
-def clear_history(self, start: int = -2, end: int = -1) -> None
-⋮----
-"""
-        Clear the message history, deleting  messages from index `start`,
-        up to index `end`.
-
-        Args:
-            start (int): index of first message to delete; default = -2
-                    (i.e. delete last 2 messages, typically these
-                    are the last user and assistant messages)
-            end (int): index of last message to delete; Default = -1
-                    (i.e. delete all messages up to the last one)
-        """
-n = len(self.message_history)
-⋮----
-start = max(0, n + start)
-end_ = n if end == -1 else end + 1
-dropped = self.message_history[start:end_]
-# consider the dropped msgs in REVERSE order, so we are
-# carefully updating self.oai_tool_calls
-⋮----
-# clear out the chat document from the ObjectRegistry
-⋮----
-def update_history(self, message: str, response: str) -> None
-⋮----
-"""
-        Update the message history with the latest user message and LLM response.
-        Args:
-            message (str): user message
-            response: (str): LLM response
-        """
-⋮----
-def export_history(self) -> str
-⋮----
-"""Export message history as a portable, versioned JSON snapshot.
-
-        Returns:
-            A JSON string containing the current message history.
-        """
-messages: List[Dict[str, Any]] = []
-⋮----
-data = message.model_dump(mode="json", exclude={"files"})
-⋮----
-"""Restore message history from :meth:`export_history` output.
-
-        Args:
-            snapshot: Versioned JSON snapshot to restore.
-            max_size_bytes: Maximum total decoded attachment size. Defaults to
-                100 MiB.
-
-        Raises:
-            ValueError: If the snapshot is malformed, has an unknown version,
-                starts with a non-system message, or exceeds ``max_size_bytes``.
-        """
-⋮----
-payload = json.loads(
-⋮----
-raw_messages = payload.get("messages")
-⋮----
-messages: List[LLMMessage] = []
-total_attachment_bytes = 0
-⋮----
-message_data = dict(raw_message)
-raw_files = message_data.get("files", [])
-⋮----
-files = []
-⋮----
-file_data = dict(raw_file)
-encoded_content = file_data.pop("content_base64")
-⋮----
-encoded_bytes = encoded_content.encode("ascii")
-padding = len(encoded_bytes) - len(encoded_bytes.rstrip(b"="))
-decoded_size = max(
-⋮----
-content = base64.b64decode(encoded_bytes, validate=True)
-⋮----
-seen_call_ids: Set[str] = set()
-⋮----
-name = message.name
-⋮----
-call_id = call.id
-⋮----
-all_calls = {
-completed_call_ids = {
-old_chat_document_ids = {
-⋮----
-def tool_format_rules(self) -> str
-⋮----
-"""
-        Specification of tool formatting rules
-        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
-        based on the currently enabled usable `ToolMessage`s
-
-        Returns:
-            str: formatting rules
-        """
-# ONLY Usable tools (i.e. LLM-generation allowed),
-usable_tool_classes: List[Type[ToolMessage]] = [
-⋮----
-format_instructions = "\n\n".join(
-# if any of the enabled classes has json_group_instructions, then use that,
-# else fall back to ToolMessage.json_group_instructions
-⋮----
-def tool_instructions(self) -> str
-⋮----
-"""
-        Instructions for tools or function-calls, for enabled and usable Tools.
-        These are inserted into system prompt regardless of whether we are using
-        our own ToolMessage mechanism or the LLM's function-call mechanism.
-
-        Returns:
-            str: concatenation of instructions for all usable tools
-        """
-enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
-⋮----
-instructions = []
-⋮----
-class_instructions = ""
-⋮----
-class_instructions = msg_cls.instructions()
-⋮----
-# example will be shown in tool_format_rules() when using TOOLs,
-# so we don't need to show it here.
-example = "" if self.config.use_tools else (msg_cls.usage_examples())
-⋮----
-example = "EXAMPLES:\n" + example
-guidance = (
-⋮----
-instructions_str = "\n\n".join(instructions)
-⋮----
-def augment_system_message(self, message: str) -> None
-⋮----
-"""
-        Augment the system message with the given message.
-        Args:
-            message (str): system message
-        """
-⋮----
-def last_message_with_role(self, role: Role) -> LLMMessage | None
-⋮----
-"""from `message_history`, return the last message with role `role`"""
-n_role_msgs = len([m for m in self.message_history if m.role == role])
-⋮----
-idx = self.nth_message_idx_with_role(role, n_role_msgs)
-⋮----
-def last_message_idx_with_role(self, role: Role) -> int
-⋮----
-"""Index of last message in message_history, with specified role.
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-indices_with_role = [
-⋮----
-def nth_message_idx_with_role(self, role: Role, n: int) -> int
-⋮----
-"""Index of `n`th message in message_history, with specified role.
-        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-⋮----
-def update_last_message(self, message: str, role: str = Role.USER) -> None
-⋮----
-"""
-        Update the last message that has role `role` in the message history.
-        Useful when we want to replace a long user prompt, that may contain context
-        documents plus a question, with just the question.
-        Args:
-            message (str): new message to replace with
-            role (str): role of message to replace
-        """
-⋮----
-# find last message in self.message_history with role `role`
-⋮----
-def delete_last_message(self, role: str = Role.USER) -> None
-⋮----
-"""
-        Delete the last message that has role `role` from the message history.
-        Args:
-            role (str): role of message to delete
-        """
-⋮----
-def _create_system_and_tools_message(self) -> LLMMessage
-⋮----
-"""
-        (Re-)Create the system message for the LLM of the agent,
-        taking into account any tool instructions that have been added
-        after the agent was initialized.
-
-        The system message will consist of:
-        (a) the system message from the `task` arg in constructor, if any,
-            otherwise the default system message from the config
-        (b) the system tool instructions, if any
-        (c) the system json tool instructions, if any
-
-        Returns:
-            LLMMessage object
-        """
-content = self.system_message
-⋮----
-# remove leading and trailing newlines and other whitespace
-⋮----
-def handle_message_fallback(self, msg: str | ChatDocument) -> Any
-⋮----
-"""
-        Fallback method for the "no-tools" scenario, i.e., the current `msg`
-        (presumably emitted by the LLM) does not have any tool that the agent
-        can handle.
-        NOTE: The `msg` may contain tools but either (a) the agent is not
-        enabled to handle them, or (b) there's an explicit `recipient` field
-        in the tool that doesn't match the agent's name.
-
-        Uses the self.config.non_tool_routing to determine the action to take.
-
-        This method can be overridden by subclasses, e.g.,
-        to create a "reminder" message when a tool is expected but the LLM "forgot"
-        to generate one.
-
-        Args:
-            msg (str | ChatDocument): The input msg to handle
-        Returns:
-            Any: The result of the handler method
-        """
-⋮----
-# we ONLY use the `handle_llm_no_tool` config option when
-# the msg is from LLM and does not contain ANY tools at all.
-⋮----
-no_tool_option = self.config.handle_llm_no_tool
-⋮----
-# in case the `no_tool_option` is one of the special NonToolAction vals
-⋮----
-# Otherwise just return `no_tool_option` as is:
-# This can be any string, such as a specific nudge/reminder to the LLM,
-# or even something like ResultTool etc.
-⋮----
-def unhandled_tools(self) -> set[str]
-⋮----
-"""The set of tools that are known but not handled.
-        Useful in task flow: an agent can refuse to accept an incoming msg
-        when it only has unhandled tools.
-        """
-⋮----
-"""
-        Add the tool (message class) to the agent, and enable either
-        - tool USE (i.e. the LLM can generate JSON to use this tool),
-        - tool HANDLING (i.e. the agent can handle JSON from this tool),
-
-        Args:
-            message_class: The ToolMessage class OR List of such classes to enable,
-                for USE, or HANDLING, or both.
-                If this is a list of ToolMessage classes, then the remain args are
-                applied to all classes.
-                Optional; if None, then apply the enabling to all tools in the
-                agent's toolset that have been enabled so far.
-            use: IF True, allow the agent (LLM) to use this tool (or all tools),
-                else disallow
-            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
-                tool (or all tools)
-            force: whether to FORCE the agent (LLM) to USE the specific
-                 tool represented by `message_class`.
-                 `force` is ignored if `message_class` is None.
-            require_recipient: whether to require that recipient be specified
-                when using the tool message (only applies if `use` is True).
-            include_defaults: whether to include fields that have default values,
-                in the "properties" section of the JSON format instructions.
-                (Normally the OpenAI completion API ignores these fields,
-                but the Assistant fn-calling seems to pay attn to these,
-                and if we don't want this, we should set this to False.)
-        """
-⋮----
-# Validate that use/handle are booleans, not accidentally passed tool classes
-⋮----
-param = "use" if isclass(use) else "handle"
-⋮----
-message_class = message_class.require_recipient()
-⋮----
-request = message_class.default_value("request")
-existing_class = self.llm_tools_map.get(request)
-existing_origin = (
-message_origin = message_class.__dict__.get(
-⋮----
-# XMLToolMessage is not compatible with OpenAI's Tools/functions API,
-# so we disable use of functions API, enable langroid-native Tools,
-# which are prompt-based.
-⋮----
-super().enable_message_handling(message_class)  # enables handling only
-tools = self._get_tool_list(message_class)
-⋮----
-llm_function = message_class.llm_function_schema(defaults=include_defaults)
-⋮----
-# `t` was designated as "enabled for handling" ONLY for
-# output_format enforcement, but we are explicitly ]
-# enabling it for handling here, so we set the variable to None.
-⋮----
-tool_class = self.llm_tools_map[t]
-allow_llm_use = tool_class._allow_llm_use
-⋮----
-allow_llm_use = allow_llm_use.default
-⋮----
-# `t` was designated as "enabled for use" ONLY for output_format
-# enforcement, but we are explicitly enabling it for use here,
-# so we set the variable to None.
-⋮----
-def _update_tool_instructions(self) -> None
-⋮----
-# Set tool instructions and JSON format instructions,
-# in case Tools have been enabled/disabled.
-⋮----
-def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]
-⋮----
-"""
-        Returns the current set of enabled requests for inference and tools configs.
-        Used for restoring setings overriden by `set_output_format`.
-        """
-⋮----
-@property
-    def all_llm_tools_known(self) -> set[str]
-⋮----
-"""All known tools; we include `output_format` if it is a `ToolMessage`."""
-known = self.llm_tools_known
-⋮----
-"""
-        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
-        switches to the native Langroid tools mechanism to ensure that no tool
-        calls not of `output_type` are generated. By default, `force_tools`
-        follows the `use_tools_on_output_format` parameter in the config.
-
-        If `output_type` is None, restores to the state prior to setting
-        `output_format`.
-
-        If `use`, we enable use of `output_type` when it is a subclass
-        of `ToolMesage`. Note that this primarily controls instruction
-        generation: the model will always generate `output_type` regardless
-        of whether `use` is set. Defaults to the `use_output_format`
-        parameter in the config. Similarly, handling of `output_type` is
-        controlled by `handle`, which defaults to the
-        `handle_output_format` parameter in the config.
-
-        `instructions` controls whether we generate instructions specifying
-        the output format schema. Defaults to the `instructions_output_format`
-        parameter in the config.
-
-        `is_copy` is set when called via `__getitem__`. In that case, we must
-        copy certain fields to ensure that we do not overwrite the main agent's
-        setings.
-        """
-# Disable usage of an output format which was not specifically enabled
-# by `enable_message`
-⋮----
-# Disable handling of an output format which did not specifically have
-# handling enabled via `enable_message`
-⋮----
-# Reset any previous instructions
-⋮----
-force_tools = self.config.use_tools_on_output_format
-⋮----
-output_type = get_pydantic_wrapper(output_type)
-⋮----
-name = output_type.default_value("request")
-⋮----
-use = self.config.use_output_format
-⋮----
-handle = self.config.handle_output_format
-⋮----
-is_usable = name in self.llm_tools_usable.union(
-is_handled = name in self.llm_tools_handled.union(
-⋮----
-# We must copy `llm_tools_usable` so the base agent
-# is unmodified
-⋮----
-# If handling the tool, do the same for `llm_tools_handled`
-⋮----
-# Enable `output_type`
-⋮----
-# Do not override existing settings
-⋮----
-# If the `output_type` ToilMessage was not already enabled for
-# use, this means we are ONLY enabling it for use specifically
-# for enforcing this output format, so we set the
-# `enabled_use_output_forma  to this output_type, to
-# record that it should be disabled when `output_format` is changed
-⋮----
-# (same reasoning as for use-enabling)
-⋮----
-generated_tool_instructions = name in self.llm_tools_usable.union(
-⋮----
-generated_tool_instructions = False
-⋮----
-instructions = self.config.instructions_output_format
-⋮----
-# Already generated tool instructions as part of "enabling for use",
-# so only need to generate a reminder to use this tool.
-name = cast(ToolMessage, output_type).default_value("request")
-⋮----
-output_format_schema = output_type.llm_function_schema(
-⋮----
-output_format_schema = output_type.model_json_schema()
-⋮----
-def __getitem__(self, output_type: type) -> Self
-⋮----
-"""
-        Returns a (shallow) copy of `self` with a forced output type.
-        """
-clone = copy.copy(self)
-⋮----
-"""
-        Disable this agent from RESPONDING to a `message_class` (Tool). If
-            `message_class` is None, then disable this agent from responding to ALL.
-        Args:
-            message_class: The ToolMessage class to disable; Optional.
-        """
-⋮----
-"""
-        Disable this agent from USING a message class (Tool).
-        If `message_class` is None, then disable this agent from USING ALL tools.
-        Args:
-            message_class: The ToolMessage class to disable.
-                If None, disable all.
-        """
-⋮----
-def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None
-⋮----
-"""
-        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
-        Args:
-            message_class: The only ToolMessage class to allow
-        """
-request = message_class.model_fields["request"].default
-to_remove = [r for r in self.llm_tools_usable if r != request]
-⋮----
-def _load_output_format(self, message: ChatDocument) -> None
-⋮----
-"""
-        If set, attempts to parse a value of type `self.output_format` from the message
-        contents or any tool/function call and assigns it to `content_any`.
-        """
-⋮----
-any_succeeded = False
-attempts: list[str | LLMFunctionCall] = [
-⋮----
-content = json.loads(attempt)
-⋮----
-content = attempt.arguments
-⋮----
-content_any = self.output_format.model_validate(content)
-⋮----
-message.content_any = content_any.value  # type: ignore
-⋮----
-any_succeeded = True
-⋮----
-"""
-        Extracts messages and tracks whether any errors occurred. If strict mode
-        was enabled, disables it for the tool, else triggers strict recovery.
-        """
-⋮----
-most_recent_sent_by_llm = (
-was_llm = most_recent_sent_by_llm or (
-⋮----
-tools = super().get_tool_messages(msg, all_tools)
-⋮----
-# Check if tool class was attached to the exception
-⋮----
-tool_class = ve.tool_class  # type: ignore
-⋮----
-was_strict = (
-# If the result of strict output for a tool using the
-# OpenAI tools API fails to parse, we infer that the
-# schema edits necessary for compatibility prevented
-# adherence to the underlying `ToolMessage` schema and
-# disable strict output for the tool
-⋮----
-# We will trigger the strict recovery mechanism to force
-# the LLM to correct its output, allowing us to parse
-⋮----
-def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None
-⋮----
-"""
-        Returns a `ToolMessage` which wraps all enabled tools, excluding those
-        where strict recovery is disabled. Used in strict recovery.
-        """
-possible_tools = tuple(
-⋮----
-any_tool_type = Union.__getitem__(possible_tools)  # type ignore
-⋮----
-maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
-⋮----
-class AnyTool(ToolMessage)
-⋮----
-purpose: str = "To call a tool/function."
-request: str = "tool_or_function"
-tool: maybe_optional_type  # type: ignore
-⋮----
-def response(self, agent: ChatAgent) -> None | str | ChatDocument
-⋮----
-# One-time use
-⋮----
-# As the ToolMessage schema accepts invalid
-# `tool.request` values, reparse with the
-# corresponding tool
-request = self.tool.request
-⋮----
-tool = agent.llm_tools_map[request].model_validate_json(
-⋮----
-# Every call builds a distinct class; share one origin so enabling a
-# regenerated AnyTool under "tool_or_function" stays idempotent instead
-# of tripping the same-name/different-tool registration guard.
-AnyTool.__tool_message_origin__ = (  # type: ignore[attr-defined]
-⋮----
-"""Returns instructions for strict recovery."""
-optional_instructions = (
-response_prefix = "If you intended to make such a call, r" if optional else "R"
-instruction_prefix = "If you do so, b" if optional else "B"
-⋮----
-schema_instructions = (
-⋮----
-"""
-        Truncate message at idx in msg history to `tokens` tokens.
-
-        If inplace is True, the message is truncated in place, else
-        it LEAVES the original message INTACT and returns a new message
-        """
-⋮----
-llm_msg = self.message_history[idx]
-⋮----
-llm_msg = copy.deepcopy(self.message_history[idx])
-⋮----
-orig_content = llm_msg.content
-new_content = (
-⋮----
-else orig_content[: tokens * 4]  # approx truncation
-⋮----
-def _reduce_raw_tool_results(self, message: ChatDocument) -> None
-⋮----
-"""
-        If message is the result of a ToolMessage that had
-        a `_max_retained_tokens` set to a non-None value, then we replace contents
-        with a placeholder message.
-        """
-parent_message: ChatDocument | None = message.parent
-tools = [] if parent_message is None else parent_message.tool_messages
-truncate_tools = []
-⋮----
-max_retained_tokens = t._max_retained_tokens
-⋮----
-max_retained_tokens = max_retained_tokens.default
-⋮----
-limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
-⋮----
-max_retained_tokens = limiting_tool._max_retained_tokens
-⋮----
-tool_name = limiting_tool.default_value("request")
-max_tokens: int = max_retained_tokens
-truncation_warning = f"""
-⋮----
-"""
-        Respond to a single user message, appended to the message history,
-        in "chat" mode
-        Args:
-            message (str|ChatDocument): message or ChatDocument object to respond to.
-                If None, use the self.task_messages
-        Returns:
-            LLM response as a ChatDocument object
-        """
-⋮----
-# If enabled and a tool error occurred, we recover by generating the tool in
-# strict json mode
-⋮----
-AnyTool = self._get_any_tool_message()
-⋮----
-recovery_message = self._strict_recovery_instructions(AnyTool)
-augmented_message = message
-⋮----
-augmented_message = recovery_message
-⋮----
-augmented_message = augmented_message + recovery_message
-⋮----
-# only use the augmented message for this one response...
-result = self.llm_response(augmented_message)
-# ... restore the original user message so that the AnyTool recover
-# instructions don't persist in the message history
-# (this can cause the LLM to use the AnyTool directly as a tool)
-⋮----
-msg = message if isinstance(message, str) else message.content
-⋮----
-tool_choice = (
-⋮----
-response = self.llm_response_messages(hist, output_len, tool_choice)
-⋮----
-# Preserve trail of tool_ids for OpenAI Assistant fn-calls
-⋮----
-"""
-        Async version of `llm_response`. See there for details.
-        """
-⋮----
-response = await self.llm_response_messages_async(
-⋮----
-def init_message_history(self) -> None
-⋮----
-"""
-        Initialize the message history with the system message and user message
-        """
-⋮----
-"""
-        Prepare messages to be sent to self.llm_response_messages,
-            which is the main method that calls the LLM API to get a response.
-            If desired output tokens + message history exceeds the model context length,
-            then first the max output tokens is reduced to fit, and if that is not
-            possible, older messages may be truncated to accommodate at least
-            self.config.llm.min_output_tokens of output.
-
-        Returns:
-            Tuple[List[LLMMessage], int]: (messages, output_len)
-                messages = Full list of messages to send
-                output_len = max expected number of tokens in response
-        """
-⋮----
-# this means agent has been used to get LLM response already,
-# and so the last message is an "assistant" response.
-# We delete this last assistant response and re-generate it.
-⋮----
-# initial messages have not yet been loaded, so load them
-⋮----
-# for debugging, show the initial message history
-⋮----
-# update the system message with the latest tool instructions
-⋮----
-# either the message is a str, or it is a fresh ChatDocument
-# different from the last message in the history
-llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
-llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
-# Canonicalize retained whitespace-only results before token counting.
-⋮----
-# process tools if any
-done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
-⋮----
-hist = self.message_history
-output_len = self.config.llm.model_max_output_tokens
-⋮----
-# chat + output > max context length,
-# so first try to shorten requested output len to fit;
-# use an extra margin of CHAT_HISTORY_BUFFER tokens
-# in case our calcs are off (and to allow for some extra tokens)
-output_len = (
-⋮----
-# unacceptably small output len, so compress early parts of
-# conversation history based on the configured strategy
-strategy = self.config.context_overflow_strategy
-⋮----
-# Truncate content of individual messages while preserving
-# the message sequence (important for LLM APIs that require
-# alternating USER/ASSISTANT messages)
-msg_idx_to_compress = 1  # don't touch system msg
-# we will try compressing msg indices up to but not including
-# last user msg
-last_msg_idx_to_compress = (
-n_truncated = 0
-_target_tokens = (
-# Truncation floor: never reduce a message's content below
-# this many tokens.
-_min_keep_tokens = 30
-_truncation_warning = "... [Contents truncated!]"
-⋮----
-def _content_tokens(text: str | None) -> int
-⋮----
-"""Token count of message *content* only.
-
-                        `truncate_message` only trims `message.content`, so
-                        using the full `_message_num_tokens` (which includes
-                        attachment payloads) would inflate the count and make
-                        the keep-target too large to ever converge, for
-                        messages carrying file attachments.
-                        """
-⋮----
-# approx fallback, matches truncate_message
-⋮----
-# Account for the warning that truncate_message appends
-# ("\n" + warning), so the final token count of a
-# truncated message does not exceed its keep-target.
-_warning_tokens = _content_tokens("\n" + _truncation_warning)
-# NOTE: loop termination is guaranteed:
-# msg_idx_to_compress strictly increases every iteration
-# (truncate or skip), and once it exceeds
-# last_msg_idx_to_compress a ValueError is raised. (The
-# token count need not decrease every iteration, so
-# termination rests on the index advancing.)
-⋮----
-# We want to preserve the first message (typically
-# system msg) and last message (user msg).
-⋮----
-_msg_tokens = _content_tokens(hist[msg_idx_to_compress].content)
-⋮----
-# Truncating this message cannot shrink the total:
-# its content is already at/below the keep-floor
-# plus the appended warning; leave it intact.
-⋮----
-# Distribute the current excess evenly across the
-# remaining *compressible* messages, so each retains
-# as much content as possible instead of being
-# collapsed to the fixed 30-token floor. The excess is
-# recomputed every iteration, so the distribution
-# self-corrects as we move forward through the
-# history.
-_current_excess = self.chat_num_tokens(hist) - _target_tokens
-# Shrink capacity of each *later* message in the
-# compressible range: its content above the floor (net
-# of the appended warning). Non-positive entries are
-# the tiny messages the skip-check above will leave
-# untouched; they must not dilute the even share, so
-# only messages with positive capacity count toward
-# the denominator (plus this message, which passed the
-# skip-check and is therefore compressible).
-_later_capacities = [
-_n_remaining = 1 + sum(1 for c in _later_capacities if c > 0)
-_even_share = math.ceil(_current_excess / _n_remaining)
-# Later messages can shed at most their capacity; this
-# message must absorb whatever they cannot, so that
-# this single forward pass reaches the target whenever
-# that is possible at all.
-_later_capacity = sum(c for c in _later_capacities if c > 0)
-_reduction = max(_even_share, _current_excess - _later_capacity)
-# Extra 2-token slack: re-encoding truncated content
-# plus the appended warning can merge/split tokens at
-# the boundary, so aim slightly below the target to
-# keep the achieved reduction from falling short.
-_keep_tokens = max(
-# compress the msg at idx `msg_idx_to_compress`
-⋮----
-output_len = min(
-⋮----
-# we MUST have truncated at least one msg
-msg_tokens = self.chat_num_tokens()
-⋮----
-else:  # strategy == "drop_turns"
-# Drop complete conversation turns. A complete turn is defined
-# as a USER message followed by all messages until the next
-# USER message. This is more aggressive but cleaner for voice
-# agents with limited context.
-n_dropped_turns = 0
-⋮----
-# Find the last USER message index
-last_user_idx = self.last_message_idx_with_role(role=Role.USER)
-⋮----
-# Find the first complete turn to drop (skip system message)
-first_user_idx = -1
-⋮----
-first_user_idx = i
-⋮----
-# Find the end of this turn: last message before next USER
-next_user_idx = -1
-⋮----
-next_user_idx = i
-⋮----
-# Drop the turn
-⋮----
-# we MUST have dropped at least one turn
-⋮----
-# record the position of the corresponding LLMMessage in
-# the message_history
-⋮----
-"""
-        Get function/tool spec/output format arguments for
-        OpenAI-compatible LLM API call
-        """
-functions: Optional[List[LLMFunctionSpec]] = None
-fun_call: str | Dict[str, str] = "none"
-tools: Optional[List[OpenAIToolSpec]] = None
-force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
-⋮----
-functions = [
-fun_call = (
-⋮----
-def to_maybe_strict_spec(function: str) -> OpenAIToolSpec
-⋮----
-spec = self.llm_functions_map[function]
-strict = self._strict_mode_for_tool(function)
-⋮----
-strict_spec = copy.deepcopy(spec)
-⋮----
-strict_spec = spec
-⋮----
-tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
-force_tool = (
-output_format = None
-⋮----
-spec = self.output_format.llm_function_schema(
-⋮----
-output_format = OpenAIJsonSchemaSpec(
-⋮----
-# We always require that outputs strictly match the schema
-⋮----
-param_spec = self.output_format.model_json_schema()
-⋮----
-"""
-        Respond to a series of messages, e.g. with OpenAI ChatCompletion
-        Args:
-            messages: seq of messages (with role, content fields) sent to LLM
-            output_len: max number of tokens expected in response.
-                    If None, use the LLM's default model_max_output_tokens.
-        Returns:
-            Document (i.e. with fields "content", "metadata")
-        """
-⋮----
-output_len = output_len or self.config.llm.model_max_output_tokens
-streamer = noop_fn
-⋮----
-streamer = self.callbacks.start_llm_stream()
-⋮----
-with ExitStack() as stack:  # for conditionally using rich spinner
-⋮----
-# show rich spinner only if not streaming!
-# (Why? b/c the intent of showing a spinner is to "show progress",
-# and we don't need to do that when streaming, since
-# streaming output already shows progress.)
-cm = status(
-⋮----
-response = self.llm.chat(
-⋮----
-# Create temp ChatDocument for tool check, then clean up to avoid
-# polluting ObjectRegistry (see PR #939 discussion)
-temp_doc = ChatDocument.from_LLMResponse(
-⋮----
-response,  # .usage attrib is updated!
-⋮----
-chat_doc = ChatDocument.from_LLMResponse(
-⋮----
-# If using strict output format, parse the output JSON
-⋮----
-"""
-        Async version of `llm_response_messages`. See there for details.
-        """
-⋮----
-streamer_async = async_noop_fn
-⋮----
-streamer_async = await self.callbacks.start_llm_stream_async()
-⋮----
-response = await self.llm.achat(
-⋮----
-"""
-        Call a callback method, only passing 'reasoning' if it accepts it.
-
-        This provides backward compatibility for custom callbacks that don't
-        have the 'reasoning' parameter in their signature.
-
-        Args:
-            callback_name: Name of the callback method (e.g., 'show_llm_response')
-            reasoning: The reasoning content to pass if supported
-            **kwargs: Other arguments to pass to the callback
-        """
-callback = getattr(self.callbacks, callback_name, None)
-⋮----
-# Check if callback accepts 'reasoning' param or **kwargs
-⋮----
-sig = inspect.signature(callback)
-params = sig.parameters
-accepts_reasoning = "reasoning" in params or any(
-⋮----
-# If we can't inspect the signature, assume it doesn't accept reasoning
-accepts_reasoning = False
-⋮----
-is_cached = (
-⋮----
-# We would have already displayed the msg "live" ONLY if
-# streaming was enabled, AND we did not find a cached response.
-# If we are here, it means the response has not yet been displayed.
-cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
-# Track whether we created a temp ChatDocument for cleanup
-is_temp_doc = isinstance(response, LLMResponse)
-chat_doc = (
-# TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
-⋮----
-content = response.message or ""
-tools_content = response.tools_content()
-⋮----
-content = response.content
-tools_content = ""
-reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
-⋮----
-# Clean up temp ChatDocument to avoid polluting ObjectRegistry
-⋮----
-# we are in the context immediately after an LLM responded,
-# we won't have citations yet, so we're done
-⋮----
-citation = (
-⋮----
-reasoning="",  # Citations don't have reasoning
-⋮----
-def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument
-⋮----
-"""
-        Get LLM response to `prompt` (which presumably includes the `message`
-        somewhere, along with possible large "context" passages),
-        but only include `message` as the USER message, and not the
-        full `prompt`, in the message history.
-        Args:
-            message: the original, relatively short, user request or query
-            prompt: the full prompt potentially containing `message` plus context
-
-        Returns:
-            Document object containing the response.
-        """
-# we explicitly call THIS class's respond method,
-# not a derived class's (or else there would be infinite recursion!)
-with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
-⋮----
-"""
-        Async version of `_llm_response_temp_context`. See there for details.
-        """
-⋮----
-answer_doc = cast(
-⋮----
-"""
-        LLM Response to single message, and restore message_history.
-        In effect a "one-off" message & response that leaves agent
-        message history state intact.
-
-        Args:
-            message (str|ChatDocument): message to respond to.
-
-        Returns:
-            A Document object with the response.
-
-        """
-# explicitly call THIS class's respond method,
-⋮----
-n_msgs = len(self.message_history)
-⋮----
-response = cast(ChatDocument, ChatAgent.llm_response(self, message))
-# If there is a response, then we will have two additional
-# messages in the message history, i.e. the user message and the
-# assistant response. We want to (carefully) remove these two messages.
-⋮----
-msg = self.message_history.pop()
-⋮----
-"""
-        Async version of `llm_response_forget`. See there for details.
-        """
-⋮----
-response = cast(
-⋮----
-def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int
-⋮----
-"""
-        Total number of tokens in the message history so far.
-
-        Args:
-            messages: if provided, compute the number of tokens in this list of
-                messages, rather than the current message history.
-        Returns:
-            int: number of tokens in message history
-        """
-⋮----
-hist = messages if messages is not None else self.message_history
-⋮----
-def _message_num_tokens(self, message: LLMMessage) -> int
-⋮----
-"""Count tokens for a message, including serialized user attachments."""
-⋮----
-def _attachment_num_tokens(self, message: LLMMessage) -> int
-⋮----
-"""
-        Estimate attachment contribution using the serialized payload
-        that is sent in the API request for user messages.
-        """
-⋮----
-model = self._chat_model_name_for_attachments()
-⋮----
-def _chat_model_name_for_attachments(self) -> str
-⋮----
-"""Return the model name used for attachment serialization."""
-⋮----
-def message_history_str(self, i: Optional[int] = None) -> str
-⋮----
-"""
-        Return a string representation of the message history
-        Args:
-            i: if provided, return only the i-th message when i is postive,
-                or last k messages when i = -k.
-        Returns:
-        """
-⋮----
-def __del__(self) -> None
-⋮----
-"""
-        Cleanup method called when the ChatAgent is garbage collected.
-        Note: We don't close LLM clients here because they may be shared
-        across multiple agents when client caching is enabled.
-        The clients are managed centrally and cleaned up via atexit hooks.
-        """
-# Previously we closed clients here, but this caused issues when
-# multiple agents shared the same cached client instance.
-# Clients are now managed centrally in langroid.language_models.client_cache
-</file>
-
 <file path="langroid/language_models/openai_gpt.py">
 OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
 ⋮----
@@ -76588,13 +75045,1656 @@ response_dict = response.model_dump()
 cached, hashed_key, response = await self._achat_completions_with_backoff(  # type: ignore
 </file>
 
+<file path="tests/main/test_llm.py">
+# allow streaming globally, but can be turned off by individual models
+⋮----
+@pytest.mark.parametrize("use_cache", [True, False])
+def test_openai_gpt(test_settings: Settings, streaming, country, capital, use_cache)
+⋮----
+test_settings.cache = False  # cache response but don't retrieve from cache
+⋮----
+cfg = OpenAIGPTConfig(
+⋮----
+stream=streaming,  # use streaming output if enabled globally
+⋮----
+mdl = OpenAIGPT(config=cfg)
+question = "What is the capital of " + country + "?"
+# chat mode via `generate`,
+# i.e. use same call as for completion, but the setting below
+# actually calls `chat` under the hood
+⋮----
+# check that "generate" works when "use_chat_for_completion" is True
+response = mdl.generate(prompt=question, max_tokens=800)
+⋮----
+# actual chat mode
+messages = [
+response = mdl.chat(messages=messages, max_tokens=500)
+⋮----
+# should be from cache this time, Provided config.cache_config is not None
+⋮----
+# pass intentional bad msg to test error handling
+⋮----
+_ = mdl.chat(messages=messages, max_tokens=500)
+⋮----
+def _test_context_length_error(test_settings: Settings, mode: str, max_tokens: int)
+⋮----
+"""
+    Test disabled, see TODO below.
+    Also it takes too long since we are trying to test
+    that it raises the expected error when the context length is exceeded.
+    Args:
+        test_settings: from conftest.py
+        mode: "completion" or "chat"
+        max_tokens: number of tokens to generate
+    """
+⋮----
+parser = Parser(config=ParsingConfig())
+llm = OpenAIGPT(config=cfg)
+context_length = (
+⋮----
+toks_per_sentence = int(parser.num_tokens(generate_random_sentences(1000)) / 1000)
+max_sentences = int(context_length * 1.5 / toks_per_sentence)
+big_message = generate_random_sentences(max_sentences + 1)
+big_message_tokens = parser.num_tokens(big_message)
+⋮----
+response = None
+# TODO need to figure out what error type to expect here
+⋮----
+response = llm.chat(big_message, max_tokens=max_tokens)
+⋮----
+response = llm.generate(prompt=big_message, max_tokens=max_tokens)
+⋮----
+@pytest.mark.parametrize("ctx", [16_000, None])
+def test_llm_config_context_length(mdl: str, ctx: int | None)
+⋮----
+llm_config = lm.OpenAIGPTConfig(
+⋮----
+chat_context_length=ctx,  # even if wrong, use if explicitly set
+⋮----
+mdl = lm.OpenAIGPT(config=llm_config)
+⋮----
+alias_llm = lm.OpenAIGPT(config=lm.OpenAIGPTConfig(chat_model=alias_model))
+canonical_llm = lm.OpenAIGPT(config=lm.OpenAIGPTConfig(chat_model=canonical_model))
+⋮----
+def test_get_model_info_warns_on_unknown_models() -> None
+⋮----
+model_name = "gemini/gemini-999-unknown-preview"
+# Ensure this model hasn't been warned about in a prior test so the
+# warning actually fires.  The cache key is a tuple of the full model
+# strings passed to _warn_unknown_model (i.e. with the provider prefix).
+⋮----
+handler = logging.handlers.MemoryHandler(capacity=100)
+logger = logging.getLogger("langroid.language_models.model_info")
+⋮----
+# Call twice: every lookup of an unknown model must return the
+# fallback-default ModelInfo, but the warning must fire only once
+# (deduped via WARNED_UNKNOWN_MODELS).
+first_info = get_model_info(model_name)
+second_info = get_model_info(model_name)
+⋮----
+messages = [record.getMessage() for record in handler.buffer]
+matching = [
+⋮----
+def test_model_selection(test_settings: Settings)
+⋮----
+defaultOpenAIChatModel = lr.language_models.openai_gpt.default_openai_chat_model
+⋮----
+def get_response(llm)
+⋮----
+def simulate_response(llm)
+⋮----
+# Default is GPT4o; we should not generate the warning in this case
+⋮----
+llm = OpenAIGPT(config=OpenAIGPTConfig(chat_model=OpenAIChatModel.GPT3_5_TURBO))
+⋮----
+llm = OpenAIGPT(config=OpenAIGPTConfig())
+⋮----
+# Default is GPT3.5 (simulate GPT 4 inaccessible)
+⋮----
+# No warnings generated if we specify the model explicitly
+⋮----
+# No warnings generated if we are using a local model
+llm = OpenAIGPT(config=OpenAIGPTConfig(api_base="localhost:8000"))
+⋮----
+llm = OpenAIGPT(config=OpenAIGPTConfig(chat_model="local/localhost:8000"))
+⋮----
+llm = OpenAIGPT(config=OpenAIGPTConfig(chat_model="litellm/ollama/llama"))
+⋮----
+# We should warn on the first usage of a model with auto-selected GPT-3.5
+⋮----
+# We should not warn on subsequent uses and models with auto-selected GPT-3.5
+⋮----
+def test_keys()
+⋮----
+# Do not override the explicit settings below
+⋮----
+providers = [
+key_dict = {p: f"{p.upper()}_API_KEY" for p in providers}
+⋮----
+config = lm.OpenAIGPTConfig(
+⋮----
+llm = lm.OpenAIGPT(config)
+⋮----
+rand_key = str(random.randint(0, 10**9))
+⋮----
+def test_llm_langdb(model: str)
+⋮----
+"""Test that LLM access via LangDB works."""
+# override any chat model passed via --m arg to pytest cmd
+⋮----
+llm_config_langdb = lm.OpenAIGPTConfig(
+llm = lm.OpenAIGPT(config=llm_config_langdb)
+result = llm.chat("what is 3+4?")
+⋮----
+def test_llm_openrouter(model: str)
+⋮----
+llm = lm.OpenAIGPT(config=llm_config)
+⋮----
+def test_llm_portkey(model: str)
+⋮----
+"""Test that LLM access via Portkey works."""
+⋮----
+# Skip if PORTKEY_API_KEY is not set
+⋮----
+# Extract provider from model string
+provider = model.split("/")[1] if "/" in model else ""
+provider_key_var = f"{provider.upper()}_API_KEY"
+⋮----
+# Skip if provider API key is not set
+⋮----
+llm_config_portkey = lm.OpenAIGPTConfig(
+llm = lm.OpenAIGPT(config=llm_config_portkey)
+result = llm.chat("what is 3+4 equal to?")
+⋮----
+def test_portkey_params()
+⋮----
+"""Test that PortkeyParams are correctly configured."""
+⋮----
+# Test with explicit parameters
+params = PortkeyParams(
+⋮----
+headers = params.get_headers()
+⋮----
+# Test model string parsing
+⋮----
+# Test fallback parsing
+⋮----
+# Test provider API key retrieval
+⋮----
+key = params.get_provider_api_key("test_provider")
+⋮----
+def test_portkey_integration()
+⋮----
+"""Test that Portkey integration is properly configured in OpenAIGPT."""
+⋮----
+# Save the current chat model setting
+original_chat_model = settings.chat_model
+⋮----
+# Clear any global chat model override
+⋮----
+# Test basic portkey model configuration
+⋮----
+# Check that model was parsed correctly
+⋮----
+# Check headers are set correctly
+⋮----
+# Restore original chat model setting
+⋮----
+def test_gemini_api_base()
+⋮----
+"""Test that Gemini api_base is configurable for Vertex AI support."""
+⋮----
+# Save and clear env vars that could interfere
+saved_openai_api_base = os.environ.pop("OPENAI_API_BASE", None)
+saved_gemini_api_base = os.environ.pop("GEMINI_API_BASE", None)
+⋮----
+# Default: api_base should be GEMINI_BASE_URL
+⋮----
+# Custom api_base: should override default (e.g. Vertex AI endpoint)
+vertex_url = "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project/locations/us-central1/endpoints/openapi"
+⋮----
+# Empty string api_base: should fall back to default
+⋮----
+# None api_base: should fall back to default
+⋮----
+# OPENAI_API_BASE env var should NOT leak into Gemini api_base
+⋮----
+# GEMINI_API_BASE env var should be used (e.g. Vertex AI)
+⋮----
+# GEMINI_API_BASE should take priority over OPENAI_API_BASE
+⋮----
+# Restore original env vars
+⋮----
+def test_gemini_google_prefix(monkeypatch)
+⋮----
+"""`google/`-prefixed Gemini models route to the Gemini API (issue #995)."""
+⋮----
+llm = lm.OpenAIGPT(lm.OpenAIGPTConfig(chat_model=chat_model))
+⋮----
+def test_gemini_ignores_last_case_variant_openai_api_base(monkeypatch)
+⋮----
+"""Gemini routing follows pydantic's last-wins env case normalization."""
+⋮----
+llm = lm.OpenAIGPT(lm.OpenAIGPTConfig(chat_model="google/gemini-2.0-flash"))
+⋮----
+def test_non_gemini_google_model_is_not_rerouted(monkeypatch, chat_model)
+⋮----
+"""Non-Gemini Google models retain caller routing and credentials."""
+⋮----
+caller_api_key = "caller-api-key"
+⋮----
+llm = lm.OpenAIGPT(
+⋮----
+"""Gemini aliases retain an explicitly configured API base."""
+⋮----
+expected_model = (
+⋮----
+def test_gemini_model_copy_preserves_explicit_api_base(monkeypatch, chat_model)
+⋮----
+"""Gemini configs copied with an API base retain the caller endpoint."""
+⋮----
+custom_base = "https://caller.example/v1"
+config = lm.OpenAIGPTConfig(chat_model=chat_model).model_copy(
+⋮----
+def test_gemini_assignment_preserves_explicit_api_base(monkeypatch, chat_model)
+⋮----
+"""Gemini configs assigned an API base retain the caller endpoint."""
+⋮----
+config = lm.OpenAIGPTConfig(chat_model=chat_model)
+⋮----
+def test_gemini_dynamic_config_preserves_api_base(monkeypatch)
+⋮----
+"""Dynamically prefixed Gemini settings retain their API base."""
+⋮----
+vertex_config = lm.OpenAIGPTConfig.create("vertex")
+⋮----
+llm = lm.OpenAIGPT(vertex_config(chat_model="google/gemini-2.0-flash"))
+⋮----
+def test_followup_standalone()
+⋮----
+"""Test that followup_to_standalone works."""
+⋮----
+llm = OpenAIGPT(OpenAIGPTConfig())
+dialog = [
+followup = "What about 11?"
+response = llm.followup_to_standalone(dialog, followup)
+⋮----
+def test_llm_pdf_attachment()
+⋮----
+"""Test sending a PDF file attachment to the LLM."""
+⋮----
+# Path to the test PDF file
+pdf_path = Path("tests/main/data/dummy.pdf")
+⋮----
+# Create a FileAttachment from the PDF file
+attachment = FileAttachment.from_path(pdf_path)
+⋮----
+# Verify the attachment properties
+⋮----
+# Create messages with the attachment
+⋮----
+# Set up the LLM with a suitable model that supports PDFs
+llm = OpenAIGPT(OpenAIGPTConfig(max_output_tokens=1000))
+⋮----
+# Get response from the LLM
+response = llm.chat(messages=messages)
+⋮----
+# follow-up question
+⋮----
+def test_llm_multi_pdf_attachments()
+⋮----
+# multiple attachments
+pdf_path2 = Path("tests/main/data/sample-test.pdf")
+⋮----
+attachment2 = FileAttachment.from_path(pdf_path2)
+⋮----
+def test_llm_pdf_bytes_and_split()
+⋮----
+"""Test sending PDF files to LLM as bytes and split into pages."""
+⋮----
+# Test creating attachment from bytes
+⋮----
+pdf_bytes = f.read()
+⋮----
+attachment_from_bytes = FileAttachment.from_bytes(
+⋮----
+llm = OpenAIGPT(OpenAIGPTConfig(max_output_tokens=100))
+⋮----
+# Test creating attachment from file-like object
+pdf_io = io.BytesIO(pdf_bytes)
+attachment_from_io = FileAttachment.from_io(
+⋮----
+# Test splitting PDF into pages and sending individual pages
+⋮----
+doc = fitz.open(pdf_path)
+page_attachments = []
+⋮----
+# Extract page as PDF
+page_pdf = io.BytesIO()
+page_doc = fitz.open()
+⋮----
+# Create attachment for this page
+page_attachment = FileAttachment.from_io(
+⋮----
+# Send just the first page
+⋮----
+# Test with multiple pages as separate attachments
+⋮----
+def test_llm_image_input(path: str)
+⋮----
+attachment = FileAttachment.from_path(path, detail="low")
+⋮----
+llm = OpenAIGPT(OpenAIGPTConfig(max_output_tokens=500))
+⋮----
+def test_litellm_model_key()
+⋮----
+"""
+    Test that passing in explicit api_key works with `litellm/*` models
+    """
+model = "litellm/anthropic/claude-3-5-haiku-latest"
+# disable any chat model passed via --m arg to pytest cmd
+⋮----
+class CustomOpenAIGPTConfig(lm.OpenAIGPTConfig)
+⋮----
+"""OpenAI config that doesn't auto-load from environment variables."""
+⋮----
+# Disable environment prefix to prevent auto-loading
+model_config = SettingsConfigDict(env_prefix="")
+⋮----
+llm_config = CustomOpenAIGPTConfig(
+⋮----
+response = llm.chat("What is 3+4?")
+</file>
+
 <file path=".pre-commit-config.yaml">
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.16.0
+  rev: v0.16.4
   hooks:
     - id: ruff
+</file>
+
+<file path="langroid/agent/chat_agent.py">
+console = Console()
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+# Stable origin sentinel for the dynamically generated strict-recovery AnyTool
+# class ("tool_or_function"): a fresh class is built per call (its tool-union
+# type varies), so re-registration must be recognized as the same logical tool.
+_ANY_TOOL_MESSAGE_ORIGIN: Any = object()
+⋮----
+# Safety margin (in tokens) subtracted from the model context length when
+# shrinking chat history and/or the requested output length to fit, in case
+# our token-count estimates are off.
+CHAT_HISTORY_BUFFER = 300
+⋮----
+def _reject_json_constant(constant: str) -> None
+⋮----
+"""Reject JavaScript numeric constants that are not valid JSON."""
+⋮----
+def _parse_json_float(value: str) -> float
+⋮----
+"""Parse a JSON float while rejecting exponent overflow."""
+parsed = float(value)
+⋮----
+def _is_identified_result(message: LLMMessage) -> bool
+⋮----
+"""Whether a TOOL/FUNCTION result has its identifier and no call payload.
+
+    Such results must survive even with empty content so their calls can be
+    marked complete (issue #1063).
+    """
+has_identifier = (
+⋮----
+def _llm_message_has_payload(message: LLMMessage) -> bool
+⋮----
+"""Whether a message has the fields required for a valid history entry."""
+⋮----
+class ChatAgentConfig(AgentConfig)
+⋮----
+"""
+    Configuration for ChatAgent
+
+    Attributes:
+        system_message: system message to include in message sequence
+             (typically defines role and task of agent).
+             Used only if `task` is not specified in the constructor.
+        user_message: user message to include in message sequence.
+             Used only if `task` is not specified in the constructor.
+        use_tools: whether to use our own ToolMessages mechanism
+        handle_llm_no_tool (Any): desired agent_response when
+            LLM generates non-tool msg.
+        use_functions_api: whether to use functions/tools native to the LLM API
+                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
+        use_tools_api: When `use_functions_api` is True, if this is also True,
+            the OpenAI tool-call API is used, rather than the older/deprecated
+            function-call API. However the tool-call API has some tricky aspects,
+            hence we set this to False by default.
+        strict_recovery: whether to enable strict schema recovery when there
+            is a tool-generation error.
+        enable_orchestration_tool_handling: whether to enable handling of orchestration
+            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
+        output_format: When supported by the LLM (certain OpenAI LLMs
+            and local LLMs served by providers such as vLLM), ensures
+            that the output is a JSON matching the corresponding
+            schema via grammar-based decoding
+        handle_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for handling".
+        use_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for use" (by LLM) and
+            instructions on using T are added to the system message.
+        instructions_output_format: Controls whether we generate instructions for
+            `output_format` in the system message.
+        use_tools_on_output_format: Controls whether to automatically switch
+            to the Langroid-native tools mechanism when `output_format` is set.
+            Note that LLMs may generate tool calls which do not belong to
+            `output_format` even when strict JSON mode is enabled, so this should be
+            enabled when such tool calls are not desired.
+        output_format_include_defaults: Whether to include fields with default arguments
+            in the output schema
+        full_citations: Whether to show source reference citation + content for each
+            citation, or just the main reference citation.
+        search_for_tools_everywhere: Whether to search for tools everywhere,
+            or only in specific LLM response elements based on use_tools /
+            use_functions_api / use_tools_api config settings.
+        recognize_recipient_in_content: Whether to parse LLM response text content
+            for recipient routing patterns, specifically:
+            - ``TO[<recipient>]:<content>`` addressing format, and
+            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
+            When False, only structured routing via function_call/tool_call
+            ``recipient`` fields is recognized. Default is True.
+            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
+            which controls Task-level signals like DONE, PASS, and SEND_TO.
+            To fully disable all text-based routing, set both to False.
+        context_overflow_strategy: Strategy for handling context overflow when
+            message history exceeds model context length. Options:
+            - "truncate": Truncate content of early messages (preserves all messages
+              but with shortened content). This maintains the message sequence.
+            - "drop_turns": Drop complete conversation turns (USER + all responses
+              until next USER). More aggressive but cleaner for voice agents.
+            Default is "truncate" for backward compatibility.
+    """
+⋮----
+system_message: str = "You are a helpful assistant."
+user_message: Optional[str] = None
+handle_llm_no_tool: Any = None
+use_tools: bool = True
+use_functions_api: bool = False
+use_tools_api: bool = True
+strict_recovery: bool = True
+enable_orchestration_tool_handling: bool = True
+output_format: Optional[type] = None
+handle_output_format: bool = True
+use_output_format: bool = True
+instructions_output_format: bool = True
+output_format_include_defaults: bool = True
+use_tools_on_output_format: bool = True
+full_citations: bool = True  # show source + content for each citation?
+search_for_tools_everywhere: bool = True
+recognize_recipient_in_content: bool = True
+context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
+⋮----
+def _set_fn_or_tools(self) -> None
+⋮----
+"""
+        Enable Langroid Tool or OpenAI-like fn-calling,
+        depending on config settings.
+        """
+⋮----
+class ChatAgent(Agent)
+⋮----
+"""
+    Chat Agent interacting with external env
+    (could be human, or external tools).
+    The agent (the LLM actually) is provided with an optional "Task Spec",
+    which is a sequence of `LLMMessage`s. These are used to initialize
+    the `task_messages` of the agent.
+    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
+    The `Agent` class mainly exists to hold various common methods and attributes.
+    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
+    `llm_response` method uses "chat mode" API (i.e. one that takes a
+    message sequence rather than a single message),
+    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
+    that takes a single message).
+    """
+⋮----
+"""
+        Chat-mode agent initialized with task spec as the initial message sequence
+        Args:
+            config: settings for the agent
+
+        """
+⋮----
+# emit the attachment-token-estimate warning at most once per agent
+⋮----
+# An agent's "task" is defined by a system msg and an optional user msg;
+# These are "priming" messages that kick off the agent's conversation.
+⋮----
+# if task contains a system msg, we override the config system msg
+⋮----
+# if task contains a user msg, we override the config user msg
+⋮----
+# system-level instructions for using tools/functions:
+# We maintain these as tools/functions are enabled/disabled,
+# and whenever an LLM response is sought, these are used to
+# recreate the system message (via `_create_system_and_tools_message`)
+# each time, so it reflects the current set of enabled tools/functions.
+# (a) these are general instructions on using certain tools/functions,
+#   if they are specified in a ToolMessage class as a classmethod `instructions`
+⋮----
+# (b) these are only for the builtin in Langroid TOOLS mechanism:
+⋮----
+# This variable is not None and equals a `ToolMessage` T, if and only if:
+# (a) T has been set as the output_format of this agent, AND
+# (b) T has been "enabled for use" ONLY for enforcing this output format, AND
+# (c) T has NOT been explicitly "enabled for use" by this Agent.
+⋮----
+# As above but deals with "enabled for handling" instead of "enabled for use".
+⋮----
+# instructions specifically related to enforcing `output_format`
+⋮----
+# controls whether to disable strict schemas for this agent if
+# strict mode causes exception
+⋮----
+# Tracks whether any strict tool is enabled; used to determine whether to set
+# `self.disable_strict` on an exception
+⋮----
+# Tracks the set of tools on which we force-disable strict decoding
+⋮----
+# search for tools according to the agent configuration
+⋮----
+# Only enable HANDLING by `agent_response`, NOT LLM generation of these.
+# This is useful where tool-handlers or agent_response generate these
+# tools, and need to be handled.
+# We don't want enable orch tool GENERATION by default, since that
+# might clutter-up the LLM system message unnecessarily.
+⋮----
+def init_state(self) -> None
+⋮----
+"""
+        Initialize the state of the agent. Just conversation state here,
+        but subclasses can override this to initialize other state.
+        """
+⋮----
+@staticmethod
+    def from_id(id: str) -> "ChatAgent"
+⋮----
+"""
+        Get an agent from its ID
+        Args:
+            agent_id (str): ID of the agent
+        Returns:
+            ChatAgent: The agent with the given ID
+        """
+⋮----
+def clone(self, i: int = 0) -> "ChatAgent"
+⋮----
+"""Create i'th clone of this agent, ensuring tool use/handling is cloned.
+        Important: We assume all member variables are in the __init__ method here
+        and in the Agent class.
+        TODO: We are attempting to clone an agent after its state has been
+        changed in possibly many ways. Below is an imperfect solution. Caution advised.
+        Revisit later.
+        """
+agent_cls = type(self)
+# Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
+# instead of deepcopy which loses subclass information
+config_copy = self.config.model_copy(deep=True)
+⋮----
+new_agent = agent_cls(config_copy)
+⋮----
+# Ensure each clone gets its own vecdb client when supported.
+⋮----
+def _clone_extra_state(self, new_agent: "ChatAgent") -> None
+⋮----
+"""Hook for subclasses to copy additional state into clones."""
+⋮----
+def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool
+⋮----
+"""Should we enable strict mode for a given tool?"""
+⋮----
+tool_class = self.llm_tools_map[tool]
+⋮----
+tool_class = tool
+name = tool_class.default_value("request")
+⋮----
+strict: Optional[bool] = tool_class.default_value("strict")
+⋮----
+strict = self._strict_tools_available()
+⋮----
+def _fn_call_available(self) -> bool
+⋮----
+"""Does this agent's LLM support function calling?"""
+⋮----
+def _strict_tools_available(self) -> bool
+⋮----
+"""Does this agent's LLM support strict tools?"""
+⋮----
+def _json_schema_available(self) -> bool
+⋮----
+"""Does this agent's LLM support strict JSON schema output format?"""
+⋮----
+def set_system_message(self, msg: str) -> None
+⋮----
+# if there is message history, update the system message in it
+⋮----
+def set_user_message(self, msg: str) -> None
+⋮----
+@property
+    def task_messages(self) -> List[LLMMessage]
+⋮----
+"""
+        The task messages are the initial messages that define the task
+        of the agent. There will be at least a system message plus possibly a user msg.
+        Returns:
+            List[LLMMessage]: the task messages
+        """
+msgs = [self._create_system_and_tools_message()]
+⋮----
+def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None
+⋮----
+id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
+⋮----
+# dropping tool result, so ADD the corresponding tool-call back
+# to the list of pending calls!
+id = msg.tool_call_id
+⋮----
+# dropping a msg with tool-calls, so DROP these from pending list
+# as well as from id -> call map
+⋮----
+def clear_history(self, start: int = -2, end: int = -1) -> None
+⋮----
+"""
+        Clear the message history, deleting  messages from index `start`,
+        up to index `end`.
+
+        Args:
+            start (int): index of first message to delete; default = -2
+                    (i.e. delete last 2 messages, typically these
+                    are the last user and assistant messages)
+            end (int): index of last message to delete; Default = -1
+                    (i.e. delete all messages up to the last one)
+        """
+n = len(self.message_history)
+⋮----
+start = max(0, n + start)
+end_ = n if end == -1 else end + 1
+dropped = self.message_history[start:end_]
+# consider the dropped msgs in REVERSE order, so we are
+# carefully updating self.oai_tool_calls
+⋮----
+# clear out the chat document from the ObjectRegistry
+⋮----
+def update_history(self, message: str, response: str) -> None
+⋮----
+"""
+        Update the message history with the latest user message and LLM response.
+        Args:
+            message (str): user message
+            response: (str): LLM response
+        """
+⋮----
+def export_history(self) -> str
+⋮----
+"""Export message history as a portable, versioned JSON snapshot.
+
+        Returns:
+            A JSON string containing the current message history.
+        """
+messages: List[Dict[str, Any]] = []
+⋮----
+data = message.model_dump(mode="json", exclude={"files"})
+⋮----
+"""Restore message history from :meth:`export_history` output.
+
+        Args:
+            snapshot: Versioned JSON snapshot to restore.
+            max_size_bytes: Maximum total decoded attachment size. Defaults to
+                100 MiB.
+
+        Raises:
+            ValueError: If the snapshot is malformed, has an unknown version,
+                starts with a non-system message, or exceeds ``max_size_bytes``.
+        """
+⋮----
+payload = json.loads(
+⋮----
+raw_messages = payload.get("messages")
+⋮----
+messages: List[LLMMessage] = []
+total_attachment_bytes = 0
+⋮----
+message_data = dict(raw_message)
+raw_files = message_data.get("files", [])
+⋮----
+files = []
+⋮----
+file_data = dict(raw_file)
+encoded_content = file_data.pop("content_base64")
+⋮----
+encoded_bytes = encoded_content.encode("ascii")
+padding = len(encoded_bytes) - len(encoded_bytes.rstrip(b"="))
+decoded_size = max(
+⋮----
+content = base64.b64decode(encoded_bytes, validate=True)
+⋮----
+seen_call_ids: Set[str] = set()
+⋮----
+name = message.name
+⋮----
+call_id = call.id
+⋮----
+all_calls = {
+completed_call_ids = {
+old_chat_document_ids = {
+⋮----
+def tool_format_rules(self) -> str
+⋮----
+"""
+        Specification of tool formatting rules
+        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
+        based on the currently enabled usable `ToolMessage`s
+
+        Returns:
+            str: formatting rules
+        """
+# ONLY Usable tools (i.e. LLM-generation allowed),
+usable_tool_classes: List[Type[ToolMessage]] = [
+⋮----
+format_instructions = "\n\n".join(
+# if any of the enabled classes has json_group_instructions, then use that,
+# else fall back to ToolMessage.json_group_instructions
+⋮----
+def tool_instructions(self) -> str
+⋮----
+"""
+        Instructions for tools or function-calls, for enabled and usable Tools.
+        These are inserted into system prompt regardless of whether we are using
+        our own ToolMessage mechanism or the LLM's function-call mechanism.
+
+        Returns:
+            str: concatenation of instructions for all usable tools
+        """
+enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
+⋮----
+instructions = []
+⋮----
+class_instructions = ""
+⋮----
+class_instructions = msg_cls.instructions()
+⋮----
+# example will be shown in tool_format_rules() when using TOOLs,
+# so we don't need to show it here.
+example = "" if self.config.use_tools else (msg_cls.usage_examples())
+⋮----
+example = "EXAMPLES:\n" + example
+guidance = (
+⋮----
+instructions_str = "\n\n".join(instructions)
+⋮----
+def augment_system_message(self, message: str) -> None
+⋮----
+"""
+        Augment the system message with the given message.
+        Args:
+            message (str): system message
+        """
+⋮----
+def last_message_with_role(self, role: Role) -> LLMMessage | None
+⋮----
+"""from `message_history`, return the last message with role `role`"""
+n_role_msgs = len([m for m in self.message_history if m.role == role])
+⋮----
+idx = self.nth_message_idx_with_role(role, n_role_msgs)
+⋮----
+def last_message_idx_with_role(self, role: Role) -> int
+⋮----
+"""Index of last message in message_history, with specified role.
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+indices_with_role = [
+⋮----
+def nth_message_idx_with_role(self, role: Role, n: int) -> int
+⋮----
+"""Index of `n`th message in message_history, with specified role.
+        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+⋮----
+def update_last_message(self, message: str, role: str = Role.USER) -> None
+⋮----
+"""
+        Update the last message that has role `role` in the message history.
+        Useful when we want to replace a long user prompt, that may contain context
+        documents plus a question, with just the question.
+        Args:
+            message (str): new message to replace with
+            role (str): role of message to replace
+        """
+⋮----
+# find last message in self.message_history with role `role`
+⋮----
+def delete_last_message(self, role: str = Role.USER) -> None
+⋮----
+"""
+        Delete the last message that has role `role` from the message history.
+        Args:
+            role (str): role of message to delete
+        """
+⋮----
+def _create_system_and_tools_message(self) -> LLMMessage
+⋮----
+"""
+        (Re-)Create the system message for the LLM of the agent,
+        taking into account any tool instructions that have been added
+        after the agent was initialized.
+
+        The system message will consist of:
+        (a) the system message from the `task` arg in constructor, if any,
+            otherwise the default system message from the config
+        (b) the system tool instructions, if any
+        (c) the system json tool instructions, if any
+
+        Returns:
+            LLMMessage object
+        """
+content = self.system_message
+⋮----
+# remove leading and trailing newlines and other whitespace
+⋮----
+def handle_message_fallback(self, msg: str | ChatDocument) -> Any
+⋮----
+"""
+        Fallback method for the "no-tools" scenario, i.e., the current `msg`
+        (presumably emitted by the LLM) does not have any tool that the agent
+        can handle.
+        NOTE: The `msg` may contain tools but either (a) the agent is not
+        enabled to handle them, or (b) there's an explicit `recipient` field
+        in the tool that doesn't match the agent's name.
+
+        Uses the self.config.non_tool_routing to determine the action to take.
+
+        This method can be overridden by subclasses, e.g.,
+        to create a "reminder" message when a tool is expected but the LLM "forgot"
+        to generate one.
+
+        Args:
+            msg (str | ChatDocument): The input msg to handle
+        Returns:
+            Any: The result of the handler method
+        """
+⋮----
+# we ONLY use the `handle_llm_no_tool` config option when
+# the msg is from LLM and does not contain ANY tools at all.
+⋮----
+no_tool_option = self.config.handle_llm_no_tool
+⋮----
+# in case the `no_tool_option` is one of the special NonToolAction vals
+⋮----
+# Otherwise just return `no_tool_option` as is:
+# This can be any string, such as a specific nudge/reminder to the LLM,
+# or even something like ResultTool etc.
+⋮----
+def unhandled_tools(self) -> set[str]
+⋮----
+"""The set of tools that are known but not handled.
+        Useful in task flow: an agent can refuse to accept an incoming msg
+        when it only has unhandled tools.
+        """
+⋮----
+"""
+        Add the tool (message class) to the agent, and enable either
+        - tool USE (i.e. the LLM can generate JSON to use this tool),
+        - tool HANDLING (i.e. the agent can handle JSON from this tool),
+
+        Args:
+            message_class: The ToolMessage class OR List of such classes to enable,
+                for USE, or HANDLING, or both.
+                If this is a list of ToolMessage classes, then the remain args are
+                applied to all classes.
+                Optional; if None, then apply the enabling to all tools in the
+                agent's toolset that have been enabled so far.
+            use: IF True, allow the agent (LLM) to use this tool (or all tools),
+                else disallow
+            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
+                tool (or all tools)
+            force: whether to FORCE the agent (LLM) to USE the specific
+                 tool represented by `message_class`.
+                 `force` is ignored if `message_class` is None.
+            require_recipient: whether to require that recipient be specified
+                when using the tool message (only applies if `use` is True).
+            include_defaults: whether to include fields that have default values,
+                in the "properties" section of the JSON format instructions.
+                (Normally the OpenAI completion API ignores these fields,
+                but the Assistant fn-calling seems to pay attn to these,
+                and if we don't want this, we should set this to False.)
+        """
+⋮----
+# Validate that use/handle are booleans, not accidentally passed tool classes
+⋮----
+param = "use" if isclass(use) else "handle"
+⋮----
+message_class = message_class.require_recipient()
+⋮----
+request = message_class.default_value("request")
+existing_class = self.llm_tools_map.get(request)
+existing_origin = (
+message_origin = message_class.__dict__.get(
+⋮----
+# XMLToolMessage is not compatible with OpenAI's Tools/functions API,
+# so we disable use of functions API, enable langroid-native Tools,
+# which are prompt-based.
+⋮----
+super().enable_message_handling(message_class)  # enables handling only
+tools = self._get_tool_list(message_class)
+⋮----
+llm_function = message_class.llm_function_schema(defaults=include_defaults)
+⋮----
+# `t` was designated as "enabled for handling" ONLY for
+# output_format enforcement, but we are explicitly ]
+# enabling it for handling here, so we set the variable to None.
+⋮----
+tool_class = self.llm_tools_map[t]
+allow_llm_use = tool_class._allow_llm_use
+⋮----
+allow_llm_use = allow_llm_use.default
+⋮----
+# `t` was designated as "enabled for use" ONLY for output_format
+# enforcement, but we are explicitly enabling it for use here,
+# so we set the variable to None.
+⋮----
+def _update_tool_instructions(self) -> None
+⋮----
+# Set tool instructions and JSON format instructions,
+# in case Tools have been enabled/disabled.
+⋮----
+def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]
+⋮----
+"""
+        Returns the current set of enabled requests for inference and tools configs.
+        Used for restoring setings overriden by `set_output_format`.
+        """
+⋮----
+@property
+    def all_llm_tools_known(self) -> set[str]
+⋮----
+"""All known tools; we include `output_format` if it is a `ToolMessage`."""
+known = self.llm_tools_known
+⋮----
+"""
+        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
+        switches to the native Langroid tools mechanism to ensure that no tool
+        calls not of `output_type` are generated. By default, `force_tools`
+        follows the `use_tools_on_output_format` parameter in the config.
+
+        If `output_type` is None, restores to the state prior to setting
+        `output_format`.
+
+        If `use`, we enable use of `output_type` when it is a subclass
+        of `ToolMesage`. Note that this primarily controls instruction
+        generation: the model will always generate `output_type` regardless
+        of whether `use` is set. Defaults to the `use_output_format`
+        parameter in the config. Similarly, handling of `output_type` is
+        controlled by `handle`, which defaults to the
+        `handle_output_format` parameter in the config.
+
+        `instructions` controls whether we generate instructions specifying
+        the output format schema. Defaults to the `instructions_output_format`
+        parameter in the config.
+
+        `is_copy` is set when called via `__getitem__`. In that case, we must
+        copy certain fields to ensure that we do not overwrite the main agent's
+        setings.
+        """
+# Disable usage of an output format which was not specifically enabled
+# by `enable_message`
+⋮----
+# Disable handling of an output format which did not specifically have
+# handling enabled via `enable_message`
+⋮----
+# Reset any previous instructions
+⋮----
+force_tools = self.config.use_tools_on_output_format
+⋮----
+output_type = get_pydantic_wrapper(output_type)
+⋮----
+name = output_type.default_value("request")
+⋮----
+use = self.config.use_output_format
+⋮----
+handle = self.config.handle_output_format
+⋮----
+is_usable = name in self.llm_tools_usable.union(
+is_handled = name in self.llm_tools_handled.union(
+⋮----
+# We must copy `llm_tools_usable` so the base agent
+# is unmodified
+⋮----
+# If handling the tool, do the same for `llm_tools_handled`
+⋮----
+# Enable `output_type`
+⋮----
+# Do not override existing settings
+⋮----
+# If the `output_type` ToilMessage was not already enabled for
+# use, this means we are ONLY enabling it for use specifically
+# for enforcing this output format, so we set the
+# `enabled_use_output_forma  to this output_type, to
+# record that it should be disabled when `output_format` is changed
+⋮----
+# (same reasoning as for use-enabling)
+⋮----
+generated_tool_instructions = name in self.llm_tools_usable.union(
+⋮----
+generated_tool_instructions = False
+⋮----
+instructions = self.config.instructions_output_format
+⋮----
+# Already generated tool instructions as part of "enabling for use",
+# so only need to generate a reminder to use this tool.
+name = cast(ToolMessage, output_type).default_value("request")
+⋮----
+output_format_schema = output_type.llm_function_schema(
+⋮----
+output_format_schema = output_type.model_json_schema()
+⋮----
+def __getitem__(self, output_type: type) -> Self
+⋮----
+"""
+        Returns a (shallow) copy of `self` with a forced output type.
+        """
+clone = copy.copy(self)
+⋮----
+"""
+        Disable this agent from RESPONDING to a `message_class` (Tool). If
+            `message_class` is None, then disable this agent from responding to ALL.
+        Args:
+            message_class: The ToolMessage class to disable; Optional.
+        """
+⋮----
+"""
+        Disable this agent from USING a message class (Tool).
+        If `message_class` is None, then disable this agent from USING ALL tools.
+        Args:
+            message_class: The ToolMessage class to disable.
+                If None, disable all.
+        """
+⋮----
+def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None
+⋮----
+"""
+        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
+        Args:
+            message_class: The only ToolMessage class to allow
+        """
+request = message_class.model_fields["request"].default
+to_remove = [r for r in self.llm_tools_usable if r != request]
+⋮----
+def _load_output_format(self, message: ChatDocument) -> None
+⋮----
+"""
+        If set, attempts to parse a value of type `self.output_format` from the message
+        contents or any tool/function call and assigns it to `content_any`.
+        """
+⋮----
+any_succeeded = False
+attempts: list[str | LLMFunctionCall] = [
+⋮----
+content = json.loads(attempt)
+⋮----
+content = attempt.arguments
+⋮----
+content_any = self.output_format.model_validate(content)
+⋮----
+message.content_any = content_any.value  # type: ignore
+⋮----
+any_succeeded = True
+⋮----
+"""
+        Extracts messages and tracks whether any errors occurred. If strict mode
+        was enabled, disables it for the tool, else triggers strict recovery.
+        """
+⋮----
+most_recent_sent_by_llm = (
+was_llm = most_recent_sent_by_llm or (
+⋮----
+tools = super().get_tool_messages(msg, all_tools)
+⋮----
+# Check if tool class was attached to the exception
+⋮----
+tool_class = ve.tool_class  # type: ignore
+⋮----
+was_strict = (
+# If the result of strict output for a tool using the
+# OpenAI tools API fails to parse, we infer that the
+# schema edits necessary for compatibility prevented
+# adherence to the underlying `ToolMessage` schema and
+# disable strict output for the tool
+⋮----
+# We will trigger the strict recovery mechanism to force
+# the LLM to correct its output, allowing us to parse
+⋮----
+def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None
+⋮----
+"""
+        Returns a `ToolMessage` which wraps all enabled tools, excluding those
+        where strict recovery is disabled. Used in strict recovery.
+        """
+possible_tools = tuple(
+⋮----
+any_tool_type = Union.__getitem__(possible_tools)  # type ignore
+⋮----
+maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
+⋮----
+class AnyTool(ToolMessage)
+⋮----
+purpose: str = "To call a tool/function."
+request: str = "tool_or_function"
+tool: maybe_optional_type  # type: ignore
+⋮----
+def response(self, agent: ChatAgent) -> None | str | ChatDocument
+⋮----
+# One-time use
+⋮----
+# As the ToolMessage schema accepts invalid
+# `tool.request` values, reparse with the
+# corresponding tool
+request = self.tool.request
+⋮----
+tool = agent.llm_tools_map[request].model_validate_json(
+⋮----
+# Every call builds a distinct class; share one origin so enabling a
+# regenerated AnyTool under "tool_or_function" stays idempotent instead
+# of tripping the same-name/different-tool registration guard.
+AnyTool.__tool_message_origin__ = (  # type: ignore[attr-defined]
+⋮----
+"""Returns instructions for strict recovery."""
+optional_instructions = (
+response_prefix = "If you intended to make such a call, r" if optional else "R"
+instruction_prefix = "If you do so, b" if optional else "B"
+⋮----
+schema_instructions = (
+⋮----
+"""
+        Truncate message at idx in msg history to `tokens` tokens.
+
+        If inplace is True, the message is truncated in place, else
+        it LEAVES the original message INTACT and returns a new message
+        """
+⋮----
+llm_msg = self.message_history[idx]
+⋮----
+llm_msg = copy.deepcopy(self.message_history[idx])
+⋮----
+orig_content = llm_msg.content
+new_content = (
+⋮----
+else orig_content[: tokens * 4]  # approx truncation
+⋮----
+def _reduce_raw_tool_results(self, message: ChatDocument) -> None
+⋮----
+"""
+        If message is the result of a ToolMessage that had
+        a `_max_retained_tokens` set to a non-None value, then we replace contents
+        with a placeholder message.
+        """
+parent_message: ChatDocument | None = message.parent
+tools = [] if parent_message is None else parent_message.tool_messages
+truncate_tools = []
+⋮----
+max_retained_tokens = t._max_retained_tokens
+⋮----
+max_retained_tokens = max_retained_tokens.default
+⋮----
+limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
+⋮----
+max_retained_tokens = limiting_tool._max_retained_tokens
+⋮----
+tool_name = limiting_tool.default_value("request")
+max_tokens: int = max_retained_tokens
+truncation_warning = f"""
+⋮----
+"""
+        Respond to a single user message, appended to the message history,
+        in "chat" mode
+        Args:
+            message (str|ChatDocument): message or ChatDocument object to respond to.
+                If None, use the self.task_messages
+        Returns:
+            LLM response as a ChatDocument object
+        """
+⋮----
+# If enabled and a tool error occurred, we recover by generating the tool in
+# strict json mode
+⋮----
+AnyTool = self._get_any_tool_message()
+⋮----
+recovery_message = self._strict_recovery_instructions(AnyTool)
+augmented_message = message
+⋮----
+augmented_message = recovery_message
+⋮----
+augmented_message = augmented_message + recovery_message
+⋮----
+# only use the augmented message for this one response...
+result = self.llm_response(augmented_message)
+# ... restore the original user message so that the AnyTool recover
+# instructions don't persist in the message history
+# (this can cause the LLM to use the AnyTool directly as a tool)
+⋮----
+msg = message if isinstance(message, str) else message.content
+⋮----
+tool_choice = (
+⋮----
+response = self.llm_response_messages(hist, output_len, tool_choice)
+⋮----
+# Preserve trail of tool_ids for OpenAI Assistant fn-calls
+⋮----
+"""
+        Async version of `llm_response`. See there for details.
+        """
+⋮----
+response = await self.llm_response_messages_async(
+⋮----
+def init_message_history(self) -> None
+⋮----
+"""
+        Initialize the message history with the system message and user message
+        """
+⋮----
+"""
+        Prepare messages to be sent to self.llm_response_messages,
+            which is the main method that calls the LLM API to get a response.
+            If desired output tokens + message history exceeds the model context length,
+            then first the max output tokens is reduced to fit, and if that is not
+            possible, older messages may be truncated to accommodate at least
+            self.config.llm.min_output_tokens of output.
+
+        Returns:
+            Tuple[List[LLMMessage], int]: (messages, output_len)
+                messages = Full list of messages to send
+                output_len = max expected number of tokens in response
+        """
+⋮----
+# this means agent has been used to get LLM response already,
+# and so the last message is an "assistant" response.
+# We delete this last assistant response and re-generate it.
+⋮----
+# initial messages have not yet been loaded, so load them
+⋮----
+# for debugging, show the initial message history
+⋮----
+# update the system message with the latest tool instructions
+⋮----
+# either the message is a str, or it is a fresh ChatDocument
+# different from the last message in the history
+llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
+llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
+# Canonicalize retained whitespace-only results before token counting.
+⋮----
+# process tools if any
+done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
+⋮----
+hist = self.message_history
+output_len = self.config.llm.model_max_output_tokens
+⋮----
+# chat + output > max context length,
+# so first try to shorten requested output len to fit;
+# use an extra margin of CHAT_HISTORY_BUFFER tokens
+# in case our calcs are off (and to allow for some extra tokens)
+output_len = (
+⋮----
+# unacceptably small output len, so compress early parts of
+# conversation history based on the configured strategy
+strategy = self.config.context_overflow_strategy
+⋮----
+# Truncate content of individual messages while preserving
+# the message sequence (important for LLM APIs that require
+# alternating USER/ASSISTANT messages)
+msg_idx_to_compress = 1  # don't touch system msg
+# we will try compressing msg indices up to but not including
+# last user msg
+last_msg_idx_to_compress = (
+n_truncated = 0
+_target_tokens = (
+# Truncation floor: never reduce a message's content below
+# this many tokens.
+_min_keep_tokens = 30
+_truncation_warning = "... [Contents truncated!]"
+⋮----
+def _content_tokens(text: str | None) -> int
+⋮----
+"""Token count of message *content* only.
+
+                        `truncate_message` only trims `message.content`, so
+                        using the full `_message_num_tokens` (which includes
+                        attachment payloads) would inflate the count and make
+                        the keep-target too large to ever converge, for
+                        messages carrying file attachments.
+                        """
+⋮----
+# approx fallback, matches truncate_message
+⋮----
+# Account for the warning that truncate_message appends
+# ("\n" + warning), so the final token count of a
+# truncated message does not exceed its keep-target.
+_warning_tokens = _content_tokens("\n" + _truncation_warning)
+# NOTE: loop termination is guaranteed:
+# msg_idx_to_compress strictly increases every iteration
+# (truncate or skip), and once it exceeds
+# last_msg_idx_to_compress a ValueError is raised. (The
+# token count need not decrease every iteration, so
+# termination rests on the index advancing.)
+⋮----
+# We want to preserve the first message (typically
+# system msg) and last message (user msg).
+⋮----
+_msg_tokens = _content_tokens(hist[msg_idx_to_compress].content)
+⋮----
+# Truncating this message cannot shrink the total:
+# its content is already at/below the keep-floor
+# plus the appended warning; leave it intact.
+⋮----
+# Distribute the current excess evenly across the
+# remaining *compressible* messages, so each retains
+# as much content as possible instead of being
+# collapsed to the fixed 30-token floor. The excess is
+# recomputed every iteration, so the distribution
+# self-corrects as we move forward through the
+# history.
+_current_excess = self.chat_num_tokens(hist) - _target_tokens
+# Shrink capacity of each *later* message in the
+# compressible range: its content above the floor (net
+# of the appended warning). Non-positive entries are
+# the tiny messages the skip-check above will leave
+# untouched; they must not dilute the even share, so
+# only messages with positive capacity count toward
+# the denominator (plus this message, which passed the
+# skip-check and is therefore compressible).
+_later_capacities = [
+_n_remaining = 1 + sum(1 for c in _later_capacities if c > 0)
+_even_share = math.ceil(_current_excess / _n_remaining)
+# Later messages can shed at most their capacity; this
+# message must absorb whatever they cannot, so that
+# this single forward pass reaches the target whenever
+# that is possible at all.
+_later_capacity = sum(c for c in _later_capacities if c > 0)
+_reduction = max(_even_share, _current_excess - _later_capacity)
+# Extra 2-token slack: re-encoding truncated content
+# plus the appended warning can merge/split tokens at
+# the boundary, so aim slightly below the target to
+# keep the achieved reduction from falling short.
+_keep_tokens = max(
+# compress the msg at idx `msg_idx_to_compress`
+⋮----
+output_len = min(
+⋮----
+# we MUST have truncated at least one msg
+msg_tokens = self.chat_num_tokens()
+⋮----
+else:  # strategy == "drop_turns"
+# Drop complete conversation turns. A complete turn is defined
+# as a USER message followed by all messages until the next
+# USER message. This is more aggressive but cleaner for voice
+# agents with limited context.
+n_dropped_turns = 0
+⋮----
+# Find the last USER message index
+last_user_idx = self.last_message_idx_with_role(role=Role.USER)
+⋮----
+# Find the first complete turn to drop (skip system message)
+first_user_idx = -1
+⋮----
+first_user_idx = i
+⋮----
+# Find the end of this turn: last message before next USER
+next_user_idx = -1
+⋮----
+next_user_idx = i
+⋮----
+# Drop the turn
+⋮----
+# we MUST have dropped at least one turn
+⋮----
+# record the position of the corresponding LLMMessage in
+# the message_history
+⋮----
+"""
+        Get function/tool spec/output format arguments for
+        OpenAI-compatible LLM API call
+        """
+functions: Optional[List[LLMFunctionSpec]] = None
+fun_call: str | Dict[str, str] = "none"
+tools: Optional[List[OpenAIToolSpec]] = None
+force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
+⋮----
+functions = [
+fun_call = (
+⋮----
+def to_maybe_strict_spec(function: str) -> OpenAIToolSpec
+⋮----
+spec = self.llm_functions_map[function]
+strict = self._strict_mode_for_tool(function)
+⋮----
+strict_spec = copy.deepcopy(spec)
+⋮----
+strict_spec = spec
+⋮----
+tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
+force_tool = (
+output_format = None
+⋮----
+spec = self.output_format.llm_function_schema(
+⋮----
+output_format = OpenAIJsonSchemaSpec(
+⋮----
+# We always require that outputs strictly match the schema
+⋮----
+param_spec = self.output_format.model_json_schema()
+⋮----
+"""
+        Respond to a series of messages, e.g. with OpenAI ChatCompletion
+        Args:
+            messages: seq of messages (with role, content fields) sent to LLM
+            output_len: max number of tokens expected in response.
+                    If None, use the LLM's default model_max_output_tokens.
+        Returns:
+            Document (i.e. with fields "content", "metadata")
+        """
+⋮----
+output_len = output_len or self.config.llm.model_max_output_tokens
+streamer = noop_fn
+⋮----
+streamer = self.callbacks.start_llm_stream()
+⋮----
+with ExitStack() as stack:  # for conditionally using rich spinner
+⋮----
+# show rich spinner only if not streaming!
+# (Why? b/c the intent of showing a spinner is to "show progress",
+# and we don't need to do that when streaming, since
+# streaming output already shows progress.)
+cm = status(
+⋮----
+response = self.llm.chat(
+⋮----
+# Create temp ChatDocument for tool check, then clean up to avoid
+# polluting ObjectRegistry (see PR #939 discussion)
+temp_doc = ChatDocument.from_LLMResponse(
+⋮----
+response,  # .usage attrib is updated!
+⋮----
+chat_doc = ChatDocument.from_LLMResponse(
+⋮----
+# If using strict output format, parse the output JSON
+⋮----
+"""
+        Async version of `llm_response_messages`. See there for details.
+        """
+⋮----
+streamer_async = async_noop_fn
+⋮----
+streamer_async = await self.callbacks.start_llm_stream_async()
+⋮----
+response = await self.llm.achat(
+⋮----
+"""
+        Call a callback method, only passing 'reasoning' if it accepts it.
+
+        This provides backward compatibility for custom callbacks that don't
+        have the 'reasoning' parameter in their signature.
+
+        Args:
+            callback_name: Name of the callback method (e.g., 'show_llm_response')
+            reasoning: The reasoning content to pass if supported
+            **kwargs: Other arguments to pass to the callback
+        """
+callback = getattr(self.callbacks, callback_name, None)
+⋮----
+# Check if callback accepts 'reasoning' param or **kwargs
+⋮----
+sig = inspect.signature(callback)
+params = sig.parameters
+accepts_reasoning = "reasoning" in params or any(
+⋮----
+# If we can't inspect the signature, assume it doesn't accept reasoning
+accepts_reasoning = False
+⋮----
+is_cached = (
+⋮----
+# We would have already displayed the msg "live" ONLY if
+# streaming was enabled, AND we did not find a cached response.
+# If we are here, it means the response has not yet been displayed.
+cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
+# Track whether we created a temp ChatDocument for cleanup
+is_temp_doc = isinstance(response, LLMResponse)
+chat_doc = (
+# TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
+⋮----
+content = response.message or ""
+tools_content = response.tools_content()
+⋮----
+content = response.content
+tools_content = ""
+reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
+⋮----
+# Clean up temp ChatDocument to avoid polluting ObjectRegistry
+⋮----
+# we are in the context immediately after an LLM responded,
+# we won't have citations yet, so we're done
+⋮----
+citation = (
+⋮----
+reasoning="",  # Citations don't have reasoning
+⋮----
+def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument
+⋮----
+"""
+        Get LLM response to `prompt` (which presumably includes the `message`
+        somewhere, along with possible large "context" passages),
+        but only include `message` as the USER message, and not the
+        full `prompt`, in the message history.
+        Args:
+            message: the original, relatively short, user request or query
+            prompt: the full prompt potentially containing `message` plus context
+
+        Returns:
+            Document object containing the response.
+        """
+# we explicitly call THIS class's respond method,
+# not a derived class's (or else there would be infinite recursion!)
+with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
+⋮----
+"""
+        Async version of `_llm_response_temp_context`. See there for details.
+        """
+⋮----
+answer_doc = cast(
+⋮----
+"""
+        LLM Response to single message, and restore message_history.
+        In effect a "one-off" message & response that leaves agent
+        message history state intact.
+
+        Args:
+            message (str|ChatDocument): message to respond to.
+
+        Returns:
+            A Document object with the response.
+
+        """
+# explicitly call THIS class's respond method,
+⋮----
+n_msgs = len(self.message_history)
+⋮----
+response = cast(ChatDocument, ChatAgent.llm_response(self, message))
+# If there is a response, then we will have two additional
+# messages in the message history, i.e. the user message and the
+# assistant response. We want to (carefully) remove these two messages.
+⋮----
+msg = self.message_history.pop()
+⋮----
+"""
+        Async version of `llm_response_forget`. See there for details.
+        """
+⋮----
+response = cast(
+⋮----
+def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int
+⋮----
+"""
+        Total number of tokens in the message history so far.
+
+        Args:
+            messages: if provided, compute the number of tokens in this list of
+                messages, rather than the current message history.
+        Returns:
+            int: number of tokens in message history
+        """
+⋮----
+hist = messages if messages is not None else self.message_history
+⋮----
+def _message_num_tokens(self, message: LLMMessage) -> int
+⋮----
+"""Count tokens for a message, including serialized user attachments."""
+⋮----
+def _attachment_num_tokens(self, message: LLMMessage) -> int
+⋮----
+"""
+        Estimate attachment contribution using the serialized payload
+        that is sent in the API request for user messages.
+        """
+⋮----
+model = self._chat_model_name_for_attachments()
+n_tokens = sum(
+⋮----
+def _chat_model_name_for_attachments(self) -> str
+⋮----
+"""Return the model name used for attachment serialization."""
+⋮----
+def message_history_str(self, i: Optional[int] = None) -> str
+⋮----
+"""
+        Return a string representation of the message history
+        Args:
+            i: if provided, return only the i-th message when i is postive,
+                or last k messages when i = -k.
+        Returns:
+        """
+⋮----
+def __del__(self) -> None
+⋮----
+"""
+        Cleanup method called when the ChatAgent is garbage collected.
+        Note: We don't close LLM clients here because they may be shared
+        across multiple agents when client caching is enabled.
+        The clients are managed centrally and cleaned up via atexit hooks.
+        """
+# Previously we closed clients here, but this caused issues when
+# multiple agents shared the same cached client instance.
+# Clients are now managed centrally in langroid.language_models.client_cache
 </file>
 
 <file path="mkdocs.yml">
@@ -76749,6 +76849,7 @@ nav:
       - Markdown, HTML Parsing: notes/markdown-html-parsing.md
       - Context-Overflow Handling: notes/context-overflow.md
       - Batch Processing: notes/batch-processing.md
+      - Attachment Token Preflight: notes/attachment-token-preflight.md
 
   - Examples:
     - Guide: examples/guide.md
@@ -76797,7 +76898,7 @@ extra_javascript:
 <file path="pyproject.toml">
 [project]
 name = "langroid"
-version = "0.65.16"
+version = "0.66.0"
 authors = [
     {name = "Prasad Chalasani", email = "pchalasani@gmail.com"},
 ]

--- a/llms-no-tests-compressed.txt
+++ b/llms-no-tests-compressed.txt
@@ -109,6 +109,7 @@ docs/
     pure-lambda-non-circular.png
   notes/
     async-streaming.md
+    attachment-token-preflight.md
     azure-openai-models.md
     batch-processing.md
     chat-history-snapshots.md
@@ -37804,6 +37805,55 @@ the LLM will try its best to interpret what you want, and offer choices when con
     - Illustrates function-calling/tools and code-generation
 </file>
 
+<file path="docs/notes/attachment-token-preflight.md">
+# Attachment Token Preflight
+
+Before each LLM call, Langroid runs a local context-length preflight: it counts
+the tokens in the pending message history (`ChatAgent.chat_num_tokens()`) and,
+if needed, reduces the requested output length, truncates old messages, or
+drops old turns so the request fits the model's context window.
+
+Historically this preflight counted only each message's text `content`, ignoring
+`LLMMessage.files` (`FileAttachment` objects). But attachments ARE serialized
+into the actual API request — for Gemini and other OpenAI-compatible paths,
+`FileAttachment.to_dict()` turns an attached PDF or image into a `data:` URI
+containing the full base64 payload. A ~1.9 MB PDF becomes roughly 2.6 million
+base64 characters, so the local check could pass while the real payload was far
+larger (issue #996).
+
+## Behavior
+
+The preflight now includes an estimate for each attachment on `USER` messages:
+
+- Each attachment is serialized exactly as it would be for the API request
+  (`FileAttachment.to_dict(model)`), and the resulting JSON is tokenized with
+  the agent's parser, the same way message text is counted.
+- Attachments that are NOT inlined — e.g. a `FileAttachment` carrying an
+  `http(s)` URL, which is sent as the URL itself rather than base64 bytes —
+  contribute only the tokens of their small serialized form, not the size of
+  the remote file.
+- Messages with no attachments are counted exactly as before; token accounting
+  is unchanged for attachment-free histories.
+
+When attachments contribute to the count for an agent, a warning is logged once
+(per agent, not per message) noting that the count is an estimate.
+
+## How conservative is the estimate?
+
+The estimate measures the serialized request payload (base64 data URI plus the
+surrounding JSON), tokenized like ordinary text. Provider-side accounting may
+differ in either direction:
+
+- Providers that bill inlined files as text-like payload will be close to this
+  estimate.
+- Providers that convert files to their own internal representation (e.g.
+  per-page or per-image token charges) may count fewer or more tokens.
+
+The goal is to keep the local preflight from drastically *under*-estimating the
+request size when large files are attached, so context-window overflows are
+caught locally instead of surfacing as provider-side errors.
+</file>
+
 <file path="docs/notes/batch-processing.md">
 # Batch Processing
 
@@ -47066,6 +47116,580 @@ excludes = excludes.union({"request"})
 schema = generate_simple_schema(
 </file>
 
+<file path="langroid/language_models/base.py">
+logger = logging.getLogger(__name__)
+⋮----
+def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
+⋮----
+async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
+⋮----
+FunctionCallTypes = Literal["none", "auto"]
+ToolChoiceTypes = Literal["none", "auto", "required"]
+ToolTypes = Literal["function"]
+⋮----
+DEFAULT_CONTEXT_LENGTH = 16_000
+⋮----
+class StreamEventType(Enum)
+⋮----
+TEXT = 1
+FUNC_NAME = 2
+FUNC_ARGS = 3
+TOOL_NAME = 4
+TOOL_ARGS = 5
+REASONING = 6
+⋮----
+class RetryParams(BaseSettings)
+⋮----
+max_retries: int = 5
+initial_delay: float = 1.0
+exponential_base: float = 1.3
+jitter: bool = True
+⋮----
+class LLMConfig(BaseSettings)
+⋮----
+"""
+    Common configuration for all language models.
+    """
+⋮----
+type: str = "openai"
+streamer: Optional[Callable[[Any], None]] = noop_fn
+streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
+api_base: str | None = None
+formatter: None | str = None
+# specify None if you want to use the full max output tokens of the model
+max_output_tokens: int | None = 8192
+timeout: int = 20  # timeout for API requests
+chat_model: str = ""
+completion_model: str = ""
+temperature: float = 0.0
+chat_context_length: int | None = None
+async_stream_quiet: bool = False  # suppress streaming output in async mode?
+completion_context_length: int | None = None
+# if input length + max_output_tokens > context length of model,
+# we will try shortening requested output
+min_output_tokens: int = 64
+use_completion_for_chat: bool = False  # use completion model for chat?
+# use chat model for completion? For OpenAI models, this MUST be set to True!
+use_chat_for_completion: bool = True
+stream: bool = True  # stream output from API?
+# TODO: we could have a `stream_reasoning` flag here to control whether to show
+# reasoning output from reasoning models
+cache_config: None | CacheDBConfig = RedisCacheConfig()
+thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
+retry_params: RetryParams = RetryParams()
+⋮----
+@property
+    def model_max_output_tokens(self) -> int
+⋮----
+# Build fallback names by progressively stripping provider prefixes
+# (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
+# succeeds even before OpenAIGPT.__init__ strips the prefix.
+parts = self.chat_model.split("/")
+fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
+⋮----
+class LLMFunctionCall(BaseModel)
+⋮----
+"""
+    Structure of LLM response indicating it "wants" to call a function.
+    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
+    """
+⋮----
+name: str  # name of function to call
+arguments: Optional[Dict[str, Any]] = None
+⋮----
+@staticmethod
+    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall"
+⋮----
+"""
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+fun_call = LLMFunctionCall(name=message["name"])
+fun_args_str = message["arguments"]
+# sometimes may be malformed with invalid indents,
+# so we try to be safe by removing newlines.
+⋮----
+fun_args_str = fun_args_str.replace("\n", "").strip()
+dict_or_list = parse_imperfect_json(fun_args_str)
+⋮----
+fun_args = dict_or_list
+⋮----
+fun_args = None
+⋮----
+def __str__(self) -> str
+⋮----
+class LLMFunctionSpec(BaseModel)
+⋮----
+"""
+    Description of a function available for the LLM to use.
+    To be used when calling the LLM `chat()` method with the `functions` parameter.
+    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
+    """
+⋮----
+name: str
+description: str
+parameters: Dict[str, Any]
+⋮----
+class OpenAIToolCall(BaseModel)
+⋮----
+"""
+    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
+    See https://platform.openai.com/docs/api-reference/chat/create
+
+    Attributes:
+        id: The id of the tool call.
+        type: The type of the tool call;
+            only "function" is currently possible (7/26/24).
+        function: The function call.
+    """
+⋮----
+id: str | None = None
+type: ToolTypes = "function"
+function: LLMFunctionCall | None = None
+extra_content: Dict[str, Any] | None = None
+⋮----
+@staticmethod
+    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall"
+⋮----
+id = message["id"]
+type = message["type"]
+function = LLMFunctionCall.from_dict(message["function"])
+extra_content = message.get("extra_content")
+⋮----
+class OpenAIToolSpec(BaseModel)
+⋮----
+type: ToolTypes
+strict: Optional[bool] = None
+function: LLMFunctionSpec
+⋮----
+class OpenAIJsonSchemaSpec(BaseModel)
+⋮----
+def to_dict(self) -> Dict[str, Any]
+⋮----
+json_schema: Dict[str, Any] = {
+⋮----
+class LLMTokenUsage(BaseModel)
+⋮----
+"""
+    Usage of tokens by an LLM.
+    """
+⋮----
+prompt_tokens: int = 0
+cached_tokens: int = 0
+completion_tokens: int = 0
+cost: float = 0.0
+calls: int = 0  # how many API calls - not used as of 2025-04-04
+⋮----
+def reset(self) -> None
+⋮----
+@property
+    def total_tokens(self) -> int
+⋮----
+class Role(str, Enum)
+⋮----
+"""
+    Possible roles for a message in a chat.
+    """
+⋮----
+USER = "user"
+SYSTEM = "system"
+ASSISTANT = "assistant"
+FUNCTION = "function"
+TOOL = "tool"
+⋮----
+class LLMMessage(BaseModel)
+⋮----
+"""
+    Class representing an entry in the msg-history sent to the LLM API.
+    It could be one of these:
+    - a user message
+    - an LLM ("Assistant") response
+    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
+    - a result or results from executing a fn or tool-call(s)
+    """
+⋮----
+role: Role
+name: Optional[str] = None
+tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
+tool_id: str = ""  # used by OpenAIAssistant
+# None means "no content" (the model returned only a tool/function call).
+# This is distinct from "" and is dropped from the API payload by api_dict;
+# see api_dict for how a fully-empty message is handled per-API.
+content: Optional[str] = None
+files: List[FileAttachment] = []
+function_call: Optional[LLMFunctionCall] = None
+tool_calls: Optional[List[OpenAIToolCall]] = None
+timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+# link to corresponding chat document, for provenance/rewind purposes
+chat_document_id: str = ""
+⋮----
+def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]
+⋮----
+"""
+        Convert to dictionary for API request, keeping ONLY
+        the fields that are expected in an API call!
+        E.g., DROP the tool_id, since it is only for use in the Assistant API,
+            not the completion API.
+
+        Args:
+            has_system_role: whether the message has a system role (if not,
+                set to "user" role)
+        Returns:
+            dict: dictionary representation of LLM message
+        """
+d = self.model_dump()
+files: List[FileAttachment] = d.pop("files")
+⋮----
+# In there are files, then content is an array of
+# different content-parts
+⋮----
+# if there is a key k = "role" with value "system", change to "user"
+# in case has_system_role is False
+⋮----
+# drop None values since API doesn't accept them (this omits `content`
+# entirely when it is None, i.e. "no content")
+dict_no_none = {k: v for k, v in d.items() if v is not None}
+⋮----
+# OpenAI API does not like empty name
+⋮----
+# arguments must be a string
+⋮----
+# convert tool calls to API format
+⋮----
+# An empty tool-call list is not a call and conveys no useful API
+# information. Omitting it also lets the empty-message fallback
+# below produce a valid message.
+⋮----
+# A message with empty content (None was dropped above, or "") AND no
+# tool/function call would be an entirely empty message, which some APIs
+# (e.g. Gemini) reject; fall back to a single space in that case only.
+# When there IS a tool/function call, empty content is fine (and Gemini
+# 3.x in fact REQUIRES it — it rejects an assistant turn that carries
+# both a call and non-empty text content).
+has_call = bool(dict_no_none.get("tool_calls")) or (
+⋮----
+# IMPORTANT! drop fields that are not expected in API call
+⋮----
+content = "FUNC: " + json.dumps(self.function_call)
+⋮----
+content = self.content or ""
+name_str = f" ({self.name})" if self.name else ""
+⋮----
+class LLMResponse(BaseModel)
+⋮----
+"""
+    Class representing response from LLM.
+    """
+⋮----
+# None means the model returned NO content (e.g. only a tool/function
+# call), which is distinct from an empty string "". Preserving this
+# distinction lets the message be faithfully reproduced downstream
+# (see ChatDocument.content_is_none and LLMMessage.content).
+message: Optional[str] = None
+reasoning: str = ""  # optional reasoning text from reasoning models
+# Original message text including inline thought signatures (e.g.
+# <thinking>...</thinking>). Only set when reasoning was extracted
+# from the message text via get_reasoning_final(); NOT set when
+# reasoning comes from a separate API field (e.g. reasoning_content),
+# since in that case the message text never contained thought tags.
+message_with_reasoning: Optional[str] = None
+# TODO tool_id needs to generalize to multi-tool calls
+⋮----
+oai_tool_calls: Optional[List[OpenAIToolCall]] = None
+⋮----
+usage: Optional[LLMTokenUsage] = None
+cached: bool = False
+⋮----
+def tools_content(self) -> str
+⋮----
+def to_LLMMessage(self) -> LLMMessage
+⋮----
+"""Convert LLM response to an LLMMessage, to be included in the
+        message-list sent to the API.
+        This is currently NOT used in any significant way in the library, and is only
+        provided as a utility to construct a message list for the API when directly
+        working with an LLM object.
+
+        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
+        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
+        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
+        """
+⋮----
+"""
+        If `message` or `function_call` of an LLM response contains an explicit
+        recipient name, return this recipient name and `message` stripped
+        of the recipient name if specified.
+
+        Two cases:
+        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
+        (b) `message` is empty and function_call/tool_call with explicit `recipient`
+
+        Args:
+            recognize_recipient_in_content (bool): When True (default), parses
+                message text for ``TO[<recipient>]:<content>`` patterns and
+                top-level JSON ``{"recipient": "..."}`` fields. When False,
+                only function_call/tool_call ``recipient`` fields are checked.
+
+        Returns:
+            (str): name of recipient, which may be empty string if no recipient
+            (str): content of message
+
+        """
+⋮----
+# in this case we ignore message, since all information is in function_call
+msg = ""
+args = self.function_call.arguments
+recipient = ""
+⋮----
+recipient = args.get("recipient", "")
+⋮----
+msg = self.message or ""
+⋮----
+# get the first tool that has a recipient field, if any
+⋮----
+recipient = tc.function.arguments.get(
+⋮----
+)  # type: ignore
+⋮----
+# It's not a function or tool call, so continue looking to see
+# if a recipient is specified in the message.
+⋮----
+# First check if message contains "TO: <recipient> <content>"
+⋮----
+# check if there is a top level json that specifies 'recipient',
+# and retain the entire message as content.
+⋮----
+recipient_name = top_level_json_field(msg, "recipient") if msg else ""
+content = msg
+⋮----
+# Define an abstract base class for language models
+class LanguageModel(ABC)
+⋮----
+"""
+    Abstract base class for language models.
+    """
+⋮----
+# usage cost by model, accumulates here
+usage_cost_dict: Dict[str, LLMTokenUsage] = {}
+⋮----
+def __init__(self, config: LLMConfig = LLMConfig())
+⋮----
+@staticmethod
+    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]
+⋮----
+"""
+        Create a language model.
+        Args:
+            config: configuration for language model
+        Returns: instance of language model
+        """
+⋮----
+openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
+⋮----
+openai = AzureGPT
+⋮----
+openai = OpenAIGPT
+cls = dict(
+return cls(config)  # type: ignore
+⋮----
+@staticmethod
+    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]
+⋮----
+"""
+        Given an even-length sequence of strings, split into a sequence of pairs
+
+        Args:
+            lst (List[str]): sequence of strings
+
+        Returns:
+            List[Tuple[str,str]]: sequence of pairs of strings
+        """
+evens = lst[::2]
+odds = lst[1::2]
+⋮----
+"""
+        From the chat history, extract system prompt, user-assistant turns, and
+        final user msg.
+
+        Args:
+            messages (List[LLMMessage]): List of messages in the chat history
+
+        Returns:
+            Tuple[str, List[Tuple[str,str]], str]:
+                system prompt, user-assistant turns, final user msg
+
+        """
+# Handle various degenerate cases
+messages = [m for m in messages]  # copy
+DUMMY_SYS_PROMPT = "You are a helpful assistant."
+DUMMY_USER_PROMPT = "Follow the instructions above."
+⋮----
+system_prompt = messages[0].content or ""
+⋮----
+# now we have messages = [Sys,...]
+⋮----
+# now we have messages = [Sys, msg, ...]
+⋮----
+# now we have messages = [Sys, user, ...]
+⋮----
+# now we have messages = [Sys, user, ..., user]
+# so we omit the first and last elements and make pairs of user-asst messages
+conversation = [m.content or "" for m in messages[1:-1]]
+user_prompt = messages[-1].content or ""
+pairs = LanguageModel.user_assistant_pairs(conversation)
+⋮----
+@abstractmethod
+    def set_stream(self, stream: bool) -> bool
+⋮----
+"""Enable or disable streaming output from API.
+        Return previous value of stream."""
+⋮----
+@abstractmethod
+    def get_stream(self) -> bool
+⋮----
+"""Get streaming status"""
+⋮----
+@abstractmethod
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+@abstractmethod
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+"""
+        Get chat-completion response from LLM.
+
+        Args:
+            messages: message-history to send to the LLM
+            max_tokens: max tokens to generate
+            tools: tools available for the LLM to use in its response
+            tool_choice: tool call mode, one of "none", "auto", "required",
+                or a dict specifying a specific tool.
+            functions: functions available for LLM to call (deprecated)
+            function_call: function calling mode, "auto", "none", or a specific fn
+                    (deprecated)
+        """
+⋮----
+"""Async version of `chat`. See `chat` for details."""
+⋮----
+def __call__(self, prompt: str, max_tokens: int) -> LLMResponse
+⋮----
+@staticmethod
+    def _fallback_model_names(model: str) -> List[str]
+⋮----
+parts = model.split("/")
+fallbacks = []
+⋮----
+def info(self) -> ModelInfo
+⋮----
+"""Info of relevant chat model"""
+orig_model = (
+⋮----
+def completion_info(self) -> ModelInfo
+⋮----
+"""Info of relevant completion model"""
+⋮----
+def supports_functions_or_tools(self) -> bool
+⋮----
+"""
+        Does this Model's API support "native" tool-calling, i.e.
+        can we call the API with arguments that contain a list of available tools,
+        and their schemas?
+        Note that, given the plethora of LLM provider APIs this determination is
+        imperfect at best, and leans towards returning True.
+        When the API calls fails with an error indicating tools are not supported,
+        then users are encouraged to use the Langroid-based prompt-based
+        ToolMessage mechanism, which works with ANY LLM. To enable this,
+        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
+        """
+⋮----
+def chat_context_length(self) -> int
+⋮----
+def completion_context_length(self) -> int
+⋮----
+def chat_cost(self) -> Tuple[float, float, float]
+⋮----
+"""
+        Return the cost per 1000 tokens for chat completions.
+
+        Returns:
+            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
+                per 1000 tokens
+        """
+⋮----
+def reset_usage_cost(self) -> None
+⋮----
+counter = self.usage_cost_dict[mdl]
+⋮----
+"""
+        Update usage cost for this LLM.
+        Args:
+            chat (bool): whether to update for chat or completion model
+            prompts (int): number of tokens used for prompts
+            completions (int): number of tokens used for completions
+            cost (float): total token cost in USD
+        """
+mdl = self.config.chat_model if chat else self.config.completion_model
+⋮----
+@classmethod
+    def usage_cost_summary(cls) -> str
+⋮----
+s = ""
+⋮----
+@classmethod
+    def tot_tokens_cost(cls) -> Tuple[int, float]
+⋮----
+"""
+        Return total tokens used and total cost across all models.
+        """
+total_tokens = 0
+total_cost = 0.0
+⋮----
+def get_reasoning_final(self, message: str) -> Tuple[str, str]
+⋮----
+"""Extract "reasoning" and "final answer" from an LLM response, if the
+        reasoning is found within configured delimiters, like <think>, </think>.
+        E.g.,
+        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
+
+        Args:
+            message (str): message from LLM
+
+        Returns:
+            Tuple[str, str]: reasoning, final answer
+        """
+⋮----
+parts = message.split(start)
+⋮----
+"""
+        Given a chat history and a question, convert it to a standalone question.
+        Args:
+            chat_history: list of tuples of (question, answer)
+            query: follow-up question
+
+        Returns: standalone version of the question
+        """
+history = collate_chat_history(chat_history)
+⋮----
+prompt = f"""
+⋮----
+follow_up_question = f"""
+⋮----
+standalone = (
+standalone = standalone.strip()
+⋮----
+class StreamingIfAllowed
+⋮----
+"""Context to temporarily enable or disable streaming, if allowed globally via
+    `settings.stream`"""
+⋮----
+def __init__(self, llm: LanguageModel, stream: bool = True)
+⋮----
+def __enter__(self) -> None
+⋮----
+def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
+</file>
+
 <file path="langroid/parsing/parser.py">
 logger = logging.getLogger(__name__)
 ⋮----
@@ -52405,580 +53029,6 @@ sender_role = Role.ASSISTANT
 tool_id=tool_id,  # for OpenAI Assistant
 </file>
 
-<file path="langroid/language_models/base.py">
-logger = logging.getLogger(__name__)
-⋮----
-def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
-⋮----
-async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
-⋮----
-FunctionCallTypes = Literal["none", "auto"]
-ToolChoiceTypes = Literal["none", "auto", "required"]
-ToolTypes = Literal["function"]
-⋮----
-DEFAULT_CONTEXT_LENGTH = 16_000
-⋮----
-class StreamEventType(Enum)
-⋮----
-TEXT = 1
-FUNC_NAME = 2
-FUNC_ARGS = 3
-TOOL_NAME = 4
-TOOL_ARGS = 5
-REASONING = 6
-⋮----
-class RetryParams(BaseSettings)
-⋮----
-max_retries: int = 5
-initial_delay: float = 1.0
-exponential_base: float = 1.3
-jitter: bool = True
-⋮----
-class LLMConfig(BaseSettings)
-⋮----
-"""
-    Common configuration for all language models.
-    """
-⋮----
-type: str = "openai"
-streamer: Optional[Callable[[Any], None]] = noop_fn
-streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
-api_base: str | None = None
-formatter: None | str = None
-# specify None if you want to use the full max output tokens of the model
-max_output_tokens: int | None = 8192
-timeout: int = 20  # timeout for API requests
-chat_model: str = ""
-completion_model: str = ""
-temperature: float = 0.0
-chat_context_length: int | None = None
-async_stream_quiet: bool = False  # suppress streaming output in async mode?
-completion_context_length: int | None = None
-# if input length + max_output_tokens > context length of model,
-# we will try shortening requested output
-min_output_tokens: int = 64
-use_completion_for_chat: bool = False  # use completion model for chat?
-# use chat model for completion? For OpenAI models, this MUST be set to True!
-use_chat_for_completion: bool = True
-stream: bool = True  # stream output from API?
-# TODO: we could have a `stream_reasoning` flag here to control whether to show
-# reasoning output from reasoning models
-cache_config: None | CacheDBConfig = RedisCacheConfig()
-thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
-retry_params: RetryParams = RetryParams()
-⋮----
-@property
-    def model_max_output_tokens(self) -> int
-⋮----
-# Build fallback names by progressively stripping provider prefixes
-# (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
-# succeeds even before OpenAIGPT.__init__ strips the prefix.
-parts = self.chat_model.split("/")
-fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
-⋮----
-class LLMFunctionCall(BaseModel)
-⋮----
-"""
-    Structure of LLM response indicating it "wants" to call a function.
-    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
-    """
-⋮----
-name: str  # name of function to call
-arguments: Optional[Dict[str, Any]] = None
-⋮----
-@staticmethod
-    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall"
-⋮----
-"""
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-fun_call = LLMFunctionCall(name=message["name"])
-fun_args_str = message["arguments"]
-# sometimes may be malformed with invalid indents,
-# so we try to be safe by removing newlines.
-⋮----
-fun_args_str = fun_args_str.replace("\n", "").strip()
-dict_or_list = parse_imperfect_json(fun_args_str)
-⋮----
-fun_args = dict_or_list
-⋮----
-fun_args = None
-⋮----
-def __str__(self) -> str
-⋮----
-class LLMFunctionSpec(BaseModel)
-⋮----
-"""
-    Description of a function available for the LLM to use.
-    To be used when calling the LLM `chat()` method with the `functions` parameter.
-    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
-    """
-⋮----
-name: str
-description: str
-parameters: Dict[str, Any]
-⋮----
-class OpenAIToolCall(BaseModel)
-⋮----
-"""
-    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
-    See https://platform.openai.com/docs/api-reference/chat/create
-
-    Attributes:
-        id: The id of the tool call.
-        type: The type of the tool call;
-            only "function" is currently possible (7/26/24).
-        function: The function call.
-    """
-⋮----
-id: str | None = None
-type: ToolTypes = "function"
-function: LLMFunctionCall | None = None
-extra_content: Dict[str, Any] | None = None
-⋮----
-@staticmethod
-    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall"
-⋮----
-id = message["id"]
-type = message["type"]
-function = LLMFunctionCall.from_dict(message["function"])
-extra_content = message.get("extra_content")
-⋮----
-class OpenAIToolSpec(BaseModel)
-⋮----
-type: ToolTypes
-strict: Optional[bool] = None
-function: LLMFunctionSpec
-⋮----
-class OpenAIJsonSchemaSpec(BaseModel)
-⋮----
-def to_dict(self) -> Dict[str, Any]
-⋮----
-json_schema: Dict[str, Any] = {
-⋮----
-class LLMTokenUsage(BaseModel)
-⋮----
-"""
-    Usage of tokens by an LLM.
-    """
-⋮----
-prompt_tokens: int = 0
-cached_tokens: int = 0
-completion_tokens: int = 0
-cost: float = 0.0
-calls: int = 0  # how many API calls - not used as of 2025-04-04
-⋮----
-def reset(self) -> None
-⋮----
-@property
-    def total_tokens(self) -> int
-⋮----
-class Role(str, Enum)
-⋮----
-"""
-    Possible roles for a message in a chat.
-    """
-⋮----
-USER = "user"
-SYSTEM = "system"
-ASSISTANT = "assistant"
-FUNCTION = "function"
-TOOL = "tool"
-⋮----
-class LLMMessage(BaseModel)
-⋮----
-"""
-    Class representing an entry in the msg-history sent to the LLM API.
-    It could be one of these:
-    - a user message
-    - an LLM ("Assistant") response
-    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
-    - a result or results from executing a fn or tool-call(s)
-    """
-⋮----
-role: Role
-name: Optional[str] = None
-tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
-tool_id: str = ""  # used by OpenAIAssistant
-# None means "no content" (the model returned only a tool/function call).
-# This is distinct from "" and is dropped from the API payload by api_dict;
-# see api_dict for how a fully-empty message is handled per-API.
-content: Optional[str] = None
-files: List[FileAttachment] = []
-function_call: Optional[LLMFunctionCall] = None
-tool_calls: Optional[List[OpenAIToolCall]] = None
-timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-# link to corresponding chat document, for provenance/rewind purposes
-chat_document_id: str = ""
-⋮----
-def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]
-⋮----
-"""
-        Convert to dictionary for API request, keeping ONLY
-        the fields that are expected in an API call!
-        E.g., DROP the tool_id, since it is only for use in the Assistant API,
-            not the completion API.
-
-        Args:
-            has_system_role: whether the message has a system role (if not,
-                set to "user" role)
-        Returns:
-            dict: dictionary representation of LLM message
-        """
-d = self.model_dump()
-files: List[FileAttachment] = d.pop("files")
-⋮----
-# In there are files, then content is an array of
-# different content-parts
-⋮----
-# if there is a key k = "role" with value "system", change to "user"
-# in case has_system_role is False
-⋮----
-# drop None values since API doesn't accept them (this omits `content`
-# entirely when it is None, i.e. "no content")
-dict_no_none = {k: v for k, v in d.items() if v is not None}
-⋮----
-# OpenAI API does not like empty name
-⋮----
-# arguments must be a string
-⋮----
-# convert tool calls to API format
-⋮----
-# An empty tool-call list is not a call and conveys no useful API
-# information. Omitting it also lets the empty-message fallback
-# below produce a valid message.
-⋮----
-# A message with empty content (None was dropped above, or "") AND no
-# tool/function call would be an entirely empty message, which some APIs
-# (e.g. Gemini) reject; fall back to a single space in that case only.
-# When there IS a tool/function call, empty content is fine (and Gemini
-# 3.x in fact REQUIRES it — it rejects an assistant turn that carries
-# both a call and non-empty text content).
-has_call = bool(dict_no_none.get("tool_calls")) or (
-⋮----
-# IMPORTANT! drop fields that are not expected in API call
-⋮----
-content = "FUNC: " + json.dumps(self.function_call)
-⋮----
-content = self.content or ""
-name_str = f" ({self.name})" if self.name else ""
-⋮----
-class LLMResponse(BaseModel)
-⋮----
-"""
-    Class representing response from LLM.
-    """
-⋮----
-# None means the model returned NO content (e.g. only a tool/function
-# call), which is distinct from an empty string "". Preserving this
-# distinction lets the message be faithfully reproduced downstream
-# (see ChatDocument.content_is_none and LLMMessage.content).
-message: Optional[str] = None
-reasoning: str = ""  # optional reasoning text from reasoning models
-# Original message text including inline thought signatures (e.g.
-# <thinking>...</thinking>). Only set when reasoning was extracted
-# from the message text via get_reasoning_final(); NOT set when
-# reasoning comes from a separate API field (e.g. reasoning_content),
-# since in that case the message text never contained thought tags.
-message_with_reasoning: Optional[str] = None
-# TODO tool_id needs to generalize to multi-tool calls
-⋮----
-oai_tool_calls: Optional[List[OpenAIToolCall]] = None
-⋮----
-usage: Optional[LLMTokenUsage] = None
-cached: bool = False
-⋮----
-def tools_content(self) -> str
-⋮----
-def to_LLMMessage(self) -> LLMMessage
-⋮----
-"""Convert LLM response to an LLMMessage, to be included in the
-        message-list sent to the API.
-        This is currently NOT used in any significant way in the library, and is only
-        provided as a utility to construct a message list for the API when directly
-        working with an LLM object.
-
-        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
-        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
-        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
-        """
-⋮----
-"""
-        If `message` or `function_call` of an LLM response contains an explicit
-        recipient name, return this recipient name and `message` stripped
-        of the recipient name if specified.
-
-        Two cases:
-        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
-        (b) `message` is empty and function_call/tool_call with explicit `recipient`
-
-        Args:
-            recognize_recipient_in_content (bool): When True (default), parses
-                message text for ``TO[<recipient>]:<content>`` patterns and
-                top-level JSON ``{"recipient": "..."}`` fields. When False,
-                only function_call/tool_call ``recipient`` fields are checked.
-
-        Returns:
-            (str): name of recipient, which may be empty string if no recipient
-            (str): content of message
-
-        """
-⋮----
-# in this case we ignore message, since all information is in function_call
-msg = ""
-args = self.function_call.arguments
-recipient = ""
-⋮----
-recipient = args.get("recipient", "")
-⋮----
-msg = self.message or ""
-⋮----
-# get the first tool that has a recipient field, if any
-⋮----
-recipient = tc.function.arguments.get(
-⋮----
-)  # type: ignore
-⋮----
-# It's not a function or tool call, so continue looking to see
-# if a recipient is specified in the message.
-⋮----
-# First check if message contains "TO: <recipient> <content>"
-⋮----
-# check if there is a top level json that specifies 'recipient',
-# and retain the entire message as content.
-⋮----
-recipient_name = top_level_json_field(msg, "recipient") if msg else ""
-content = msg
-⋮----
-# Define an abstract base class for language models
-class LanguageModel(ABC)
-⋮----
-"""
-    Abstract base class for language models.
-    """
-⋮----
-# usage cost by model, accumulates here
-usage_cost_dict: Dict[str, LLMTokenUsage] = {}
-⋮----
-def __init__(self, config: LLMConfig = LLMConfig())
-⋮----
-@staticmethod
-    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]
-⋮----
-"""
-        Create a language model.
-        Args:
-            config: configuration for language model
-        Returns: instance of language model
-        """
-⋮----
-openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
-⋮----
-openai = AzureGPT
-⋮----
-openai = OpenAIGPT
-cls = dict(
-return cls(config)  # type: ignore
-⋮----
-@staticmethod
-    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]
-⋮----
-"""
-        Given an even-length sequence of strings, split into a sequence of pairs
-
-        Args:
-            lst (List[str]): sequence of strings
-
-        Returns:
-            List[Tuple[str,str]]: sequence of pairs of strings
-        """
-evens = lst[::2]
-odds = lst[1::2]
-⋮----
-"""
-        From the chat history, extract system prompt, user-assistant turns, and
-        final user msg.
-
-        Args:
-            messages (List[LLMMessage]): List of messages in the chat history
-
-        Returns:
-            Tuple[str, List[Tuple[str,str]], str]:
-                system prompt, user-assistant turns, final user msg
-
-        """
-# Handle various degenerate cases
-messages = [m for m in messages]  # copy
-DUMMY_SYS_PROMPT = "You are a helpful assistant."
-DUMMY_USER_PROMPT = "Follow the instructions above."
-⋮----
-system_prompt = messages[0].content or ""
-⋮----
-# now we have messages = [Sys,...]
-⋮----
-# now we have messages = [Sys, msg, ...]
-⋮----
-# now we have messages = [Sys, user, ...]
-⋮----
-# now we have messages = [Sys, user, ..., user]
-# so we omit the first and last elements and make pairs of user-asst messages
-conversation = [m.content or "" for m in messages[1:-1]]
-user_prompt = messages[-1].content or ""
-pairs = LanguageModel.user_assistant_pairs(conversation)
-⋮----
-@abstractmethod
-    def set_stream(self, stream: bool) -> bool
-⋮----
-"""Enable or disable streaming output from API.
-        Return previous value of stream."""
-⋮----
-@abstractmethod
-    def get_stream(self) -> bool
-⋮----
-"""Get streaming status"""
-⋮----
-@abstractmethod
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-@abstractmethod
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-"""
-        Get chat-completion response from LLM.
-
-        Args:
-            messages: message-history to send to the LLM
-            max_tokens: max tokens to generate
-            tools: tools available for the LLM to use in its response
-            tool_choice: tool call mode, one of "none", "auto", "required",
-                or a dict specifying a specific tool.
-            functions: functions available for LLM to call (deprecated)
-            function_call: function calling mode, "auto", "none", or a specific fn
-                    (deprecated)
-        """
-⋮----
-"""Async version of `chat`. See `chat` for details."""
-⋮----
-def __call__(self, prompt: str, max_tokens: int) -> LLMResponse
-⋮----
-@staticmethod
-    def _fallback_model_names(model: str) -> List[str]
-⋮----
-parts = model.split("/")
-fallbacks = []
-⋮----
-def info(self) -> ModelInfo
-⋮----
-"""Info of relevant chat model"""
-orig_model = (
-⋮----
-def completion_info(self) -> ModelInfo
-⋮----
-"""Info of relevant completion model"""
-⋮----
-def supports_functions_or_tools(self) -> bool
-⋮----
-"""
-        Does this Model's API support "native" tool-calling, i.e.
-        can we call the API with arguments that contain a list of available tools,
-        and their schemas?
-        Note that, given the plethora of LLM provider APIs this determination is
-        imperfect at best, and leans towards returning True.
-        When the API calls fails with an error indicating tools are not supported,
-        then users are encouraged to use the Langroid-based prompt-based
-        ToolMessage mechanism, which works with ANY LLM. To enable this,
-        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
-        """
-⋮----
-def chat_context_length(self) -> int
-⋮----
-def completion_context_length(self) -> int
-⋮----
-def chat_cost(self) -> Tuple[float, float, float]
-⋮----
-"""
-        Return the cost per 1000 tokens for chat completions.
-
-        Returns:
-            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
-                per 1000 tokens
-        """
-⋮----
-def reset_usage_cost(self) -> None
-⋮----
-counter = self.usage_cost_dict[mdl]
-⋮----
-"""
-        Update usage cost for this LLM.
-        Args:
-            chat (bool): whether to update for chat or completion model
-            prompts (int): number of tokens used for prompts
-            completions (int): number of tokens used for completions
-            cost (float): total token cost in USD
-        """
-mdl = self.config.chat_model if chat else self.config.completion_model
-⋮----
-@classmethod
-    def usage_cost_summary(cls) -> str
-⋮----
-s = ""
-⋮----
-@classmethod
-    def tot_tokens_cost(cls) -> Tuple[int, float]
-⋮----
-"""
-        Return total tokens used and total cost across all models.
-        """
-total_tokens = 0
-total_cost = 0.0
-⋮----
-def get_reasoning_final(self, message: str) -> Tuple[str, str]
-⋮----
-"""Extract "reasoning" and "final answer" from an LLM response, if the
-        reasoning is found within configured delimiters, like <think>, </think>.
-        E.g.,
-        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
-
-        Args:
-            message (str): message from LLM
-
-        Returns:
-            Tuple[str, str]: reasoning, final answer
-        """
-⋮----
-parts = message.split(start)
-⋮----
-"""
-        Given a chat history and a question, convert it to a standalone question.
-        Args:
-            chat_history: list of tuples of (question, answer)
-            query: follow-up question
-
-        Returns: standalone version of the question
-        """
-history = collate_chat_history(chat_history)
-⋮----
-prompt = f"""
-⋮----
-follow_up_question = f"""
-⋮----
-standalone = (
-standalone = standalone.strip()
-⋮----
-class StreamingIfAllowed
-⋮----
-"""Context to temporarily enable or disable streaming, if allowed globally via
-    `settings.stream`"""
-⋮----
-def __init__(self, llm: LanguageModel, stream: bool = True)
-⋮----
-def __enter__(self) -> None
-⋮----
-def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
-</file>
-
 <file path="langroid/language_models/client_cache.py">
 """
 Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
@@ -57492,1285 +57542,6 @@ model_names = tuple(_model_name(model) for model in models)
 def _model_name(model: str | ModelName) -> str
 </file>
 
-<file path="langroid/agent/chat_agent.py">
-console = Console()
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-# Stable origin sentinel for the dynamically generated strict-recovery AnyTool
-# class ("tool_or_function"): a fresh class is built per call (its tool-union
-# type varies), so re-registration must be recognized as the same logical tool.
-_ANY_TOOL_MESSAGE_ORIGIN: Any = object()
-⋮----
-# Safety margin (in tokens) subtracted from the model context length when
-# shrinking chat history and/or the requested output length to fit, in case
-# our token-count estimates are off.
-CHAT_HISTORY_BUFFER = 300
-⋮----
-def _reject_json_constant(constant: str) -> None
-⋮----
-"""Reject JavaScript numeric constants that are not valid JSON."""
-⋮----
-def _parse_json_float(value: str) -> float
-⋮----
-"""Parse a JSON float while rejecting exponent overflow."""
-parsed = float(value)
-⋮----
-def _is_identified_result(message: LLMMessage) -> bool
-⋮----
-"""Whether a TOOL/FUNCTION result has its identifier and no call payload.
-
-    Such results must survive even with empty content so their calls can be
-    marked complete (issue #1063).
-    """
-has_identifier = (
-⋮----
-def _llm_message_has_payload(message: LLMMessage) -> bool
-⋮----
-"""Whether a message has the fields required for a valid history entry."""
-⋮----
-class ChatAgentConfig(AgentConfig)
-⋮----
-"""
-    Configuration for ChatAgent
-
-    Attributes:
-        system_message: system message to include in message sequence
-             (typically defines role and task of agent).
-             Used only if `task` is not specified in the constructor.
-        user_message: user message to include in message sequence.
-             Used only if `task` is not specified in the constructor.
-        use_tools: whether to use our own ToolMessages mechanism
-        handle_llm_no_tool (Any): desired agent_response when
-            LLM generates non-tool msg.
-        use_functions_api: whether to use functions/tools native to the LLM API
-                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
-        use_tools_api: When `use_functions_api` is True, if this is also True,
-            the OpenAI tool-call API is used, rather than the older/deprecated
-            function-call API. However the tool-call API has some tricky aspects,
-            hence we set this to False by default.
-        strict_recovery: whether to enable strict schema recovery when there
-            is a tool-generation error.
-        enable_orchestration_tool_handling: whether to enable handling of orchestration
-            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
-        output_format: When supported by the LLM (certain OpenAI LLMs
-            and local LLMs served by providers such as vLLM), ensures
-            that the output is a JSON matching the corresponding
-            schema via grammar-based decoding
-        handle_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for handling".
-        use_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for use" (by LLM) and
-            instructions on using T are added to the system message.
-        instructions_output_format: Controls whether we generate instructions for
-            `output_format` in the system message.
-        use_tools_on_output_format: Controls whether to automatically switch
-            to the Langroid-native tools mechanism when `output_format` is set.
-            Note that LLMs may generate tool calls which do not belong to
-            `output_format` even when strict JSON mode is enabled, so this should be
-            enabled when such tool calls are not desired.
-        output_format_include_defaults: Whether to include fields with default arguments
-            in the output schema
-        full_citations: Whether to show source reference citation + content for each
-            citation, or just the main reference citation.
-        search_for_tools_everywhere: Whether to search for tools everywhere,
-            or only in specific LLM response elements based on use_tools /
-            use_functions_api / use_tools_api config settings.
-        recognize_recipient_in_content: Whether to parse LLM response text content
-            for recipient routing patterns, specifically:
-            - ``TO[<recipient>]:<content>`` addressing format, and
-            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
-            When False, only structured routing via function_call/tool_call
-            ``recipient`` fields is recognized. Default is True.
-            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
-            which controls Task-level signals like DONE, PASS, and SEND_TO.
-            To fully disable all text-based routing, set both to False.
-        context_overflow_strategy: Strategy for handling context overflow when
-            message history exceeds model context length. Options:
-            - "truncate": Truncate content of early messages (preserves all messages
-              but with shortened content). This maintains the message sequence.
-            - "drop_turns": Drop complete conversation turns (USER + all responses
-              until next USER). More aggressive but cleaner for voice agents.
-            Default is "truncate" for backward compatibility.
-    """
-⋮----
-system_message: str = "You are a helpful assistant."
-user_message: Optional[str] = None
-handle_llm_no_tool: Any = None
-use_tools: bool = True
-use_functions_api: bool = False
-use_tools_api: bool = True
-strict_recovery: bool = True
-enable_orchestration_tool_handling: bool = True
-output_format: Optional[type] = None
-handle_output_format: bool = True
-use_output_format: bool = True
-instructions_output_format: bool = True
-output_format_include_defaults: bool = True
-use_tools_on_output_format: bool = True
-full_citations: bool = True  # show source + content for each citation?
-search_for_tools_everywhere: bool = True
-recognize_recipient_in_content: bool = True
-context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
-⋮----
-def _set_fn_or_tools(self) -> None
-⋮----
-"""
-        Enable Langroid Tool or OpenAI-like fn-calling,
-        depending on config settings.
-        """
-⋮----
-class ChatAgent(Agent)
-⋮----
-"""
-    Chat Agent interacting with external env
-    (could be human, or external tools).
-    The agent (the LLM actually) is provided with an optional "Task Spec",
-    which is a sequence of `LLMMessage`s. These are used to initialize
-    the `task_messages` of the agent.
-    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
-    The `Agent` class mainly exists to hold various common methods and attributes.
-    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
-    `llm_response` method uses "chat mode" API (i.e. one that takes a
-    message sequence rather than a single message),
-    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
-    that takes a single message).
-    """
-⋮----
-"""
-        Chat-mode agent initialized with task spec as the initial message sequence
-        Args:
-            config: settings for the agent
-
-        """
-⋮----
-# An agent's "task" is defined by a system msg and an optional user msg;
-# These are "priming" messages that kick off the agent's conversation.
-⋮----
-# if task contains a system msg, we override the config system msg
-⋮----
-# if task contains a user msg, we override the config user msg
-⋮----
-# system-level instructions for using tools/functions:
-# We maintain these as tools/functions are enabled/disabled,
-# and whenever an LLM response is sought, these are used to
-# recreate the system message (via `_create_system_and_tools_message`)
-# each time, so it reflects the current set of enabled tools/functions.
-# (a) these are general instructions on using certain tools/functions,
-#   if they are specified in a ToolMessage class as a classmethod `instructions`
-⋮----
-# (b) these are only for the builtin in Langroid TOOLS mechanism:
-⋮----
-# This variable is not None and equals a `ToolMessage` T, if and only if:
-# (a) T has been set as the output_format of this agent, AND
-# (b) T has been "enabled for use" ONLY for enforcing this output format, AND
-# (c) T has NOT been explicitly "enabled for use" by this Agent.
-⋮----
-# As above but deals with "enabled for handling" instead of "enabled for use".
-⋮----
-# instructions specifically related to enforcing `output_format`
-⋮----
-# controls whether to disable strict schemas for this agent if
-# strict mode causes exception
-⋮----
-# Tracks whether any strict tool is enabled; used to determine whether to set
-# `self.disable_strict` on an exception
-⋮----
-# Tracks the set of tools on which we force-disable strict decoding
-⋮----
-# search for tools according to the agent configuration
-⋮----
-# Only enable HANDLING by `agent_response`, NOT LLM generation of these.
-# This is useful where tool-handlers or agent_response generate these
-# tools, and need to be handled.
-# We don't want enable orch tool GENERATION by default, since that
-# might clutter-up the LLM system message unnecessarily.
-⋮----
-def init_state(self) -> None
-⋮----
-"""
-        Initialize the state of the agent. Just conversation state here,
-        but subclasses can override this to initialize other state.
-        """
-⋮----
-@staticmethod
-    def from_id(id: str) -> "ChatAgent"
-⋮----
-"""
-        Get an agent from its ID
-        Args:
-            agent_id (str): ID of the agent
-        Returns:
-            ChatAgent: The agent with the given ID
-        """
-⋮----
-def clone(self, i: int = 0) -> "ChatAgent"
-⋮----
-"""Create i'th clone of this agent, ensuring tool use/handling is cloned.
-        Important: We assume all member variables are in the __init__ method here
-        and in the Agent class.
-        TODO: We are attempting to clone an agent after its state has been
-        changed in possibly many ways. Below is an imperfect solution. Caution advised.
-        Revisit later.
-        """
-agent_cls = type(self)
-# Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
-# instead of deepcopy which loses subclass information
-config_copy = self.config.model_copy(deep=True)
-⋮----
-new_agent = agent_cls(config_copy)
-⋮----
-# Ensure each clone gets its own vecdb client when supported.
-⋮----
-def _clone_extra_state(self, new_agent: "ChatAgent") -> None
-⋮----
-"""Hook for subclasses to copy additional state into clones."""
-⋮----
-def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool
-⋮----
-"""Should we enable strict mode for a given tool?"""
-⋮----
-tool_class = self.llm_tools_map[tool]
-⋮----
-tool_class = tool
-name = tool_class.default_value("request")
-⋮----
-strict: Optional[bool] = tool_class.default_value("strict")
-⋮----
-strict = self._strict_tools_available()
-⋮----
-def _fn_call_available(self) -> bool
-⋮----
-"""Does this agent's LLM support function calling?"""
-⋮----
-def _strict_tools_available(self) -> bool
-⋮----
-"""Does this agent's LLM support strict tools?"""
-⋮----
-def _json_schema_available(self) -> bool
-⋮----
-"""Does this agent's LLM support strict JSON schema output format?"""
-⋮----
-def set_system_message(self, msg: str) -> None
-⋮----
-# if there is message history, update the system message in it
-⋮----
-def set_user_message(self, msg: str) -> None
-⋮----
-@property
-    def task_messages(self) -> List[LLMMessage]
-⋮----
-"""
-        The task messages are the initial messages that define the task
-        of the agent. There will be at least a system message plus possibly a user msg.
-        Returns:
-            List[LLMMessage]: the task messages
-        """
-msgs = [self._create_system_and_tools_message()]
-⋮----
-def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None
-⋮----
-id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
-⋮----
-# dropping tool result, so ADD the corresponding tool-call back
-# to the list of pending calls!
-id = msg.tool_call_id
-⋮----
-# dropping a msg with tool-calls, so DROP these from pending list
-# as well as from id -> call map
-⋮----
-def clear_history(self, start: int = -2, end: int = -1) -> None
-⋮----
-"""
-        Clear the message history, deleting  messages from index `start`,
-        up to index `end`.
-
-        Args:
-            start (int): index of first message to delete; default = -2
-                    (i.e. delete last 2 messages, typically these
-                    are the last user and assistant messages)
-            end (int): index of last message to delete; Default = -1
-                    (i.e. delete all messages up to the last one)
-        """
-n = len(self.message_history)
-⋮----
-start = max(0, n + start)
-end_ = n if end == -1 else end + 1
-dropped = self.message_history[start:end_]
-# consider the dropped msgs in REVERSE order, so we are
-# carefully updating self.oai_tool_calls
-⋮----
-# clear out the chat document from the ObjectRegistry
-⋮----
-def update_history(self, message: str, response: str) -> None
-⋮----
-"""
-        Update the message history with the latest user message and LLM response.
-        Args:
-            message (str): user message
-            response: (str): LLM response
-        """
-⋮----
-def export_history(self) -> str
-⋮----
-"""Export message history as a portable, versioned JSON snapshot.
-
-        Returns:
-            A JSON string containing the current message history.
-        """
-messages: List[Dict[str, Any]] = []
-⋮----
-data = message.model_dump(mode="json", exclude={"files"})
-⋮----
-"""Restore message history from :meth:`export_history` output.
-
-        Args:
-            snapshot: Versioned JSON snapshot to restore.
-            max_size_bytes: Maximum total decoded attachment size. Defaults to
-                100 MiB.
-
-        Raises:
-            ValueError: If the snapshot is malformed, has an unknown version,
-                starts with a non-system message, or exceeds ``max_size_bytes``.
-        """
-⋮----
-payload = json.loads(
-⋮----
-raw_messages = payload.get("messages")
-⋮----
-messages: List[LLMMessage] = []
-total_attachment_bytes = 0
-⋮----
-message_data = dict(raw_message)
-raw_files = message_data.get("files", [])
-⋮----
-files = []
-⋮----
-file_data = dict(raw_file)
-encoded_content = file_data.pop("content_base64")
-⋮----
-encoded_bytes = encoded_content.encode("ascii")
-padding = len(encoded_bytes) - len(encoded_bytes.rstrip(b"="))
-decoded_size = max(
-⋮----
-content = base64.b64decode(encoded_bytes, validate=True)
-⋮----
-seen_call_ids: Set[str] = set()
-⋮----
-name = message.name
-⋮----
-call_id = call.id
-⋮----
-all_calls = {
-completed_call_ids = {
-old_chat_document_ids = {
-⋮----
-def tool_format_rules(self) -> str
-⋮----
-"""
-        Specification of tool formatting rules
-        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
-        based on the currently enabled usable `ToolMessage`s
-
-        Returns:
-            str: formatting rules
-        """
-# ONLY Usable tools (i.e. LLM-generation allowed),
-usable_tool_classes: List[Type[ToolMessage]] = [
-⋮----
-format_instructions = "\n\n".join(
-# if any of the enabled classes has json_group_instructions, then use that,
-# else fall back to ToolMessage.json_group_instructions
-⋮----
-def tool_instructions(self) -> str
-⋮----
-"""
-        Instructions for tools or function-calls, for enabled and usable Tools.
-        These are inserted into system prompt regardless of whether we are using
-        our own ToolMessage mechanism or the LLM's function-call mechanism.
-
-        Returns:
-            str: concatenation of instructions for all usable tools
-        """
-enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
-⋮----
-instructions = []
-⋮----
-class_instructions = ""
-⋮----
-class_instructions = msg_cls.instructions()
-⋮----
-# example will be shown in tool_format_rules() when using TOOLs,
-# so we don't need to show it here.
-example = "" if self.config.use_tools else (msg_cls.usage_examples())
-⋮----
-example = "EXAMPLES:\n" + example
-guidance = (
-⋮----
-instructions_str = "\n\n".join(instructions)
-⋮----
-def augment_system_message(self, message: str) -> None
-⋮----
-"""
-        Augment the system message with the given message.
-        Args:
-            message (str): system message
-        """
-⋮----
-def last_message_with_role(self, role: Role) -> LLMMessage | None
-⋮----
-"""from `message_history`, return the last message with role `role`"""
-n_role_msgs = len([m for m in self.message_history if m.role == role])
-⋮----
-idx = self.nth_message_idx_with_role(role, n_role_msgs)
-⋮----
-def last_message_idx_with_role(self, role: Role) -> int
-⋮----
-"""Index of last message in message_history, with specified role.
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-indices_with_role = [
-⋮----
-def nth_message_idx_with_role(self, role: Role, n: int) -> int
-⋮----
-"""Index of `n`th message in message_history, with specified role.
-        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-⋮----
-def update_last_message(self, message: str, role: str = Role.USER) -> None
-⋮----
-"""
-        Update the last message that has role `role` in the message history.
-        Useful when we want to replace a long user prompt, that may contain context
-        documents plus a question, with just the question.
-        Args:
-            message (str): new message to replace with
-            role (str): role of message to replace
-        """
-⋮----
-# find last message in self.message_history with role `role`
-⋮----
-def delete_last_message(self, role: str = Role.USER) -> None
-⋮----
-"""
-        Delete the last message that has role `role` from the message history.
-        Args:
-            role (str): role of message to delete
-        """
-⋮----
-def _create_system_and_tools_message(self) -> LLMMessage
-⋮----
-"""
-        (Re-)Create the system message for the LLM of the agent,
-        taking into account any tool instructions that have been added
-        after the agent was initialized.
-
-        The system message will consist of:
-        (a) the system message from the `task` arg in constructor, if any,
-            otherwise the default system message from the config
-        (b) the system tool instructions, if any
-        (c) the system json tool instructions, if any
-
-        Returns:
-            LLMMessage object
-        """
-content = self.system_message
-⋮----
-# remove leading and trailing newlines and other whitespace
-⋮----
-def handle_message_fallback(self, msg: str | ChatDocument) -> Any
-⋮----
-"""
-        Fallback method for the "no-tools" scenario, i.e., the current `msg`
-        (presumably emitted by the LLM) does not have any tool that the agent
-        can handle.
-        NOTE: The `msg` may contain tools but either (a) the agent is not
-        enabled to handle them, or (b) there's an explicit `recipient` field
-        in the tool that doesn't match the agent's name.
-
-        Uses the self.config.non_tool_routing to determine the action to take.
-
-        This method can be overridden by subclasses, e.g.,
-        to create a "reminder" message when a tool is expected but the LLM "forgot"
-        to generate one.
-
-        Args:
-            msg (str | ChatDocument): The input msg to handle
-        Returns:
-            Any: The result of the handler method
-        """
-⋮----
-# we ONLY use the `handle_llm_no_tool` config option when
-# the msg is from LLM and does not contain ANY tools at all.
-⋮----
-no_tool_option = self.config.handle_llm_no_tool
-⋮----
-# in case the `no_tool_option` is one of the special NonToolAction vals
-⋮----
-# Otherwise just return `no_tool_option` as is:
-# This can be any string, such as a specific nudge/reminder to the LLM,
-# or even something like ResultTool etc.
-⋮----
-def unhandled_tools(self) -> set[str]
-⋮----
-"""The set of tools that are known but not handled.
-        Useful in task flow: an agent can refuse to accept an incoming msg
-        when it only has unhandled tools.
-        """
-⋮----
-"""
-        Add the tool (message class) to the agent, and enable either
-        - tool USE (i.e. the LLM can generate JSON to use this tool),
-        - tool HANDLING (i.e. the agent can handle JSON from this tool),
-
-        Args:
-            message_class: The ToolMessage class OR List of such classes to enable,
-                for USE, or HANDLING, or both.
-                If this is a list of ToolMessage classes, then the remain args are
-                applied to all classes.
-                Optional; if None, then apply the enabling to all tools in the
-                agent's toolset that have been enabled so far.
-            use: IF True, allow the agent (LLM) to use this tool (or all tools),
-                else disallow
-            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
-                tool (or all tools)
-            force: whether to FORCE the agent (LLM) to USE the specific
-                 tool represented by `message_class`.
-                 `force` is ignored if `message_class` is None.
-            require_recipient: whether to require that recipient be specified
-                when using the tool message (only applies if `use` is True).
-            include_defaults: whether to include fields that have default values,
-                in the "properties" section of the JSON format instructions.
-                (Normally the OpenAI completion API ignores these fields,
-                but the Assistant fn-calling seems to pay attn to these,
-                and if we don't want this, we should set this to False.)
-        """
-⋮----
-# Validate that use/handle are booleans, not accidentally passed tool classes
-⋮----
-param = "use" if isclass(use) else "handle"
-⋮----
-message_class = message_class.require_recipient()
-⋮----
-request = message_class.default_value("request")
-existing_class = self.llm_tools_map.get(request)
-existing_origin = (
-message_origin = message_class.__dict__.get(
-⋮----
-# XMLToolMessage is not compatible with OpenAI's Tools/functions API,
-# so we disable use of functions API, enable langroid-native Tools,
-# which are prompt-based.
-⋮----
-super().enable_message_handling(message_class)  # enables handling only
-tools = self._get_tool_list(message_class)
-⋮----
-llm_function = message_class.llm_function_schema(defaults=include_defaults)
-⋮----
-# `t` was designated as "enabled for handling" ONLY for
-# output_format enforcement, but we are explicitly ]
-# enabling it for handling here, so we set the variable to None.
-⋮----
-tool_class = self.llm_tools_map[t]
-allow_llm_use = tool_class._allow_llm_use
-⋮----
-allow_llm_use = allow_llm_use.default
-⋮----
-# `t` was designated as "enabled for use" ONLY for output_format
-# enforcement, but we are explicitly enabling it for use here,
-# so we set the variable to None.
-⋮----
-def _update_tool_instructions(self) -> None
-⋮----
-# Set tool instructions and JSON format instructions,
-# in case Tools have been enabled/disabled.
-⋮----
-def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]
-⋮----
-"""
-        Returns the current set of enabled requests for inference and tools configs.
-        Used for restoring setings overriden by `set_output_format`.
-        """
-⋮----
-@property
-    def all_llm_tools_known(self) -> set[str]
-⋮----
-"""All known tools; we include `output_format` if it is a `ToolMessage`."""
-known = self.llm_tools_known
-⋮----
-"""
-        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
-        switches to the native Langroid tools mechanism to ensure that no tool
-        calls not of `output_type` are generated. By default, `force_tools`
-        follows the `use_tools_on_output_format` parameter in the config.
-
-        If `output_type` is None, restores to the state prior to setting
-        `output_format`.
-
-        If `use`, we enable use of `output_type` when it is a subclass
-        of `ToolMesage`. Note that this primarily controls instruction
-        generation: the model will always generate `output_type` regardless
-        of whether `use` is set. Defaults to the `use_output_format`
-        parameter in the config. Similarly, handling of `output_type` is
-        controlled by `handle`, which defaults to the
-        `handle_output_format` parameter in the config.
-
-        `instructions` controls whether we generate instructions specifying
-        the output format schema. Defaults to the `instructions_output_format`
-        parameter in the config.
-
-        `is_copy` is set when called via `__getitem__`. In that case, we must
-        copy certain fields to ensure that we do not overwrite the main agent's
-        setings.
-        """
-# Disable usage of an output format which was not specifically enabled
-# by `enable_message`
-⋮----
-# Disable handling of an output format which did not specifically have
-# handling enabled via `enable_message`
-⋮----
-# Reset any previous instructions
-⋮----
-force_tools = self.config.use_tools_on_output_format
-⋮----
-output_type = get_pydantic_wrapper(output_type)
-⋮----
-name = output_type.default_value("request")
-⋮----
-use = self.config.use_output_format
-⋮----
-handle = self.config.handle_output_format
-⋮----
-is_usable = name in self.llm_tools_usable.union(
-is_handled = name in self.llm_tools_handled.union(
-⋮----
-# We must copy `llm_tools_usable` so the base agent
-# is unmodified
-⋮----
-# If handling the tool, do the same for `llm_tools_handled`
-⋮----
-# Enable `output_type`
-⋮----
-# Do not override existing settings
-⋮----
-# If the `output_type` ToilMessage was not already enabled for
-# use, this means we are ONLY enabling it for use specifically
-# for enforcing this output format, so we set the
-# `enabled_use_output_forma  to this output_type, to
-# record that it should be disabled when `output_format` is changed
-⋮----
-# (same reasoning as for use-enabling)
-⋮----
-generated_tool_instructions = name in self.llm_tools_usable.union(
-⋮----
-generated_tool_instructions = False
-⋮----
-instructions = self.config.instructions_output_format
-⋮----
-# Already generated tool instructions as part of "enabling for use",
-# so only need to generate a reminder to use this tool.
-name = cast(ToolMessage, output_type).default_value("request")
-⋮----
-output_format_schema = output_type.llm_function_schema(
-⋮----
-output_format_schema = output_type.model_json_schema()
-⋮----
-def __getitem__(self, output_type: type) -> Self
-⋮----
-"""
-        Returns a (shallow) copy of `self` with a forced output type.
-        """
-clone = copy.copy(self)
-⋮----
-"""
-        Disable this agent from RESPONDING to a `message_class` (Tool). If
-            `message_class` is None, then disable this agent from responding to ALL.
-        Args:
-            message_class: The ToolMessage class to disable; Optional.
-        """
-⋮----
-"""
-        Disable this agent from USING a message class (Tool).
-        If `message_class` is None, then disable this agent from USING ALL tools.
-        Args:
-            message_class: The ToolMessage class to disable.
-                If None, disable all.
-        """
-⋮----
-def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None
-⋮----
-"""
-        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
-        Args:
-            message_class: The only ToolMessage class to allow
-        """
-request = message_class.model_fields["request"].default
-to_remove = [r for r in self.llm_tools_usable if r != request]
-⋮----
-def _load_output_format(self, message: ChatDocument) -> None
-⋮----
-"""
-        If set, attempts to parse a value of type `self.output_format` from the message
-        contents or any tool/function call and assigns it to `content_any`.
-        """
-⋮----
-any_succeeded = False
-attempts: list[str | LLMFunctionCall] = [
-⋮----
-content = json.loads(attempt)
-⋮----
-content = attempt.arguments
-⋮----
-content_any = self.output_format.model_validate(content)
-⋮----
-message.content_any = content_any.value  # type: ignore
-⋮----
-any_succeeded = True
-⋮----
-"""
-        Extracts messages and tracks whether any errors occurred. If strict mode
-        was enabled, disables it for the tool, else triggers strict recovery.
-        """
-⋮----
-most_recent_sent_by_llm = (
-was_llm = most_recent_sent_by_llm or (
-⋮----
-tools = super().get_tool_messages(msg, all_tools)
-⋮----
-# Check if tool class was attached to the exception
-⋮----
-tool_class = ve.tool_class  # type: ignore
-⋮----
-was_strict = (
-# If the result of strict output for a tool using the
-# OpenAI tools API fails to parse, we infer that the
-# schema edits necessary for compatibility prevented
-# adherence to the underlying `ToolMessage` schema and
-# disable strict output for the tool
-⋮----
-# We will trigger the strict recovery mechanism to force
-# the LLM to correct its output, allowing us to parse
-⋮----
-def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None
-⋮----
-"""
-        Returns a `ToolMessage` which wraps all enabled tools, excluding those
-        where strict recovery is disabled. Used in strict recovery.
-        """
-possible_tools = tuple(
-⋮----
-any_tool_type = Union.__getitem__(possible_tools)  # type ignore
-⋮----
-maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
-⋮----
-class AnyTool(ToolMessage)
-⋮----
-purpose: str = "To call a tool/function."
-request: str = "tool_or_function"
-tool: maybe_optional_type  # type: ignore
-⋮----
-def response(self, agent: ChatAgent) -> None | str | ChatDocument
-⋮----
-# One-time use
-⋮----
-# As the ToolMessage schema accepts invalid
-# `tool.request` values, reparse with the
-# corresponding tool
-request = self.tool.request
-⋮----
-tool = agent.llm_tools_map[request].model_validate_json(
-⋮----
-# Every call builds a distinct class; share one origin so enabling a
-# regenerated AnyTool under "tool_or_function" stays idempotent instead
-# of tripping the same-name/different-tool registration guard.
-AnyTool.__tool_message_origin__ = (  # type: ignore[attr-defined]
-⋮----
-"""Returns instructions for strict recovery."""
-optional_instructions = (
-response_prefix = "If you intended to make such a call, r" if optional else "R"
-instruction_prefix = "If you do so, b" if optional else "B"
-⋮----
-schema_instructions = (
-⋮----
-"""
-        Truncate message at idx in msg history to `tokens` tokens.
-
-        If inplace is True, the message is truncated in place, else
-        it LEAVES the original message INTACT and returns a new message
-        """
-⋮----
-llm_msg = self.message_history[idx]
-⋮----
-llm_msg = copy.deepcopy(self.message_history[idx])
-⋮----
-orig_content = llm_msg.content
-new_content = (
-⋮----
-else orig_content[: tokens * 4]  # approx truncation
-⋮----
-def _reduce_raw_tool_results(self, message: ChatDocument) -> None
-⋮----
-"""
-        If message is the result of a ToolMessage that had
-        a `_max_retained_tokens` set to a non-None value, then we replace contents
-        with a placeholder message.
-        """
-parent_message: ChatDocument | None = message.parent
-tools = [] if parent_message is None else parent_message.tool_messages
-truncate_tools = []
-⋮----
-max_retained_tokens = t._max_retained_tokens
-⋮----
-max_retained_tokens = max_retained_tokens.default
-⋮----
-limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
-⋮----
-max_retained_tokens = limiting_tool._max_retained_tokens
-⋮----
-tool_name = limiting_tool.default_value("request")
-max_tokens: int = max_retained_tokens
-truncation_warning = f"""
-⋮----
-"""
-        Respond to a single user message, appended to the message history,
-        in "chat" mode
-        Args:
-            message (str|ChatDocument): message or ChatDocument object to respond to.
-                If None, use the self.task_messages
-        Returns:
-            LLM response as a ChatDocument object
-        """
-⋮----
-# If enabled and a tool error occurred, we recover by generating the tool in
-# strict json mode
-⋮----
-AnyTool = self._get_any_tool_message()
-⋮----
-recovery_message = self._strict_recovery_instructions(AnyTool)
-augmented_message = message
-⋮----
-augmented_message = recovery_message
-⋮----
-augmented_message = augmented_message + recovery_message
-⋮----
-# only use the augmented message for this one response...
-result = self.llm_response(augmented_message)
-# ... restore the original user message so that the AnyTool recover
-# instructions don't persist in the message history
-# (this can cause the LLM to use the AnyTool directly as a tool)
-⋮----
-msg = message if isinstance(message, str) else message.content
-⋮----
-tool_choice = (
-⋮----
-response = self.llm_response_messages(hist, output_len, tool_choice)
-⋮----
-# Preserve trail of tool_ids for OpenAI Assistant fn-calls
-⋮----
-"""
-        Async version of `llm_response`. See there for details.
-        """
-⋮----
-response = await self.llm_response_messages_async(
-⋮----
-def init_message_history(self) -> None
-⋮----
-"""
-        Initialize the message history with the system message and user message
-        """
-⋮----
-"""
-        Prepare messages to be sent to self.llm_response_messages,
-            which is the main method that calls the LLM API to get a response.
-            If desired output tokens + message history exceeds the model context length,
-            then first the max output tokens is reduced to fit, and if that is not
-            possible, older messages may be truncated to accommodate at least
-            self.config.llm.min_output_tokens of output.
-
-        Returns:
-            Tuple[List[LLMMessage], int]: (messages, output_len)
-                messages = Full list of messages to send
-                output_len = max expected number of tokens in response
-        """
-⋮----
-# this means agent has been used to get LLM response already,
-# and so the last message is an "assistant" response.
-# We delete this last assistant response and re-generate it.
-⋮----
-# initial messages have not yet been loaded, so load them
-⋮----
-# for debugging, show the initial message history
-⋮----
-# update the system message with the latest tool instructions
-⋮----
-# either the message is a str, or it is a fresh ChatDocument
-# different from the last message in the history
-llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
-llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
-# Canonicalize retained whitespace-only results before token counting.
-⋮----
-# process tools if any
-done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
-⋮----
-hist = self.message_history
-output_len = self.config.llm.model_max_output_tokens
-⋮----
-# chat + output > max context length,
-# so first try to shorten requested output len to fit;
-# use an extra margin of CHAT_HISTORY_BUFFER tokens
-# in case our calcs are off (and to allow for some extra tokens)
-output_len = (
-⋮----
-# unacceptably small output len, so compress early parts of
-# conversation history based on the configured strategy
-strategy = self.config.context_overflow_strategy
-⋮----
-# Truncate content of individual messages while preserving
-# the message sequence (important for LLM APIs that require
-# alternating USER/ASSISTANT messages)
-msg_idx_to_compress = 1  # don't touch system msg
-# we will try compressing msg indices up to but not including
-# last user msg
-last_msg_idx_to_compress = (
-n_truncated = 0
-_target_tokens = (
-# Truncation floor: never reduce a message's content below
-# this many tokens.
-_min_keep_tokens = 30
-_truncation_warning = "... [Contents truncated!]"
-⋮----
-def _content_tokens(text: str | None) -> int
-⋮----
-"""Token count of message *content* only.
-
-                        `truncate_message` only trims `message.content`, so
-                        using the full `_message_num_tokens` (which includes
-                        attachment payloads) would inflate the count and make
-                        the keep-target too large to ever converge, for
-                        messages carrying file attachments.
-                        """
-⋮----
-# approx fallback, matches truncate_message
-⋮----
-# Account for the warning that truncate_message appends
-# ("\n" + warning), so the final token count of a
-# truncated message does not exceed its keep-target.
-_warning_tokens = _content_tokens("\n" + _truncation_warning)
-# NOTE: loop termination is guaranteed:
-# msg_idx_to_compress strictly increases every iteration
-# (truncate or skip), and once it exceeds
-# last_msg_idx_to_compress a ValueError is raised. (The
-# token count need not decrease every iteration, so
-# termination rests on the index advancing.)
-⋮----
-# We want to preserve the first message (typically
-# system msg) and last message (user msg).
-⋮----
-_msg_tokens = _content_tokens(hist[msg_idx_to_compress].content)
-⋮----
-# Truncating this message cannot shrink the total:
-# its content is already at/below the keep-floor
-# plus the appended warning; leave it intact.
-⋮----
-# Distribute the current excess evenly across the
-# remaining *compressible* messages, so each retains
-# as much content as possible instead of being
-# collapsed to the fixed 30-token floor. The excess is
-# recomputed every iteration, so the distribution
-# self-corrects as we move forward through the
-# history.
-_current_excess = self.chat_num_tokens(hist) - _target_tokens
-# Shrink capacity of each *later* message in the
-# compressible range: its content above the floor (net
-# of the appended warning). Non-positive entries are
-# the tiny messages the skip-check above will leave
-# untouched; they must not dilute the even share, so
-# only messages with positive capacity count toward
-# the denominator (plus this message, which passed the
-# skip-check and is therefore compressible).
-_later_capacities = [
-_n_remaining = 1 + sum(1 for c in _later_capacities if c > 0)
-_even_share = math.ceil(_current_excess / _n_remaining)
-# Later messages can shed at most their capacity; this
-# message must absorb whatever they cannot, so that
-# this single forward pass reaches the target whenever
-# that is possible at all.
-_later_capacity = sum(c for c in _later_capacities if c > 0)
-_reduction = max(_even_share, _current_excess - _later_capacity)
-# Extra 2-token slack: re-encoding truncated content
-# plus the appended warning can merge/split tokens at
-# the boundary, so aim slightly below the target to
-# keep the achieved reduction from falling short.
-_keep_tokens = max(
-# compress the msg at idx `msg_idx_to_compress`
-⋮----
-output_len = min(
-⋮----
-# we MUST have truncated at least one msg
-msg_tokens = self.chat_num_tokens()
-⋮----
-else:  # strategy == "drop_turns"
-# Drop complete conversation turns. A complete turn is defined
-# as a USER message followed by all messages until the next
-# USER message. This is more aggressive but cleaner for voice
-# agents with limited context.
-n_dropped_turns = 0
-⋮----
-# Find the last USER message index
-last_user_idx = self.last_message_idx_with_role(role=Role.USER)
-⋮----
-# Find the first complete turn to drop (skip system message)
-first_user_idx = -1
-⋮----
-first_user_idx = i
-⋮----
-# Find the end of this turn: last message before next USER
-next_user_idx = -1
-⋮----
-next_user_idx = i
-⋮----
-# Drop the turn
-⋮----
-# we MUST have dropped at least one turn
-⋮----
-# record the position of the corresponding LLMMessage in
-# the message_history
-⋮----
-"""
-        Get function/tool spec/output format arguments for
-        OpenAI-compatible LLM API call
-        """
-functions: Optional[List[LLMFunctionSpec]] = None
-fun_call: str | Dict[str, str] = "none"
-tools: Optional[List[OpenAIToolSpec]] = None
-force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
-⋮----
-functions = [
-fun_call = (
-⋮----
-def to_maybe_strict_spec(function: str) -> OpenAIToolSpec
-⋮----
-spec = self.llm_functions_map[function]
-strict = self._strict_mode_for_tool(function)
-⋮----
-strict_spec = copy.deepcopy(spec)
-⋮----
-strict_spec = spec
-⋮----
-tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
-force_tool = (
-output_format = None
-⋮----
-spec = self.output_format.llm_function_schema(
-⋮----
-output_format = OpenAIJsonSchemaSpec(
-⋮----
-# We always require that outputs strictly match the schema
-⋮----
-param_spec = self.output_format.model_json_schema()
-⋮----
-"""
-        Respond to a series of messages, e.g. with OpenAI ChatCompletion
-        Args:
-            messages: seq of messages (with role, content fields) sent to LLM
-            output_len: max number of tokens expected in response.
-                    If None, use the LLM's default model_max_output_tokens.
-        Returns:
-            Document (i.e. with fields "content", "metadata")
-        """
-⋮----
-output_len = output_len or self.config.llm.model_max_output_tokens
-streamer = noop_fn
-⋮----
-streamer = self.callbacks.start_llm_stream()
-⋮----
-with ExitStack() as stack:  # for conditionally using rich spinner
-⋮----
-# show rich spinner only if not streaming!
-# (Why? b/c the intent of showing a spinner is to "show progress",
-# and we don't need to do that when streaming, since
-# streaming output already shows progress.)
-cm = status(
-⋮----
-response = self.llm.chat(
-⋮----
-# Create temp ChatDocument for tool check, then clean up to avoid
-# polluting ObjectRegistry (see PR #939 discussion)
-temp_doc = ChatDocument.from_LLMResponse(
-⋮----
-response,  # .usage attrib is updated!
-⋮----
-chat_doc = ChatDocument.from_LLMResponse(
-⋮----
-# If using strict output format, parse the output JSON
-⋮----
-"""
-        Async version of `llm_response_messages`. See there for details.
-        """
-⋮----
-streamer_async = async_noop_fn
-⋮----
-streamer_async = await self.callbacks.start_llm_stream_async()
-⋮----
-response = await self.llm.achat(
-⋮----
-"""
-        Call a callback method, only passing 'reasoning' if it accepts it.
-
-        This provides backward compatibility for custom callbacks that don't
-        have the 'reasoning' parameter in their signature.
-
-        Args:
-            callback_name: Name of the callback method (e.g., 'show_llm_response')
-            reasoning: The reasoning content to pass if supported
-            **kwargs: Other arguments to pass to the callback
-        """
-callback = getattr(self.callbacks, callback_name, None)
-⋮----
-# Check if callback accepts 'reasoning' param or **kwargs
-⋮----
-sig = inspect.signature(callback)
-params = sig.parameters
-accepts_reasoning = "reasoning" in params or any(
-⋮----
-# If we can't inspect the signature, assume it doesn't accept reasoning
-accepts_reasoning = False
-⋮----
-is_cached = (
-⋮----
-# We would have already displayed the msg "live" ONLY if
-# streaming was enabled, AND we did not find a cached response.
-# If we are here, it means the response has not yet been displayed.
-cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
-# Track whether we created a temp ChatDocument for cleanup
-is_temp_doc = isinstance(response, LLMResponse)
-chat_doc = (
-# TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
-⋮----
-content = response.message or ""
-tools_content = response.tools_content()
-⋮----
-content = response.content
-tools_content = ""
-reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
-⋮----
-# Clean up temp ChatDocument to avoid polluting ObjectRegistry
-⋮----
-# we are in the context immediately after an LLM responded,
-# we won't have citations yet, so we're done
-⋮----
-citation = (
-⋮----
-reasoning="",  # Citations don't have reasoning
-⋮----
-def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument
-⋮----
-"""
-        Get LLM response to `prompt` (which presumably includes the `message`
-        somewhere, along with possible large "context" passages),
-        but only include `message` as the USER message, and not the
-        full `prompt`, in the message history.
-        Args:
-            message: the original, relatively short, user request or query
-            prompt: the full prompt potentially containing `message` plus context
-
-        Returns:
-            Document object containing the response.
-        """
-# we explicitly call THIS class's respond method,
-# not a derived class's (or else there would be infinite recursion!)
-with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
-⋮----
-"""
-        Async version of `_llm_response_temp_context`. See there for details.
-        """
-⋮----
-answer_doc = cast(
-⋮----
-"""
-        LLM Response to single message, and restore message_history.
-        In effect a "one-off" message & response that leaves agent
-        message history state intact.
-
-        Args:
-            message (str|ChatDocument): message to respond to.
-
-        Returns:
-            A Document object with the response.
-
-        """
-# explicitly call THIS class's respond method,
-⋮----
-n_msgs = len(self.message_history)
-⋮----
-response = cast(ChatDocument, ChatAgent.llm_response(self, message))
-# If there is a response, then we will have two additional
-# messages in the message history, i.e. the user message and the
-# assistant response. We want to (carefully) remove these two messages.
-⋮----
-msg = self.message_history.pop()
-⋮----
-"""
-        Async version of `llm_response_forget`. See there for details.
-        """
-⋮----
-response = cast(
-⋮----
-def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int
-⋮----
-"""
-        Total number of tokens in the message history so far.
-
-        Args:
-            messages: if provided, compute the number of tokens in this list of
-                messages, rather than the current message history.
-        Returns:
-            int: number of tokens in message history
-        """
-⋮----
-hist = messages if messages is not None else self.message_history
-⋮----
-def _message_num_tokens(self, message: LLMMessage) -> int
-⋮----
-"""Count tokens for a message, including serialized user attachments."""
-⋮----
-def _attachment_num_tokens(self, message: LLMMessage) -> int
-⋮----
-"""
-        Estimate attachment contribution using the serialized payload
-        that is sent in the API request for user messages.
-        """
-⋮----
-model = self._chat_model_name_for_attachments()
-⋮----
-def _chat_model_name_for_attachments(self) -> str
-⋮----
-"""Return the model name used for attachment serialization."""
-⋮----
-def message_history_str(self, i: Optional[int] = None) -> str
-⋮----
-"""
-        Return a string representation of the message history
-        Args:
-            i: if provided, return only the i-th message when i is postive,
-                or last k messages when i = -k.
-        Returns:
-        """
-⋮----
-def __del__(self) -> None
-⋮----
-"""
-        Cleanup method called when the ChatAgent is garbage collected.
-        Note: We don't close LLM clients here because they may be shared
-        across multiple agents when client caching is enabled.
-        The clients are managed centrally and cleaned up via atexit hooks.
-        """
-# Previously we closed clients here, but this caused issues when
-# multiple agents shared the same cached client instance.
-# Clients are now managed centrally in langroid.language_models.client_cache
-</file>
-
 <file path="langroid/language_models/openai_gpt.py">
 OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
 ⋮----
@@ -59884,9 +58655,1291 @@ cached, hashed_key, response = await self._achat_completions_with_backoff(  # ty
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.16.0
+  rev: v0.16.4
   hooks:
     - id: ruff
+</file>
+
+<file path="langroid/agent/chat_agent.py">
+console = Console()
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+# Stable origin sentinel for the dynamically generated strict-recovery AnyTool
+# class ("tool_or_function"): a fresh class is built per call (its tool-union
+# type varies), so re-registration must be recognized as the same logical tool.
+_ANY_TOOL_MESSAGE_ORIGIN: Any = object()
+⋮----
+# Safety margin (in tokens) subtracted from the model context length when
+# shrinking chat history and/or the requested output length to fit, in case
+# our token-count estimates are off.
+CHAT_HISTORY_BUFFER = 300
+⋮----
+def _reject_json_constant(constant: str) -> None
+⋮----
+"""Reject JavaScript numeric constants that are not valid JSON."""
+⋮----
+def _parse_json_float(value: str) -> float
+⋮----
+"""Parse a JSON float while rejecting exponent overflow."""
+parsed = float(value)
+⋮----
+def _is_identified_result(message: LLMMessage) -> bool
+⋮----
+"""Whether a TOOL/FUNCTION result has its identifier and no call payload.
+
+    Such results must survive even with empty content so their calls can be
+    marked complete (issue #1063).
+    """
+has_identifier = (
+⋮----
+def _llm_message_has_payload(message: LLMMessage) -> bool
+⋮----
+"""Whether a message has the fields required for a valid history entry."""
+⋮----
+class ChatAgentConfig(AgentConfig)
+⋮----
+"""
+    Configuration for ChatAgent
+
+    Attributes:
+        system_message: system message to include in message sequence
+             (typically defines role and task of agent).
+             Used only if `task` is not specified in the constructor.
+        user_message: user message to include in message sequence.
+             Used only if `task` is not specified in the constructor.
+        use_tools: whether to use our own ToolMessages mechanism
+        handle_llm_no_tool (Any): desired agent_response when
+            LLM generates non-tool msg.
+        use_functions_api: whether to use functions/tools native to the LLM API
+                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
+        use_tools_api: When `use_functions_api` is True, if this is also True,
+            the OpenAI tool-call API is used, rather than the older/deprecated
+            function-call API. However the tool-call API has some tricky aspects,
+            hence we set this to False by default.
+        strict_recovery: whether to enable strict schema recovery when there
+            is a tool-generation error.
+        enable_orchestration_tool_handling: whether to enable handling of orchestration
+            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
+        output_format: When supported by the LLM (certain OpenAI LLMs
+            and local LLMs served by providers such as vLLM), ensures
+            that the output is a JSON matching the corresponding
+            schema via grammar-based decoding
+        handle_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for handling".
+        use_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for use" (by LLM) and
+            instructions on using T are added to the system message.
+        instructions_output_format: Controls whether we generate instructions for
+            `output_format` in the system message.
+        use_tools_on_output_format: Controls whether to automatically switch
+            to the Langroid-native tools mechanism when `output_format` is set.
+            Note that LLMs may generate tool calls which do not belong to
+            `output_format` even when strict JSON mode is enabled, so this should be
+            enabled when such tool calls are not desired.
+        output_format_include_defaults: Whether to include fields with default arguments
+            in the output schema
+        full_citations: Whether to show source reference citation + content for each
+            citation, or just the main reference citation.
+        search_for_tools_everywhere: Whether to search for tools everywhere,
+            or only in specific LLM response elements based on use_tools /
+            use_functions_api / use_tools_api config settings.
+        recognize_recipient_in_content: Whether to parse LLM response text content
+            for recipient routing patterns, specifically:
+            - ``TO[<recipient>]:<content>`` addressing format, and
+            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
+            When False, only structured routing via function_call/tool_call
+            ``recipient`` fields is recognized. Default is True.
+            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
+            which controls Task-level signals like DONE, PASS, and SEND_TO.
+            To fully disable all text-based routing, set both to False.
+        context_overflow_strategy: Strategy for handling context overflow when
+            message history exceeds model context length. Options:
+            - "truncate": Truncate content of early messages (preserves all messages
+              but with shortened content). This maintains the message sequence.
+            - "drop_turns": Drop complete conversation turns (USER + all responses
+              until next USER). More aggressive but cleaner for voice agents.
+            Default is "truncate" for backward compatibility.
+    """
+⋮----
+system_message: str = "You are a helpful assistant."
+user_message: Optional[str] = None
+handle_llm_no_tool: Any = None
+use_tools: bool = True
+use_functions_api: bool = False
+use_tools_api: bool = True
+strict_recovery: bool = True
+enable_orchestration_tool_handling: bool = True
+output_format: Optional[type] = None
+handle_output_format: bool = True
+use_output_format: bool = True
+instructions_output_format: bool = True
+output_format_include_defaults: bool = True
+use_tools_on_output_format: bool = True
+full_citations: bool = True  # show source + content for each citation?
+search_for_tools_everywhere: bool = True
+recognize_recipient_in_content: bool = True
+context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
+⋮----
+def _set_fn_or_tools(self) -> None
+⋮----
+"""
+        Enable Langroid Tool or OpenAI-like fn-calling,
+        depending on config settings.
+        """
+⋮----
+class ChatAgent(Agent)
+⋮----
+"""
+    Chat Agent interacting with external env
+    (could be human, or external tools).
+    The agent (the LLM actually) is provided with an optional "Task Spec",
+    which is a sequence of `LLMMessage`s. These are used to initialize
+    the `task_messages` of the agent.
+    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
+    The `Agent` class mainly exists to hold various common methods and attributes.
+    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
+    `llm_response` method uses "chat mode" API (i.e. one that takes a
+    message sequence rather than a single message),
+    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
+    that takes a single message).
+    """
+⋮----
+"""
+        Chat-mode agent initialized with task spec as the initial message sequence
+        Args:
+            config: settings for the agent
+
+        """
+⋮----
+# emit the attachment-token-estimate warning at most once per agent
+⋮----
+# An agent's "task" is defined by a system msg and an optional user msg;
+# These are "priming" messages that kick off the agent's conversation.
+⋮----
+# if task contains a system msg, we override the config system msg
+⋮----
+# if task contains a user msg, we override the config user msg
+⋮----
+# system-level instructions for using tools/functions:
+# We maintain these as tools/functions are enabled/disabled,
+# and whenever an LLM response is sought, these are used to
+# recreate the system message (via `_create_system_and_tools_message`)
+# each time, so it reflects the current set of enabled tools/functions.
+# (a) these are general instructions on using certain tools/functions,
+#   if they are specified in a ToolMessage class as a classmethod `instructions`
+⋮----
+# (b) these are only for the builtin in Langroid TOOLS mechanism:
+⋮----
+# This variable is not None and equals a `ToolMessage` T, if and only if:
+# (a) T has been set as the output_format of this agent, AND
+# (b) T has been "enabled for use" ONLY for enforcing this output format, AND
+# (c) T has NOT been explicitly "enabled for use" by this Agent.
+⋮----
+# As above but deals with "enabled for handling" instead of "enabled for use".
+⋮----
+# instructions specifically related to enforcing `output_format`
+⋮----
+# controls whether to disable strict schemas for this agent if
+# strict mode causes exception
+⋮----
+# Tracks whether any strict tool is enabled; used to determine whether to set
+# `self.disable_strict` on an exception
+⋮----
+# Tracks the set of tools on which we force-disable strict decoding
+⋮----
+# search for tools according to the agent configuration
+⋮----
+# Only enable HANDLING by `agent_response`, NOT LLM generation of these.
+# This is useful where tool-handlers or agent_response generate these
+# tools, and need to be handled.
+# We don't want enable orch tool GENERATION by default, since that
+# might clutter-up the LLM system message unnecessarily.
+⋮----
+def init_state(self) -> None
+⋮----
+"""
+        Initialize the state of the agent. Just conversation state here,
+        but subclasses can override this to initialize other state.
+        """
+⋮----
+@staticmethod
+    def from_id(id: str) -> "ChatAgent"
+⋮----
+"""
+        Get an agent from its ID
+        Args:
+            agent_id (str): ID of the agent
+        Returns:
+            ChatAgent: The agent with the given ID
+        """
+⋮----
+def clone(self, i: int = 0) -> "ChatAgent"
+⋮----
+"""Create i'th clone of this agent, ensuring tool use/handling is cloned.
+        Important: We assume all member variables are in the __init__ method here
+        and in the Agent class.
+        TODO: We are attempting to clone an agent after its state has been
+        changed in possibly many ways. Below is an imperfect solution. Caution advised.
+        Revisit later.
+        """
+agent_cls = type(self)
+# Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
+# instead of deepcopy which loses subclass information
+config_copy = self.config.model_copy(deep=True)
+⋮----
+new_agent = agent_cls(config_copy)
+⋮----
+# Ensure each clone gets its own vecdb client when supported.
+⋮----
+def _clone_extra_state(self, new_agent: "ChatAgent") -> None
+⋮----
+"""Hook for subclasses to copy additional state into clones."""
+⋮----
+def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool
+⋮----
+"""Should we enable strict mode for a given tool?"""
+⋮----
+tool_class = self.llm_tools_map[tool]
+⋮----
+tool_class = tool
+name = tool_class.default_value("request")
+⋮----
+strict: Optional[bool] = tool_class.default_value("strict")
+⋮----
+strict = self._strict_tools_available()
+⋮----
+def _fn_call_available(self) -> bool
+⋮----
+"""Does this agent's LLM support function calling?"""
+⋮----
+def _strict_tools_available(self) -> bool
+⋮----
+"""Does this agent's LLM support strict tools?"""
+⋮----
+def _json_schema_available(self) -> bool
+⋮----
+"""Does this agent's LLM support strict JSON schema output format?"""
+⋮----
+def set_system_message(self, msg: str) -> None
+⋮----
+# if there is message history, update the system message in it
+⋮----
+def set_user_message(self, msg: str) -> None
+⋮----
+@property
+    def task_messages(self) -> List[LLMMessage]
+⋮----
+"""
+        The task messages are the initial messages that define the task
+        of the agent. There will be at least a system message plus possibly a user msg.
+        Returns:
+            List[LLMMessage]: the task messages
+        """
+msgs = [self._create_system_and_tools_message()]
+⋮----
+def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None
+⋮----
+id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
+⋮----
+# dropping tool result, so ADD the corresponding tool-call back
+# to the list of pending calls!
+id = msg.tool_call_id
+⋮----
+# dropping a msg with tool-calls, so DROP these from pending list
+# as well as from id -> call map
+⋮----
+def clear_history(self, start: int = -2, end: int = -1) -> None
+⋮----
+"""
+        Clear the message history, deleting  messages from index `start`,
+        up to index `end`.
+
+        Args:
+            start (int): index of first message to delete; default = -2
+                    (i.e. delete last 2 messages, typically these
+                    are the last user and assistant messages)
+            end (int): index of last message to delete; Default = -1
+                    (i.e. delete all messages up to the last one)
+        """
+n = len(self.message_history)
+⋮----
+start = max(0, n + start)
+end_ = n if end == -1 else end + 1
+dropped = self.message_history[start:end_]
+# consider the dropped msgs in REVERSE order, so we are
+# carefully updating self.oai_tool_calls
+⋮----
+# clear out the chat document from the ObjectRegistry
+⋮----
+def update_history(self, message: str, response: str) -> None
+⋮----
+"""
+        Update the message history with the latest user message and LLM response.
+        Args:
+            message (str): user message
+            response: (str): LLM response
+        """
+⋮----
+def export_history(self) -> str
+⋮----
+"""Export message history as a portable, versioned JSON snapshot.
+
+        Returns:
+            A JSON string containing the current message history.
+        """
+messages: List[Dict[str, Any]] = []
+⋮----
+data = message.model_dump(mode="json", exclude={"files"})
+⋮----
+"""Restore message history from :meth:`export_history` output.
+
+        Args:
+            snapshot: Versioned JSON snapshot to restore.
+            max_size_bytes: Maximum total decoded attachment size. Defaults to
+                100 MiB.
+
+        Raises:
+            ValueError: If the snapshot is malformed, has an unknown version,
+                starts with a non-system message, or exceeds ``max_size_bytes``.
+        """
+⋮----
+payload = json.loads(
+⋮----
+raw_messages = payload.get("messages")
+⋮----
+messages: List[LLMMessage] = []
+total_attachment_bytes = 0
+⋮----
+message_data = dict(raw_message)
+raw_files = message_data.get("files", [])
+⋮----
+files = []
+⋮----
+file_data = dict(raw_file)
+encoded_content = file_data.pop("content_base64")
+⋮----
+encoded_bytes = encoded_content.encode("ascii")
+padding = len(encoded_bytes) - len(encoded_bytes.rstrip(b"="))
+decoded_size = max(
+⋮----
+content = base64.b64decode(encoded_bytes, validate=True)
+⋮----
+seen_call_ids: Set[str] = set()
+⋮----
+name = message.name
+⋮----
+call_id = call.id
+⋮----
+all_calls = {
+completed_call_ids = {
+old_chat_document_ids = {
+⋮----
+def tool_format_rules(self) -> str
+⋮----
+"""
+        Specification of tool formatting rules
+        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
+        based on the currently enabled usable `ToolMessage`s
+
+        Returns:
+            str: formatting rules
+        """
+# ONLY Usable tools (i.e. LLM-generation allowed),
+usable_tool_classes: List[Type[ToolMessage]] = [
+⋮----
+format_instructions = "\n\n".join(
+# if any of the enabled classes has json_group_instructions, then use that,
+# else fall back to ToolMessage.json_group_instructions
+⋮----
+def tool_instructions(self) -> str
+⋮----
+"""
+        Instructions for tools or function-calls, for enabled and usable Tools.
+        These are inserted into system prompt regardless of whether we are using
+        our own ToolMessage mechanism or the LLM's function-call mechanism.
+
+        Returns:
+            str: concatenation of instructions for all usable tools
+        """
+enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
+⋮----
+instructions = []
+⋮----
+class_instructions = ""
+⋮----
+class_instructions = msg_cls.instructions()
+⋮----
+# example will be shown in tool_format_rules() when using TOOLs,
+# so we don't need to show it here.
+example = "" if self.config.use_tools else (msg_cls.usage_examples())
+⋮----
+example = "EXAMPLES:\n" + example
+guidance = (
+⋮----
+instructions_str = "\n\n".join(instructions)
+⋮----
+def augment_system_message(self, message: str) -> None
+⋮----
+"""
+        Augment the system message with the given message.
+        Args:
+            message (str): system message
+        """
+⋮----
+def last_message_with_role(self, role: Role) -> LLMMessage | None
+⋮----
+"""from `message_history`, return the last message with role `role`"""
+n_role_msgs = len([m for m in self.message_history if m.role == role])
+⋮----
+idx = self.nth_message_idx_with_role(role, n_role_msgs)
+⋮----
+def last_message_idx_with_role(self, role: Role) -> int
+⋮----
+"""Index of last message in message_history, with specified role.
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+indices_with_role = [
+⋮----
+def nth_message_idx_with_role(self, role: Role, n: int) -> int
+⋮----
+"""Index of `n`th message in message_history, with specified role.
+        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+⋮----
+def update_last_message(self, message: str, role: str = Role.USER) -> None
+⋮----
+"""
+        Update the last message that has role `role` in the message history.
+        Useful when we want to replace a long user prompt, that may contain context
+        documents plus a question, with just the question.
+        Args:
+            message (str): new message to replace with
+            role (str): role of message to replace
+        """
+⋮----
+# find last message in self.message_history with role `role`
+⋮----
+def delete_last_message(self, role: str = Role.USER) -> None
+⋮----
+"""
+        Delete the last message that has role `role` from the message history.
+        Args:
+            role (str): role of message to delete
+        """
+⋮----
+def _create_system_and_tools_message(self) -> LLMMessage
+⋮----
+"""
+        (Re-)Create the system message for the LLM of the agent,
+        taking into account any tool instructions that have been added
+        after the agent was initialized.
+
+        The system message will consist of:
+        (a) the system message from the `task` arg in constructor, if any,
+            otherwise the default system message from the config
+        (b) the system tool instructions, if any
+        (c) the system json tool instructions, if any
+
+        Returns:
+            LLMMessage object
+        """
+content = self.system_message
+⋮----
+# remove leading and trailing newlines and other whitespace
+⋮----
+def handle_message_fallback(self, msg: str | ChatDocument) -> Any
+⋮----
+"""
+        Fallback method for the "no-tools" scenario, i.e., the current `msg`
+        (presumably emitted by the LLM) does not have any tool that the agent
+        can handle.
+        NOTE: The `msg` may contain tools but either (a) the agent is not
+        enabled to handle them, or (b) there's an explicit `recipient` field
+        in the tool that doesn't match the agent's name.
+
+        Uses the self.config.non_tool_routing to determine the action to take.
+
+        This method can be overridden by subclasses, e.g.,
+        to create a "reminder" message when a tool is expected but the LLM "forgot"
+        to generate one.
+
+        Args:
+            msg (str | ChatDocument): The input msg to handle
+        Returns:
+            Any: The result of the handler method
+        """
+⋮----
+# we ONLY use the `handle_llm_no_tool` config option when
+# the msg is from LLM and does not contain ANY tools at all.
+⋮----
+no_tool_option = self.config.handle_llm_no_tool
+⋮----
+# in case the `no_tool_option` is one of the special NonToolAction vals
+⋮----
+# Otherwise just return `no_tool_option` as is:
+# This can be any string, such as a specific nudge/reminder to the LLM,
+# or even something like ResultTool etc.
+⋮----
+def unhandled_tools(self) -> set[str]
+⋮----
+"""The set of tools that are known but not handled.
+        Useful in task flow: an agent can refuse to accept an incoming msg
+        when it only has unhandled tools.
+        """
+⋮----
+"""
+        Add the tool (message class) to the agent, and enable either
+        - tool USE (i.e. the LLM can generate JSON to use this tool),
+        - tool HANDLING (i.e. the agent can handle JSON from this tool),
+
+        Args:
+            message_class: The ToolMessage class OR List of such classes to enable,
+                for USE, or HANDLING, or both.
+                If this is a list of ToolMessage classes, then the remain args are
+                applied to all classes.
+                Optional; if None, then apply the enabling to all tools in the
+                agent's toolset that have been enabled so far.
+            use: IF True, allow the agent (LLM) to use this tool (or all tools),
+                else disallow
+            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
+                tool (or all tools)
+            force: whether to FORCE the agent (LLM) to USE the specific
+                 tool represented by `message_class`.
+                 `force` is ignored if `message_class` is None.
+            require_recipient: whether to require that recipient be specified
+                when using the tool message (only applies if `use` is True).
+            include_defaults: whether to include fields that have default values,
+                in the "properties" section of the JSON format instructions.
+                (Normally the OpenAI completion API ignores these fields,
+                but the Assistant fn-calling seems to pay attn to these,
+                and if we don't want this, we should set this to False.)
+        """
+⋮----
+# Validate that use/handle are booleans, not accidentally passed tool classes
+⋮----
+param = "use" if isclass(use) else "handle"
+⋮----
+message_class = message_class.require_recipient()
+⋮----
+request = message_class.default_value("request")
+existing_class = self.llm_tools_map.get(request)
+existing_origin = (
+message_origin = message_class.__dict__.get(
+⋮----
+# XMLToolMessage is not compatible with OpenAI's Tools/functions API,
+# so we disable use of functions API, enable langroid-native Tools,
+# which are prompt-based.
+⋮----
+super().enable_message_handling(message_class)  # enables handling only
+tools = self._get_tool_list(message_class)
+⋮----
+llm_function = message_class.llm_function_schema(defaults=include_defaults)
+⋮----
+# `t` was designated as "enabled for handling" ONLY for
+# output_format enforcement, but we are explicitly ]
+# enabling it for handling here, so we set the variable to None.
+⋮----
+tool_class = self.llm_tools_map[t]
+allow_llm_use = tool_class._allow_llm_use
+⋮----
+allow_llm_use = allow_llm_use.default
+⋮----
+# `t` was designated as "enabled for use" ONLY for output_format
+# enforcement, but we are explicitly enabling it for use here,
+# so we set the variable to None.
+⋮----
+def _update_tool_instructions(self) -> None
+⋮----
+# Set tool instructions and JSON format instructions,
+# in case Tools have been enabled/disabled.
+⋮----
+def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]
+⋮----
+"""
+        Returns the current set of enabled requests for inference and tools configs.
+        Used for restoring setings overriden by `set_output_format`.
+        """
+⋮----
+@property
+    def all_llm_tools_known(self) -> set[str]
+⋮----
+"""All known tools; we include `output_format` if it is a `ToolMessage`."""
+known = self.llm_tools_known
+⋮----
+"""
+        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
+        switches to the native Langroid tools mechanism to ensure that no tool
+        calls not of `output_type` are generated. By default, `force_tools`
+        follows the `use_tools_on_output_format` parameter in the config.
+
+        If `output_type` is None, restores to the state prior to setting
+        `output_format`.
+
+        If `use`, we enable use of `output_type` when it is a subclass
+        of `ToolMesage`. Note that this primarily controls instruction
+        generation: the model will always generate `output_type` regardless
+        of whether `use` is set. Defaults to the `use_output_format`
+        parameter in the config. Similarly, handling of `output_type` is
+        controlled by `handle`, which defaults to the
+        `handle_output_format` parameter in the config.
+
+        `instructions` controls whether we generate instructions specifying
+        the output format schema. Defaults to the `instructions_output_format`
+        parameter in the config.
+
+        `is_copy` is set when called via `__getitem__`. In that case, we must
+        copy certain fields to ensure that we do not overwrite the main agent's
+        setings.
+        """
+# Disable usage of an output format which was not specifically enabled
+# by `enable_message`
+⋮----
+# Disable handling of an output format which did not specifically have
+# handling enabled via `enable_message`
+⋮----
+# Reset any previous instructions
+⋮----
+force_tools = self.config.use_tools_on_output_format
+⋮----
+output_type = get_pydantic_wrapper(output_type)
+⋮----
+name = output_type.default_value("request")
+⋮----
+use = self.config.use_output_format
+⋮----
+handle = self.config.handle_output_format
+⋮----
+is_usable = name in self.llm_tools_usable.union(
+is_handled = name in self.llm_tools_handled.union(
+⋮----
+# We must copy `llm_tools_usable` so the base agent
+# is unmodified
+⋮----
+# If handling the tool, do the same for `llm_tools_handled`
+⋮----
+# Enable `output_type`
+⋮----
+# Do not override existing settings
+⋮----
+# If the `output_type` ToilMessage was not already enabled for
+# use, this means we are ONLY enabling it for use specifically
+# for enforcing this output format, so we set the
+# `enabled_use_output_forma  to this output_type, to
+# record that it should be disabled when `output_format` is changed
+⋮----
+# (same reasoning as for use-enabling)
+⋮----
+generated_tool_instructions = name in self.llm_tools_usable.union(
+⋮----
+generated_tool_instructions = False
+⋮----
+instructions = self.config.instructions_output_format
+⋮----
+# Already generated tool instructions as part of "enabling for use",
+# so only need to generate a reminder to use this tool.
+name = cast(ToolMessage, output_type).default_value("request")
+⋮----
+output_format_schema = output_type.llm_function_schema(
+⋮----
+output_format_schema = output_type.model_json_schema()
+⋮----
+def __getitem__(self, output_type: type) -> Self
+⋮----
+"""
+        Returns a (shallow) copy of `self` with a forced output type.
+        """
+clone = copy.copy(self)
+⋮----
+"""
+        Disable this agent from RESPONDING to a `message_class` (Tool). If
+            `message_class` is None, then disable this agent from responding to ALL.
+        Args:
+            message_class: The ToolMessage class to disable; Optional.
+        """
+⋮----
+"""
+        Disable this agent from USING a message class (Tool).
+        If `message_class` is None, then disable this agent from USING ALL tools.
+        Args:
+            message_class: The ToolMessage class to disable.
+                If None, disable all.
+        """
+⋮----
+def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None
+⋮----
+"""
+        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
+        Args:
+            message_class: The only ToolMessage class to allow
+        """
+request = message_class.model_fields["request"].default
+to_remove = [r for r in self.llm_tools_usable if r != request]
+⋮----
+def _load_output_format(self, message: ChatDocument) -> None
+⋮----
+"""
+        If set, attempts to parse a value of type `self.output_format` from the message
+        contents or any tool/function call and assigns it to `content_any`.
+        """
+⋮----
+any_succeeded = False
+attempts: list[str | LLMFunctionCall] = [
+⋮----
+content = json.loads(attempt)
+⋮----
+content = attempt.arguments
+⋮----
+content_any = self.output_format.model_validate(content)
+⋮----
+message.content_any = content_any.value  # type: ignore
+⋮----
+any_succeeded = True
+⋮----
+"""
+        Extracts messages and tracks whether any errors occurred. If strict mode
+        was enabled, disables it for the tool, else triggers strict recovery.
+        """
+⋮----
+most_recent_sent_by_llm = (
+was_llm = most_recent_sent_by_llm or (
+⋮----
+tools = super().get_tool_messages(msg, all_tools)
+⋮----
+# Check if tool class was attached to the exception
+⋮----
+tool_class = ve.tool_class  # type: ignore
+⋮----
+was_strict = (
+# If the result of strict output for a tool using the
+# OpenAI tools API fails to parse, we infer that the
+# schema edits necessary for compatibility prevented
+# adherence to the underlying `ToolMessage` schema and
+# disable strict output for the tool
+⋮----
+# We will trigger the strict recovery mechanism to force
+# the LLM to correct its output, allowing us to parse
+⋮----
+def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None
+⋮----
+"""
+        Returns a `ToolMessage` which wraps all enabled tools, excluding those
+        where strict recovery is disabled. Used in strict recovery.
+        """
+possible_tools = tuple(
+⋮----
+any_tool_type = Union.__getitem__(possible_tools)  # type ignore
+⋮----
+maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
+⋮----
+class AnyTool(ToolMessage)
+⋮----
+purpose: str = "To call a tool/function."
+request: str = "tool_or_function"
+tool: maybe_optional_type  # type: ignore
+⋮----
+def response(self, agent: ChatAgent) -> None | str | ChatDocument
+⋮----
+# One-time use
+⋮----
+# As the ToolMessage schema accepts invalid
+# `tool.request` values, reparse with the
+# corresponding tool
+request = self.tool.request
+⋮----
+tool = agent.llm_tools_map[request].model_validate_json(
+⋮----
+# Every call builds a distinct class; share one origin so enabling a
+# regenerated AnyTool under "tool_or_function" stays idempotent instead
+# of tripping the same-name/different-tool registration guard.
+AnyTool.__tool_message_origin__ = (  # type: ignore[attr-defined]
+⋮----
+"""Returns instructions for strict recovery."""
+optional_instructions = (
+response_prefix = "If you intended to make such a call, r" if optional else "R"
+instruction_prefix = "If you do so, b" if optional else "B"
+⋮----
+schema_instructions = (
+⋮----
+"""
+        Truncate message at idx in msg history to `tokens` tokens.
+
+        If inplace is True, the message is truncated in place, else
+        it LEAVES the original message INTACT and returns a new message
+        """
+⋮----
+llm_msg = self.message_history[idx]
+⋮----
+llm_msg = copy.deepcopy(self.message_history[idx])
+⋮----
+orig_content = llm_msg.content
+new_content = (
+⋮----
+else orig_content[: tokens * 4]  # approx truncation
+⋮----
+def _reduce_raw_tool_results(self, message: ChatDocument) -> None
+⋮----
+"""
+        If message is the result of a ToolMessage that had
+        a `_max_retained_tokens` set to a non-None value, then we replace contents
+        with a placeholder message.
+        """
+parent_message: ChatDocument | None = message.parent
+tools = [] if parent_message is None else parent_message.tool_messages
+truncate_tools = []
+⋮----
+max_retained_tokens = t._max_retained_tokens
+⋮----
+max_retained_tokens = max_retained_tokens.default
+⋮----
+limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
+⋮----
+max_retained_tokens = limiting_tool._max_retained_tokens
+⋮----
+tool_name = limiting_tool.default_value("request")
+max_tokens: int = max_retained_tokens
+truncation_warning = f"""
+⋮----
+"""
+        Respond to a single user message, appended to the message history,
+        in "chat" mode
+        Args:
+            message (str|ChatDocument): message or ChatDocument object to respond to.
+                If None, use the self.task_messages
+        Returns:
+            LLM response as a ChatDocument object
+        """
+⋮----
+# If enabled and a tool error occurred, we recover by generating the tool in
+# strict json mode
+⋮----
+AnyTool = self._get_any_tool_message()
+⋮----
+recovery_message = self._strict_recovery_instructions(AnyTool)
+augmented_message = message
+⋮----
+augmented_message = recovery_message
+⋮----
+augmented_message = augmented_message + recovery_message
+⋮----
+# only use the augmented message for this one response...
+result = self.llm_response(augmented_message)
+# ... restore the original user message so that the AnyTool recover
+# instructions don't persist in the message history
+# (this can cause the LLM to use the AnyTool directly as a tool)
+⋮----
+msg = message if isinstance(message, str) else message.content
+⋮----
+tool_choice = (
+⋮----
+response = self.llm_response_messages(hist, output_len, tool_choice)
+⋮----
+# Preserve trail of tool_ids for OpenAI Assistant fn-calls
+⋮----
+"""
+        Async version of `llm_response`. See there for details.
+        """
+⋮----
+response = await self.llm_response_messages_async(
+⋮----
+def init_message_history(self) -> None
+⋮----
+"""
+        Initialize the message history with the system message and user message
+        """
+⋮----
+"""
+        Prepare messages to be sent to self.llm_response_messages,
+            which is the main method that calls the LLM API to get a response.
+            If desired output tokens + message history exceeds the model context length,
+            then first the max output tokens is reduced to fit, and if that is not
+            possible, older messages may be truncated to accommodate at least
+            self.config.llm.min_output_tokens of output.
+
+        Returns:
+            Tuple[List[LLMMessage], int]: (messages, output_len)
+                messages = Full list of messages to send
+                output_len = max expected number of tokens in response
+        """
+⋮----
+# this means agent has been used to get LLM response already,
+# and so the last message is an "assistant" response.
+# We delete this last assistant response and re-generate it.
+⋮----
+# initial messages have not yet been loaded, so load them
+⋮----
+# for debugging, show the initial message history
+⋮----
+# update the system message with the latest tool instructions
+⋮----
+# either the message is a str, or it is a fresh ChatDocument
+# different from the last message in the history
+llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
+llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
+# Canonicalize retained whitespace-only results before token counting.
+⋮----
+# process tools if any
+done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
+⋮----
+hist = self.message_history
+output_len = self.config.llm.model_max_output_tokens
+⋮----
+# chat + output > max context length,
+# so first try to shorten requested output len to fit;
+# use an extra margin of CHAT_HISTORY_BUFFER tokens
+# in case our calcs are off (and to allow for some extra tokens)
+output_len = (
+⋮----
+# unacceptably small output len, so compress early parts of
+# conversation history based on the configured strategy
+strategy = self.config.context_overflow_strategy
+⋮----
+# Truncate content of individual messages while preserving
+# the message sequence (important for LLM APIs that require
+# alternating USER/ASSISTANT messages)
+msg_idx_to_compress = 1  # don't touch system msg
+# we will try compressing msg indices up to but not including
+# last user msg
+last_msg_idx_to_compress = (
+n_truncated = 0
+_target_tokens = (
+# Truncation floor: never reduce a message's content below
+# this many tokens.
+_min_keep_tokens = 30
+_truncation_warning = "... [Contents truncated!]"
+⋮----
+def _content_tokens(text: str | None) -> int
+⋮----
+"""Token count of message *content* only.
+
+                        `truncate_message` only trims `message.content`, so
+                        using the full `_message_num_tokens` (which includes
+                        attachment payloads) would inflate the count and make
+                        the keep-target too large to ever converge, for
+                        messages carrying file attachments.
+                        """
+⋮----
+# approx fallback, matches truncate_message
+⋮----
+# Account for the warning that truncate_message appends
+# ("\n" + warning), so the final token count of a
+# truncated message does not exceed its keep-target.
+_warning_tokens = _content_tokens("\n" + _truncation_warning)
+# NOTE: loop termination is guaranteed:
+# msg_idx_to_compress strictly increases every iteration
+# (truncate or skip), and once it exceeds
+# last_msg_idx_to_compress a ValueError is raised. (The
+# token count need not decrease every iteration, so
+# termination rests on the index advancing.)
+⋮----
+# We want to preserve the first message (typically
+# system msg) and last message (user msg).
+⋮----
+_msg_tokens = _content_tokens(hist[msg_idx_to_compress].content)
+⋮----
+# Truncating this message cannot shrink the total:
+# its content is already at/below the keep-floor
+# plus the appended warning; leave it intact.
+⋮----
+# Distribute the current excess evenly across the
+# remaining *compressible* messages, so each retains
+# as much content as possible instead of being
+# collapsed to the fixed 30-token floor. The excess is
+# recomputed every iteration, so the distribution
+# self-corrects as we move forward through the
+# history.
+_current_excess = self.chat_num_tokens(hist) - _target_tokens
+# Shrink capacity of each *later* message in the
+# compressible range: its content above the floor (net
+# of the appended warning). Non-positive entries are
+# the tiny messages the skip-check above will leave
+# untouched; they must not dilute the even share, so
+# only messages with positive capacity count toward
+# the denominator (plus this message, which passed the
+# skip-check and is therefore compressible).
+_later_capacities = [
+_n_remaining = 1 + sum(1 for c in _later_capacities if c > 0)
+_even_share = math.ceil(_current_excess / _n_remaining)
+# Later messages can shed at most their capacity; this
+# message must absorb whatever they cannot, so that
+# this single forward pass reaches the target whenever
+# that is possible at all.
+_later_capacity = sum(c for c in _later_capacities if c > 0)
+_reduction = max(_even_share, _current_excess - _later_capacity)
+# Extra 2-token slack: re-encoding truncated content
+# plus the appended warning can merge/split tokens at
+# the boundary, so aim slightly below the target to
+# keep the achieved reduction from falling short.
+_keep_tokens = max(
+# compress the msg at idx `msg_idx_to_compress`
+⋮----
+output_len = min(
+⋮----
+# we MUST have truncated at least one msg
+msg_tokens = self.chat_num_tokens()
+⋮----
+else:  # strategy == "drop_turns"
+# Drop complete conversation turns. A complete turn is defined
+# as a USER message followed by all messages until the next
+# USER message. This is more aggressive but cleaner for voice
+# agents with limited context.
+n_dropped_turns = 0
+⋮----
+# Find the last USER message index
+last_user_idx = self.last_message_idx_with_role(role=Role.USER)
+⋮----
+# Find the first complete turn to drop (skip system message)
+first_user_idx = -1
+⋮----
+first_user_idx = i
+⋮----
+# Find the end of this turn: last message before next USER
+next_user_idx = -1
+⋮----
+next_user_idx = i
+⋮----
+# Drop the turn
+⋮----
+# we MUST have dropped at least one turn
+⋮----
+# record the position of the corresponding LLMMessage in
+# the message_history
+⋮----
+"""
+        Get function/tool spec/output format arguments for
+        OpenAI-compatible LLM API call
+        """
+functions: Optional[List[LLMFunctionSpec]] = None
+fun_call: str | Dict[str, str] = "none"
+tools: Optional[List[OpenAIToolSpec]] = None
+force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
+⋮----
+functions = [
+fun_call = (
+⋮----
+def to_maybe_strict_spec(function: str) -> OpenAIToolSpec
+⋮----
+spec = self.llm_functions_map[function]
+strict = self._strict_mode_for_tool(function)
+⋮----
+strict_spec = copy.deepcopy(spec)
+⋮----
+strict_spec = spec
+⋮----
+tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
+force_tool = (
+output_format = None
+⋮----
+spec = self.output_format.llm_function_schema(
+⋮----
+output_format = OpenAIJsonSchemaSpec(
+⋮----
+# We always require that outputs strictly match the schema
+⋮----
+param_spec = self.output_format.model_json_schema()
+⋮----
+"""
+        Respond to a series of messages, e.g. with OpenAI ChatCompletion
+        Args:
+            messages: seq of messages (with role, content fields) sent to LLM
+            output_len: max number of tokens expected in response.
+                    If None, use the LLM's default model_max_output_tokens.
+        Returns:
+            Document (i.e. with fields "content", "metadata")
+        """
+⋮----
+output_len = output_len or self.config.llm.model_max_output_tokens
+streamer = noop_fn
+⋮----
+streamer = self.callbacks.start_llm_stream()
+⋮----
+with ExitStack() as stack:  # for conditionally using rich spinner
+⋮----
+# show rich spinner only if not streaming!
+# (Why? b/c the intent of showing a spinner is to "show progress",
+# and we don't need to do that when streaming, since
+# streaming output already shows progress.)
+cm = status(
+⋮----
+response = self.llm.chat(
+⋮----
+# Create temp ChatDocument for tool check, then clean up to avoid
+# polluting ObjectRegistry (see PR #939 discussion)
+temp_doc = ChatDocument.from_LLMResponse(
+⋮----
+response,  # .usage attrib is updated!
+⋮----
+chat_doc = ChatDocument.from_LLMResponse(
+⋮----
+# If using strict output format, parse the output JSON
+⋮----
+"""
+        Async version of `llm_response_messages`. See there for details.
+        """
+⋮----
+streamer_async = async_noop_fn
+⋮----
+streamer_async = await self.callbacks.start_llm_stream_async()
+⋮----
+response = await self.llm.achat(
+⋮----
+"""
+        Call a callback method, only passing 'reasoning' if it accepts it.
+
+        This provides backward compatibility for custom callbacks that don't
+        have the 'reasoning' parameter in their signature.
+
+        Args:
+            callback_name: Name of the callback method (e.g., 'show_llm_response')
+            reasoning: The reasoning content to pass if supported
+            **kwargs: Other arguments to pass to the callback
+        """
+callback = getattr(self.callbacks, callback_name, None)
+⋮----
+# Check if callback accepts 'reasoning' param or **kwargs
+⋮----
+sig = inspect.signature(callback)
+params = sig.parameters
+accepts_reasoning = "reasoning" in params or any(
+⋮----
+# If we can't inspect the signature, assume it doesn't accept reasoning
+accepts_reasoning = False
+⋮----
+is_cached = (
+⋮----
+# We would have already displayed the msg "live" ONLY if
+# streaming was enabled, AND we did not find a cached response.
+# If we are here, it means the response has not yet been displayed.
+cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
+# Track whether we created a temp ChatDocument for cleanup
+is_temp_doc = isinstance(response, LLMResponse)
+chat_doc = (
+# TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
+⋮----
+content = response.message or ""
+tools_content = response.tools_content()
+⋮----
+content = response.content
+tools_content = ""
+reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
+⋮----
+# Clean up temp ChatDocument to avoid polluting ObjectRegistry
+⋮----
+# we are in the context immediately after an LLM responded,
+# we won't have citations yet, so we're done
+⋮----
+citation = (
+⋮----
+reasoning="",  # Citations don't have reasoning
+⋮----
+def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument
+⋮----
+"""
+        Get LLM response to `prompt` (which presumably includes the `message`
+        somewhere, along with possible large "context" passages),
+        but only include `message` as the USER message, and not the
+        full `prompt`, in the message history.
+        Args:
+            message: the original, relatively short, user request or query
+            prompt: the full prompt potentially containing `message` plus context
+
+        Returns:
+            Document object containing the response.
+        """
+# we explicitly call THIS class's respond method,
+# not a derived class's (or else there would be infinite recursion!)
+with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
+⋮----
+"""
+        Async version of `_llm_response_temp_context`. See there for details.
+        """
+⋮----
+answer_doc = cast(
+⋮----
+"""
+        LLM Response to single message, and restore message_history.
+        In effect a "one-off" message & response that leaves agent
+        message history state intact.
+
+        Args:
+            message (str|ChatDocument): message to respond to.
+
+        Returns:
+            A Document object with the response.
+
+        """
+# explicitly call THIS class's respond method,
+⋮----
+n_msgs = len(self.message_history)
+⋮----
+response = cast(ChatDocument, ChatAgent.llm_response(self, message))
+# If there is a response, then we will have two additional
+# messages in the message history, i.e. the user message and the
+# assistant response. We want to (carefully) remove these two messages.
+⋮----
+msg = self.message_history.pop()
+⋮----
+"""
+        Async version of `llm_response_forget`. See there for details.
+        """
+⋮----
+response = cast(
+⋮----
+def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int
+⋮----
+"""
+        Total number of tokens in the message history so far.
+
+        Args:
+            messages: if provided, compute the number of tokens in this list of
+                messages, rather than the current message history.
+        Returns:
+            int: number of tokens in message history
+        """
+⋮----
+hist = messages if messages is not None else self.message_history
+⋮----
+def _message_num_tokens(self, message: LLMMessage) -> int
+⋮----
+"""Count tokens for a message, including serialized user attachments."""
+⋮----
+def _attachment_num_tokens(self, message: LLMMessage) -> int
+⋮----
+"""
+        Estimate attachment contribution using the serialized payload
+        that is sent in the API request for user messages.
+        """
+⋮----
+model = self._chat_model_name_for_attachments()
+n_tokens = sum(
+⋮----
+def _chat_model_name_for_attachments(self) -> str
+⋮----
+"""Return the model name used for attachment serialization."""
+⋮----
+def message_history_str(self, i: Optional[int] = None) -> str
+⋮----
+"""
+        Return a string representation of the message history
+        Args:
+            i: if provided, return only the i-th message when i is postive,
+                or last k messages when i = -k.
+        Returns:
+        """
+⋮----
+def __del__(self) -> None
+⋮----
+"""
+        Cleanup method called when the ChatAgent is garbage collected.
+        Note: We don't close LLM clients here because they may be shared
+        across multiple agents when client caching is enabled.
+        The clients are managed centrally and cleaned up via atexit hooks.
+        """
+# Previously we closed clients here, but this caused issues when
+# multiple agents shared the same cached client instance.
+# Clients are now managed centrally in langroid.language_models.client_cache
 </file>
 
 <file path="mkdocs.yml">
@@ -60041,6 +60094,7 @@ nav:
       - Markdown, HTML Parsing: notes/markdown-html-parsing.md
       - Context-Overflow Handling: notes/context-overflow.md
       - Batch Processing: notes/batch-processing.md
+      - Attachment Token Preflight: notes/attachment-token-preflight.md
 
   - Examples:
     - Guide: examples/guide.md
@@ -60089,7 +60143,7 @@ extra_javascript:
 <file path="pyproject.toml">
 [project]
 name = "langroid"
-version = "0.65.16"
+version = "0.66.0"
 authors = [
     {name = "Prasad Chalasani", email = "pchalasani@gmail.com"},
 ]

--- a/llms-no-tests-no-examples-compressed.txt
+++ b/llms-no-tests-no-examples-compressed.txt
@@ -109,6 +109,7 @@ docs/
     pure-lambda-non-circular.png
   notes/
     async-streaming.md
+    attachment-token-preflight.md
     azure-openai-models.md
     batch-processing.md
     chat-history-snapshots.md
@@ -21287,6 +21288,55 @@ the LLM will try its best to interpret what you want, and offer choices when con
     - Illustrates function-calling/tools and code-generation
 </file>
 
+<file path="docs/notes/attachment-token-preflight.md">
+# Attachment Token Preflight
+
+Before each LLM call, Langroid runs a local context-length preflight: it counts
+the tokens in the pending message history (`ChatAgent.chat_num_tokens()`) and,
+if needed, reduces the requested output length, truncates old messages, or
+drops old turns so the request fits the model's context window.
+
+Historically this preflight counted only each message's text `content`, ignoring
+`LLMMessage.files` (`FileAttachment` objects). But attachments ARE serialized
+into the actual API request — for Gemini and other OpenAI-compatible paths,
+`FileAttachment.to_dict()` turns an attached PDF or image into a `data:` URI
+containing the full base64 payload. A ~1.9 MB PDF becomes roughly 2.6 million
+base64 characters, so the local check could pass while the real payload was far
+larger (issue #996).
+
+## Behavior
+
+The preflight now includes an estimate for each attachment on `USER` messages:
+
+- Each attachment is serialized exactly as it would be for the API request
+  (`FileAttachment.to_dict(model)`), and the resulting JSON is tokenized with
+  the agent's parser, the same way message text is counted.
+- Attachments that are NOT inlined — e.g. a `FileAttachment` carrying an
+  `http(s)` URL, which is sent as the URL itself rather than base64 bytes —
+  contribute only the tokens of their small serialized form, not the size of
+  the remote file.
+- Messages with no attachments are counted exactly as before; token accounting
+  is unchanged for attachment-free histories.
+
+When attachments contribute to the count for an agent, a warning is logged once
+(per agent, not per message) noting that the count is an estimate.
+
+## How conservative is the estimate?
+
+The estimate measures the serialized request payload (base64 data URI plus the
+surrounding JSON), tokenized like ordinary text. Provider-side accounting may
+differ in either direction:
+
+- Providers that bill inlined files as text-like payload will be close to this
+  estimate.
+- Providers that convert files to their own internal representation (e.g.
+  per-page or per-image token charges) may count fewer or more tokens.
+
+The goal is to keep the local preflight from drastically *under*-estimating the
+request size when large files are attached, so context-window overflows are
+caught locally instead of surfacing as provider-side errors.
+</file>
+
 <file path="docs/notes/batch-processing.md">
 # Batch Processing
 
@@ -30224,6 +30274,580 @@ excludes = excludes.union({"request"})
 schema = generate_simple_schema(
 </file>
 
+<file path="langroid/language_models/base.py">
+logger = logging.getLogger(__name__)
+⋮----
+def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
+⋮----
+async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
+⋮----
+FunctionCallTypes = Literal["none", "auto"]
+ToolChoiceTypes = Literal["none", "auto", "required"]
+ToolTypes = Literal["function"]
+⋮----
+DEFAULT_CONTEXT_LENGTH = 16_000
+⋮----
+class StreamEventType(Enum)
+⋮----
+TEXT = 1
+FUNC_NAME = 2
+FUNC_ARGS = 3
+TOOL_NAME = 4
+TOOL_ARGS = 5
+REASONING = 6
+⋮----
+class RetryParams(BaseSettings)
+⋮----
+max_retries: int = 5
+initial_delay: float = 1.0
+exponential_base: float = 1.3
+jitter: bool = True
+⋮----
+class LLMConfig(BaseSettings)
+⋮----
+"""
+    Common configuration for all language models.
+    """
+⋮----
+type: str = "openai"
+streamer: Optional[Callable[[Any], None]] = noop_fn
+streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
+api_base: str | None = None
+formatter: None | str = None
+# specify None if you want to use the full max output tokens of the model
+max_output_tokens: int | None = 8192
+timeout: int = 20  # timeout for API requests
+chat_model: str = ""
+completion_model: str = ""
+temperature: float = 0.0
+chat_context_length: int | None = None
+async_stream_quiet: bool = False  # suppress streaming output in async mode?
+completion_context_length: int | None = None
+# if input length + max_output_tokens > context length of model,
+# we will try shortening requested output
+min_output_tokens: int = 64
+use_completion_for_chat: bool = False  # use completion model for chat?
+# use chat model for completion? For OpenAI models, this MUST be set to True!
+use_chat_for_completion: bool = True
+stream: bool = True  # stream output from API?
+# TODO: we could have a `stream_reasoning` flag here to control whether to show
+# reasoning output from reasoning models
+cache_config: None | CacheDBConfig = RedisCacheConfig()
+thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
+retry_params: RetryParams = RetryParams()
+⋮----
+@property
+    def model_max_output_tokens(self) -> int
+⋮----
+# Build fallback names by progressively stripping provider prefixes
+# (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
+# succeeds even before OpenAIGPT.__init__ strips the prefix.
+parts = self.chat_model.split("/")
+fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
+⋮----
+class LLMFunctionCall(BaseModel)
+⋮----
+"""
+    Structure of LLM response indicating it "wants" to call a function.
+    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
+    """
+⋮----
+name: str  # name of function to call
+arguments: Optional[Dict[str, Any]] = None
+⋮----
+@staticmethod
+    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall"
+⋮----
+"""
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+fun_call = LLMFunctionCall(name=message["name"])
+fun_args_str = message["arguments"]
+# sometimes may be malformed with invalid indents,
+# so we try to be safe by removing newlines.
+⋮----
+fun_args_str = fun_args_str.replace("\n", "").strip()
+dict_or_list = parse_imperfect_json(fun_args_str)
+⋮----
+fun_args = dict_or_list
+⋮----
+fun_args = None
+⋮----
+def __str__(self) -> str
+⋮----
+class LLMFunctionSpec(BaseModel)
+⋮----
+"""
+    Description of a function available for the LLM to use.
+    To be used when calling the LLM `chat()` method with the `functions` parameter.
+    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
+    """
+⋮----
+name: str
+description: str
+parameters: Dict[str, Any]
+⋮----
+class OpenAIToolCall(BaseModel)
+⋮----
+"""
+    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
+    See https://platform.openai.com/docs/api-reference/chat/create
+
+    Attributes:
+        id: The id of the tool call.
+        type: The type of the tool call;
+            only "function" is currently possible (7/26/24).
+        function: The function call.
+    """
+⋮----
+id: str | None = None
+type: ToolTypes = "function"
+function: LLMFunctionCall | None = None
+extra_content: Dict[str, Any] | None = None
+⋮----
+@staticmethod
+    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall"
+⋮----
+id = message["id"]
+type = message["type"]
+function = LLMFunctionCall.from_dict(message["function"])
+extra_content = message.get("extra_content")
+⋮----
+class OpenAIToolSpec(BaseModel)
+⋮----
+type: ToolTypes
+strict: Optional[bool] = None
+function: LLMFunctionSpec
+⋮----
+class OpenAIJsonSchemaSpec(BaseModel)
+⋮----
+def to_dict(self) -> Dict[str, Any]
+⋮----
+json_schema: Dict[str, Any] = {
+⋮----
+class LLMTokenUsage(BaseModel)
+⋮----
+"""
+    Usage of tokens by an LLM.
+    """
+⋮----
+prompt_tokens: int = 0
+cached_tokens: int = 0
+completion_tokens: int = 0
+cost: float = 0.0
+calls: int = 0  # how many API calls - not used as of 2025-04-04
+⋮----
+def reset(self) -> None
+⋮----
+@property
+    def total_tokens(self) -> int
+⋮----
+class Role(str, Enum)
+⋮----
+"""
+    Possible roles for a message in a chat.
+    """
+⋮----
+USER = "user"
+SYSTEM = "system"
+ASSISTANT = "assistant"
+FUNCTION = "function"
+TOOL = "tool"
+⋮----
+class LLMMessage(BaseModel)
+⋮----
+"""
+    Class representing an entry in the msg-history sent to the LLM API.
+    It could be one of these:
+    - a user message
+    - an LLM ("Assistant") response
+    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
+    - a result or results from executing a fn or tool-call(s)
+    """
+⋮----
+role: Role
+name: Optional[str] = None
+tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
+tool_id: str = ""  # used by OpenAIAssistant
+# None means "no content" (the model returned only a tool/function call).
+# This is distinct from "" and is dropped from the API payload by api_dict;
+# see api_dict for how a fully-empty message is handled per-API.
+content: Optional[str] = None
+files: List[FileAttachment] = []
+function_call: Optional[LLMFunctionCall] = None
+tool_calls: Optional[List[OpenAIToolCall]] = None
+timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+# link to corresponding chat document, for provenance/rewind purposes
+chat_document_id: str = ""
+⋮----
+def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]
+⋮----
+"""
+        Convert to dictionary for API request, keeping ONLY
+        the fields that are expected in an API call!
+        E.g., DROP the tool_id, since it is only for use in the Assistant API,
+            not the completion API.
+
+        Args:
+            has_system_role: whether the message has a system role (if not,
+                set to "user" role)
+        Returns:
+            dict: dictionary representation of LLM message
+        """
+d = self.model_dump()
+files: List[FileAttachment] = d.pop("files")
+⋮----
+# In there are files, then content is an array of
+# different content-parts
+⋮----
+# if there is a key k = "role" with value "system", change to "user"
+# in case has_system_role is False
+⋮----
+# drop None values since API doesn't accept them (this omits `content`
+# entirely when it is None, i.e. "no content")
+dict_no_none = {k: v for k, v in d.items() if v is not None}
+⋮----
+# OpenAI API does not like empty name
+⋮----
+# arguments must be a string
+⋮----
+# convert tool calls to API format
+⋮----
+# An empty tool-call list is not a call and conveys no useful API
+# information. Omitting it also lets the empty-message fallback
+# below produce a valid message.
+⋮----
+# A message with empty content (None was dropped above, or "") AND no
+# tool/function call would be an entirely empty message, which some APIs
+# (e.g. Gemini) reject; fall back to a single space in that case only.
+# When there IS a tool/function call, empty content is fine (and Gemini
+# 3.x in fact REQUIRES it — it rejects an assistant turn that carries
+# both a call and non-empty text content).
+has_call = bool(dict_no_none.get("tool_calls")) or (
+⋮----
+# IMPORTANT! drop fields that are not expected in API call
+⋮----
+content = "FUNC: " + json.dumps(self.function_call)
+⋮----
+content = self.content or ""
+name_str = f" ({self.name})" if self.name else ""
+⋮----
+class LLMResponse(BaseModel)
+⋮----
+"""
+    Class representing response from LLM.
+    """
+⋮----
+# None means the model returned NO content (e.g. only a tool/function
+# call), which is distinct from an empty string "". Preserving this
+# distinction lets the message be faithfully reproduced downstream
+# (see ChatDocument.content_is_none and LLMMessage.content).
+message: Optional[str] = None
+reasoning: str = ""  # optional reasoning text from reasoning models
+# Original message text including inline thought signatures (e.g.
+# <thinking>...</thinking>). Only set when reasoning was extracted
+# from the message text via get_reasoning_final(); NOT set when
+# reasoning comes from a separate API field (e.g. reasoning_content),
+# since in that case the message text never contained thought tags.
+message_with_reasoning: Optional[str] = None
+# TODO tool_id needs to generalize to multi-tool calls
+⋮----
+oai_tool_calls: Optional[List[OpenAIToolCall]] = None
+⋮----
+usage: Optional[LLMTokenUsage] = None
+cached: bool = False
+⋮----
+def tools_content(self) -> str
+⋮----
+def to_LLMMessage(self) -> LLMMessage
+⋮----
+"""Convert LLM response to an LLMMessage, to be included in the
+        message-list sent to the API.
+        This is currently NOT used in any significant way in the library, and is only
+        provided as a utility to construct a message list for the API when directly
+        working with an LLM object.
+
+        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
+        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
+        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
+        """
+⋮----
+"""
+        If `message` or `function_call` of an LLM response contains an explicit
+        recipient name, return this recipient name and `message` stripped
+        of the recipient name if specified.
+
+        Two cases:
+        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
+        (b) `message` is empty and function_call/tool_call with explicit `recipient`
+
+        Args:
+            recognize_recipient_in_content (bool): When True (default), parses
+                message text for ``TO[<recipient>]:<content>`` patterns and
+                top-level JSON ``{"recipient": "..."}`` fields. When False,
+                only function_call/tool_call ``recipient`` fields are checked.
+
+        Returns:
+            (str): name of recipient, which may be empty string if no recipient
+            (str): content of message
+
+        """
+⋮----
+# in this case we ignore message, since all information is in function_call
+msg = ""
+args = self.function_call.arguments
+recipient = ""
+⋮----
+recipient = args.get("recipient", "")
+⋮----
+msg = self.message or ""
+⋮----
+# get the first tool that has a recipient field, if any
+⋮----
+recipient = tc.function.arguments.get(
+⋮----
+)  # type: ignore
+⋮----
+# It's not a function or tool call, so continue looking to see
+# if a recipient is specified in the message.
+⋮----
+# First check if message contains "TO: <recipient> <content>"
+⋮----
+# check if there is a top level json that specifies 'recipient',
+# and retain the entire message as content.
+⋮----
+recipient_name = top_level_json_field(msg, "recipient") if msg else ""
+content = msg
+⋮----
+# Define an abstract base class for language models
+class LanguageModel(ABC)
+⋮----
+"""
+    Abstract base class for language models.
+    """
+⋮----
+# usage cost by model, accumulates here
+usage_cost_dict: Dict[str, LLMTokenUsage] = {}
+⋮----
+def __init__(self, config: LLMConfig = LLMConfig())
+⋮----
+@staticmethod
+    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]
+⋮----
+"""
+        Create a language model.
+        Args:
+            config: configuration for language model
+        Returns: instance of language model
+        """
+⋮----
+openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
+⋮----
+openai = AzureGPT
+⋮----
+openai = OpenAIGPT
+cls = dict(
+return cls(config)  # type: ignore
+⋮----
+@staticmethod
+    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]
+⋮----
+"""
+        Given an even-length sequence of strings, split into a sequence of pairs
+
+        Args:
+            lst (List[str]): sequence of strings
+
+        Returns:
+            List[Tuple[str,str]]: sequence of pairs of strings
+        """
+evens = lst[::2]
+odds = lst[1::2]
+⋮----
+"""
+        From the chat history, extract system prompt, user-assistant turns, and
+        final user msg.
+
+        Args:
+            messages (List[LLMMessage]): List of messages in the chat history
+
+        Returns:
+            Tuple[str, List[Tuple[str,str]], str]:
+                system prompt, user-assistant turns, final user msg
+
+        """
+# Handle various degenerate cases
+messages = [m for m in messages]  # copy
+DUMMY_SYS_PROMPT = "You are a helpful assistant."
+DUMMY_USER_PROMPT = "Follow the instructions above."
+⋮----
+system_prompt = messages[0].content or ""
+⋮----
+# now we have messages = [Sys,...]
+⋮----
+# now we have messages = [Sys, msg, ...]
+⋮----
+# now we have messages = [Sys, user, ...]
+⋮----
+# now we have messages = [Sys, user, ..., user]
+# so we omit the first and last elements and make pairs of user-asst messages
+conversation = [m.content or "" for m in messages[1:-1]]
+user_prompt = messages[-1].content or ""
+pairs = LanguageModel.user_assistant_pairs(conversation)
+⋮----
+@abstractmethod
+    def set_stream(self, stream: bool) -> bool
+⋮----
+"""Enable or disable streaming output from API.
+        Return previous value of stream."""
+⋮----
+@abstractmethod
+    def get_stream(self) -> bool
+⋮----
+"""Get streaming status"""
+⋮----
+@abstractmethod
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+@abstractmethod
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+"""
+        Get chat-completion response from LLM.
+
+        Args:
+            messages: message-history to send to the LLM
+            max_tokens: max tokens to generate
+            tools: tools available for the LLM to use in its response
+            tool_choice: tool call mode, one of "none", "auto", "required",
+                or a dict specifying a specific tool.
+            functions: functions available for LLM to call (deprecated)
+            function_call: function calling mode, "auto", "none", or a specific fn
+                    (deprecated)
+        """
+⋮----
+"""Async version of `chat`. See `chat` for details."""
+⋮----
+def __call__(self, prompt: str, max_tokens: int) -> LLMResponse
+⋮----
+@staticmethod
+    def _fallback_model_names(model: str) -> List[str]
+⋮----
+parts = model.split("/")
+fallbacks = []
+⋮----
+def info(self) -> ModelInfo
+⋮----
+"""Info of relevant chat model"""
+orig_model = (
+⋮----
+def completion_info(self) -> ModelInfo
+⋮----
+"""Info of relevant completion model"""
+⋮----
+def supports_functions_or_tools(self) -> bool
+⋮----
+"""
+        Does this Model's API support "native" tool-calling, i.e.
+        can we call the API with arguments that contain a list of available tools,
+        and their schemas?
+        Note that, given the plethora of LLM provider APIs this determination is
+        imperfect at best, and leans towards returning True.
+        When the API calls fails with an error indicating tools are not supported,
+        then users are encouraged to use the Langroid-based prompt-based
+        ToolMessage mechanism, which works with ANY LLM. To enable this,
+        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
+        """
+⋮----
+def chat_context_length(self) -> int
+⋮----
+def completion_context_length(self) -> int
+⋮----
+def chat_cost(self) -> Tuple[float, float, float]
+⋮----
+"""
+        Return the cost per 1000 tokens for chat completions.
+
+        Returns:
+            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
+                per 1000 tokens
+        """
+⋮----
+def reset_usage_cost(self) -> None
+⋮----
+counter = self.usage_cost_dict[mdl]
+⋮----
+"""
+        Update usage cost for this LLM.
+        Args:
+            chat (bool): whether to update for chat or completion model
+            prompts (int): number of tokens used for prompts
+            completions (int): number of tokens used for completions
+            cost (float): total token cost in USD
+        """
+mdl = self.config.chat_model if chat else self.config.completion_model
+⋮----
+@classmethod
+    def usage_cost_summary(cls) -> str
+⋮----
+s = ""
+⋮----
+@classmethod
+    def tot_tokens_cost(cls) -> Tuple[int, float]
+⋮----
+"""
+        Return total tokens used and total cost across all models.
+        """
+total_tokens = 0
+total_cost = 0.0
+⋮----
+def get_reasoning_final(self, message: str) -> Tuple[str, str]
+⋮----
+"""Extract "reasoning" and "final answer" from an LLM response, if the
+        reasoning is found within configured delimiters, like <think>, </think>.
+        E.g.,
+        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
+
+        Args:
+            message (str): message from LLM
+
+        Returns:
+            Tuple[str, str]: reasoning, final answer
+        """
+⋮----
+parts = message.split(start)
+⋮----
+"""
+        Given a chat history and a question, convert it to a standalone question.
+        Args:
+            chat_history: list of tuples of (question, answer)
+            query: follow-up question
+
+        Returns: standalone version of the question
+        """
+history = collate_chat_history(chat_history)
+⋮----
+prompt = f"""
+⋮----
+follow_up_question = f"""
+⋮----
+standalone = (
+standalone = standalone.strip()
+⋮----
+class StreamingIfAllowed
+⋮----
+"""Context to temporarily enable or disable streaming, if allowed globally via
+    `settings.stream`"""
+⋮----
+def __init__(self, llm: LanguageModel, stream: bool = True)
+⋮----
+def __enter__(self) -> None
+⋮----
+def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
+</file>
+
 <file path="langroid/parsing/parser.py">
 logger = logging.getLogger(__name__)
 ⋮----
@@ -35563,580 +36187,6 @@ sender_role = Role.ASSISTANT
 tool_id=tool_id,  # for OpenAI Assistant
 </file>
 
-<file path="langroid/language_models/base.py">
-logger = logging.getLogger(__name__)
-⋮----
-def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
-⋮----
-async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
-⋮----
-FunctionCallTypes = Literal["none", "auto"]
-ToolChoiceTypes = Literal["none", "auto", "required"]
-ToolTypes = Literal["function"]
-⋮----
-DEFAULT_CONTEXT_LENGTH = 16_000
-⋮----
-class StreamEventType(Enum)
-⋮----
-TEXT = 1
-FUNC_NAME = 2
-FUNC_ARGS = 3
-TOOL_NAME = 4
-TOOL_ARGS = 5
-REASONING = 6
-⋮----
-class RetryParams(BaseSettings)
-⋮----
-max_retries: int = 5
-initial_delay: float = 1.0
-exponential_base: float = 1.3
-jitter: bool = True
-⋮----
-class LLMConfig(BaseSettings)
-⋮----
-"""
-    Common configuration for all language models.
-    """
-⋮----
-type: str = "openai"
-streamer: Optional[Callable[[Any], None]] = noop_fn
-streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
-api_base: str | None = None
-formatter: None | str = None
-# specify None if you want to use the full max output tokens of the model
-max_output_tokens: int | None = 8192
-timeout: int = 20  # timeout for API requests
-chat_model: str = ""
-completion_model: str = ""
-temperature: float = 0.0
-chat_context_length: int | None = None
-async_stream_quiet: bool = False  # suppress streaming output in async mode?
-completion_context_length: int | None = None
-# if input length + max_output_tokens > context length of model,
-# we will try shortening requested output
-min_output_tokens: int = 64
-use_completion_for_chat: bool = False  # use completion model for chat?
-# use chat model for completion? For OpenAI models, this MUST be set to True!
-use_chat_for_completion: bool = True
-stream: bool = True  # stream output from API?
-# TODO: we could have a `stream_reasoning` flag here to control whether to show
-# reasoning output from reasoning models
-cache_config: None | CacheDBConfig = RedisCacheConfig()
-thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
-retry_params: RetryParams = RetryParams()
-⋮----
-@property
-    def model_max_output_tokens(self) -> int
-⋮----
-# Build fallback names by progressively stripping provider prefixes
-# (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
-# succeeds even before OpenAIGPT.__init__ strips the prefix.
-parts = self.chat_model.split("/")
-fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
-⋮----
-class LLMFunctionCall(BaseModel)
-⋮----
-"""
-    Structure of LLM response indicating it "wants" to call a function.
-    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
-    """
-⋮----
-name: str  # name of function to call
-arguments: Optional[Dict[str, Any]] = None
-⋮----
-@staticmethod
-    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall"
-⋮----
-"""
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-fun_call = LLMFunctionCall(name=message["name"])
-fun_args_str = message["arguments"]
-# sometimes may be malformed with invalid indents,
-# so we try to be safe by removing newlines.
-⋮----
-fun_args_str = fun_args_str.replace("\n", "").strip()
-dict_or_list = parse_imperfect_json(fun_args_str)
-⋮----
-fun_args = dict_or_list
-⋮----
-fun_args = None
-⋮----
-def __str__(self) -> str
-⋮----
-class LLMFunctionSpec(BaseModel)
-⋮----
-"""
-    Description of a function available for the LLM to use.
-    To be used when calling the LLM `chat()` method with the `functions` parameter.
-    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
-    """
-⋮----
-name: str
-description: str
-parameters: Dict[str, Any]
-⋮----
-class OpenAIToolCall(BaseModel)
-⋮----
-"""
-    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
-    See https://platform.openai.com/docs/api-reference/chat/create
-
-    Attributes:
-        id: The id of the tool call.
-        type: The type of the tool call;
-            only "function" is currently possible (7/26/24).
-        function: The function call.
-    """
-⋮----
-id: str | None = None
-type: ToolTypes = "function"
-function: LLMFunctionCall | None = None
-extra_content: Dict[str, Any] | None = None
-⋮----
-@staticmethod
-    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall"
-⋮----
-id = message["id"]
-type = message["type"]
-function = LLMFunctionCall.from_dict(message["function"])
-extra_content = message.get("extra_content")
-⋮----
-class OpenAIToolSpec(BaseModel)
-⋮----
-type: ToolTypes
-strict: Optional[bool] = None
-function: LLMFunctionSpec
-⋮----
-class OpenAIJsonSchemaSpec(BaseModel)
-⋮----
-def to_dict(self) -> Dict[str, Any]
-⋮----
-json_schema: Dict[str, Any] = {
-⋮----
-class LLMTokenUsage(BaseModel)
-⋮----
-"""
-    Usage of tokens by an LLM.
-    """
-⋮----
-prompt_tokens: int = 0
-cached_tokens: int = 0
-completion_tokens: int = 0
-cost: float = 0.0
-calls: int = 0  # how many API calls - not used as of 2025-04-04
-⋮----
-def reset(self) -> None
-⋮----
-@property
-    def total_tokens(self) -> int
-⋮----
-class Role(str, Enum)
-⋮----
-"""
-    Possible roles for a message in a chat.
-    """
-⋮----
-USER = "user"
-SYSTEM = "system"
-ASSISTANT = "assistant"
-FUNCTION = "function"
-TOOL = "tool"
-⋮----
-class LLMMessage(BaseModel)
-⋮----
-"""
-    Class representing an entry in the msg-history sent to the LLM API.
-    It could be one of these:
-    - a user message
-    - an LLM ("Assistant") response
-    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
-    - a result or results from executing a fn or tool-call(s)
-    """
-⋮----
-role: Role
-name: Optional[str] = None
-tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
-tool_id: str = ""  # used by OpenAIAssistant
-# None means "no content" (the model returned only a tool/function call).
-# This is distinct from "" and is dropped from the API payload by api_dict;
-# see api_dict for how a fully-empty message is handled per-API.
-content: Optional[str] = None
-files: List[FileAttachment] = []
-function_call: Optional[LLMFunctionCall] = None
-tool_calls: Optional[List[OpenAIToolCall]] = None
-timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-# link to corresponding chat document, for provenance/rewind purposes
-chat_document_id: str = ""
-⋮----
-def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]
-⋮----
-"""
-        Convert to dictionary for API request, keeping ONLY
-        the fields that are expected in an API call!
-        E.g., DROP the tool_id, since it is only for use in the Assistant API,
-            not the completion API.
-
-        Args:
-            has_system_role: whether the message has a system role (if not,
-                set to "user" role)
-        Returns:
-            dict: dictionary representation of LLM message
-        """
-d = self.model_dump()
-files: List[FileAttachment] = d.pop("files")
-⋮----
-# In there are files, then content is an array of
-# different content-parts
-⋮----
-# if there is a key k = "role" with value "system", change to "user"
-# in case has_system_role is False
-⋮----
-# drop None values since API doesn't accept them (this omits `content`
-# entirely when it is None, i.e. "no content")
-dict_no_none = {k: v for k, v in d.items() if v is not None}
-⋮----
-# OpenAI API does not like empty name
-⋮----
-# arguments must be a string
-⋮----
-# convert tool calls to API format
-⋮----
-# An empty tool-call list is not a call and conveys no useful API
-# information. Omitting it also lets the empty-message fallback
-# below produce a valid message.
-⋮----
-# A message with empty content (None was dropped above, or "") AND no
-# tool/function call would be an entirely empty message, which some APIs
-# (e.g. Gemini) reject; fall back to a single space in that case only.
-# When there IS a tool/function call, empty content is fine (and Gemini
-# 3.x in fact REQUIRES it — it rejects an assistant turn that carries
-# both a call and non-empty text content).
-has_call = bool(dict_no_none.get("tool_calls")) or (
-⋮----
-# IMPORTANT! drop fields that are not expected in API call
-⋮----
-content = "FUNC: " + json.dumps(self.function_call)
-⋮----
-content = self.content or ""
-name_str = f" ({self.name})" if self.name else ""
-⋮----
-class LLMResponse(BaseModel)
-⋮----
-"""
-    Class representing response from LLM.
-    """
-⋮----
-# None means the model returned NO content (e.g. only a tool/function
-# call), which is distinct from an empty string "". Preserving this
-# distinction lets the message be faithfully reproduced downstream
-# (see ChatDocument.content_is_none and LLMMessage.content).
-message: Optional[str] = None
-reasoning: str = ""  # optional reasoning text from reasoning models
-# Original message text including inline thought signatures (e.g.
-# <thinking>...</thinking>). Only set when reasoning was extracted
-# from the message text via get_reasoning_final(); NOT set when
-# reasoning comes from a separate API field (e.g. reasoning_content),
-# since in that case the message text never contained thought tags.
-message_with_reasoning: Optional[str] = None
-# TODO tool_id needs to generalize to multi-tool calls
-⋮----
-oai_tool_calls: Optional[List[OpenAIToolCall]] = None
-⋮----
-usage: Optional[LLMTokenUsage] = None
-cached: bool = False
-⋮----
-def tools_content(self) -> str
-⋮----
-def to_LLMMessage(self) -> LLMMessage
-⋮----
-"""Convert LLM response to an LLMMessage, to be included in the
-        message-list sent to the API.
-        This is currently NOT used in any significant way in the library, and is only
-        provided as a utility to construct a message list for the API when directly
-        working with an LLM object.
-
-        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
-        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
-        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
-        """
-⋮----
-"""
-        If `message` or `function_call` of an LLM response contains an explicit
-        recipient name, return this recipient name and `message` stripped
-        of the recipient name if specified.
-
-        Two cases:
-        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
-        (b) `message` is empty and function_call/tool_call with explicit `recipient`
-
-        Args:
-            recognize_recipient_in_content (bool): When True (default), parses
-                message text for ``TO[<recipient>]:<content>`` patterns and
-                top-level JSON ``{"recipient": "..."}`` fields. When False,
-                only function_call/tool_call ``recipient`` fields are checked.
-
-        Returns:
-            (str): name of recipient, which may be empty string if no recipient
-            (str): content of message
-
-        """
-⋮----
-# in this case we ignore message, since all information is in function_call
-msg = ""
-args = self.function_call.arguments
-recipient = ""
-⋮----
-recipient = args.get("recipient", "")
-⋮----
-msg = self.message or ""
-⋮----
-# get the first tool that has a recipient field, if any
-⋮----
-recipient = tc.function.arguments.get(
-⋮----
-)  # type: ignore
-⋮----
-# It's not a function or tool call, so continue looking to see
-# if a recipient is specified in the message.
-⋮----
-# First check if message contains "TO: <recipient> <content>"
-⋮----
-# check if there is a top level json that specifies 'recipient',
-# and retain the entire message as content.
-⋮----
-recipient_name = top_level_json_field(msg, "recipient") if msg else ""
-content = msg
-⋮----
-# Define an abstract base class for language models
-class LanguageModel(ABC)
-⋮----
-"""
-    Abstract base class for language models.
-    """
-⋮----
-# usage cost by model, accumulates here
-usage_cost_dict: Dict[str, LLMTokenUsage] = {}
-⋮----
-def __init__(self, config: LLMConfig = LLMConfig())
-⋮----
-@staticmethod
-    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]
-⋮----
-"""
-        Create a language model.
-        Args:
-            config: configuration for language model
-        Returns: instance of language model
-        """
-⋮----
-openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
-⋮----
-openai = AzureGPT
-⋮----
-openai = OpenAIGPT
-cls = dict(
-return cls(config)  # type: ignore
-⋮----
-@staticmethod
-    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]
-⋮----
-"""
-        Given an even-length sequence of strings, split into a sequence of pairs
-
-        Args:
-            lst (List[str]): sequence of strings
-
-        Returns:
-            List[Tuple[str,str]]: sequence of pairs of strings
-        """
-evens = lst[::2]
-odds = lst[1::2]
-⋮----
-"""
-        From the chat history, extract system prompt, user-assistant turns, and
-        final user msg.
-
-        Args:
-            messages (List[LLMMessage]): List of messages in the chat history
-
-        Returns:
-            Tuple[str, List[Tuple[str,str]], str]:
-                system prompt, user-assistant turns, final user msg
-
-        """
-# Handle various degenerate cases
-messages = [m for m in messages]  # copy
-DUMMY_SYS_PROMPT = "You are a helpful assistant."
-DUMMY_USER_PROMPT = "Follow the instructions above."
-⋮----
-system_prompt = messages[0].content or ""
-⋮----
-# now we have messages = [Sys,...]
-⋮----
-# now we have messages = [Sys, msg, ...]
-⋮----
-# now we have messages = [Sys, user, ...]
-⋮----
-# now we have messages = [Sys, user, ..., user]
-# so we omit the first and last elements and make pairs of user-asst messages
-conversation = [m.content or "" for m in messages[1:-1]]
-user_prompt = messages[-1].content or ""
-pairs = LanguageModel.user_assistant_pairs(conversation)
-⋮----
-@abstractmethod
-    def set_stream(self, stream: bool) -> bool
-⋮----
-"""Enable or disable streaming output from API.
-        Return previous value of stream."""
-⋮----
-@abstractmethod
-    def get_stream(self) -> bool
-⋮----
-"""Get streaming status"""
-⋮----
-@abstractmethod
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-@abstractmethod
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-"""
-        Get chat-completion response from LLM.
-
-        Args:
-            messages: message-history to send to the LLM
-            max_tokens: max tokens to generate
-            tools: tools available for the LLM to use in its response
-            tool_choice: tool call mode, one of "none", "auto", "required",
-                or a dict specifying a specific tool.
-            functions: functions available for LLM to call (deprecated)
-            function_call: function calling mode, "auto", "none", or a specific fn
-                    (deprecated)
-        """
-⋮----
-"""Async version of `chat`. See `chat` for details."""
-⋮----
-def __call__(self, prompt: str, max_tokens: int) -> LLMResponse
-⋮----
-@staticmethod
-    def _fallback_model_names(model: str) -> List[str]
-⋮----
-parts = model.split("/")
-fallbacks = []
-⋮----
-def info(self) -> ModelInfo
-⋮----
-"""Info of relevant chat model"""
-orig_model = (
-⋮----
-def completion_info(self) -> ModelInfo
-⋮----
-"""Info of relevant completion model"""
-⋮----
-def supports_functions_or_tools(self) -> bool
-⋮----
-"""
-        Does this Model's API support "native" tool-calling, i.e.
-        can we call the API with arguments that contain a list of available tools,
-        and their schemas?
-        Note that, given the plethora of LLM provider APIs this determination is
-        imperfect at best, and leans towards returning True.
-        When the API calls fails with an error indicating tools are not supported,
-        then users are encouraged to use the Langroid-based prompt-based
-        ToolMessage mechanism, which works with ANY LLM. To enable this,
-        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
-        """
-⋮----
-def chat_context_length(self) -> int
-⋮----
-def completion_context_length(self) -> int
-⋮----
-def chat_cost(self) -> Tuple[float, float, float]
-⋮----
-"""
-        Return the cost per 1000 tokens for chat completions.
-
-        Returns:
-            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
-                per 1000 tokens
-        """
-⋮----
-def reset_usage_cost(self) -> None
-⋮----
-counter = self.usage_cost_dict[mdl]
-⋮----
-"""
-        Update usage cost for this LLM.
-        Args:
-            chat (bool): whether to update for chat or completion model
-            prompts (int): number of tokens used for prompts
-            completions (int): number of tokens used for completions
-            cost (float): total token cost in USD
-        """
-mdl = self.config.chat_model if chat else self.config.completion_model
-⋮----
-@classmethod
-    def usage_cost_summary(cls) -> str
-⋮----
-s = ""
-⋮----
-@classmethod
-    def tot_tokens_cost(cls) -> Tuple[int, float]
-⋮----
-"""
-        Return total tokens used and total cost across all models.
-        """
-total_tokens = 0
-total_cost = 0.0
-⋮----
-def get_reasoning_final(self, message: str) -> Tuple[str, str]
-⋮----
-"""Extract "reasoning" and "final answer" from an LLM response, if the
-        reasoning is found within configured delimiters, like <think>, </think>.
-        E.g.,
-        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
-
-        Args:
-            message (str): message from LLM
-
-        Returns:
-            Tuple[str, str]: reasoning, final answer
-        """
-⋮----
-parts = message.split(start)
-⋮----
-"""
-        Given a chat history and a question, convert it to a standalone question.
-        Args:
-            chat_history: list of tuples of (question, answer)
-            query: follow-up question
-
-        Returns: standalone version of the question
-        """
-history = collate_chat_history(chat_history)
-⋮----
-prompt = f"""
-⋮----
-follow_up_question = f"""
-⋮----
-standalone = (
-standalone = standalone.strip()
-⋮----
-class StreamingIfAllowed
-⋮----
-"""Context to temporarily enable or disable streaming, if allowed globally via
-    `settings.stream`"""
-⋮----
-def __init__(self, llm: LanguageModel, stream: bool = True)
-⋮----
-def __enter__(self) -> None
-⋮----
-def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
-</file>
-
 <file path="langroid/language_models/client_cache.py">
 """
 Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
@@ -40650,1285 +40700,6 @@ model_names = tuple(_model_name(model) for model in models)
 def _model_name(model: str | ModelName) -> str
 </file>
 
-<file path="langroid/agent/chat_agent.py">
-console = Console()
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-# Stable origin sentinel for the dynamically generated strict-recovery AnyTool
-# class ("tool_or_function"): a fresh class is built per call (its tool-union
-# type varies), so re-registration must be recognized as the same logical tool.
-_ANY_TOOL_MESSAGE_ORIGIN: Any = object()
-⋮----
-# Safety margin (in tokens) subtracted from the model context length when
-# shrinking chat history and/or the requested output length to fit, in case
-# our token-count estimates are off.
-CHAT_HISTORY_BUFFER = 300
-⋮----
-def _reject_json_constant(constant: str) -> None
-⋮----
-"""Reject JavaScript numeric constants that are not valid JSON."""
-⋮----
-def _parse_json_float(value: str) -> float
-⋮----
-"""Parse a JSON float while rejecting exponent overflow."""
-parsed = float(value)
-⋮----
-def _is_identified_result(message: LLMMessage) -> bool
-⋮----
-"""Whether a TOOL/FUNCTION result has its identifier and no call payload.
-
-    Such results must survive even with empty content so their calls can be
-    marked complete (issue #1063).
-    """
-has_identifier = (
-⋮----
-def _llm_message_has_payload(message: LLMMessage) -> bool
-⋮----
-"""Whether a message has the fields required for a valid history entry."""
-⋮----
-class ChatAgentConfig(AgentConfig)
-⋮----
-"""
-    Configuration for ChatAgent
-
-    Attributes:
-        system_message: system message to include in message sequence
-             (typically defines role and task of agent).
-             Used only if `task` is not specified in the constructor.
-        user_message: user message to include in message sequence.
-             Used only if `task` is not specified in the constructor.
-        use_tools: whether to use our own ToolMessages mechanism
-        handle_llm_no_tool (Any): desired agent_response when
-            LLM generates non-tool msg.
-        use_functions_api: whether to use functions/tools native to the LLM API
-                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
-        use_tools_api: When `use_functions_api` is True, if this is also True,
-            the OpenAI tool-call API is used, rather than the older/deprecated
-            function-call API. However the tool-call API has some tricky aspects,
-            hence we set this to False by default.
-        strict_recovery: whether to enable strict schema recovery when there
-            is a tool-generation error.
-        enable_orchestration_tool_handling: whether to enable handling of orchestration
-            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
-        output_format: When supported by the LLM (certain OpenAI LLMs
-            and local LLMs served by providers such as vLLM), ensures
-            that the output is a JSON matching the corresponding
-            schema via grammar-based decoding
-        handle_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for handling".
-        use_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for use" (by LLM) and
-            instructions on using T are added to the system message.
-        instructions_output_format: Controls whether we generate instructions for
-            `output_format` in the system message.
-        use_tools_on_output_format: Controls whether to automatically switch
-            to the Langroid-native tools mechanism when `output_format` is set.
-            Note that LLMs may generate tool calls which do not belong to
-            `output_format` even when strict JSON mode is enabled, so this should be
-            enabled when such tool calls are not desired.
-        output_format_include_defaults: Whether to include fields with default arguments
-            in the output schema
-        full_citations: Whether to show source reference citation + content for each
-            citation, or just the main reference citation.
-        search_for_tools_everywhere: Whether to search for tools everywhere,
-            or only in specific LLM response elements based on use_tools /
-            use_functions_api / use_tools_api config settings.
-        recognize_recipient_in_content: Whether to parse LLM response text content
-            for recipient routing patterns, specifically:
-            - ``TO[<recipient>]:<content>`` addressing format, and
-            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
-            When False, only structured routing via function_call/tool_call
-            ``recipient`` fields is recognized. Default is True.
-            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
-            which controls Task-level signals like DONE, PASS, and SEND_TO.
-            To fully disable all text-based routing, set both to False.
-        context_overflow_strategy: Strategy for handling context overflow when
-            message history exceeds model context length. Options:
-            - "truncate": Truncate content of early messages (preserves all messages
-              but with shortened content). This maintains the message sequence.
-            - "drop_turns": Drop complete conversation turns (USER + all responses
-              until next USER). More aggressive but cleaner for voice agents.
-            Default is "truncate" for backward compatibility.
-    """
-⋮----
-system_message: str = "You are a helpful assistant."
-user_message: Optional[str] = None
-handle_llm_no_tool: Any = None
-use_tools: bool = True
-use_functions_api: bool = False
-use_tools_api: bool = True
-strict_recovery: bool = True
-enable_orchestration_tool_handling: bool = True
-output_format: Optional[type] = None
-handle_output_format: bool = True
-use_output_format: bool = True
-instructions_output_format: bool = True
-output_format_include_defaults: bool = True
-use_tools_on_output_format: bool = True
-full_citations: bool = True  # show source + content for each citation?
-search_for_tools_everywhere: bool = True
-recognize_recipient_in_content: bool = True
-context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
-⋮----
-def _set_fn_or_tools(self) -> None
-⋮----
-"""
-        Enable Langroid Tool or OpenAI-like fn-calling,
-        depending on config settings.
-        """
-⋮----
-class ChatAgent(Agent)
-⋮----
-"""
-    Chat Agent interacting with external env
-    (could be human, or external tools).
-    The agent (the LLM actually) is provided with an optional "Task Spec",
-    which is a sequence of `LLMMessage`s. These are used to initialize
-    the `task_messages` of the agent.
-    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
-    The `Agent` class mainly exists to hold various common methods and attributes.
-    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
-    `llm_response` method uses "chat mode" API (i.e. one that takes a
-    message sequence rather than a single message),
-    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
-    that takes a single message).
-    """
-⋮----
-"""
-        Chat-mode agent initialized with task spec as the initial message sequence
-        Args:
-            config: settings for the agent
-
-        """
-⋮----
-# An agent's "task" is defined by a system msg and an optional user msg;
-# These are "priming" messages that kick off the agent's conversation.
-⋮----
-# if task contains a system msg, we override the config system msg
-⋮----
-# if task contains a user msg, we override the config user msg
-⋮----
-# system-level instructions for using tools/functions:
-# We maintain these as tools/functions are enabled/disabled,
-# and whenever an LLM response is sought, these are used to
-# recreate the system message (via `_create_system_and_tools_message`)
-# each time, so it reflects the current set of enabled tools/functions.
-# (a) these are general instructions on using certain tools/functions,
-#   if they are specified in a ToolMessage class as a classmethod `instructions`
-⋮----
-# (b) these are only for the builtin in Langroid TOOLS mechanism:
-⋮----
-# This variable is not None and equals a `ToolMessage` T, if and only if:
-# (a) T has been set as the output_format of this agent, AND
-# (b) T has been "enabled for use" ONLY for enforcing this output format, AND
-# (c) T has NOT been explicitly "enabled for use" by this Agent.
-⋮----
-# As above but deals with "enabled for handling" instead of "enabled for use".
-⋮----
-# instructions specifically related to enforcing `output_format`
-⋮----
-# controls whether to disable strict schemas for this agent if
-# strict mode causes exception
-⋮----
-# Tracks whether any strict tool is enabled; used to determine whether to set
-# `self.disable_strict` on an exception
-⋮----
-# Tracks the set of tools on which we force-disable strict decoding
-⋮----
-# search for tools according to the agent configuration
-⋮----
-# Only enable HANDLING by `agent_response`, NOT LLM generation of these.
-# This is useful where tool-handlers or agent_response generate these
-# tools, and need to be handled.
-# We don't want enable orch tool GENERATION by default, since that
-# might clutter-up the LLM system message unnecessarily.
-⋮----
-def init_state(self) -> None
-⋮----
-"""
-        Initialize the state of the agent. Just conversation state here,
-        but subclasses can override this to initialize other state.
-        """
-⋮----
-@staticmethod
-    def from_id(id: str) -> "ChatAgent"
-⋮----
-"""
-        Get an agent from its ID
-        Args:
-            agent_id (str): ID of the agent
-        Returns:
-            ChatAgent: The agent with the given ID
-        """
-⋮----
-def clone(self, i: int = 0) -> "ChatAgent"
-⋮----
-"""Create i'th clone of this agent, ensuring tool use/handling is cloned.
-        Important: We assume all member variables are in the __init__ method here
-        and in the Agent class.
-        TODO: We are attempting to clone an agent after its state has been
-        changed in possibly many ways. Below is an imperfect solution. Caution advised.
-        Revisit later.
-        """
-agent_cls = type(self)
-# Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
-# instead of deepcopy which loses subclass information
-config_copy = self.config.model_copy(deep=True)
-⋮----
-new_agent = agent_cls(config_copy)
-⋮----
-# Ensure each clone gets its own vecdb client when supported.
-⋮----
-def _clone_extra_state(self, new_agent: "ChatAgent") -> None
-⋮----
-"""Hook for subclasses to copy additional state into clones."""
-⋮----
-def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool
-⋮----
-"""Should we enable strict mode for a given tool?"""
-⋮----
-tool_class = self.llm_tools_map[tool]
-⋮----
-tool_class = tool
-name = tool_class.default_value("request")
-⋮----
-strict: Optional[bool] = tool_class.default_value("strict")
-⋮----
-strict = self._strict_tools_available()
-⋮----
-def _fn_call_available(self) -> bool
-⋮----
-"""Does this agent's LLM support function calling?"""
-⋮----
-def _strict_tools_available(self) -> bool
-⋮----
-"""Does this agent's LLM support strict tools?"""
-⋮----
-def _json_schema_available(self) -> bool
-⋮----
-"""Does this agent's LLM support strict JSON schema output format?"""
-⋮----
-def set_system_message(self, msg: str) -> None
-⋮----
-# if there is message history, update the system message in it
-⋮----
-def set_user_message(self, msg: str) -> None
-⋮----
-@property
-    def task_messages(self) -> List[LLMMessage]
-⋮----
-"""
-        The task messages are the initial messages that define the task
-        of the agent. There will be at least a system message plus possibly a user msg.
-        Returns:
-            List[LLMMessage]: the task messages
-        """
-msgs = [self._create_system_and_tools_message()]
-⋮----
-def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None
-⋮----
-id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
-⋮----
-# dropping tool result, so ADD the corresponding tool-call back
-# to the list of pending calls!
-id = msg.tool_call_id
-⋮----
-# dropping a msg with tool-calls, so DROP these from pending list
-# as well as from id -> call map
-⋮----
-def clear_history(self, start: int = -2, end: int = -1) -> None
-⋮----
-"""
-        Clear the message history, deleting  messages from index `start`,
-        up to index `end`.
-
-        Args:
-            start (int): index of first message to delete; default = -2
-                    (i.e. delete last 2 messages, typically these
-                    are the last user and assistant messages)
-            end (int): index of last message to delete; Default = -1
-                    (i.e. delete all messages up to the last one)
-        """
-n = len(self.message_history)
-⋮----
-start = max(0, n + start)
-end_ = n if end == -1 else end + 1
-dropped = self.message_history[start:end_]
-# consider the dropped msgs in REVERSE order, so we are
-# carefully updating self.oai_tool_calls
-⋮----
-# clear out the chat document from the ObjectRegistry
-⋮----
-def update_history(self, message: str, response: str) -> None
-⋮----
-"""
-        Update the message history with the latest user message and LLM response.
-        Args:
-            message (str): user message
-            response: (str): LLM response
-        """
-⋮----
-def export_history(self) -> str
-⋮----
-"""Export message history as a portable, versioned JSON snapshot.
-
-        Returns:
-            A JSON string containing the current message history.
-        """
-messages: List[Dict[str, Any]] = []
-⋮----
-data = message.model_dump(mode="json", exclude={"files"})
-⋮----
-"""Restore message history from :meth:`export_history` output.
-
-        Args:
-            snapshot: Versioned JSON snapshot to restore.
-            max_size_bytes: Maximum total decoded attachment size. Defaults to
-                100 MiB.
-
-        Raises:
-            ValueError: If the snapshot is malformed, has an unknown version,
-                starts with a non-system message, or exceeds ``max_size_bytes``.
-        """
-⋮----
-payload = json.loads(
-⋮----
-raw_messages = payload.get("messages")
-⋮----
-messages: List[LLMMessage] = []
-total_attachment_bytes = 0
-⋮----
-message_data = dict(raw_message)
-raw_files = message_data.get("files", [])
-⋮----
-files = []
-⋮----
-file_data = dict(raw_file)
-encoded_content = file_data.pop("content_base64")
-⋮----
-encoded_bytes = encoded_content.encode("ascii")
-padding = len(encoded_bytes) - len(encoded_bytes.rstrip(b"="))
-decoded_size = max(
-⋮----
-content = base64.b64decode(encoded_bytes, validate=True)
-⋮----
-seen_call_ids: Set[str] = set()
-⋮----
-name = message.name
-⋮----
-call_id = call.id
-⋮----
-all_calls = {
-completed_call_ids = {
-old_chat_document_ids = {
-⋮----
-def tool_format_rules(self) -> str
-⋮----
-"""
-        Specification of tool formatting rules
-        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
-        based on the currently enabled usable `ToolMessage`s
-
-        Returns:
-            str: formatting rules
-        """
-# ONLY Usable tools (i.e. LLM-generation allowed),
-usable_tool_classes: List[Type[ToolMessage]] = [
-⋮----
-format_instructions = "\n\n".join(
-# if any of the enabled classes has json_group_instructions, then use that,
-# else fall back to ToolMessage.json_group_instructions
-⋮----
-def tool_instructions(self) -> str
-⋮----
-"""
-        Instructions for tools or function-calls, for enabled and usable Tools.
-        These are inserted into system prompt regardless of whether we are using
-        our own ToolMessage mechanism or the LLM's function-call mechanism.
-
-        Returns:
-            str: concatenation of instructions for all usable tools
-        """
-enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
-⋮----
-instructions = []
-⋮----
-class_instructions = ""
-⋮----
-class_instructions = msg_cls.instructions()
-⋮----
-# example will be shown in tool_format_rules() when using TOOLs,
-# so we don't need to show it here.
-example = "" if self.config.use_tools else (msg_cls.usage_examples())
-⋮----
-example = "EXAMPLES:\n" + example
-guidance = (
-⋮----
-instructions_str = "\n\n".join(instructions)
-⋮----
-def augment_system_message(self, message: str) -> None
-⋮----
-"""
-        Augment the system message with the given message.
-        Args:
-            message (str): system message
-        """
-⋮----
-def last_message_with_role(self, role: Role) -> LLMMessage | None
-⋮----
-"""from `message_history`, return the last message with role `role`"""
-n_role_msgs = len([m for m in self.message_history if m.role == role])
-⋮----
-idx = self.nth_message_idx_with_role(role, n_role_msgs)
-⋮----
-def last_message_idx_with_role(self, role: Role) -> int
-⋮----
-"""Index of last message in message_history, with specified role.
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-indices_with_role = [
-⋮----
-def nth_message_idx_with_role(self, role: Role, n: int) -> int
-⋮----
-"""Index of `n`th message in message_history, with specified role.
-        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-⋮----
-def update_last_message(self, message: str, role: str = Role.USER) -> None
-⋮----
-"""
-        Update the last message that has role `role` in the message history.
-        Useful when we want to replace a long user prompt, that may contain context
-        documents plus a question, with just the question.
-        Args:
-            message (str): new message to replace with
-            role (str): role of message to replace
-        """
-⋮----
-# find last message in self.message_history with role `role`
-⋮----
-def delete_last_message(self, role: str = Role.USER) -> None
-⋮----
-"""
-        Delete the last message that has role `role` from the message history.
-        Args:
-            role (str): role of message to delete
-        """
-⋮----
-def _create_system_and_tools_message(self) -> LLMMessage
-⋮----
-"""
-        (Re-)Create the system message for the LLM of the agent,
-        taking into account any tool instructions that have been added
-        after the agent was initialized.
-
-        The system message will consist of:
-        (a) the system message from the `task` arg in constructor, if any,
-            otherwise the default system message from the config
-        (b) the system tool instructions, if any
-        (c) the system json tool instructions, if any
-
-        Returns:
-            LLMMessage object
-        """
-content = self.system_message
-⋮----
-# remove leading and trailing newlines and other whitespace
-⋮----
-def handle_message_fallback(self, msg: str | ChatDocument) -> Any
-⋮----
-"""
-        Fallback method for the "no-tools" scenario, i.e., the current `msg`
-        (presumably emitted by the LLM) does not have any tool that the agent
-        can handle.
-        NOTE: The `msg` may contain tools but either (a) the agent is not
-        enabled to handle them, or (b) there's an explicit `recipient` field
-        in the tool that doesn't match the agent's name.
-
-        Uses the self.config.non_tool_routing to determine the action to take.
-
-        This method can be overridden by subclasses, e.g.,
-        to create a "reminder" message when a tool is expected but the LLM "forgot"
-        to generate one.
-
-        Args:
-            msg (str | ChatDocument): The input msg to handle
-        Returns:
-            Any: The result of the handler method
-        """
-⋮----
-# we ONLY use the `handle_llm_no_tool` config option when
-# the msg is from LLM and does not contain ANY tools at all.
-⋮----
-no_tool_option = self.config.handle_llm_no_tool
-⋮----
-# in case the `no_tool_option` is one of the special NonToolAction vals
-⋮----
-# Otherwise just return `no_tool_option` as is:
-# This can be any string, such as a specific nudge/reminder to the LLM,
-# or even something like ResultTool etc.
-⋮----
-def unhandled_tools(self) -> set[str]
-⋮----
-"""The set of tools that are known but not handled.
-        Useful in task flow: an agent can refuse to accept an incoming msg
-        when it only has unhandled tools.
-        """
-⋮----
-"""
-        Add the tool (message class) to the agent, and enable either
-        - tool USE (i.e. the LLM can generate JSON to use this tool),
-        - tool HANDLING (i.e. the agent can handle JSON from this tool),
-
-        Args:
-            message_class: The ToolMessage class OR List of such classes to enable,
-                for USE, or HANDLING, or both.
-                If this is a list of ToolMessage classes, then the remain args are
-                applied to all classes.
-                Optional; if None, then apply the enabling to all tools in the
-                agent's toolset that have been enabled so far.
-            use: IF True, allow the agent (LLM) to use this tool (or all tools),
-                else disallow
-            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
-                tool (or all tools)
-            force: whether to FORCE the agent (LLM) to USE the specific
-                 tool represented by `message_class`.
-                 `force` is ignored if `message_class` is None.
-            require_recipient: whether to require that recipient be specified
-                when using the tool message (only applies if `use` is True).
-            include_defaults: whether to include fields that have default values,
-                in the "properties" section of the JSON format instructions.
-                (Normally the OpenAI completion API ignores these fields,
-                but the Assistant fn-calling seems to pay attn to these,
-                and if we don't want this, we should set this to False.)
-        """
-⋮----
-# Validate that use/handle are booleans, not accidentally passed tool classes
-⋮----
-param = "use" if isclass(use) else "handle"
-⋮----
-message_class = message_class.require_recipient()
-⋮----
-request = message_class.default_value("request")
-existing_class = self.llm_tools_map.get(request)
-existing_origin = (
-message_origin = message_class.__dict__.get(
-⋮----
-# XMLToolMessage is not compatible with OpenAI's Tools/functions API,
-# so we disable use of functions API, enable langroid-native Tools,
-# which are prompt-based.
-⋮----
-super().enable_message_handling(message_class)  # enables handling only
-tools = self._get_tool_list(message_class)
-⋮----
-llm_function = message_class.llm_function_schema(defaults=include_defaults)
-⋮----
-# `t` was designated as "enabled for handling" ONLY for
-# output_format enforcement, but we are explicitly ]
-# enabling it for handling here, so we set the variable to None.
-⋮----
-tool_class = self.llm_tools_map[t]
-allow_llm_use = tool_class._allow_llm_use
-⋮----
-allow_llm_use = allow_llm_use.default
-⋮----
-# `t` was designated as "enabled for use" ONLY for output_format
-# enforcement, but we are explicitly enabling it for use here,
-# so we set the variable to None.
-⋮----
-def _update_tool_instructions(self) -> None
-⋮----
-# Set tool instructions and JSON format instructions,
-# in case Tools have been enabled/disabled.
-⋮----
-def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]
-⋮----
-"""
-        Returns the current set of enabled requests for inference and tools configs.
-        Used for restoring setings overriden by `set_output_format`.
-        """
-⋮----
-@property
-    def all_llm_tools_known(self) -> set[str]
-⋮----
-"""All known tools; we include `output_format` if it is a `ToolMessage`."""
-known = self.llm_tools_known
-⋮----
-"""
-        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
-        switches to the native Langroid tools mechanism to ensure that no tool
-        calls not of `output_type` are generated. By default, `force_tools`
-        follows the `use_tools_on_output_format` parameter in the config.
-
-        If `output_type` is None, restores to the state prior to setting
-        `output_format`.
-
-        If `use`, we enable use of `output_type` when it is a subclass
-        of `ToolMesage`. Note that this primarily controls instruction
-        generation: the model will always generate `output_type` regardless
-        of whether `use` is set. Defaults to the `use_output_format`
-        parameter in the config. Similarly, handling of `output_type` is
-        controlled by `handle`, which defaults to the
-        `handle_output_format` parameter in the config.
-
-        `instructions` controls whether we generate instructions specifying
-        the output format schema. Defaults to the `instructions_output_format`
-        parameter in the config.
-
-        `is_copy` is set when called via `__getitem__`. In that case, we must
-        copy certain fields to ensure that we do not overwrite the main agent's
-        setings.
-        """
-# Disable usage of an output format which was not specifically enabled
-# by `enable_message`
-⋮----
-# Disable handling of an output format which did not specifically have
-# handling enabled via `enable_message`
-⋮----
-# Reset any previous instructions
-⋮----
-force_tools = self.config.use_tools_on_output_format
-⋮----
-output_type = get_pydantic_wrapper(output_type)
-⋮----
-name = output_type.default_value("request")
-⋮----
-use = self.config.use_output_format
-⋮----
-handle = self.config.handle_output_format
-⋮----
-is_usable = name in self.llm_tools_usable.union(
-is_handled = name in self.llm_tools_handled.union(
-⋮----
-# We must copy `llm_tools_usable` so the base agent
-# is unmodified
-⋮----
-# If handling the tool, do the same for `llm_tools_handled`
-⋮----
-# Enable `output_type`
-⋮----
-# Do not override existing settings
-⋮----
-# If the `output_type` ToilMessage was not already enabled for
-# use, this means we are ONLY enabling it for use specifically
-# for enforcing this output format, so we set the
-# `enabled_use_output_forma  to this output_type, to
-# record that it should be disabled when `output_format` is changed
-⋮----
-# (same reasoning as for use-enabling)
-⋮----
-generated_tool_instructions = name in self.llm_tools_usable.union(
-⋮----
-generated_tool_instructions = False
-⋮----
-instructions = self.config.instructions_output_format
-⋮----
-# Already generated tool instructions as part of "enabling for use",
-# so only need to generate a reminder to use this tool.
-name = cast(ToolMessage, output_type).default_value("request")
-⋮----
-output_format_schema = output_type.llm_function_schema(
-⋮----
-output_format_schema = output_type.model_json_schema()
-⋮----
-def __getitem__(self, output_type: type) -> Self
-⋮----
-"""
-        Returns a (shallow) copy of `self` with a forced output type.
-        """
-clone = copy.copy(self)
-⋮----
-"""
-        Disable this agent from RESPONDING to a `message_class` (Tool). If
-            `message_class` is None, then disable this agent from responding to ALL.
-        Args:
-            message_class: The ToolMessage class to disable; Optional.
-        """
-⋮----
-"""
-        Disable this agent from USING a message class (Tool).
-        If `message_class` is None, then disable this agent from USING ALL tools.
-        Args:
-            message_class: The ToolMessage class to disable.
-                If None, disable all.
-        """
-⋮----
-def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None
-⋮----
-"""
-        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
-        Args:
-            message_class: The only ToolMessage class to allow
-        """
-request = message_class.model_fields["request"].default
-to_remove = [r for r in self.llm_tools_usable if r != request]
-⋮----
-def _load_output_format(self, message: ChatDocument) -> None
-⋮----
-"""
-        If set, attempts to parse a value of type `self.output_format` from the message
-        contents or any tool/function call and assigns it to `content_any`.
-        """
-⋮----
-any_succeeded = False
-attempts: list[str | LLMFunctionCall] = [
-⋮----
-content = json.loads(attempt)
-⋮----
-content = attempt.arguments
-⋮----
-content_any = self.output_format.model_validate(content)
-⋮----
-message.content_any = content_any.value  # type: ignore
-⋮----
-any_succeeded = True
-⋮----
-"""
-        Extracts messages and tracks whether any errors occurred. If strict mode
-        was enabled, disables it for the tool, else triggers strict recovery.
-        """
-⋮----
-most_recent_sent_by_llm = (
-was_llm = most_recent_sent_by_llm or (
-⋮----
-tools = super().get_tool_messages(msg, all_tools)
-⋮----
-# Check if tool class was attached to the exception
-⋮----
-tool_class = ve.tool_class  # type: ignore
-⋮----
-was_strict = (
-# If the result of strict output for a tool using the
-# OpenAI tools API fails to parse, we infer that the
-# schema edits necessary for compatibility prevented
-# adherence to the underlying `ToolMessage` schema and
-# disable strict output for the tool
-⋮----
-# We will trigger the strict recovery mechanism to force
-# the LLM to correct its output, allowing us to parse
-⋮----
-def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None
-⋮----
-"""
-        Returns a `ToolMessage` which wraps all enabled tools, excluding those
-        where strict recovery is disabled. Used in strict recovery.
-        """
-possible_tools = tuple(
-⋮----
-any_tool_type = Union.__getitem__(possible_tools)  # type ignore
-⋮----
-maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
-⋮----
-class AnyTool(ToolMessage)
-⋮----
-purpose: str = "To call a tool/function."
-request: str = "tool_or_function"
-tool: maybe_optional_type  # type: ignore
-⋮----
-def response(self, agent: ChatAgent) -> None | str | ChatDocument
-⋮----
-# One-time use
-⋮----
-# As the ToolMessage schema accepts invalid
-# `tool.request` values, reparse with the
-# corresponding tool
-request = self.tool.request
-⋮----
-tool = agent.llm_tools_map[request].model_validate_json(
-⋮----
-# Every call builds a distinct class; share one origin so enabling a
-# regenerated AnyTool under "tool_or_function" stays idempotent instead
-# of tripping the same-name/different-tool registration guard.
-AnyTool.__tool_message_origin__ = (  # type: ignore[attr-defined]
-⋮----
-"""Returns instructions for strict recovery."""
-optional_instructions = (
-response_prefix = "If you intended to make such a call, r" if optional else "R"
-instruction_prefix = "If you do so, b" if optional else "B"
-⋮----
-schema_instructions = (
-⋮----
-"""
-        Truncate message at idx in msg history to `tokens` tokens.
-
-        If inplace is True, the message is truncated in place, else
-        it LEAVES the original message INTACT and returns a new message
-        """
-⋮----
-llm_msg = self.message_history[idx]
-⋮----
-llm_msg = copy.deepcopy(self.message_history[idx])
-⋮----
-orig_content = llm_msg.content
-new_content = (
-⋮----
-else orig_content[: tokens * 4]  # approx truncation
-⋮----
-def _reduce_raw_tool_results(self, message: ChatDocument) -> None
-⋮----
-"""
-        If message is the result of a ToolMessage that had
-        a `_max_retained_tokens` set to a non-None value, then we replace contents
-        with a placeholder message.
-        """
-parent_message: ChatDocument | None = message.parent
-tools = [] if parent_message is None else parent_message.tool_messages
-truncate_tools = []
-⋮----
-max_retained_tokens = t._max_retained_tokens
-⋮----
-max_retained_tokens = max_retained_tokens.default
-⋮----
-limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
-⋮----
-max_retained_tokens = limiting_tool._max_retained_tokens
-⋮----
-tool_name = limiting_tool.default_value("request")
-max_tokens: int = max_retained_tokens
-truncation_warning = f"""
-⋮----
-"""
-        Respond to a single user message, appended to the message history,
-        in "chat" mode
-        Args:
-            message (str|ChatDocument): message or ChatDocument object to respond to.
-                If None, use the self.task_messages
-        Returns:
-            LLM response as a ChatDocument object
-        """
-⋮----
-# If enabled and a tool error occurred, we recover by generating the tool in
-# strict json mode
-⋮----
-AnyTool = self._get_any_tool_message()
-⋮----
-recovery_message = self._strict_recovery_instructions(AnyTool)
-augmented_message = message
-⋮----
-augmented_message = recovery_message
-⋮----
-augmented_message = augmented_message + recovery_message
-⋮----
-# only use the augmented message for this one response...
-result = self.llm_response(augmented_message)
-# ... restore the original user message so that the AnyTool recover
-# instructions don't persist in the message history
-# (this can cause the LLM to use the AnyTool directly as a tool)
-⋮----
-msg = message if isinstance(message, str) else message.content
-⋮----
-tool_choice = (
-⋮----
-response = self.llm_response_messages(hist, output_len, tool_choice)
-⋮----
-# Preserve trail of tool_ids for OpenAI Assistant fn-calls
-⋮----
-"""
-        Async version of `llm_response`. See there for details.
-        """
-⋮----
-response = await self.llm_response_messages_async(
-⋮----
-def init_message_history(self) -> None
-⋮----
-"""
-        Initialize the message history with the system message and user message
-        """
-⋮----
-"""
-        Prepare messages to be sent to self.llm_response_messages,
-            which is the main method that calls the LLM API to get a response.
-            If desired output tokens + message history exceeds the model context length,
-            then first the max output tokens is reduced to fit, and if that is not
-            possible, older messages may be truncated to accommodate at least
-            self.config.llm.min_output_tokens of output.
-
-        Returns:
-            Tuple[List[LLMMessage], int]: (messages, output_len)
-                messages = Full list of messages to send
-                output_len = max expected number of tokens in response
-        """
-⋮----
-# this means agent has been used to get LLM response already,
-# and so the last message is an "assistant" response.
-# We delete this last assistant response and re-generate it.
-⋮----
-# initial messages have not yet been loaded, so load them
-⋮----
-# for debugging, show the initial message history
-⋮----
-# update the system message with the latest tool instructions
-⋮----
-# either the message is a str, or it is a fresh ChatDocument
-# different from the last message in the history
-llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
-llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
-# Canonicalize retained whitespace-only results before token counting.
-⋮----
-# process tools if any
-done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
-⋮----
-hist = self.message_history
-output_len = self.config.llm.model_max_output_tokens
-⋮----
-# chat + output > max context length,
-# so first try to shorten requested output len to fit;
-# use an extra margin of CHAT_HISTORY_BUFFER tokens
-# in case our calcs are off (and to allow for some extra tokens)
-output_len = (
-⋮----
-# unacceptably small output len, so compress early parts of
-# conversation history based on the configured strategy
-strategy = self.config.context_overflow_strategy
-⋮----
-# Truncate content of individual messages while preserving
-# the message sequence (important for LLM APIs that require
-# alternating USER/ASSISTANT messages)
-msg_idx_to_compress = 1  # don't touch system msg
-# we will try compressing msg indices up to but not including
-# last user msg
-last_msg_idx_to_compress = (
-n_truncated = 0
-_target_tokens = (
-# Truncation floor: never reduce a message's content below
-# this many tokens.
-_min_keep_tokens = 30
-_truncation_warning = "... [Contents truncated!]"
-⋮----
-def _content_tokens(text: str | None) -> int
-⋮----
-"""Token count of message *content* only.
-
-                        `truncate_message` only trims `message.content`, so
-                        using the full `_message_num_tokens` (which includes
-                        attachment payloads) would inflate the count and make
-                        the keep-target too large to ever converge, for
-                        messages carrying file attachments.
-                        """
-⋮----
-# approx fallback, matches truncate_message
-⋮----
-# Account for the warning that truncate_message appends
-# ("\n" + warning), so the final token count of a
-# truncated message does not exceed its keep-target.
-_warning_tokens = _content_tokens("\n" + _truncation_warning)
-# NOTE: loop termination is guaranteed:
-# msg_idx_to_compress strictly increases every iteration
-# (truncate or skip), and once it exceeds
-# last_msg_idx_to_compress a ValueError is raised. (The
-# token count need not decrease every iteration, so
-# termination rests on the index advancing.)
-⋮----
-# We want to preserve the first message (typically
-# system msg) and last message (user msg).
-⋮----
-_msg_tokens = _content_tokens(hist[msg_idx_to_compress].content)
-⋮----
-# Truncating this message cannot shrink the total:
-# its content is already at/below the keep-floor
-# plus the appended warning; leave it intact.
-⋮----
-# Distribute the current excess evenly across the
-# remaining *compressible* messages, so each retains
-# as much content as possible instead of being
-# collapsed to the fixed 30-token floor. The excess is
-# recomputed every iteration, so the distribution
-# self-corrects as we move forward through the
-# history.
-_current_excess = self.chat_num_tokens(hist) - _target_tokens
-# Shrink capacity of each *later* message in the
-# compressible range: its content above the floor (net
-# of the appended warning). Non-positive entries are
-# the tiny messages the skip-check above will leave
-# untouched; they must not dilute the even share, so
-# only messages with positive capacity count toward
-# the denominator (plus this message, which passed the
-# skip-check and is therefore compressible).
-_later_capacities = [
-_n_remaining = 1 + sum(1 for c in _later_capacities if c > 0)
-_even_share = math.ceil(_current_excess / _n_remaining)
-# Later messages can shed at most their capacity; this
-# message must absorb whatever they cannot, so that
-# this single forward pass reaches the target whenever
-# that is possible at all.
-_later_capacity = sum(c for c in _later_capacities if c > 0)
-_reduction = max(_even_share, _current_excess - _later_capacity)
-# Extra 2-token slack: re-encoding truncated content
-# plus the appended warning can merge/split tokens at
-# the boundary, so aim slightly below the target to
-# keep the achieved reduction from falling short.
-_keep_tokens = max(
-# compress the msg at idx `msg_idx_to_compress`
-⋮----
-output_len = min(
-⋮----
-# we MUST have truncated at least one msg
-msg_tokens = self.chat_num_tokens()
-⋮----
-else:  # strategy == "drop_turns"
-# Drop complete conversation turns. A complete turn is defined
-# as a USER message followed by all messages until the next
-# USER message. This is more aggressive but cleaner for voice
-# agents with limited context.
-n_dropped_turns = 0
-⋮----
-# Find the last USER message index
-last_user_idx = self.last_message_idx_with_role(role=Role.USER)
-⋮----
-# Find the first complete turn to drop (skip system message)
-first_user_idx = -1
-⋮----
-first_user_idx = i
-⋮----
-# Find the end of this turn: last message before next USER
-next_user_idx = -1
-⋮----
-next_user_idx = i
-⋮----
-# Drop the turn
-⋮----
-# we MUST have dropped at least one turn
-⋮----
-# record the position of the corresponding LLMMessage in
-# the message_history
-⋮----
-"""
-        Get function/tool spec/output format arguments for
-        OpenAI-compatible LLM API call
-        """
-functions: Optional[List[LLMFunctionSpec]] = None
-fun_call: str | Dict[str, str] = "none"
-tools: Optional[List[OpenAIToolSpec]] = None
-force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
-⋮----
-functions = [
-fun_call = (
-⋮----
-def to_maybe_strict_spec(function: str) -> OpenAIToolSpec
-⋮----
-spec = self.llm_functions_map[function]
-strict = self._strict_mode_for_tool(function)
-⋮----
-strict_spec = copy.deepcopy(spec)
-⋮----
-strict_spec = spec
-⋮----
-tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
-force_tool = (
-output_format = None
-⋮----
-spec = self.output_format.llm_function_schema(
-⋮----
-output_format = OpenAIJsonSchemaSpec(
-⋮----
-# We always require that outputs strictly match the schema
-⋮----
-param_spec = self.output_format.model_json_schema()
-⋮----
-"""
-        Respond to a series of messages, e.g. with OpenAI ChatCompletion
-        Args:
-            messages: seq of messages (with role, content fields) sent to LLM
-            output_len: max number of tokens expected in response.
-                    If None, use the LLM's default model_max_output_tokens.
-        Returns:
-            Document (i.e. with fields "content", "metadata")
-        """
-⋮----
-output_len = output_len or self.config.llm.model_max_output_tokens
-streamer = noop_fn
-⋮----
-streamer = self.callbacks.start_llm_stream()
-⋮----
-with ExitStack() as stack:  # for conditionally using rich spinner
-⋮----
-# show rich spinner only if not streaming!
-# (Why? b/c the intent of showing a spinner is to "show progress",
-# and we don't need to do that when streaming, since
-# streaming output already shows progress.)
-cm = status(
-⋮----
-response = self.llm.chat(
-⋮----
-# Create temp ChatDocument for tool check, then clean up to avoid
-# polluting ObjectRegistry (see PR #939 discussion)
-temp_doc = ChatDocument.from_LLMResponse(
-⋮----
-response,  # .usage attrib is updated!
-⋮----
-chat_doc = ChatDocument.from_LLMResponse(
-⋮----
-# If using strict output format, parse the output JSON
-⋮----
-"""
-        Async version of `llm_response_messages`. See there for details.
-        """
-⋮----
-streamer_async = async_noop_fn
-⋮----
-streamer_async = await self.callbacks.start_llm_stream_async()
-⋮----
-response = await self.llm.achat(
-⋮----
-"""
-        Call a callback method, only passing 'reasoning' if it accepts it.
-
-        This provides backward compatibility for custom callbacks that don't
-        have the 'reasoning' parameter in their signature.
-
-        Args:
-            callback_name: Name of the callback method (e.g., 'show_llm_response')
-            reasoning: The reasoning content to pass if supported
-            **kwargs: Other arguments to pass to the callback
-        """
-callback = getattr(self.callbacks, callback_name, None)
-⋮----
-# Check if callback accepts 'reasoning' param or **kwargs
-⋮----
-sig = inspect.signature(callback)
-params = sig.parameters
-accepts_reasoning = "reasoning" in params or any(
-⋮----
-# If we can't inspect the signature, assume it doesn't accept reasoning
-accepts_reasoning = False
-⋮----
-is_cached = (
-⋮----
-# We would have already displayed the msg "live" ONLY if
-# streaming was enabled, AND we did not find a cached response.
-# If we are here, it means the response has not yet been displayed.
-cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
-# Track whether we created a temp ChatDocument for cleanup
-is_temp_doc = isinstance(response, LLMResponse)
-chat_doc = (
-# TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
-⋮----
-content = response.message or ""
-tools_content = response.tools_content()
-⋮----
-content = response.content
-tools_content = ""
-reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
-⋮----
-# Clean up temp ChatDocument to avoid polluting ObjectRegistry
-⋮----
-# we are in the context immediately after an LLM responded,
-# we won't have citations yet, so we're done
-⋮----
-citation = (
-⋮----
-reasoning="",  # Citations don't have reasoning
-⋮----
-def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument
-⋮----
-"""
-        Get LLM response to `prompt` (which presumably includes the `message`
-        somewhere, along with possible large "context" passages),
-        but only include `message` as the USER message, and not the
-        full `prompt`, in the message history.
-        Args:
-            message: the original, relatively short, user request or query
-            prompt: the full prompt potentially containing `message` plus context
-
-        Returns:
-            Document object containing the response.
-        """
-# we explicitly call THIS class's respond method,
-# not a derived class's (or else there would be infinite recursion!)
-with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
-⋮----
-"""
-        Async version of `_llm_response_temp_context`. See there for details.
-        """
-⋮----
-answer_doc = cast(
-⋮----
-"""
-        LLM Response to single message, and restore message_history.
-        In effect a "one-off" message & response that leaves agent
-        message history state intact.
-
-        Args:
-            message (str|ChatDocument): message to respond to.
-
-        Returns:
-            A Document object with the response.
-
-        """
-# explicitly call THIS class's respond method,
-⋮----
-n_msgs = len(self.message_history)
-⋮----
-response = cast(ChatDocument, ChatAgent.llm_response(self, message))
-# If there is a response, then we will have two additional
-# messages in the message history, i.e. the user message and the
-# assistant response. We want to (carefully) remove these two messages.
-⋮----
-msg = self.message_history.pop()
-⋮----
-"""
-        Async version of `llm_response_forget`. See there for details.
-        """
-⋮----
-response = cast(
-⋮----
-def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int
-⋮----
-"""
-        Total number of tokens in the message history so far.
-
-        Args:
-            messages: if provided, compute the number of tokens in this list of
-                messages, rather than the current message history.
-        Returns:
-            int: number of tokens in message history
-        """
-⋮----
-hist = messages if messages is not None else self.message_history
-⋮----
-def _message_num_tokens(self, message: LLMMessage) -> int
-⋮----
-"""Count tokens for a message, including serialized user attachments."""
-⋮----
-def _attachment_num_tokens(self, message: LLMMessage) -> int
-⋮----
-"""
-        Estimate attachment contribution using the serialized payload
-        that is sent in the API request for user messages.
-        """
-⋮----
-model = self._chat_model_name_for_attachments()
-⋮----
-def _chat_model_name_for_attachments(self) -> str
-⋮----
-"""Return the model name used for attachment serialization."""
-⋮----
-def message_history_str(self, i: Optional[int] = None) -> str
-⋮----
-"""
-        Return a string representation of the message history
-        Args:
-            i: if provided, return only the i-th message when i is postive,
-                or last k messages when i = -k.
-        Returns:
-        """
-⋮----
-def __del__(self) -> None
-⋮----
-"""
-        Cleanup method called when the ChatAgent is garbage collected.
-        Note: We don't close LLM clients here because they may be shared
-        across multiple agents when client caching is enabled.
-        The clients are managed centrally and cleaned up via atexit hooks.
-        """
-# Previously we closed clients here, but this caused issues when
-# multiple agents shared the same cached client instance.
-# Clients are now managed centrally in langroid.language_models.client_cache
-</file>
-
 <file path="langroid/language_models/openai_gpt.py">
 OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
 ⋮----
@@ -43042,9 +41813,1291 @@ cached, hashed_key, response = await self._achat_completions_with_backoff(  # ty
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.16.0
+  rev: v0.16.4
   hooks:
     - id: ruff
+</file>
+
+<file path="langroid/agent/chat_agent.py">
+console = Console()
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+# Stable origin sentinel for the dynamically generated strict-recovery AnyTool
+# class ("tool_or_function"): a fresh class is built per call (its tool-union
+# type varies), so re-registration must be recognized as the same logical tool.
+_ANY_TOOL_MESSAGE_ORIGIN: Any = object()
+⋮----
+# Safety margin (in tokens) subtracted from the model context length when
+# shrinking chat history and/or the requested output length to fit, in case
+# our token-count estimates are off.
+CHAT_HISTORY_BUFFER = 300
+⋮----
+def _reject_json_constant(constant: str) -> None
+⋮----
+"""Reject JavaScript numeric constants that are not valid JSON."""
+⋮----
+def _parse_json_float(value: str) -> float
+⋮----
+"""Parse a JSON float while rejecting exponent overflow."""
+parsed = float(value)
+⋮----
+def _is_identified_result(message: LLMMessage) -> bool
+⋮----
+"""Whether a TOOL/FUNCTION result has its identifier and no call payload.
+
+    Such results must survive even with empty content so their calls can be
+    marked complete (issue #1063).
+    """
+has_identifier = (
+⋮----
+def _llm_message_has_payload(message: LLMMessage) -> bool
+⋮----
+"""Whether a message has the fields required for a valid history entry."""
+⋮----
+class ChatAgentConfig(AgentConfig)
+⋮----
+"""
+    Configuration for ChatAgent
+
+    Attributes:
+        system_message: system message to include in message sequence
+             (typically defines role and task of agent).
+             Used only if `task` is not specified in the constructor.
+        user_message: user message to include in message sequence.
+             Used only if `task` is not specified in the constructor.
+        use_tools: whether to use our own ToolMessages mechanism
+        handle_llm_no_tool (Any): desired agent_response when
+            LLM generates non-tool msg.
+        use_functions_api: whether to use functions/tools native to the LLM API
+                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
+        use_tools_api: When `use_functions_api` is True, if this is also True,
+            the OpenAI tool-call API is used, rather than the older/deprecated
+            function-call API. However the tool-call API has some tricky aspects,
+            hence we set this to False by default.
+        strict_recovery: whether to enable strict schema recovery when there
+            is a tool-generation error.
+        enable_orchestration_tool_handling: whether to enable handling of orchestration
+            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
+        output_format: When supported by the LLM (certain OpenAI LLMs
+            and local LLMs served by providers such as vLLM), ensures
+            that the output is a JSON matching the corresponding
+            schema via grammar-based decoding
+        handle_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for handling".
+        use_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for use" (by LLM) and
+            instructions on using T are added to the system message.
+        instructions_output_format: Controls whether we generate instructions for
+            `output_format` in the system message.
+        use_tools_on_output_format: Controls whether to automatically switch
+            to the Langroid-native tools mechanism when `output_format` is set.
+            Note that LLMs may generate tool calls which do not belong to
+            `output_format` even when strict JSON mode is enabled, so this should be
+            enabled when such tool calls are not desired.
+        output_format_include_defaults: Whether to include fields with default arguments
+            in the output schema
+        full_citations: Whether to show source reference citation + content for each
+            citation, or just the main reference citation.
+        search_for_tools_everywhere: Whether to search for tools everywhere,
+            or only in specific LLM response elements based on use_tools /
+            use_functions_api / use_tools_api config settings.
+        recognize_recipient_in_content: Whether to parse LLM response text content
+            for recipient routing patterns, specifically:
+            - ``TO[<recipient>]:<content>`` addressing format, and
+            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
+            When False, only structured routing via function_call/tool_call
+            ``recipient`` fields is recognized. Default is True.
+            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
+            which controls Task-level signals like DONE, PASS, and SEND_TO.
+            To fully disable all text-based routing, set both to False.
+        context_overflow_strategy: Strategy for handling context overflow when
+            message history exceeds model context length. Options:
+            - "truncate": Truncate content of early messages (preserves all messages
+              but with shortened content). This maintains the message sequence.
+            - "drop_turns": Drop complete conversation turns (USER + all responses
+              until next USER). More aggressive but cleaner for voice agents.
+            Default is "truncate" for backward compatibility.
+    """
+⋮----
+system_message: str = "You are a helpful assistant."
+user_message: Optional[str] = None
+handle_llm_no_tool: Any = None
+use_tools: bool = True
+use_functions_api: bool = False
+use_tools_api: bool = True
+strict_recovery: bool = True
+enable_orchestration_tool_handling: bool = True
+output_format: Optional[type] = None
+handle_output_format: bool = True
+use_output_format: bool = True
+instructions_output_format: bool = True
+output_format_include_defaults: bool = True
+use_tools_on_output_format: bool = True
+full_citations: bool = True  # show source + content for each citation?
+search_for_tools_everywhere: bool = True
+recognize_recipient_in_content: bool = True
+context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
+⋮----
+def _set_fn_or_tools(self) -> None
+⋮----
+"""
+        Enable Langroid Tool or OpenAI-like fn-calling,
+        depending on config settings.
+        """
+⋮----
+class ChatAgent(Agent)
+⋮----
+"""
+    Chat Agent interacting with external env
+    (could be human, or external tools).
+    The agent (the LLM actually) is provided with an optional "Task Spec",
+    which is a sequence of `LLMMessage`s. These are used to initialize
+    the `task_messages` of the agent.
+    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
+    The `Agent` class mainly exists to hold various common methods and attributes.
+    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
+    `llm_response` method uses "chat mode" API (i.e. one that takes a
+    message sequence rather than a single message),
+    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
+    that takes a single message).
+    """
+⋮----
+"""
+        Chat-mode agent initialized with task spec as the initial message sequence
+        Args:
+            config: settings for the agent
+
+        """
+⋮----
+# emit the attachment-token-estimate warning at most once per agent
+⋮----
+# An agent's "task" is defined by a system msg and an optional user msg;
+# These are "priming" messages that kick off the agent's conversation.
+⋮----
+# if task contains a system msg, we override the config system msg
+⋮----
+# if task contains a user msg, we override the config user msg
+⋮----
+# system-level instructions for using tools/functions:
+# We maintain these as tools/functions are enabled/disabled,
+# and whenever an LLM response is sought, these are used to
+# recreate the system message (via `_create_system_and_tools_message`)
+# each time, so it reflects the current set of enabled tools/functions.
+# (a) these are general instructions on using certain tools/functions,
+#   if they are specified in a ToolMessage class as a classmethod `instructions`
+⋮----
+# (b) these are only for the builtin in Langroid TOOLS mechanism:
+⋮----
+# This variable is not None and equals a `ToolMessage` T, if and only if:
+# (a) T has been set as the output_format of this agent, AND
+# (b) T has been "enabled for use" ONLY for enforcing this output format, AND
+# (c) T has NOT been explicitly "enabled for use" by this Agent.
+⋮----
+# As above but deals with "enabled for handling" instead of "enabled for use".
+⋮----
+# instructions specifically related to enforcing `output_format`
+⋮----
+# controls whether to disable strict schemas for this agent if
+# strict mode causes exception
+⋮----
+# Tracks whether any strict tool is enabled; used to determine whether to set
+# `self.disable_strict` on an exception
+⋮----
+# Tracks the set of tools on which we force-disable strict decoding
+⋮----
+# search for tools according to the agent configuration
+⋮----
+# Only enable HANDLING by `agent_response`, NOT LLM generation of these.
+# This is useful where tool-handlers or agent_response generate these
+# tools, and need to be handled.
+# We don't want enable orch tool GENERATION by default, since that
+# might clutter-up the LLM system message unnecessarily.
+⋮----
+def init_state(self) -> None
+⋮----
+"""
+        Initialize the state of the agent. Just conversation state here,
+        but subclasses can override this to initialize other state.
+        """
+⋮----
+@staticmethod
+    def from_id(id: str) -> "ChatAgent"
+⋮----
+"""
+        Get an agent from its ID
+        Args:
+            agent_id (str): ID of the agent
+        Returns:
+            ChatAgent: The agent with the given ID
+        """
+⋮----
+def clone(self, i: int = 0) -> "ChatAgent"
+⋮----
+"""Create i'th clone of this agent, ensuring tool use/handling is cloned.
+        Important: We assume all member variables are in the __init__ method here
+        and in the Agent class.
+        TODO: We are attempting to clone an agent after its state has been
+        changed in possibly many ways. Below is an imperfect solution. Caution advised.
+        Revisit later.
+        """
+agent_cls = type(self)
+# Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
+# instead of deepcopy which loses subclass information
+config_copy = self.config.model_copy(deep=True)
+⋮----
+new_agent = agent_cls(config_copy)
+⋮----
+# Ensure each clone gets its own vecdb client when supported.
+⋮----
+def _clone_extra_state(self, new_agent: "ChatAgent") -> None
+⋮----
+"""Hook for subclasses to copy additional state into clones."""
+⋮----
+def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool
+⋮----
+"""Should we enable strict mode for a given tool?"""
+⋮----
+tool_class = self.llm_tools_map[tool]
+⋮----
+tool_class = tool
+name = tool_class.default_value("request")
+⋮----
+strict: Optional[bool] = tool_class.default_value("strict")
+⋮----
+strict = self._strict_tools_available()
+⋮----
+def _fn_call_available(self) -> bool
+⋮----
+"""Does this agent's LLM support function calling?"""
+⋮----
+def _strict_tools_available(self) -> bool
+⋮----
+"""Does this agent's LLM support strict tools?"""
+⋮----
+def _json_schema_available(self) -> bool
+⋮----
+"""Does this agent's LLM support strict JSON schema output format?"""
+⋮----
+def set_system_message(self, msg: str) -> None
+⋮----
+# if there is message history, update the system message in it
+⋮----
+def set_user_message(self, msg: str) -> None
+⋮----
+@property
+    def task_messages(self) -> List[LLMMessage]
+⋮----
+"""
+        The task messages are the initial messages that define the task
+        of the agent. There will be at least a system message plus possibly a user msg.
+        Returns:
+            List[LLMMessage]: the task messages
+        """
+msgs = [self._create_system_and_tools_message()]
+⋮----
+def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None
+⋮----
+id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
+⋮----
+# dropping tool result, so ADD the corresponding tool-call back
+# to the list of pending calls!
+id = msg.tool_call_id
+⋮----
+# dropping a msg with tool-calls, so DROP these from pending list
+# as well as from id -> call map
+⋮----
+def clear_history(self, start: int = -2, end: int = -1) -> None
+⋮----
+"""
+        Clear the message history, deleting  messages from index `start`,
+        up to index `end`.
+
+        Args:
+            start (int): index of first message to delete; default = -2
+                    (i.e. delete last 2 messages, typically these
+                    are the last user and assistant messages)
+            end (int): index of last message to delete; Default = -1
+                    (i.e. delete all messages up to the last one)
+        """
+n = len(self.message_history)
+⋮----
+start = max(0, n + start)
+end_ = n if end == -1 else end + 1
+dropped = self.message_history[start:end_]
+# consider the dropped msgs in REVERSE order, so we are
+# carefully updating self.oai_tool_calls
+⋮----
+# clear out the chat document from the ObjectRegistry
+⋮----
+def update_history(self, message: str, response: str) -> None
+⋮----
+"""
+        Update the message history with the latest user message and LLM response.
+        Args:
+            message (str): user message
+            response: (str): LLM response
+        """
+⋮----
+def export_history(self) -> str
+⋮----
+"""Export message history as a portable, versioned JSON snapshot.
+
+        Returns:
+            A JSON string containing the current message history.
+        """
+messages: List[Dict[str, Any]] = []
+⋮----
+data = message.model_dump(mode="json", exclude={"files"})
+⋮----
+"""Restore message history from :meth:`export_history` output.
+
+        Args:
+            snapshot: Versioned JSON snapshot to restore.
+            max_size_bytes: Maximum total decoded attachment size. Defaults to
+                100 MiB.
+
+        Raises:
+            ValueError: If the snapshot is malformed, has an unknown version,
+                starts with a non-system message, or exceeds ``max_size_bytes``.
+        """
+⋮----
+payload = json.loads(
+⋮----
+raw_messages = payload.get("messages")
+⋮----
+messages: List[LLMMessage] = []
+total_attachment_bytes = 0
+⋮----
+message_data = dict(raw_message)
+raw_files = message_data.get("files", [])
+⋮----
+files = []
+⋮----
+file_data = dict(raw_file)
+encoded_content = file_data.pop("content_base64")
+⋮----
+encoded_bytes = encoded_content.encode("ascii")
+padding = len(encoded_bytes) - len(encoded_bytes.rstrip(b"="))
+decoded_size = max(
+⋮----
+content = base64.b64decode(encoded_bytes, validate=True)
+⋮----
+seen_call_ids: Set[str] = set()
+⋮----
+name = message.name
+⋮----
+call_id = call.id
+⋮----
+all_calls = {
+completed_call_ids = {
+old_chat_document_ids = {
+⋮----
+def tool_format_rules(self) -> str
+⋮----
+"""
+        Specification of tool formatting rules
+        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
+        based on the currently enabled usable `ToolMessage`s
+
+        Returns:
+            str: formatting rules
+        """
+# ONLY Usable tools (i.e. LLM-generation allowed),
+usable_tool_classes: List[Type[ToolMessage]] = [
+⋮----
+format_instructions = "\n\n".join(
+# if any of the enabled classes has json_group_instructions, then use that,
+# else fall back to ToolMessage.json_group_instructions
+⋮----
+def tool_instructions(self) -> str
+⋮----
+"""
+        Instructions for tools or function-calls, for enabled and usable Tools.
+        These are inserted into system prompt regardless of whether we are using
+        our own ToolMessage mechanism or the LLM's function-call mechanism.
+
+        Returns:
+            str: concatenation of instructions for all usable tools
+        """
+enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
+⋮----
+instructions = []
+⋮----
+class_instructions = ""
+⋮----
+class_instructions = msg_cls.instructions()
+⋮----
+# example will be shown in tool_format_rules() when using TOOLs,
+# so we don't need to show it here.
+example = "" if self.config.use_tools else (msg_cls.usage_examples())
+⋮----
+example = "EXAMPLES:\n" + example
+guidance = (
+⋮----
+instructions_str = "\n\n".join(instructions)
+⋮----
+def augment_system_message(self, message: str) -> None
+⋮----
+"""
+        Augment the system message with the given message.
+        Args:
+            message (str): system message
+        """
+⋮----
+def last_message_with_role(self, role: Role) -> LLMMessage | None
+⋮----
+"""from `message_history`, return the last message with role `role`"""
+n_role_msgs = len([m for m in self.message_history if m.role == role])
+⋮----
+idx = self.nth_message_idx_with_role(role, n_role_msgs)
+⋮----
+def last_message_idx_with_role(self, role: Role) -> int
+⋮----
+"""Index of last message in message_history, with specified role.
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+indices_with_role = [
+⋮----
+def nth_message_idx_with_role(self, role: Role, n: int) -> int
+⋮----
+"""Index of `n`th message in message_history, with specified role.
+        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+⋮----
+def update_last_message(self, message: str, role: str = Role.USER) -> None
+⋮----
+"""
+        Update the last message that has role `role` in the message history.
+        Useful when we want to replace a long user prompt, that may contain context
+        documents plus a question, with just the question.
+        Args:
+            message (str): new message to replace with
+            role (str): role of message to replace
+        """
+⋮----
+# find last message in self.message_history with role `role`
+⋮----
+def delete_last_message(self, role: str = Role.USER) -> None
+⋮----
+"""
+        Delete the last message that has role `role` from the message history.
+        Args:
+            role (str): role of message to delete
+        """
+⋮----
+def _create_system_and_tools_message(self) -> LLMMessage
+⋮----
+"""
+        (Re-)Create the system message for the LLM of the agent,
+        taking into account any tool instructions that have been added
+        after the agent was initialized.
+
+        The system message will consist of:
+        (a) the system message from the `task` arg in constructor, if any,
+            otherwise the default system message from the config
+        (b) the system tool instructions, if any
+        (c) the system json tool instructions, if any
+
+        Returns:
+            LLMMessage object
+        """
+content = self.system_message
+⋮----
+# remove leading and trailing newlines and other whitespace
+⋮----
+def handle_message_fallback(self, msg: str | ChatDocument) -> Any
+⋮----
+"""
+        Fallback method for the "no-tools" scenario, i.e., the current `msg`
+        (presumably emitted by the LLM) does not have any tool that the agent
+        can handle.
+        NOTE: The `msg` may contain tools but either (a) the agent is not
+        enabled to handle them, or (b) there's an explicit `recipient` field
+        in the tool that doesn't match the agent's name.
+
+        Uses the self.config.non_tool_routing to determine the action to take.
+
+        This method can be overridden by subclasses, e.g.,
+        to create a "reminder" message when a tool is expected but the LLM "forgot"
+        to generate one.
+
+        Args:
+            msg (str | ChatDocument): The input msg to handle
+        Returns:
+            Any: The result of the handler method
+        """
+⋮----
+# we ONLY use the `handle_llm_no_tool` config option when
+# the msg is from LLM and does not contain ANY tools at all.
+⋮----
+no_tool_option = self.config.handle_llm_no_tool
+⋮----
+# in case the `no_tool_option` is one of the special NonToolAction vals
+⋮----
+# Otherwise just return `no_tool_option` as is:
+# This can be any string, such as a specific nudge/reminder to the LLM,
+# or even something like ResultTool etc.
+⋮----
+def unhandled_tools(self) -> set[str]
+⋮----
+"""The set of tools that are known but not handled.
+        Useful in task flow: an agent can refuse to accept an incoming msg
+        when it only has unhandled tools.
+        """
+⋮----
+"""
+        Add the tool (message class) to the agent, and enable either
+        - tool USE (i.e. the LLM can generate JSON to use this tool),
+        - tool HANDLING (i.e. the agent can handle JSON from this tool),
+
+        Args:
+            message_class: The ToolMessage class OR List of such classes to enable,
+                for USE, or HANDLING, or both.
+                If this is a list of ToolMessage classes, then the remain args are
+                applied to all classes.
+                Optional; if None, then apply the enabling to all tools in the
+                agent's toolset that have been enabled so far.
+            use: IF True, allow the agent (LLM) to use this tool (or all tools),
+                else disallow
+            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
+                tool (or all tools)
+            force: whether to FORCE the agent (LLM) to USE the specific
+                 tool represented by `message_class`.
+                 `force` is ignored if `message_class` is None.
+            require_recipient: whether to require that recipient be specified
+                when using the tool message (only applies if `use` is True).
+            include_defaults: whether to include fields that have default values,
+                in the "properties" section of the JSON format instructions.
+                (Normally the OpenAI completion API ignores these fields,
+                but the Assistant fn-calling seems to pay attn to these,
+                and if we don't want this, we should set this to False.)
+        """
+⋮----
+# Validate that use/handle are booleans, not accidentally passed tool classes
+⋮----
+param = "use" if isclass(use) else "handle"
+⋮----
+message_class = message_class.require_recipient()
+⋮----
+request = message_class.default_value("request")
+existing_class = self.llm_tools_map.get(request)
+existing_origin = (
+message_origin = message_class.__dict__.get(
+⋮----
+# XMLToolMessage is not compatible with OpenAI's Tools/functions API,
+# so we disable use of functions API, enable langroid-native Tools,
+# which are prompt-based.
+⋮----
+super().enable_message_handling(message_class)  # enables handling only
+tools = self._get_tool_list(message_class)
+⋮----
+llm_function = message_class.llm_function_schema(defaults=include_defaults)
+⋮----
+# `t` was designated as "enabled for handling" ONLY for
+# output_format enforcement, but we are explicitly ]
+# enabling it for handling here, so we set the variable to None.
+⋮----
+tool_class = self.llm_tools_map[t]
+allow_llm_use = tool_class._allow_llm_use
+⋮----
+allow_llm_use = allow_llm_use.default
+⋮----
+# `t` was designated as "enabled for use" ONLY for output_format
+# enforcement, but we are explicitly enabling it for use here,
+# so we set the variable to None.
+⋮----
+def _update_tool_instructions(self) -> None
+⋮----
+# Set tool instructions and JSON format instructions,
+# in case Tools have been enabled/disabled.
+⋮----
+def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]
+⋮----
+"""
+        Returns the current set of enabled requests for inference and tools configs.
+        Used for restoring setings overriden by `set_output_format`.
+        """
+⋮----
+@property
+    def all_llm_tools_known(self) -> set[str]
+⋮----
+"""All known tools; we include `output_format` if it is a `ToolMessage`."""
+known = self.llm_tools_known
+⋮----
+"""
+        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
+        switches to the native Langroid tools mechanism to ensure that no tool
+        calls not of `output_type` are generated. By default, `force_tools`
+        follows the `use_tools_on_output_format` parameter in the config.
+
+        If `output_type` is None, restores to the state prior to setting
+        `output_format`.
+
+        If `use`, we enable use of `output_type` when it is a subclass
+        of `ToolMesage`. Note that this primarily controls instruction
+        generation: the model will always generate `output_type` regardless
+        of whether `use` is set. Defaults to the `use_output_format`
+        parameter in the config. Similarly, handling of `output_type` is
+        controlled by `handle`, which defaults to the
+        `handle_output_format` parameter in the config.
+
+        `instructions` controls whether we generate instructions specifying
+        the output format schema. Defaults to the `instructions_output_format`
+        parameter in the config.
+
+        `is_copy` is set when called via `__getitem__`. In that case, we must
+        copy certain fields to ensure that we do not overwrite the main agent's
+        setings.
+        """
+# Disable usage of an output format which was not specifically enabled
+# by `enable_message`
+⋮----
+# Disable handling of an output format which did not specifically have
+# handling enabled via `enable_message`
+⋮----
+# Reset any previous instructions
+⋮----
+force_tools = self.config.use_tools_on_output_format
+⋮----
+output_type = get_pydantic_wrapper(output_type)
+⋮----
+name = output_type.default_value("request")
+⋮----
+use = self.config.use_output_format
+⋮----
+handle = self.config.handle_output_format
+⋮----
+is_usable = name in self.llm_tools_usable.union(
+is_handled = name in self.llm_tools_handled.union(
+⋮----
+# We must copy `llm_tools_usable` so the base agent
+# is unmodified
+⋮----
+# If handling the tool, do the same for `llm_tools_handled`
+⋮----
+# Enable `output_type`
+⋮----
+# Do not override existing settings
+⋮----
+# If the `output_type` ToilMessage was not already enabled for
+# use, this means we are ONLY enabling it for use specifically
+# for enforcing this output format, so we set the
+# `enabled_use_output_forma  to this output_type, to
+# record that it should be disabled when `output_format` is changed
+⋮----
+# (same reasoning as for use-enabling)
+⋮----
+generated_tool_instructions = name in self.llm_tools_usable.union(
+⋮----
+generated_tool_instructions = False
+⋮----
+instructions = self.config.instructions_output_format
+⋮----
+# Already generated tool instructions as part of "enabling for use",
+# so only need to generate a reminder to use this tool.
+name = cast(ToolMessage, output_type).default_value("request")
+⋮----
+output_format_schema = output_type.llm_function_schema(
+⋮----
+output_format_schema = output_type.model_json_schema()
+⋮----
+def __getitem__(self, output_type: type) -> Self
+⋮----
+"""
+        Returns a (shallow) copy of `self` with a forced output type.
+        """
+clone = copy.copy(self)
+⋮----
+"""
+        Disable this agent from RESPONDING to a `message_class` (Tool). If
+            `message_class` is None, then disable this agent from responding to ALL.
+        Args:
+            message_class: The ToolMessage class to disable; Optional.
+        """
+⋮----
+"""
+        Disable this agent from USING a message class (Tool).
+        If `message_class` is None, then disable this agent from USING ALL tools.
+        Args:
+            message_class: The ToolMessage class to disable.
+                If None, disable all.
+        """
+⋮----
+def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None
+⋮----
+"""
+        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
+        Args:
+            message_class: The only ToolMessage class to allow
+        """
+request = message_class.model_fields["request"].default
+to_remove = [r for r in self.llm_tools_usable if r != request]
+⋮----
+def _load_output_format(self, message: ChatDocument) -> None
+⋮----
+"""
+        If set, attempts to parse a value of type `self.output_format` from the message
+        contents or any tool/function call and assigns it to `content_any`.
+        """
+⋮----
+any_succeeded = False
+attempts: list[str | LLMFunctionCall] = [
+⋮----
+content = json.loads(attempt)
+⋮----
+content = attempt.arguments
+⋮----
+content_any = self.output_format.model_validate(content)
+⋮----
+message.content_any = content_any.value  # type: ignore
+⋮----
+any_succeeded = True
+⋮----
+"""
+        Extracts messages and tracks whether any errors occurred. If strict mode
+        was enabled, disables it for the tool, else triggers strict recovery.
+        """
+⋮----
+most_recent_sent_by_llm = (
+was_llm = most_recent_sent_by_llm or (
+⋮----
+tools = super().get_tool_messages(msg, all_tools)
+⋮----
+# Check if tool class was attached to the exception
+⋮----
+tool_class = ve.tool_class  # type: ignore
+⋮----
+was_strict = (
+# If the result of strict output for a tool using the
+# OpenAI tools API fails to parse, we infer that the
+# schema edits necessary for compatibility prevented
+# adherence to the underlying `ToolMessage` schema and
+# disable strict output for the tool
+⋮----
+# We will trigger the strict recovery mechanism to force
+# the LLM to correct its output, allowing us to parse
+⋮----
+def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None
+⋮----
+"""
+        Returns a `ToolMessage` which wraps all enabled tools, excluding those
+        where strict recovery is disabled. Used in strict recovery.
+        """
+possible_tools = tuple(
+⋮----
+any_tool_type = Union.__getitem__(possible_tools)  # type ignore
+⋮----
+maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
+⋮----
+class AnyTool(ToolMessage)
+⋮----
+purpose: str = "To call a tool/function."
+request: str = "tool_or_function"
+tool: maybe_optional_type  # type: ignore
+⋮----
+def response(self, agent: ChatAgent) -> None | str | ChatDocument
+⋮----
+# One-time use
+⋮----
+# As the ToolMessage schema accepts invalid
+# `tool.request` values, reparse with the
+# corresponding tool
+request = self.tool.request
+⋮----
+tool = agent.llm_tools_map[request].model_validate_json(
+⋮----
+# Every call builds a distinct class; share one origin so enabling a
+# regenerated AnyTool under "tool_or_function" stays idempotent instead
+# of tripping the same-name/different-tool registration guard.
+AnyTool.__tool_message_origin__ = (  # type: ignore[attr-defined]
+⋮----
+"""Returns instructions for strict recovery."""
+optional_instructions = (
+response_prefix = "If you intended to make such a call, r" if optional else "R"
+instruction_prefix = "If you do so, b" if optional else "B"
+⋮----
+schema_instructions = (
+⋮----
+"""
+        Truncate message at idx in msg history to `tokens` tokens.
+
+        If inplace is True, the message is truncated in place, else
+        it LEAVES the original message INTACT and returns a new message
+        """
+⋮----
+llm_msg = self.message_history[idx]
+⋮----
+llm_msg = copy.deepcopy(self.message_history[idx])
+⋮----
+orig_content = llm_msg.content
+new_content = (
+⋮----
+else orig_content[: tokens * 4]  # approx truncation
+⋮----
+def _reduce_raw_tool_results(self, message: ChatDocument) -> None
+⋮----
+"""
+        If message is the result of a ToolMessage that had
+        a `_max_retained_tokens` set to a non-None value, then we replace contents
+        with a placeholder message.
+        """
+parent_message: ChatDocument | None = message.parent
+tools = [] if parent_message is None else parent_message.tool_messages
+truncate_tools = []
+⋮----
+max_retained_tokens = t._max_retained_tokens
+⋮----
+max_retained_tokens = max_retained_tokens.default
+⋮----
+limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
+⋮----
+max_retained_tokens = limiting_tool._max_retained_tokens
+⋮----
+tool_name = limiting_tool.default_value("request")
+max_tokens: int = max_retained_tokens
+truncation_warning = f"""
+⋮----
+"""
+        Respond to a single user message, appended to the message history,
+        in "chat" mode
+        Args:
+            message (str|ChatDocument): message or ChatDocument object to respond to.
+                If None, use the self.task_messages
+        Returns:
+            LLM response as a ChatDocument object
+        """
+⋮----
+# If enabled and a tool error occurred, we recover by generating the tool in
+# strict json mode
+⋮----
+AnyTool = self._get_any_tool_message()
+⋮----
+recovery_message = self._strict_recovery_instructions(AnyTool)
+augmented_message = message
+⋮----
+augmented_message = recovery_message
+⋮----
+augmented_message = augmented_message + recovery_message
+⋮----
+# only use the augmented message for this one response...
+result = self.llm_response(augmented_message)
+# ... restore the original user message so that the AnyTool recover
+# instructions don't persist in the message history
+# (this can cause the LLM to use the AnyTool directly as a tool)
+⋮----
+msg = message if isinstance(message, str) else message.content
+⋮----
+tool_choice = (
+⋮----
+response = self.llm_response_messages(hist, output_len, tool_choice)
+⋮----
+# Preserve trail of tool_ids for OpenAI Assistant fn-calls
+⋮----
+"""
+        Async version of `llm_response`. See there for details.
+        """
+⋮----
+response = await self.llm_response_messages_async(
+⋮----
+def init_message_history(self) -> None
+⋮----
+"""
+        Initialize the message history with the system message and user message
+        """
+⋮----
+"""
+        Prepare messages to be sent to self.llm_response_messages,
+            which is the main method that calls the LLM API to get a response.
+            If desired output tokens + message history exceeds the model context length,
+            then first the max output tokens is reduced to fit, and if that is not
+            possible, older messages may be truncated to accommodate at least
+            self.config.llm.min_output_tokens of output.
+
+        Returns:
+            Tuple[List[LLMMessage], int]: (messages, output_len)
+                messages = Full list of messages to send
+                output_len = max expected number of tokens in response
+        """
+⋮----
+# this means agent has been used to get LLM response already,
+# and so the last message is an "assistant" response.
+# We delete this last assistant response and re-generate it.
+⋮----
+# initial messages have not yet been loaded, so load them
+⋮----
+# for debugging, show the initial message history
+⋮----
+# update the system message with the latest tool instructions
+⋮----
+# either the message is a str, or it is a fresh ChatDocument
+# different from the last message in the history
+llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
+llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
+# Canonicalize retained whitespace-only results before token counting.
+⋮----
+# process tools if any
+done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
+⋮----
+hist = self.message_history
+output_len = self.config.llm.model_max_output_tokens
+⋮----
+# chat + output > max context length,
+# so first try to shorten requested output len to fit;
+# use an extra margin of CHAT_HISTORY_BUFFER tokens
+# in case our calcs are off (and to allow for some extra tokens)
+output_len = (
+⋮----
+# unacceptably small output len, so compress early parts of
+# conversation history based on the configured strategy
+strategy = self.config.context_overflow_strategy
+⋮----
+# Truncate content of individual messages while preserving
+# the message sequence (important for LLM APIs that require
+# alternating USER/ASSISTANT messages)
+msg_idx_to_compress = 1  # don't touch system msg
+# we will try compressing msg indices up to but not including
+# last user msg
+last_msg_idx_to_compress = (
+n_truncated = 0
+_target_tokens = (
+# Truncation floor: never reduce a message's content below
+# this many tokens.
+_min_keep_tokens = 30
+_truncation_warning = "... [Contents truncated!]"
+⋮----
+def _content_tokens(text: str | None) -> int
+⋮----
+"""Token count of message *content* only.
+
+                        `truncate_message` only trims `message.content`, so
+                        using the full `_message_num_tokens` (which includes
+                        attachment payloads) would inflate the count and make
+                        the keep-target too large to ever converge, for
+                        messages carrying file attachments.
+                        """
+⋮----
+# approx fallback, matches truncate_message
+⋮----
+# Account for the warning that truncate_message appends
+# ("\n" + warning), so the final token count of a
+# truncated message does not exceed its keep-target.
+_warning_tokens = _content_tokens("\n" + _truncation_warning)
+# NOTE: loop termination is guaranteed:
+# msg_idx_to_compress strictly increases every iteration
+# (truncate or skip), and once it exceeds
+# last_msg_idx_to_compress a ValueError is raised. (The
+# token count need not decrease every iteration, so
+# termination rests on the index advancing.)
+⋮----
+# We want to preserve the first message (typically
+# system msg) and last message (user msg).
+⋮----
+_msg_tokens = _content_tokens(hist[msg_idx_to_compress].content)
+⋮----
+# Truncating this message cannot shrink the total:
+# its content is already at/below the keep-floor
+# plus the appended warning; leave it intact.
+⋮----
+# Distribute the current excess evenly across the
+# remaining *compressible* messages, so each retains
+# as much content as possible instead of being
+# collapsed to the fixed 30-token floor. The excess is
+# recomputed every iteration, so the distribution
+# self-corrects as we move forward through the
+# history.
+_current_excess = self.chat_num_tokens(hist) - _target_tokens
+# Shrink capacity of each *later* message in the
+# compressible range: its content above the floor (net
+# of the appended warning). Non-positive entries are
+# the tiny messages the skip-check above will leave
+# untouched; they must not dilute the even share, so
+# only messages with positive capacity count toward
+# the denominator (plus this message, which passed the
+# skip-check and is therefore compressible).
+_later_capacities = [
+_n_remaining = 1 + sum(1 for c in _later_capacities if c > 0)
+_even_share = math.ceil(_current_excess / _n_remaining)
+# Later messages can shed at most their capacity; this
+# message must absorb whatever they cannot, so that
+# this single forward pass reaches the target whenever
+# that is possible at all.
+_later_capacity = sum(c for c in _later_capacities if c > 0)
+_reduction = max(_even_share, _current_excess - _later_capacity)
+# Extra 2-token slack: re-encoding truncated content
+# plus the appended warning can merge/split tokens at
+# the boundary, so aim slightly below the target to
+# keep the achieved reduction from falling short.
+_keep_tokens = max(
+# compress the msg at idx `msg_idx_to_compress`
+⋮----
+output_len = min(
+⋮----
+# we MUST have truncated at least one msg
+msg_tokens = self.chat_num_tokens()
+⋮----
+else:  # strategy == "drop_turns"
+# Drop complete conversation turns. A complete turn is defined
+# as a USER message followed by all messages until the next
+# USER message. This is more aggressive but cleaner for voice
+# agents with limited context.
+n_dropped_turns = 0
+⋮----
+# Find the last USER message index
+last_user_idx = self.last_message_idx_with_role(role=Role.USER)
+⋮----
+# Find the first complete turn to drop (skip system message)
+first_user_idx = -1
+⋮----
+first_user_idx = i
+⋮----
+# Find the end of this turn: last message before next USER
+next_user_idx = -1
+⋮----
+next_user_idx = i
+⋮----
+# Drop the turn
+⋮----
+# we MUST have dropped at least one turn
+⋮----
+# record the position of the corresponding LLMMessage in
+# the message_history
+⋮----
+"""
+        Get function/tool spec/output format arguments for
+        OpenAI-compatible LLM API call
+        """
+functions: Optional[List[LLMFunctionSpec]] = None
+fun_call: str | Dict[str, str] = "none"
+tools: Optional[List[OpenAIToolSpec]] = None
+force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
+⋮----
+functions = [
+fun_call = (
+⋮----
+def to_maybe_strict_spec(function: str) -> OpenAIToolSpec
+⋮----
+spec = self.llm_functions_map[function]
+strict = self._strict_mode_for_tool(function)
+⋮----
+strict_spec = copy.deepcopy(spec)
+⋮----
+strict_spec = spec
+⋮----
+tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
+force_tool = (
+output_format = None
+⋮----
+spec = self.output_format.llm_function_schema(
+⋮----
+output_format = OpenAIJsonSchemaSpec(
+⋮----
+# We always require that outputs strictly match the schema
+⋮----
+param_spec = self.output_format.model_json_schema()
+⋮----
+"""
+        Respond to a series of messages, e.g. with OpenAI ChatCompletion
+        Args:
+            messages: seq of messages (with role, content fields) sent to LLM
+            output_len: max number of tokens expected in response.
+                    If None, use the LLM's default model_max_output_tokens.
+        Returns:
+            Document (i.e. with fields "content", "metadata")
+        """
+⋮----
+output_len = output_len or self.config.llm.model_max_output_tokens
+streamer = noop_fn
+⋮----
+streamer = self.callbacks.start_llm_stream()
+⋮----
+with ExitStack() as stack:  # for conditionally using rich spinner
+⋮----
+# show rich spinner only if not streaming!
+# (Why? b/c the intent of showing a spinner is to "show progress",
+# and we don't need to do that when streaming, since
+# streaming output already shows progress.)
+cm = status(
+⋮----
+response = self.llm.chat(
+⋮----
+# Create temp ChatDocument for tool check, then clean up to avoid
+# polluting ObjectRegistry (see PR #939 discussion)
+temp_doc = ChatDocument.from_LLMResponse(
+⋮----
+response,  # .usage attrib is updated!
+⋮----
+chat_doc = ChatDocument.from_LLMResponse(
+⋮----
+# If using strict output format, parse the output JSON
+⋮----
+"""
+        Async version of `llm_response_messages`. See there for details.
+        """
+⋮----
+streamer_async = async_noop_fn
+⋮----
+streamer_async = await self.callbacks.start_llm_stream_async()
+⋮----
+response = await self.llm.achat(
+⋮----
+"""
+        Call a callback method, only passing 'reasoning' if it accepts it.
+
+        This provides backward compatibility for custom callbacks that don't
+        have the 'reasoning' parameter in their signature.
+
+        Args:
+            callback_name: Name of the callback method (e.g., 'show_llm_response')
+            reasoning: The reasoning content to pass if supported
+            **kwargs: Other arguments to pass to the callback
+        """
+callback = getattr(self.callbacks, callback_name, None)
+⋮----
+# Check if callback accepts 'reasoning' param or **kwargs
+⋮----
+sig = inspect.signature(callback)
+params = sig.parameters
+accepts_reasoning = "reasoning" in params or any(
+⋮----
+# If we can't inspect the signature, assume it doesn't accept reasoning
+accepts_reasoning = False
+⋮----
+is_cached = (
+⋮----
+# We would have already displayed the msg "live" ONLY if
+# streaming was enabled, AND we did not find a cached response.
+# If we are here, it means the response has not yet been displayed.
+cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
+# Track whether we created a temp ChatDocument for cleanup
+is_temp_doc = isinstance(response, LLMResponse)
+chat_doc = (
+# TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
+⋮----
+content = response.message or ""
+tools_content = response.tools_content()
+⋮----
+content = response.content
+tools_content = ""
+reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
+⋮----
+# Clean up temp ChatDocument to avoid polluting ObjectRegistry
+⋮----
+# we are in the context immediately after an LLM responded,
+# we won't have citations yet, so we're done
+⋮----
+citation = (
+⋮----
+reasoning="",  # Citations don't have reasoning
+⋮----
+def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument
+⋮----
+"""
+        Get LLM response to `prompt` (which presumably includes the `message`
+        somewhere, along with possible large "context" passages),
+        but only include `message` as the USER message, and not the
+        full `prompt`, in the message history.
+        Args:
+            message: the original, relatively short, user request or query
+            prompt: the full prompt potentially containing `message` plus context
+
+        Returns:
+            Document object containing the response.
+        """
+# we explicitly call THIS class's respond method,
+# not a derived class's (or else there would be infinite recursion!)
+with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
+⋮----
+"""
+        Async version of `_llm_response_temp_context`. See there for details.
+        """
+⋮----
+answer_doc = cast(
+⋮----
+"""
+        LLM Response to single message, and restore message_history.
+        In effect a "one-off" message & response that leaves agent
+        message history state intact.
+
+        Args:
+            message (str|ChatDocument): message to respond to.
+
+        Returns:
+            A Document object with the response.
+
+        """
+# explicitly call THIS class's respond method,
+⋮----
+n_msgs = len(self.message_history)
+⋮----
+response = cast(ChatDocument, ChatAgent.llm_response(self, message))
+# If there is a response, then we will have two additional
+# messages in the message history, i.e. the user message and the
+# assistant response. We want to (carefully) remove these two messages.
+⋮----
+msg = self.message_history.pop()
+⋮----
+"""
+        Async version of `llm_response_forget`. See there for details.
+        """
+⋮----
+response = cast(
+⋮----
+def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int
+⋮----
+"""
+        Total number of tokens in the message history so far.
+
+        Args:
+            messages: if provided, compute the number of tokens in this list of
+                messages, rather than the current message history.
+        Returns:
+            int: number of tokens in message history
+        """
+⋮----
+hist = messages if messages is not None else self.message_history
+⋮----
+def _message_num_tokens(self, message: LLMMessage) -> int
+⋮----
+"""Count tokens for a message, including serialized user attachments."""
+⋮----
+def _attachment_num_tokens(self, message: LLMMessage) -> int
+⋮----
+"""
+        Estimate attachment contribution using the serialized payload
+        that is sent in the API request for user messages.
+        """
+⋮----
+model = self._chat_model_name_for_attachments()
+n_tokens = sum(
+⋮----
+def _chat_model_name_for_attachments(self) -> str
+⋮----
+"""Return the model name used for attachment serialization."""
+⋮----
+def message_history_str(self, i: Optional[int] = None) -> str
+⋮----
+"""
+        Return a string representation of the message history
+        Args:
+            i: if provided, return only the i-th message when i is postive,
+                or last k messages when i = -k.
+        Returns:
+        """
+⋮----
+def __del__(self) -> None
+⋮----
+"""
+        Cleanup method called when the ChatAgent is garbage collected.
+        Note: We don't close LLM clients here because they may be shared
+        across multiple agents when client caching is enabled.
+        The clients are managed centrally and cleaned up via atexit hooks.
+        """
+# Previously we closed clients here, but this caused issues when
+# multiple agents shared the same cached client instance.
+# Clients are now managed centrally in langroid.language_models.client_cache
 </file>
 
 <file path="mkdocs.yml">
@@ -43199,6 +43252,7 @@ nav:
       - Markdown, HTML Parsing: notes/markdown-html-parsing.md
       - Context-Overflow Handling: notes/context-overflow.md
       - Batch Processing: notes/batch-processing.md
+      - Attachment Token Preflight: notes/attachment-token-preflight.md
 
   - Examples:
     - Guide: examples/guide.md
@@ -43247,7 +43301,7 @@ extra_javascript:
 <file path="pyproject.toml">
 [project]
 name = "langroid"
-version = "0.65.16"
+version = "0.66.0"
 authors = [
     {name = "Prasad Chalasani", email = "pchalasani@gmail.com"},
 ]

--- a/llms-no-tests-no-examples.txt
+++ b/llms-no-tests-no-examples.txt
@@ -107,6 +107,7 @@ docs/
     pure-lambda-non-circular.png
   notes/
     async-streaming.md
+    attachment-token-preflight.md
     azure-openai-models.md
     batch-processing.md
     chat-history-snapshots.md
@@ -26526,6 +26527,55 @@ the LLM will try its best to interpret what you want, and offer choices when con
     - Illustrates function-calling/tools and code-generation
 </file>
 
+<file path="docs/notes/attachment-token-preflight.md">
+# Attachment Token Preflight
+
+Before each LLM call, Langroid runs a local context-length preflight: it counts
+the tokens in the pending message history (`ChatAgent.chat_num_tokens()`) and,
+if needed, reduces the requested output length, truncates old messages, or
+drops old turns so the request fits the model's context window.
+
+Historically this preflight counted only each message's text `content`, ignoring
+`LLMMessage.files` (`FileAttachment` objects). But attachments ARE serialized
+into the actual API request — for Gemini and other OpenAI-compatible paths,
+`FileAttachment.to_dict()` turns an attached PDF or image into a `data:` URI
+containing the full base64 payload. A ~1.9 MB PDF becomes roughly 2.6 million
+base64 characters, so the local check could pass while the real payload was far
+larger (issue #996).
+
+## Behavior
+
+The preflight now includes an estimate for each attachment on `USER` messages:
+
+- Each attachment is serialized exactly as it would be for the API request
+  (`FileAttachment.to_dict(model)`), and the resulting JSON is tokenized with
+  the agent's parser, the same way message text is counted.
+- Attachments that are NOT inlined — e.g. a `FileAttachment` carrying an
+  `http(s)` URL, which is sent as the URL itself rather than base64 bytes —
+  contribute only the tokens of their small serialized form, not the size of
+  the remote file.
+- Messages with no attachments are counted exactly as before; token accounting
+  is unchanged for attachment-free histories.
+
+When attachments contribute to the count for an agent, a warning is logged once
+(per agent, not per message) noting that the count is an estimate.
+
+## How conservative is the estimate?
+
+The estimate measures the serialized request payload (base64 data URI plus the
+surrounding JSON), tokenized like ordinary text. Provider-side accounting may
+differ in either direction:
+
+- Providers that bill inlined files as text-like payload will be close to this
+  estimate.
+- Providers that convert files to their own internal representation (e.g.
+  per-page or per-image token charges) may count fewer or more tokens.
+
+The goal is to keep the local preflight from drastically *under*-estimating the
+request size when large files are attached, so context-window overflows are
+caught locally instead of surfacing as provider-side errors.
+</file>
+
 <file path="docs/notes/batch-processing.md">
 # Batch Processing
 
@@ -41169,6 +41219,886 @@ class ToolMessage(ABC, BaseModel):
         return schema
 </file>
 
+<file path="langroid/language_models/base.py">
+import json
+import logging
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from enum import Enum
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
+
+from langroid.cachedb.base import CacheDBConfig
+from langroid.cachedb.redis_cachedb import RedisCacheConfig
+from langroid.language_models.model_info import ModelInfo, get_model_info
+from langroid.parsing.agent_chats import parse_message
+from langroid.parsing.file_attachment import FileAttachment
+from langroid.parsing.parse_json import parse_imperfect_json, top_level_json_field
+from langroid.prompts.dialog import collate_chat_history
+from langroid.utils.configuration import settings
+from langroid.utils.output.printing import show_if_debug
+
+logger = logging.getLogger(__name__)
+
+
+def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+    pass
+
+
+async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+    pass
+
+
+FunctionCallTypes = Literal["none", "auto"]
+ToolChoiceTypes = Literal["none", "auto", "required"]
+ToolTypes = Literal["function"]
+
+DEFAULT_CONTEXT_LENGTH = 16_000
+
+
+class StreamEventType(Enum):
+    TEXT = 1
+    FUNC_NAME = 2
+    FUNC_ARGS = 3
+    TOOL_NAME = 4
+    TOOL_ARGS = 5
+    REASONING = 6
+
+
+class RetryParams(BaseSettings):
+    max_retries: int = 5
+    initial_delay: float = 1.0
+    exponential_base: float = 1.3
+    jitter: bool = True
+
+
+class LLMConfig(BaseSettings):
+    """
+    Common configuration for all language models.
+    """
+
+    type: str = "openai"
+    streamer: Optional[Callable[[Any], None]] = noop_fn
+    streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
+    api_base: str | None = None
+    formatter: None | str = None
+    # specify None if you want to use the full max output tokens of the model
+    max_output_tokens: int | None = 8192
+    timeout: int = 20  # timeout for API requests
+    chat_model: str = ""
+    completion_model: str = ""
+    temperature: float = 0.0
+    chat_context_length: int | None = None
+    async_stream_quiet: bool = False  # suppress streaming output in async mode?
+    completion_context_length: int | None = None
+    # if input length + max_output_tokens > context length of model,
+    # we will try shortening requested output
+    min_output_tokens: int = 64
+    use_completion_for_chat: bool = False  # use completion model for chat?
+    # use chat model for completion? For OpenAI models, this MUST be set to True!
+    use_chat_for_completion: bool = True
+    stream: bool = True  # stream output from API?
+    # TODO: we could have a `stream_reasoning` flag here to control whether to show
+    # reasoning output from reasoning models
+    cache_config: None | CacheDBConfig = RedisCacheConfig()
+    thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
+    retry_params: RetryParams = RetryParams()
+
+    @property
+    def model_max_output_tokens(self) -> int:
+        if self.max_output_tokens:
+            return self.max_output_tokens
+        # Build fallback names by progressively stripping provider prefixes
+        # (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
+        # succeeds even before OpenAIGPT.__init__ strips the prefix.
+        parts = self.chat_model.split("/")
+        fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
+        return get_model_info(self.chat_model, fallbacks).max_output_tokens
+
+
+class LLMFunctionCall(BaseModel):
+    """
+    Structure of LLM response indicating it "wants" to call a function.
+    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
+    """
+
+    name: str  # name of function to call
+    arguments: Optional[Dict[str, Any]] = None
+
+    @staticmethod
+    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall":
+        """
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+        fun_call = LLMFunctionCall(name=message["name"])
+        fun_args_str = message["arguments"]
+        # sometimes may be malformed with invalid indents,
+        # so we try to be safe by removing newlines.
+        if fun_args_str is not None:
+            fun_args_str = fun_args_str.replace("\n", "").strip()
+            dict_or_list = parse_imperfect_json(fun_args_str)
+
+            if not isinstance(dict_or_list, dict):
+                raise ValueError(
+                    f"""
+                        Invalid function args: {fun_args_str}
+                        parsed as {dict_or_list},
+                        which is not a valid dict.
+                        """
+                )
+            fun_args = dict_or_list
+        else:
+            fun_args = None
+        fun_call.arguments = fun_args
+
+        return fun_call
+
+    def __str__(self) -> str:
+        return "FUNC: " + json.dumps(self.model_dump(), indent=2)
+
+
+class LLMFunctionSpec(BaseModel):
+    """
+    Description of a function available for the LLM to use.
+    To be used when calling the LLM `chat()` method with the `functions` parameter.
+    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
+    """
+
+    name: str
+    description: str
+    parameters: Dict[str, Any]
+
+
+class OpenAIToolCall(BaseModel):
+    """
+    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
+    See https://platform.openai.com/docs/api-reference/chat/create
+
+    Attributes:
+        id: The id of the tool call.
+        type: The type of the tool call;
+            only "function" is currently possible (7/26/24).
+        function: The function call.
+    """
+
+    id: str | None = None
+    type: ToolTypes = "function"
+    function: LLMFunctionCall | None = None
+    extra_content: Dict[str, Any] | None = None
+
+    @staticmethod
+    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall":
+        """
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+        id = message["id"]
+        type = message["type"]
+        function = LLMFunctionCall.from_dict(message["function"])
+        extra_content = message.get("extra_content")
+        return OpenAIToolCall(
+            id=id, type=type, function=function, extra_content=extra_content
+        )
+
+    def __str__(self) -> str:
+        if self.function is None:
+            return ""
+        return "OAI-TOOL: " + json.dumps(self.function.model_dump(), indent=2)
+
+
+class OpenAIToolSpec(BaseModel):
+    type: ToolTypes
+    strict: Optional[bool] = None
+    function: LLMFunctionSpec
+
+
+class OpenAIJsonSchemaSpec(BaseModel):
+    strict: Optional[bool] = None
+    function: LLMFunctionSpec
+
+    def to_dict(self) -> Dict[str, Any]:
+        json_schema: Dict[str, Any] = {
+            "name": self.function.name,
+            "description": self.function.description,
+            "schema": self.function.parameters,
+        }
+        if self.strict is not None:
+            json_schema["strict"] = self.strict
+
+        return {
+            "type": "json_schema",
+            "json_schema": json_schema,
+        }
+
+
+class LLMTokenUsage(BaseModel):
+    """
+    Usage of tokens by an LLM.
+    """
+
+    prompt_tokens: int = 0
+    cached_tokens: int = 0
+    completion_tokens: int = 0
+    cost: float = 0.0
+    calls: int = 0  # how many API calls - not used as of 2025-04-04
+
+    def reset(self) -> None:
+        self.prompt_tokens = 0
+        self.cached_tokens = 0
+        self.completion_tokens = 0
+        self.cost = 0.0
+        self.calls = 0
+
+    def __str__(self) -> str:
+        return (
+            f"Tokens = "
+            f"(prompt {self.prompt_tokens}, cached {self.cached_tokens}, "
+            f"completion {self.completion_tokens}), "
+            f"Cost={self.cost}, Calls={self.calls}"
+        )
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+
+class Role(str, Enum):
+    """
+    Possible roles for a message in a chat.
+    """
+
+    USER = "user"
+    SYSTEM = "system"
+    ASSISTANT = "assistant"
+    FUNCTION = "function"
+    TOOL = "tool"
+
+
+class LLMMessage(BaseModel):
+    """
+    Class representing an entry in the msg-history sent to the LLM API.
+    It could be one of these:
+    - a user message
+    - an LLM ("Assistant") response
+    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
+    - a result or results from executing a fn or tool-call(s)
+    """
+
+    role: Role
+    name: Optional[str] = None
+    tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
+    tool_id: str = ""  # used by OpenAIAssistant
+    # None means "no content" (the model returned only a tool/function call).
+    # This is distinct from "" and is dropped from the API payload by api_dict;
+    # see api_dict for how a fully-empty message is handled per-API.
+    content: Optional[str] = None
+    files: List[FileAttachment] = []
+    function_call: Optional[LLMFunctionCall] = None
+    tool_calls: Optional[List[OpenAIToolCall]] = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    # link to corresponding chat document, for provenance/rewind purposes
+    chat_document_id: str = ""
+
+    def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]:
+        """
+        Convert to dictionary for API request, keeping ONLY
+        the fields that are expected in an API call!
+        E.g., DROP the tool_id, since it is only for use in the Assistant API,
+            not the completion API.
+
+        Args:
+            has_system_role: whether the message has a system role (if not,
+                set to "user" role)
+        Returns:
+            dict: dictionary representation of LLM message
+        """
+        d = self.model_dump()
+        files: List[FileAttachment] = d.pop("files")
+        if len(files) > 0 and self.role == Role.USER:
+            # In there are files, then content is an array of
+            # different content-parts
+            d["content"] = [
+                dict(
+                    type="text",
+                    text=self.content or "",
+                )
+            ] + [f.to_dict(model) for f in self.files]
+
+        # if there is a key k = "role" with value "system", change to "user"
+        # in case has_system_role is False
+        if not has_system_role and "role" in d and d["role"] == "system":
+            d["role"] = "user"
+            if d.get("content"):
+                d["content"] = "[ADDITIONAL SYSTEM MESSAGE:]\n\n" + d["content"]
+        # drop None values since API doesn't accept them (this omits `content`
+        # entirely when it is None, i.e. "no content")
+        dict_no_none = {k: v for k, v in d.items() if v is not None}
+        if "name" in dict_no_none and dict_no_none["name"] == "":
+            # OpenAI API does not like empty name
+            del dict_no_none["name"]
+        if "function_call" in dict_no_none:
+            # arguments must be a string
+            if "arguments" in dict_no_none["function_call"]:
+                dict_no_none["function_call"]["arguments"] = json.dumps(
+                    dict_no_none["function_call"]["arguments"]
+                )
+        if dict_no_none.get("tool_calls"):
+            # convert tool calls to API format
+            for tc in dict_no_none["tool_calls"]:
+                if "arguments" in tc["function"]:
+                    # arguments must be a string
+                    if tc["function"]["arguments"] is None:
+                        tc["function"]["arguments"] = "{}"
+                    else:
+                        tc["function"]["arguments"] = json.dumps(
+                            tc["function"]["arguments"]
+                        )
+                if "extra_content" in tc and tc["extra_content"] is None:
+                    del tc["extra_content"]
+        else:
+            # An empty tool-call list is not a call and conveys no useful API
+            # information. Omitting it also lets the empty-message fallback
+            # below produce a valid message.
+            dict_no_none.pop("tool_calls", None)
+        # A message with empty content (None was dropped above, or "") AND no
+        # tool/function call would be an entirely empty message, which some APIs
+        # (e.g. Gemini) reject; fall back to a single space in that case only.
+        # When there IS a tool/function call, empty content is fine (and Gemini
+        # 3.x in fact REQUIRES it — it rejects an assistant turn that carries
+        # both a call and non-empty text content).
+        has_call = bool(dict_no_none.get("tool_calls")) or (
+            dict_no_none.get("function_call") is not None
+        )
+        if not has_call and not dict_no_none.get("content"):
+            dict_no_none["content"] = " "
+        # IMPORTANT! drop fields that are not expected in API call
+        dict_no_none.pop("tool_id", None)
+        dict_no_none.pop("timestamp", None)
+        dict_no_none.pop("chat_document_id", None)
+        return dict_no_none
+
+    def __str__(self) -> str:
+        if self.function_call is not None:
+            content = "FUNC: " + json.dumps(self.function_call)
+        else:
+            content = self.content or ""
+        name_str = f" ({self.name})" if self.name else ""
+        return f"{self.role} {name_str}: {content}"
+
+
+class LLMResponse(BaseModel):
+    """
+    Class representing response from LLM.
+    """
+
+    # None means the model returned NO content (e.g. only a tool/function
+    # call), which is distinct from an empty string "". Preserving this
+    # distinction lets the message be faithfully reproduced downstream
+    # (see ChatDocument.content_is_none and LLMMessage.content).
+    message: Optional[str] = None
+    reasoning: str = ""  # optional reasoning text from reasoning models
+    # Original message text including inline thought signatures (e.g.
+    # <thinking>...</thinking>). Only set when reasoning was extracted
+    # from the message text via get_reasoning_final(); NOT set when
+    # reasoning comes from a separate API field (e.g. reasoning_content),
+    # since in that case the message text never contained thought tags.
+    message_with_reasoning: Optional[str] = None
+    # TODO tool_id needs to generalize to multi-tool calls
+    tool_id: str = ""  # used by OpenAIAssistant
+    oai_tool_calls: Optional[List[OpenAIToolCall]] = None
+    function_call: Optional[LLMFunctionCall] = None
+    usage: Optional[LLMTokenUsage] = None
+    cached: bool = False
+
+    def __str__(self) -> str:
+        if self.function_call is not None:
+            return str(self.function_call)
+        elif self.oai_tool_calls:
+            return "\n".join(str(tc) for tc in self.oai_tool_calls)
+        else:
+            return self.message or ""
+
+    def tools_content(self) -> str:
+        if self.function_call is not None:
+            return str(self.function_call)
+        elif self.oai_tool_calls:
+            return "\n".join(str(tc) for tc in self.oai_tool_calls)
+        else:
+            return ""
+
+    def to_LLMMessage(self) -> LLMMessage:
+        """Convert LLM response to an LLMMessage, to be included in the
+        message-list sent to the API.
+        This is currently NOT used in any significant way in the library, and is only
+        provided as a utility to construct a message list for the API when directly
+        working with an LLM object.
+
+        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
+        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
+        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
+        """
+        return LLMMessage(
+            role=Role.ASSISTANT,
+            content=self.message,
+            name=None if self.function_call is None else self.function_call.name,
+            function_call=self.function_call,
+            tool_calls=self.oai_tool_calls,
+        )
+
+    def get_recipient_and_message(
+        self,
+        recognize_recipient_in_content: bool = True,
+    ) -> Tuple[str, str]:
+        """
+        If `message` or `function_call` of an LLM response contains an explicit
+        recipient name, return this recipient name and `message` stripped
+        of the recipient name if specified.
+
+        Two cases:
+        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
+        (b) `message` is empty and function_call/tool_call with explicit `recipient`
+
+        Args:
+            recognize_recipient_in_content (bool): When True (default), parses
+                message text for ``TO[<recipient>]:<content>`` patterns and
+                top-level JSON ``{"recipient": "..."}`` fields. When False,
+                only function_call/tool_call ``recipient`` fields are checked.
+
+        Returns:
+            (str): name of recipient, which may be empty string if no recipient
+            (str): content of message
+
+        """
+
+        if self.function_call is not None:
+            # in this case we ignore message, since all information is in function_call
+            msg = ""
+            args = self.function_call.arguments
+            recipient = ""
+            if isinstance(args, dict):
+                recipient = args.get("recipient", "")
+            return recipient, msg
+        else:
+            msg = self.message or ""
+            if self.oai_tool_calls is not None:
+                # get the first tool that has a recipient field, if any
+                for tc in self.oai_tool_calls:
+                    if tc.function is not None and tc.function.arguments is not None:
+                        recipient = tc.function.arguments.get(
+                            "recipient"
+                        )  # type: ignore
+                        if recipient is not None and recipient != "":
+                            return recipient, ""
+
+        if not recognize_recipient_in_content:
+            return "", msg
+
+        # It's not a function or tool call, so continue looking to see
+        # if a recipient is specified in the message.
+
+        # First check if message contains "TO: <recipient> <content>"
+        recipient_name, content = parse_message(msg) if msg is not None else ("", "")
+        # check if there is a top level json that specifies 'recipient',
+        # and retain the entire message as content.
+        if recipient_name == "":
+            recipient_name = top_level_json_field(msg, "recipient") if msg else ""
+            content = msg
+        return recipient_name, content
+
+
+# Define an abstract base class for language models
+class LanguageModel(ABC):
+    """
+    Abstract base class for language models.
+    """
+
+    # usage cost by model, accumulates here
+    usage_cost_dict: Dict[str, LLMTokenUsage] = {}
+
+    def __init__(self, config: LLMConfig = LLMConfig()):
+        self.config = config
+        self.chat_model_orig = config.chat_model
+
+    @staticmethod
+    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]:
+        """
+        Create a language model.
+        Args:
+            config: configuration for language model
+        Returns: instance of language model
+        """
+        if type(config) is LLMConfig:
+            raise ValueError(
+                """
+                Cannot create a Language Model object from LLMConfig.
+                Please specify a specific subclass of LLMConfig e.g.,
+                OpenAIGPTConfig. If you are creating a ChatAgent from
+                a ChatAgentConfig, please specify the `llm` field of this config
+                as a specific subclass of LLMConfig, e.g., OpenAIGPTConfig.
+                """
+            )
+        from langroid.language_models.azure_openai import AzureGPT
+        from langroid.language_models.mock_lm import MockLM, MockLMConfig
+        from langroid.language_models.openai_gpt import OpenAIGPT
+
+        if config is None or config.type is None:
+            return None
+
+        if config.type == "mock":
+            return MockLM(cast(MockLMConfig, config))
+
+        openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
+
+        if config.type == "azure":
+            openai = AzureGPT
+        else:
+            openai = OpenAIGPT
+        cls = dict(
+            openai=openai,
+        ).get(config.type, openai)
+        return cls(config)  # type: ignore
+
+    @staticmethod
+    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]:
+        """
+        Given an even-length sequence of strings, split into a sequence of pairs
+
+        Args:
+            lst (List[str]): sequence of strings
+
+        Returns:
+            List[Tuple[str,str]]: sequence of pairs of strings
+        """
+        evens = lst[::2]
+        odds = lst[1::2]
+        return list(zip(evens, odds))
+
+    @staticmethod
+    def get_chat_history_components(
+        messages: List[LLMMessage],
+    ) -> Tuple[str, List[Tuple[str, str]], str]:
+        """
+        From the chat history, extract system prompt, user-assistant turns, and
+        final user msg.
+
+        Args:
+            messages (List[LLMMessage]): List of messages in the chat history
+
+        Returns:
+            Tuple[str, List[Tuple[str,str]], str]:
+                system prompt, user-assistant turns, final user msg
+
+        """
+        # Handle various degenerate cases
+        messages = [m for m in messages]  # copy
+        DUMMY_SYS_PROMPT = "You are a helpful assistant."
+        DUMMY_USER_PROMPT = "Follow the instructions above."
+        if len(messages) == 0 or messages[0].role != Role.SYSTEM:
+            logger.warning("No system msg, creating dummy system prompt")
+            messages.insert(0, LLMMessage(content=DUMMY_SYS_PROMPT, role=Role.SYSTEM))
+        system_prompt = messages[0].content or ""
+
+        # now we have messages = [Sys,...]
+        if len(messages) == 1:
+            logger.warning(
+                "Got only system message in chat history, creating dummy user prompt"
+            )
+            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, msg, ...]
+
+        if messages[1].role != Role.USER:
+            messages.insert(1, LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, user, ...]
+        if messages[-1].role != Role.USER:
+            logger.warning(
+                "Last message in chat history is not a user message,"
+                " creating dummy user prompt"
+            )
+            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, user, ..., user]
+        # so we omit the first and last elements and make pairs of user-asst messages
+        conversation = [m.content or "" for m in messages[1:-1]]
+        user_prompt = messages[-1].content or ""
+        pairs = LanguageModel.user_assistant_pairs(conversation)
+        return system_prompt, pairs, user_prompt
+
+    @abstractmethod
+    def set_stream(self, stream: bool) -> bool:
+        """Enable or disable streaming output from API.
+        Return previous value of stream."""
+        pass
+
+    @abstractmethod
+    def get_stream(self) -> bool:
+        """Get streaming status"""
+        pass
+
+    @abstractmethod
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        pass
+
+    @abstractmethod
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        pass
+
+    @abstractmethod
+    def chat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """
+        Get chat-completion response from LLM.
+
+        Args:
+            messages: message-history to send to the LLM
+            max_tokens: max tokens to generate
+            tools: tools available for the LLM to use in its response
+            tool_choice: tool call mode, one of "none", "auto", "required",
+                or a dict specifying a specific tool.
+            functions: functions available for LLM to call (deprecated)
+            function_call: function calling mode, "auto", "none", or a specific fn
+                    (deprecated)
+        """
+
+        pass
+
+    @abstractmethod
+    async def achat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """Async version of `chat`. See `chat` for details."""
+        pass
+
+    def __call__(self, prompt: str, max_tokens: int) -> LLMResponse:
+        return self.generate(prompt, max_tokens)
+
+    @staticmethod
+    def _fallback_model_names(model: str) -> List[str]:
+        parts = model.split("/")
+        fallbacks = []
+        for i in range(1, len(parts)):
+            fallbacks.append("/".join(parts[i:]))
+        return fallbacks
+
+    def info(self) -> ModelInfo:
+        """Info of relevant chat model"""
+        orig_model = (
+            self.config.completion_model
+            if self.config.use_completion_for_chat
+            else self.chat_model_orig
+        )
+        return get_model_info(orig_model, self._fallback_model_names(orig_model))
+
+    def completion_info(self) -> ModelInfo:
+        """Info of relevant completion model"""
+        orig_model = (
+            self.chat_model_orig
+            if self.config.use_chat_for_completion
+            else self.config.completion_model
+        )
+        return get_model_info(orig_model, self._fallback_model_names(orig_model))
+
+    def supports_functions_or_tools(self) -> bool:
+        """
+        Does this Model's API support "native" tool-calling, i.e.
+        can we call the API with arguments that contain a list of available tools,
+        and their schemas?
+        Note that, given the plethora of LLM provider APIs this determination is
+        imperfect at best, and leans towards returning True.
+        When the API calls fails with an error indicating tools are not supported,
+        then users are encouraged to use the Langroid-based prompt-based
+        ToolMessage mechanism, which works with ANY LLM. To enable this,
+        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
+        """
+        return self.info().has_tools
+
+    def chat_context_length(self) -> int:
+        return self.config.chat_context_length or DEFAULT_CONTEXT_LENGTH
+
+    def completion_context_length(self) -> int:
+        return self.config.completion_context_length or DEFAULT_CONTEXT_LENGTH
+
+    def chat_cost(self) -> Tuple[float, float, float]:
+        """
+        Return the cost per 1000 tokens for chat completions.
+
+        Returns:
+            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
+                per 1000 tokens
+        """
+        return (0.0, 0.0, 0.0)
+
+    def reset_usage_cost(self) -> None:
+        for mdl in [self.config.chat_model, self.config.completion_model]:
+            if mdl is None:
+                return
+            if mdl not in self.usage_cost_dict:
+                self.usage_cost_dict[mdl] = LLMTokenUsage()
+            counter = self.usage_cost_dict[mdl]
+            counter.reset()
+
+    def update_usage_cost(
+        self, chat: bool, prompts: int, completions: int, cost: float
+    ) -> None:
+        """
+        Update usage cost for this LLM.
+        Args:
+            chat (bool): whether to update for chat or completion model
+            prompts (int): number of tokens used for prompts
+            completions (int): number of tokens used for completions
+            cost (float): total token cost in USD
+        """
+        mdl = self.config.chat_model if chat else self.config.completion_model
+        if mdl is None:
+            return
+        if mdl not in self.usage_cost_dict:
+            self.usage_cost_dict[mdl] = LLMTokenUsage()
+        counter = self.usage_cost_dict[mdl]
+        counter.prompt_tokens += prompts
+        counter.completion_tokens += completions
+        counter.cost += cost
+        counter.calls += 1
+
+    @classmethod
+    def usage_cost_summary(cls) -> str:
+        s = ""
+        for model, counter in cls.usage_cost_dict.items():
+            s += f"{model}: {counter}\n"
+        return s
+
+    @classmethod
+    def tot_tokens_cost(cls) -> Tuple[int, float]:
+        """
+        Return total tokens used and total cost across all models.
+        """
+        total_tokens = 0
+        total_cost = 0.0
+        for counter in cls.usage_cost_dict.values():
+            total_tokens += counter.total_tokens
+            total_cost += counter.cost
+        return total_tokens, total_cost
+
+    def get_reasoning_final(self, message: str) -> Tuple[str, str]:
+        """Extract "reasoning" and "final answer" from an LLM response, if the
+        reasoning is found within configured delimiters, like <think>, </think>.
+        E.g.,
+        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
+
+        Args:
+            message (str): message from LLM
+
+        Returns:
+            Tuple[str, str]: reasoning, final answer
+        """
+        start, end = self.config.thought_delimiters
+        if start in message and end in message:
+            parts = message.split(start)
+            if len(parts) > 1:
+                reasoning, final = parts[1].split(end)
+                return reasoning, final
+        return "", message
+
+    def followup_to_standalone(
+        self, chat_history: List[Tuple[str, str]], question: str
+    ) -> str:
+        """
+        Given a chat history and a question, convert it to a standalone question.
+        Args:
+            chat_history: list of tuples of (question, answer)
+            query: follow-up question
+
+        Returns: standalone version of the question
+        """
+        history = collate_chat_history(chat_history)
+
+        prompt = f"""
+        You are an expert at understanding a CHAT HISTORY between an AI Assistant
+        and a User, and you are highly skilled in rephrasing the User's FOLLOW-UP
+        QUESTION/REQUEST as a STANDALONE QUESTION/REQUEST that can be understood
+        WITHOUT the context of the chat history.
+
+        Below is the CHAT HISTORY. When the User asks you to rephrase a
+        FOLLOW-UP QUESTION/REQUEST, your ONLY task is to simply return the
+        question REPHRASED as a STANDALONE QUESTION/REQUEST, without any additional
+        text or context.
+
+        <CHAT_HISTORY>
+        {history}
+        </CHAT_HISTORY>
+        """.strip()
+
+        follow_up_question = f"""
+        Please rephrase this as a stand-alone question or request:
+        <FOLLOW-UP-QUESTION-OR-REQUEST>
+        {question}
+        </FOLLOW-UP-QUESTION-OR-REQUEST>
+        """.strip()
+
+        show_if_debug(prompt, "FOLLOWUP->STANDALONE-PROMPT= ")
+        standalone = (
+            self.chat(
+                messages=[
+                    LLMMessage(role=Role.SYSTEM, content=prompt),
+                    LLMMessage(role=Role.USER, content=follow_up_question),
+                ],
+                max_tokens=1024,
+            ).message
+            or ""
+        )
+        standalone = standalone.strip()
+
+        show_if_debug(prompt, "FOLLOWUP->STANDALONE-RESPONSE= ")
+        return standalone
+
+
+class StreamingIfAllowed:
+    """Context to temporarily enable or disable streaming, if allowed globally via
+    `settings.stream`"""
+
+    def __init__(self, llm: LanguageModel, stream: bool = True):
+        self.llm = llm
+        self.stream = stream
+
+    def __enter__(self) -> None:
+        self.old_stream = self.llm.set_stream(settings.stream and self.stream)
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.llm.set_stream(self.old_stream)
+</file>
+
 <file path="langroid/parsing/parser.py">
 import logging
 import re
@@ -49391,886 +50321,6 @@ class ChatDocument(Document):
 
 LLMMessage.model_rebuild()
 ChatDocMetaData.model_rebuild()
-</file>
-
-<file path="langroid/language_models/base.py">
-import json
-import logging
-from abc import ABC, abstractmethod
-from datetime import datetime, timezone
-from enum import Enum
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
-
-from pydantic import BaseModel, Field
-from pydantic_settings import BaseSettings
-
-from langroid.cachedb.base import CacheDBConfig
-from langroid.cachedb.redis_cachedb import RedisCacheConfig
-from langroid.language_models.model_info import ModelInfo, get_model_info
-from langroid.parsing.agent_chats import parse_message
-from langroid.parsing.file_attachment import FileAttachment
-from langroid.parsing.parse_json import parse_imperfect_json, top_level_json_field
-from langroid.prompts.dialog import collate_chat_history
-from langroid.utils.configuration import settings
-from langroid.utils.output.printing import show_if_debug
-
-logger = logging.getLogger(__name__)
-
-
-def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
-    pass
-
-
-async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
-    pass
-
-
-FunctionCallTypes = Literal["none", "auto"]
-ToolChoiceTypes = Literal["none", "auto", "required"]
-ToolTypes = Literal["function"]
-
-DEFAULT_CONTEXT_LENGTH = 16_000
-
-
-class StreamEventType(Enum):
-    TEXT = 1
-    FUNC_NAME = 2
-    FUNC_ARGS = 3
-    TOOL_NAME = 4
-    TOOL_ARGS = 5
-    REASONING = 6
-
-
-class RetryParams(BaseSettings):
-    max_retries: int = 5
-    initial_delay: float = 1.0
-    exponential_base: float = 1.3
-    jitter: bool = True
-
-
-class LLMConfig(BaseSettings):
-    """
-    Common configuration for all language models.
-    """
-
-    type: str = "openai"
-    streamer: Optional[Callable[[Any], None]] = noop_fn
-    streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
-    api_base: str | None = None
-    formatter: None | str = None
-    # specify None if you want to use the full max output tokens of the model
-    max_output_tokens: int | None = 8192
-    timeout: int = 20  # timeout for API requests
-    chat_model: str = ""
-    completion_model: str = ""
-    temperature: float = 0.0
-    chat_context_length: int | None = None
-    async_stream_quiet: bool = False  # suppress streaming output in async mode?
-    completion_context_length: int | None = None
-    # if input length + max_output_tokens > context length of model,
-    # we will try shortening requested output
-    min_output_tokens: int = 64
-    use_completion_for_chat: bool = False  # use completion model for chat?
-    # use chat model for completion? For OpenAI models, this MUST be set to True!
-    use_chat_for_completion: bool = True
-    stream: bool = True  # stream output from API?
-    # TODO: we could have a `stream_reasoning` flag here to control whether to show
-    # reasoning output from reasoning models
-    cache_config: None | CacheDBConfig = RedisCacheConfig()
-    thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
-    retry_params: RetryParams = RetryParams()
-
-    @property
-    def model_max_output_tokens(self) -> int:
-        if self.max_output_tokens:
-            return self.max_output_tokens
-        # Build fallback names by progressively stripping provider prefixes
-        # (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
-        # succeeds even before OpenAIGPT.__init__ strips the prefix.
-        parts = self.chat_model.split("/")
-        fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
-        return get_model_info(self.chat_model, fallbacks).max_output_tokens
-
-
-class LLMFunctionCall(BaseModel):
-    """
-    Structure of LLM response indicating it "wants" to call a function.
-    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
-    """
-
-    name: str  # name of function to call
-    arguments: Optional[Dict[str, Any]] = None
-
-    @staticmethod
-    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall":
-        """
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-        fun_call = LLMFunctionCall(name=message["name"])
-        fun_args_str = message["arguments"]
-        # sometimes may be malformed with invalid indents,
-        # so we try to be safe by removing newlines.
-        if fun_args_str is not None:
-            fun_args_str = fun_args_str.replace("\n", "").strip()
-            dict_or_list = parse_imperfect_json(fun_args_str)
-
-            if not isinstance(dict_or_list, dict):
-                raise ValueError(
-                    f"""
-                        Invalid function args: {fun_args_str}
-                        parsed as {dict_or_list},
-                        which is not a valid dict.
-                        """
-                )
-            fun_args = dict_or_list
-        else:
-            fun_args = None
-        fun_call.arguments = fun_args
-
-        return fun_call
-
-    def __str__(self) -> str:
-        return "FUNC: " + json.dumps(self.model_dump(), indent=2)
-
-
-class LLMFunctionSpec(BaseModel):
-    """
-    Description of a function available for the LLM to use.
-    To be used when calling the LLM `chat()` method with the `functions` parameter.
-    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
-    """
-
-    name: str
-    description: str
-    parameters: Dict[str, Any]
-
-
-class OpenAIToolCall(BaseModel):
-    """
-    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
-    See https://platform.openai.com/docs/api-reference/chat/create
-
-    Attributes:
-        id: The id of the tool call.
-        type: The type of the tool call;
-            only "function" is currently possible (7/26/24).
-        function: The function call.
-    """
-
-    id: str | None = None
-    type: ToolTypes = "function"
-    function: LLMFunctionCall | None = None
-    extra_content: Dict[str, Any] | None = None
-
-    @staticmethod
-    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall":
-        """
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-        id = message["id"]
-        type = message["type"]
-        function = LLMFunctionCall.from_dict(message["function"])
-        extra_content = message.get("extra_content")
-        return OpenAIToolCall(
-            id=id, type=type, function=function, extra_content=extra_content
-        )
-
-    def __str__(self) -> str:
-        if self.function is None:
-            return ""
-        return "OAI-TOOL: " + json.dumps(self.function.model_dump(), indent=2)
-
-
-class OpenAIToolSpec(BaseModel):
-    type: ToolTypes
-    strict: Optional[bool] = None
-    function: LLMFunctionSpec
-
-
-class OpenAIJsonSchemaSpec(BaseModel):
-    strict: Optional[bool] = None
-    function: LLMFunctionSpec
-
-    def to_dict(self) -> Dict[str, Any]:
-        json_schema: Dict[str, Any] = {
-            "name": self.function.name,
-            "description": self.function.description,
-            "schema": self.function.parameters,
-        }
-        if self.strict is not None:
-            json_schema["strict"] = self.strict
-
-        return {
-            "type": "json_schema",
-            "json_schema": json_schema,
-        }
-
-
-class LLMTokenUsage(BaseModel):
-    """
-    Usage of tokens by an LLM.
-    """
-
-    prompt_tokens: int = 0
-    cached_tokens: int = 0
-    completion_tokens: int = 0
-    cost: float = 0.0
-    calls: int = 0  # how many API calls - not used as of 2025-04-04
-
-    def reset(self) -> None:
-        self.prompt_tokens = 0
-        self.cached_tokens = 0
-        self.completion_tokens = 0
-        self.cost = 0.0
-        self.calls = 0
-
-    def __str__(self) -> str:
-        return (
-            f"Tokens = "
-            f"(prompt {self.prompt_tokens}, cached {self.cached_tokens}, "
-            f"completion {self.completion_tokens}), "
-            f"Cost={self.cost}, Calls={self.calls}"
-        )
-
-    @property
-    def total_tokens(self) -> int:
-        return self.prompt_tokens + self.completion_tokens
-
-
-class Role(str, Enum):
-    """
-    Possible roles for a message in a chat.
-    """
-
-    USER = "user"
-    SYSTEM = "system"
-    ASSISTANT = "assistant"
-    FUNCTION = "function"
-    TOOL = "tool"
-
-
-class LLMMessage(BaseModel):
-    """
-    Class representing an entry in the msg-history sent to the LLM API.
-    It could be one of these:
-    - a user message
-    - an LLM ("Assistant") response
-    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
-    - a result or results from executing a fn or tool-call(s)
-    """
-
-    role: Role
-    name: Optional[str] = None
-    tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
-    tool_id: str = ""  # used by OpenAIAssistant
-    # None means "no content" (the model returned only a tool/function call).
-    # This is distinct from "" and is dropped from the API payload by api_dict;
-    # see api_dict for how a fully-empty message is handled per-API.
-    content: Optional[str] = None
-    files: List[FileAttachment] = []
-    function_call: Optional[LLMFunctionCall] = None
-    tool_calls: Optional[List[OpenAIToolCall]] = None
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    # link to corresponding chat document, for provenance/rewind purposes
-    chat_document_id: str = ""
-
-    def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]:
-        """
-        Convert to dictionary for API request, keeping ONLY
-        the fields that are expected in an API call!
-        E.g., DROP the tool_id, since it is only for use in the Assistant API,
-            not the completion API.
-
-        Args:
-            has_system_role: whether the message has a system role (if not,
-                set to "user" role)
-        Returns:
-            dict: dictionary representation of LLM message
-        """
-        d = self.model_dump()
-        files: List[FileAttachment] = d.pop("files")
-        if len(files) > 0 and self.role == Role.USER:
-            # In there are files, then content is an array of
-            # different content-parts
-            d["content"] = [
-                dict(
-                    type="text",
-                    text=self.content or "",
-                )
-            ] + [f.to_dict(model) for f in self.files]
-
-        # if there is a key k = "role" with value "system", change to "user"
-        # in case has_system_role is False
-        if not has_system_role and "role" in d and d["role"] == "system":
-            d["role"] = "user"
-            if d.get("content"):
-                d["content"] = "[ADDITIONAL SYSTEM MESSAGE:]\n\n" + d["content"]
-        # drop None values since API doesn't accept them (this omits `content`
-        # entirely when it is None, i.e. "no content")
-        dict_no_none = {k: v for k, v in d.items() if v is not None}
-        if "name" in dict_no_none and dict_no_none["name"] == "":
-            # OpenAI API does not like empty name
-            del dict_no_none["name"]
-        if "function_call" in dict_no_none:
-            # arguments must be a string
-            if "arguments" in dict_no_none["function_call"]:
-                dict_no_none["function_call"]["arguments"] = json.dumps(
-                    dict_no_none["function_call"]["arguments"]
-                )
-        if dict_no_none.get("tool_calls"):
-            # convert tool calls to API format
-            for tc in dict_no_none["tool_calls"]:
-                if "arguments" in tc["function"]:
-                    # arguments must be a string
-                    if tc["function"]["arguments"] is None:
-                        tc["function"]["arguments"] = "{}"
-                    else:
-                        tc["function"]["arguments"] = json.dumps(
-                            tc["function"]["arguments"]
-                        )
-                if "extra_content" in tc and tc["extra_content"] is None:
-                    del tc["extra_content"]
-        else:
-            # An empty tool-call list is not a call and conveys no useful API
-            # information. Omitting it also lets the empty-message fallback
-            # below produce a valid message.
-            dict_no_none.pop("tool_calls", None)
-        # A message with empty content (None was dropped above, or "") AND no
-        # tool/function call would be an entirely empty message, which some APIs
-        # (e.g. Gemini) reject; fall back to a single space in that case only.
-        # When there IS a tool/function call, empty content is fine (and Gemini
-        # 3.x in fact REQUIRES it — it rejects an assistant turn that carries
-        # both a call and non-empty text content).
-        has_call = bool(dict_no_none.get("tool_calls")) or (
-            dict_no_none.get("function_call") is not None
-        )
-        if not has_call and not dict_no_none.get("content"):
-            dict_no_none["content"] = " "
-        # IMPORTANT! drop fields that are not expected in API call
-        dict_no_none.pop("tool_id", None)
-        dict_no_none.pop("timestamp", None)
-        dict_no_none.pop("chat_document_id", None)
-        return dict_no_none
-
-    def __str__(self) -> str:
-        if self.function_call is not None:
-            content = "FUNC: " + json.dumps(self.function_call)
-        else:
-            content = self.content or ""
-        name_str = f" ({self.name})" if self.name else ""
-        return f"{self.role} {name_str}: {content}"
-
-
-class LLMResponse(BaseModel):
-    """
-    Class representing response from LLM.
-    """
-
-    # None means the model returned NO content (e.g. only a tool/function
-    # call), which is distinct from an empty string "". Preserving this
-    # distinction lets the message be faithfully reproduced downstream
-    # (see ChatDocument.content_is_none and LLMMessage.content).
-    message: Optional[str] = None
-    reasoning: str = ""  # optional reasoning text from reasoning models
-    # Original message text including inline thought signatures (e.g.
-    # <thinking>...</thinking>). Only set when reasoning was extracted
-    # from the message text via get_reasoning_final(); NOT set when
-    # reasoning comes from a separate API field (e.g. reasoning_content),
-    # since in that case the message text never contained thought tags.
-    message_with_reasoning: Optional[str] = None
-    # TODO tool_id needs to generalize to multi-tool calls
-    tool_id: str = ""  # used by OpenAIAssistant
-    oai_tool_calls: Optional[List[OpenAIToolCall]] = None
-    function_call: Optional[LLMFunctionCall] = None
-    usage: Optional[LLMTokenUsage] = None
-    cached: bool = False
-
-    def __str__(self) -> str:
-        if self.function_call is not None:
-            return str(self.function_call)
-        elif self.oai_tool_calls:
-            return "\n".join(str(tc) for tc in self.oai_tool_calls)
-        else:
-            return self.message or ""
-
-    def tools_content(self) -> str:
-        if self.function_call is not None:
-            return str(self.function_call)
-        elif self.oai_tool_calls:
-            return "\n".join(str(tc) for tc in self.oai_tool_calls)
-        else:
-            return ""
-
-    def to_LLMMessage(self) -> LLMMessage:
-        """Convert LLM response to an LLMMessage, to be included in the
-        message-list sent to the API.
-        This is currently NOT used in any significant way in the library, and is only
-        provided as a utility to construct a message list for the API when directly
-        working with an LLM object.
-
-        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
-        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
-        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
-        """
-        return LLMMessage(
-            role=Role.ASSISTANT,
-            content=self.message,
-            name=None if self.function_call is None else self.function_call.name,
-            function_call=self.function_call,
-            tool_calls=self.oai_tool_calls,
-        )
-
-    def get_recipient_and_message(
-        self,
-        recognize_recipient_in_content: bool = True,
-    ) -> Tuple[str, str]:
-        """
-        If `message` or `function_call` of an LLM response contains an explicit
-        recipient name, return this recipient name and `message` stripped
-        of the recipient name if specified.
-
-        Two cases:
-        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
-        (b) `message` is empty and function_call/tool_call with explicit `recipient`
-
-        Args:
-            recognize_recipient_in_content (bool): When True (default), parses
-                message text for ``TO[<recipient>]:<content>`` patterns and
-                top-level JSON ``{"recipient": "..."}`` fields. When False,
-                only function_call/tool_call ``recipient`` fields are checked.
-
-        Returns:
-            (str): name of recipient, which may be empty string if no recipient
-            (str): content of message
-
-        """
-
-        if self.function_call is not None:
-            # in this case we ignore message, since all information is in function_call
-            msg = ""
-            args = self.function_call.arguments
-            recipient = ""
-            if isinstance(args, dict):
-                recipient = args.get("recipient", "")
-            return recipient, msg
-        else:
-            msg = self.message or ""
-            if self.oai_tool_calls is not None:
-                # get the first tool that has a recipient field, if any
-                for tc in self.oai_tool_calls:
-                    if tc.function is not None and tc.function.arguments is not None:
-                        recipient = tc.function.arguments.get(
-                            "recipient"
-                        )  # type: ignore
-                        if recipient is not None and recipient != "":
-                            return recipient, ""
-
-        if not recognize_recipient_in_content:
-            return "", msg
-
-        # It's not a function or tool call, so continue looking to see
-        # if a recipient is specified in the message.
-
-        # First check if message contains "TO: <recipient> <content>"
-        recipient_name, content = parse_message(msg) if msg is not None else ("", "")
-        # check if there is a top level json that specifies 'recipient',
-        # and retain the entire message as content.
-        if recipient_name == "":
-            recipient_name = top_level_json_field(msg, "recipient") if msg else ""
-            content = msg
-        return recipient_name, content
-
-
-# Define an abstract base class for language models
-class LanguageModel(ABC):
-    """
-    Abstract base class for language models.
-    """
-
-    # usage cost by model, accumulates here
-    usage_cost_dict: Dict[str, LLMTokenUsage] = {}
-
-    def __init__(self, config: LLMConfig = LLMConfig()):
-        self.config = config
-        self.chat_model_orig = config.chat_model
-
-    @staticmethod
-    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]:
-        """
-        Create a language model.
-        Args:
-            config: configuration for language model
-        Returns: instance of language model
-        """
-        if type(config) is LLMConfig:
-            raise ValueError(
-                """
-                Cannot create a Language Model object from LLMConfig.
-                Please specify a specific subclass of LLMConfig e.g.,
-                OpenAIGPTConfig. If you are creating a ChatAgent from
-                a ChatAgentConfig, please specify the `llm` field of this config
-                as a specific subclass of LLMConfig, e.g., OpenAIGPTConfig.
-                """
-            )
-        from langroid.language_models.azure_openai import AzureGPT
-        from langroid.language_models.mock_lm import MockLM, MockLMConfig
-        from langroid.language_models.openai_gpt import OpenAIGPT
-
-        if config is None or config.type is None:
-            return None
-
-        if config.type == "mock":
-            return MockLM(cast(MockLMConfig, config))
-
-        openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
-
-        if config.type == "azure":
-            openai = AzureGPT
-        else:
-            openai = OpenAIGPT
-        cls = dict(
-            openai=openai,
-        ).get(config.type, openai)
-        return cls(config)  # type: ignore
-
-    @staticmethod
-    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]:
-        """
-        Given an even-length sequence of strings, split into a sequence of pairs
-
-        Args:
-            lst (List[str]): sequence of strings
-
-        Returns:
-            List[Tuple[str,str]]: sequence of pairs of strings
-        """
-        evens = lst[::2]
-        odds = lst[1::2]
-        return list(zip(evens, odds))
-
-    @staticmethod
-    def get_chat_history_components(
-        messages: List[LLMMessage],
-    ) -> Tuple[str, List[Tuple[str, str]], str]:
-        """
-        From the chat history, extract system prompt, user-assistant turns, and
-        final user msg.
-
-        Args:
-            messages (List[LLMMessage]): List of messages in the chat history
-
-        Returns:
-            Tuple[str, List[Tuple[str,str]], str]:
-                system prompt, user-assistant turns, final user msg
-
-        """
-        # Handle various degenerate cases
-        messages = [m for m in messages]  # copy
-        DUMMY_SYS_PROMPT = "You are a helpful assistant."
-        DUMMY_USER_PROMPT = "Follow the instructions above."
-        if len(messages) == 0 or messages[0].role != Role.SYSTEM:
-            logger.warning("No system msg, creating dummy system prompt")
-            messages.insert(0, LLMMessage(content=DUMMY_SYS_PROMPT, role=Role.SYSTEM))
-        system_prompt = messages[0].content or ""
-
-        # now we have messages = [Sys,...]
-        if len(messages) == 1:
-            logger.warning(
-                "Got only system message in chat history, creating dummy user prompt"
-            )
-            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, msg, ...]
-
-        if messages[1].role != Role.USER:
-            messages.insert(1, LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, user, ...]
-        if messages[-1].role != Role.USER:
-            logger.warning(
-                "Last message in chat history is not a user message,"
-                " creating dummy user prompt"
-            )
-            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, user, ..., user]
-        # so we omit the first and last elements and make pairs of user-asst messages
-        conversation = [m.content or "" for m in messages[1:-1]]
-        user_prompt = messages[-1].content or ""
-        pairs = LanguageModel.user_assistant_pairs(conversation)
-        return system_prompt, pairs, user_prompt
-
-    @abstractmethod
-    def set_stream(self, stream: bool) -> bool:
-        """Enable or disable streaming output from API.
-        Return previous value of stream."""
-        pass
-
-    @abstractmethod
-    def get_stream(self) -> bool:
-        """Get streaming status"""
-        pass
-
-    @abstractmethod
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        pass
-
-    @abstractmethod
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        pass
-
-    @abstractmethod
-    def chat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """
-        Get chat-completion response from LLM.
-
-        Args:
-            messages: message-history to send to the LLM
-            max_tokens: max tokens to generate
-            tools: tools available for the LLM to use in its response
-            tool_choice: tool call mode, one of "none", "auto", "required",
-                or a dict specifying a specific tool.
-            functions: functions available for LLM to call (deprecated)
-            function_call: function calling mode, "auto", "none", or a specific fn
-                    (deprecated)
-        """
-
-        pass
-
-    @abstractmethod
-    async def achat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """Async version of `chat`. See `chat` for details."""
-        pass
-
-    def __call__(self, prompt: str, max_tokens: int) -> LLMResponse:
-        return self.generate(prompt, max_tokens)
-
-    @staticmethod
-    def _fallback_model_names(model: str) -> List[str]:
-        parts = model.split("/")
-        fallbacks = []
-        for i in range(1, len(parts)):
-            fallbacks.append("/".join(parts[i:]))
-        return fallbacks
-
-    def info(self) -> ModelInfo:
-        """Info of relevant chat model"""
-        orig_model = (
-            self.config.completion_model
-            if self.config.use_completion_for_chat
-            else self.chat_model_orig
-        )
-        return get_model_info(orig_model, self._fallback_model_names(orig_model))
-
-    def completion_info(self) -> ModelInfo:
-        """Info of relevant completion model"""
-        orig_model = (
-            self.chat_model_orig
-            if self.config.use_chat_for_completion
-            else self.config.completion_model
-        )
-        return get_model_info(orig_model, self._fallback_model_names(orig_model))
-
-    def supports_functions_or_tools(self) -> bool:
-        """
-        Does this Model's API support "native" tool-calling, i.e.
-        can we call the API with arguments that contain a list of available tools,
-        and their schemas?
-        Note that, given the plethora of LLM provider APIs this determination is
-        imperfect at best, and leans towards returning True.
-        When the API calls fails with an error indicating tools are not supported,
-        then users are encouraged to use the Langroid-based prompt-based
-        ToolMessage mechanism, which works with ANY LLM. To enable this,
-        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
-        """
-        return self.info().has_tools
-
-    def chat_context_length(self) -> int:
-        return self.config.chat_context_length or DEFAULT_CONTEXT_LENGTH
-
-    def completion_context_length(self) -> int:
-        return self.config.completion_context_length or DEFAULT_CONTEXT_LENGTH
-
-    def chat_cost(self) -> Tuple[float, float, float]:
-        """
-        Return the cost per 1000 tokens for chat completions.
-
-        Returns:
-            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
-                per 1000 tokens
-        """
-        return (0.0, 0.0, 0.0)
-
-    def reset_usage_cost(self) -> None:
-        for mdl in [self.config.chat_model, self.config.completion_model]:
-            if mdl is None:
-                return
-            if mdl not in self.usage_cost_dict:
-                self.usage_cost_dict[mdl] = LLMTokenUsage()
-            counter = self.usage_cost_dict[mdl]
-            counter.reset()
-
-    def update_usage_cost(
-        self, chat: bool, prompts: int, completions: int, cost: float
-    ) -> None:
-        """
-        Update usage cost for this LLM.
-        Args:
-            chat (bool): whether to update for chat or completion model
-            prompts (int): number of tokens used for prompts
-            completions (int): number of tokens used for completions
-            cost (float): total token cost in USD
-        """
-        mdl = self.config.chat_model if chat else self.config.completion_model
-        if mdl is None:
-            return
-        if mdl not in self.usage_cost_dict:
-            self.usage_cost_dict[mdl] = LLMTokenUsage()
-        counter = self.usage_cost_dict[mdl]
-        counter.prompt_tokens += prompts
-        counter.completion_tokens += completions
-        counter.cost += cost
-        counter.calls += 1
-
-    @classmethod
-    def usage_cost_summary(cls) -> str:
-        s = ""
-        for model, counter in cls.usage_cost_dict.items():
-            s += f"{model}: {counter}\n"
-        return s
-
-    @classmethod
-    def tot_tokens_cost(cls) -> Tuple[int, float]:
-        """
-        Return total tokens used and total cost across all models.
-        """
-        total_tokens = 0
-        total_cost = 0.0
-        for counter in cls.usage_cost_dict.values():
-            total_tokens += counter.total_tokens
-            total_cost += counter.cost
-        return total_tokens, total_cost
-
-    def get_reasoning_final(self, message: str) -> Tuple[str, str]:
-        """Extract "reasoning" and "final answer" from an LLM response, if the
-        reasoning is found within configured delimiters, like <think>, </think>.
-        E.g.,
-        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
-
-        Args:
-            message (str): message from LLM
-
-        Returns:
-            Tuple[str, str]: reasoning, final answer
-        """
-        start, end = self.config.thought_delimiters
-        if start in message and end in message:
-            parts = message.split(start)
-            if len(parts) > 1:
-                reasoning, final = parts[1].split(end)
-                return reasoning, final
-        return "", message
-
-    def followup_to_standalone(
-        self, chat_history: List[Tuple[str, str]], question: str
-    ) -> str:
-        """
-        Given a chat history and a question, convert it to a standalone question.
-        Args:
-            chat_history: list of tuples of (question, answer)
-            query: follow-up question
-
-        Returns: standalone version of the question
-        """
-        history = collate_chat_history(chat_history)
-
-        prompt = f"""
-        You are an expert at understanding a CHAT HISTORY between an AI Assistant
-        and a User, and you are highly skilled in rephrasing the User's FOLLOW-UP
-        QUESTION/REQUEST as a STANDALONE QUESTION/REQUEST that can be understood
-        WITHOUT the context of the chat history.
-
-        Below is the CHAT HISTORY. When the User asks you to rephrase a
-        FOLLOW-UP QUESTION/REQUEST, your ONLY task is to simply return the
-        question REPHRASED as a STANDALONE QUESTION/REQUEST, without any additional
-        text or context.
-
-        <CHAT_HISTORY>
-        {history}
-        </CHAT_HISTORY>
-        """.strip()
-
-        follow_up_question = f"""
-        Please rephrase this as a stand-alone question or request:
-        <FOLLOW-UP-QUESTION-OR-REQUEST>
-        {question}
-        </FOLLOW-UP-QUESTION-OR-REQUEST>
-        """.strip()
-
-        show_if_debug(prompt, "FOLLOWUP->STANDALONE-PROMPT= ")
-        standalone = (
-            self.chat(
-                messages=[
-                    LLMMessage(role=Role.SYSTEM, content=prompt),
-                    LLMMessage(role=Role.USER, content=follow_up_question),
-                ],
-                max_tokens=1024,
-            ).message
-            or ""
-        )
-        standalone = standalone.strip()
-
-        show_if_debug(prompt, "FOLLOWUP->STANDALONE-RESPONSE= ")
-        return standalone
-
-
-class StreamingIfAllowed:
-    """Context to temporarily enable or disable streaming, if allowed globally via
-    `settings.stream`"""
-
-    def __init__(self, llm: LanguageModel, stream: bool = True):
-        self.llm = llm
-        self.stream = stream
-
-    def __enter__(self) -> None:
-        self.old_stream = self.llm.set_stream(settings.stream and self.stream)
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self.llm.set_stream(self.old_stream)
 </file>
 
 <file path="langroid/language_models/client_cache.py">
@@ -59490,2746 +59540,6 @@ def _model_name(model: str | ModelName) -> str:
     return model.value
 </file>
 
-<file path="langroid/agent/chat_agent.py">
-import base64
-import copy
-import inspect
-import json
-import logging
-import math
-import textwrap
-from contextlib import ExitStack
-from inspect import isclass
-from typing import (
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Self,
-    Set,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
-
-import openai
-from pydantic import BaseModel, ValidationError
-from pydantic.fields import ModelPrivateAttr
-from rich import print
-from rich.console import Console
-from rich.markup import escape
-
-from langroid.agent.base import (
-    Agent,
-    AgentConfig,
-    SearchForTools,
-    async_noop_fn,
-    noop_fn,
-)
-from langroid.agent.chat_document import ChatDocument
-from langroid.agent.tool_message import (
-    ToolMessage,
-    format_schema_for_strict,
-)
-from langroid.agent.xml_tool_message import XMLToolMessage
-from langroid.language_models.base import (
-    LLMFunctionCall,
-    LLMFunctionSpec,
-    LLMMessage,
-    LLMResponse,
-    OpenAIJsonSchemaSpec,
-    OpenAIToolSpec,
-    Role,
-    StreamingIfAllowed,
-    ToolChoiceTypes,
-)
-from langroid.language_models.openai_gpt import OpenAIGPT
-from langroid.mytypes import Entity, NonToolAction
-from langroid.parsing.file_attachment import FileAttachment
-from langroid.utils.configuration import settings
-from langroid.utils.object_registry import ObjectRegistry
-from langroid.utils.output import status
-from langroid.utils.pydantic_utils import PydanticWrapper, get_pydantic_wrapper
-from langroid.utils.types import is_callable
-
-console = Console()
-
-logger = logging.getLogger(__name__)
-
-# Stable origin sentinel for the dynamically generated strict-recovery AnyTool
-# class ("tool_or_function"): a fresh class is built per call (its tool-union
-# type varies), so re-registration must be recognized as the same logical tool.
-_ANY_TOOL_MESSAGE_ORIGIN: Any = object()
-
-# Safety margin (in tokens) subtracted from the model context length when
-# shrinking chat history and/or the requested output length to fit, in case
-# our token-count estimates are off.
-CHAT_HISTORY_BUFFER = 300
-
-
-def _reject_json_constant(constant: str) -> None:
-    """Reject JavaScript numeric constants that are not valid JSON."""
-    raise ValueError(f"non-JSON numeric constant: {constant}")
-
-
-def _parse_json_float(value: str) -> float:
-    """Parse a JSON float while rejecting exponent overflow."""
-    parsed = float(value)
-    if not math.isfinite(parsed):
-        raise ValueError(f"non-finite JSON number: {value}")
-    return parsed
-
-
-def _is_identified_result(message: LLMMessage) -> bool:
-    """Whether a TOOL/FUNCTION result has its identifier and no call payload.
-
-    Such results must survive even with empty content so their calls can be
-    marked complete (issue #1063).
-    """
-    has_identifier = (
-        message.role == Role.TOOL and bool((message.tool_call_id or "").strip())
-    ) or (message.role == Role.FUNCTION and bool((message.name or "").strip()))
-    return has_identifier and message.function_call is None and not message.tool_calls
-
-
-def _llm_message_has_payload(message: LLMMessage) -> bool:
-    """Whether a message has the fields required for a valid history entry."""
-    return (
-        (message.content or "").strip() != ""
-        or message.function_call is not None
-        or bool(message.tool_calls)
-        or _is_identified_result(message)
-    )
-
-
-class ChatAgentConfig(AgentConfig):
-    """
-    Configuration for ChatAgent
-
-    Attributes:
-        system_message: system message to include in message sequence
-             (typically defines role and task of agent).
-             Used only if `task` is not specified in the constructor.
-        user_message: user message to include in message sequence.
-             Used only if `task` is not specified in the constructor.
-        use_tools: whether to use our own ToolMessages mechanism
-        handle_llm_no_tool (Any): desired agent_response when
-            LLM generates non-tool msg.
-        use_functions_api: whether to use functions/tools native to the LLM API
-                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
-        use_tools_api: When `use_functions_api` is True, if this is also True,
-            the OpenAI tool-call API is used, rather than the older/deprecated
-            function-call API. However the tool-call API has some tricky aspects,
-            hence we set this to False by default.
-        strict_recovery: whether to enable strict schema recovery when there
-            is a tool-generation error.
-        enable_orchestration_tool_handling: whether to enable handling of orchestration
-            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
-        output_format: When supported by the LLM (certain OpenAI LLMs
-            and local LLMs served by providers such as vLLM), ensures
-            that the output is a JSON matching the corresponding
-            schema via grammar-based decoding
-        handle_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for handling".
-        use_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for use" (by LLM) and
-            instructions on using T are added to the system message.
-        instructions_output_format: Controls whether we generate instructions for
-            `output_format` in the system message.
-        use_tools_on_output_format: Controls whether to automatically switch
-            to the Langroid-native tools mechanism when `output_format` is set.
-            Note that LLMs may generate tool calls which do not belong to
-            `output_format` even when strict JSON mode is enabled, so this should be
-            enabled when such tool calls are not desired.
-        output_format_include_defaults: Whether to include fields with default arguments
-            in the output schema
-        full_citations: Whether to show source reference citation + content for each
-            citation, or just the main reference citation.
-        search_for_tools_everywhere: Whether to search for tools everywhere,
-            or only in specific LLM response elements based on use_tools /
-            use_functions_api / use_tools_api config settings.
-        recognize_recipient_in_content: Whether to parse LLM response text content
-            for recipient routing patterns, specifically:
-            - ``TO[<recipient>]:<content>`` addressing format, and
-            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
-            When False, only structured routing via function_call/tool_call
-            ``recipient`` fields is recognized. Default is True.
-            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
-            which controls Task-level signals like DONE, PASS, and SEND_TO.
-            To fully disable all text-based routing, set both to False.
-        context_overflow_strategy: Strategy for handling context overflow when
-            message history exceeds model context length. Options:
-            - "truncate": Truncate content of early messages (preserves all messages
-              but with shortened content). This maintains the message sequence.
-            - "drop_turns": Drop complete conversation turns (USER + all responses
-              until next USER). More aggressive but cleaner for voice agents.
-            Default is "truncate" for backward compatibility.
-    """
-
-    system_message: str = "You are a helpful assistant."
-    user_message: Optional[str] = None
-    handle_llm_no_tool: Any = None
-    use_tools: bool = True
-    use_functions_api: bool = False
-    use_tools_api: bool = True
-    strict_recovery: bool = True
-    enable_orchestration_tool_handling: bool = True
-    output_format: Optional[type] = None
-    handle_output_format: bool = True
-    use_output_format: bool = True
-    instructions_output_format: bool = True
-    output_format_include_defaults: bool = True
-    use_tools_on_output_format: bool = True
-    full_citations: bool = True  # show source + content for each citation?
-    search_for_tools_everywhere: bool = True
-    recognize_recipient_in_content: bool = True
-    context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
-
-    def _set_fn_or_tools(self) -> None:
-        """
-        Enable Langroid Tool or OpenAI-like fn-calling,
-        depending on config settings.
-        """
-        if not self.use_functions_api or not self.use_tools:
-            return
-        if self.use_functions_api and self.use_tools:
-            logger.debug(
-                """
-                You have enabled both `use_tools` and `use_functions_api`.
-                Setting `use_functions_api` to False.
-                """
-            )
-            self.use_tools = True
-            self.use_functions_api = False
-
-
-class ChatAgent(Agent):
-    """
-    Chat Agent interacting with external env
-    (could be human, or external tools).
-    The agent (the LLM actually) is provided with an optional "Task Spec",
-    which is a sequence of `LLMMessage`s. These are used to initialize
-    the `task_messages` of the agent.
-    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
-    The `Agent` class mainly exists to hold various common methods and attributes.
-    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
-    `llm_response` method uses "chat mode" API (i.e. one that takes a
-    message sequence rather than a single message),
-    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
-    that takes a single message).
-    """
-
-    def __init__(
-        self,
-        config: ChatAgentConfig = ChatAgentConfig(),
-        task: Optional[List[LLMMessage]] = None,
-    ):
-        """
-        Chat-mode agent initialized with task spec as the initial message sequence
-        Args:
-            config: settings for the agent
-
-        """
-        super().__init__(config)
-        self.config: ChatAgentConfig = config
-        self.config._set_fn_or_tools()
-        self.message_history: List[LLMMessage] = []
-        self.init_state()
-        # An agent's "task" is defined by a system msg and an optional user msg;
-        # These are "priming" messages that kick off the agent's conversation.
-        self.system_message: str = self.config.system_message
-        self.user_message: str | None = self.config.user_message
-
-        if task is not None:
-            # if task contains a system msg, we override the config system msg
-            if len(task) > 0 and task[0].role == Role.SYSTEM:
-                self.system_message = task[0].content or ""
-            # if task contains a user msg, we override the config user msg
-            if len(task) > 1 and task[1].role == Role.USER:
-                self.user_message = task[1].content
-
-        # system-level instructions for using tools/functions:
-        # We maintain these as tools/functions are enabled/disabled,
-        # and whenever an LLM response is sought, these are used to
-        # recreate the system message (via `_create_system_and_tools_message`)
-        # each time, so it reflects the current set of enabled tools/functions.
-        # (a) these are general instructions on using certain tools/functions,
-        #   if they are specified in a ToolMessage class as a classmethod `instructions`
-        self.system_tool_instructions: str = ""
-        # (b) these are only for the builtin in Langroid TOOLS mechanism:
-        self.system_tool_format_instructions: str = ""
-
-        self.llm_functions_map: Dict[str, LLMFunctionSpec] = {}
-        self.llm_functions_handled: Set[str] = set()
-        self.llm_functions_usable: Set[str] = set()
-        self.llm_function_force: Optional[Dict[str, str]] = None
-
-        self.output_format: Optional[type[ToolMessage | BaseModel]] = None
-
-        self.saved_requests_and_tool_setings = self._requests_and_tool_settings()
-        # This variable is not None and equals a `ToolMessage` T, if and only if:
-        # (a) T has been set as the output_format of this agent, AND
-        # (b) T has been "enabled for use" ONLY for enforcing this output format, AND
-        # (c) T has NOT been explicitly "enabled for use" by this Agent.
-        self.enabled_use_output_format: Optional[type[ToolMessage]] = None
-        # As above but deals with "enabled for handling" instead of "enabled for use".
-        self.enabled_handling_output_format: Optional[type[ToolMessage]] = None
-        if config.output_format is not None:
-            self.set_output_format(config.output_format)
-        # instructions specifically related to enforcing `output_format`
-        self.output_format_instructions = ""
-
-        # controls whether to disable strict schemas for this agent if
-        # strict mode causes exception
-        self.disable_strict = False
-        # Tracks whether any strict tool is enabled; used to determine whether to set
-        # `self.disable_strict` on an exception
-        self.any_strict = False
-        # Tracks the set of tools on which we force-disable strict decoding
-        self.disable_strict_tools_set: set[str] = set()
-
-        # search for tools according to the agent configuration
-        if not config.search_for_tools_everywhere:
-            if config.use_functions_api:
-                if config.use_tools_api:
-                    self.search_for_tools = {SearchForTools.TOOLS.value}
-                else:
-                    self.search_for_tools = {SearchForTools.FUNCTIONS.value}
-            else:
-                self.search_for_tools = {SearchForTools.CONTENT.value}
-
-        if self.config.enable_orchestration_tool_handling:
-            # Only enable HANDLING by `agent_response`, NOT LLM generation of these.
-            # This is useful where tool-handlers or agent_response generate these
-            # tools, and need to be handled.
-            # We don't want enable orch tool GENERATION by default, since that
-            # might clutter-up the LLM system message unnecessarily.
-            from langroid.agent.tools.orchestration import (
-                AgentDoneTool,
-                AgentSendTool,
-                DonePassTool,
-                DoneTool,
-                ForwardTool,
-                PassTool,
-                ResultTool,
-                SendTool,
-            )
-
-            self.enable_message(ForwardTool, use=False, handle=True)
-            self.enable_message(DoneTool, use=False, handle=True)
-            self.enable_message(AgentDoneTool, use=False, handle=True)
-            self.enable_message(PassTool, use=False, handle=True)
-            self.enable_message(DonePassTool, use=False, handle=True)
-            self.enable_message(SendTool, use=False, handle=True)
-            self.enable_message(AgentSendTool, use=False, handle=True)
-            self.enable_message(ResultTool, use=False, handle=True)
-
-    def init_state(self) -> None:
-        """
-        Initialize the state of the agent. Just conversation state here,
-        but subclasses can override this to initialize other state.
-        """
-        super().init_state()
-        self.clear_history(0)
-        self.clear_dialog()
-
-    @staticmethod
-    def from_id(id: str) -> "ChatAgent":
-        """
-        Get an agent from its ID
-        Args:
-            agent_id (str): ID of the agent
-        Returns:
-            ChatAgent: The agent with the given ID
-        """
-        return cast(ChatAgent, Agent.from_id(id))
-
-    def clone(self, i: int = 0) -> "ChatAgent":
-        """Create i'th clone of this agent, ensuring tool use/handling is cloned.
-        Important: We assume all member variables are in the __init__ method here
-        and in the Agent class.
-        TODO: We are attempting to clone an agent after its state has been
-        changed in possibly many ways. Below is an imperfect solution. Caution advised.
-        Revisit later.
-        """
-        agent_cls = type(self)
-        # Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
-        # instead of deepcopy which loses subclass information
-        config_copy = self.config.model_copy(deep=True)
-        config_copy.name = f"{config_copy.name}-{i}"
-        new_agent = agent_cls(config_copy)
-        new_agent.system_tool_instructions = self.system_tool_instructions
-        new_agent.system_tool_format_instructions = self.system_tool_format_instructions
-        new_agent.llm_tools_map = self.llm_tools_map
-        new_agent.llm_tools_known = self.llm_tools_known
-        new_agent.llm_tools_handled = self.llm_tools_handled
-        new_agent.llm_tools_usable = self.llm_tools_usable
-        new_agent.llm_functions_map = self.llm_functions_map
-        new_agent.llm_functions_handled = self.llm_functions_handled
-        new_agent.llm_functions_usable = self.llm_functions_usable
-        new_agent.llm_function_force = self.llm_function_force
-        # Ensure each clone gets its own vecdb client when supported.
-        new_agent.vecdb = None if self.vecdb is None else self.vecdb.clone()
-        self._clone_extra_state(new_agent)
-        new_agent.id = ObjectRegistry.new_id()
-        if self.config.add_to_registry:
-            ObjectRegistry.register_object(new_agent)
-        return new_agent
-
-    def _clone_extra_state(self, new_agent: "ChatAgent") -> None:
-        """Hook for subclasses to copy additional state into clones."""
-
-    def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool:
-        """Should we enable strict mode for a given tool?"""
-        if isinstance(tool, str):
-            tool_class = self.llm_tools_map[tool]
-        else:
-            tool_class = tool
-        name = tool_class.default_value("request")
-        if name in self.disable_strict_tools_set or self.disable_strict:
-            return False
-        strict: Optional[bool] = tool_class.default_value("strict")
-        if strict is None:
-            strict = self._strict_tools_available()
-
-        return strict
-
-    def _fn_call_available(self) -> bool:
-        """Does this agent's LLM support function calling?"""
-        return self.llm is not None and self.llm.supports_functions_or_tools()
-
-    def _strict_tools_available(self) -> bool:
-        """Does this agent's LLM support strict tools?"""
-        return (
-            not self.disable_strict
-            and self.llm is not None
-            and isinstance(self.llm, OpenAIGPT)
-            and self.llm.config.parallel_tool_calls is False
-            and self.llm.supports_strict_tools
-        )
-
-    def _json_schema_available(self) -> bool:
-        """Does this agent's LLM support strict JSON schema output format?"""
-        return (
-            not self.disable_strict
-            and self.llm is not None
-            and isinstance(self.llm, OpenAIGPT)
-            and self.llm.supports_json_schema
-        )
-
-    def set_system_message(self, msg: str) -> None:
-        self.system_message = msg
-        if len(self.message_history) > 0:
-            # if there is message history, update the system message in it
-            self.message_history[0].content = msg
-
-    def set_user_message(self, msg: str) -> None:
-        self.user_message = msg
-
-    @property
-    def task_messages(self) -> List[LLMMessage]:
-        """
-        The task messages are the initial messages that define the task
-        of the agent. There will be at least a system message plus possibly a user msg.
-        Returns:
-            List[LLMMessage]: the task messages
-        """
-        msgs = [self._create_system_and_tools_message()]
-        if self.user_message:
-            msgs.append(LLMMessage(role=Role.USER, content=self.user_message))
-        return msgs
-
-    def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None:
-        id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
-        if msg.role == Role.TOOL:
-            # dropping tool result, so ADD the corresponding tool-call back
-            # to the list of pending calls!
-            id = msg.tool_call_id
-            if id in self.oai_tool_id2call:
-                self.oai_tool_calls.append(self.oai_tool_id2call[id])
-        elif msg.tool_calls is not None:
-            # dropping a msg with tool-calls, so DROP these from pending list
-            # as well as from id -> call map
-            for tool_call in msg.tool_calls:
-                if tool_call.id in id2idx:
-                    self.oai_tool_calls.pop(id2idx[tool_call.id])
-                if tool_call.id in self.oai_tool_id2call:
-                    del self.oai_tool_id2call[tool_call.id]
-
-    def clear_history(self, start: int = -2, end: int = -1) -> None:
-        """
-        Clear the message history, deleting  messages from index `start`,
-        up to index `end`.
-
-        Args:
-            start (int): index of first message to delete; default = -2
-                    (i.e. delete last 2 messages, typically these
-                    are the last user and assistant messages)
-            end (int): index of last message to delete; Default = -1
-                    (i.e. delete all messages up to the last one)
-        """
-        n = len(self.message_history)
-        if start < 0:
-            start = max(0, n + start)
-        end_ = n if end == -1 else end + 1
-        dropped = self.message_history[start:end_]
-        # consider the dropped msgs in REVERSE order, so we are
-        # carefully updating self.oai_tool_calls
-        for msg in reversed(dropped):
-            self._drop_msg_update_tool_calls(msg)
-            # clear out the chat document from the ObjectRegistry
-            ChatDocument.delete_id(msg.chat_document_id)
-        del self.message_history[start:end_]
-
-    def update_history(self, message: str, response: str) -> None:
-        """
-        Update the message history with the latest user message and LLM response.
-        Args:
-            message (str): user message
-            response: (str): LLM response
-        """
-        self.message_history.extend(
-            [
-                LLMMessage(role=Role.USER, content=message),
-                LLMMessage(role=Role.ASSISTANT, content=response),
-            ]
-        )
-
-    def export_history(self) -> str:
-        """Export message history as a portable, versioned JSON snapshot.
-
-        Returns:
-            A JSON string containing the current message history.
-        """
-        messages: List[Dict[str, Any]] = []
-        for message in self.message_history:
-            json.dumps(
-                message.model_dump(mode="python", exclude={"files"}),
-                allow_nan=False,
-                default=str,
-            )
-            data = message.model_dump(mode="json", exclude={"files"})
-            data["chat_document_id"] = ""
-            data["files"] = [
-                {
-                    "content_base64": base64.b64encode(file.content).decode("ascii"),
-                    "filename": file.filename,
-                    "mime_type": file.mime_type,
-                    "url": file.url,
-                    "detail": file.detail,
-                }
-                for file in message.files
-            ]
-            messages.append(data)
-        return json.dumps({"version": 1, "messages": messages}, allow_nan=False)
-
-    def import_history(
-        self,
-        snapshot: str,
-        max_size_bytes: int = 100 * 1024 * 1024,
-    ) -> None:
-        """Restore message history from :meth:`export_history` output.
-
-        Args:
-            snapshot: Versioned JSON snapshot to restore.
-            max_size_bytes: Maximum total decoded attachment size. Defaults to
-                100 MiB.
-
-        Raises:
-            ValueError: If the snapshot is malformed, has an unknown version,
-                starts with a non-system message, or exceeds ``max_size_bytes``.
-        """
-        try:
-            if max_size_bytes < 0:
-                raise ValueError("max_size_bytes must be non-negative")
-            payload = json.loads(
-                snapshot,
-                parse_constant=_reject_json_constant,
-                parse_float=_parse_json_float,
-            )
-            if (
-                not isinstance(payload, dict)
-                or type(payload.get("version")) is not int
-                or payload["version"] != 1
-            ):
-                raise ValueError("unsupported version")
-            raw_messages = payload.get("messages")
-            if not isinstance(raw_messages, list):
-                raise ValueError("messages must be a list")
-            if not raw_messages:
-                raise ValueError("messages must not be empty")
-
-            messages: List[LLMMessage] = []
-            total_attachment_bytes = 0
-            for raw_message in raw_messages:
-                if not isinstance(raw_message, dict):
-                    raise ValueError("message must be an object")
-                message_data = dict(raw_message)
-                raw_files = message_data.get("files", [])
-                if not isinstance(raw_files, list):
-                    raise ValueError("files must be a list")
-                files = []
-                for raw_file in raw_files:
-                    if not isinstance(raw_file, dict):
-                        raise ValueError("file must be an object")
-                    file_data = dict(raw_file)
-                    encoded_content = file_data.pop("content_base64")
-                    if not isinstance(encoded_content, str):
-                        raise ValueError("content_base64 must be a string")
-                    encoded_bytes = encoded_content.encode("ascii")
-                    padding = len(encoded_bytes) - len(encoded_bytes.rstrip(b"="))
-                    decoded_size = max(
-                        0,
-                        len(encoded_bytes) // 4 * 3 - min(padding, 2),
-                    )
-                    if total_attachment_bytes + decoded_size > max_size_bytes:
-                        raise ValueError(
-                            "decoded attachments exceed "
-                            f"max_size_bytes={max_size_bytes}"
-                        )
-                    content = base64.b64decode(encoded_bytes, validate=True)
-                    total_attachment_bytes += len(content)
-                    if total_attachment_bytes > max_size_bytes:
-                        raise ValueError(
-                            "decoded attachments exceed "
-                            f"max_size_bytes={max_size_bytes}"
-                        )
-                    files.append(FileAttachment(content=content, **file_data))
-                message_data["files"] = files
-                message_data["chat_document_id"] = ""
-                messages.append(LLMMessage.model_validate(message_data))
-            if messages[0].role != Role.SYSTEM:
-                raise ValueError("first message must have role 'system'")
-            seen_call_ids: Set[str] = set()
-            for message in messages:
-                if message.role in (Role.TOOL, Role.FUNCTION) and (
-                    message.function_call is not None or message.tool_calls is not None
-                ):
-                    raise ValueError("result messages must not contain call payloads")
-                if message.function_call is not None and message.role != Role.ASSISTANT:
-                    raise ValueError("function calls must have role 'assistant'")
-                if message.function_call is not None:
-                    if not message.function_call.name.strip():
-                        raise ValueError("function call names must be nonblank")
-                if message.tool_call_id is not None and message.role != Role.TOOL:
-                    raise ValueError("tool_call_id is only valid on tool results")
-                if message.role == Role.FUNCTION:
-                    name = message.name
-                    if name is None or not name or name != name.strip():
-                        raise ValueError(
-                            "function result name must be nonblank and normalized"
-                        )
-                if message.tool_calls is not None:
-                    if message.role != Role.ASSISTANT:
-                        raise ValueError("tool calls must have role 'assistant'")
-                    for call in message.tool_calls:
-                        if call.function is None:
-                            raise ValueError("tool calls must include a function")
-                        if not call.function.name.strip():
-                            raise ValueError("function call names must be nonblank")
-                        call_id = call.id
-                        if call_id is None or not call_id or call_id != call_id.strip():
-                            raise ValueError(
-                                "tool call IDs must be nonblank and normalized"
-                            )
-                        if call_id in seen_call_ids:
-                            raise ValueError("tool call IDs must be unique")
-                        seen_call_ids.add(call_id)
-                    if not message.tool_calls:
-                        message.tool_calls = None
-        except (
-            KeyError,
-            RecursionError,
-            TypeError,
-            UnicodeEncodeError,
-            ValueError,
-        ) as exc:
-            raise ValueError(f"Invalid history snapshot: {exc}") from exc
-
-        all_calls = {
-            call.id: call
-            for message in messages
-            for call in (message.tool_calls or [])
-            if call.id is not None
-        }
-        completed_call_ids = {
-            message.tool_call_id
-            for message in messages
-            if message.role == Role.TOOL and message.tool_call_id is not None
-        }
-        old_chat_document_ids = {
-            message.chat_document_id
-            for message in self.message_history
-            if message.chat_document_id
-        }
-        for chat_document_id in old_chat_document_ids:
-            ChatDocument.delete_id(chat_document_id)
-        self.message_history = messages
-        self.oai_tool_id2call = all_calls
-        self.oai_tool_calls = [
-            call
-            for call_id, call in all_calls.items()
-            if call_id not in completed_call_ids
-        ]
-
-    def tool_format_rules(self) -> str:
-        """
-        Specification of tool formatting rules
-        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
-        based on the currently enabled usable `ToolMessage`s
-
-        Returns:
-            str: formatting rules
-        """
-        # ONLY Usable tools (i.e. LLM-generation allowed),
-        usable_tool_classes: List[Type[ToolMessage]] = [
-            t
-            for t in list(self.llm_tools_map.values())
-            if t.default_value("request") in self.llm_tools_usable
-        ]
-
-        if len(usable_tool_classes) == 0:
-            return ""
-        format_instructions = "\n\n".join(
-            [
-                msg_cls.format_instructions(tool=self.config.use_tools)
-                for msg_cls in usable_tool_classes
-            ]
-        )
-        # if any of the enabled classes has json_group_instructions, then use that,
-        # else fall back to ToolMessage.json_group_instructions
-        for msg_cls in usable_tool_classes:
-            if hasattr(msg_cls, "json_group_instructions") and callable(
-                getattr(msg_cls, "json_group_instructions")
-            ):
-                return msg_cls.group_format_instructions().format(
-                    format_instructions=format_instructions
-                )
-        return ToolMessage.group_format_instructions().format(
-            format_instructions=format_instructions
-        )
-
-    def tool_instructions(self) -> str:
-        """
-        Instructions for tools or function-calls, for enabled and usable Tools.
-        These are inserted into system prompt regardless of whether we are using
-        our own ToolMessage mechanism or the LLM's function-call mechanism.
-
-        Returns:
-            str: concatenation of instructions for all usable tools
-        """
-        enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
-        if len(enabled_classes) == 0:
-            return ""
-        instructions = []
-        for msg_cls in enabled_classes:
-            if msg_cls.default_value("request") in self.llm_tools_usable:
-                class_instructions = ""
-                if hasattr(msg_cls, "instructions") and inspect.ismethod(
-                    msg_cls.instructions
-                ):
-                    class_instructions = msg_cls.instructions()
-                if (
-                    self.config.use_tools
-                    and hasattr(msg_cls, "langroid_tools_instructions")
-                    and inspect.ismethod(msg_cls.langroid_tools_instructions)
-                ):
-                    class_instructions += msg_cls.langroid_tools_instructions()
-                # example will be shown in tool_format_rules() when using TOOLs,
-                # so we don't need to show it here.
-                example = "" if self.config.use_tools else (msg_cls.usage_examples())
-                if example != "":
-                    example = "EXAMPLES:\n" + example
-                guidance = (
-                    ""
-                    if class_instructions == ""
-                    else ("GUIDANCE: " + class_instructions)
-                )
-                if guidance == "" and example == "":
-                    continue
-                instructions.append(
-                    textwrap.dedent(
-                        f"""
-                        TOOL: {msg_cls.default_value("request")}:
-                        {guidance}
-                        {example}
-                        """.lstrip()
-                    )
-                )
-        if len(instructions) == 0:
-            return ""
-        instructions_str = "\n\n".join(instructions)
-        return textwrap.dedent(
-            f"""
-            === GUIDELINES ON SOME TOOLS/FUNCTIONS USAGE ===
-            {instructions_str}
-            """.lstrip()
-        )
-
-    def augment_system_message(self, message: str) -> None:
-        """
-        Augment the system message with the given message.
-        Args:
-            message (str): system message
-        """
-        self.system_message += "\n\n" + message
-
-    def last_message_with_role(self, role: Role) -> LLMMessage | None:
-        """from `message_history`, return the last message with role `role`"""
-        n_role_msgs = len([m for m in self.message_history if m.role == role])
-        if n_role_msgs == 0:
-            return None
-        idx = self.nth_message_idx_with_role(role, n_role_msgs)
-        return self.message_history[idx]
-
-    def last_message_idx_with_role(self, role: Role) -> int:
-        """Index of last message in message_history, with specified role.
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-        indices_with_role = [
-            i for i, m in enumerate(self.message_history) if m.role == role
-        ]
-        if len(indices_with_role) == 0:
-            return -1
-        return indices_with_role[-1]
-
-    def nth_message_idx_with_role(self, role: Role, n: int) -> int:
-        """Index of `n`th message in message_history, with specified role.
-        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-        indices_with_role = [
-            i for i, m in enumerate(self.message_history) if m.role == role
-        ]
-
-        if len(indices_with_role) < n:
-            return -1
-        return indices_with_role[n - 1]
-
-    def update_last_message(self, message: str, role: str = Role.USER) -> None:
-        """
-        Update the last message that has role `role` in the message history.
-        Useful when we want to replace a long user prompt, that may contain context
-        documents plus a question, with just the question.
-        Args:
-            message (str): new message to replace with
-            role (str): role of message to replace
-        """
-        if len(self.message_history) == 0:
-            return
-        # find last message in self.message_history with role `role`
-        for i in range(len(self.message_history) - 1, -1, -1):
-            if self.message_history[i].role == role:
-                self.message_history[i].content = message
-                break
-
-    def delete_last_message(self, role: str = Role.USER) -> None:
-        """
-        Delete the last message that has role `role` from the message history.
-        Args:
-            role (str): role of message to delete
-        """
-        if len(self.message_history) == 0:
-            return
-        # find last message in self.message_history with role `role`
-        for i in range(len(self.message_history) - 1, -1, -1):
-            if self.message_history[i].role == role:
-                self.message_history.pop(i)
-                break
-
-    def _create_system_and_tools_message(self) -> LLMMessage:
-        """
-        (Re-)Create the system message for the LLM of the agent,
-        taking into account any tool instructions that have been added
-        after the agent was initialized.
-
-        The system message will consist of:
-        (a) the system message from the `task` arg in constructor, if any,
-            otherwise the default system message from the config
-        (b) the system tool instructions, if any
-        (c) the system json tool instructions, if any
-
-        Returns:
-            LLMMessage object
-        """
-        content = self.system_message
-        if self.system_tool_instructions != "":
-            content += "\n\n" + self.system_tool_instructions
-        if self.system_tool_format_instructions != "":
-            content += "\n\n" + self.system_tool_format_instructions
-        if self.output_format_instructions != "":
-            content += "\n\n" + self.output_format_instructions
-
-        # remove leading and trailing newlines and other whitespace
-        return LLMMessage(role=Role.SYSTEM, content=content.strip())
-
-    def handle_message_fallback(self, msg: str | ChatDocument) -> Any:
-        """
-        Fallback method for the "no-tools" scenario, i.e., the current `msg`
-        (presumably emitted by the LLM) does not have any tool that the agent
-        can handle.
-        NOTE: The `msg` may contain tools but either (a) the agent is not
-        enabled to handle them, or (b) there's an explicit `recipient` field
-        in the tool that doesn't match the agent's name.
-
-        Uses the self.config.non_tool_routing to determine the action to take.
-
-        This method can be overridden by subclasses, e.g.,
-        to create a "reminder" message when a tool is expected but the LLM "forgot"
-        to generate one.
-
-        Args:
-            msg (str | ChatDocument): The input msg to handle
-        Returns:
-            Any: The result of the handler method
-        """
-        if (
-            isinstance(msg, str)
-            or msg.metadata.sender != Entity.LLM
-            or self.config.handle_llm_no_tool is None
-            or self.has_only_unhandled_tools(msg)
-        ):
-            return None
-        # we ONLY use the `handle_llm_no_tool` config option when
-        # the msg is from LLM and does not contain ANY tools at all.
-        from langroid.agent.tools.orchestration import AgentDoneTool, ForwardTool
-
-        no_tool_option = self.config.handle_llm_no_tool
-        if no_tool_option in list(NonToolAction):
-            # in case the `no_tool_option` is one of the special NonToolAction vals
-            match self.config.handle_llm_no_tool:
-                case NonToolAction.FORWARD_USER:
-                    return ForwardTool(agent="User")
-                case NonToolAction.DONE:
-                    return AgentDoneTool(content=msg.content, tools=msg.tool_messages)
-        elif is_callable(no_tool_option):
-            return no_tool_option(msg)
-        # Otherwise just return `no_tool_option` as is:
-        # This can be any string, such as a specific nudge/reminder to the LLM,
-        # or even something like ResultTool etc.
-        return no_tool_option
-
-    def unhandled_tools(self) -> set[str]:
-        """The set of tools that are known but not handled.
-        Useful in task flow: an agent can refuse to accept an incoming msg
-        when it only has unhandled tools.
-        """
-        return self.llm_tools_known - self.llm_tools_handled
-
-    def enable_message(
-        self,
-        message_class: Optional[Type[ToolMessage] | List[Type[ToolMessage]]],
-        use: bool = True,
-        handle: bool = True,
-        force: bool = False,
-        require_recipient: bool = False,
-        include_defaults: bool = True,
-    ) -> None:
-        """
-        Add the tool (message class) to the agent, and enable either
-        - tool USE (i.e. the LLM can generate JSON to use this tool),
-        - tool HANDLING (i.e. the agent can handle JSON from this tool),
-
-        Args:
-            message_class: The ToolMessage class OR List of such classes to enable,
-                for USE, or HANDLING, or both.
-                If this is a list of ToolMessage classes, then the remain args are
-                applied to all classes.
-                Optional; if None, then apply the enabling to all tools in the
-                agent's toolset that have been enabled so far.
-            use: IF True, allow the agent (LLM) to use this tool (or all tools),
-                else disallow
-            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
-                tool (or all tools)
-            force: whether to FORCE the agent (LLM) to USE the specific
-                 tool represented by `message_class`.
-                 `force` is ignored if `message_class` is None.
-            require_recipient: whether to require that recipient be specified
-                when using the tool message (only applies if `use` is True).
-            include_defaults: whether to include fields that have default values,
-                in the "properties" section of the JSON format instructions.
-                (Normally the OpenAI completion API ignores these fields,
-                but the Assistant fn-calling seems to pay attn to these,
-                and if we don't want this, we should set this to False.)
-        """
-        if message_class is not None and isinstance(message_class, list):
-            for mc in message_class:
-                self.enable_message(
-                    mc,
-                    use=use,
-                    handle=handle,
-                    force=force,
-                    require_recipient=require_recipient,
-                    include_defaults=include_defaults,
-                )
-            return None
-
-        # Validate that use/handle are booleans, not accidentally passed tool classes
-        if isclass(use) or isclass(handle):
-            param = "use" if isclass(use) else "handle"
-            raise TypeError(
-                textwrap.dedent(
-                    f"""
-                    Invalid arguments to enable_message().
-                    It appears you passed multiple ToolMessage classes as separate
-                    arguments instead of as a list.
-
-                    Correct usage:
-                        agent.enable_message([Tool1, Tool2, Tool3])
-
-                    Incorrect usage:
-                        agent.enable_message(Tool1, Tool2, Tool3)
-
-                    The '{param}' parameter must be a boolean, not a class.
-                    """
-                )
-            )
-
-        if require_recipient and message_class is not None:
-            message_class = message_class.require_recipient()
-        if message_class is not None:
-            if not issubclass(message_class, ToolMessage):
-                raise ValueError("message_class must be a subclass of ToolMessage")
-            request = message_class.default_value("request")
-            existing_class = self.llm_tools_map.get(request)
-            existing_origin = (
-                existing_class.__dict__.get("__tool_message_origin__", existing_class)
-                if existing_class is not None
-                else None
-            )
-            message_origin = message_class.__dict__.get(
-                "__tool_message_origin__", message_class
-            )
-            if existing_class is not None and existing_origin is not message_origin:
-                raise ValueError(
-                    f"Tool request name {request!r} is already registered to "
-                    f"{existing_class.__name__}; cannot register "
-                    f"{message_class.__name__}"
-                )
-        if isinstance(message_class, XMLToolMessage):
-            # XMLToolMessage is not compatible with OpenAI's Tools/functions API,
-            # so we disable use of functions API, enable langroid-native Tools,
-            # which are prompt-based.
-            self.config.use_functions_api = False
-            self.config.use_tools = True
-        super().enable_message_handling(message_class)  # enables handling only
-        tools = self._get_tool_list(message_class)
-        if message_class is not None:
-            if request == "":
-                raise ValueError(
-                    f"""
-                    ToolMessage class {message_class} must have a non-empty
-                    'request' field if it is to be enabled as a tool.
-                    """
-                )
-            llm_function = message_class.llm_function_schema(defaults=include_defaults)
-            self.llm_functions_map[request] = llm_function
-            if force:
-                self.llm_function_force = dict(name=request)
-            else:
-                self.llm_function_force = None
-
-        for t in tools:
-            self.llm_tools_known.add(t)
-
-            if handle:
-                self.llm_tools_handled.add(t)
-                self.llm_functions_handled.add(t)
-
-                if (
-                    self.enabled_handling_output_format is not None
-                    and self.enabled_handling_output_format.name() == t
-                ):
-                    # `t` was designated as "enabled for handling" ONLY for
-                    # output_format enforcement, but we are explicitly ]
-                    # enabling it for handling here, so we set the variable to None.
-                    self.enabled_handling_output_format = None
-            else:
-                self.llm_tools_handled.discard(t)
-                self.llm_functions_handled.discard(t)
-
-            if use:
-                tool_class = self.llm_tools_map[t]
-                allow_llm_use = tool_class._allow_llm_use
-                if isinstance(allow_llm_use, ModelPrivateAttr):
-                    allow_llm_use = allow_llm_use.default
-                if allow_llm_use:
-                    self.llm_tools_usable.add(t)
-                    self.llm_functions_usable.add(t)
-                else:
-                    logger.warning(
-                        f"""
-                        ToolMessage class {tool_class} does not allow LLM use,
-                        because `_allow_llm_use=False` either in the Tool or a
-                        parent class of this tool;
-                        so not enabling LLM use for this tool!
-                        If you intended an LLM to use this tool,
-                        set `_allow_llm_use=True` when you define the tool.
-                        """
-                    )
-                if (
-                    self.enabled_use_output_format is not None
-                    and self.enabled_use_output_format.default_value("request") == t
-                ):
-                    # `t` was designated as "enabled for use" ONLY for output_format
-                    # enforcement, but we are explicitly enabling it for use here,
-                    # so we set the variable to None.
-                    self.enabled_use_output_format = None
-            else:
-                self.llm_tools_usable.discard(t)
-                self.llm_functions_usable.discard(t)
-
-        self._update_tool_instructions()
-
-    def _update_tool_instructions(self) -> None:
-        # Set tool instructions and JSON format instructions,
-        # in case Tools have been enabled/disabled.
-        if self.config.use_tools:
-            self.system_tool_format_instructions = self.tool_format_rules()
-        self.system_tool_instructions = self.tool_instructions()
-
-    def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]:
-        """
-        Returns the current set of enabled requests for inference and tools configs.
-        Used for restoring setings overriden by `set_output_format`.
-        """
-        return (
-            self.enabled_requests_for_inference,
-            self.config.use_functions_api,
-            self.config.use_tools,
-        )
-
-    @property
-    def all_llm_tools_known(self) -> set[str]:
-        """All known tools; we include `output_format` if it is a `ToolMessage`."""
-        known = self.llm_tools_known
-
-        if self.output_format is not None and issubclass(
-            self.output_format, ToolMessage
-        ):
-            return known.union({self.output_format.default_value("request")})
-
-        return known
-
-    def set_output_format(
-        self,
-        output_type: Optional[type],
-        force_tools: Optional[bool] = None,
-        use: Optional[bool] = None,
-        handle: Optional[bool] = None,
-        instructions: Optional[bool] = None,
-        is_copy: bool = False,
-    ) -> None:
-        """
-        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
-        switches to the native Langroid tools mechanism to ensure that no tool
-        calls not of `output_type` are generated. By default, `force_tools`
-        follows the `use_tools_on_output_format` parameter in the config.
-
-        If `output_type` is None, restores to the state prior to setting
-        `output_format`.
-
-        If `use`, we enable use of `output_type` when it is a subclass
-        of `ToolMesage`. Note that this primarily controls instruction
-        generation: the model will always generate `output_type` regardless
-        of whether `use` is set. Defaults to the `use_output_format`
-        parameter in the config. Similarly, handling of `output_type` is
-        controlled by `handle`, which defaults to the
-        `handle_output_format` parameter in the config.
-
-        `instructions` controls whether we generate instructions specifying
-        the output format schema. Defaults to the `instructions_output_format`
-        parameter in the config.
-
-        `is_copy` is set when called via `__getitem__`. In that case, we must
-        copy certain fields to ensure that we do not overwrite the main agent's
-        setings.
-        """
-        # Disable usage of an output format which was not specifically enabled
-        # by `enable_message`
-        if self.enabled_use_output_format is not None:
-            self.disable_message_use(self.enabled_use_output_format)
-            self.enabled_use_output_format = None
-
-        # Disable handling of an output format which did not specifically have
-        # handling enabled via `enable_message`
-        if self.enabled_handling_output_format is not None:
-            self.disable_message_handling(self.enabled_handling_output_format)
-            self.enabled_handling_output_format = None
-
-        # Reset any previous instructions
-        self.output_format_instructions = ""
-
-        if output_type is None:
-            self.output_format = None
-            (
-                requests_for_inference,
-                use_functions_api,
-                use_tools,
-            ) = self.saved_requests_and_tool_setings
-            self.config = self.config.model_copy()
-            self.enabled_requests_for_inference = requests_for_inference
-            self.config.use_functions_api = use_functions_api
-            self.config.use_tools = use_tools
-        else:
-            if force_tools is None:
-                force_tools = self.config.use_tools_on_output_format
-
-            if not any(
-                (isclass(output_type) and issubclass(output_type, t))
-                for t in [ToolMessage, BaseModel]
-            ):
-                output_type = get_pydantic_wrapper(output_type)
-
-            if self.output_format is None and force_tools:
-                self.saved_requests_and_tool_setings = (
-                    self._requests_and_tool_settings()
-                )
-
-            self.output_format = output_type
-            if issubclass(output_type, ToolMessage):
-                name = output_type.default_value("request")
-                if use is None:
-                    use = self.config.use_output_format
-
-                if handle is None:
-                    handle = self.config.handle_output_format
-
-                if use or handle:
-                    is_usable = name in self.llm_tools_usable.union(
-                        self.llm_functions_usable
-                    )
-                    is_handled = name in self.llm_tools_handled.union(
-                        self.llm_functions_handled
-                    )
-
-                    if is_copy:
-                        if use:
-                            # We must copy `llm_tools_usable` so the base agent
-                            # is unmodified
-                            self.llm_tools_usable = self.llm_tools_usable.copy()
-                            self.llm_functions_usable = self.llm_functions_usable.copy()
-                        if handle:
-                            # If handling the tool, do the same for `llm_tools_handled`
-                            self.llm_tools_handled = self.llm_tools_handled.copy()
-                            self.llm_functions_handled = (
-                                self.llm_functions_handled.copy()
-                            )
-                    # Enable `output_type`
-                    self.enable_message(
-                        output_type,
-                        # Do not override existing settings
-                        use=use or is_usable,
-                        handle=handle or is_handled,
-                    )
-
-                    # If the `output_type` ToilMessage was not already enabled for
-                    # use, this means we are ONLY enabling it for use specifically
-                    # for enforcing this output format, so we set the
-                    # `enabled_use_output_forma  to this output_type, to
-                    # record that it should be disabled when `output_format` is changed
-                    if not is_usable:
-                        self.enabled_use_output_format = output_type
-
-                    # (same reasoning as for use-enabling)
-                    if not is_handled:
-                        self.enabled_handling_output_format = output_type
-
-                generated_tool_instructions = name in self.llm_tools_usable.union(
-                    self.llm_functions_usable
-                )
-            else:
-                generated_tool_instructions = False
-
-            if instructions is None:
-                instructions = self.config.instructions_output_format
-            if issubclass(output_type, BaseModel) and instructions:
-                if generated_tool_instructions:
-                    # Already generated tool instructions as part of "enabling for use",
-                    # so only need to generate a reminder to use this tool.
-                    name = cast(ToolMessage, output_type).default_value("request")
-                    self.output_format_instructions = textwrap.dedent(
-                        f"""
-                        === OUTPUT FORMAT INSTRUCTIONS ===
-
-                        Please provide output using the `{name}` tool/function.
-                        """
-                    )
-                else:
-                    if issubclass(output_type, ToolMessage):
-                        output_format_schema = output_type.llm_function_schema(
-                            request=True,
-                            defaults=self.config.output_format_include_defaults,
-                        ).parameters
-                    else:
-                        output_format_schema = output_type.model_json_schema()
-
-                    format_schema_for_strict(output_format_schema)
-
-                    self.output_format_instructions = textwrap.dedent(
-                        f"""
-                        === OUTPUT FORMAT INSTRUCTIONS ===
-                        Please provide output as JSON with the following schema:
-
-                        {output_format_schema}
-                        """
-                    )
-
-            if force_tools:
-                if issubclass(output_type, ToolMessage):
-                    self.enabled_requests_for_inference = {
-                        output_type.default_value("request")
-                    }
-                if self.config.use_functions_api:
-                    self.config = self.config.model_copy()
-                    self.config.use_functions_api = False
-                    self.config.use_tools = True
-
-    def __getitem__(self, output_type: type) -> Self:
-        """
-        Returns a (shallow) copy of `self` with a forced output type.
-        """
-        clone = copy.copy(self)
-        clone.set_output_format(output_type, is_copy=True)
-        return clone
-
-    def disable_message_handling(
-        self,
-        message_class: Optional[Type[ToolMessage]] = None,
-    ) -> None:
-        """
-        Disable this agent from RESPONDING to a `message_class` (Tool). If
-            `message_class` is None, then disable this agent from responding to ALL.
-        Args:
-            message_class: The ToolMessage class to disable; Optional.
-        """
-        super().disable_message_handling(message_class)
-        for t in self._get_tool_list(message_class):
-            self.llm_tools_handled.discard(t)
-            self.llm_functions_handled.discard(t)
-
-    def disable_message_use(
-        self,
-        message_class: Optional[Type[ToolMessage]],
-    ) -> None:
-        """
-        Disable this agent from USING a message class (Tool).
-        If `message_class` is None, then disable this agent from USING ALL tools.
-        Args:
-            message_class: The ToolMessage class to disable.
-                If None, disable all.
-        """
-        for t in self._get_tool_list(message_class):
-            self.llm_tools_usable.discard(t)
-            self.llm_functions_usable.discard(t)
-
-        self._update_tool_instructions()
-
-    def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None:
-        """
-        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
-        Args:
-            message_class: The only ToolMessage class to allow
-        """
-        request = message_class.model_fields["request"].default
-        to_remove = [r for r in self.llm_tools_usable if r != request]
-        for r in to_remove:
-            self.llm_tools_usable.discard(r)
-            self.llm_functions_usable.discard(r)
-        self._update_tool_instructions()
-
-    def _load_output_format(self, message: ChatDocument) -> None:
-        """
-        If set, attempts to parse a value of type `self.output_format` from the message
-        contents or any tool/function call and assigns it to `content_any`.
-        """
-        if self.output_format is not None:
-            any_succeeded = False
-            attempts: list[str | LLMFunctionCall] = [
-                message.content,
-            ]
-
-            if message.function_call is not None:
-                attempts.append(message.function_call)
-
-            if message.oai_tool_calls is not None:
-                attempts.extend(
-                    [
-                        c.function
-                        for c in message.oai_tool_calls
-                        if c.function is not None
-                    ]
-                )
-
-            for attempt in attempts:
-                try:
-                    if isinstance(attempt, str):
-                        content = json.loads(attempt)
-                    else:
-                        if not (
-                            issubclass(self.output_format, ToolMessage)
-                            and attempt.name
-                            == self.output_format.default_value("request")
-                        ):
-                            continue
-
-                        content = attempt.arguments
-
-                    content_any = self.output_format.model_validate(content)
-
-                    if issubclass(self.output_format, PydanticWrapper):
-                        message.content_any = content_any.value  # type: ignore
-                    else:
-                        message.content_any = content_any
-                    any_succeeded = True
-                    break
-                except (ValidationError, json.JSONDecodeError):
-                    continue
-
-            if not any_succeeded:
-                self.disable_strict = True
-                logging.warning(
-                    """
-                    Validation error occured with strict output format enabled.
-                    Disabling strict mode.
-                    """
-                )
-
-    def get_tool_messages(
-        self,
-        msg: str | ChatDocument | None,
-        all_tools: bool = False,
-    ) -> List[ToolMessage]:
-        """
-        Extracts messages and tracks whether any errors occurred. If strict mode
-        was enabled, disables it for the tool, else triggers strict recovery.
-        """
-        self.tool_error = False
-        most_recent_sent_by_llm = (
-            len(self.message_history) > 0
-            and self.message_history[-1].role == Role.ASSISTANT
-        )
-        was_llm = most_recent_sent_by_llm or (
-            isinstance(msg, ChatDocument) and msg.metadata.sender == Entity.LLM
-        )
-        try:
-            tools = super().get_tool_messages(msg, all_tools)
-        except ValidationError as ve:
-            # Check if tool class was attached to the exception
-            if hasattr(ve, "tool_class") and ve.tool_class:
-                tool_class = ve.tool_class  # type: ignore
-                if issubclass(tool_class, ToolMessage):
-                    was_strict = (
-                        self.config.use_functions_api
-                        and self.config.use_tools_api
-                        and self._strict_mode_for_tool(tool_class)
-                    )
-                    # If the result of strict output for a tool using the
-                    # OpenAI tools API fails to parse, we infer that the
-                    # schema edits necessary for compatibility prevented
-                    # adherence to the underlying `ToolMessage` schema and
-                    # disable strict output for the tool
-                    if was_strict:
-                        name = tool_class.default_value("request")
-                        self.disable_strict_tools_set.add(name)
-                        logging.warning(
-                            f"""
-                            Validation error occured with strict tool format.
-                            Disabling strict mode for the {name} tool.
-                            """
-                        )
-                    else:
-                        # We will trigger the strict recovery mechanism to force
-                        # the LLM to correct its output, allowing us to parse
-                        if isinstance(msg, ChatDocument):
-                            self.tool_error = msg.metadata.sender == Entity.LLM
-                        else:
-                            self.tool_error = most_recent_sent_by_llm
-
-            if was_llm:
-                raise ve
-            else:
-                self.tool_error = False
-                return []
-
-        if not was_llm:
-            self.tool_error = False
-
-        return tools
-
-    def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None:
-        """
-        Returns a `ToolMessage` which wraps all enabled tools, excluding those
-        where strict recovery is disabled. Used in strict recovery.
-        """
-        possible_tools = tuple(
-            self.llm_tools_map[t]
-            for t in self.llm_tools_usable
-            if t not in self.disable_strict_tools_set
-        )
-        if len(possible_tools) == 0:
-            return None
-        any_tool_type = Union.__getitem__(possible_tools)  # type ignore
-
-        maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
-
-        class AnyTool(ToolMessage):
-            purpose: str = "To call a tool/function."
-            request: str = "tool_or_function"
-            tool: maybe_optional_type  # type: ignore
-
-            def response(self, agent: ChatAgent) -> None | str | ChatDocument:
-                # One-time use
-                agent.set_output_format(None)
-
-                if self.tool is None:
-                    return None
-
-                # As the ToolMessage schema accepts invalid
-                # `tool.request` values, reparse with the
-                # corresponding tool
-                request = self.tool.request
-                if request not in agent.llm_tools_map:
-                    return None
-                tool = agent.llm_tools_map[request].model_validate_json(
-                    self.tool.to_json()
-                )
-
-                return agent.handle_tool_message(tool)
-
-            async def response_async(
-                self, agent: ChatAgent
-            ) -> None | str | ChatDocument:
-                # One-time use
-                agent.set_output_format(None)
-
-                if self.tool is None:
-                    return None
-
-                # As the ToolMessage schema accepts invalid
-                # `tool.request` values, reparse with the
-                # corresponding tool
-                request = self.tool.request
-                if request not in agent.llm_tools_map:
-                    return None
-                tool = agent.llm_tools_map[request].model_validate_json(
-                    self.tool.to_json()
-                )
-
-                return await agent.handle_tool_message_async(tool)
-
-        # Every call builds a distinct class; share one origin so enabling a
-        # regenerated AnyTool under "tool_or_function" stays idempotent instead
-        # of tripping the same-name/different-tool registration guard.
-        AnyTool.__tool_message_origin__ = (  # type: ignore[attr-defined]
-            _ANY_TOOL_MESSAGE_ORIGIN
-        )
-        return AnyTool
-
-    def _strict_recovery_instructions(
-        self,
-        tool_type: Optional[type[ToolMessage]] = None,
-        optional: bool = True,
-    ) -> str:
-        """Returns instructions for strict recovery."""
-        optional_instructions = (
-            (
-                "\n"
-                + """
-        If you did NOT intend to do so, `tool` should be null.
-        """
-            )
-            if optional
-            else ""
-        )
-        response_prefix = "If you intended to make such a call, r" if optional else "R"
-        instruction_prefix = "If you do so, b" if optional else "B"
-
-        schema_instructions = (
-            f"""
-        The schema for `tool_or_function` is as follows:
-        {tool_type.llm_function_schema(defaults=True, request=True).parameters}
-        """
-            if tool_type
-            else ""
-        )
-
-        return textwrap.dedent(
-            f"""
-        Your previous attempt to make a tool/function call appears to have failed.
-        {response_prefix}espond with your desired tool/function. Do so with the
-        `tool_or_function` tool/function where `tool` is set to your intended call.
-        {schema_instructions}
-
-        {instruction_prefix}e sure that your corrected call matches your intention
-        in your previous request. For any field with a default value which
-        you did not intend to override in your previous attempt, be sure
-        to set that field to its default value. {optional_instructions}
-        """
-        )
-
-    def truncate_message(
-        self,
-        idx: int,
-        tokens: int = 5,
-        warning: str = "...[Contents truncated!]",
-        inplace: bool = True,
-    ) -> LLMMessage:
-        """
-        Truncate message at idx in msg history to `tokens` tokens.
-
-        If inplace is True, the message is truncated in place, else
-        it LEAVES the original message INTACT and returns a new message
-        """
-        if inplace:
-            llm_msg = self.message_history[idx]
-        else:
-            llm_msg = copy.deepcopy(self.message_history[idx])
-        if llm_msg.content is None or (
-            llm_msg.content == "" and _is_identified_result(llm_msg)
-        ):
-            return llm_msg
-        orig_content = llm_msg.content
-        new_content = (
-            self.parser.truncate_tokens(orig_content, tokens)
-            if self.parser is not None
-            else orig_content[: tokens * 4]  # approx truncation
-        )
-        llm_msg.content = new_content + "\n" + warning
-        return llm_msg
-
-    def _reduce_raw_tool_results(self, message: ChatDocument) -> None:
-        """
-        If message is the result of a ToolMessage that had
-        a `_max_retained_tokens` set to a non-None value, then we replace contents
-        with a placeholder message.
-        """
-        parent_message: ChatDocument | None = message.parent
-        tools = [] if parent_message is None else parent_message.tool_messages
-        truncate_tools = []
-        for t in tools:
-            max_retained_tokens = t._max_retained_tokens
-            if isinstance(max_retained_tokens, ModelPrivateAttr):
-                max_retained_tokens = max_retained_tokens.default
-            if max_retained_tokens is not None:
-                truncate_tools.append(t)
-        limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
-        if limiting_tool is not None:
-            max_retained_tokens = limiting_tool._max_retained_tokens
-            if isinstance(max_retained_tokens, ModelPrivateAttr):
-                max_retained_tokens = max_retained_tokens.default
-            if max_retained_tokens is not None:
-                tool_name = limiting_tool.default_value("request")
-                max_tokens: int = max_retained_tokens
-                truncation_warning = f"""
-                    The result of the {tool_name} tool were too large,
-                    and has been truncated to {max_tokens} tokens.
-                    To obtain the full result, the tool needs to be re-used.
-                """
-                self.truncate_message(
-                    message.metadata.msg_idx, max_tokens, truncation_warning
-                )
-
-    def llm_response(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> Optional[ChatDocument]:
-        """
-        Respond to a single user message, appended to the message history,
-        in "chat" mode
-        Args:
-            message (str|ChatDocument): message or ChatDocument object to respond to.
-                If None, use the self.task_messages
-        Returns:
-            LLM response as a ChatDocument object
-        """
-        if self.llm is None:
-            return None
-
-        # If enabled and a tool error occurred, we recover by generating the tool in
-        # strict json mode
-        if (
-            self.tool_error
-            and self.output_format is None
-            and self._json_schema_available()
-            and self.config.strict_recovery
-        ):
-            self.tool_error = False
-            AnyTool = self._get_any_tool_message()
-            if AnyTool is None:
-                return None
-            self.set_output_format(
-                AnyTool,
-                force_tools=True,
-                use=True,
-                handle=True,
-                instructions=True,
-            )
-            recovery_message = self._strict_recovery_instructions(AnyTool)
-            augmented_message = message
-            if augmented_message is None:
-                augmented_message = recovery_message
-            elif isinstance(augmented_message, str):
-                augmented_message = augmented_message + recovery_message
-            else:
-                augmented_message.content = augmented_message.content + recovery_message
-
-            # only use the augmented message for this one response...
-            result = self.llm_response(augmented_message)
-            # ... restore the original user message so that the AnyTool recover
-            # instructions don't persist in the message history
-            # (this can cause the LLM to use the AnyTool directly as a tool)
-            if message is None:
-                self.delete_last_message(role=Role.USER)
-            else:
-                msg = message if isinstance(message, str) else message.content
-                self.update_last_message(msg, role=Role.USER)
-            return result
-
-        hist, output_len = self._prep_llm_messages(message)
-        if len(hist) == 0:
-            return None
-        tool_choice = (
-            "auto"
-            if isinstance(message, str)
-            else (message.oai_tool_choice if message is not None else "auto")
-        )
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
-            try:
-                response = self.llm_response_messages(hist, output_len, tool_choice)
-            except openai.BadRequestError as e:
-                if self.any_strict:
-                    self.disable_strict = True
-                    self.set_output_format(None)
-                    logging.warning(
-                        f"""
-                        OpenAI BadRequestError raised with strict mode enabled.
-                        Message: {e.message}
-                        Disabling strict mode and retrying.
-                        """
-                    )
-                    return self.llm_response(message)
-                else:
-                    raise e
-        self.message_history.extend(ChatDocument.to_LLMMessage(response))
-        response.metadata.msg_idx = len(self.message_history) - 1
-        response.metadata.agent_id = self.id
-        if isinstance(message, ChatDocument):
-            self._reduce_raw_tool_results(message)
-        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
-        response.metadata.tool_ids = (
-            []
-            if isinstance(message, str)
-            else message.metadata.tool_ids if message is not None else []
-        )
-
-        return response
-
-    async def llm_response_async(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> Optional[ChatDocument]:
-        """
-        Async version of `llm_response`. See there for details.
-        """
-        if self.llm is None:
-            return None
-
-        # If enabled and a tool error occurred, we recover by generating the tool in
-        # strict json mode
-        if (
-            self.tool_error
-            and self.output_format is None
-            and self._json_schema_available()
-            and self.config.strict_recovery
-        ):
-            self.tool_error = False
-            AnyTool = self._get_any_tool_message()
-            self.set_output_format(
-                AnyTool,
-                force_tools=True,
-                use=True,
-                handle=True,
-                instructions=True,
-            )
-            recovery_message = self._strict_recovery_instructions(AnyTool)
-            augmented_message = message
-            if augmented_message is None:
-                augmented_message = recovery_message
-            elif isinstance(augmented_message, str):
-                augmented_message = augmented_message + recovery_message
-            else:
-                augmented_message.content = augmented_message.content + recovery_message
-
-            # only use the augmented message for this one response...
-            result = self.llm_response(augmented_message)
-            # ... restore the original user message so that the AnyTool recover
-            # instructions don't persist in the message history
-            # (this can cause the LLM to use the AnyTool directly as a tool)
-            if message is None:
-                self.delete_last_message(role=Role.USER)
-            else:
-                msg = message if isinstance(message, str) else message.content
-                self.update_last_message(msg, role=Role.USER)
-            return result
-
-        hist, output_len = self._prep_llm_messages(message)
-        if len(hist) == 0:
-            return None
-        tool_choice = (
-            "auto"
-            if isinstance(message, str)
-            else (message.oai_tool_choice if message is not None else "auto")
-        )
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
-            try:
-                response = await self.llm_response_messages_async(
-                    hist, output_len, tool_choice
-                )
-            except openai.BadRequestError as e:
-                if self.any_strict:
-                    self.disable_strict = True
-                    self.set_output_format(None)
-                    logging.warning(
-                        f"""
-                        OpenAI BadRequestError raised with strict mode enabled.
-                        Message: {e.message}
-                        Disabling strict mode and retrying.
-                        """
-                    )
-                    return await self.llm_response_async(message)
-                else:
-                    raise e
-        self.message_history.extend(ChatDocument.to_LLMMessage(response))
-        response.metadata.msg_idx = len(self.message_history) - 1
-        response.metadata.agent_id = self.id
-        if isinstance(message, ChatDocument):
-            self._reduce_raw_tool_results(message)
-        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
-        response.metadata.tool_ids = (
-            []
-            if isinstance(message, str)
-            else message.metadata.tool_ids if message is not None else []
-        )
-
-        return response
-
-    def init_message_history(self) -> None:
-        """
-        Initialize the message history with the system message and user message
-        """
-        self.message_history = [self._create_system_and_tools_message()]
-        if self.user_message:
-            self.message_history.append(
-                LLMMessage(role=Role.USER, content=self.user_message)
-            )
-
-    def _prep_llm_messages(
-        self,
-        message: Optional[str | ChatDocument] = None,
-        truncate: bool = True,
-    ) -> Tuple[List[LLMMessage], int]:
-        """
-        Prepare messages to be sent to self.llm_response_messages,
-            which is the main method that calls the LLM API to get a response.
-            If desired output tokens + message history exceeds the model context length,
-            then first the max output tokens is reduced to fit, and if that is not
-            possible, older messages may be truncated to accommodate at least
-            self.config.llm.min_output_tokens of output.
-
-        Returns:
-            Tuple[List[LLMMessage], int]: (messages, output_len)
-                messages = Full list of messages to send
-                output_len = max expected number of tokens in response
-        """
-
-        if (
-            not self.llm_can_respond(message)
-            or self.config.llm is None
-            or self.llm is None
-        ):
-            return [], 0
-
-        if message is None and len(self.message_history) > 0:
-            # this means agent has been used to get LLM response already,
-            # and so the last message is an "assistant" response.
-            # We delete this last assistant response and re-generate it.
-            self.clear_history(-1)
-            logger.warning(
-                "Re-generating the last assistant response since message is None"
-            )
-
-        if len(self.message_history) == 0:
-            # initial messages have not yet been loaded, so load them
-            self.init_message_history()
-
-            # for debugging, show the initial message history
-            if settings.debug:
-                print(
-                    f"""
-                [grey37]LLM Initial Msg History:
-                {escape(self.message_history_str())}
-                [/grey37]
-                """
-                )
-        else:
-            assert self.message_history[0].role == Role.SYSTEM
-            # update the system message with the latest tool instructions
-            self.message_history[0] = self._create_system_and_tools_message()
-
-        if message is not None:
-            if (
-                isinstance(message, str)
-                or message.id() != self.message_history[-1].chat_document_id
-            ):
-                # either the message is a str, or it is a fresh ChatDocument
-                # different from the last message in the history
-                llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
-                llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
-                # Canonicalize retained whitespace-only results before token counting.
-                for llm_msg in llm_msgs:
-                    if (
-                        _is_identified_result(llm_msg)
-                        and llm_msg.content is not None
-                        and llm_msg.content.strip() == ""
-                    ):
-                        llm_msg.content = ""
-                if len(llm_msgs) == 0:
-                    return [], 0
-                # process tools if any
-                done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
-                self.oai_tool_calls = [
-                    t for t in self.oai_tool_calls if t.id not in done_tools
-                ]
-                self.message_history.extend(llm_msgs)
-
-        hist = self.message_history
-        output_len = self.config.llm.model_max_output_tokens
-        if (
-            truncate
-            and output_len > self.llm.chat_context_length() - self.chat_num_tokens(hist)
-        ):
-            # chat + output > max context length,
-            # so first try to shorten requested output len to fit;
-            # use an extra margin of CHAT_HISTORY_BUFFER tokens
-            # in case our calcs are off (and to allow for some extra tokens)
-            output_len = (
-                self.llm.chat_context_length()
-                - self.chat_num_tokens(hist)
-                - CHAT_HISTORY_BUFFER
-            )
-            if output_len > self.config.llm.min_output_tokens:
-                logger.debug(
-                    f"""
-                    Chat Model context length is {self.llm.chat_context_length()},
-                    but the current message history is {self.chat_num_tokens(hist)}
-                    tokens long, which does not allow
-                    {self.config.llm.model_max_output_tokens} output tokens.
-                    Therefore we reduced `max_output_tokens` to {output_len} tokens,
-                    so they can fit within the model's context length
-                    """
-                )
-            else:
-                # unacceptably small output len, so compress early parts of
-                # conversation history based on the configured strategy
-                strategy = self.config.context_overflow_strategy
-
-                if strategy == "truncate":
-                    # Truncate content of individual messages while preserving
-                    # the message sequence (important for LLM APIs that require
-                    # alternating USER/ASSISTANT messages)
-                    msg_idx_to_compress = 1  # don't touch system msg
-                    # we will try compressing msg indices up to but not including
-                    # last user msg
-                    last_msg_idx_to_compress = (
-                        self.last_message_idx_with_role(
-                            role=Role.USER,
-                        )
-                        - 1
-                    )
-                    n_truncated = 0
-                    _target_tokens = (
-                        self.llm.chat_context_length()
-                        - self.config.llm.min_output_tokens
-                        - CHAT_HISTORY_BUFFER
-                    )
-                    # Truncation floor: never reduce a message's content below
-                    # this many tokens.
-                    _min_keep_tokens = 30
-                    _truncation_warning = "... [Contents truncated!]"
-
-                    def _content_tokens(text: str | None) -> int:
-                        """Token count of message *content* only.
-
-                        `truncate_message` only trims `message.content`, so
-                        using the full `_message_num_tokens` (which includes
-                        attachment payloads) would inflate the count and make
-                        the keep-target too large to ever converge, for
-                        messages carrying file attachments.
-                        """
-                        return (
-                            self.parser.num_tokens(text or "")
-                            if self.parser is not None
-                            # approx fallback, matches truncate_message
-                            else len(text or "") // 4
-                        )
-
-                    # Account for the warning that truncate_message appends
-                    # ("\n" + warning), so the final token count of a
-                    # truncated message does not exceed its keep-target.
-                    _warning_tokens = _content_tokens("\n" + _truncation_warning)
-                    # NOTE: loop termination is guaranteed:
-                    # msg_idx_to_compress strictly increases every iteration
-                    # (truncate or skip), and once it exceeds
-                    # last_msg_idx_to_compress a ValueError is raised. (The
-                    # token count need not decrease every iteration, so
-                    # termination rests on the index advancing.)
-                    while self.chat_num_tokens(hist) > _target_tokens:
-                        if msg_idx_to_compress > last_msg_idx_to_compress:
-                            # We want to preserve the first message (typically
-                            # system msg) and last message (user msg).
-                            raise ValueError(
-                                """
-                            The (message history + max_output_tokens) is longer than the
-                            max chat context length of this model, and we have tried
-                            reducing the requested max output tokens, as well as
-                            truncating early parts of the message history, to
-                            accommodate the model context length, but we have run out
-                            of msgs to truncate.
-
-                            HINT: In the `llm` field of your `ChatAgentConfig` object,
-                            which is of type `LLMConfig/OpenAIGPTConfig`, try
-                            - increasing `chat_context_length`
-                                (if accurate for the model), or
-                            - decreasing `max_output_tokens`
-                            """
-                            )
-                        _msg_tokens = _content_tokens(hist[msg_idx_to_compress].content)
-                        if _msg_tokens <= _min_keep_tokens + _warning_tokens:
-                            # Truncating this message cannot shrink the total:
-                            # its content is already at/below the keep-floor
-                            # plus the appended warning; leave it intact.
-                            msg_idx_to_compress += 1
-                            continue
-                        n_truncated += 1
-                        # Distribute the current excess evenly across the
-                        # remaining *compressible* messages, so each retains
-                        # as much content as possible instead of being
-                        # collapsed to the fixed 30-token floor. The excess is
-                        # recomputed every iteration, so the distribution
-                        # self-corrects as we move forward through the
-                        # history.
-                        _current_excess = self.chat_num_tokens(hist) - _target_tokens
-                        # Shrink capacity of each *later* message in the
-                        # compressible range: its content above the floor (net
-                        # of the appended warning). Non-positive entries are
-                        # the tiny messages the skip-check above will leave
-                        # untouched; they must not dilute the even share, so
-                        # only messages with positive capacity count toward
-                        # the denominator (plus this message, which passed the
-                        # skip-check and is therefore compressible).
-                        _later_capacities = [
-                            _content_tokens(m.content)
-                            - _min_keep_tokens
-                            - _warning_tokens
-                            for m in hist[
-                                msg_idx_to_compress + 1 : last_msg_idx_to_compress + 1
-                            ]
-                        ]
-                        _n_remaining = 1 + sum(1 for c in _later_capacities if c > 0)
-                        _even_share = math.ceil(_current_excess / _n_remaining)
-                        # Later messages can shed at most their capacity; this
-                        # message must absorb whatever they cannot, so that
-                        # this single forward pass reaches the target whenever
-                        # that is possible at all.
-                        _later_capacity = sum(c for c in _later_capacities if c > 0)
-                        _reduction = max(_even_share, _current_excess - _later_capacity)
-                        # Extra 2-token slack: re-encoding truncated content
-                        # plus the appended warning can merge/split tokens at
-                        # the boundary, so aim slightly below the target to
-                        # keep the achieved reduction from falling short.
-                        _keep_tokens = max(
-                            _min_keep_tokens,
-                            _msg_tokens - _reduction - _warning_tokens - 2,
-                        )
-                        # compress the msg at idx `msg_idx_to_compress`
-                        hist[msg_idx_to_compress] = self.truncate_message(
-                            msg_idx_to_compress,
-                            tokens=_keep_tokens,
-                            warning=_truncation_warning,
-                        )
-                        msg_idx_to_compress += 1
-
-                    output_len = min(
-                        self.config.llm.model_max_output_tokens,
-                        self.llm.chat_context_length()
-                        - self.chat_num_tokens(hist)
-                        - CHAT_HISTORY_BUFFER,
-                    )
-                    if output_len < self.config.llm.min_output_tokens:
-                        raise ValueError(
-                            f"""
-                            Tried to shorten prompt history for chat mode
-                            but even after truncating all messages except system msg
-                            and last (user) msg, the history token len
-                            {self.chat_num_tokens(hist)} is too long to accommodate
-                            the desired minimum output tokens
-                            {self.config.llm.min_output_tokens} within the
-                            model's context length {self.llm.chat_context_length()}.
-                            Please try shortening the system msg or user prompts,
-                            or adjust `config.llm.min_output_tokens` to be smaller.
-                            """
-                        )
-                    else:
-                        # we MUST have truncated at least one msg
-                        msg_tokens = self.chat_num_tokens()
-                        logger.warning(
-                            f"""
-                        Chat Model context length is {self.llm.chat_context_length()}
-                        tokens, but the current message history is {msg_tokens} tokens
-                        long, which does not allow
-                        {self.config.llm.model_max_output_tokens} output tokens.
-                        Therefore we truncated the first {n_truncated} messages
-                        in the conversation history so that history token
-                        length is reduced to {self.chat_num_tokens(hist)}, and
-                        we use `max_output_tokens = {output_len}`,
-                        so they can fit within the model's context length
-                        of {self.llm.chat_context_length()} tokens.
-                        """
-                        )
-
-                else:  # strategy == "drop_turns"
-                    # Drop complete conversation turns. A complete turn is defined
-                    # as a USER message followed by all messages until the next
-                    # USER message. This is more aggressive but cleaner for voice
-                    # agents with limited context.
-                    n_dropped_turns = 0
-                    while (
-                        self.chat_num_tokens(hist)
-                        > self.llm.chat_context_length()
-                        - self.config.llm.min_output_tokens
-                        - CHAT_HISTORY_BUFFER
-                    ):
-                        # Find the last USER message index
-                        last_user_idx = self.last_message_idx_with_role(role=Role.USER)
-                        if last_user_idx == -1:
-                            break
-
-                        # Find the first complete turn to drop (skip system message)
-                        first_user_idx = -1
-                        for i in range(1, last_user_idx):
-                            if hist[i].role == Role.USER:
-                                first_user_idx = i
-                                break
-                        if first_user_idx == -1:
-                            break
-
-                        # Find the end of this turn: last message before next USER
-                        next_user_idx = -1
-                        for i in range(first_user_idx + 1, last_user_idx + 1):
-                            if hist[i].role == Role.USER:
-                                next_user_idx = i
-                                break
-                        if next_user_idx == -1:
-                            break
-
-                        # Drop the turn
-                        self.clear_history(first_user_idx, next_user_idx - 1)
-                        n_dropped_turns += 1
-
-                    output_len = min(
-                        self.config.llm.model_max_output_tokens,
-                        self.llm.chat_context_length()
-                        - self.chat_num_tokens(hist)
-                        - CHAT_HISTORY_BUFFER,
-                    )
-                    if output_len < self.config.llm.min_output_tokens:
-                        raise ValueError(
-                            f"""
-                            Tried to shorten prompt history for chat mode
-                            but even after dropping complete turns except the system
-                            msg and last turn, the history token len
-                            {self.chat_num_tokens(hist)} is too long to accommodate
-                            the desired minimum output tokens
-                            {self.config.llm.min_output_tokens} within the
-                            model's context length {self.llm.chat_context_length()}.
-                            Please try shortening the system msg or user prompts,
-                            or adjust `config.llm.min_output_tokens` to be smaller.
-                            """
-                        )
-                    else:
-                        # we MUST have dropped at least one turn
-                        msg_tokens = self.chat_num_tokens()
-                        logger.warning(
-                            f"""
-                        Chat Model context length is {self.llm.chat_context_length()}
-                        tokens, but the current message history is {msg_tokens} tokens
-                        long, which does not allow
-                        {self.config.llm.model_max_output_tokens} output tokens.
-                        Therefore we dropped the first {n_dropped_turns} complete
-                        turn(s) from the conversation history so that history token
-                        length is reduced to {self.chat_num_tokens(hist)}, and
-                        we use `max_output_tokens = {output_len}`,
-                        so they can fit within the model's context length
-                        of {self.llm.chat_context_length()} tokens.
-                        """
-                        )
-
-        if isinstance(message, ChatDocument):
-            # record the position of the corresponding LLMMessage in
-            # the message_history
-            message.metadata.msg_idx = len(hist) - 1
-            message.metadata.agent_id = self.id
-        return hist, output_len
-
-    def _function_args(
-        self,
-    ) -> Tuple[
-        Optional[List[LLMFunctionSpec]],
-        str | Dict[str, str],
-        Optional[List[OpenAIToolSpec]],
-        Optional[Dict[str, Dict[str, str] | str]],
-        Optional[OpenAIJsonSchemaSpec],
-    ]:
-        """
-        Get function/tool spec/output format arguments for
-        OpenAI-compatible LLM API call
-        """
-        functions: Optional[List[LLMFunctionSpec]] = None
-        fun_call: str | Dict[str, str] = "none"
-        tools: Optional[List[OpenAIToolSpec]] = None
-        force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
-        self.any_strict = False
-        if self.config.use_functions_api and len(self.llm_functions_usable) > 0:
-            if not self.config.use_tools_api:
-                functions = [
-                    self.llm_functions_map[f] for f in self.llm_functions_usable
-                ]
-                fun_call = (
-                    "auto"
-                    if self.llm_function_force is None
-                    else self.llm_function_force
-                )
-            else:
-
-                def to_maybe_strict_spec(function: str) -> OpenAIToolSpec:
-                    spec = self.llm_functions_map[function]
-                    strict = self._strict_mode_for_tool(function)
-                    if strict:
-                        self.any_strict = True
-                        strict_spec = copy.deepcopy(spec)
-                        format_schema_for_strict(strict_spec.parameters)
-                    else:
-                        strict_spec = spec
-
-                    return OpenAIToolSpec(
-                        type="function",
-                        strict=strict,
-                        function=strict_spec,
-                    )
-
-                tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
-                force_tool = (
-                    None
-                    if self.llm_function_force is None
-                    else {
-                        "type": "function",
-                        "function": {"name": self.llm_function_force["name"]},
-                    }
-                )
-        output_format = None
-        if self.output_format is not None and self._json_schema_available():
-            self.any_strict = True
-            if issubclass(self.output_format, ToolMessage) and not issubclass(
-                self.output_format, XMLToolMessage
-            ):
-                spec = self.output_format.llm_function_schema(
-                    request=True,
-                    defaults=self.config.output_format_include_defaults,
-                )
-                format_schema_for_strict(spec.parameters)
-
-                output_format = OpenAIJsonSchemaSpec(
-                    # We always require that outputs strictly match the schema
-                    strict=True,
-                    function=spec,
-                )
-            elif issubclass(self.output_format, BaseModel):
-                param_spec = self.output_format.model_json_schema()
-                format_schema_for_strict(param_spec)
-
-                output_format = OpenAIJsonSchemaSpec(
-                    # We always require that outputs strictly match the schema
-                    strict=True,
-                    function=LLMFunctionSpec(
-                        name="json_output",
-                        description="Strict Json output format.",
-                        parameters=param_spec,
-                    ),
-                )
-
-        return functions, fun_call, tools, force_tool, output_format
-
-    def llm_response_messages(
-        self,
-        messages: List[LLMMessage],
-        output_len: Optional[int] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-    ) -> ChatDocument:
-        """
-        Respond to a series of messages, e.g. with OpenAI ChatCompletion
-        Args:
-            messages: seq of messages (with role, content fields) sent to LLM
-            output_len: max number of tokens expected in response.
-                    If None, use the LLM's default model_max_output_tokens.
-        Returns:
-            Document (i.e. with fields "content", "metadata")
-        """
-        assert self.config.llm is not None and self.llm is not None
-        output_len = output_len or self.config.llm.model_max_output_tokens
-        streamer = noop_fn
-        if self.llm.get_stream():
-            streamer = self.callbacks.start_llm_stream()
-        self.llm.config.streamer = streamer
-        with ExitStack() as stack:  # for conditionally using rich spinner
-            if not self.llm.get_stream() and not settings.quiet:
-                # show rich spinner only if not streaming!
-                # (Why? b/c the intent of showing a spinner is to "show progress",
-                # and we don't need to do that when streaming, since
-                # streaming output already shows progress.)
-                cm = status(
-                    "LLM responding to messages...",
-                    log_if_quiet=False,
-                )
-                stack.enter_context(cm)
-            if self.llm.get_stream() and not settings.quiet:
-                console.print(f"[green]{self.indent}", end="")
-            functions, fun_call, tools, force_tool, output_format = (
-                self._function_args()
-            )
-            assert self.llm is not None
-            response = self.llm.chat(
-                messages,
-                output_len,
-                tools=tools,
-                tool_choice=force_tool or tool_choice,
-                functions=functions,
-                function_call=fun_call,
-                response_format=output_format,
-            )
-        if self.llm.get_stream():
-            # Create temp ChatDocument for tool check, then clean up to avoid
-            # polluting ObjectRegistry (see PR #939 discussion)
-            temp_doc = ChatDocument.from_LLMResponse(
-                response,
-                displayed=True,
-                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-            )
-            self._call_callback_with_reasoning(
-                "finish_llm_stream",
-                reasoning=response.reasoning,
-                content=response.message or "",
-                tools_content=response.tools_content(),
-                is_tool=self.has_tool_message_attempt(temp_doc),
-            )
-            ObjectRegistry.remove(temp_doc.id())
-        self.llm.config.streamer = noop_fn
-        if response.cached:
-            self.callbacks.cancel_llm_stream()
-        self._render_llm_response(response)
-        self.update_token_usage(
-            response,  # .usage attrib is updated!
-            messages,
-            self.llm.get_stream(),
-            chat=True,
-            print_response_stats=self.config.show_stats and not settings.quiet,
-        )
-        chat_doc = ChatDocument.from_LLMResponse(
-            response,
-            displayed=True,
-            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-        )
-        self.oai_tool_calls = response.oai_tool_calls or []
-        self.oai_tool_id2call.update(
-            {t.id: t for t in self.oai_tool_calls if t.id is not None}
-        )
-
-        # If using strict output format, parse the output JSON
-        self._load_output_format(chat_doc)
-
-        return chat_doc
-
-    async def llm_response_messages_async(
-        self,
-        messages: List[LLMMessage],
-        output_len: Optional[int] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-    ) -> ChatDocument:
-        """
-        Async version of `llm_response_messages`. See there for details.
-        """
-        assert self.config.llm is not None and self.llm is not None
-        output_len = output_len or self.config.llm.model_max_output_tokens
-        functions, fun_call, tools, force_tool, output_format = self._function_args()
-        assert self.llm is not None
-
-        streamer_async = async_noop_fn
-        if self.llm.get_stream():
-            streamer_async = await self.callbacks.start_llm_stream_async()
-        self.llm.config.streamer_async = streamer_async
-
-        response = await self.llm.achat(
-            messages,
-            output_len,
-            tools=tools,
-            tool_choice=force_tool or tool_choice,
-            functions=functions,
-            function_call=fun_call,
-            response_format=output_format,
-        )
-        if self.llm.get_stream():
-            # Create temp ChatDocument for tool check, then clean up to avoid
-            # polluting ObjectRegistry (see PR #939 discussion)
-            temp_doc = ChatDocument.from_LLMResponse(
-                response,
-                displayed=True,
-                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-            )
-            self._call_callback_with_reasoning(
-                "finish_llm_stream",
-                reasoning=response.reasoning,
-                content=response.message or "",
-                tools_content=response.tools_content(),
-                is_tool=self.has_tool_message_attempt(temp_doc),
-            )
-            ObjectRegistry.remove(temp_doc.id())
-        self.llm.config.streamer_async = async_noop_fn
-        if response.cached:
-            self.callbacks.cancel_llm_stream()
-        self._render_llm_response(response)
-        self.update_token_usage(
-            response,  # .usage attrib is updated!
-            messages,
-            self.llm.get_stream(),
-            chat=True,
-            print_response_stats=self.config.show_stats and not settings.quiet,
-        )
-        chat_doc = ChatDocument.from_LLMResponse(
-            response,
-            displayed=True,
-            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-        )
-        self.oai_tool_calls = response.oai_tool_calls or []
-        self.oai_tool_id2call.update(
-            {t.id: t for t in self.oai_tool_calls if t.id is not None}
-        )
-
-        # If using strict output format, parse the output JSON
-        self._load_output_format(chat_doc)
-
-        return chat_doc
-
-    def _call_callback_with_reasoning(
-        self,
-        callback_name: str,
-        reasoning: str,
-        **kwargs: Any,
-    ) -> None:
-        """
-        Call a callback method, only passing 'reasoning' if it accepts it.
-
-        This provides backward compatibility for custom callbacks that don't
-        have the 'reasoning' parameter in their signature.
-
-        Args:
-            callback_name: Name of the callback method (e.g., 'show_llm_response')
-            reasoning: The reasoning content to pass if supported
-            **kwargs: Other arguments to pass to the callback
-        """
-        callback = getattr(self.callbacks, callback_name, None)
-        if callback is None:
-            return
-
-        # Check if callback accepts 'reasoning' param or **kwargs
-        try:
-            sig = inspect.signature(callback)
-            params = sig.parameters
-            accepts_reasoning = "reasoning" in params or any(
-                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-            )
-        except (ValueError, TypeError):
-            # If we can't inspect the signature, assume it doesn't accept reasoning
-            accepts_reasoning = False
-
-        if accepts_reasoning:
-            callback(reasoning=reasoning, **kwargs)
-        else:
-            callback(**kwargs)
-
-    def _render_llm_response(
-        self, response: ChatDocument | LLMResponse, citation_only: bool = False
-    ) -> None:
-        is_cached = (
-            response.cached
-            if isinstance(response, LLMResponse)
-            else response.metadata.cached
-        )
-        if self.llm is None:
-            return
-        if not citation_only and (not self.llm.get_stream() or is_cached):
-            # We would have already displayed the msg "live" ONLY if
-            # streaming was enabled, AND we did not find a cached response.
-            # If we are here, it means the response has not yet been displayed.
-            cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
-            # Track whether we created a temp ChatDocument for cleanup
-            is_temp_doc = isinstance(response, LLMResponse)
-            chat_doc = (
-                response
-                if isinstance(response, ChatDocument)
-                else ChatDocument.from_LLMResponse(
-                    response,
-                    displayed=True,
-                    recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-                )
-            )
-            # TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
-            if not settings.quiet:
-                print(cached + "[green]" + escape(str(response)))
-            if isinstance(response, LLMResponse):
-                content = response.message or ""
-                tools_content = response.tools_content()
-            else:
-                content = response.content
-                tools_content = ""
-            reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
-            self._call_callback_with_reasoning(
-                "show_llm_response",
-                reasoning=reasoning,
-                content=content,
-                tools_content=tools_content,
-                is_tool=self.has_tool_message_attempt(chat_doc),
-                cached=is_cached,
-            )
-            # Clean up temp ChatDocument to avoid polluting ObjectRegistry
-            if is_temp_doc:
-                ObjectRegistry.remove(chat_doc.id())
-        if isinstance(response, LLMResponse):
-            # we are in the context immediately after an LLM responded,
-            # we won't have citations yet, so we're done
-            return
-        if response.metadata.has_citation:
-            citation = (
-                response.metadata.source_content
-                if self.config.full_citations
-                else response.metadata.source
-            )
-            if not settings.quiet:
-                print("[grey37]SOURCES:\n" + escape(citation) + "[/grey37]")
-            self._call_callback_with_reasoning(
-                "show_llm_response",
-                reasoning="",  # Citations don't have reasoning
-                content=str(citation),
-                tools_content="",
-                is_tool=False,
-                cached=False,
-                language="text",
-            )
-
-    def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument:
-        """
-        Get LLM response to `prompt` (which presumably includes the `message`
-        somewhere, along with possible large "context" passages),
-        but only include `message` as the USER message, and not the
-        full `prompt`, in the message history.
-        Args:
-            message: the original, relatively short, user request or query
-            prompt: the full prompt potentially containing `message` plus context
-
-        Returns:
-            Document object containing the response.
-        """
-        # we explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
-        self.update_last_message(message, role=Role.USER)
-        return answer_doc
-
-    async def _llm_response_temp_context_async(
-        self, message: str, prompt: str
-    ) -> ChatDocument:
-        """
-        Async version of `_llm_response_temp_context`. See there for details.
-        """
-        # we explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            answer_doc = cast(
-                ChatDocument,
-                await ChatAgent.llm_response_async(self, prompt),
-            )
-        self.update_last_message(message, role=Role.USER)
-        return answer_doc
-
-    def llm_response_forget(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> ChatDocument:
-        """
-        LLM Response to single message, and restore message_history.
-        In effect a "one-off" message & response that leaves agent
-        message history state intact.
-
-        Args:
-            message (str|ChatDocument): message to respond to.
-
-        Returns:
-            A Document object with the response.
-
-        """
-        # explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        n_msgs = len(self.message_history)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            response = cast(ChatDocument, ChatAgent.llm_response(self, message))
-        # If there is a response, then we will have two additional
-        # messages in the message history, i.e. the user message and the
-        # assistant response. We want to (carefully) remove these two messages.
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-
-        # If using strict output format, parse the output JSON
-        self._load_output_format(response)
-
-        return response
-
-    async def llm_response_forget_async(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> ChatDocument:
-        """
-        Async version of `llm_response_forget`. See there for details.
-        """
-        # explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        n_msgs = len(self.message_history)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            response = cast(
-                ChatDocument, await ChatAgent.llm_response_async(self, message)
-            )
-        # If there is a response, then we will have two additional
-        # messages in the message history, i.e. the user message and the
-        # assistant response. We want to (carefully) remove these two messages.
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-        return response
-
-    def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int:
-        """
-        Total number of tokens in the message history so far.
-
-        Args:
-            messages: if provided, compute the number of tokens in this list of
-                messages, rather than the current message history.
-        Returns:
-            int: number of tokens in message history
-        """
-        if self.parser is None:
-            raise ValueError(
-                "ChatAgent.parser is None. "
-                "You must set ChatAgent.parser "
-                "before calling chat_num_tokens()."
-            )
-        hist = messages if messages is not None else self.message_history
-        return sum([self._message_num_tokens(m) for m in hist])
-
-    def _message_num_tokens(self, message: LLMMessage) -> int:
-        """Count tokens for a message, including serialized user attachments."""
-        if self.parser is None:
-            raise ValueError(
-                "ChatAgent.parser is None. "
-                "You must set ChatAgent.parser "
-                "before calling _message_num_tokens()."
-            )
-
-        return self.parser.num_tokens(
-            message.content or ""
-        ) + self._attachment_num_tokens(message)
-
-    def _attachment_num_tokens(self, message: LLMMessage) -> int:
-        """
-        Estimate attachment contribution using the serialized payload
-        that is sent in the API request for user messages.
-        """
-        if self.parser is None or message.role != Role.USER or len(message.files) == 0:
-            return 0
-
-        model = self._chat_model_name_for_attachments()
-        return sum(
-            self.parser.num_tokens(
-                json.dumps(
-                    attachment.to_dict(model),
-                    separators=(",", ":"),
-                    sort_keys=True,
-                )
-            )
-            for attachment in message.files
-        )
-
-    def _chat_model_name_for_attachments(self) -> str:
-        """Return the model name used for attachment serialization."""
-        if self.llm is None:
-            return self.config.llm.chat_model if self.config.llm is not None else ""
-
-        return cast(
-            str,
-            getattr(
-                self.llm,
-                "chat_model_orig",
-                getattr(
-                    getattr(self.llm, "config", None),
-                    "chat_model",
-                    self.config.llm.chat_model if self.config.llm is not None else "",
-                ),
-            ),
-        )
-
-    def message_history_str(self, i: Optional[int] = None) -> str:
-        """
-        Return a string representation of the message history
-        Args:
-            i: if provided, return only the i-th message when i is postive,
-                or last k messages when i = -k.
-        Returns:
-        """
-        if i is None:
-            return "\n".join([str(m) for m in self.message_history])
-        elif i > 0:
-            return str(self.message_history[i])
-        else:
-            return "\n".join([str(m) for m in self.message_history[i:]])
-
-    def __del__(self) -> None:
-        """
-        Cleanup method called when the ChatAgent is garbage collected.
-        Note: We don't close LLM clients here because they may be shared
-        across multiple agents when client caching is enabled.
-        The clients are managed centrally and cleaned up via atexit hooks.
-        """
-        # Previously we closed clients here, but this caused issues when
-        # multiple agents shared the same cached client instance.
-        # Clients are now managed centrally in langroid.language_models.client_cache
-        pass
-</file>
-
 <file path="langroid/language_models/openai_gpt.py">
 import hashlib
 import json
@@ -64832,9 +62142,2760 @@ class OpenAIGPT(LanguageModel):
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.16.0
+  rev: v0.16.4
   hooks:
     - id: ruff
+</file>
+
+<file path="langroid/agent/chat_agent.py">
+import base64
+import copy
+import inspect
+import json
+import logging
+import math
+import textwrap
+from contextlib import ExitStack
+from inspect import isclass
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Self,
+    Set,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+import openai
+from pydantic import BaseModel, ValidationError
+from pydantic.fields import ModelPrivateAttr
+from rich import print
+from rich.console import Console
+from rich.markup import escape
+
+from langroid.agent.base import (
+    Agent,
+    AgentConfig,
+    SearchForTools,
+    async_noop_fn,
+    noop_fn,
+)
+from langroid.agent.chat_document import ChatDocument
+from langroid.agent.tool_message import (
+    ToolMessage,
+    format_schema_for_strict,
+)
+from langroid.agent.xml_tool_message import XMLToolMessage
+from langroid.language_models.base import (
+    LLMFunctionCall,
+    LLMFunctionSpec,
+    LLMMessage,
+    LLMResponse,
+    OpenAIJsonSchemaSpec,
+    OpenAIToolSpec,
+    Role,
+    StreamingIfAllowed,
+    ToolChoiceTypes,
+)
+from langroid.language_models.openai_gpt import OpenAIGPT
+from langroid.mytypes import Entity, NonToolAction
+from langroid.parsing.file_attachment import FileAttachment
+from langroid.utils.configuration import settings
+from langroid.utils.object_registry import ObjectRegistry
+from langroid.utils.output import status
+from langroid.utils.pydantic_utils import PydanticWrapper, get_pydantic_wrapper
+from langroid.utils.types import is_callable
+
+console = Console()
+
+logger = logging.getLogger(__name__)
+
+# Stable origin sentinel for the dynamically generated strict-recovery AnyTool
+# class ("tool_or_function"): a fresh class is built per call (its tool-union
+# type varies), so re-registration must be recognized as the same logical tool.
+_ANY_TOOL_MESSAGE_ORIGIN: Any = object()
+
+# Safety margin (in tokens) subtracted from the model context length when
+# shrinking chat history and/or the requested output length to fit, in case
+# our token-count estimates are off.
+CHAT_HISTORY_BUFFER = 300
+
+
+def _reject_json_constant(constant: str) -> None:
+    """Reject JavaScript numeric constants that are not valid JSON."""
+    raise ValueError(f"non-JSON numeric constant: {constant}")
+
+
+def _parse_json_float(value: str) -> float:
+    """Parse a JSON float while rejecting exponent overflow."""
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"non-finite JSON number: {value}")
+    return parsed
+
+
+def _is_identified_result(message: LLMMessage) -> bool:
+    """Whether a TOOL/FUNCTION result has its identifier and no call payload.
+
+    Such results must survive even with empty content so their calls can be
+    marked complete (issue #1063).
+    """
+    has_identifier = (
+        message.role == Role.TOOL and bool((message.tool_call_id or "").strip())
+    ) or (message.role == Role.FUNCTION and bool((message.name or "").strip()))
+    return has_identifier and message.function_call is None and not message.tool_calls
+
+
+def _llm_message_has_payload(message: LLMMessage) -> bool:
+    """Whether a message has the fields required for a valid history entry."""
+    return (
+        (message.content or "").strip() != ""
+        or message.function_call is not None
+        or bool(message.tool_calls)
+        or _is_identified_result(message)
+    )
+
+
+class ChatAgentConfig(AgentConfig):
+    """
+    Configuration for ChatAgent
+
+    Attributes:
+        system_message: system message to include in message sequence
+             (typically defines role and task of agent).
+             Used only if `task` is not specified in the constructor.
+        user_message: user message to include in message sequence.
+             Used only if `task` is not specified in the constructor.
+        use_tools: whether to use our own ToolMessages mechanism
+        handle_llm_no_tool (Any): desired agent_response when
+            LLM generates non-tool msg.
+        use_functions_api: whether to use functions/tools native to the LLM API
+                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
+        use_tools_api: When `use_functions_api` is True, if this is also True,
+            the OpenAI tool-call API is used, rather than the older/deprecated
+            function-call API. However the tool-call API has some tricky aspects,
+            hence we set this to False by default.
+        strict_recovery: whether to enable strict schema recovery when there
+            is a tool-generation error.
+        enable_orchestration_tool_handling: whether to enable handling of orchestration
+            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
+        output_format: When supported by the LLM (certain OpenAI LLMs
+            and local LLMs served by providers such as vLLM), ensures
+            that the output is a JSON matching the corresponding
+            schema via grammar-based decoding
+        handle_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for handling".
+        use_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for use" (by LLM) and
+            instructions on using T are added to the system message.
+        instructions_output_format: Controls whether we generate instructions for
+            `output_format` in the system message.
+        use_tools_on_output_format: Controls whether to automatically switch
+            to the Langroid-native tools mechanism when `output_format` is set.
+            Note that LLMs may generate tool calls which do not belong to
+            `output_format` even when strict JSON mode is enabled, so this should be
+            enabled when such tool calls are not desired.
+        output_format_include_defaults: Whether to include fields with default arguments
+            in the output schema
+        full_citations: Whether to show source reference citation + content for each
+            citation, or just the main reference citation.
+        search_for_tools_everywhere: Whether to search for tools everywhere,
+            or only in specific LLM response elements based on use_tools /
+            use_functions_api / use_tools_api config settings.
+        recognize_recipient_in_content: Whether to parse LLM response text content
+            for recipient routing patterns, specifically:
+            - ``TO[<recipient>]:<content>`` addressing format, and
+            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
+            When False, only structured routing via function_call/tool_call
+            ``recipient`` fields is recognized. Default is True.
+            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
+            which controls Task-level signals like DONE, PASS, and SEND_TO.
+            To fully disable all text-based routing, set both to False.
+        context_overflow_strategy: Strategy for handling context overflow when
+            message history exceeds model context length. Options:
+            - "truncate": Truncate content of early messages (preserves all messages
+              but with shortened content). This maintains the message sequence.
+            - "drop_turns": Drop complete conversation turns (USER + all responses
+              until next USER). More aggressive but cleaner for voice agents.
+            Default is "truncate" for backward compatibility.
+    """
+
+    system_message: str = "You are a helpful assistant."
+    user_message: Optional[str] = None
+    handle_llm_no_tool: Any = None
+    use_tools: bool = True
+    use_functions_api: bool = False
+    use_tools_api: bool = True
+    strict_recovery: bool = True
+    enable_orchestration_tool_handling: bool = True
+    output_format: Optional[type] = None
+    handle_output_format: bool = True
+    use_output_format: bool = True
+    instructions_output_format: bool = True
+    output_format_include_defaults: bool = True
+    use_tools_on_output_format: bool = True
+    full_citations: bool = True  # show source + content for each citation?
+    search_for_tools_everywhere: bool = True
+    recognize_recipient_in_content: bool = True
+    context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
+
+    def _set_fn_or_tools(self) -> None:
+        """
+        Enable Langroid Tool or OpenAI-like fn-calling,
+        depending on config settings.
+        """
+        if not self.use_functions_api or not self.use_tools:
+            return
+        if self.use_functions_api and self.use_tools:
+            logger.debug(
+                """
+                You have enabled both `use_tools` and `use_functions_api`.
+                Setting `use_functions_api` to False.
+                """
+            )
+            self.use_tools = True
+            self.use_functions_api = False
+
+
+class ChatAgent(Agent):
+    """
+    Chat Agent interacting with external env
+    (could be human, or external tools).
+    The agent (the LLM actually) is provided with an optional "Task Spec",
+    which is a sequence of `LLMMessage`s. These are used to initialize
+    the `task_messages` of the agent.
+    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
+    The `Agent` class mainly exists to hold various common methods and attributes.
+    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
+    `llm_response` method uses "chat mode" API (i.e. one that takes a
+    message sequence rather than a single message),
+    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
+    that takes a single message).
+    """
+
+    def __init__(
+        self,
+        config: ChatAgentConfig = ChatAgentConfig(),
+        task: Optional[List[LLMMessage]] = None,
+    ):
+        """
+        Chat-mode agent initialized with task spec as the initial message sequence
+        Args:
+            config: settings for the agent
+
+        """
+        super().__init__(config)
+        self.config: ChatAgentConfig = config
+        self.config._set_fn_or_tools()
+        self.message_history: List[LLMMessage] = []
+        # emit the attachment-token-estimate warning at most once per agent
+        self._attachment_tokens_warned: bool = False
+        self.init_state()
+        # An agent's "task" is defined by a system msg and an optional user msg;
+        # These are "priming" messages that kick off the agent's conversation.
+        self.system_message: str = self.config.system_message
+        self.user_message: str | None = self.config.user_message
+
+        if task is not None:
+            # if task contains a system msg, we override the config system msg
+            if len(task) > 0 and task[0].role == Role.SYSTEM:
+                self.system_message = task[0].content or ""
+            # if task contains a user msg, we override the config user msg
+            if len(task) > 1 and task[1].role == Role.USER:
+                self.user_message = task[1].content
+
+        # system-level instructions for using tools/functions:
+        # We maintain these as tools/functions are enabled/disabled,
+        # and whenever an LLM response is sought, these are used to
+        # recreate the system message (via `_create_system_and_tools_message`)
+        # each time, so it reflects the current set of enabled tools/functions.
+        # (a) these are general instructions on using certain tools/functions,
+        #   if they are specified in a ToolMessage class as a classmethod `instructions`
+        self.system_tool_instructions: str = ""
+        # (b) these are only for the builtin in Langroid TOOLS mechanism:
+        self.system_tool_format_instructions: str = ""
+
+        self.llm_functions_map: Dict[str, LLMFunctionSpec] = {}
+        self.llm_functions_handled: Set[str] = set()
+        self.llm_functions_usable: Set[str] = set()
+        self.llm_function_force: Optional[Dict[str, str]] = None
+
+        self.output_format: Optional[type[ToolMessage | BaseModel]] = None
+
+        self.saved_requests_and_tool_setings = self._requests_and_tool_settings()
+        # This variable is not None and equals a `ToolMessage` T, if and only if:
+        # (a) T has been set as the output_format of this agent, AND
+        # (b) T has been "enabled for use" ONLY for enforcing this output format, AND
+        # (c) T has NOT been explicitly "enabled for use" by this Agent.
+        self.enabled_use_output_format: Optional[type[ToolMessage]] = None
+        # As above but deals with "enabled for handling" instead of "enabled for use".
+        self.enabled_handling_output_format: Optional[type[ToolMessage]] = None
+        if config.output_format is not None:
+            self.set_output_format(config.output_format)
+        # instructions specifically related to enforcing `output_format`
+        self.output_format_instructions = ""
+
+        # controls whether to disable strict schemas for this agent if
+        # strict mode causes exception
+        self.disable_strict = False
+        # Tracks whether any strict tool is enabled; used to determine whether to set
+        # `self.disable_strict` on an exception
+        self.any_strict = False
+        # Tracks the set of tools on which we force-disable strict decoding
+        self.disable_strict_tools_set: set[str] = set()
+
+        # search for tools according to the agent configuration
+        if not config.search_for_tools_everywhere:
+            if config.use_functions_api:
+                if config.use_tools_api:
+                    self.search_for_tools = {SearchForTools.TOOLS.value}
+                else:
+                    self.search_for_tools = {SearchForTools.FUNCTIONS.value}
+            else:
+                self.search_for_tools = {SearchForTools.CONTENT.value}
+
+        if self.config.enable_orchestration_tool_handling:
+            # Only enable HANDLING by `agent_response`, NOT LLM generation of these.
+            # This is useful where tool-handlers or agent_response generate these
+            # tools, and need to be handled.
+            # We don't want enable orch tool GENERATION by default, since that
+            # might clutter-up the LLM system message unnecessarily.
+            from langroid.agent.tools.orchestration import (
+                AgentDoneTool,
+                AgentSendTool,
+                DonePassTool,
+                DoneTool,
+                ForwardTool,
+                PassTool,
+                ResultTool,
+                SendTool,
+            )
+
+            self.enable_message(ForwardTool, use=False, handle=True)
+            self.enable_message(DoneTool, use=False, handle=True)
+            self.enable_message(AgentDoneTool, use=False, handle=True)
+            self.enable_message(PassTool, use=False, handle=True)
+            self.enable_message(DonePassTool, use=False, handle=True)
+            self.enable_message(SendTool, use=False, handle=True)
+            self.enable_message(AgentSendTool, use=False, handle=True)
+            self.enable_message(ResultTool, use=False, handle=True)
+
+    def init_state(self) -> None:
+        """
+        Initialize the state of the agent. Just conversation state here,
+        but subclasses can override this to initialize other state.
+        """
+        super().init_state()
+        self.clear_history(0)
+        self.clear_dialog()
+
+    @staticmethod
+    def from_id(id: str) -> "ChatAgent":
+        """
+        Get an agent from its ID
+        Args:
+            agent_id (str): ID of the agent
+        Returns:
+            ChatAgent: The agent with the given ID
+        """
+        return cast(ChatAgent, Agent.from_id(id))
+
+    def clone(self, i: int = 0) -> "ChatAgent":
+        """Create i'th clone of this agent, ensuring tool use/handling is cloned.
+        Important: We assume all member variables are in the __init__ method here
+        and in the Agent class.
+        TODO: We are attempting to clone an agent after its state has been
+        changed in possibly many ways. Below is an imperfect solution. Caution advised.
+        Revisit later.
+        """
+        agent_cls = type(self)
+        # Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
+        # instead of deepcopy which loses subclass information
+        config_copy = self.config.model_copy(deep=True)
+        config_copy.name = f"{config_copy.name}-{i}"
+        new_agent = agent_cls(config_copy)
+        new_agent.system_tool_instructions = self.system_tool_instructions
+        new_agent.system_tool_format_instructions = self.system_tool_format_instructions
+        new_agent.llm_tools_map = self.llm_tools_map
+        new_agent.llm_tools_known = self.llm_tools_known
+        new_agent.llm_tools_handled = self.llm_tools_handled
+        new_agent.llm_tools_usable = self.llm_tools_usable
+        new_agent.llm_functions_map = self.llm_functions_map
+        new_agent.llm_functions_handled = self.llm_functions_handled
+        new_agent.llm_functions_usable = self.llm_functions_usable
+        new_agent.llm_function_force = self.llm_function_force
+        # Ensure each clone gets its own vecdb client when supported.
+        new_agent.vecdb = None if self.vecdb is None else self.vecdb.clone()
+        self._clone_extra_state(new_agent)
+        new_agent.id = ObjectRegistry.new_id()
+        if self.config.add_to_registry:
+            ObjectRegistry.register_object(new_agent)
+        return new_agent
+
+    def _clone_extra_state(self, new_agent: "ChatAgent") -> None:
+        """Hook for subclasses to copy additional state into clones."""
+
+    def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool:
+        """Should we enable strict mode for a given tool?"""
+        if isinstance(tool, str):
+            tool_class = self.llm_tools_map[tool]
+        else:
+            tool_class = tool
+        name = tool_class.default_value("request")
+        if name in self.disable_strict_tools_set or self.disable_strict:
+            return False
+        strict: Optional[bool] = tool_class.default_value("strict")
+        if strict is None:
+            strict = self._strict_tools_available()
+
+        return strict
+
+    def _fn_call_available(self) -> bool:
+        """Does this agent's LLM support function calling?"""
+        return self.llm is not None and self.llm.supports_functions_or_tools()
+
+    def _strict_tools_available(self) -> bool:
+        """Does this agent's LLM support strict tools?"""
+        return (
+            not self.disable_strict
+            and self.llm is not None
+            and isinstance(self.llm, OpenAIGPT)
+            and self.llm.config.parallel_tool_calls is False
+            and self.llm.supports_strict_tools
+        )
+
+    def _json_schema_available(self) -> bool:
+        """Does this agent's LLM support strict JSON schema output format?"""
+        return (
+            not self.disable_strict
+            and self.llm is not None
+            and isinstance(self.llm, OpenAIGPT)
+            and self.llm.supports_json_schema
+        )
+
+    def set_system_message(self, msg: str) -> None:
+        self.system_message = msg
+        if len(self.message_history) > 0:
+            # if there is message history, update the system message in it
+            self.message_history[0].content = msg
+
+    def set_user_message(self, msg: str) -> None:
+        self.user_message = msg
+
+    @property
+    def task_messages(self) -> List[LLMMessage]:
+        """
+        The task messages are the initial messages that define the task
+        of the agent. There will be at least a system message plus possibly a user msg.
+        Returns:
+            List[LLMMessage]: the task messages
+        """
+        msgs = [self._create_system_and_tools_message()]
+        if self.user_message:
+            msgs.append(LLMMessage(role=Role.USER, content=self.user_message))
+        return msgs
+
+    def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None:
+        id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
+        if msg.role == Role.TOOL:
+            # dropping tool result, so ADD the corresponding tool-call back
+            # to the list of pending calls!
+            id = msg.tool_call_id
+            if id in self.oai_tool_id2call:
+                self.oai_tool_calls.append(self.oai_tool_id2call[id])
+        elif msg.tool_calls is not None:
+            # dropping a msg with tool-calls, so DROP these from pending list
+            # as well as from id -> call map
+            for tool_call in msg.tool_calls:
+                if tool_call.id in id2idx:
+                    self.oai_tool_calls.pop(id2idx[tool_call.id])
+                if tool_call.id in self.oai_tool_id2call:
+                    del self.oai_tool_id2call[tool_call.id]
+
+    def clear_history(self, start: int = -2, end: int = -1) -> None:
+        """
+        Clear the message history, deleting  messages from index `start`,
+        up to index `end`.
+
+        Args:
+            start (int): index of first message to delete; default = -2
+                    (i.e. delete last 2 messages, typically these
+                    are the last user and assistant messages)
+            end (int): index of last message to delete; Default = -1
+                    (i.e. delete all messages up to the last one)
+        """
+        n = len(self.message_history)
+        if start < 0:
+            start = max(0, n + start)
+        end_ = n if end == -1 else end + 1
+        dropped = self.message_history[start:end_]
+        # consider the dropped msgs in REVERSE order, so we are
+        # carefully updating self.oai_tool_calls
+        for msg in reversed(dropped):
+            self._drop_msg_update_tool_calls(msg)
+            # clear out the chat document from the ObjectRegistry
+            ChatDocument.delete_id(msg.chat_document_id)
+        del self.message_history[start:end_]
+
+    def update_history(self, message: str, response: str) -> None:
+        """
+        Update the message history with the latest user message and LLM response.
+        Args:
+            message (str): user message
+            response: (str): LLM response
+        """
+        self.message_history.extend(
+            [
+                LLMMessage(role=Role.USER, content=message),
+                LLMMessage(role=Role.ASSISTANT, content=response),
+            ]
+        )
+
+    def export_history(self) -> str:
+        """Export message history as a portable, versioned JSON snapshot.
+
+        Returns:
+            A JSON string containing the current message history.
+        """
+        messages: List[Dict[str, Any]] = []
+        for message in self.message_history:
+            json.dumps(
+                message.model_dump(mode="python", exclude={"files"}),
+                allow_nan=False,
+                default=str,
+            )
+            data = message.model_dump(mode="json", exclude={"files"})
+            data["chat_document_id"] = ""
+            data["files"] = [
+                {
+                    "content_base64": base64.b64encode(file.content).decode("ascii"),
+                    "filename": file.filename,
+                    "mime_type": file.mime_type,
+                    "url": file.url,
+                    "detail": file.detail,
+                }
+                for file in message.files
+            ]
+            messages.append(data)
+        return json.dumps({"version": 1, "messages": messages}, allow_nan=False)
+
+    def import_history(
+        self,
+        snapshot: str,
+        max_size_bytes: int = 100 * 1024 * 1024,
+    ) -> None:
+        """Restore message history from :meth:`export_history` output.
+
+        Args:
+            snapshot: Versioned JSON snapshot to restore.
+            max_size_bytes: Maximum total decoded attachment size. Defaults to
+                100 MiB.
+
+        Raises:
+            ValueError: If the snapshot is malformed, has an unknown version,
+                starts with a non-system message, or exceeds ``max_size_bytes``.
+        """
+        try:
+            if max_size_bytes < 0:
+                raise ValueError("max_size_bytes must be non-negative")
+            payload = json.loads(
+                snapshot,
+                parse_constant=_reject_json_constant,
+                parse_float=_parse_json_float,
+            )
+            if (
+                not isinstance(payload, dict)
+                or type(payload.get("version")) is not int
+                or payload["version"] != 1
+            ):
+                raise ValueError("unsupported version")
+            raw_messages = payload.get("messages")
+            if not isinstance(raw_messages, list):
+                raise ValueError("messages must be a list")
+            if not raw_messages:
+                raise ValueError("messages must not be empty")
+
+            messages: List[LLMMessage] = []
+            total_attachment_bytes = 0
+            for raw_message in raw_messages:
+                if not isinstance(raw_message, dict):
+                    raise ValueError("message must be an object")
+                message_data = dict(raw_message)
+                raw_files = message_data.get("files", [])
+                if not isinstance(raw_files, list):
+                    raise ValueError("files must be a list")
+                files = []
+                for raw_file in raw_files:
+                    if not isinstance(raw_file, dict):
+                        raise ValueError("file must be an object")
+                    file_data = dict(raw_file)
+                    encoded_content = file_data.pop("content_base64")
+                    if not isinstance(encoded_content, str):
+                        raise ValueError("content_base64 must be a string")
+                    encoded_bytes = encoded_content.encode("ascii")
+                    padding = len(encoded_bytes) - len(encoded_bytes.rstrip(b"="))
+                    decoded_size = max(
+                        0,
+                        len(encoded_bytes) // 4 * 3 - min(padding, 2),
+                    )
+                    if total_attachment_bytes + decoded_size > max_size_bytes:
+                        raise ValueError(
+                            "decoded attachments exceed "
+                            f"max_size_bytes={max_size_bytes}"
+                        )
+                    content = base64.b64decode(encoded_bytes, validate=True)
+                    total_attachment_bytes += len(content)
+                    if total_attachment_bytes > max_size_bytes:
+                        raise ValueError(
+                            "decoded attachments exceed "
+                            f"max_size_bytes={max_size_bytes}"
+                        )
+                    files.append(FileAttachment(content=content, **file_data))
+                message_data["files"] = files
+                message_data["chat_document_id"] = ""
+                messages.append(LLMMessage.model_validate(message_data))
+            if messages[0].role != Role.SYSTEM:
+                raise ValueError("first message must have role 'system'")
+            seen_call_ids: Set[str] = set()
+            for message in messages:
+                if message.role in (Role.TOOL, Role.FUNCTION) and (
+                    message.function_call is not None or message.tool_calls is not None
+                ):
+                    raise ValueError("result messages must not contain call payloads")
+                if message.function_call is not None and message.role != Role.ASSISTANT:
+                    raise ValueError("function calls must have role 'assistant'")
+                if message.function_call is not None:
+                    if not message.function_call.name.strip():
+                        raise ValueError("function call names must be nonblank")
+                if message.tool_call_id is not None and message.role != Role.TOOL:
+                    raise ValueError("tool_call_id is only valid on tool results")
+                if message.role == Role.FUNCTION:
+                    name = message.name
+                    if name is None or not name or name != name.strip():
+                        raise ValueError(
+                            "function result name must be nonblank and normalized"
+                        )
+                if message.tool_calls is not None:
+                    if message.role != Role.ASSISTANT:
+                        raise ValueError("tool calls must have role 'assistant'")
+                    for call in message.tool_calls:
+                        if call.function is None:
+                            raise ValueError("tool calls must include a function")
+                        if not call.function.name.strip():
+                            raise ValueError("function call names must be nonblank")
+                        call_id = call.id
+                        if call_id is None or not call_id or call_id != call_id.strip():
+                            raise ValueError(
+                                "tool call IDs must be nonblank and normalized"
+                            )
+                        if call_id in seen_call_ids:
+                            raise ValueError("tool call IDs must be unique")
+                        seen_call_ids.add(call_id)
+                    if not message.tool_calls:
+                        message.tool_calls = None
+        except (
+            KeyError,
+            RecursionError,
+            TypeError,
+            UnicodeEncodeError,
+            ValueError,
+        ) as exc:
+            raise ValueError(f"Invalid history snapshot: {exc}") from exc
+
+        all_calls = {
+            call.id: call
+            for message in messages
+            for call in (message.tool_calls or [])
+            if call.id is not None
+        }
+        completed_call_ids = {
+            message.tool_call_id
+            for message in messages
+            if message.role == Role.TOOL and message.tool_call_id is not None
+        }
+        old_chat_document_ids = {
+            message.chat_document_id
+            for message in self.message_history
+            if message.chat_document_id
+        }
+        for chat_document_id in old_chat_document_ids:
+            ChatDocument.delete_id(chat_document_id)
+        self.message_history = messages
+        self.oai_tool_id2call = all_calls
+        self.oai_tool_calls = [
+            call
+            for call_id, call in all_calls.items()
+            if call_id not in completed_call_ids
+        ]
+
+    def tool_format_rules(self) -> str:
+        """
+        Specification of tool formatting rules
+        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
+        based on the currently enabled usable `ToolMessage`s
+
+        Returns:
+            str: formatting rules
+        """
+        # ONLY Usable tools (i.e. LLM-generation allowed),
+        usable_tool_classes: List[Type[ToolMessage]] = [
+            t
+            for t in list(self.llm_tools_map.values())
+            if t.default_value("request") in self.llm_tools_usable
+        ]
+
+        if len(usable_tool_classes) == 0:
+            return ""
+        format_instructions = "\n\n".join(
+            [
+                msg_cls.format_instructions(tool=self.config.use_tools)
+                for msg_cls in usable_tool_classes
+            ]
+        )
+        # if any of the enabled classes has json_group_instructions, then use that,
+        # else fall back to ToolMessage.json_group_instructions
+        for msg_cls in usable_tool_classes:
+            if hasattr(msg_cls, "json_group_instructions") and callable(
+                getattr(msg_cls, "json_group_instructions")
+            ):
+                return msg_cls.group_format_instructions().format(
+                    format_instructions=format_instructions
+                )
+        return ToolMessage.group_format_instructions().format(
+            format_instructions=format_instructions
+        )
+
+    def tool_instructions(self) -> str:
+        """
+        Instructions for tools or function-calls, for enabled and usable Tools.
+        These are inserted into system prompt regardless of whether we are using
+        our own ToolMessage mechanism or the LLM's function-call mechanism.
+
+        Returns:
+            str: concatenation of instructions for all usable tools
+        """
+        enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
+        if len(enabled_classes) == 0:
+            return ""
+        instructions = []
+        for msg_cls in enabled_classes:
+            if msg_cls.default_value("request") in self.llm_tools_usable:
+                class_instructions = ""
+                if hasattr(msg_cls, "instructions") and inspect.ismethod(
+                    msg_cls.instructions
+                ):
+                    class_instructions = msg_cls.instructions()
+                if (
+                    self.config.use_tools
+                    and hasattr(msg_cls, "langroid_tools_instructions")
+                    and inspect.ismethod(msg_cls.langroid_tools_instructions)
+                ):
+                    class_instructions += msg_cls.langroid_tools_instructions()
+                # example will be shown in tool_format_rules() when using TOOLs,
+                # so we don't need to show it here.
+                example = "" if self.config.use_tools else (msg_cls.usage_examples())
+                if example != "":
+                    example = "EXAMPLES:\n" + example
+                guidance = (
+                    ""
+                    if class_instructions == ""
+                    else ("GUIDANCE: " + class_instructions)
+                )
+                if guidance == "" and example == "":
+                    continue
+                instructions.append(
+                    textwrap.dedent(
+                        f"""
+                        TOOL: {msg_cls.default_value("request")}:
+                        {guidance}
+                        {example}
+                        """.lstrip()
+                    )
+                )
+        if len(instructions) == 0:
+            return ""
+        instructions_str = "\n\n".join(instructions)
+        return textwrap.dedent(
+            f"""
+            === GUIDELINES ON SOME TOOLS/FUNCTIONS USAGE ===
+            {instructions_str}
+            """.lstrip()
+        )
+
+    def augment_system_message(self, message: str) -> None:
+        """
+        Augment the system message with the given message.
+        Args:
+            message (str): system message
+        """
+        self.system_message += "\n\n" + message
+
+    def last_message_with_role(self, role: Role) -> LLMMessage | None:
+        """from `message_history`, return the last message with role `role`"""
+        n_role_msgs = len([m for m in self.message_history if m.role == role])
+        if n_role_msgs == 0:
+            return None
+        idx = self.nth_message_idx_with_role(role, n_role_msgs)
+        return self.message_history[idx]
+
+    def last_message_idx_with_role(self, role: Role) -> int:
+        """Index of last message in message_history, with specified role.
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+        indices_with_role = [
+            i for i, m in enumerate(self.message_history) if m.role == role
+        ]
+        if len(indices_with_role) == 0:
+            return -1
+        return indices_with_role[-1]
+
+    def nth_message_idx_with_role(self, role: Role, n: int) -> int:
+        """Index of `n`th message in message_history, with specified role.
+        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+        indices_with_role = [
+            i for i, m in enumerate(self.message_history) if m.role == role
+        ]
+
+        if len(indices_with_role) < n:
+            return -1
+        return indices_with_role[n - 1]
+
+    def update_last_message(self, message: str, role: str = Role.USER) -> None:
+        """
+        Update the last message that has role `role` in the message history.
+        Useful when we want to replace a long user prompt, that may contain context
+        documents plus a question, with just the question.
+        Args:
+            message (str): new message to replace with
+            role (str): role of message to replace
+        """
+        if len(self.message_history) == 0:
+            return
+        # find last message in self.message_history with role `role`
+        for i in range(len(self.message_history) - 1, -1, -1):
+            if self.message_history[i].role == role:
+                self.message_history[i].content = message
+                break
+
+    def delete_last_message(self, role: str = Role.USER) -> None:
+        """
+        Delete the last message that has role `role` from the message history.
+        Args:
+            role (str): role of message to delete
+        """
+        if len(self.message_history) == 0:
+            return
+        # find last message in self.message_history with role `role`
+        for i in range(len(self.message_history) - 1, -1, -1):
+            if self.message_history[i].role == role:
+                self.message_history.pop(i)
+                break
+
+    def _create_system_and_tools_message(self) -> LLMMessage:
+        """
+        (Re-)Create the system message for the LLM of the agent,
+        taking into account any tool instructions that have been added
+        after the agent was initialized.
+
+        The system message will consist of:
+        (a) the system message from the `task` arg in constructor, if any,
+            otherwise the default system message from the config
+        (b) the system tool instructions, if any
+        (c) the system json tool instructions, if any
+
+        Returns:
+            LLMMessage object
+        """
+        content = self.system_message
+        if self.system_tool_instructions != "":
+            content += "\n\n" + self.system_tool_instructions
+        if self.system_tool_format_instructions != "":
+            content += "\n\n" + self.system_tool_format_instructions
+        if self.output_format_instructions != "":
+            content += "\n\n" + self.output_format_instructions
+
+        # remove leading and trailing newlines and other whitespace
+        return LLMMessage(role=Role.SYSTEM, content=content.strip())
+
+    def handle_message_fallback(self, msg: str | ChatDocument) -> Any:
+        """
+        Fallback method for the "no-tools" scenario, i.e., the current `msg`
+        (presumably emitted by the LLM) does not have any tool that the agent
+        can handle.
+        NOTE: The `msg` may contain tools but either (a) the agent is not
+        enabled to handle them, or (b) there's an explicit `recipient` field
+        in the tool that doesn't match the agent's name.
+
+        Uses the self.config.non_tool_routing to determine the action to take.
+
+        This method can be overridden by subclasses, e.g.,
+        to create a "reminder" message when a tool is expected but the LLM "forgot"
+        to generate one.
+
+        Args:
+            msg (str | ChatDocument): The input msg to handle
+        Returns:
+            Any: The result of the handler method
+        """
+        if (
+            isinstance(msg, str)
+            or msg.metadata.sender != Entity.LLM
+            or self.config.handle_llm_no_tool is None
+            or self.has_only_unhandled_tools(msg)
+        ):
+            return None
+        # we ONLY use the `handle_llm_no_tool` config option when
+        # the msg is from LLM and does not contain ANY tools at all.
+        from langroid.agent.tools.orchestration import AgentDoneTool, ForwardTool
+
+        no_tool_option = self.config.handle_llm_no_tool
+        if no_tool_option in list(NonToolAction):
+            # in case the `no_tool_option` is one of the special NonToolAction vals
+            match self.config.handle_llm_no_tool:
+                case NonToolAction.FORWARD_USER:
+                    return ForwardTool(agent="User")
+                case NonToolAction.DONE:
+                    return AgentDoneTool(content=msg.content, tools=msg.tool_messages)
+        elif is_callable(no_tool_option):
+            return no_tool_option(msg)
+        # Otherwise just return `no_tool_option` as is:
+        # This can be any string, such as a specific nudge/reminder to the LLM,
+        # or even something like ResultTool etc.
+        return no_tool_option
+
+    def unhandled_tools(self) -> set[str]:
+        """The set of tools that are known but not handled.
+        Useful in task flow: an agent can refuse to accept an incoming msg
+        when it only has unhandled tools.
+        """
+        return self.llm_tools_known - self.llm_tools_handled
+
+    def enable_message(
+        self,
+        message_class: Optional[Type[ToolMessage] | List[Type[ToolMessage]]],
+        use: bool = True,
+        handle: bool = True,
+        force: bool = False,
+        require_recipient: bool = False,
+        include_defaults: bool = True,
+    ) -> None:
+        """
+        Add the tool (message class) to the agent, and enable either
+        - tool USE (i.e. the LLM can generate JSON to use this tool),
+        - tool HANDLING (i.e. the agent can handle JSON from this tool),
+
+        Args:
+            message_class: The ToolMessage class OR List of such classes to enable,
+                for USE, or HANDLING, or both.
+                If this is a list of ToolMessage classes, then the remain args are
+                applied to all classes.
+                Optional; if None, then apply the enabling to all tools in the
+                agent's toolset that have been enabled so far.
+            use: IF True, allow the agent (LLM) to use this tool (or all tools),
+                else disallow
+            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
+                tool (or all tools)
+            force: whether to FORCE the agent (LLM) to USE the specific
+                 tool represented by `message_class`.
+                 `force` is ignored if `message_class` is None.
+            require_recipient: whether to require that recipient be specified
+                when using the tool message (only applies if `use` is True).
+            include_defaults: whether to include fields that have default values,
+                in the "properties" section of the JSON format instructions.
+                (Normally the OpenAI completion API ignores these fields,
+                but the Assistant fn-calling seems to pay attn to these,
+                and if we don't want this, we should set this to False.)
+        """
+        if message_class is not None and isinstance(message_class, list):
+            for mc in message_class:
+                self.enable_message(
+                    mc,
+                    use=use,
+                    handle=handle,
+                    force=force,
+                    require_recipient=require_recipient,
+                    include_defaults=include_defaults,
+                )
+            return None
+
+        # Validate that use/handle are booleans, not accidentally passed tool classes
+        if isclass(use) or isclass(handle):
+            param = "use" if isclass(use) else "handle"
+            raise TypeError(
+                textwrap.dedent(
+                    f"""
+                    Invalid arguments to enable_message().
+                    It appears you passed multiple ToolMessage classes as separate
+                    arguments instead of as a list.
+
+                    Correct usage:
+                        agent.enable_message([Tool1, Tool2, Tool3])
+
+                    Incorrect usage:
+                        agent.enable_message(Tool1, Tool2, Tool3)
+
+                    The '{param}' parameter must be a boolean, not a class.
+                    """
+                )
+            )
+
+        if require_recipient and message_class is not None:
+            message_class = message_class.require_recipient()
+        if message_class is not None:
+            if not issubclass(message_class, ToolMessage):
+                raise ValueError("message_class must be a subclass of ToolMessage")
+            request = message_class.default_value("request")
+            existing_class = self.llm_tools_map.get(request)
+            existing_origin = (
+                existing_class.__dict__.get("__tool_message_origin__", existing_class)
+                if existing_class is not None
+                else None
+            )
+            message_origin = message_class.__dict__.get(
+                "__tool_message_origin__", message_class
+            )
+            if existing_class is not None and existing_origin is not message_origin:
+                raise ValueError(
+                    f"Tool request name {request!r} is already registered to "
+                    f"{existing_class.__name__}; cannot register "
+                    f"{message_class.__name__}"
+                )
+        if isinstance(message_class, XMLToolMessage):
+            # XMLToolMessage is not compatible with OpenAI's Tools/functions API,
+            # so we disable use of functions API, enable langroid-native Tools,
+            # which are prompt-based.
+            self.config.use_functions_api = False
+            self.config.use_tools = True
+        super().enable_message_handling(message_class)  # enables handling only
+        tools = self._get_tool_list(message_class)
+        if message_class is not None:
+            if request == "":
+                raise ValueError(
+                    f"""
+                    ToolMessage class {message_class} must have a non-empty
+                    'request' field if it is to be enabled as a tool.
+                    """
+                )
+            llm_function = message_class.llm_function_schema(defaults=include_defaults)
+            self.llm_functions_map[request] = llm_function
+            if force:
+                self.llm_function_force = dict(name=request)
+            else:
+                self.llm_function_force = None
+
+        for t in tools:
+            self.llm_tools_known.add(t)
+
+            if handle:
+                self.llm_tools_handled.add(t)
+                self.llm_functions_handled.add(t)
+
+                if (
+                    self.enabled_handling_output_format is not None
+                    and self.enabled_handling_output_format.name() == t
+                ):
+                    # `t` was designated as "enabled for handling" ONLY for
+                    # output_format enforcement, but we are explicitly ]
+                    # enabling it for handling here, so we set the variable to None.
+                    self.enabled_handling_output_format = None
+            else:
+                self.llm_tools_handled.discard(t)
+                self.llm_functions_handled.discard(t)
+
+            if use:
+                tool_class = self.llm_tools_map[t]
+                allow_llm_use = tool_class._allow_llm_use
+                if isinstance(allow_llm_use, ModelPrivateAttr):
+                    allow_llm_use = allow_llm_use.default
+                if allow_llm_use:
+                    self.llm_tools_usable.add(t)
+                    self.llm_functions_usable.add(t)
+                else:
+                    logger.warning(
+                        f"""
+                        ToolMessage class {tool_class} does not allow LLM use,
+                        because `_allow_llm_use=False` either in the Tool or a
+                        parent class of this tool;
+                        so not enabling LLM use for this tool!
+                        If you intended an LLM to use this tool,
+                        set `_allow_llm_use=True` when you define the tool.
+                        """
+                    )
+                if (
+                    self.enabled_use_output_format is not None
+                    and self.enabled_use_output_format.default_value("request") == t
+                ):
+                    # `t` was designated as "enabled for use" ONLY for output_format
+                    # enforcement, but we are explicitly enabling it for use here,
+                    # so we set the variable to None.
+                    self.enabled_use_output_format = None
+            else:
+                self.llm_tools_usable.discard(t)
+                self.llm_functions_usable.discard(t)
+
+        self._update_tool_instructions()
+
+    def _update_tool_instructions(self) -> None:
+        # Set tool instructions and JSON format instructions,
+        # in case Tools have been enabled/disabled.
+        if self.config.use_tools:
+            self.system_tool_format_instructions = self.tool_format_rules()
+        self.system_tool_instructions = self.tool_instructions()
+
+    def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]:
+        """
+        Returns the current set of enabled requests for inference and tools configs.
+        Used for restoring setings overriden by `set_output_format`.
+        """
+        return (
+            self.enabled_requests_for_inference,
+            self.config.use_functions_api,
+            self.config.use_tools,
+        )
+
+    @property
+    def all_llm_tools_known(self) -> set[str]:
+        """All known tools; we include `output_format` if it is a `ToolMessage`."""
+        known = self.llm_tools_known
+
+        if self.output_format is not None and issubclass(
+            self.output_format, ToolMessage
+        ):
+            return known.union({self.output_format.default_value("request")})
+
+        return known
+
+    def set_output_format(
+        self,
+        output_type: Optional[type],
+        force_tools: Optional[bool] = None,
+        use: Optional[bool] = None,
+        handle: Optional[bool] = None,
+        instructions: Optional[bool] = None,
+        is_copy: bool = False,
+    ) -> None:
+        """
+        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
+        switches to the native Langroid tools mechanism to ensure that no tool
+        calls not of `output_type` are generated. By default, `force_tools`
+        follows the `use_tools_on_output_format` parameter in the config.
+
+        If `output_type` is None, restores to the state prior to setting
+        `output_format`.
+
+        If `use`, we enable use of `output_type` when it is a subclass
+        of `ToolMesage`. Note that this primarily controls instruction
+        generation: the model will always generate `output_type` regardless
+        of whether `use` is set. Defaults to the `use_output_format`
+        parameter in the config. Similarly, handling of `output_type` is
+        controlled by `handle`, which defaults to the
+        `handle_output_format` parameter in the config.
+
+        `instructions` controls whether we generate instructions specifying
+        the output format schema. Defaults to the `instructions_output_format`
+        parameter in the config.
+
+        `is_copy` is set when called via `__getitem__`. In that case, we must
+        copy certain fields to ensure that we do not overwrite the main agent's
+        setings.
+        """
+        # Disable usage of an output format which was not specifically enabled
+        # by `enable_message`
+        if self.enabled_use_output_format is not None:
+            self.disable_message_use(self.enabled_use_output_format)
+            self.enabled_use_output_format = None
+
+        # Disable handling of an output format which did not specifically have
+        # handling enabled via `enable_message`
+        if self.enabled_handling_output_format is not None:
+            self.disable_message_handling(self.enabled_handling_output_format)
+            self.enabled_handling_output_format = None
+
+        # Reset any previous instructions
+        self.output_format_instructions = ""
+
+        if output_type is None:
+            self.output_format = None
+            (
+                requests_for_inference,
+                use_functions_api,
+                use_tools,
+            ) = self.saved_requests_and_tool_setings
+            self.config = self.config.model_copy()
+            self.enabled_requests_for_inference = requests_for_inference
+            self.config.use_functions_api = use_functions_api
+            self.config.use_tools = use_tools
+        else:
+            if force_tools is None:
+                force_tools = self.config.use_tools_on_output_format
+
+            if not any(
+                (isclass(output_type) and issubclass(output_type, t))
+                for t in [ToolMessage, BaseModel]
+            ):
+                output_type = get_pydantic_wrapper(output_type)
+
+            if self.output_format is None and force_tools:
+                self.saved_requests_and_tool_setings = (
+                    self._requests_and_tool_settings()
+                )
+
+            self.output_format = output_type
+            if issubclass(output_type, ToolMessage):
+                name = output_type.default_value("request")
+                if use is None:
+                    use = self.config.use_output_format
+
+                if handle is None:
+                    handle = self.config.handle_output_format
+
+                if use or handle:
+                    is_usable = name in self.llm_tools_usable.union(
+                        self.llm_functions_usable
+                    )
+                    is_handled = name in self.llm_tools_handled.union(
+                        self.llm_functions_handled
+                    )
+
+                    if is_copy:
+                        if use:
+                            # We must copy `llm_tools_usable` so the base agent
+                            # is unmodified
+                            self.llm_tools_usable = self.llm_tools_usable.copy()
+                            self.llm_functions_usable = self.llm_functions_usable.copy()
+                        if handle:
+                            # If handling the tool, do the same for `llm_tools_handled`
+                            self.llm_tools_handled = self.llm_tools_handled.copy()
+                            self.llm_functions_handled = (
+                                self.llm_functions_handled.copy()
+                            )
+                    # Enable `output_type`
+                    self.enable_message(
+                        output_type,
+                        # Do not override existing settings
+                        use=use or is_usable,
+                        handle=handle or is_handled,
+                    )
+
+                    # If the `output_type` ToilMessage was not already enabled for
+                    # use, this means we are ONLY enabling it for use specifically
+                    # for enforcing this output format, so we set the
+                    # `enabled_use_output_forma  to this output_type, to
+                    # record that it should be disabled when `output_format` is changed
+                    if not is_usable:
+                        self.enabled_use_output_format = output_type
+
+                    # (same reasoning as for use-enabling)
+                    if not is_handled:
+                        self.enabled_handling_output_format = output_type
+
+                generated_tool_instructions = name in self.llm_tools_usable.union(
+                    self.llm_functions_usable
+                )
+            else:
+                generated_tool_instructions = False
+
+            if instructions is None:
+                instructions = self.config.instructions_output_format
+            if issubclass(output_type, BaseModel) and instructions:
+                if generated_tool_instructions:
+                    # Already generated tool instructions as part of "enabling for use",
+                    # so only need to generate a reminder to use this tool.
+                    name = cast(ToolMessage, output_type).default_value("request")
+                    self.output_format_instructions = textwrap.dedent(
+                        f"""
+                        === OUTPUT FORMAT INSTRUCTIONS ===
+
+                        Please provide output using the `{name}` tool/function.
+                        """
+                    )
+                else:
+                    if issubclass(output_type, ToolMessage):
+                        output_format_schema = output_type.llm_function_schema(
+                            request=True,
+                            defaults=self.config.output_format_include_defaults,
+                        ).parameters
+                    else:
+                        output_format_schema = output_type.model_json_schema()
+
+                    format_schema_for_strict(output_format_schema)
+
+                    self.output_format_instructions = textwrap.dedent(
+                        f"""
+                        === OUTPUT FORMAT INSTRUCTIONS ===
+                        Please provide output as JSON with the following schema:
+
+                        {output_format_schema}
+                        """
+                    )
+
+            if force_tools:
+                if issubclass(output_type, ToolMessage):
+                    self.enabled_requests_for_inference = {
+                        output_type.default_value("request")
+                    }
+                if self.config.use_functions_api:
+                    self.config = self.config.model_copy()
+                    self.config.use_functions_api = False
+                    self.config.use_tools = True
+
+    def __getitem__(self, output_type: type) -> Self:
+        """
+        Returns a (shallow) copy of `self` with a forced output type.
+        """
+        clone = copy.copy(self)
+        clone.set_output_format(output_type, is_copy=True)
+        return clone
+
+    def disable_message_handling(
+        self,
+        message_class: Optional[Type[ToolMessage]] = None,
+    ) -> None:
+        """
+        Disable this agent from RESPONDING to a `message_class` (Tool). If
+            `message_class` is None, then disable this agent from responding to ALL.
+        Args:
+            message_class: The ToolMessage class to disable; Optional.
+        """
+        super().disable_message_handling(message_class)
+        for t in self._get_tool_list(message_class):
+            self.llm_tools_handled.discard(t)
+            self.llm_functions_handled.discard(t)
+
+    def disable_message_use(
+        self,
+        message_class: Optional[Type[ToolMessage]],
+    ) -> None:
+        """
+        Disable this agent from USING a message class (Tool).
+        If `message_class` is None, then disable this agent from USING ALL tools.
+        Args:
+            message_class: The ToolMessage class to disable.
+                If None, disable all.
+        """
+        for t in self._get_tool_list(message_class):
+            self.llm_tools_usable.discard(t)
+            self.llm_functions_usable.discard(t)
+
+        self._update_tool_instructions()
+
+    def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None:
+        """
+        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
+        Args:
+            message_class: The only ToolMessage class to allow
+        """
+        request = message_class.model_fields["request"].default
+        to_remove = [r for r in self.llm_tools_usable if r != request]
+        for r in to_remove:
+            self.llm_tools_usable.discard(r)
+            self.llm_functions_usable.discard(r)
+        self._update_tool_instructions()
+
+    def _load_output_format(self, message: ChatDocument) -> None:
+        """
+        If set, attempts to parse a value of type `self.output_format` from the message
+        contents or any tool/function call and assigns it to `content_any`.
+        """
+        if self.output_format is not None:
+            any_succeeded = False
+            attempts: list[str | LLMFunctionCall] = [
+                message.content,
+            ]
+
+            if message.function_call is not None:
+                attempts.append(message.function_call)
+
+            if message.oai_tool_calls is not None:
+                attempts.extend(
+                    [
+                        c.function
+                        for c in message.oai_tool_calls
+                        if c.function is not None
+                    ]
+                )
+
+            for attempt in attempts:
+                try:
+                    if isinstance(attempt, str):
+                        content = json.loads(attempt)
+                    else:
+                        if not (
+                            issubclass(self.output_format, ToolMessage)
+                            and attempt.name
+                            == self.output_format.default_value("request")
+                        ):
+                            continue
+
+                        content = attempt.arguments
+
+                    content_any = self.output_format.model_validate(content)
+
+                    if issubclass(self.output_format, PydanticWrapper):
+                        message.content_any = content_any.value  # type: ignore
+                    else:
+                        message.content_any = content_any
+                    any_succeeded = True
+                    break
+                except (ValidationError, json.JSONDecodeError):
+                    continue
+
+            if not any_succeeded:
+                self.disable_strict = True
+                logging.warning(
+                    """
+                    Validation error occured with strict output format enabled.
+                    Disabling strict mode.
+                    """
+                )
+
+    def get_tool_messages(
+        self,
+        msg: str | ChatDocument | None,
+        all_tools: bool = False,
+    ) -> List[ToolMessage]:
+        """
+        Extracts messages and tracks whether any errors occurred. If strict mode
+        was enabled, disables it for the tool, else triggers strict recovery.
+        """
+        self.tool_error = False
+        most_recent_sent_by_llm = (
+            len(self.message_history) > 0
+            and self.message_history[-1].role == Role.ASSISTANT
+        )
+        was_llm = most_recent_sent_by_llm or (
+            isinstance(msg, ChatDocument) and msg.metadata.sender == Entity.LLM
+        )
+        try:
+            tools = super().get_tool_messages(msg, all_tools)
+        except ValidationError as ve:
+            # Check if tool class was attached to the exception
+            if hasattr(ve, "tool_class") and ve.tool_class:
+                tool_class = ve.tool_class  # type: ignore
+                if issubclass(tool_class, ToolMessage):
+                    was_strict = (
+                        self.config.use_functions_api
+                        and self.config.use_tools_api
+                        and self._strict_mode_for_tool(tool_class)
+                    )
+                    # If the result of strict output for a tool using the
+                    # OpenAI tools API fails to parse, we infer that the
+                    # schema edits necessary for compatibility prevented
+                    # adherence to the underlying `ToolMessage` schema and
+                    # disable strict output for the tool
+                    if was_strict:
+                        name = tool_class.default_value("request")
+                        self.disable_strict_tools_set.add(name)
+                        logging.warning(
+                            f"""
+                            Validation error occured with strict tool format.
+                            Disabling strict mode for the {name} tool.
+                            """
+                        )
+                    else:
+                        # We will trigger the strict recovery mechanism to force
+                        # the LLM to correct its output, allowing us to parse
+                        if isinstance(msg, ChatDocument):
+                            self.tool_error = msg.metadata.sender == Entity.LLM
+                        else:
+                            self.tool_error = most_recent_sent_by_llm
+
+            if was_llm:
+                raise ve
+            else:
+                self.tool_error = False
+                return []
+
+        if not was_llm:
+            self.tool_error = False
+
+        return tools
+
+    def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None:
+        """
+        Returns a `ToolMessage` which wraps all enabled tools, excluding those
+        where strict recovery is disabled. Used in strict recovery.
+        """
+        possible_tools = tuple(
+            self.llm_tools_map[t]
+            for t in self.llm_tools_usable
+            if t not in self.disable_strict_tools_set
+        )
+        if len(possible_tools) == 0:
+            return None
+        any_tool_type = Union.__getitem__(possible_tools)  # type ignore
+
+        maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
+
+        class AnyTool(ToolMessage):
+            purpose: str = "To call a tool/function."
+            request: str = "tool_or_function"
+            tool: maybe_optional_type  # type: ignore
+
+            def response(self, agent: ChatAgent) -> None | str | ChatDocument:
+                # One-time use
+                agent.set_output_format(None)
+
+                if self.tool is None:
+                    return None
+
+                # As the ToolMessage schema accepts invalid
+                # `tool.request` values, reparse with the
+                # corresponding tool
+                request = self.tool.request
+                if request not in agent.llm_tools_map:
+                    return None
+                tool = agent.llm_tools_map[request].model_validate_json(
+                    self.tool.to_json()
+                )
+
+                return agent.handle_tool_message(tool)
+
+            async def response_async(
+                self, agent: ChatAgent
+            ) -> None | str | ChatDocument:
+                # One-time use
+                agent.set_output_format(None)
+
+                if self.tool is None:
+                    return None
+
+                # As the ToolMessage schema accepts invalid
+                # `tool.request` values, reparse with the
+                # corresponding tool
+                request = self.tool.request
+                if request not in agent.llm_tools_map:
+                    return None
+                tool = agent.llm_tools_map[request].model_validate_json(
+                    self.tool.to_json()
+                )
+
+                return await agent.handle_tool_message_async(tool)
+
+        # Every call builds a distinct class; share one origin so enabling a
+        # regenerated AnyTool under "tool_or_function" stays idempotent instead
+        # of tripping the same-name/different-tool registration guard.
+        AnyTool.__tool_message_origin__ = (  # type: ignore[attr-defined]
+            _ANY_TOOL_MESSAGE_ORIGIN
+        )
+        return AnyTool
+
+    def _strict_recovery_instructions(
+        self,
+        tool_type: Optional[type[ToolMessage]] = None,
+        optional: bool = True,
+    ) -> str:
+        """Returns instructions for strict recovery."""
+        optional_instructions = (
+            (
+                "\n"
+                + """
+        If you did NOT intend to do so, `tool` should be null.
+        """
+            )
+            if optional
+            else ""
+        )
+        response_prefix = "If you intended to make such a call, r" if optional else "R"
+        instruction_prefix = "If you do so, b" if optional else "B"
+
+        schema_instructions = (
+            f"""
+        The schema for `tool_or_function` is as follows:
+        {tool_type.llm_function_schema(defaults=True, request=True).parameters}
+        """
+            if tool_type
+            else ""
+        )
+
+        return textwrap.dedent(
+            f"""
+        Your previous attempt to make a tool/function call appears to have failed.
+        {response_prefix}espond with your desired tool/function. Do so with the
+        `tool_or_function` tool/function where `tool` is set to your intended call.
+        {schema_instructions}
+
+        {instruction_prefix}e sure that your corrected call matches your intention
+        in your previous request. For any field with a default value which
+        you did not intend to override in your previous attempt, be sure
+        to set that field to its default value. {optional_instructions}
+        """
+        )
+
+    def truncate_message(
+        self,
+        idx: int,
+        tokens: int = 5,
+        warning: str = "...[Contents truncated!]",
+        inplace: bool = True,
+    ) -> LLMMessage:
+        """
+        Truncate message at idx in msg history to `tokens` tokens.
+
+        If inplace is True, the message is truncated in place, else
+        it LEAVES the original message INTACT and returns a new message
+        """
+        if inplace:
+            llm_msg = self.message_history[idx]
+        else:
+            llm_msg = copy.deepcopy(self.message_history[idx])
+        if llm_msg.content is None or (
+            llm_msg.content == "" and _is_identified_result(llm_msg)
+        ):
+            return llm_msg
+        orig_content = llm_msg.content
+        new_content = (
+            self.parser.truncate_tokens(orig_content, tokens)
+            if self.parser is not None
+            else orig_content[: tokens * 4]  # approx truncation
+        )
+        llm_msg.content = new_content + "\n" + warning
+        return llm_msg
+
+    def _reduce_raw_tool_results(self, message: ChatDocument) -> None:
+        """
+        If message is the result of a ToolMessage that had
+        a `_max_retained_tokens` set to a non-None value, then we replace contents
+        with a placeholder message.
+        """
+        parent_message: ChatDocument | None = message.parent
+        tools = [] if parent_message is None else parent_message.tool_messages
+        truncate_tools = []
+        for t in tools:
+            max_retained_tokens = t._max_retained_tokens
+            if isinstance(max_retained_tokens, ModelPrivateAttr):
+                max_retained_tokens = max_retained_tokens.default
+            if max_retained_tokens is not None:
+                truncate_tools.append(t)
+        limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
+        if limiting_tool is not None:
+            max_retained_tokens = limiting_tool._max_retained_tokens
+            if isinstance(max_retained_tokens, ModelPrivateAttr):
+                max_retained_tokens = max_retained_tokens.default
+            if max_retained_tokens is not None:
+                tool_name = limiting_tool.default_value("request")
+                max_tokens: int = max_retained_tokens
+                truncation_warning = f"""
+                    The result of the {tool_name} tool were too large,
+                    and has been truncated to {max_tokens} tokens.
+                    To obtain the full result, the tool needs to be re-used.
+                """
+                self.truncate_message(
+                    message.metadata.msg_idx, max_tokens, truncation_warning
+                )
+
+    def llm_response(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> Optional[ChatDocument]:
+        """
+        Respond to a single user message, appended to the message history,
+        in "chat" mode
+        Args:
+            message (str|ChatDocument): message or ChatDocument object to respond to.
+                If None, use the self.task_messages
+        Returns:
+            LLM response as a ChatDocument object
+        """
+        if self.llm is None:
+            return None
+
+        # If enabled and a tool error occurred, we recover by generating the tool in
+        # strict json mode
+        if (
+            self.tool_error
+            and self.output_format is None
+            and self._json_schema_available()
+            and self.config.strict_recovery
+        ):
+            self.tool_error = False
+            AnyTool = self._get_any_tool_message()
+            if AnyTool is None:
+                return None
+            self.set_output_format(
+                AnyTool,
+                force_tools=True,
+                use=True,
+                handle=True,
+                instructions=True,
+            )
+            recovery_message = self._strict_recovery_instructions(AnyTool)
+            augmented_message = message
+            if augmented_message is None:
+                augmented_message = recovery_message
+            elif isinstance(augmented_message, str):
+                augmented_message = augmented_message + recovery_message
+            else:
+                augmented_message.content = augmented_message.content + recovery_message
+
+            # only use the augmented message for this one response...
+            result = self.llm_response(augmented_message)
+            # ... restore the original user message so that the AnyTool recover
+            # instructions don't persist in the message history
+            # (this can cause the LLM to use the AnyTool directly as a tool)
+            if message is None:
+                self.delete_last_message(role=Role.USER)
+            else:
+                msg = message if isinstance(message, str) else message.content
+                self.update_last_message(msg, role=Role.USER)
+            return result
+
+        hist, output_len = self._prep_llm_messages(message)
+        if len(hist) == 0:
+            return None
+        tool_choice = (
+            "auto"
+            if isinstance(message, str)
+            else (message.oai_tool_choice if message is not None else "auto")
+        )
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
+            try:
+                response = self.llm_response_messages(hist, output_len, tool_choice)
+            except openai.BadRequestError as e:
+                if self.any_strict:
+                    self.disable_strict = True
+                    self.set_output_format(None)
+                    logging.warning(
+                        f"""
+                        OpenAI BadRequestError raised with strict mode enabled.
+                        Message: {e.message}
+                        Disabling strict mode and retrying.
+                        """
+                    )
+                    return self.llm_response(message)
+                else:
+                    raise e
+        self.message_history.extend(ChatDocument.to_LLMMessage(response))
+        response.metadata.msg_idx = len(self.message_history) - 1
+        response.metadata.agent_id = self.id
+        if isinstance(message, ChatDocument):
+            self._reduce_raw_tool_results(message)
+        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
+        response.metadata.tool_ids = (
+            []
+            if isinstance(message, str)
+            else message.metadata.tool_ids if message is not None else []
+        )
+
+        return response
+
+    async def llm_response_async(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> Optional[ChatDocument]:
+        """
+        Async version of `llm_response`. See there for details.
+        """
+        if self.llm is None:
+            return None
+
+        # If enabled and a tool error occurred, we recover by generating the tool in
+        # strict json mode
+        if (
+            self.tool_error
+            and self.output_format is None
+            and self._json_schema_available()
+            and self.config.strict_recovery
+        ):
+            self.tool_error = False
+            AnyTool = self._get_any_tool_message()
+            self.set_output_format(
+                AnyTool,
+                force_tools=True,
+                use=True,
+                handle=True,
+                instructions=True,
+            )
+            recovery_message = self._strict_recovery_instructions(AnyTool)
+            augmented_message = message
+            if augmented_message is None:
+                augmented_message = recovery_message
+            elif isinstance(augmented_message, str):
+                augmented_message = augmented_message + recovery_message
+            else:
+                augmented_message.content = augmented_message.content + recovery_message
+
+            # only use the augmented message for this one response...
+            result = self.llm_response(augmented_message)
+            # ... restore the original user message so that the AnyTool recover
+            # instructions don't persist in the message history
+            # (this can cause the LLM to use the AnyTool directly as a tool)
+            if message is None:
+                self.delete_last_message(role=Role.USER)
+            else:
+                msg = message if isinstance(message, str) else message.content
+                self.update_last_message(msg, role=Role.USER)
+            return result
+
+        hist, output_len = self._prep_llm_messages(message)
+        if len(hist) == 0:
+            return None
+        tool_choice = (
+            "auto"
+            if isinstance(message, str)
+            else (message.oai_tool_choice if message is not None else "auto")
+        )
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
+            try:
+                response = await self.llm_response_messages_async(
+                    hist, output_len, tool_choice
+                )
+            except openai.BadRequestError as e:
+                if self.any_strict:
+                    self.disable_strict = True
+                    self.set_output_format(None)
+                    logging.warning(
+                        f"""
+                        OpenAI BadRequestError raised with strict mode enabled.
+                        Message: {e.message}
+                        Disabling strict mode and retrying.
+                        """
+                    )
+                    return await self.llm_response_async(message)
+                else:
+                    raise e
+        self.message_history.extend(ChatDocument.to_LLMMessage(response))
+        response.metadata.msg_idx = len(self.message_history) - 1
+        response.metadata.agent_id = self.id
+        if isinstance(message, ChatDocument):
+            self._reduce_raw_tool_results(message)
+        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
+        response.metadata.tool_ids = (
+            []
+            if isinstance(message, str)
+            else message.metadata.tool_ids if message is not None else []
+        )
+
+        return response
+
+    def init_message_history(self) -> None:
+        """
+        Initialize the message history with the system message and user message
+        """
+        self.message_history = [self._create_system_and_tools_message()]
+        if self.user_message:
+            self.message_history.append(
+                LLMMessage(role=Role.USER, content=self.user_message)
+            )
+
+    def _prep_llm_messages(
+        self,
+        message: Optional[str | ChatDocument] = None,
+        truncate: bool = True,
+    ) -> Tuple[List[LLMMessage], int]:
+        """
+        Prepare messages to be sent to self.llm_response_messages,
+            which is the main method that calls the LLM API to get a response.
+            If desired output tokens + message history exceeds the model context length,
+            then first the max output tokens is reduced to fit, and if that is not
+            possible, older messages may be truncated to accommodate at least
+            self.config.llm.min_output_tokens of output.
+
+        Returns:
+            Tuple[List[LLMMessage], int]: (messages, output_len)
+                messages = Full list of messages to send
+                output_len = max expected number of tokens in response
+        """
+
+        if (
+            not self.llm_can_respond(message)
+            or self.config.llm is None
+            or self.llm is None
+        ):
+            return [], 0
+
+        if message is None and len(self.message_history) > 0:
+            # this means agent has been used to get LLM response already,
+            # and so the last message is an "assistant" response.
+            # We delete this last assistant response and re-generate it.
+            self.clear_history(-1)
+            logger.warning(
+                "Re-generating the last assistant response since message is None"
+            )
+
+        if len(self.message_history) == 0:
+            # initial messages have not yet been loaded, so load them
+            self.init_message_history()
+
+            # for debugging, show the initial message history
+            if settings.debug:
+                print(
+                    f"""
+                [grey37]LLM Initial Msg History:
+                {escape(self.message_history_str())}
+                [/grey37]
+                """
+                )
+        else:
+            assert self.message_history[0].role == Role.SYSTEM
+            # update the system message with the latest tool instructions
+            self.message_history[0] = self._create_system_and_tools_message()
+
+        if message is not None:
+            if (
+                isinstance(message, str)
+                or message.id() != self.message_history[-1].chat_document_id
+            ):
+                # either the message is a str, or it is a fresh ChatDocument
+                # different from the last message in the history
+                llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
+                llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
+                # Canonicalize retained whitespace-only results before token counting.
+                for llm_msg in llm_msgs:
+                    if (
+                        _is_identified_result(llm_msg)
+                        and llm_msg.content is not None
+                        and llm_msg.content.strip() == ""
+                    ):
+                        llm_msg.content = ""
+                if len(llm_msgs) == 0:
+                    return [], 0
+                # process tools if any
+                done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
+                self.oai_tool_calls = [
+                    t for t in self.oai_tool_calls if t.id not in done_tools
+                ]
+                self.message_history.extend(llm_msgs)
+
+        hist = self.message_history
+        output_len = self.config.llm.model_max_output_tokens
+        if (
+            truncate
+            and output_len > self.llm.chat_context_length() - self.chat_num_tokens(hist)
+        ):
+            # chat + output > max context length,
+            # so first try to shorten requested output len to fit;
+            # use an extra margin of CHAT_HISTORY_BUFFER tokens
+            # in case our calcs are off (and to allow for some extra tokens)
+            output_len = (
+                self.llm.chat_context_length()
+                - self.chat_num_tokens(hist)
+                - CHAT_HISTORY_BUFFER
+            )
+            if output_len > self.config.llm.min_output_tokens:
+                logger.debug(
+                    f"""
+                    Chat Model context length is {self.llm.chat_context_length()},
+                    but the current message history is {self.chat_num_tokens(hist)}
+                    tokens long, which does not allow
+                    {self.config.llm.model_max_output_tokens} output tokens.
+                    Therefore we reduced `max_output_tokens` to {output_len} tokens,
+                    so they can fit within the model's context length
+                    """
+                )
+            else:
+                # unacceptably small output len, so compress early parts of
+                # conversation history based on the configured strategy
+                strategy = self.config.context_overflow_strategy
+
+                if strategy == "truncate":
+                    # Truncate content of individual messages while preserving
+                    # the message sequence (important for LLM APIs that require
+                    # alternating USER/ASSISTANT messages)
+                    msg_idx_to_compress = 1  # don't touch system msg
+                    # we will try compressing msg indices up to but not including
+                    # last user msg
+                    last_msg_idx_to_compress = (
+                        self.last_message_idx_with_role(
+                            role=Role.USER,
+                        )
+                        - 1
+                    )
+                    n_truncated = 0
+                    _target_tokens = (
+                        self.llm.chat_context_length()
+                        - self.config.llm.min_output_tokens
+                        - CHAT_HISTORY_BUFFER
+                    )
+                    # Truncation floor: never reduce a message's content below
+                    # this many tokens.
+                    _min_keep_tokens = 30
+                    _truncation_warning = "... [Contents truncated!]"
+
+                    def _content_tokens(text: str | None) -> int:
+                        """Token count of message *content* only.
+
+                        `truncate_message` only trims `message.content`, so
+                        using the full `_message_num_tokens` (which includes
+                        attachment payloads) would inflate the count and make
+                        the keep-target too large to ever converge, for
+                        messages carrying file attachments.
+                        """
+                        return (
+                            self.parser.num_tokens(text or "")
+                            if self.parser is not None
+                            # approx fallback, matches truncate_message
+                            else len(text or "") // 4
+                        )
+
+                    # Account for the warning that truncate_message appends
+                    # ("\n" + warning), so the final token count of a
+                    # truncated message does not exceed its keep-target.
+                    _warning_tokens = _content_tokens("\n" + _truncation_warning)
+                    # NOTE: loop termination is guaranteed:
+                    # msg_idx_to_compress strictly increases every iteration
+                    # (truncate or skip), and once it exceeds
+                    # last_msg_idx_to_compress a ValueError is raised. (The
+                    # token count need not decrease every iteration, so
+                    # termination rests on the index advancing.)
+                    while self.chat_num_tokens(hist) > _target_tokens:
+                        if msg_idx_to_compress > last_msg_idx_to_compress:
+                            # We want to preserve the first message (typically
+                            # system msg) and last message (user msg).
+                            raise ValueError(
+                                """
+                            The (message history + max_output_tokens) is longer than the
+                            max chat context length of this model, and we have tried
+                            reducing the requested max output tokens, as well as
+                            truncating early parts of the message history, to
+                            accommodate the model context length, but we have run out
+                            of msgs to truncate.
+
+                            HINT: In the `llm` field of your `ChatAgentConfig` object,
+                            which is of type `LLMConfig/OpenAIGPTConfig`, try
+                            - increasing `chat_context_length`
+                                (if accurate for the model), or
+                            - decreasing `max_output_tokens`
+                            """
+                            )
+                        _msg_tokens = _content_tokens(hist[msg_idx_to_compress].content)
+                        if _msg_tokens <= _min_keep_tokens + _warning_tokens:
+                            # Truncating this message cannot shrink the total:
+                            # its content is already at/below the keep-floor
+                            # plus the appended warning; leave it intact.
+                            msg_idx_to_compress += 1
+                            continue
+                        n_truncated += 1
+                        # Distribute the current excess evenly across the
+                        # remaining *compressible* messages, so each retains
+                        # as much content as possible instead of being
+                        # collapsed to the fixed 30-token floor. The excess is
+                        # recomputed every iteration, so the distribution
+                        # self-corrects as we move forward through the
+                        # history.
+                        _current_excess = self.chat_num_tokens(hist) - _target_tokens
+                        # Shrink capacity of each *later* message in the
+                        # compressible range: its content above the floor (net
+                        # of the appended warning). Non-positive entries are
+                        # the tiny messages the skip-check above will leave
+                        # untouched; they must not dilute the even share, so
+                        # only messages with positive capacity count toward
+                        # the denominator (plus this message, which passed the
+                        # skip-check and is therefore compressible).
+                        _later_capacities = [
+                            _content_tokens(m.content)
+                            - _min_keep_tokens
+                            - _warning_tokens
+                            for m in hist[
+                                msg_idx_to_compress + 1 : last_msg_idx_to_compress + 1
+                            ]
+                        ]
+                        _n_remaining = 1 + sum(1 for c in _later_capacities if c > 0)
+                        _even_share = math.ceil(_current_excess / _n_remaining)
+                        # Later messages can shed at most their capacity; this
+                        # message must absorb whatever they cannot, so that
+                        # this single forward pass reaches the target whenever
+                        # that is possible at all.
+                        _later_capacity = sum(c for c in _later_capacities if c > 0)
+                        _reduction = max(_even_share, _current_excess - _later_capacity)
+                        # Extra 2-token slack: re-encoding truncated content
+                        # plus the appended warning can merge/split tokens at
+                        # the boundary, so aim slightly below the target to
+                        # keep the achieved reduction from falling short.
+                        _keep_tokens = max(
+                            _min_keep_tokens,
+                            _msg_tokens - _reduction - _warning_tokens - 2,
+                        )
+                        # compress the msg at idx `msg_idx_to_compress`
+                        hist[msg_idx_to_compress] = self.truncate_message(
+                            msg_idx_to_compress,
+                            tokens=_keep_tokens,
+                            warning=_truncation_warning,
+                        )
+                        msg_idx_to_compress += 1
+
+                    output_len = min(
+                        self.config.llm.model_max_output_tokens,
+                        self.llm.chat_context_length()
+                        - self.chat_num_tokens(hist)
+                        - CHAT_HISTORY_BUFFER,
+                    )
+                    if output_len < self.config.llm.min_output_tokens:
+                        raise ValueError(
+                            f"""
+                            Tried to shorten prompt history for chat mode
+                            but even after truncating all messages except system msg
+                            and last (user) msg, the history token len
+                            {self.chat_num_tokens(hist)} is too long to accommodate
+                            the desired minimum output tokens
+                            {self.config.llm.min_output_tokens} within the
+                            model's context length {self.llm.chat_context_length()}.
+                            Please try shortening the system msg or user prompts,
+                            or adjust `config.llm.min_output_tokens` to be smaller.
+                            """
+                        )
+                    else:
+                        # we MUST have truncated at least one msg
+                        msg_tokens = self.chat_num_tokens()
+                        logger.warning(
+                            f"""
+                        Chat Model context length is {self.llm.chat_context_length()}
+                        tokens, but the current message history is {msg_tokens} tokens
+                        long, which does not allow
+                        {self.config.llm.model_max_output_tokens} output tokens.
+                        Therefore we truncated the first {n_truncated} messages
+                        in the conversation history so that history token
+                        length is reduced to {self.chat_num_tokens(hist)}, and
+                        we use `max_output_tokens = {output_len}`,
+                        so they can fit within the model's context length
+                        of {self.llm.chat_context_length()} tokens.
+                        """
+                        )
+
+                else:  # strategy == "drop_turns"
+                    # Drop complete conversation turns. A complete turn is defined
+                    # as a USER message followed by all messages until the next
+                    # USER message. This is more aggressive but cleaner for voice
+                    # agents with limited context.
+                    n_dropped_turns = 0
+                    while (
+                        self.chat_num_tokens(hist)
+                        > self.llm.chat_context_length()
+                        - self.config.llm.min_output_tokens
+                        - CHAT_HISTORY_BUFFER
+                    ):
+                        # Find the last USER message index
+                        last_user_idx = self.last_message_idx_with_role(role=Role.USER)
+                        if last_user_idx == -1:
+                            break
+
+                        # Find the first complete turn to drop (skip system message)
+                        first_user_idx = -1
+                        for i in range(1, last_user_idx):
+                            if hist[i].role == Role.USER:
+                                first_user_idx = i
+                                break
+                        if first_user_idx == -1:
+                            break
+
+                        # Find the end of this turn: last message before next USER
+                        next_user_idx = -1
+                        for i in range(first_user_idx + 1, last_user_idx + 1):
+                            if hist[i].role == Role.USER:
+                                next_user_idx = i
+                                break
+                        if next_user_idx == -1:
+                            break
+
+                        # Drop the turn
+                        self.clear_history(first_user_idx, next_user_idx - 1)
+                        n_dropped_turns += 1
+
+                    output_len = min(
+                        self.config.llm.model_max_output_tokens,
+                        self.llm.chat_context_length()
+                        - self.chat_num_tokens(hist)
+                        - CHAT_HISTORY_BUFFER,
+                    )
+                    if output_len < self.config.llm.min_output_tokens:
+                        raise ValueError(
+                            f"""
+                            Tried to shorten prompt history for chat mode
+                            but even after dropping complete turns except the system
+                            msg and last turn, the history token len
+                            {self.chat_num_tokens(hist)} is too long to accommodate
+                            the desired minimum output tokens
+                            {self.config.llm.min_output_tokens} within the
+                            model's context length {self.llm.chat_context_length()}.
+                            Please try shortening the system msg or user prompts,
+                            or adjust `config.llm.min_output_tokens` to be smaller.
+                            """
+                        )
+                    else:
+                        # we MUST have dropped at least one turn
+                        msg_tokens = self.chat_num_tokens()
+                        logger.warning(
+                            f"""
+                        Chat Model context length is {self.llm.chat_context_length()}
+                        tokens, but the current message history is {msg_tokens} tokens
+                        long, which does not allow
+                        {self.config.llm.model_max_output_tokens} output tokens.
+                        Therefore we dropped the first {n_dropped_turns} complete
+                        turn(s) from the conversation history so that history token
+                        length is reduced to {self.chat_num_tokens(hist)}, and
+                        we use `max_output_tokens = {output_len}`,
+                        so they can fit within the model's context length
+                        of {self.llm.chat_context_length()} tokens.
+                        """
+                        )
+
+        if isinstance(message, ChatDocument):
+            # record the position of the corresponding LLMMessage in
+            # the message_history
+            message.metadata.msg_idx = len(hist) - 1
+            message.metadata.agent_id = self.id
+        return hist, output_len
+
+    def _function_args(
+        self,
+    ) -> Tuple[
+        Optional[List[LLMFunctionSpec]],
+        str | Dict[str, str],
+        Optional[List[OpenAIToolSpec]],
+        Optional[Dict[str, Dict[str, str] | str]],
+        Optional[OpenAIJsonSchemaSpec],
+    ]:
+        """
+        Get function/tool spec/output format arguments for
+        OpenAI-compatible LLM API call
+        """
+        functions: Optional[List[LLMFunctionSpec]] = None
+        fun_call: str | Dict[str, str] = "none"
+        tools: Optional[List[OpenAIToolSpec]] = None
+        force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
+        self.any_strict = False
+        if self.config.use_functions_api and len(self.llm_functions_usable) > 0:
+            if not self.config.use_tools_api:
+                functions = [
+                    self.llm_functions_map[f] for f in self.llm_functions_usable
+                ]
+                fun_call = (
+                    "auto"
+                    if self.llm_function_force is None
+                    else self.llm_function_force
+                )
+            else:
+
+                def to_maybe_strict_spec(function: str) -> OpenAIToolSpec:
+                    spec = self.llm_functions_map[function]
+                    strict = self._strict_mode_for_tool(function)
+                    if strict:
+                        self.any_strict = True
+                        strict_spec = copy.deepcopy(spec)
+                        format_schema_for_strict(strict_spec.parameters)
+                    else:
+                        strict_spec = spec
+
+                    return OpenAIToolSpec(
+                        type="function",
+                        strict=strict,
+                        function=strict_spec,
+                    )
+
+                tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
+                force_tool = (
+                    None
+                    if self.llm_function_force is None
+                    else {
+                        "type": "function",
+                        "function": {"name": self.llm_function_force["name"]},
+                    }
+                )
+        output_format = None
+        if self.output_format is not None and self._json_schema_available():
+            self.any_strict = True
+            if issubclass(self.output_format, ToolMessage) and not issubclass(
+                self.output_format, XMLToolMessage
+            ):
+                spec = self.output_format.llm_function_schema(
+                    request=True,
+                    defaults=self.config.output_format_include_defaults,
+                )
+                format_schema_for_strict(spec.parameters)
+
+                output_format = OpenAIJsonSchemaSpec(
+                    # We always require that outputs strictly match the schema
+                    strict=True,
+                    function=spec,
+                )
+            elif issubclass(self.output_format, BaseModel):
+                param_spec = self.output_format.model_json_schema()
+                format_schema_for_strict(param_spec)
+
+                output_format = OpenAIJsonSchemaSpec(
+                    # We always require that outputs strictly match the schema
+                    strict=True,
+                    function=LLMFunctionSpec(
+                        name="json_output",
+                        description="Strict Json output format.",
+                        parameters=param_spec,
+                    ),
+                )
+
+        return functions, fun_call, tools, force_tool, output_format
+
+    def llm_response_messages(
+        self,
+        messages: List[LLMMessage],
+        output_len: Optional[int] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+    ) -> ChatDocument:
+        """
+        Respond to a series of messages, e.g. with OpenAI ChatCompletion
+        Args:
+            messages: seq of messages (with role, content fields) sent to LLM
+            output_len: max number of tokens expected in response.
+                    If None, use the LLM's default model_max_output_tokens.
+        Returns:
+            Document (i.e. with fields "content", "metadata")
+        """
+        assert self.config.llm is not None and self.llm is not None
+        output_len = output_len or self.config.llm.model_max_output_tokens
+        streamer = noop_fn
+        if self.llm.get_stream():
+            streamer = self.callbacks.start_llm_stream()
+        self.llm.config.streamer = streamer
+        with ExitStack() as stack:  # for conditionally using rich spinner
+            if not self.llm.get_stream() and not settings.quiet:
+                # show rich spinner only if not streaming!
+                # (Why? b/c the intent of showing a spinner is to "show progress",
+                # and we don't need to do that when streaming, since
+                # streaming output already shows progress.)
+                cm = status(
+                    "LLM responding to messages...",
+                    log_if_quiet=False,
+                )
+                stack.enter_context(cm)
+            if self.llm.get_stream() and not settings.quiet:
+                console.print(f"[green]{self.indent}", end="")
+            functions, fun_call, tools, force_tool, output_format = (
+                self._function_args()
+            )
+            assert self.llm is not None
+            response = self.llm.chat(
+                messages,
+                output_len,
+                tools=tools,
+                tool_choice=force_tool or tool_choice,
+                functions=functions,
+                function_call=fun_call,
+                response_format=output_format,
+            )
+        if self.llm.get_stream():
+            # Create temp ChatDocument for tool check, then clean up to avoid
+            # polluting ObjectRegistry (see PR #939 discussion)
+            temp_doc = ChatDocument.from_LLMResponse(
+                response,
+                displayed=True,
+                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+            )
+            self._call_callback_with_reasoning(
+                "finish_llm_stream",
+                reasoning=response.reasoning,
+                content=response.message or "",
+                tools_content=response.tools_content(),
+                is_tool=self.has_tool_message_attempt(temp_doc),
+            )
+            ObjectRegistry.remove(temp_doc.id())
+        self.llm.config.streamer = noop_fn
+        if response.cached:
+            self.callbacks.cancel_llm_stream()
+        self._render_llm_response(response)
+        self.update_token_usage(
+            response,  # .usage attrib is updated!
+            messages,
+            self.llm.get_stream(),
+            chat=True,
+            print_response_stats=self.config.show_stats and not settings.quiet,
+        )
+        chat_doc = ChatDocument.from_LLMResponse(
+            response,
+            displayed=True,
+            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+        )
+        self.oai_tool_calls = response.oai_tool_calls or []
+        self.oai_tool_id2call.update(
+            {t.id: t for t in self.oai_tool_calls if t.id is not None}
+        )
+
+        # If using strict output format, parse the output JSON
+        self._load_output_format(chat_doc)
+
+        return chat_doc
+
+    async def llm_response_messages_async(
+        self,
+        messages: List[LLMMessage],
+        output_len: Optional[int] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+    ) -> ChatDocument:
+        """
+        Async version of `llm_response_messages`. See there for details.
+        """
+        assert self.config.llm is not None and self.llm is not None
+        output_len = output_len or self.config.llm.model_max_output_tokens
+        functions, fun_call, tools, force_tool, output_format = self._function_args()
+        assert self.llm is not None
+
+        streamer_async = async_noop_fn
+        if self.llm.get_stream():
+            streamer_async = await self.callbacks.start_llm_stream_async()
+        self.llm.config.streamer_async = streamer_async
+
+        response = await self.llm.achat(
+            messages,
+            output_len,
+            tools=tools,
+            tool_choice=force_tool or tool_choice,
+            functions=functions,
+            function_call=fun_call,
+            response_format=output_format,
+        )
+        if self.llm.get_stream():
+            # Create temp ChatDocument for tool check, then clean up to avoid
+            # polluting ObjectRegistry (see PR #939 discussion)
+            temp_doc = ChatDocument.from_LLMResponse(
+                response,
+                displayed=True,
+                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+            )
+            self._call_callback_with_reasoning(
+                "finish_llm_stream",
+                reasoning=response.reasoning,
+                content=response.message or "",
+                tools_content=response.tools_content(),
+                is_tool=self.has_tool_message_attempt(temp_doc),
+            )
+            ObjectRegistry.remove(temp_doc.id())
+        self.llm.config.streamer_async = async_noop_fn
+        if response.cached:
+            self.callbacks.cancel_llm_stream()
+        self._render_llm_response(response)
+        self.update_token_usage(
+            response,  # .usage attrib is updated!
+            messages,
+            self.llm.get_stream(),
+            chat=True,
+            print_response_stats=self.config.show_stats and not settings.quiet,
+        )
+        chat_doc = ChatDocument.from_LLMResponse(
+            response,
+            displayed=True,
+            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+        )
+        self.oai_tool_calls = response.oai_tool_calls or []
+        self.oai_tool_id2call.update(
+            {t.id: t for t in self.oai_tool_calls if t.id is not None}
+        )
+
+        # If using strict output format, parse the output JSON
+        self._load_output_format(chat_doc)
+
+        return chat_doc
+
+    def _call_callback_with_reasoning(
+        self,
+        callback_name: str,
+        reasoning: str,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Call a callback method, only passing 'reasoning' if it accepts it.
+
+        This provides backward compatibility for custom callbacks that don't
+        have the 'reasoning' parameter in their signature.
+
+        Args:
+            callback_name: Name of the callback method (e.g., 'show_llm_response')
+            reasoning: The reasoning content to pass if supported
+            **kwargs: Other arguments to pass to the callback
+        """
+        callback = getattr(self.callbacks, callback_name, None)
+        if callback is None:
+            return
+
+        # Check if callback accepts 'reasoning' param or **kwargs
+        try:
+            sig = inspect.signature(callback)
+            params = sig.parameters
+            accepts_reasoning = "reasoning" in params or any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+            )
+        except (ValueError, TypeError):
+            # If we can't inspect the signature, assume it doesn't accept reasoning
+            accepts_reasoning = False
+
+        if accepts_reasoning:
+            callback(reasoning=reasoning, **kwargs)
+        else:
+            callback(**kwargs)
+
+    def _render_llm_response(
+        self, response: ChatDocument | LLMResponse, citation_only: bool = False
+    ) -> None:
+        is_cached = (
+            response.cached
+            if isinstance(response, LLMResponse)
+            else response.metadata.cached
+        )
+        if self.llm is None:
+            return
+        if not citation_only and (not self.llm.get_stream() or is_cached):
+            # We would have already displayed the msg "live" ONLY if
+            # streaming was enabled, AND we did not find a cached response.
+            # If we are here, it means the response has not yet been displayed.
+            cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
+            # Track whether we created a temp ChatDocument for cleanup
+            is_temp_doc = isinstance(response, LLMResponse)
+            chat_doc = (
+                response
+                if isinstance(response, ChatDocument)
+                else ChatDocument.from_LLMResponse(
+                    response,
+                    displayed=True,
+                    recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+                )
+            )
+            # TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
+            if not settings.quiet:
+                print(cached + "[green]" + escape(str(response)))
+            if isinstance(response, LLMResponse):
+                content = response.message or ""
+                tools_content = response.tools_content()
+            else:
+                content = response.content
+                tools_content = ""
+            reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
+            self._call_callback_with_reasoning(
+                "show_llm_response",
+                reasoning=reasoning,
+                content=content,
+                tools_content=tools_content,
+                is_tool=self.has_tool_message_attempt(chat_doc),
+                cached=is_cached,
+            )
+            # Clean up temp ChatDocument to avoid polluting ObjectRegistry
+            if is_temp_doc:
+                ObjectRegistry.remove(chat_doc.id())
+        if isinstance(response, LLMResponse):
+            # we are in the context immediately after an LLM responded,
+            # we won't have citations yet, so we're done
+            return
+        if response.metadata.has_citation:
+            citation = (
+                response.metadata.source_content
+                if self.config.full_citations
+                else response.metadata.source
+            )
+            if not settings.quiet:
+                print("[grey37]SOURCES:\n" + escape(citation) + "[/grey37]")
+            self._call_callback_with_reasoning(
+                "show_llm_response",
+                reasoning="",  # Citations don't have reasoning
+                content=str(citation),
+                tools_content="",
+                is_tool=False,
+                cached=False,
+                language="text",
+            )
+
+    def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument:
+        """
+        Get LLM response to `prompt` (which presumably includes the `message`
+        somewhere, along with possible large "context" passages),
+        but only include `message` as the USER message, and not the
+        full `prompt`, in the message history.
+        Args:
+            message: the original, relatively short, user request or query
+            prompt: the full prompt potentially containing `message` plus context
+
+        Returns:
+            Document object containing the response.
+        """
+        # we explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
+        self.update_last_message(message, role=Role.USER)
+        return answer_doc
+
+    async def _llm_response_temp_context_async(
+        self, message: str, prompt: str
+    ) -> ChatDocument:
+        """
+        Async version of `_llm_response_temp_context`. See there for details.
+        """
+        # we explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            answer_doc = cast(
+                ChatDocument,
+                await ChatAgent.llm_response_async(self, prompt),
+            )
+        self.update_last_message(message, role=Role.USER)
+        return answer_doc
+
+    def llm_response_forget(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> ChatDocument:
+        """
+        LLM Response to single message, and restore message_history.
+        In effect a "one-off" message & response that leaves agent
+        message history state intact.
+
+        Args:
+            message (str|ChatDocument): message to respond to.
+
+        Returns:
+            A Document object with the response.
+
+        """
+        # explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        n_msgs = len(self.message_history)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            response = cast(ChatDocument, ChatAgent.llm_response(self, message))
+        # If there is a response, then we will have two additional
+        # messages in the message history, i.e. the user message and the
+        # assistant response. We want to (carefully) remove these two messages.
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+
+        # If using strict output format, parse the output JSON
+        self._load_output_format(response)
+
+        return response
+
+    async def llm_response_forget_async(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> ChatDocument:
+        """
+        Async version of `llm_response_forget`. See there for details.
+        """
+        # explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        n_msgs = len(self.message_history)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            response = cast(
+                ChatDocument, await ChatAgent.llm_response_async(self, message)
+            )
+        # If there is a response, then we will have two additional
+        # messages in the message history, i.e. the user message and the
+        # assistant response. We want to (carefully) remove these two messages.
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+        return response
+
+    def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int:
+        """
+        Total number of tokens in the message history so far.
+
+        Args:
+            messages: if provided, compute the number of tokens in this list of
+                messages, rather than the current message history.
+        Returns:
+            int: number of tokens in message history
+        """
+        if self.parser is None:
+            raise ValueError(
+                "ChatAgent.parser is None. "
+                "You must set ChatAgent.parser "
+                "before calling chat_num_tokens()."
+            )
+        hist = messages if messages is not None else self.message_history
+        return sum([self._message_num_tokens(m) for m in hist])
+
+    def _message_num_tokens(self, message: LLMMessage) -> int:
+        """Count tokens for a message, including serialized user attachments."""
+        if self.parser is None:
+            raise ValueError(
+                "ChatAgent.parser is None. "
+                "You must set ChatAgent.parser "
+                "before calling _message_num_tokens()."
+            )
+
+        return self.parser.num_tokens(
+            message.content or ""
+        ) + self._attachment_num_tokens(message)
+
+    def _attachment_num_tokens(self, message: LLMMessage) -> int:
+        """
+        Estimate attachment contribution using the serialized payload
+        that is sent in the API request for user messages.
+        """
+        if self.parser is None or message.role != Role.USER or len(message.files) == 0:
+            return 0
+
+        model = self._chat_model_name_for_attachments()
+        n_tokens = sum(
+            self.parser.num_tokens(
+                json.dumps(
+                    attachment.to_dict(model),
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+            )
+            for attachment in message.files
+        )
+        if n_tokens > 0 and not self._attachment_tokens_warned:
+            self._attachment_tokens_warned = True
+            logger.warning(
+                "File attachment payloads are included in context-length "
+                "token accounting; this count is an estimate based on the "
+                "serialized (e.g. base64 data-URI) form of each attachment, "
+                "and may differ from the provider's own accounting."
+            )
+        return n_tokens
+
+    def _chat_model_name_for_attachments(self) -> str:
+        """Return the model name used for attachment serialization."""
+        if self.llm is None:
+            return self.config.llm.chat_model if self.config.llm is not None else ""
+
+        return cast(
+            str,
+            getattr(
+                self.llm,
+                "chat_model_orig",
+                getattr(
+                    getattr(self.llm, "config", None),
+                    "chat_model",
+                    self.config.llm.chat_model if self.config.llm is not None else "",
+                ),
+            ),
+        )
+
+    def message_history_str(self, i: Optional[int] = None) -> str:
+        """
+        Return a string representation of the message history
+        Args:
+            i: if provided, return only the i-th message when i is postive,
+                or last k messages when i = -k.
+        Returns:
+        """
+        if i is None:
+            return "\n".join([str(m) for m in self.message_history])
+        elif i > 0:
+            return str(self.message_history[i])
+        else:
+            return "\n".join([str(m) for m in self.message_history[i:]])
+
+    def __del__(self) -> None:
+        """
+        Cleanup method called when the ChatAgent is garbage collected.
+        Note: We don't close LLM clients here because they may be shared
+        across multiple agents when client caching is enabled.
+        The clients are managed centrally and cleaned up via atexit hooks.
+        """
+        # Previously we closed clients here, but this caused issues when
+        # multiple agents shared the same cached client instance.
+        # Clients are now managed centrally in langroid.language_models.client_cache
+        pass
 </file>
 
 <file path="mkdocs.yml">
@@ -64989,6 +65050,7 @@ nav:
       - Markdown, HTML Parsing: notes/markdown-html-parsing.md
       - Context-Overflow Handling: notes/context-overflow.md
       - Batch Processing: notes/batch-processing.md
+      - Attachment Token Preflight: notes/attachment-token-preflight.md
 
   - Examples:
     - Guide: examples/guide.md
@@ -65037,7 +65099,7 @@ extra_javascript:
 <file path="pyproject.toml">
 [project]
 name = "langroid"
-version = "0.65.16"
+version = "0.66.0"
 authors = [
     {name = "Prasad Chalasani", email = "pchalasani@gmail.com"},
 ]

--- a/llms-no-tests.txt
+++ b/llms-no-tests.txt
@@ -107,6 +107,7 @@ docs/
     pure-lambda-non-circular.png
   notes/
     async-streaming.md
+    attachment-token-preflight.md
     azure-openai-models.md
     batch-processing.md
     chat-history-snapshots.md
@@ -56637,6 +56638,55 @@ the LLM will try its best to interpret what you want, and offer choices when con
     - Illustrates function-calling/tools and code-generation
 </file>
 
+<file path="docs/notes/attachment-token-preflight.md">
+# Attachment Token Preflight
+
+Before each LLM call, Langroid runs a local context-length preflight: it counts
+the tokens in the pending message history (`ChatAgent.chat_num_tokens()`) and,
+if needed, reduces the requested output length, truncates old messages, or
+drops old turns so the request fits the model's context window.
+
+Historically this preflight counted only each message's text `content`, ignoring
+`LLMMessage.files` (`FileAttachment` objects). But attachments ARE serialized
+into the actual API request — for Gemini and other OpenAI-compatible paths,
+`FileAttachment.to_dict()` turns an attached PDF or image into a `data:` URI
+containing the full base64 payload. A ~1.9 MB PDF becomes roughly 2.6 million
+base64 characters, so the local check could pass while the real payload was far
+larger (issue #996).
+
+## Behavior
+
+The preflight now includes an estimate for each attachment on `USER` messages:
+
+- Each attachment is serialized exactly as it would be for the API request
+  (`FileAttachment.to_dict(model)`), and the resulting JSON is tokenized with
+  the agent's parser, the same way message text is counted.
+- Attachments that are NOT inlined — e.g. a `FileAttachment` carrying an
+  `http(s)` URL, which is sent as the URL itself rather than base64 bytes —
+  contribute only the tokens of their small serialized form, not the size of
+  the remote file.
+- Messages with no attachments are counted exactly as before; token accounting
+  is unchanged for attachment-free histories.
+
+When attachments contribute to the count for an agent, a warning is logged once
+(per agent, not per message) noting that the count is an estimate.
+
+## How conservative is the estimate?
+
+The estimate measures the serialized request payload (base64 data URI plus the
+surrounding JSON), tokenized like ordinary text. Provider-side accounting may
+differ in either direction:
+
+- Providers that bill inlined files as text-like payload will be close to this
+  estimate.
+- Providers that convert files to their own internal representation (e.g.
+  per-page or per-image token charges) may count fewer or more tokens.
+
+The goal is to keep the local preflight from drastically *under*-estimating the
+request size when large files are attached, so context-window overflows are
+caught locally instead of surfacing as provider-side errors.
+</file>
+
 <file path="docs/notes/batch-processing.md">
 # Batch Processing
 
@@ -72081,6 +72131,886 @@ class ToolMessage(ABC, BaseModel):
         return schema
 </file>
 
+<file path="langroid/language_models/base.py">
+import json
+import logging
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from enum import Enum
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
+
+from langroid.cachedb.base import CacheDBConfig
+from langroid.cachedb.redis_cachedb import RedisCacheConfig
+from langroid.language_models.model_info import ModelInfo, get_model_info
+from langroid.parsing.agent_chats import parse_message
+from langroid.parsing.file_attachment import FileAttachment
+from langroid.parsing.parse_json import parse_imperfect_json, top_level_json_field
+from langroid.prompts.dialog import collate_chat_history
+from langroid.utils.configuration import settings
+from langroid.utils.output.printing import show_if_debug
+
+logger = logging.getLogger(__name__)
+
+
+def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+    pass
+
+
+async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+    pass
+
+
+FunctionCallTypes = Literal["none", "auto"]
+ToolChoiceTypes = Literal["none", "auto", "required"]
+ToolTypes = Literal["function"]
+
+DEFAULT_CONTEXT_LENGTH = 16_000
+
+
+class StreamEventType(Enum):
+    TEXT = 1
+    FUNC_NAME = 2
+    FUNC_ARGS = 3
+    TOOL_NAME = 4
+    TOOL_ARGS = 5
+    REASONING = 6
+
+
+class RetryParams(BaseSettings):
+    max_retries: int = 5
+    initial_delay: float = 1.0
+    exponential_base: float = 1.3
+    jitter: bool = True
+
+
+class LLMConfig(BaseSettings):
+    """
+    Common configuration for all language models.
+    """
+
+    type: str = "openai"
+    streamer: Optional[Callable[[Any], None]] = noop_fn
+    streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
+    api_base: str | None = None
+    formatter: None | str = None
+    # specify None if you want to use the full max output tokens of the model
+    max_output_tokens: int | None = 8192
+    timeout: int = 20  # timeout for API requests
+    chat_model: str = ""
+    completion_model: str = ""
+    temperature: float = 0.0
+    chat_context_length: int | None = None
+    async_stream_quiet: bool = False  # suppress streaming output in async mode?
+    completion_context_length: int | None = None
+    # if input length + max_output_tokens > context length of model,
+    # we will try shortening requested output
+    min_output_tokens: int = 64
+    use_completion_for_chat: bool = False  # use completion model for chat?
+    # use chat model for completion? For OpenAI models, this MUST be set to True!
+    use_chat_for_completion: bool = True
+    stream: bool = True  # stream output from API?
+    # TODO: we could have a `stream_reasoning` flag here to control whether to show
+    # reasoning output from reasoning models
+    cache_config: None | CacheDBConfig = RedisCacheConfig()
+    thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
+    retry_params: RetryParams = RetryParams()
+
+    @property
+    def model_max_output_tokens(self) -> int:
+        if self.max_output_tokens:
+            return self.max_output_tokens
+        # Build fallback names by progressively stripping provider prefixes
+        # (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
+        # succeeds even before OpenAIGPT.__init__ strips the prefix.
+        parts = self.chat_model.split("/")
+        fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
+        return get_model_info(self.chat_model, fallbacks).max_output_tokens
+
+
+class LLMFunctionCall(BaseModel):
+    """
+    Structure of LLM response indicating it "wants" to call a function.
+    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
+    """
+
+    name: str  # name of function to call
+    arguments: Optional[Dict[str, Any]] = None
+
+    @staticmethod
+    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall":
+        """
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+        fun_call = LLMFunctionCall(name=message["name"])
+        fun_args_str = message["arguments"]
+        # sometimes may be malformed with invalid indents,
+        # so we try to be safe by removing newlines.
+        if fun_args_str is not None:
+            fun_args_str = fun_args_str.replace("\n", "").strip()
+            dict_or_list = parse_imperfect_json(fun_args_str)
+
+            if not isinstance(dict_or_list, dict):
+                raise ValueError(
+                    f"""
+                        Invalid function args: {fun_args_str}
+                        parsed as {dict_or_list},
+                        which is not a valid dict.
+                        """
+                )
+            fun_args = dict_or_list
+        else:
+            fun_args = None
+        fun_call.arguments = fun_args
+
+        return fun_call
+
+    def __str__(self) -> str:
+        return "FUNC: " + json.dumps(self.model_dump(), indent=2)
+
+
+class LLMFunctionSpec(BaseModel):
+    """
+    Description of a function available for the LLM to use.
+    To be used when calling the LLM `chat()` method with the `functions` parameter.
+    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
+    """
+
+    name: str
+    description: str
+    parameters: Dict[str, Any]
+
+
+class OpenAIToolCall(BaseModel):
+    """
+    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
+    See https://platform.openai.com/docs/api-reference/chat/create
+
+    Attributes:
+        id: The id of the tool call.
+        type: The type of the tool call;
+            only "function" is currently possible (7/26/24).
+        function: The function call.
+    """
+
+    id: str | None = None
+    type: ToolTypes = "function"
+    function: LLMFunctionCall | None = None
+    extra_content: Dict[str, Any] | None = None
+
+    @staticmethod
+    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall":
+        """
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+        id = message["id"]
+        type = message["type"]
+        function = LLMFunctionCall.from_dict(message["function"])
+        extra_content = message.get("extra_content")
+        return OpenAIToolCall(
+            id=id, type=type, function=function, extra_content=extra_content
+        )
+
+    def __str__(self) -> str:
+        if self.function is None:
+            return ""
+        return "OAI-TOOL: " + json.dumps(self.function.model_dump(), indent=2)
+
+
+class OpenAIToolSpec(BaseModel):
+    type: ToolTypes
+    strict: Optional[bool] = None
+    function: LLMFunctionSpec
+
+
+class OpenAIJsonSchemaSpec(BaseModel):
+    strict: Optional[bool] = None
+    function: LLMFunctionSpec
+
+    def to_dict(self) -> Dict[str, Any]:
+        json_schema: Dict[str, Any] = {
+            "name": self.function.name,
+            "description": self.function.description,
+            "schema": self.function.parameters,
+        }
+        if self.strict is not None:
+            json_schema["strict"] = self.strict
+
+        return {
+            "type": "json_schema",
+            "json_schema": json_schema,
+        }
+
+
+class LLMTokenUsage(BaseModel):
+    """
+    Usage of tokens by an LLM.
+    """
+
+    prompt_tokens: int = 0
+    cached_tokens: int = 0
+    completion_tokens: int = 0
+    cost: float = 0.0
+    calls: int = 0  # how many API calls - not used as of 2025-04-04
+
+    def reset(self) -> None:
+        self.prompt_tokens = 0
+        self.cached_tokens = 0
+        self.completion_tokens = 0
+        self.cost = 0.0
+        self.calls = 0
+
+    def __str__(self) -> str:
+        return (
+            f"Tokens = "
+            f"(prompt {self.prompt_tokens}, cached {self.cached_tokens}, "
+            f"completion {self.completion_tokens}), "
+            f"Cost={self.cost}, Calls={self.calls}"
+        )
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+
+class Role(str, Enum):
+    """
+    Possible roles for a message in a chat.
+    """
+
+    USER = "user"
+    SYSTEM = "system"
+    ASSISTANT = "assistant"
+    FUNCTION = "function"
+    TOOL = "tool"
+
+
+class LLMMessage(BaseModel):
+    """
+    Class representing an entry in the msg-history sent to the LLM API.
+    It could be one of these:
+    - a user message
+    - an LLM ("Assistant") response
+    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
+    - a result or results from executing a fn or tool-call(s)
+    """
+
+    role: Role
+    name: Optional[str] = None
+    tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
+    tool_id: str = ""  # used by OpenAIAssistant
+    # None means "no content" (the model returned only a tool/function call).
+    # This is distinct from "" and is dropped from the API payload by api_dict;
+    # see api_dict for how a fully-empty message is handled per-API.
+    content: Optional[str] = None
+    files: List[FileAttachment] = []
+    function_call: Optional[LLMFunctionCall] = None
+    tool_calls: Optional[List[OpenAIToolCall]] = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    # link to corresponding chat document, for provenance/rewind purposes
+    chat_document_id: str = ""
+
+    def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]:
+        """
+        Convert to dictionary for API request, keeping ONLY
+        the fields that are expected in an API call!
+        E.g., DROP the tool_id, since it is only for use in the Assistant API,
+            not the completion API.
+
+        Args:
+            has_system_role: whether the message has a system role (if not,
+                set to "user" role)
+        Returns:
+            dict: dictionary representation of LLM message
+        """
+        d = self.model_dump()
+        files: List[FileAttachment] = d.pop("files")
+        if len(files) > 0 and self.role == Role.USER:
+            # In there are files, then content is an array of
+            # different content-parts
+            d["content"] = [
+                dict(
+                    type="text",
+                    text=self.content or "",
+                )
+            ] + [f.to_dict(model) for f in self.files]
+
+        # if there is a key k = "role" with value "system", change to "user"
+        # in case has_system_role is False
+        if not has_system_role and "role" in d and d["role"] == "system":
+            d["role"] = "user"
+            if d.get("content"):
+                d["content"] = "[ADDITIONAL SYSTEM MESSAGE:]\n\n" + d["content"]
+        # drop None values since API doesn't accept them (this omits `content`
+        # entirely when it is None, i.e. "no content")
+        dict_no_none = {k: v for k, v in d.items() if v is not None}
+        if "name" in dict_no_none and dict_no_none["name"] == "":
+            # OpenAI API does not like empty name
+            del dict_no_none["name"]
+        if "function_call" in dict_no_none:
+            # arguments must be a string
+            if "arguments" in dict_no_none["function_call"]:
+                dict_no_none["function_call"]["arguments"] = json.dumps(
+                    dict_no_none["function_call"]["arguments"]
+                )
+        if dict_no_none.get("tool_calls"):
+            # convert tool calls to API format
+            for tc in dict_no_none["tool_calls"]:
+                if "arguments" in tc["function"]:
+                    # arguments must be a string
+                    if tc["function"]["arguments"] is None:
+                        tc["function"]["arguments"] = "{}"
+                    else:
+                        tc["function"]["arguments"] = json.dumps(
+                            tc["function"]["arguments"]
+                        )
+                if "extra_content" in tc and tc["extra_content"] is None:
+                    del tc["extra_content"]
+        else:
+            # An empty tool-call list is not a call and conveys no useful API
+            # information. Omitting it also lets the empty-message fallback
+            # below produce a valid message.
+            dict_no_none.pop("tool_calls", None)
+        # A message with empty content (None was dropped above, or "") AND no
+        # tool/function call would be an entirely empty message, which some APIs
+        # (e.g. Gemini) reject; fall back to a single space in that case only.
+        # When there IS a tool/function call, empty content is fine (and Gemini
+        # 3.x in fact REQUIRES it — it rejects an assistant turn that carries
+        # both a call and non-empty text content).
+        has_call = bool(dict_no_none.get("tool_calls")) or (
+            dict_no_none.get("function_call") is not None
+        )
+        if not has_call and not dict_no_none.get("content"):
+            dict_no_none["content"] = " "
+        # IMPORTANT! drop fields that are not expected in API call
+        dict_no_none.pop("tool_id", None)
+        dict_no_none.pop("timestamp", None)
+        dict_no_none.pop("chat_document_id", None)
+        return dict_no_none
+
+    def __str__(self) -> str:
+        if self.function_call is not None:
+            content = "FUNC: " + json.dumps(self.function_call)
+        else:
+            content = self.content or ""
+        name_str = f" ({self.name})" if self.name else ""
+        return f"{self.role} {name_str}: {content}"
+
+
+class LLMResponse(BaseModel):
+    """
+    Class representing response from LLM.
+    """
+
+    # None means the model returned NO content (e.g. only a tool/function
+    # call), which is distinct from an empty string "". Preserving this
+    # distinction lets the message be faithfully reproduced downstream
+    # (see ChatDocument.content_is_none and LLMMessage.content).
+    message: Optional[str] = None
+    reasoning: str = ""  # optional reasoning text from reasoning models
+    # Original message text including inline thought signatures (e.g.
+    # <thinking>...</thinking>). Only set when reasoning was extracted
+    # from the message text via get_reasoning_final(); NOT set when
+    # reasoning comes from a separate API field (e.g. reasoning_content),
+    # since in that case the message text never contained thought tags.
+    message_with_reasoning: Optional[str] = None
+    # TODO tool_id needs to generalize to multi-tool calls
+    tool_id: str = ""  # used by OpenAIAssistant
+    oai_tool_calls: Optional[List[OpenAIToolCall]] = None
+    function_call: Optional[LLMFunctionCall] = None
+    usage: Optional[LLMTokenUsage] = None
+    cached: bool = False
+
+    def __str__(self) -> str:
+        if self.function_call is not None:
+            return str(self.function_call)
+        elif self.oai_tool_calls:
+            return "\n".join(str(tc) for tc in self.oai_tool_calls)
+        else:
+            return self.message or ""
+
+    def tools_content(self) -> str:
+        if self.function_call is not None:
+            return str(self.function_call)
+        elif self.oai_tool_calls:
+            return "\n".join(str(tc) for tc in self.oai_tool_calls)
+        else:
+            return ""
+
+    def to_LLMMessage(self) -> LLMMessage:
+        """Convert LLM response to an LLMMessage, to be included in the
+        message-list sent to the API.
+        This is currently NOT used in any significant way in the library, and is only
+        provided as a utility to construct a message list for the API when directly
+        working with an LLM object.
+
+        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
+        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
+        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
+        """
+        return LLMMessage(
+            role=Role.ASSISTANT,
+            content=self.message,
+            name=None if self.function_call is None else self.function_call.name,
+            function_call=self.function_call,
+            tool_calls=self.oai_tool_calls,
+        )
+
+    def get_recipient_and_message(
+        self,
+        recognize_recipient_in_content: bool = True,
+    ) -> Tuple[str, str]:
+        """
+        If `message` or `function_call` of an LLM response contains an explicit
+        recipient name, return this recipient name and `message` stripped
+        of the recipient name if specified.
+
+        Two cases:
+        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
+        (b) `message` is empty and function_call/tool_call with explicit `recipient`
+
+        Args:
+            recognize_recipient_in_content (bool): When True (default), parses
+                message text for ``TO[<recipient>]:<content>`` patterns and
+                top-level JSON ``{"recipient": "..."}`` fields. When False,
+                only function_call/tool_call ``recipient`` fields are checked.
+
+        Returns:
+            (str): name of recipient, which may be empty string if no recipient
+            (str): content of message
+
+        """
+
+        if self.function_call is not None:
+            # in this case we ignore message, since all information is in function_call
+            msg = ""
+            args = self.function_call.arguments
+            recipient = ""
+            if isinstance(args, dict):
+                recipient = args.get("recipient", "")
+            return recipient, msg
+        else:
+            msg = self.message or ""
+            if self.oai_tool_calls is not None:
+                # get the first tool that has a recipient field, if any
+                for tc in self.oai_tool_calls:
+                    if tc.function is not None and tc.function.arguments is not None:
+                        recipient = tc.function.arguments.get(
+                            "recipient"
+                        )  # type: ignore
+                        if recipient is not None and recipient != "":
+                            return recipient, ""
+
+        if not recognize_recipient_in_content:
+            return "", msg
+
+        # It's not a function or tool call, so continue looking to see
+        # if a recipient is specified in the message.
+
+        # First check if message contains "TO: <recipient> <content>"
+        recipient_name, content = parse_message(msg) if msg is not None else ("", "")
+        # check if there is a top level json that specifies 'recipient',
+        # and retain the entire message as content.
+        if recipient_name == "":
+            recipient_name = top_level_json_field(msg, "recipient") if msg else ""
+            content = msg
+        return recipient_name, content
+
+
+# Define an abstract base class for language models
+class LanguageModel(ABC):
+    """
+    Abstract base class for language models.
+    """
+
+    # usage cost by model, accumulates here
+    usage_cost_dict: Dict[str, LLMTokenUsage] = {}
+
+    def __init__(self, config: LLMConfig = LLMConfig()):
+        self.config = config
+        self.chat_model_orig = config.chat_model
+
+    @staticmethod
+    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]:
+        """
+        Create a language model.
+        Args:
+            config: configuration for language model
+        Returns: instance of language model
+        """
+        if type(config) is LLMConfig:
+            raise ValueError(
+                """
+                Cannot create a Language Model object from LLMConfig.
+                Please specify a specific subclass of LLMConfig e.g.,
+                OpenAIGPTConfig. If you are creating a ChatAgent from
+                a ChatAgentConfig, please specify the `llm` field of this config
+                as a specific subclass of LLMConfig, e.g., OpenAIGPTConfig.
+                """
+            )
+        from langroid.language_models.azure_openai import AzureGPT
+        from langroid.language_models.mock_lm import MockLM, MockLMConfig
+        from langroid.language_models.openai_gpt import OpenAIGPT
+
+        if config is None or config.type is None:
+            return None
+
+        if config.type == "mock":
+            return MockLM(cast(MockLMConfig, config))
+
+        openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
+
+        if config.type == "azure":
+            openai = AzureGPT
+        else:
+            openai = OpenAIGPT
+        cls = dict(
+            openai=openai,
+        ).get(config.type, openai)
+        return cls(config)  # type: ignore
+
+    @staticmethod
+    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]:
+        """
+        Given an even-length sequence of strings, split into a sequence of pairs
+
+        Args:
+            lst (List[str]): sequence of strings
+
+        Returns:
+            List[Tuple[str,str]]: sequence of pairs of strings
+        """
+        evens = lst[::2]
+        odds = lst[1::2]
+        return list(zip(evens, odds))
+
+    @staticmethod
+    def get_chat_history_components(
+        messages: List[LLMMessage],
+    ) -> Tuple[str, List[Tuple[str, str]], str]:
+        """
+        From the chat history, extract system prompt, user-assistant turns, and
+        final user msg.
+
+        Args:
+            messages (List[LLMMessage]): List of messages in the chat history
+
+        Returns:
+            Tuple[str, List[Tuple[str,str]], str]:
+                system prompt, user-assistant turns, final user msg
+
+        """
+        # Handle various degenerate cases
+        messages = [m for m in messages]  # copy
+        DUMMY_SYS_PROMPT = "You are a helpful assistant."
+        DUMMY_USER_PROMPT = "Follow the instructions above."
+        if len(messages) == 0 or messages[0].role != Role.SYSTEM:
+            logger.warning("No system msg, creating dummy system prompt")
+            messages.insert(0, LLMMessage(content=DUMMY_SYS_PROMPT, role=Role.SYSTEM))
+        system_prompt = messages[0].content or ""
+
+        # now we have messages = [Sys,...]
+        if len(messages) == 1:
+            logger.warning(
+                "Got only system message in chat history, creating dummy user prompt"
+            )
+            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, msg, ...]
+
+        if messages[1].role != Role.USER:
+            messages.insert(1, LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, user, ...]
+        if messages[-1].role != Role.USER:
+            logger.warning(
+                "Last message in chat history is not a user message,"
+                " creating dummy user prompt"
+            )
+            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, user, ..., user]
+        # so we omit the first and last elements and make pairs of user-asst messages
+        conversation = [m.content or "" for m in messages[1:-1]]
+        user_prompt = messages[-1].content or ""
+        pairs = LanguageModel.user_assistant_pairs(conversation)
+        return system_prompt, pairs, user_prompt
+
+    @abstractmethod
+    def set_stream(self, stream: bool) -> bool:
+        """Enable or disable streaming output from API.
+        Return previous value of stream."""
+        pass
+
+    @abstractmethod
+    def get_stream(self) -> bool:
+        """Get streaming status"""
+        pass
+
+    @abstractmethod
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        pass
+
+    @abstractmethod
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        pass
+
+    @abstractmethod
+    def chat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """
+        Get chat-completion response from LLM.
+
+        Args:
+            messages: message-history to send to the LLM
+            max_tokens: max tokens to generate
+            tools: tools available for the LLM to use in its response
+            tool_choice: tool call mode, one of "none", "auto", "required",
+                or a dict specifying a specific tool.
+            functions: functions available for LLM to call (deprecated)
+            function_call: function calling mode, "auto", "none", or a specific fn
+                    (deprecated)
+        """
+
+        pass
+
+    @abstractmethod
+    async def achat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """Async version of `chat`. See `chat` for details."""
+        pass
+
+    def __call__(self, prompt: str, max_tokens: int) -> LLMResponse:
+        return self.generate(prompt, max_tokens)
+
+    @staticmethod
+    def _fallback_model_names(model: str) -> List[str]:
+        parts = model.split("/")
+        fallbacks = []
+        for i in range(1, len(parts)):
+            fallbacks.append("/".join(parts[i:]))
+        return fallbacks
+
+    def info(self) -> ModelInfo:
+        """Info of relevant chat model"""
+        orig_model = (
+            self.config.completion_model
+            if self.config.use_completion_for_chat
+            else self.chat_model_orig
+        )
+        return get_model_info(orig_model, self._fallback_model_names(orig_model))
+
+    def completion_info(self) -> ModelInfo:
+        """Info of relevant completion model"""
+        orig_model = (
+            self.chat_model_orig
+            if self.config.use_chat_for_completion
+            else self.config.completion_model
+        )
+        return get_model_info(orig_model, self._fallback_model_names(orig_model))
+
+    def supports_functions_or_tools(self) -> bool:
+        """
+        Does this Model's API support "native" tool-calling, i.e.
+        can we call the API with arguments that contain a list of available tools,
+        and their schemas?
+        Note that, given the plethora of LLM provider APIs this determination is
+        imperfect at best, and leans towards returning True.
+        When the API calls fails with an error indicating tools are not supported,
+        then users are encouraged to use the Langroid-based prompt-based
+        ToolMessage mechanism, which works with ANY LLM. To enable this,
+        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
+        """
+        return self.info().has_tools
+
+    def chat_context_length(self) -> int:
+        return self.config.chat_context_length or DEFAULT_CONTEXT_LENGTH
+
+    def completion_context_length(self) -> int:
+        return self.config.completion_context_length or DEFAULT_CONTEXT_LENGTH
+
+    def chat_cost(self) -> Tuple[float, float, float]:
+        """
+        Return the cost per 1000 tokens for chat completions.
+
+        Returns:
+            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
+                per 1000 tokens
+        """
+        return (0.0, 0.0, 0.0)
+
+    def reset_usage_cost(self) -> None:
+        for mdl in [self.config.chat_model, self.config.completion_model]:
+            if mdl is None:
+                return
+            if mdl not in self.usage_cost_dict:
+                self.usage_cost_dict[mdl] = LLMTokenUsage()
+            counter = self.usage_cost_dict[mdl]
+            counter.reset()
+
+    def update_usage_cost(
+        self, chat: bool, prompts: int, completions: int, cost: float
+    ) -> None:
+        """
+        Update usage cost for this LLM.
+        Args:
+            chat (bool): whether to update for chat or completion model
+            prompts (int): number of tokens used for prompts
+            completions (int): number of tokens used for completions
+            cost (float): total token cost in USD
+        """
+        mdl = self.config.chat_model if chat else self.config.completion_model
+        if mdl is None:
+            return
+        if mdl not in self.usage_cost_dict:
+            self.usage_cost_dict[mdl] = LLMTokenUsage()
+        counter = self.usage_cost_dict[mdl]
+        counter.prompt_tokens += prompts
+        counter.completion_tokens += completions
+        counter.cost += cost
+        counter.calls += 1
+
+    @classmethod
+    def usage_cost_summary(cls) -> str:
+        s = ""
+        for model, counter in cls.usage_cost_dict.items():
+            s += f"{model}: {counter}\n"
+        return s
+
+    @classmethod
+    def tot_tokens_cost(cls) -> Tuple[int, float]:
+        """
+        Return total tokens used and total cost across all models.
+        """
+        total_tokens = 0
+        total_cost = 0.0
+        for counter in cls.usage_cost_dict.values():
+            total_tokens += counter.total_tokens
+            total_cost += counter.cost
+        return total_tokens, total_cost
+
+    def get_reasoning_final(self, message: str) -> Tuple[str, str]:
+        """Extract "reasoning" and "final answer" from an LLM response, if the
+        reasoning is found within configured delimiters, like <think>, </think>.
+        E.g.,
+        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
+
+        Args:
+            message (str): message from LLM
+
+        Returns:
+            Tuple[str, str]: reasoning, final answer
+        """
+        start, end = self.config.thought_delimiters
+        if start in message and end in message:
+            parts = message.split(start)
+            if len(parts) > 1:
+                reasoning, final = parts[1].split(end)
+                return reasoning, final
+        return "", message
+
+    def followup_to_standalone(
+        self, chat_history: List[Tuple[str, str]], question: str
+    ) -> str:
+        """
+        Given a chat history and a question, convert it to a standalone question.
+        Args:
+            chat_history: list of tuples of (question, answer)
+            query: follow-up question
+
+        Returns: standalone version of the question
+        """
+        history = collate_chat_history(chat_history)
+
+        prompt = f"""
+        You are an expert at understanding a CHAT HISTORY between an AI Assistant
+        and a User, and you are highly skilled in rephrasing the User's FOLLOW-UP
+        QUESTION/REQUEST as a STANDALONE QUESTION/REQUEST that can be understood
+        WITHOUT the context of the chat history.
+
+        Below is the CHAT HISTORY. When the User asks you to rephrase a
+        FOLLOW-UP QUESTION/REQUEST, your ONLY task is to simply return the
+        question REPHRASED as a STANDALONE QUESTION/REQUEST, without any additional
+        text or context.
+
+        <CHAT_HISTORY>
+        {history}
+        </CHAT_HISTORY>
+        """.strip()
+
+        follow_up_question = f"""
+        Please rephrase this as a stand-alone question or request:
+        <FOLLOW-UP-QUESTION-OR-REQUEST>
+        {question}
+        </FOLLOW-UP-QUESTION-OR-REQUEST>
+        """.strip()
+
+        show_if_debug(prompt, "FOLLOWUP->STANDALONE-PROMPT= ")
+        standalone = (
+            self.chat(
+                messages=[
+                    LLMMessage(role=Role.SYSTEM, content=prompt),
+                    LLMMessage(role=Role.USER, content=follow_up_question),
+                ],
+                max_tokens=1024,
+            ).message
+            or ""
+        )
+        standalone = standalone.strip()
+
+        show_if_debug(prompt, "FOLLOWUP->STANDALONE-RESPONSE= ")
+        return standalone
+
+
+class StreamingIfAllowed:
+    """Context to temporarily enable or disable streaming, if allowed globally via
+    `settings.stream`"""
+
+    def __init__(self, llm: LanguageModel, stream: bool = True):
+        self.llm = llm
+        self.stream = stream
+
+    def __enter__(self) -> None:
+        self.old_stream = self.llm.set_stream(settings.stream and self.stream)
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.llm.set_stream(self.old_stream)
+</file>
+
 <file path="langroid/parsing/parser.py">
 import logging
 import re
@@ -80303,886 +81233,6 @@ class ChatDocument(Document):
 
 LLMMessage.model_rebuild()
 ChatDocMetaData.model_rebuild()
-</file>
-
-<file path="langroid/language_models/base.py">
-import json
-import logging
-from abc import ABC, abstractmethod
-from datetime import datetime, timezone
-from enum import Enum
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
-
-from pydantic import BaseModel, Field
-from pydantic_settings import BaseSettings
-
-from langroid.cachedb.base import CacheDBConfig
-from langroid.cachedb.redis_cachedb import RedisCacheConfig
-from langroid.language_models.model_info import ModelInfo, get_model_info
-from langroid.parsing.agent_chats import parse_message
-from langroid.parsing.file_attachment import FileAttachment
-from langroid.parsing.parse_json import parse_imperfect_json, top_level_json_field
-from langroid.prompts.dialog import collate_chat_history
-from langroid.utils.configuration import settings
-from langroid.utils.output.printing import show_if_debug
-
-logger = logging.getLogger(__name__)
-
-
-def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
-    pass
-
-
-async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
-    pass
-
-
-FunctionCallTypes = Literal["none", "auto"]
-ToolChoiceTypes = Literal["none", "auto", "required"]
-ToolTypes = Literal["function"]
-
-DEFAULT_CONTEXT_LENGTH = 16_000
-
-
-class StreamEventType(Enum):
-    TEXT = 1
-    FUNC_NAME = 2
-    FUNC_ARGS = 3
-    TOOL_NAME = 4
-    TOOL_ARGS = 5
-    REASONING = 6
-
-
-class RetryParams(BaseSettings):
-    max_retries: int = 5
-    initial_delay: float = 1.0
-    exponential_base: float = 1.3
-    jitter: bool = True
-
-
-class LLMConfig(BaseSettings):
-    """
-    Common configuration for all language models.
-    """
-
-    type: str = "openai"
-    streamer: Optional[Callable[[Any], None]] = noop_fn
-    streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
-    api_base: str | None = None
-    formatter: None | str = None
-    # specify None if you want to use the full max output tokens of the model
-    max_output_tokens: int | None = 8192
-    timeout: int = 20  # timeout for API requests
-    chat_model: str = ""
-    completion_model: str = ""
-    temperature: float = 0.0
-    chat_context_length: int | None = None
-    async_stream_quiet: bool = False  # suppress streaming output in async mode?
-    completion_context_length: int | None = None
-    # if input length + max_output_tokens > context length of model,
-    # we will try shortening requested output
-    min_output_tokens: int = 64
-    use_completion_for_chat: bool = False  # use completion model for chat?
-    # use chat model for completion? For OpenAI models, this MUST be set to True!
-    use_chat_for_completion: bool = True
-    stream: bool = True  # stream output from API?
-    # TODO: we could have a `stream_reasoning` flag here to control whether to show
-    # reasoning output from reasoning models
-    cache_config: None | CacheDBConfig = RedisCacheConfig()
-    thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
-    retry_params: RetryParams = RetryParams()
-
-    @property
-    def model_max_output_tokens(self) -> int:
-        if self.max_output_tokens:
-            return self.max_output_tokens
-        # Build fallback names by progressively stripping provider prefixes
-        # (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
-        # succeeds even before OpenAIGPT.__init__ strips the prefix.
-        parts = self.chat_model.split("/")
-        fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
-        return get_model_info(self.chat_model, fallbacks).max_output_tokens
-
-
-class LLMFunctionCall(BaseModel):
-    """
-    Structure of LLM response indicating it "wants" to call a function.
-    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
-    """
-
-    name: str  # name of function to call
-    arguments: Optional[Dict[str, Any]] = None
-
-    @staticmethod
-    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall":
-        """
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-        fun_call = LLMFunctionCall(name=message["name"])
-        fun_args_str = message["arguments"]
-        # sometimes may be malformed with invalid indents,
-        # so we try to be safe by removing newlines.
-        if fun_args_str is not None:
-            fun_args_str = fun_args_str.replace("\n", "").strip()
-            dict_or_list = parse_imperfect_json(fun_args_str)
-
-            if not isinstance(dict_or_list, dict):
-                raise ValueError(
-                    f"""
-                        Invalid function args: {fun_args_str}
-                        parsed as {dict_or_list},
-                        which is not a valid dict.
-                        """
-                )
-            fun_args = dict_or_list
-        else:
-            fun_args = None
-        fun_call.arguments = fun_args
-
-        return fun_call
-
-    def __str__(self) -> str:
-        return "FUNC: " + json.dumps(self.model_dump(), indent=2)
-
-
-class LLMFunctionSpec(BaseModel):
-    """
-    Description of a function available for the LLM to use.
-    To be used when calling the LLM `chat()` method with the `functions` parameter.
-    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
-    """
-
-    name: str
-    description: str
-    parameters: Dict[str, Any]
-
-
-class OpenAIToolCall(BaseModel):
-    """
-    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
-    See https://platform.openai.com/docs/api-reference/chat/create
-
-    Attributes:
-        id: The id of the tool call.
-        type: The type of the tool call;
-            only "function" is currently possible (7/26/24).
-        function: The function call.
-    """
-
-    id: str | None = None
-    type: ToolTypes = "function"
-    function: LLMFunctionCall | None = None
-    extra_content: Dict[str, Any] | None = None
-
-    @staticmethod
-    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall":
-        """
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-        id = message["id"]
-        type = message["type"]
-        function = LLMFunctionCall.from_dict(message["function"])
-        extra_content = message.get("extra_content")
-        return OpenAIToolCall(
-            id=id, type=type, function=function, extra_content=extra_content
-        )
-
-    def __str__(self) -> str:
-        if self.function is None:
-            return ""
-        return "OAI-TOOL: " + json.dumps(self.function.model_dump(), indent=2)
-
-
-class OpenAIToolSpec(BaseModel):
-    type: ToolTypes
-    strict: Optional[bool] = None
-    function: LLMFunctionSpec
-
-
-class OpenAIJsonSchemaSpec(BaseModel):
-    strict: Optional[bool] = None
-    function: LLMFunctionSpec
-
-    def to_dict(self) -> Dict[str, Any]:
-        json_schema: Dict[str, Any] = {
-            "name": self.function.name,
-            "description": self.function.description,
-            "schema": self.function.parameters,
-        }
-        if self.strict is not None:
-            json_schema["strict"] = self.strict
-
-        return {
-            "type": "json_schema",
-            "json_schema": json_schema,
-        }
-
-
-class LLMTokenUsage(BaseModel):
-    """
-    Usage of tokens by an LLM.
-    """
-
-    prompt_tokens: int = 0
-    cached_tokens: int = 0
-    completion_tokens: int = 0
-    cost: float = 0.0
-    calls: int = 0  # how many API calls - not used as of 2025-04-04
-
-    def reset(self) -> None:
-        self.prompt_tokens = 0
-        self.cached_tokens = 0
-        self.completion_tokens = 0
-        self.cost = 0.0
-        self.calls = 0
-
-    def __str__(self) -> str:
-        return (
-            f"Tokens = "
-            f"(prompt {self.prompt_tokens}, cached {self.cached_tokens}, "
-            f"completion {self.completion_tokens}), "
-            f"Cost={self.cost}, Calls={self.calls}"
-        )
-
-    @property
-    def total_tokens(self) -> int:
-        return self.prompt_tokens + self.completion_tokens
-
-
-class Role(str, Enum):
-    """
-    Possible roles for a message in a chat.
-    """
-
-    USER = "user"
-    SYSTEM = "system"
-    ASSISTANT = "assistant"
-    FUNCTION = "function"
-    TOOL = "tool"
-
-
-class LLMMessage(BaseModel):
-    """
-    Class representing an entry in the msg-history sent to the LLM API.
-    It could be one of these:
-    - a user message
-    - an LLM ("Assistant") response
-    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
-    - a result or results from executing a fn or tool-call(s)
-    """
-
-    role: Role
-    name: Optional[str] = None
-    tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
-    tool_id: str = ""  # used by OpenAIAssistant
-    # None means "no content" (the model returned only a tool/function call).
-    # This is distinct from "" and is dropped from the API payload by api_dict;
-    # see api_dict for how a fully-empty message is handled per-API.
-    content: Optional[str] = None
-    files: List[FileAttachment] = []
-    function_call: Optional[LLMFunctionCall] = None
-    tool_calls: Optional[List[OpenAIToolCall]] = None
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    # link to corresponding chat document, for provenance/rewind purposes
-    chat_document_id: str = ""
-
-    def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]:
-        """
-        Convert to dictionary for API request, keeping ONLY
-        the fields that are expected in an API call!
-        E.g., DROP the tool_id, since it is only for use in the Assistant API,
-            not the completion API.
-
-        Args:
-            has_system_role: whether the message has a system role (if not,
-                set to "user" role)
-        Returns:
-            dict: dictionary representation of LLM message
-        """
-        d = self.model_dump()
-        files: List[FileAttachment] = d.pop("files")
-        if len(files) > 0 and self.role == Role.USER:
-            # In there are files, then content is an array of
-            # different content-parts
-            d["content"] = [
-                dict(
-                    type="text",
-                    text=self.content or "",
-                )
-            ] + [f.to_dict(model) for f in self.files]
-
-        # if there is a key k = "role" with value "system", change to "user"
-        # in case has_system_role is False
-        if not has_system_role and "role" in d and d["role"] == "system":
-            d["role"] = "user"
-            if d.get("content"):
-                d["content"] = "[ADDITIONAL SYSTEM MESSAGE:]\n\n" + d["content"]
-        # drop None values since API doesn't accept them (this omits `content`
-        # entirely when it is None, i.e. "no content")
-        dict_no_none = {k: v for k, v in d.items() if v is not None}
-        if "name" in dict_no_none and dict_no_none["name"] == "":
-            # OpenAI API does not like empty name
-            del dict_no_none["name"]
-        if "function_call" in dict_no_none:
-            # arguments must be a string
-            if "arguments" in dict_no_none["function_call"]:
-                dict_no_none["function_call"]["arguments"] = json.dumps(
-                    dict_no_none["function_call"]["arguments"]
-                )
-        if dict_no_none.get("tool_calls"):
-            # convert tool calls to API format
-            for tc in dict_no_none["tool_calls"]:
-                if "arguments" in tc["function"]:
-                    # arguments must be a string
-                    if tc["function"]["arguments"] is None:
-                        tc["function"]["arguments"] = "{}"
-                    else:
-                        tc["function"]["arguments"] = json.dumps(
-                            tc["function"]["arguments"]
-                        )
-                if "extra_content" in tc and tc["extra_content"] is None:
-                    del tc["extra_content"]
-        else:
-            # An empty tool-call list is not a call and conveys no useful API
-            # information. Omitting it also lets the empty-message fallback
-            # below produce a valid message.
-            dict_no_none.pop("tool_calls", None)
-        # A message with empty content (None was dropped above, or "") AND no
-        # tool/function call would be an entirely empty message, which some APIs
-        # (e.g. Gemini) reject; fall back to a single space in that case only.
-        # When there IS a tool/function call, empty content is fine (and Gemini
-        # 3.x in fact REQUIRES it — it rejects an assistant turn that carries
-        # both a call and non-empty text content).
-        has_call = bool(dict_no_none.get("tool_calls")) or (
-            dict_no_none.get("function_call") is not None
-        )
-        if not has_call and not dict_no_none.get("content"):
-            dict_no_none["content"] = " "
-        # IMPORTANT! drop fields that are not expected in API call
-        dict_no_none.pop("tool_id", None)
-        dict_no_none.pop("timestamp", None)
-        dict_no_none.pop("chat_document_id", None)
-        return dict_no_none
-
-    def __str__(self) -> str:
-        if self.function_call is not None:
-            content = "FUNC: " + json.dumps(self.function_call)
-        else:
-            content = self.content or ""
-        name_str = f" ({self.name})" if self.name else ""
-        return f"{self.role} {name_str}: {content}"
-
-
-class LLMResponse(BaseModel):
-    """
-    Class representing response from LLM.
-    """
-
-    # None means the model returned NO content (e.g. only a tool/function
-    # call), which is distinct from an empty string "". Preserving this
-    # distinction lets the message be faithfully reproduced downstream
-    # (see ChatDocument.content_is_none and LLMMessage.content).
-    message: Optional[str] = None
-    reasoning: str = ""  # optional reasoning text from reasoning models
-    # Original message text including inline thought signatures (e.g.
-    # <thinking>...</thinking>). Only set when reasoning was extracted
-    # from the message text via get_reasoning_final(); NOT set when
-    # reasoning comes from a separate API field (e.g. reasoning_content),
-    # since in that case the message text never contained thought tags.
-    message_with_reasoning: Optional[str] = None
-    # TODO tool_id needs to generalize to multi-tool calls
-    tool_id: str = ""  # used by OpenAIAssistant
-    oai_tool_calls: Optional[List[OpenAIToolCall]] = None
-    function_call: Optional[LLMFunctionCall] = None
-    usage: Optional[LLMTokenUsage] = None
-    cached: bool = False
-
-    def __str__(self) -> str:
-        if self.function_call is not None:
-            return str(self.function_call)
-        elif self.oai_tool_calls:
-            return "\n".join(str(tc) for tc in self.oai_tool_calls)
-        else:
-            return self.message or ""
-
-    def tools_content(self) -> str:
-        if self.function_call is not None:
-            return str(self.function_call)
-        elif self.oai_tool_calls:
-            return "\n".join(str(tc) for tc in self.oai_tool_calls)
-        else:
-            return ""
-
-    def to_LLMMessage(self) -> LLMMessage:
-        """Convert LLM response to an LLMMessage, to be included in the
-        message-list sent to the API.
-        This is currently NOT used in any significant way in the library, and is only
-        provided as a utility to construct a message list for the API when directly
-        working with an LLM object.
-
-        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
-        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
-        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
-        """
-        return LLMMessage(
-            role=Role.ASSISTANT,
-            content=self.message,
-            name=None if self.function_call is None else self.function_call.name,
-            function_call=self.function_call,
-            tool_calls=self.oai_tool_calls,
-        )
-
-    def get_recipient_and_message(
-        self,
-        recognize_recipient_in_content: bool = True,
-    ) -> Tuple[str, str]:
-        """
-        If `message` or `function_call` of an LLM response contains an explicit
-        recipient name, return this recipient name and `message` stripped
-        of the recipient name if specified.
-
-        Two cases:
-        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
-        (b) `message` is empty and function_call/tool_call with explicit `recipient`
-
-        Args:
-            recognize_recipient_in_content (bool): When True (default), parses
-                message text for ``TO[<recipient>]:<content>`` patterns and
-                top-level JSON ``{"recipient": "..."}`` fields. When False,
-                only function_call/tool_call ``recipient`` fields are checked.
-
-        Returns:
-            (str): name of recipient, which may be empty string if no recipient
-            (str): content of message
-
-        """
-
-        if self.function_call is not None:
-            # in this case we ignore message, since all information is in function_call
-            msg = ""
-            args = self.function_call.arguments
-            recipient = ""
-            if isinstance(args, dict):
-                recipient = args.get("recipient", "")
-            return recipient, msg
-        else:
-            msg = self.message or ""
-            if self.oai_tool_calls is not None:
-                # get the first tool that has a recipient field, if any
-                for tc in self.oai_tool_calls:
-                    if tc.function is not None and tc.function.arguments is not None:
-                        recipient = tc.function.arguments.get(
-                            "recipient"
-                        )  # type: ignore
-                        if recipient is not None and recipient != "":
-                            return recipient, ""
-
-        if not recognize_recipient_in_content:
-            return "", msg
-
-        # It's not a function or tool call, so continue looking to see
-        # if a recipient is specified in the message.
-
-        # First check if message contains "TO: <recipient> <content>"
-        recipient_name, content = parse_message(msg) if msg is not None else ("", "")
-        # check if there is a top level json that specifies 'recipient',
-        # and retain the entire message as content.
-        if recipient_name == "":
-            recipient_name = top_level_json_field(msg, "recipient") if msg else ""
-            content = msg
-        return recipient_name, content
-
-
-# Define an abstract base class for language models
-class LanguageModel(ABC):
-    """
-    Abstract base class for language models.
-    """
-
-    # usage cost by model, accumulates here
-    usage_cost_dict: Dict[str, LLMTokenUsage] = {}
-
-    def __init__(self, config: LLMConfig = LLMConfig()):
-        self.config = config
-        self.chat_model_orig = config.chat_model
-
-    @staticmethod
-    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]:
-        """
-        Create a language model.
-        Args:
-            config: configuration for language model
-        Returns: instance of language model
-        """
-        if type(config) is LLMConfig:
-            raise ValueError(
-                """
-                Cannot create a Language Model object from LLMConfig.
-                Please specify a specific subclass of LLMConfig e.g.,
-                OpenAIGPTConfig. If you are creating a ChatAgent from
-                a ChatAgentConfig, please specify the `llm` field of this config
-                as a specific subclass of LLMConfig, e.g., OpenAIGPTConfig.
-                """
-            )
-        from langroid.language_models.azure_openai import AzureGPT
-        from langroid.language_models.mock_lm import MockLM, MockLMConfig
-        from langroid.language_models.openai_gpt import OpenAIGPT
-
-        if config is None or config.type is None:
-            return None
-
-        if config.type == "mock":
-            return MockLM(cast(MockLMConfig, config))
-
-        openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
-
-        if config.type == "azure":
-            openai = AzureGPT
-        else:
-            openai = OpenAIGPT
-        cls = dict(
-            openai=openai,
-        ).get(config.type, openai)
-        return cls(config)  # type: ignore
-
-    @staticmethod
-    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]:
-        """
-        Given an even-length sequence of strings, split into a sequence of pairs
-
-        Args:
-            lst (List[str]): sequence of strings
-
-        Returns:
-            List[Tuple[str,str]]: sequence of pairs of strings
-        """
-        evens = lst[::2]
-        odds = lst[1::2]
-        return list(zip(evens, odds))
-
-    @staticmethod
-    def get_chat_history_components(
-        messages: List[LLMMessage],
-    ) -> Tuple[str, List[Tuple[str, str]], str]:
-        """
-        From the chat history, extract system prompt, user-assistant turns, and
-        final user msg.
-
-        Args:
-            messages (List[LLMMessage]): List of messages in the chat history
-
-        Returns:
-            Tuple[str, List[Tuple[str,str]], str]:
-                system prompt, user-assistant turns, final user msg
-
-        """
-        # Handle various degenerate cases
-        messages = [m for m in messages]  # copy
-        DUMMY_SYS_PROMPT = "You are a helpful assistant."
-        DUMMY_USER_PROMPT = "Follow the instructions above."
-        if len(messages) == 0 or messages[0].role != Role.SYSTEM:
-            logger.warning("No system msg, creating dummy system prompt")
-            messages.insert(0, LLMMessage(content=DUMMY_SYS_PROMPT, role=Role.SYSTEM))
-        system_prompt = messages[0].content or ""
-
-        # now we have messages = [Sys,...]
-        if len(messages) == 1:
-            logger.warning(
-                "Got only system message in chat history, creating dummy user prompt"
-            )
-            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, msg, ...]
-
-        if messages[1].role != Role.USER:
-            messages.insert(1, LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, user, ...]
-        if messages[-1].role != Role.USER:
-            logger.warning(
-                "Last message in chat history is not a user message,"
-                " creating dummy user prompt"
-            )
-            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, user, ..., user]
-        # so we omit the first and last elements and make pairs of user-asst messages
-        conversation = [m.content or "" for m in messages[1:-1]]
-        user_prompt = messages[-1].content or ""
-        pairs = LanguageModel.user_assistant_pairs(conversation)
-        return system_prompt, pairs, user_prompt
-
-    @abstractmethod
-    def set_stream(self, stream: bool) -> bool:
-        """Enable or disable streaming output from API.
-        Return previous value of stream."""
-        pass
-
-    @abstractmethod
-    def get_stream(self) -> bool:
-        """Get streaming status"""
-        pass
-
-    @abstractmethod
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        pass
-
-    @abstractmethod
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        pass
-
-    @abstractmethod
-    def chat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """
-        Get chat-completion response from LLM.
-
-        Args:
-            messages: message-history to send to the LLM
-            max_tokens: max tokens to generate
-            tools: tools available for the LLM to use in its response
-            tool_choice: tool call mode, one of "none", "auto", "required",
-                or a dict specifying a specific tool.
-            functions: functions available for LLM to call (deprecated)
-            function_call: function calling mode, "auto", "none", or a specific fn
-                    (deprecated)
-        """
-
-        pass
-
-    @abstractmethod
-    async def achat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """Async version of `chat`. See `chat` for details."""
-        pass
-
-    def __call__(self, prompt: str, max_tokens: int) -> LLMResponse:
-        return self.generate(prompt, max_tokens)
-
-    @staticmethod
-    def _fallback_model_names(model: str) -> List[str]:
-        parts = model.split("/")
-        fallbacks = []
-        for i in range(1, len(parts)):
-            fallbacks.append("/".join(parts[i:]))
-        return fallbacks
-
-    def info(self) -> ModelInfo:
-        """Info of relevant chat model"""
-        orig_model = (
-            self.config.completion_model
-            if self.config.use_completion_for_chat
-            else self.chat_model_orig
-        )
-        return get_model_info(orig_model, self._fallback_model_names(orig_model))
-
-    def completion_info(self) -> ModelInfo:
-        """Info of relevant completion model"""
-        orig_model = (
-            self.chat_model_orig
-            if self.config.use_chat_for_completion
-            else self.config.completion_model
-        )
-        return get_model_info(orig_model, self._fallback_model_names(orig_model))
-
-    def supports_functions_or_tools(self) -> bool:
-        """
-        Does this Model's API support "native" tool-calling, i.e.
-        can we call the API with arguments that contain a list of available tools,
-        and their schemas?
-        Note that, given the plethora of LLM provider APIs this determination is
-        imperfect at best, and leans towards returning True.
-        When the API calls fails with an error indicating tools are not supported,
-        then users are encouraged to use the Langroid-based prompt-based
-        ToolMessage mechanism, which works with ANY LLM. To enable this,
-        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
-        """
-        return self.info().has_tools
-
-    def chat_context_length(self) -> int:
-        return self.config.chat_context_length or DEFAULT_CONTEXT_LENGTH
-
-    def completion_context_length(self) -> int:
-        return self.config.completion_context_length or DEFAULT_CONTEXT_LENGTH
-
-    def chat_cost(self) -> Tuple[float, float, float]:
-        """
-        Return the cost per 1000 tokens for chat completions.
-
-        Returns:
-            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
-                per 1000 tokens
-        """
-        return (0.0, 0.0, 0.0)
-
-    def reset_usage_cost(self) -> None:
-        for mdl in [self.config.chat_model, self.config.completion_model]:
-            if mdl is None:
-                return
-            if mdl not in self.usage_cost_dict:
-                self.usage_cost_dict[mdl] = LLMTokenUsage()
-            counter = self.usage_cost_dict[mdl]
-            counter.reset()
-
-    def update_usage_cost(
-        self, chat: bool, prompts: int, completions: int, cost: float
-    ) -> None:
-        """
-        Update usage cost for this LLM.
-        Args:
-            chat (bool): whether to update for chat or completion model
-            prompts (int): number of tokens used for prompts
-            completions (int): number of tokens used for completions
-            cost (float): total token cost in USD
-        """
-        mdl = self.config.chat_model if chat else self.config.completion_model
-        if mdl is None:
-            return
-        if mdl not in self.usage_cost_dict:
-            self.usage_cost_dict[mdl] = LLMTokenUsage()
-        counter = self.usage_cost_dict[mdl]
-        counter.prompt_tokens += prompts
-        counter.completion_tokens += completions
-        counter.cost += cost
-        counter.calls += 1
-
-    @classmethod
-    def usage_cost_summary(cls) -> str:
-        s = ""
-        for model, counter in cls.usage_cost_dict.items():
-            s += f"{model}: {counter}\n"
-        return s
-
-    @classmethod
-    def tot_tokens_cost(cls) -> Tuple[int, float]:
-        """
-        Return total tokens used and total cost across all models.
-        """
-        total_tokens = 0
-        total_cost = 0.0
-        for counter in cls.usage_cost_dict.values():
-            total_tokens += counter.total_tokens
-            total_cost += counter.cost
-        return total_tokens, total_cost
-
-    def get_reasoning_final(self, message: str) -> Tuple[str, str]:
-        """Extract "reasoning" and "final answer" from an LLM response, if the
-        reasoning is found within configured delimiters, like <think>, </think>.
-        E.g.,
-        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
-
-        Args:
-            message (str): message from LLM
-
-        Returns:
-            Tuple[str, str]: reasoning, final answer
-        """
-        start, end = self.config.thought_delimiters
-        if start in message and end in message:
-            parts = message.split(start)
-            if len(parts) > 1:
-                reasoning, final = parts[1].split(end)
-                return reasoning, final
-        return "", message
-
-    def followup_to_standalone(
-        self, chat_history: List[Tuple[str, str]], question: str
-    ) -> str:
-        """
-        Given a chat history and a question, convert it to a standalone question.
-        Args:
-            chat_history: list of tuples of (question, answer)
-            query: follow-up question
-
-        Returns: standalone version of the question
-        """
-        history = collate_chat_history(chat_history)
-
-        prompt = f"""
-        You are an expert at understanding a CHAT HISTORY between an AI Assistant
-        and a User, and you are highly skilled in rephrasing the User's FOLLOW-UP
-        QUESTION/REQUEST as a STANDALONE QUESTION/REQUEST that can be understood
-        WITHOUT the context of the chat history.
-
-        Below is the CHAT HISTORY. When the User asks you to rephrase a
-        FOLLOW-UP QUESTION/REQUEST, your ONLY task is to simply return the
-        question REPHRASED as a STANDALONE QUESTION/REQUEST, without any additional
-        text or context.
-
-        <CHAT_HISTORY>
-        {history}
-        </CHAT_HISTORY>
-        """.strip()
-
-        follow_up_question = f"""
-        Please rephrase this as a stand-alone question or request:
-        <FOLLOW-UP-QUESTION-OR-REQUEST>
-        {question}
-        </FOLLOW-UP-QUESTION-OR-REQUEST>
-        """.strip()
-
-        show_if_debug(prompt, "FOLLOWUP->STANDALONE-PROMPT= ")
-        standalone = (
-            self.chat(
-                messages=[
-                    LLMMessage(role=Role.SYSTEM, content=prompt),
-                    LLMMessage(role=Role.USER, content=follow_up_question),
-                ],
-                max_tokens=1024,
-            ).message
-            or ""
-        )
-        standalone = standalone.strip()
-
-        show_if_debug(prompt, "FOLLOWUP->STANDALONE-RESPONSE= ")
-        return standalone
-
-
-class StreamingIfAllowed:
-    """Context to temporarily enable or disable streaming, if allowed globally via
-    `settings.stream`"""
-
-    def __init__(self, llm: LanguageModel, stream: bool = True):
-        self.llm = llm
-        self.stream = stream
-
-    def __enter__(self) -> None:
-        self.old_stream = self.llm.set_stream(settings.stream and self.stream)
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self.llm.set_stream(self.old_stream)
 </file>
 
 <file path="langroid/language_models/client_cache.py">
@@ -90402,2746 +90452,6 @@ def _model_name(model: str | ModelName) -> str:
     return model.value
 </file>
 
-<file path="langroid/agent/chat_agent.py">
-import base64
-import copy
-import inspect
-import json
-import logging
-import math
-import textwrap
-from contextlib import ExitStack
-from inspect import isclass
-from typing import (
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Self,
-    Set,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
-
-import openai
-from pydantic import BaseModel, ValidationError
-from pydantic.fields import ModelPrivateAttr
-from rich import print
-from rich.console import Console
-from rich.markup import escape
-
-from langroid.agent.base import (
-    Agent,
-    AgentConfig,
-    SearchForTools,
-    async_noop_fn,
-    noop_fn,
-)
-from langroid.agent.chat_document import ChatDocument
-from langroid.agent.tool_message import (
-    ToolMessage,
-    format_schema_for_strict,
-)
-from langroid.agent.xml_tool_message import XMLToolMessage
-from langroid.language_models.base import (
-    LLMFunctionCall,
-    LLMFunctionSpec,
-    LLMMessage,
-    LLMResponse,
-    OpenAIJsonSchemaSpec,
-    OpenAIToolSpec,
-    Role,
-    StreamingIfAllowed,
-    ToolChoiceTypes,
-)
-from langroid.language_models.openai_gpt import OpenAIGPT
-from langroid.mytypes import Entity, NonToolAction
-from langroid.parsing.file_attachment import FileAttachment
-from langroid.utils.configuration import settings
-from langroid.utils.object_registry import ObjectRegistry
-from langroid.utils.output import status
-from langroid.utils.pydantic_utils import PydanticWrapper, get_pydantic_wrapper
-from langroid.utils.types import is_callable
-
-console = Console()
-
-logger = logging.getLogger(__name__)
-
-# Stable origin sentinel for the dynamically generated strict-recovery AnyTool
-# class ("tool_or_function"): a fresh class is built per call (its tool-union
-# type varies), so re-registration must be recognized as the same logical tool.
-_ANY_TOOL_MESSAGE_ORIGIN: Any = object()
-
-# Safety margin (in tokens) subtracted from the model context length when
-# shrinking chat history and/or the requested output length to fit, in case
-# our token-count estimates are off.
-CHAT_HISTORY_BUFFER = 300
-
-
-def _reject_json_constant(constant: str) -> None:
-    """Reject JavaScript numeric constants that are not valid JSON."""
-    raise ValueError(f"non-JSON numeric constant: {constant}")
-
-
-def _parse_json_float(value: str) -> float:
-    """Parse a JSON float while rejecting exponent overflow."""
-    parsed = float(value)
-    if not math.isfinite(parsed):
-        raise ValueError(f"non-finite JSON number: {value}")
-    return parsed
-
-
-def _is_identified_result(message: LLMMessage) -> bool:
-    """Whether a TOOL/FUNCTION result has its identifier and no call payload.
-
-    Such results must survive even with empty content so their calls can be
-    marked complete (issue #1063).
-    """
-    has_identifier = (
-        message.role == Role.TOOL and bool((message.tool_call_id or "").strip())
-    ) or (message.role == Role.FUNCTION and bool((message.name or "").strip()))
-    return has_identifier and message.function_call is None and not message.tool_calls
-
-
-def _llm_message_has_payload(message: LLMMessage) -> bool:
-    """Whether a message has the fields required for a valid history entry."""
-    return (
-        (message.content or "").strip() != ""
-        or message.function_call is not None
-        or bool(message.tool_calls)
-        or _is_identified_result(message)
-    )
-
-
-class ChatAgentConfig(AgentConfig):
-    """
-    Configuration for ChatAgent
-
-    Attributes:
-        system_message: system message to include in message sequence
-             (typically defines role and task of agent).
-             Used only if `task` is not specified in the constructor.
-        user_message: user message to include in message sequence.
-             Used only if `task` is not specified in the constructor.
-        use_tools: whether to use our own ToolMessages mechanism
-        handle_llm_no_tool (Any): desired agent_response when
-            LLM generates non-tool msg.
-        use_functions_api: whether to use functions/tools native to the LLM API
-                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
-        use_tools_api: When `use_functions_api` is True, if this is also True,
-            the OpenAI tool-call API is used, rather than the older/deprecated
-            function-call API. However the tool-call API has some tricky aspects,
-            hence we set this to False by default.
-        strict_recovery: whether to enable strict schema recovery when there
-            is a tool-generation error.
-        enable_orchestration_tool_handling: whether to enable handling of orchestration
-            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
-        output_format: When supported by the LLM (certain OpenAI LLMs
-            and local LLMs served by providers such as vLLM), ensures
-            that the output is a JSON matching the corresponding
-            schema via grammar-based decoding
-        handle_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for handling".
-        use_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for use" (by LLM) and
-            instructions on using T are added to the system message.
-        instructions_output_format: Controls whether we generate instructions for
-            `output_format` in the system message.
-        use_tools_on_output_format: Controls whether to automatically switch
-            to the Langroid-native tools mechanism when `output_format` is set.
-            Note that LLMs may generate tool calls which do not belong to
-            `output_format` even when strict JSON mode is enabled, so this should be
-            enabled when such tool calls are not desired.
-        output_format_include_defaults: Whether to include fields with default arguments
-            in the output schema
-        full_citations: Whether to show source reference citation + content for each
-            citation, or just the main reference citation.
-        search_for_tools_everywhere: Whether to search for tools everywhere,
-            or only in specific LLM response elements based on use_tools /
-            use_functions_api / use_tools_api config settings.
-        recognize_recipient_in_content: Whether to parse LLM response text content
-            for recipient routing patterns, specifically:
-            - ``TO[<recipient>]:<content>`` addressing format, and
-            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
-            When False, only structured routing via function_call/tool_call
-            ``recipient`` fields is recognized. Default is True.
-            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
-            which controls Task-level signals like DONE, PASS, and SEND_TO.
-            To fully disable all text-based routing, set both to False.
-        context_overflow_strategy: Strategy for handling context overflow when
-            message history exceeds model context length. Options:
-            - "truncate": Truncate content of early messages (preserves all messages
-              but with shortened content). This maintains the message sequence.
-            - "drop_turns": Drop complete conversation turns (USER + all responses
-              until next USER). More aggressive but cleaner for voice agents.
-            Default is "truncate" for backward compatibility.
-    """
-
-    system_message: str = "You are a helpful assistant."
-    user_message: Optional[str] = None
-    handle_llm_no_tool: Any = None
-    use_tools: bool = True
-    use_functions_api: bool = False
-    use_tools_api: bool = True
-    strict_recovery: bool = True
-    enable_orchestration_tool_handling: bool = True
-    output_format: Optional[type] = None
-    handle_output_format: bool = True
-    use_output_format: bool = True
-    instructions_output_format: bool = True
-    output_format_include_defaults: bool = True
-    use_tools_on_output_format: bool = True
-    full_citations: bool = True  # show source + content for each citation?
-    search_for_tools_everywhere: bool = True
-    recognize_recipient_in_content: bool = True
-    context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
-
-    def _set_fn_or_tools(self) -> None:
-        """
-        Enable Langroid Tool or OpenAI-like fn-calling,
-        depending on config settings.
-        """
-        if not self.use_functions_api or not self.use_tools:
-            return
-        if self.use_functions_api and self.use_tools:
-            logger.debug(
-                """
-                You have enabled both `use_tools` and `use_functions_api`.
-                Setting `use_functions_api` to False.
-                """
-            )
-            self.use_tools = True
-            self.use_functions_api = False
-
-
-class ChatAgent(Agent):
-    """
-    Chat Agent interacting with external env
-    (could be human, or external tools).
-    The agent (the LLM actually) is provided with an optional "Task Spec",
-    which is a sequence of `LLMMessage`s. These are used to initialize
-    the `task_messages` of the agent.
-    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
-    The `Agent` class mainly exists to hold various common methods and attributes.
-    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
-    `llm_response` method uses "chat mode" API (i.e. one that takes a
-    message sequence rather than a single message),
-    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
-    that takes a single message).
-    """
-
-    def __init__(
-        self,
-        config: ChatAgentConfig = ChatAgentConfig(),
-        task: Optional[List[LLMMessage]] = None,
-    ):
-        """
-        Chat-mode agent initialized with task spec as the initial message sequence
-        Args:
-            config: settings for the agent
-
-        """
-        super().__init__(config)
-        self.config: ChatAgentConfig = config
-        self.config._set_fn_or_tools()
-        self.message_history: List[LLMMessage] = []
-        self.init_state()
-        # An agent's "task" is defined by a system msg and an optional user msg;
-        # These are "priming" messages that kick off the agent's conversation.
-        self.system_message: str = self.config.system_message
-        self.user_message: str | None = self.config.user_message
-
-        if task is not None:
-            # if task contains a system msg, we override the config system msg
-            if len(task) > 0 and task[0].role == Role.SYSTEM:
-                self.system_message = task[0].content or ""
-            # if task contains a user msg, we override the config user msg
-            if len(task) > 1 and task[1].role == Role.USER:
-                self.user_message = task[1].content
-
-        # system-level instructions for using tools/functions:
-        # We maintain these as tools/functions are enabled/disabled,
-        # and whenever an LLM response is sought, these are used to
-        # recreate the system message (via `_create_system_and_tools_message`)
-        # each time, so it reflects the current set of enabled tools/functions.
-        # (a) these are general instructions on using certain tools/functions,
-        #   if they are specified in a ToolMessage class as a classmethod `instructions`
-        self.system_tool_instructions: str = ""
-        # (b) these are only for the builtin in Langroid TOOLS mechanism:
-        self.system_tool_format_instructions: str = ""
-
-        self.llm_functions_map: Dict[str, LLMFunctionSpec] = {}
-        self.llm_functions_handled: Set[str] = set()
-        self.llm_functions_usable: Set[str] = set()
-        self.llm_function_force: Optional[Dict[str, str]] = None
-
-        self.output_format: Optional[type[ToolMessage | BaseModel]] = None
-
-        self.saved_requests_and_tool_setings = self._requests_and_tool_settings()
-        # This variable is not None and equals a `ToolMessage` T, if and only if:
-        # (a) T has been set as the output_format of this agent, AND
-        # (b) T has been "enabled for use" ONLY for enforcing this output format, AND
-        # (c) T has NOT been explicitly "enabled for use" by this Agent.
-        self.enabled_use_output_format: Optional[type[ToolMessage]] = None
-        # As above but deals with "enabled for handling" instead of "enabled for use".
-        self.enabled_handling_output_format: Optional[type[ToolMessage]] = None
-        if config.output_format is not None:
-            self.set_output_format(config.output_format)
-        # instructions specifically related to enforcing `output_format`
-        self.output_format_instructions = ""
-
-        # controls whether to disable strict schemas for this agent if
-        # strict mode causes exception
-        self.disable_strict = False
-        # Tracks whether any strict tool is enabled; used to determine whether to set
-        # `self.disable_strict` on an exception
-        self.any_strict = False
-        # Tracks the set of tools on which we force-disable strict decoding
-        self.disable_strict_tools_set: set[str] = set()
-
-        # search for tools according to the agent configuration
-        if not config.search_for_tools_everywhere:
-            if config.use_functions_api:
-                if config.use_tools_api:
-                    self.search_for_tools = {SearchForTools.TOOLS.value}
-                else:
-                    self.search_for_tools = {SearchForTools.FUNCTIONS.value}
-            else:
-                self.search_for_tools = {SearchForTools.CONTENT.value}
-
-        if self.config.enable_orchestration_tool_handling:
-            # Only enable HANDLING by `agent_response`, NOT LLM generation of these.
-            # This is useful where tool-handlers or agent_response generate these
-            # tools, and need to be handled.
-            # We don't want enable orch tool GENERATION by default, since that
-            # might clutter-up the LLM system message unnecessarily.
-            from langroid.agent.tools.orchestration import (
-                AgentDoneTool,
-                AgentSendTool,
-                DonePassTool,
-                DoneTool,
-                ForwardTool,
-                PassTool,
-                ResultTool,
-                SendTool,
-            )
-
-            self.enable_message(ForwardTool, use=False, handle=True)
-            self.enable_message(DoneTool, use=False, handle=True)
-            self.enable_message(AgentDoneTool, use=False, handle=True)
-            self.enable_message(PassTool, use=False, handle=True)
-            self.enable_message(DonePassTool, use=False, handle=True)
-            self.enable_message(SendTool, use=False, handle=True)
-            self.enable_message(AgentSendTool, use=False, handle=True)
-            self.enable_message(ResultTool, use=False, handle=True)
-
-    def init_state(self) -> None:
-        """
-        Initialize the state of the agent. Just conversation state here,
-        but subclasses can override this to initialize other state.
-        """
-        super().init_state()
-        self.clear_history(0)
-        self.clear_dialog()
-
-    @staticmethod
-    def from_id(id: str) -> "ChatAgent":
-        """
-        Get an agent from its ID
-        Args:
-            agent_id (str): ID of the agent
-        Returns:
-            ChatAgent: The agent with the given ID
-        """
-        return cast(ChatAgent, Agent.from_id(id))
-
-    def clone(self, i: int = 0) -> "ChatAgent":
-        """Create i'th clone of this agent, ensuring tool use/handling is cloned.
-        Important: We assume all member variables are in the __init__ method here
-        and in the Agent class.
-        TODO: We are attempting to clone an agent after its state has been
-        changed in possibly many ways. Below is an imperfect solution. Caution advised.
-        Revisit later.
-        """
-        agent_cls = type(self)
-        # Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
-        # instead of deepcopy which loses subclass information
-        config_copy = self.config.model_copy(deep=True)
-        config_copy.name = f"{config_copy.name}-{i}"
-        new_agent = agent_cls(config_copy)
-        new_agent.system_tool_instructions = self.system_tool_instructions
-        new_agent.system_tool_format_instructions = self.system_tool_format_instructions
-        new_agent.llm_tools_map = self.llm_tools_map
-        new_agent.llm_tools_known = self.llm_tools_known
-        new_agent.llm_tools_handled = self.llm_tools_handled
-        new_agent.llm_tools_usable = self.llm_tools_usable
-        new_agent.llm_functions_map = self.llm_functions_map
-        new_agent.llm_functions_handled = self.llm_functions_handled
-        new_agent.llm_functions_usable = self.llm_functions_usable
-        new_agent.llm_function_force = self.llm_function_force
-        # Ensure each clone gets its own vecdb client when supported.
-        new_agent.vecdb = None if self.vecdb is None else self.vecdb.clone()
-        self._clone_extra_state(new_agent)
-        new_agent.id = ObjectRegistry.new_id()
-        if self.config.add_to_registry:
-            ObjectRegistry.register_object(new_agent)
-        return new_agent
-
-    def _clone_extra_state(self, new_agent: "ChatAgent") -> None:
-        """Hook for subclasses to copy additional state into clones."""
-
-    def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool:
-        """Should we enable strict mode for a given tool?"""
-        if isinstance(tool, str):
-            tool_class = self.llm_tools_map[tool]
-        else:
-            tool_class = tool
-        name = tool_class.default_value("request")
-        if name in self.disable_strict_tools_set or self.disable_strict:
-            return False
-        strict: Optional[bool] = tool_class.default_value("strict")
-        if strict is None:
-            strict = self._strict_tools_available()
-
-        return strict
-
-    def _fn_call_available(self) -> bool:
-        """Does this agent's LLM support function calling?"""
-        return self.llm is not None and self.llm.supports_functions_or_tools()
-
-    def _strict_tools_available(self) -> bool:
-        """Does this agent's LLM support strict tools?"""
-        return (
-            not self.disable_strict
-            and self.llm is not None
-            and isinstance(self.llm, OpenAIGPT)
-            and self.llm.config.parallel_tool_calls is False
-            and self.llm.supports_strict_tools
-        )
-
-    def _json_schema_available(self) -> bool:
-        """Does this agent's LLM support strict JSON schema output format?"""
-        return (
-            not self.disable_strict
-            and self.llm is not None
-            and isinstance(self.llm, OpenAIGPT)
-            and self.llm.supports_json_schema
-        )
-
-    def set_system_message(self, msg: str) -> None:
-        self.system_message = msg
-        if len(self.message_history) > 0:
-            # if there is message history, update the system message in it
-            self.message_history[0].content = msg
-
-    def set_user_message(self, msg: str) -> None:
-        self.user_message = msg
-
-    @property
-    def task_messages(self) -> List[LLMMessage]:
-        """
-        The task messages are the initial messages that define the task
-        of the agent. There will be at least a system message plus possibly a user msg.
-        Returns:
-            List[LLMMessage]: the task messages
-        """
-        msgs = [self._create_system_and_tools_message()]
-        if self.user_message:
-            msgs.append(LLMMessage(role=Role.USER, content=self.user_message))
-        return msgs
-
-    def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None:
-        id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
-        if msg.role == Role.TOOL:
-            # dropping tool result, so ADD the corresponding tool-call back
-            # to the list of pending calls!
-            id = msg.tool_call_id
-            if id in self.oai_tool_id2call:
-                self.oai_tool_calls.append(self.oai_tool_id2call[id])
-        elif msg.tool_calls is not None:
-            # dropping a msg with tool-calls, so DROP these from pending list
-            # as well as from id -> call map
-            for tool_call in msg.tool_calls:
-                if tool_call.id in id2idx:
-                    self.oai_tool_calls.pop(id2idx[tool_call.id])
-                if tool_call.id in self.oai_tool_id2call:
-                    del self.oai_tool_id2call[tool_call.id]
-
-    def clear_history(self, start: int = -2, end: int = -1) -> None:
-        """
-        Clear the message history, deleting  messages from index `start`,
-        up to index `end`.
-
-        Args:
-            start (int): index of first message to delete; default = -2
-                    (i.e. delete last 2 messages, typically these
-                    are the last user and assistant messages)
-            end (int): index of last message to delete; Default = -1
-                    (i.e. delete all messages up to the last one)
-        """
-        n = len(self.message_history)
-        if start < 0:
-            start = max(0, n + start)
-        end_ = n if end == -1 else end + 1
-        dropped = self.message_history[start:end_]
-        # consider the dropped msgs in REVERSE order, so we are
-        # carefully updating self.oai_tool_calls
-        for msg in reversed(dropped):
-            self._drop_msg_update_tool_calls(msg)
-            # clear out the chat document from the ObjectRegistry
-            ChatDocument.delete_id(msg.chat_document_id)
-        del self.message_history[start:end_]
-
-    def update_history(self, message: str, response: str) -> None:
-        """
-        Update the message history with the latest user message and LLM response.
-        Args:
-            message (str): user message
-            response: (str): LLM response
-        """
-        self.message_history.extend(
-            [
-                LLMMessage(role=Role.USER, content=message),
-                LLMMessage(role=Role.ASSISTANT, content=response),
-            ]
-        )
-
-    def export_history(self) -> str:
-        """Export message history as a portable, versioned JSON snapshot.
-
-        Returns:
-            A JSON string containing the current message history.
-        """
-        messages: List[Dict[str, Any]] = []
-        for message in self.message_history:
-            json.dumps(
-                message.model_dump(mode="python", exclude={"files"}),
-                allow_nan=False,
-                default=str,
-            )
-            data = message.model_dump(mode="json", exclude={"files"})
-            data["chat_document_id"] = ""
-            data["files"] = [
-                {
-                    "content_base64": base64.b64encode(file.content).decode("ascii"),
-                    "filename": file.filename,
-                    "mime_type": file.mime_type,
-                    "url": file.url,
-                    "detail": file.detail,
-                }
-                for file in message.files
-            ]
-            messages.append(data)
-        return json.dumps({"version": 1, "messages": messages}, allow_nan=False)
-
-    def import_history(
-        self,
-        snapshot: str,
-        max_size_bytes: int = 100 * 1024 * 1024,
-    ) -> None:
-        """Restore message history from :meth:`export_history` output.
-
-        Args:
-            snapshot: Versioned JSON snapshot to restore.
-            max_size_bytes: Maximum total decoded attachment size. Defaults to
-                100 MiB.
-
-        Raises:
-            ValueError: If the snapshot is malformed, has an unknown version,
-                starts with a non-system message, or exceeds ``max_size_bytes``.
-        """
-        try:
-            if max_size_bytes < 0:
-                raise ValueError("max_size_bytes must be non-negative")
-            payload = json.loads(
-                snapshot,
-                parse_constant=_reject_json_constant,
-                parse_float=_parse_json_float,
-            )
-            if (
-                not isinstance(payload, dict)
-                or type(payload.get("version")) is not int
-                or payload["version"] != 1
-            ):
-                raise ValueError("unsupported version")
-            raw_messages = payload.get("messages")
-            if not isinstance(raw_messages, list):
-                raise ValueError("messages must be a list")
-            if not raw_messages:
-                raise ValueError("messages must not be empty")
-
-            messages: List[LLMMessage] = []
-            total_attachment_bytes = 0
-            for raw_message in raw_messages:
-                if not isinstance(raw_message, dict):
-                    raise ValueError("message must be an object")
-                message_data = dict(raw_message)
-                raw_files = message_data.get("files", [])
-                if not isinstance(raw_files, list):
-                    raise ValueError("files must be a list")
-                files = []
-                for raw_file in raw_files:
-                    if not isinstance(raw_file, dict):
-                        raise ValueError("file must be an object")
-                    file_data = dict(raw_file)
-                    encoded_content = file_data.pop("content_base64")
-                    if not isinstance(encoded_content, str):
-                        raise ValueError("content_base64 must be a string")
-                    encoded_bytes = encoded_content.encode("ascii")
-                    padding = len(encoded_bytes) - len(encoded_bytes.rstrip(b"="))
-                    decoded_size = max(
-                        0,
-                        len(encoded_bytes) // 4 * 3 - min(padding, 2),
-                    )
-                    if total_attachment_bytes + decoded_size > max_size_bytes:
-                        raise ValueError(
-                            "decoded attachments exceed "
-                            f"max_size_bytes={max_size_bytes}"
-                        )
-                    content = base64.b64decode(encoded_bytes, validate=True)
-                    total_attachment_bytes += len(content)
-                    if total_attachment_bytes > max_size_bytes:
-                        raise ValueError(
-                            "decoded attachments exceed "
-                            f"max_size_bytes={max_size_bytes}"
-                        )
-                    files.append(FileAttachment(content=content, **file_data))
-                message_data["files"] = files
-                message_data["chat_document_id"] = ""
-                messages.append(LLMMessage.model_validate(message_data))
-            if messages[0].role != Role.SYSTEM:
-                raise ValueError("first message must have role 'system'")
-            seen_call_ids: Set[str] = set()
-            for message in messages:
-                if message.role in (Role.TOOL, Role.FUNCTION) and (
-                    message.function_call is not None or message.tool_calls is not None
-                ):
-                    raise ValueError("result messages must not contain call payloads")
-                if message.function_call is not None and message.role != Role.ASSISTANT:
-                    raise ValueError("function calls must have role 'assistant'")
-                if message.function_call is not None:
-                    if not message.function_call.name.strip():
-                        raise ValueError("function call names must be nonblank")
-                if message.tool_call_id is not None and message.role != Role.TOOL:
-                    raise ValueError("tool_call_id is only valid on tool results")
-                if message.role == Role.FUNCTION:
-                    name = message.name
-                    if name is None or not name or name != name.strip():
-                        raise ValueError(
-                            "function result name must be nonblank and normalized"
-                        )
-                if message.tool_calls is not None:
-                    if message.role != Role.ASSISTANT:
-                        raise ValueError("tool calls must have role 'assistant'")
-                    for call in message.tool_calls:
-                        if call.function is None:
-                            raise ValueError("tool calls must include a function")
-                        if not call.function.name.strip():
-                            raise ValueError("function call names must be nonblank")
-                        call_id = call.id
-                        if call_id is None or not call_id or call_id != call_id.strip():
-                            raise ValueError(
-                                "tool call IDs must be nonblank and normalized"
-                            )
-                        if call_id in seen_call_ids:
-                            raise ValueError("tool call IDs must be unique")
-                        seen_call_ids.add(call_id)
-                    if not message.tool_calls:
-                        message.tool_calls = None
-        except (
-            KeyError,
-            RecursionError,
-            TypeError,
-            UnicodeEncodeError,
-            ValueError,
-        ) as exc:
-            raise ValueError(f"Invalid history snapshot: {exc}") from exc
-
-        all_calls = {
-            call.id: call
-            for message in messages
-            for call in (message.tool_calls or [])
-            if call.id is not None
-        }
-        completed_call_ids = {
-            message.tool_call_id
-            for message in messages
-            if message.role == Role.TOOL and message.tool_call_id is not None
-        }
-        old_chat_document_ids = {
-            message.chat_document_id
-            for message in self.message_history
-            if message.chat_document_id
-        }
-        for chat_document_id in old_chat_document_ids:
-            ChatDocument.delete_id(chat_document_id)
-        self.message_history = messages
-        self.oai_tool_id2call = all_calls
-        self.oai_tool_calls = [
-            call
-            for call_id, call in all_calls.items()
-            if call_id not in completed_call_ids
-        ]
-
-    def tool_format_rules(self) -> str:
-        """
-        Specification of tool formatting rules
-        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
-        based on the currently enabled usable `ToolMessage`s
-
-        Returns:
-            str: formatting rules
-        """
-        # ONLY Usable tools (i.e. LLM-generation allowed),
-        usable_tool_classes: List[Type[ToolMessage]] = [
-            t
-            for t in list(self.llm_tools_map.values())
-            if t.default_value("request") in self.llm_tools_usable
-        ]
-
-        if len(usable_tool_classes) == 0:
-            return ""
-        format_instructions = "\n\n".join(
-            [
-                msg_cls.format_instructions(tool=self.config.use_tools)
-                for msg_cls in usable_tool_classes
-            ]
-        )
-        # if any of the enabled classes has json_group_instructions, then use that,
-        # else fall back to ToolMessage.json_group_instructions
-        for msg_cls in usable_tool_classes:
-            if hasattr(msg_cls, "json_group_instructions") and callable(
-                getattr(msg_cls, "json_group_instructions")
-            ):
-                return msg_cls.group_format_instructions().format(
-                    format_instructions=format_instructions
-                )
-        return ToolMessage.group_format_instructions().format(
-            format_instructions=format_instructions
-        )
-
-    def tool_instructions(self) -> str:
-        """
-        Instructions for tools or function-calls, for enabled and usable Tools.
-        These are inserted into system prompt regardless of whether we are using
-        our own ToolMessage mechanism or the LLM's function-call mechanism.
-
-        Returns:
-            str: concatenation of instructions for all usable tools
-        """
-        enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
-        if len(enabled_classes) == 0:
-            return ""
-        instructions = []
-        for msg_cls in enabled_classes:
-            if msg_cls.default_value("request") in self.llm_tools_usable:
-                class_instructions = ""
-                if hasattr(msg_cls, "instructions") and inspect.ismethod(
-                    msg_cls.instructions
-                ):
-                    class_instructions = msg_cls.instructions()
-                if (
-                    self.config.use_tools
-                    and hasattr(msg_cls, "langroid_tools_instructions")
-                    and inspect.ismethod(msg_cls.langroid_tools_instructions)
-                ):
-                    class_instructions += msg_cls.langroid_tools_instructions()
-                # example will be shown in tool_format_rules() when using TOOLs,
-                # so we don't need to show it here.
-                example = "" if self.config.use_tools else (msg_cls.usage_examples())
-                if example != "":
-                    example = "EXAMPLES:\n" + example
-                guidance = (
-                    ""
-                    if class_instructions == ""
-                    else ("GUIDANCE: " + class_instructions)
-                )
-                if guidance == "" and example == "":
-                    continue
-                instructions.append(
-                    textwrap.dedent(
-                        f"""
-                        TOOL: {msg_cls.default_value("request")}:
-                        {guidance}
-                        {example}
-                        """.lstrip()
-                    )
-                )
-        if len(instructions) == 0:
-            return ""
-        instructions_str = "\n\n".join(instructions)
-        return textwrap.dedent(
-            f"""
-            === GUIDELINES ON SOME TOOLS/FUNCTIONS USAGE ===
-            {instructions_str}
-            """.lstrip()
-        )
-
-    def augment_system_message(self, message: str) -> None:
-        """
-        Augment the system message with the given message.
-        Args:
-            message (str): system message
-        """
-        self.system_message += "\n\n" + message
-
-    def last_message_with_role(self, role: Role) -> LLMMessage | None:
-        """from `message_history`, return the last message with role `role`"""
-        n_role_msgs = len([m for m in self.message_history if m.role == role])
-        if n_role_msgs == 0:
-            return None
-        idx = self.nth_message_idx_with_role(role, n_role_msgs)
-        return self.message_history[idx]
-
-    def last_message_idx_with_role(self, role: Role) -> int:
-        """Index of last message in message_history, with specified role.
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-        indices_with_role = [
-            i for i, m in enumerate(self.message_history) if m.role == role
-        ]
-        if len(indices_with_role) == 0:
-            return -1
-        return indices_with_role[-1]
-
-    def nth_message_idx_with_role(self, role: Role, n: int) -> int:
-        """Index of `n`th message in message_history, with specified role.
-        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-        indices_with_role = [
-            i for i, m in enumerate(self.message_history) if m.role == role
-        ]
-
-        if len(indices_with_role) < n:
-            return -1
-        return indices_with_role[n - 1]
-
-    def update_last_message(self, message: str, role: str = Role.USER) -> None:
-        """
-        Update the last message that has role `role` in the message history.
-        Useful when we want to replace a long user prompt, that may contain context
-        documents plus a question, with just the question.
-        Args:
-            message (str): new message to replace with
-            role (str): role of message to replace
-        """
-        if len(self.message_history) == 0:
-            return
-        # find last message in self.message_history with role `role`
-        for i in range(len(self.message_history) - 1, -1, -1):
-            if self.message_history[i].role == role:
-                self.message_history[i].content = message
-                break
-
-    def delete_last_message(self, role: str = Role.USER) -> None:
-        """
-        Delete the last message that has role `role` from the message history.
-        Args:
-            role (str): role of message to delete
-        """
-        if len(self.message_history) == 0:
-            return
-        # find last message in self.message_history with role `role`
-        for i in range(len(self.message_history) - 1, -1, -1):
-            if self.message_history[i].role == role:
-                self.message_history.pop(i)
-                break
-
-    def _create_system_and_tools_message(self) -> LLMMessage:
-        """
-        (Re-)Create the system message for the LLM of the agent,
-        taking into account any tool instructions that have been added
-        after the agent was initialized.
-
-        The system message will consist of:
-        (a) the system message from the `task` arg in constructor, if any,
-            otherwise the default system message from the config
-        (b) the system tool instructions, if any
-        (c) the system json tool instructions, if any
-
-        Returns:
-            LLMMessage object
-        """
-        content = self.system_message
-        if self.system_tool_instructions != "":
-            content += "\n\n" + self.system_tool_instructions
-        if self.system_tool_format_instructions != "":
-            content += "\n\n" + self.system_tool_format_instructions
-        if self.output_format_instructions != "":
-            content += "\n\n" + self.output_format_instructions
-
-        # remove leading and trailing newlines and other whitespace
-        return LLMMessage(role=Role.SYSTEM, content=content.strip())
-
-    def handle_message_fallback(self, msg: str | ChatDocument) -> Any:
-        """
-        Fallback method for the "no-tools" scenario, i.e., the current `msg`
-        (presumably emitted by the LLM) does not have any tool that the agent
-        can handle.
-        NOTE: The `msg` may contain tools but either (a) the agent is not
-        enabled to handle them, or (b) there's an explicit `recipient` field
-        in the tool that doesn't match the agent's name.
-
-        Uses the self.config.non_tool_routing to determine the action to take.
-
-        This method can be overridden by subclasses, e.g.,
-        to create a "reminder" message when a tool is expected but the LLM "forgot"
-        to generate one.
-
-        Args:
-            msg (str | ChatDocument): The input msg to handle
-        Returns:
-            Any: The result of the handler method
-        """
-        if (
-            isinstance(msg, str)
-            or msg.metadata.sender != Entity.LLM
-            or self.config.handle_llm_no_tool is None
-            or self.has_only_unhandled_tools(msg)
-        ):
-            return None
-        # we ONLY use the `handle_llm_no_tool` config option when
-        # the msg is from LLM and does not contain ANY tools at all.
-        from langroid.agent.tools.orchestration import AgentDoneTool, ForwardTool
-
-        no_tool_option = self.config.handle_llm_no_tool
-        if no_tool_option in list(NonToolAction):
-            # in case the `no_tool_option` is one of the special NonToolAction vals
-            match self.config.handle_llm_no_tool:
-                case NonToolAction.FORWARD_USER:
-                    return ForwardTool(agent="User")
-                case NonToolAction.DONE:
-                    return AgentDoneTool(content=msg.content, tools=msg.tool_messages)
-        elif is_callable(no_tool_option):
-            return no_tool_option(msg)
-        # Otherwise just return `no_tool_option` as is:
-        # This can be any string, such as a specific nudge/reminder to the LLM,
-        # or even something like ResultTool etc.
-        return no_tool_option
-
-    def unhandled_tools(self) -> set[str]:
-        """The set of tools that are known but not handled.
-        Useful in task flow: an agent can refuse to accept an incoming msg
-        when it only has unhandled tools.
-        """
-        return self.llm_tools_known - self.llm_tools_handled
-
-    def enable_message(
-        self,
-        message_class: Optional[Type[ToolMessage] | List[Type[ToolMessage]]],
-        use: bool = True,
-        handle: bool = True,
-        force: bool = False,
-        require_recipient: bool = False,
-        include_defaults: bool = True,
-    ) -> None:
-        """
-        Add the tool (message class) to the agent, and enable either
-        - tool USE (i.e. the LLM can generate JSON to use this tool),
-        - tool HANDLING (i.e. the agent can handle JSON from this tool),
-
-        Args:
-            message_class: The ToolMessage class OR List of such classes to enable,
-                for USE, or HANDLING, or both.
-                If this is a list of ToolMessage classes, then the remain args are
-                applied to all classes.
-                Optional; if None, then apply the enabling to all tools in the
-                agent's toolset that have been enabled so far.
-            use: IF True, allow the agent (LLM) to use this tool (or all tools),
-                else disallow
-            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
-                tool (or all tools)
-            force: whether to FORCE the agent (LLM) to USE the specific
-                 tool represented by `message_class`.
-                 `force` is ignored if `message_class` is None.
-            require_recipient: whether to require that recipient be specified
-                when using the tool message (only applies if `use` is True).
-            include_defaults: whether to include fields that have default values,
-                in the "properties" section of the JSON format instructions.
-                (Normally the OpenAI completion API ignores these fields,
-                but the Assistant fn-calling seems to pay attn to these,
-                and if we don't want this, we should set this to False.)
-        """
-        if message_class is not None and isinstance(message_class, list):
-            for mc in message_class:
-                self.enable_message(
-                    mc,
-                    use=use,
-                    handle=handle,
-                    force=force,
-                    require_recipient=require_recipient,
-                    include_defaults=include_defaults,
-                )
-            return None
-
-        # Validate that use/handle are booleans, not accidentally passed tool classes
-        if isclass(use) or isclass(handle):
-            param = "use" if isclass(use) else "handle"
-            raise TypeError(
-                textwrap.dedent(
-                    f"""
-                    Invalid arguments to enable_message().
-                    It appears you passed multiple ToolMessage classes as separate
-                    arguments instead of as a list.
-
-                    Correct usage:
-                        agent.enable_message([Tool1, Tool2, Tool3])
-
-                    Incorrect usage:
-                        agent.enable_message(Tool1, Tool2, Tool3)
-
-                    The '{param}' parameter must be a boolean, not a class.
-                    """
-                )
-            )
-
-        if require_recipient and message_class is not None:
-            message_class = message_class.require_recipient()
-        if message_class is not None:
-            if not issubclass(message_class, ToolMessage):
-                raise ValueError("message_class must be a subclass of ToolMessage")
-            request = message_class.default_value("request")
-            existing_class = self.llm_tools_map.get(request)
-            existing_origin = (
-                existing_class.__dict__.get("__tool_message_origin__", existing_class)
-                if existing_class is not None
-                else None
-            )
-            message_origin = message_class.__dict__.get(
-                "__tool_message_origin__", message_class
-            )
-            if existing_class is not None and existing_origin is not message_origin:
-                raise ValueError(
-                    f"Tool request name {request!r} is already registered to "
-                    f"{existing_class.__name__}; cannot register "
-                    f"{message_class.__name__}"
-                )
-        if isinstance(message_class, XMLToolMessage):
-            # XMLToolMessage is not compatible with OpenAI's Tools/functions API,
-            # so we disable use of functions API, enable langroid-native Tools,
-            # which are prompt-based.
-            self.config.use_functions_api = False
-            self.config.use_tools = True
-        super().enable_message_handling(message_class)  # enables handling only
-        tools = self._get_tool_list(message_class)
-        if message_class is not None:
-            if request == "":
-                raise ValueError(
-                    f"""
-                    ToolMessage class {message_class} must have a non-empty
-                    'request' field if it is to be enabled as a tool.
-                    """
-                )
-            llm_function = message_class.llm_function_schema(defaults=include_defaults)
-            self.llm_functions_map[request] = llm_function
-            if force:
-                self.llm_function_force = dict(name=request)
-            else:
-                self.llm_function_force = None
-
-        for t in tools:
-            self.llm_tools_known.add(t)
-
-            if handle:
-                self.llm_tools_handled.add(t)
-                self.llm_functions_handled.add(t)
-
-                if (
-                    self.enabled_handling_output_format is not None
-                    and self.enabled_handling_output_format.name() == t
-                ):
-                    # `t` was designated as "enabled for handling" ONLY for
-                    # output_format enforcement, but we are explicitly ]
-                    # enabling it for handling here, so we set the variable to None.
-                    self.enabled_handling_output_format = None
-            else:
-                self.llm_tools_handled.discard(t)
-                self.llm_functions_handled.discard(t)
-
-            if use:
-                tool_class = self.llm_tools_map[t]
-                allow_llm_use = tool_class._allow_llm_use
-                if isinstance(allow_llm_use, ModelPrivateAttr):
-                    allow_llm_use = allow_llm_use.default
-                if allow_llm_use:
-                    self.llm_tools_usable.add(t)
-                    self.llm_functions_usable.add(t)
-                else:
-                    logger.warning(
-                        f"""
-                        ToolMessage class {tool_class} does not allow LLM use,
-                        because `_allow_llm_use=False` either in the Tool or a
-                        parent class of this tool;
-                        so not enabling LLM use for this tool!
-                        If you intended an LLM to use this tool,
-                        set `_allow_llm_use=True` when you define the tool.
-                        """
-                    )
-                if (
-                    self.enabled_use_output_format is not None
-                    and self.enabled_use_output_format.default_value("request") == t
-                ):
-                    # `t` was designated as "enabled for use" ONLY for output_format
-                    # enforcement, but we are explicitly enabling it for use here,
-                    # so we set the variable to None.
-                    self.enabled_use_output_format = None
-            else:
-                self.llm_tools_usable.discard(t)
-                self.llm_functions_usable.discard(t)
-
-        self._update_tool_instructions()
-
-    def _update_tool_instructions(self) -> None:
-        # Set tool instructions and JSON format instructions,
-        # in case Tools have been enabled/disabled.
-        if self.config.use_tools:
-            self.system_tool_format_instructions = self.tool_format_rules()
-        self.system_tool_instructions = self.tool_instructions()
-
-    def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]:
-        """
-        Returns the current set of enabled requests for inference and tools configs.
-        Used for restoring setings overriden by `set_output_format`.
-        """
-        return (
-            self.enabled_requests_for_inference,
-            self.config.use_functions_api,
-            self.config.use_tools,
-        )
-
-    @property
-    def all_llm_tools_known(self) -> set[str]:
-        """All known tools; we include `output_format` if it is a `ToolMessage`."""
-        known = self.llm_tools_known
-
-        if self.output_format is not None and issubclass(
-            self.output_format, ToolMessage
-        ):
-            return known.union({self.output_format.default_value("request")})
-
-        return known
-
-    def set_output_format(
-        self,
-        output_type: Optional[type],
-        force_tools: Optional[bool] = None,
-        use: Optional[bool] = None,
-        handle: Optional[bool] = None,
-        instructions: Optional[bool] = None,
-        is_copy: bool = False,
-    ) -> None:
-        """
-        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
-        switches to the native Langroid tools mechanism to ensure that no tool
-        calls not of `output_type` are generated. By default, `force_tools`
-        follows the `use_tools_on_output_format` parameter in the config.
-
-        If `output_type` is None, restores to the state prior to setting
-        `output_format`.
-
-        If `use`, we enable use of `output_type` when it is a subclass
-        of `ToolMesage`. Note that this primarily controls instruction
-        generation: the model will always generate `output_type` regardless
-        of whether `use` is set. Defaults to the `use_output_format`
-        parameter in the config. Similarly, handling of `output_type` is
-        controlled by `handle`, which defaults to the
-        `handle_output_format` parameter in the config.
-
-        `instructions` controls whether we generate instructions specifying
-        the output format schema. Defaults to the `instructions_output_format`
-        parameter in the config.
-
-        `is_copy` is set when called via `__getitem__`. In that case, we must
-        copy certain fields to ensure that we do not overwrite the main agent's
-        setings.
-        """
-        # Disable usage of an output format which was not specifically enabled
-        # by `enable_message`
-        if self.enabled_use_output_format is not None:
-            self.disable_message_use(self.enabled_use_output_format)
-            self.enabled_use_output_format = None
-
-        # Disable handling of an output format which did not specifically have
-        # handling enabled via `enable_message`
-        if self.enabled_handling_output_format is not None:
-            self.disable_message_handling(self.enabled_handling_output_format)
-            self.enabled_handling_output_format = None
-
-        # Reset any previous instructions
-        self.output_format_instructions = ""
-
-        if output_type is None:
-            self.output_format = None
-            (
-                requests_for_inference,
-                use_functions_api,
-                use_tools,
-            ) = self.saved_requests_and_tool_setings
-            self.config = self.config.model_copy()
-            self.enabled_requests_for_inference = requests_for_inference
-            self.config.use_functions_api = use_functions_api
-            self.config.use_tools = use_tools
-        else:
-            if force_tools is None:
-                force_tools = self.config.use_tools_on_output_format
-
-            if not any(
-                (isclass(output_type) and issubclass(output_type, t))
-                for t in [ToolMessage, BaseModel]
-            ):
-                output_type = get_pydantic_wrapper(output_type)
-
-            if self.output_format is None and force_tools:
-                self.saved_requests_and_tool_setings = (
-                    self._requests_and_tool_settings()
-                )
-
-            self.output_format = output_type
-            if issubclass(output_type, ToolMessage):
-                name = output_type.default_value("request")
-                if use is None:
-                    use = self.config.use_output_format
-
-                if handle is None:
-                    handle = self.config.handle_output_format
-
-                if use or handle:
-                    is_usable = name in self.llm_tools_usable.union(
-                        self.llm_functions_usable
-                    )
-                    is_handled = name in self.llm_tools_handled.union(
-                        self.llm_functions_handled
-                    )
-
-                    if is_copy:
-                        if use:
-                            # We must copy `llm_tools_usable` so the base agent
-                            # is unmodified
-                            self.llm_tools_usable = self.llm_tools_usable.copy()
-                            self.llm_functions_usable = self.llm_functions_usable.copy()
-                        if handle:
-                            # If handling the tool, do the same for `llm_tools_handled`
-                            self.llm_tools_handled = self.llm_tools_handled.copy()
-                            self.llm_functions_handled = (
-                                self.llm_functions_handled.copy()
-                            )
-                    # Enable `output_type`
-                    self.enable_message(
-                        output_type,
-                        # Do not override existing settings
-                        use=use or is_usable,
-                        handle=handle or is_handled,
-                    )
-
-                    # If the `output_type` ToilMessage was not already enabled for
-                    # use, this means we are ONLY enabling it for use specifically
-                    # for enforcing this output format, so we set the
-                    # `enabled_use_output_forma  to this output_type, to
-                    # record that it should be disabled when `output_format` is changed
-                    if not is_usable:
-                        self.enabled_use_output_format = output_type
-
-                    # (same reasoning as for use-enabling)
-                    if not is_handled:
-                        self.enabled_handling_output_format = output_type
-
-                generated_tool_instructions = name in self.llm_tools_usable.union(
-                    self.llm_functions_usable
-                )
-            else:
-                generated_tool_instructions = False
-
-            if instructions is None:
-                instructions = self.config.instructions_output_format
-            if issubclass(output_type, BaseModel) and instructions:
-                if generated_tool_instructions:
-                    # Already generated tool instructions as part of "enabling for use",
-                    # so only need to generate a reminder to use this tool.
-                    name = cast(ToolMessage, output_type).default_value("request")
-                    self.output_format_instructions = textwrap.dedent(
-                        f"""
-                        === OUTPUT FORMAT INSTRUCTIONS ===
-
-                        Please provide output using the `{name}` tool/function.
-                        """
-                    )
-                else:
-                    if issubclass(output_type, ToolMessage):
-                        output_format_schema = output_type.llm_function_schema(
-                            request=True,
-                            defaults=self.config.output_format_include_defaults,
-                        ).parameters
-                    else:
-                        output_format_schema = output_type.model_json_schema()
-
-                    format_schema_for_strict(output_format_schema)
-
-                    self.output_format_instructions = textwrap.dedent(
-                        f"""
-                        === OUTPUT FORMAT INSTRUCTIONS ===
-                        Please provide output as JSON with the following schema:
-
-                        {output_format_schema}
-                        """
-                    )
-
-            if force_tools:
-                if issubclass(output_type, ToolMessage):
-                    self.enabled_requests_for_inference = {
-                        output_type.default_value("request")
-                    }
-                if self.config.use_functions_api:
-                    self.config = self.config.model_copy()
-                    self.config.use_functions_api = False
-                    self.config.use_tools = True
-
-    def __getitem__(self, output_type: type) -> Self:
-        """
-        Returns a (shallow) copy of `self` with a forced output type.
-        """
-        clone = copy.copy(self)
-        clone.set_output_format(output_type, is_copy=True)
-        return clone
-
-    def disable_message_handling(
-        self,
-        message_class: Optional[Type[ToolMessage]] = None,
-    ) -> None:
-        """
-        Disable this agent from RESPONDING to a `message_class` (Tool). If
-            `message_class` is None, then disable this agent from responding to ALL.
-        Args:
-            message_class: The ToolMessage class to disable; Optional.
-        """
-        super().disable_message_handling(message_class)
-        for t in self._get_tool_list(message_class):
-            self.llm_tools_handled.discard(t)
-            self.llm_functions_handled.discard(t)
-
-    def disable_message_use(
-        self,
-        message_class: Optional[Type[ToolMessage]],
-    ) -> None:
-        """
-        Disable this agent from USING a message class (Tool).
-        If `message_class` is None, then disable this agent from USING ALL tools.
-        Args:
-            message_class: The ToolMessage class to disable.
-                If None, disable all.
-        """
-        for t in self._get_tool_list(message_class):
-            self.llm_tools_usable.discard(t)
-            self.llm_functions_usable.discard(t)
-
-        self._update_tool_instructions()
-
-    def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None:
-        """
-        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
-        Args:
-            message_class: The only ToolMessage class to allow
-        """
-        request = message_class.model_fields["request"].default
-        to_remove = [r for r in self.llm_tools_usable if r != request]
-        for r in to_remove:
-            self.llm_tools_usable.discard(r)
-            self.llm_functions_usable.discard(r)
-        self._update_tool_instructions()
-
-    def _load_output_format(self, message: ChatDocument) -> None:
-        """
-        If set, attempts to parse a value of type `self.output_format` from the message
-        contents or any tool/function call and assigns it to `content_any`.
-        """
-        if self.output_format is not None:
-            any_succeeded = False
-            attempts: list[str | LLMFunctionCall] = [
-                message.content,
-            ]
-
-            if message.function_call is not None:
-                attempts.append(message.function_call)
-
-            if message.oai_tool_calls is not None:
-                attempts.extend(
-                    [
-                        c.function
-                        for c in message.oai_tool_calls
-                        if c.function is not None
-                    ]
-                )
-
-            for attempt in attempts:
-                try:
-                    if isinstance(attempt, str):
-                        content = json.loads(attempt)
-                    else:
-                        if not (
-                            issubclass(self.output_format, ToolMessage)
-                            and attempt.name
-                            == self.output_format.default_value("request")
-                        ):
-                            continue
-
-                        content = attempt.arguments
-
-                    content_any = self.output_format.model_validate(content)
-
-                    if issubclass(self.output_format, PydanticWrapper):
-                        message.content_any = content_any.value  # type: ignore
-                    else:
-                        message.content_any = content_any
-                    any_succeeded = True
-                    break
-                except (ValidationError, json.JSONDecodeError):
-                    continue
-
-            if not any_succeeded:
-                self.disable_strict = True
-                logging.warning(
-                    """
-                    Validation error occured with strict output format enabled.
-                    Disabling strict mode.
-                    """
-                )
-
-    def get_tool_messages(
-        self,
-        msg: str | ChatDocument | None,
-        all_tools: bool = False,
-    ) -> List[ToolMessage]:
-        """
-        Extracts messages and tracks whether any errors occurred. If strict mode
-        was enabled, disables it for the tool, else triggers strict recovery.
-        """
-        self.tool_error = False
-        most_recent_sent_by_llm = (
-            len(self.message_history) > 0
-            and self.message_history[-1].role == Role.ASSISTANT
-        )
-        was_llm = most_recent_sent_by_llm or (
-            isinstance(msg, ChatDocument) and msg.metadata.sender == Entity.LLM
-        )
-        try:
-            tools = super().get_tool_messages(msg, all_tools)
-        except ValidationError as ve:
-            # Check if tool class was attached to the exception
-            if hasattr(ve, "tool_class") and ve.tool_class:
-                tool_class = ve.tool_class  # type: ignore
-                if issubclass(tool_class, ToolMessage):
-                    was_strict = (
-                        self.config.use_functions_api
-                        and self.config.use_tools_api
-                        and self._strict_mode_for_tool(tool_class)
-                    )
-                    # If the result of strict output for a tool using the
-                    # OpenAI tools API fails to parse, we infer that the
-                    # schema edits necessary for compatibility prevented
-                    # adherence to the underlying `ToolMessage` schema and
-                    # disable strict output for the tool
-                    if was_strict:
-                        name = tool_class.default_value("request")
-                        self.disable_strict_tools_set.add(name)
-                        logging.warning(
-                            f"""
-                            Validation error occured with strict tool format.
-                            Disabling strict mode for the {name} tool.
-                            """
-                        )
-                    else:
-                        # We will trigger the strict recovery mechanism to force
-                        # the LLM to correct its output, allowing us to parse
-                        if isinstance(msg, ChatDocument):
-                            self.tool_error = msg.metadata.sender == Entity.LLM
-                        else:
-                            self.tool_error = most_recent_sent_by_llm
-
-            if was_llm:
-                raise ve
-            else:
-                self.tool_error = False
-                return []
-
-        if not was_llm:
-            self.tool_error = False
-
-        return tools
-
-    def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None:
-        """
-        Returns a `ToolMessage` which wraps all enabled tools, excluding those
-        where strict recovery is disabled. Used in strict recovery.
-        """
-        possible_tools = tuple(
-            self.llm_tools_map[t]
-            for t in self.llm_tools_usable
-            if t not in self.disable_strict_tools_set
-        )
-        if len(possible_tools) == 0:
-            return None
-        any_tool_type = Union.__getitem__(possible_tools)  # type ignore
-
-        maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
-
-        class AnyTool(ToolMessage):
-            purpose: str = "To call a tool/function."
-            request: str = "tool_or_function"
-            tool: maybe_optional_type  # type: ignore
-
-            def response(self, agent: ChatAgent) -> None | str | ChatDocument:
-                # One-time use
-                agent.set_output_format(None)
-
-                if self.tool is None:
-                    return None
-
-                # As the ToolMessage schema accepts invalid
-                # `tool.request` values, reparse with the
-                # corresponding tool
-                request = self.tool.request
-                if request not in agent.llm_tools_map:
-                    return None
-                tool = agent.llm_tools_map[request].model_validate_json(
-                    self.tool.to_json()
-                )
-
-                return agent.handle_tool_message(tool)
-
-            async def response_async(
-                self, agent: ChatAgent
-            ) -> None | str | ChatDocument:
-                # One-time use
-                agent.set_output_format(None)
-
-                if self.tool is None:
-                    return None
-
-                # As the ToolMessage schema accepts invalid
-                # `tool.request` values, reparse with the
-                # corresponding tool
-                request = self.tool.request
-                if request not in agent.llm_tools_map:
-                    return None
-                tool = agent.llm_tools_map[request].model_validate_json(
-                    self.tool.to_json()
-                )
-
-                return await agent.handle_tool_message_async(tool)
-
-        # Every call builds a distinct class; share one origin so enabling a
-        # regenerated AnyTool under "tool_or_function" stays idempotent instead
-        # of tripping the same-name/different-tool registration guard.
-        AnyTool.__tool_message_origin__ = (  # type: ignore[attr-defined]
-            _ANY_TOOL_MESSAGE_ORIGIN
-        )
-        return AnyTool
-
-    def _strict_recovery_instructions(
-        self,
-        tool_type: Optional[type[ToolMessage]] = None,
-        optional: bool = True,
-    ) -> str:
-        """Returns instructions for strict recovery."""
-        optional_instructions = (
-            (
-                "\n"
-                + """
-        If you did NOT intend to do so, `tool` should be null.
-        """
-            )
-            if optional
-            else ""
-        )
-        response_prefix = "If you intended to make such a call, r" if optional else "R"
-        instruction_prefix = "If you do so, b" if optional else "B"
-
-        schema_instructions = (
-            f"""
-        The schema for `tool_or_function` is as follows:
-        {tool_type.llm_function_schema(defaults=True, request=True).parameters}
-        """
-            if tool_type
-            else ""
-        )
-
-        return textwrap.dedent(
-            f"""
-        Your previous attempt to make a tool/function call appears to have failed.
-        {response_prefix}espond with your desired tool/function. Do so with the
-        `tool_or_function` tool/function where `tool` is set to your intended call.
-        {schema_instructions}
-
-        {instruction_prefix}e sure that your corrected call matches your intention
-        in your previous request. For any field with a default value which
-        you did not intend to override in your previous attempt, be sure
-        to set that field to its default value. {optional_instructions}
-        """
-        )
-
-    def truncate_message(
-        self,
-        idx: int,
-        tokens: int = 5,
-        warning: str = "...[Contents truncated!]",
-        inplace: bool = True,
-    ) -> LLMMessage:
-        """
-        Truncate message at idx in msg history to `tokens` tokens.
-
-        If inplace is True, the message is truncated in place, else
-        it LEAVES the original message INTACT and returns a new message
-        """
-        if inplace:
-            llm_msg = self.message_history[idx]
-        else:
-            llm_msg = copy.deepcopy(self.message_history[idx])
-        if llm_msg.content is None or (
-            llm_msg.content == "" and _is_identified_result(llm_msg)
-        ):
-            return llm_msg
-        orig_content = llm_msg.content
-        new_content = (
-            self.parser.truncate_tokens(orig_content, tokens)
-            if self.parser is not None
-            else orig_content[: tokens * 4]  # approx truncation
-        )
-        llm_msg.content = new_content + "\n" + warning
-        return llm_msg
-
-    def _reduce_raw_tool_results(self, message: ChatDocument) -> None:
-        """
-        If message is the result of a ToolMessage that had
-        a `_max_retained_tokens` set to a non-None value, then we replace contents
-        with a placeholder message.
-        """
-        parent_message: ChatDocument | None = message.parent
-        tools = [] if parent_message is None else parent_message.tool_messages
-        truncate_tools = []
-        for t in tools:
-            max_retained_tokens = t._max_retained_tokens
-            if isinstance(max_retained_tokens, ModelPrivateAttr):
-                max_retained_tokens = max_retained_tokens.default
-            if max_retained_tokens is not None:
-                truncate_tools.append(t)
-        limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
-        if limiting_tool is not None:
-            max_retained_tokens = limiting_tool._max_retained_tokens
-            if isinstance(max_retained_tokens, ModelPrivateAttr):
-                max_retained_tokens = max_retained_tokens.default
-            if max_retained_tokens is not None:
-                tool_name = limiting_tool.default_value("request")
-                max_tokens: int = max_retained_tokens
-                truncation_warning = f"""
-                    The result of the {tool_name} tool were too large,
-                    and has been truncated to {max_tokens} tokens.
-                    To obtain the full result, the tool needs to be re-used.
-                """
-                self.truncate_message(
-                    message.metadata.msg_idx, max_tokens, truncation_warning
-                )
-
-    def llm_response(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> Optional[ChatDocument]:
-        """
-        Respond to a single user message, appended to the message history,
-        in "chat" mode
-        Args:
-            message (str|ChatDocument): message or ChatDocument object to respond to.
-                If None, use the self.task_messages
-        Returns:
-            LLM response as a ChatDocument object
-        """
-        if self.llm is None:
-            return None
-
-        # If enabled and a tool error occurred, we recover by generating the tool in
-        # strict json mode
-        if (
-            self.tool_error
-            and self.output_format is None
-            and self._json_schema_available()
-            and self.config.strict_recovery
-        ):
-            self.tool_error = False
-            AnyTool = self._get_any_tool_message()
-            if AnyTool is None:
-                return None
-            self.set_output_format(
-                AnyTool,
-                force_tools=True,
-                use=True,
-                handle=True,
-                instructions=True,
-            )
-            recovery_message = self._strict_recovery_instructions(AnyTool)
-            augmented_message = message
-            if augmented_message is None:
-                augmented_message = recovery_message
-            elif isinstance(augmented_message, str):
-                augmented_message = augmented_message + recovery_message
-            else:
-                augmented_message.content = augmented_message.content + recovery_message
-
-            # only use the augmented message for this one response...
-            result = self.llm_response(augmented_message)
-            # ... restore the original user message so that the AnyTool recover
-            # instructions don't persist in the message history
-            # (this can cause the LLM to use the AnyTool directly as a tool)
-            if message is None:
-                self.delete_last_message(role=Role.USER)
-            else:
-                msg = message if isinstance(message, str) else message.content
-                self.update_last_message(msg, role=Role.USER)
-            return result
-
-        hist, output_len = self._prep_llm_messages(message)
-        if len(hist) == 0:
-            return None
-        tool_choice = (
-            "auto"
-            if isinstance(message, str)
-            else (message.oai_tool_choice if message is not None else "auto")
-        )
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
-            try:
-                response = self.llm_response_messages(hist, output_len, tool_choice)
-            except openai.BadRequestError as e:
-                if self.any_strict:
-                    self.disable_strict = True
-                    self.set_output_format(None)
-                    logging.warning(
-                        f"""
-                        OpenAI BadRequestError raised with strict mode enabled.
-                        Message: {e.message}
-                        Disabling strict mode and retrying.
-                        """
-                    )
-                    return self.llm_response(message)
-                else:
-                    raise e
-        self.message_history.extend(ChatDocument.to_LLMMessage(response))
-        response.metadata.msg_idx = len(self.message_history) - 1
-        response.metadata.agent_id = self.id
-        if isinstance(message, ChatDocument):
-            self._reduce_raw_tool_results(message)
-        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
-        response.metadata.tool_ids = (
-            []
-            if isinstance(message, str)
-            else message.metadata.tool_ids if message is not None else []
-        )
-
-        return response
-
-    async def llm_response_async(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> Optional[ChatDocument]:
-        """
-        Async version of `llm_response`. See there for details.
-        """
-        if self.llm is None:
-            return None
-
-        # If enabled and a tool error occurred, we recover by generating the tool in
-        # strict json mode
-        if (
-            self.tool_error
-            and self.output_format is None
-            and self._json_schema_available()
-            and self.config.strict_recovery
-        ):
-            self.tool_error = False
-            AnyTool = self._get_any_tool_message()
-            self.set_output_format(
-                AnyTool,
-                force_tools=True,
-                use=True,
-                handle=True,
-                instructions=True,
-            )
-            recovery_message = self._strict_recovery_instructions(AnyTool)
-            augmented_message = message
-            if augmented_message is None:
-                augmented_message = recovery_message
-            elif isinstance(augmented_message, str):
-                augmented_message = augmented_message + recovery_message
-            else:
-                augmented_message.content = augmented_message.content + recovery_message
-
-            # only use the augmented message for this one response...
-            result = self.llm_response(augmented_message)
-            # ... restore the original user message so that the AnyTool recover
-            # instructions don't persist in the message history
-            # (this can cause the LLM to use the AnyTool directly as a tool)
-            if message is None:
-                self.delete_last_message(role=Role.USER)
-            else:
-                msg = message if isinstance(message, str) else message.content
-                self.update_last_message(msg, role=Role.USER)
-            return result
-
-        hist, output_len = self._prep_llm_messages(message)
-        if len(hist) == 0:
-            return None
-        tool_choice = (
-            "auto"
-            if isinstance(message, str)
-            else (message.oai_tool_choice if message is not None else "auto")
-        )
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
-            try:
-                response = await self.llm_response_messages_async(
-                    hist, output_len, tool_choice
-                )
-            except openai.BadRequestError as e:
-                if self.any_strict:
-                    self.disable_strict = True
-                    self.set_output_format(None)
-                    logging.warning(
-                        f"""
-                        OpenAI BadRequestError raised with strict mode enabled.
-                        Message: {e.message}
-                        Disabling strict mode and retrying.
-                        """
-                    )
-                    return await self.llm_response_async(message)
-                else:
-                    raise e
-        self.message_history.extend(ChatDocument.to_LLMMessage(response))
-        response.metadata.msg_idx = len(self.message_history) - 1
-        response.metadata.agent_id = self.id
-        if isinstance(message, ChatDocument):
-            self._reduce_raw_tool_results(message)
-        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
-        response.metadata.tool_ids = (
-            []
-            if isinstance(message, str)
-            else message.metadata.tool_ids if message is not None else []
-        )
-
-        return response
-
-    def init_message_history(self) -> None:
-        """
-        Initialize the message history with the system message and user message
-        """
-        self.message_history = [self._create_system_and_tools_message()]
-        if self.user_message:
-            self.message_history.append(
-                LLMMessage(role=Role.USER, content=self.user_message)
-            )
-
-    def _prep_llm_messages(
-        self,
-        message: Optional[str | ChatDocument] = None,
-        truncate: bool = True,
-    ) -> Tuple[List[LLMMessage], int]:
-        """
-        Prepare messages to be sent to self.llm_response_messages,
-            which is the main method that calls the LLM API to get a response.
-            If desired output tokens + message history exceeds the model context length,
-            then first the max output tokens is reduced to fit, and if that is not
-            possible, older messages may be truncated to accommodate at least
-            self.config.llm.min_output_tokens of output.
-
-        Returns:
-            Tuple[List[LLMMessage], int]: (messages, output_len)
-                messages = Full list of messages to send
-                output_len = max expected number of tokens in response
-        """
-
-        if (
-            not self.llm_can_respond(message)
-            or self.config.llm is None
-            or self.llm is None
-        ):
-            return [], 0
-
-        if message is None and len(self.message_history) > 0:
-            # this means agent has been used to get LLM response already,
-            # and so the last message is an "assistant" response.
-            # We delete this last assistant response and re-generate it.
-            self.clear_history(-1)
-            logger.warning(
-                "Re-generating the last assistant response since message is None"
-            )
-
-        if len(self.message_history) == 0:
-            # initial messages have not yet been loaded, so load them
-            self.init_message_history()
-
-            # for debugging, show the initial message history
-            if settings.debug:
-                print(
-                    f"""
-                [grey37]LLM Initial Msg History:
-                {escape(self.message_history_str())}
-                [/grey37]
-                """
-                )
-        else:
-            assert self.message_history[0].role == Role.SYSTEM
-            # update the system message with the latest tool instructions
-            self.message_history[0] = self._create_system_and_tools_message()
-
-        if message is not None:
-            if (
-                isinstance(message, str)
-                or message.id() != self.message_history[-1].chat_document_id
-            ):
-                # either the message is a str, or it is a fresh ChatDocument
-                # different from the last message in the history
-                llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
-                llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
-                # Canonicalize retained whitespace-only results before token counting.
-                for llm_msg in llm_msgs:
-                    if (
-                        _is_identified_result(llm_msg)
-                        and llm_msg.content is not None
-                        and llm_msg.content.strip() == ""
-                    ):
-                        llm_msg.content = ""
-                if len(llm_msgs) == 0:
-                    return [], 0
-                # process tools if any
-                done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
-                self.oai_tool_calls = [
-                    t for t in self.oai_tool_calls if t.id not in done_tools
-                ]
-                self.message_history.extend(llm_msgs)
-
-        hist = self.message_history
-        output_len = self.config.llm.model_max_output_tokens
-        if (
-            truncate
-            and output_len > self.llm.chat_context_length() - self.chat_num_tokens(hist)
-        ):
-            # chat + output > max context length,
-            # so first try to shorten requested output len to fit;
-            # use an extra margin of CHAT_HISTORY_BUFFER tokens
-            # in case our calcs are off (and to allow for some extra tokens)
-            output_len = (
-                self.llm.chat_context_length()
-                - self.chat_num_tokens(hist)
-                - CHAT_HISTORY_BUFFER
-            )
-            if output_len > self.config.llm.min_output_tokens:
-                logger.debug(
-                    f"""
-                    Chat Model context length is {self.llm.chat_context_length()},
-                    but the current message history is {self.chat_num_tokens(hist)}
-                    tokens long, which does not allow
-                    {self.config.llm.model_max_output_tokens} output tokens.
-                    Therefore we reduced `max_output_tokens` to {output_len} tokens,
-                    so they can fit within the model's context length
-                    """
-                )
-            else:
-                # unacceptably small output len, so compress early parts of
-                # conversation history based on the configured strategy
-                strategy = self.config.context_overflow_strategy
-
-                if strategy == "truncate":
-                    # Truncate content of individual messages while preserving
-                    # the message sequence (important for LLM APIs that require
-                    # alternating USER/ASSISTANT messages)
-                    msg_idx_to_compress = 1  # don't touch system msg
-                    # we will try compressing msg indices up to but not including
-                    # last user msg
-                    last_msg_idx_to_compress = (
-                        self.last_message_idx_with_role(
-                            role=Role.USER,
-                        )
-                        - 1
-                    )
-                    n_truncated = 0
-                    _target_tokens = (
-                        self.llm.chat_context_length()
-                        - self.config.llm.min_output_tokens
-                        - CHAT_HISTORY_BUFFER
-                    )
-                    # Truncation floor: never reduce a message's content below
-                    # this many tokens.
-                    _min_keep_tokens = 30
-                    _truncation_warning = "... [Contents truncated!]"
-
-                    def _content_tokens(text: str | None) -> int:
-                        """Token count of message *content* only.
-
-                        `truncate_message` only trims `message.content`, so
-                        using the full `_message_num_tokens` (which includes
-                        attachment payloads) would inflate the count and make
-                        the keep-target too large to ever converge, for
-                        messages carrying file attachments.
-                        """
-                        return (
-                            self.parser.num_tokens(text or "")
-                            if self.parser is not None
-                            # approx fallback, matches truncate_message
-                            else len(text or "") // 4
-                        )
-
-                    # Account for the warning that truncate_message appends
-                    # ("\n" + warning), so the final token count of a
-                    # truncated message does not exceed its keep-target.
-                    _warning_tokens = _content_tokens("\n" + _truncation_warning)
-                    # NOTE: loop termination is guaranteed:
-                    # msg_idx_to_compress strictly increases every iteration
-                    # (truncate or skip), and once it exceeds
-                    # last_msg_idx_to_compress a ValueError is raised. (The
-                    # token count need not decrease every iteration, so
-                    # termination rests on the index advancing.)
-                    while self.chat_num_tokens(hist) > _target_tokens:
-                        if msg_idx_to_compress > last_msg_idx_to_compress:
-                            # We want to preserve the first message (typically
-                            # system msg) and last message (user msg).
-                            raise ValueError(
-                                """
-                            The (message history + max_output_tokens) is longer than the
-                            max chat context length of this model, and we have tried
-                            reducing the requested max output tokens, as well as
-                            truncating early parts of the message history, to
-                            accommodate the model context length, but we have run out
-                            of msgs to truncate.
-
-                            HINT: In the `llm` field of your `ChatAgentConfig` object,
-                            which is of type `LLMConfig/OpenAIGPTConfig`, try
-                            - increasing `chat_context_length`
-                                (if accurate for the model), or
-                            - decreasing `max_output_tokens`
-                            """
-                            )
-                        _msg_tokens = _content_tokens(hist[msg_idx_to_compress].content)
-                        if _msg_tokens <= _min_keep_tokens + _warning_tokens:
-                            # Truncating this message cannot shrink the total:
-                            # its content is already at/below the keep-floor
-                            # plus the appended warning; leave it intact.
-                            msg_idx_to_compress += 1
-                            continue
-                        n_truncated += 1
-                        # Distribute the current excess evenly across the
-                        # remaining *compressible* messages, so each retains
-                        # as much content as possible instead of being
-                        # collapsed to the fixed 30-token floor. The excess is
-                        # recomputed every iteration, so the distribution
-                        # self-corrects as we move forward through the
-                        # history.
-                        _current_excess = self.chat_num_tokens(hist) - _target_tokens
-                        # Shrink capacity of each *later* message in the
-                        # compressible range: its content above the floor (net
-                        # of the appended warning). Non-positive entries are
-                        # the tiny messages the skip-check above will leave
-                        # untouched; they must not dilute the even share, so
-                        # only messages with positive capacity count toward
-                        # the denominator (plus this message, which passed the
-                        # skip-check and is therefore compressible).
-                        _later_capacities = [
-                            _content_tokens(m.content)
-                            - _min_keep_tokens
-                            - _warning_tokens
-                            for m in hist[
-                                msg_idx_to_compress + 1 : last_msg_idx_to_compress + 1
-                            ]
-                        ]
-                        _n_remaining = 1 + sum(1 for c in _later_capacities if c > 0)
-                        _even_share = math.ceil(_current_excess / _n_remaining)
-                        # Later messages can shed at most their capacity; this
-                        # message must absorb whatever they cannot, so that
-                        # this single forward pass reaches the target whenever
-                        # that is possible at all.
-                        _later_capacity = sum(c for c in _later_capacities if c > 0)
-                        _reduction = max(_even_share, _current_excess - _later_capacity)
-                        # Extra 2-token slack: re-encoding truncated content
-                        # plus the appended warning can merge/split tokens at
-                        # the boundary, so aim slightly below the target to
-                        # keep the achieved reduction from falling short.
-                        _keep_tokens = max(
-                            _min_keep_tokens,
-                            _msg_tokens - _reduction - _warning_tokens - 2,
-                        )
-                        # compress the msg at idx `msg_idx_to_compress`
-                        hist[msg_idx_to_compress] = self.truncate_message(
-                            msg_idx_to_compress,
-                            tokens=_keep_tokens,
-                            warning=_truncation_warning,
-                        )
-                        msg_idx_to_compress += 1
-
-                    output_len = min(
-                        self.config.llm.model_max_output_tokens,
-                        self.llm.chat_context_length()
-                        - self.chat_num_tokens(hist)
-                        - CHAT_HISTORY_BUFFER,
-                    )
-                    if output_len < self.config.llm.min_output_tokens:
-                        raise ValueError(
-                            f"""
-                            Tried to shorten prompt history for chat mode
-                            but even after truncating all messages except system msg
-                            and last (user) msg, the history token len
-                            {self.chat_num_tokens(hist)} is too long to accommodate
-                            the desired minimum output tokens
-                            {self.config.llm.min_output_tokens} within the
-                            model's context length {self.llm.chat_context_length()}.
-                            Please try shortening the system msg or user prompts,
-                            or adjust `config.llm.min_output_tokens` to be smaller.
-                            """
-                        )
-                    else:
-                        # we MUST have truncated at least one msg
-                        msg_tokens = self.chat_num_tokens()
-                        logger.warning(
-                            f"""
-                        Chat Model context length is {self.llm.chat_context_length()}
-                        tokens, but the current message history is {msg_tokens} tokens
-                        long, which does not allow
-                        {self.config.llm.model_max_output_tokens} output tokens.
-                        Therefore we truncated the first {n_truncated} messages
-                        in the conversation history so that history token
-                        length is reduced to {self.chat_num_tokens(hist)}, and
-                        we use `max_output_tokens = {output_len}`,
-                        so they can fit within the model's context length
-                        of {self.llm.chat_context_length()} tokens.
-                        """
-                        )
-
-                else:  # strategy == "drop_turns"
-                    # Drop complete conversation turns. A complete turn is defined
-                    # as a USER message followed by all messages until the next
-                    # USER message. This is more aggressive but cleaner for voice
-                    # agents with limited context.
-                    n_dropped_turns = 0
-                    while (
-                        self.chat_num_tokens(hist)
-                        > self.llm.chat_context_length()
-                        - self.config.llm.min_output_tokens
-                        - CHAT_HISTORY_BUFFER
-                    ):
-                        # Find the last USER message index
-                        last_user_idx = self.last_message_idx_with_role(role=Role.USER)
-                        if last_user_idx == -1:
-                            break
-
-                        # Find the first complete turn to drop (skip system message)
-                        first_user_idx = -1
-                        for i in range(1, last_user_idx):
-                            if hist[i].role == Role.USER:
-                                first_user_idx = i
-                                break
-                        if first_user_idx == -1:
-                            break
-
-                        # Find the end of this turn: last message before next USER
-                        next_user_idx = -1
-                        for i in range(first_user_idx + 1, last_user_idx + 1):
-                            if hist[i].role == Role.USER:
-                                next_user_idx = i
-                                break
-                        if next_user_idx == -1:
-                            break
-
-                        # Drop the turn
-                        self.clear_history(first_user_idx, next_user_idx - 1)
-                        n_dropped_turns += 1
-
-                    output_len = min(
-                        self.config.llm.model_max_output_tokens,
-                        self.llm.chat_context_length()
-                        - self.chat_num_tokens(hist)
-                        - CHAT_HISTORY_BUFFER,
-                    )
-                    if output_len < self.config.llm.min_output_tokens:
-                        raise ValueError(
-                            f"""
-                            Tried to shorten prompt history for chat mode
-                            but even after dropping complete turns except the system
-                            msg and last turn, the history token len
-                            {self.chat_num_tokens(hist)} is too long to accommodate
-                            the desired minimum output tokens
-                            {self.config.llm.min_output_tokens} within the
-                            model's context length {self.llm.chat_context_length()}.
-                            Please try shortening the system msg or user prompts,
-                            or adjust `config.llm.min_output_tokens` to be smaller.
-                            """
-                        )
-                    else:
-                        # we MUST have dropped at least one turn
-                        msg_tokens = self.chat_num_tokens()
-                        logger.warning(
-                            f"""
-                        Chat Model context length is {self.llm.chat_context_length()}
-                        tokens, but the current message history is {msg_tokens} tokens
-                        long, which does not allow
-                        {self.config.llm.model_max_output_tokens} output tokens.
-                        Therefore we dropped the first {n_dropped_turns} complete
-                        turn(s) from the conversation history so that history token
-                        length is reduced to {self.chat_num_tokens(hist)}, and
-                        we use `max_output_tokens = {output_len}`,
-                        so they can fit within the model's context length
-                        of {self.llm.chat_context_length()} tokens.
-                        """
-                        )
-
-        if isinstance(message, ChatDocument):
-            # record the position of the corresponding LLMMessage in
-            # the message_history
-            message.metadata.msg_idx = len(hist) - 1
-            message.metadata.agent_id = self.id
-        return hist, output_len
-
-    def _function_args(
-        self,
-    ) -> Tuple[
-        Optional[List[LLMFunctionSpec]],
-        str | Dict[str, str],
-        Optional[List[OpenAIToolSpec]],
-        Optional[Dict[str, Dict[str, str] | str]],
-        Optional[OpenAIJsonSchemaSpec],
-    ]:
-        """
-        Get function/tool spec/output format arguments for
-        OpenAI-compatible LLM API call
-        """
-        functions: Optional[List[LLMFunctionSpec]] = None
-        fun_call: str | Dict[str, str] = "none"
-        tools: Optional[List[OpenAIToolSpec]] = None
-        force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
-        self.any_strict = False
-        if self.config.use_functions_api and len(self.llm_functions_usable) > 0:
-            if not self.config.use_tools_api:
-                functions = [
-                    self.llm_functions_map[f] for f in self.llm_functions_usable
-                ]
-                fun_call = (
-                    "auto"
-                    if self.llm_function_force is None
-                    else self.llm_function_force
-                )
-            else:
-
-                def to_maybe_strict_spec(function: str) -> OpenAIToolSpec:
-                    spec = self.llm_functions_map[function]
-                    strict = self._strict_mode_for_tool(function)
-                    if strict:
-                        self.any_strict = True
-                        strict_spec = copy.deepcopy(spec)
-                        format_schema_for_strict(strict_spec.parameters)
-                    else:
-                        strict_spec = spec
-
-                    return OpenAIToolSpec(
-                        type="function",
-                        strict=strict,
-                        function=strict_spec,
-                    )
-
-                tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
-                force_tool = (
-                    None
-                    if self.llm_function_force is None
-                    else {
-                        "type": "function",
-                        "function": {"name": self.llm_function_force["name"]},
-                    }
-                )
-        output_format = None
-        if self.output_format is not None and self._json_schema_available():
-            self.any_strict = True
-            if issubclass(self.output_format, ToolMessage) and not issubclass(
-                self.output_format, XMLToolMessage
-            ):
-                spec = self.output_format.llm_function_schema(
-                    request=True,
-                    defaults=self.config.output_format_include_defaults,
-                )
-                format_schema_for_strict(spec.parameters)
-
-                output_format = OpenAIJsonSchemaSpec(
-                    # We always require that outputs strictly match the schema
-                    strict=True,
-                    function=spec,
-                )
-            elif issubclass(self.output_format, BaseModel):
-                param_spec = self.output_format.model_json_schema()
-                format_schema_for_strict(param_spec)
-
-                output_format = OpenAIJsonSchemaSpec(
-                    # We always require that outputs strictly match the schema
-                    strict=True,
-                    function=LLMFunctionSpec(
-                        name="json_output",
-                        description="Strict Json output format.",
-                        parameters=param_spec,
-                    ),
-                )
-
-        return functions, fun_call, tools, force_tool, output_format
-
-    def llm_response_messages(
-        self,
-        messages: List[LLMMessage],
-        output_len: Optional[int] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-    ) -> ChatDocument:
-        """
-        Respond to a series of messages, e.g. with OpenAI ChatCompletion
-        Args:
-            messages: seq of messages (with role, content fields) sent to LLM
-            output_len: max number of tokens expected in response.
-                    If None, use the LLM's default model_max_output_tokens.
-        Returns:
-            Document (i.e. with fields "content", "metadata")
-        """
-        assert self.config.llm is not None and self.llm is not None
-        output_len = output_len or self.config.llm.model_max_output_tokens
-        streamer = noop_fn
-        if self.llm.get_stream():
-            streamer = self.callbacks.start_llm_stream()
-        self.llm.config.streamer = streamer
-        with ExitStack() as stack:  # for conditionally using rich spinner
-            if not self.llm.get_stream() and not settings.quiet:
-                # show rich spinner only if not streaming!
-                # (Why? b/c the intent of showing a spinner is to "show progress",
-                # and we don't need to do that when streaming, since
-                # streaming output already shows progress.)
-                cm = status(
-                    "LLM responding to messages...",
-                    log_if_quiet=False,
-                )
-                stack.enter_context(cm)
-            if self.llm.get_stream() and not settings.quiet:
-                console.print(f"[green]{self.indent}", end="")
-            functions, fun_call, tools, force_tool, output_format = (
-                self._function_args()
-            )
-            assert self.llm is not None
-            response = self.llm.chat(
-                messages,
-                output_len,
-                tools=tools,
-                tool_choice=force_tool or tool_choice,
-                functions=functions,
-                function_call=fun_call,
-                response_format=output_format,
-            )
-        if self.llm.get_stream():
-            # Create temp ChatDocument for tool check, then clean up to avoid
-            # polluting ObjectRegistry (see PR #939 discussion)
-            temp_doc = ChatDocument.from_LLMResponse(
-                response,
-                displayed=True,
-                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-            )
-            self._call_callback_with_reasoning(
-                "finish_llm_stream",
-                reasoning=response.reasoning,
-                content=response.message or "",
-                tools_content=response.tools_content(),
-                is_tool=self.has_tool_message_attempt(temp_doc),
-            )
-            ObjectRegistry.remove(temp_doc.id())
-        self.llm.config.streamer = noop_fn
-        if response.cached:
-            self.callbacks.cancel_llm_stream()
-        self._render_llm_response(response)
-        self.update_token_usage(
-            response,  # .usage attrib is updated!
-            messages,
-            self.llm.get_stream(),
-            chat=True,
-            print_response_stats=self.config.show_stats and not settings.quiet,
-        )
-        chat_doc = ChatDocument.from_LLMResponse(
-            response,
-            displayed=True,
-            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-        )
-        self.oai_tool_calls = response.oai_tool_calls or []
-        self.oai_tool_id2call.update(
-            {t.id: t for t in self.oai_tool_calls if t.id is not None}
-        )
-
-        # If using strict output format, parse the output JSON
-        self._load_output_format(chat_doc)
-
-        return chat_doc
-
-    async def llm_response_messages_async(
-        self,
-        messages: List[LLMMessage],
-        output_len: Optional[int] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-    ) -> ChatDocument:
-        """
-        Async version of `llm_response_messages`. See there for details.
-        """
-        assert self.config.llm is not None and self.llm is not None
-        output_len = output_len or self.config.llm.model_max_output_tokens
-        functions, fun_call, tools, force_tool, output_format = self._function_args()
-        assert self.llm is not None
-
-        streamer_async = async_noop_fn
-        if self.llm.get_stream():
-            streamer_async = await self.callbacks.start_llm_stream_async()
-        self.llm.config.streamer_async = streamer_async
-
-        response = await self.llm.achat(
-            messages,
-            output_len,
-            tools=tools,
-            tool_choice=force_tool or tool_choice,
-            functions=functions,
-            function_call=fun_call,
-            response_format=output_format,
-        )
-        if self.llm.get_stream():
-            # Create temp ChatDocument for tool check, then clean up to avoid
-            # polluting ObjectRegistry (see PR #939 discussion)
-            temp_doc = ChatDocument.from_LLMResponse(
-                response,
-                displayed=True,
-                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-            )
-            self._call_callback_with_reasoning(
-                "finish_llm_stream",
-                reasoning=response.reasoning,
-                content=response.message or "",
-                tools_content=response.tools_content(),
-                is_tool=self.has_tool_message_attempt(temp_doc),
-            )
-            ObjectRegistry.remove(temp_doc.id())
-        self.llm.config.streamer_async = async_noop_fn
-        if response.cached:
-            self.callbacks.cancel_llm_stream()
-        self._render_llm_response(response)
-        self.update_token_usage(
-            response,  # .usage attrib is updated!
-            messages,
-            self.llm.get_stream(),
-            chat=True,
-            print_response_stats=self.config.show_stats and not settings.quiet,
-        )
-        chat_doc = ChatDocument.from_LLMResponse(
-            response,
-            displayed=True,
-            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-        )
-        self.oai_tool_calls = response.oai_tool_calls or []
-        self.oai_tool_id2call.update(
-            {t.id: t for t in self.oai_tool_calls if t.id is not None}
-        )
-
-        # If using strict output format, parse the output JSON
-        self._load_output_format(chat_doc)
-
-        return chat_doc
-
-    def _call_callback_with_reasoning(
-        self,
-        callback_name: str,
-        reasoning: str,
-        **kwargs: Any,
-    ) -> None:
-        """
-        Call a callback method, only passing 'reasoning' if it accepts it.
-
-        This provides backward compatibility for custom callbacks that don't
-        have the 'reasoning' parameter in their signature.
-
-        Args:
-            callback_name: Name of the callback method (e.g., 'show_llm_response')
-            reasoning: The reasoning content to pass if supported
-            **kwargs: Other arguments to pass to the callback
-        """
-        callback = getattr(self.callbacks, callback_name, None)
-        if callback is None:
-            return
-
-        # Check if callback accepts 'reasoning' param or **kwargs
-        try:
-            sig = inspect.signature(callback)
-            params = sig.parameters
-            accepts_reasoning = "reasoning" in params or any(
-                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-            )
-        except (ValueError, TypeError):
-            # If we can't inspect the signature, assume it doesn't accept reasoning
-            accepts_reasoning = False
-
-        if accepts_reasoning:
-            callback(reasoning=reasoning, **kwargs)
-        else:
-            callback(**kwargs)
-
-    def _render_llm_response(
-        self, response: ChatDocument | LLMResponse, citation_only: bool = False
-    ) -> None:
-        is_cached = (
-            response.cached
-            if isinstance(response, LLMResponse)
-            else response.metadata.cached
-        )
-        if self.llm is None:
-            return
-        if not citation_only and (not self.llm.get_stream() or is_cached):
-            # We would have already displayed the msg "live" ONLY if
-            # streaming was enabled, AND we did not find a cached response.
-            # If we are here, it means the response has not yet been displayed.
-            cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
-            # Track whether we created a temp ChatDocument for cleanup
-            is_temp_doc = isinstance(response, LLMResponse)
-            chat_doc = (
-                response
-                if isinstance(response, ChatDocument)
-                else ChatDocument.from_LLMResponse(
-                    response,
-                    displayed=True,
-                    recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-                )
-            )
-            # TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
-            if not settings.quiet:
-                print(cached + "[green]" + escape(str(response)))
-            if isinstance(response, LLMResponse):
-                content = response.message or ""
-                tools_content = response.tools_content()
-            else:
-                content = response.content
-                tools_content = ""
-            reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
-            self._call_callback_with_reasoning(
-                "show_llm_response",
-                reasoning=reasoning,
-                content=content,
-                tools_content=tools_content,
-                is_tool=self.has_tool_message_attempt(chat_doc),
-                cached=is_cached,
-            )
-            # Clean up temp ChatDocument to avoid polluting ObjectRegistry
-            if is_temp_doc:
-                ObjectRegistry.remove(chat_doc.id())
-        if isinstance(response, LLMResponse):
-            # we are in the context immediately after an LLM responded,
-            # we won't have citations yet, so we're done
-            return
-        if response.metadata.has_citation:
-            citation = (
-                response.metadata.source_content
-                if self.config.full_citations
-                else response.metadata.source
-            )
-            if not settings.quiet:
-                print("[grey37]SOURCES:\n" + escape(citation) + "[/grey37]")
-            self._call_callback_with_reasoning(
-                "show_llm_response",
-                reasoning="",  # Citations don't have reasoning
-                content=str(citation),
-                tools_content="",
-                is_tool=False,
-                cached=False,
-                language="text",
-            )
-
-    def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument:
-        """
-        Get LLM response to `prompt` (which presumably includes the `message`
-        somewhere, along with possible large "context" passages),
-        but only include `message` as the USER message, and not the
-        full `prompt`, in the message history.
-        Args:
-            message: the original, relatively short, user request or query
-            prompt: the full prompt potentially containing `message` plus context
-
-        Returns:
-            Document object containing the response.
-        """
-        # we explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
-        self.update_last_message(message, role=Role.USER)
-        return answer_doc
-
-    async def _llm_response_temp_context_async(
-        self, message: str, prompt: str
-    ) -> ChatDocument:
-        """
-        Async version of `_llm_response_temp_context`. See there for details.
-        """
-        # we explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            answer_doc = cast(
-                ChatDocument,
-                await ChatAgent.llm_response_async(self, prompt),
-            )
-        self.update_last_message(message, role=Role.USER)
-        return answer_doc
-
-    def llm_response_forget(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> ChatDocument:
-        """
-        LLM Response to single message, and restore message_history.
-        In effect a "one-off" message & response that leaves agent
-        message history state intact.
-
-        Args:
-            message (str|ChatDocument): message to respond to.
-
-        Returns:
-            A Document object with the response.
-
-        """
-        # explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        n_msgs = len(self.message_history)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            response = cast(ChatDocument, ChatAgent.llm_response(self, message))
-        # If there is a response, then we will have two additional
-        # messages in the message history, i.e. the user message and the
-        # assistant response. We want to (carefully) remove these two messages.
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-
-        # If using strict output format, parse the output JSON
-        self._load_output_format(response)
-
-        return response
-
-    async def llm_response_forget_async(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> ChatDocument:
-        """
-        Async version of `llm_response_forget`. See there for details.
-        """
-        # explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        n_msgs = len(self.message_history)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            response = cast(
-                ChatDocument, await ChatAgent.llm_response_async(self, message)
-            )
-        # If there is a response, then we will have two additional
-        # messages in the message history, i.e. the user message and the
-        # assistant response. We want to (carefully) remove these two messages.
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-        return response
-
-    def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int:
-        """
-        Total number of tokens in the message history so far.
-
-        Args:
-            messages: if provided, compute the number of tokens in this list of
-                messages, rather than the current message history.
-        Returns:
-            int: number of tokens in message history
-        """
-        if self.parser is None:
-            raise ValueError(
-                "ChatAgent.parser is None. "
-                "You must set ChatAgent.parser "
-                "before calling chat_num_tokens()."
-            )
-        hist = messages if messages is not None else self.message_history
-        return sum([self._message_num_tokens(m) for m in hist])
-
-    def _message_num_tokens(self, message: LLMMessage) -> int:
-        """Count tokens for a message, including serialized user attachments."""
-        if self.parser is None:
-            raise ValueError(
-                "ChatAgent.parser is None. "
-                "You must set ChatAgent.parser "
-                "before calling _message_num_tokens()."
-            )
-
-        return self.parser.num_tokens(
-            message.content or ""
-        ) + self._attachment_num_tokens(message)
-
-    def _attachment_num_tokens(self, message: LLMMessage) -> int:
-        """
-        Estimate attachment contribution using the serialized payload
-        that is sent in the API request for user messages.
-        """
-        if self.parser is None or message.role != Role.USER or len(message.files) == 0:
-            return 0
-
-        model = self._chat_model_name_for_attachments()
-        return sum(
-            self.parser.num_tokens(
-                json.dumps(
-                    attachment.to_dict(model),
-                    separators=(",", ":"),
-                    sort_keys=True,
-                )
-            )
-            for attachment in message.files
-        )
-
-    def _chat_model_name_for_attachments(self) -> str:
-        """Return the model name used for attachment serialization."""
-        if self.llm is None:
-            return self.config.llm.chat_model if self.config.llm is not None else ""
-
-        return cast(
-            str,
-            getattr(
-                self.llm,
-                "chat_model_orig",
-                getattr(
-                    getattr(self.llm, "config", None),
-                    "chat_model",
-                    self.config.llm.chat_model if self.config.llm is not None else "",
-                ),
-            ),
-        )
-
-    def message_history_str(self, i: Optional[int] = None) -> str:
-        """
-        Return a string representation of the message history
-        Args:
-            i: if provided, return only the i-th message when i is postive,
-                or last k messages when i = -k.
-        Returns:
-        """
-        if i is None:
-            return "\n".join([str(m) for m in self.message_history])
-        elif i > 0:
-            return str(self.message_history[i])
-        else:
-            return "\n".join([str(m) for m in self.message_history[i:]])
-
-    def __del__(self) -> None:
-        """
-        Cleanup method called when the ChatAgent is garbage collected.
-        Note: We don't close LLM clients here because they may be shared
-        across multiple agents when client caching is enabled.
-        The clients are managed centrally and cleaned up via atexit hooks.
-        """
-        # Previously we closed clients here, but this caused issues when
-        # multiple agents shared the same cached client instance.
-        # Clients are now managed centrally in langroid.language_models.client_cache
-        pass
-</file>
-
 <file path="langroid/language_models/openai_gpt.py">
 import hashlib
 import json
@@ -95744,9 +93054,2760 @@ class OpenAIGPT(LanguageModel):
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.16.0
+  rev: v0.16.4
   hooks:
     - id: ruff
+</file>
+
+<file path="langroid/agent/chat_agent.py">
+import base64
+import copy
+import inspect
+import json
+import logging
+import math
+import textwrap
+from contextlib import ExitStack
+from inspect import isclass
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Self,
+    Set,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+import openai
+from pydantic import BaseModel, ValidationError
+from pydantic.fields import ModelPrivateAttr
+from rich import print
+from rich.console import Console
+from rich.markup import escape
+
+from langroid.agent.base import (
+    Agent,
+    AgentConfig,
+    SearchForTools,
+    async_noop_fn,
+    noop_fn,
+)
+from langroid.agent.chat_document import ChatDocument
+from langroid.agent.tool_message import (
+    ToolMessage,
+    format_schema_for_strict,
+)
+from langroid.agent.xml_tool_message import XMLToolMessage
+from langroid.language_models.base import (
+    LLMFunctionCall,
+    LLMFunctionSpec,
+    LLMMessage,
+    LLMResponse,
+    OpenAIJsonSchemaSpec,
+    OpenAIToolSpec,
+    Role,
+    StreamingIfAllowed,
+    ToolChoiceTypes,
+)
+from langroid.language_models.openai_gpt import OpenAIGPT
+from langroid.mytypes import Entity, NonToolAction
+from langroid.parsing.file_attachment import FileAttachment
+from langroid.utils.configuration import settings
+from langroid.utils.object_registry import ObjectRegistry
+from langroid.utils.output import status
+from langroid.utils.pydantic_utils import PydanticWrapper, get_pydantic_wrapper
+from langroid.utils.types import is_callable
+
+console = Console()
+
+logger = logging.getLogger(__name__)
+
+# Stable origin sentinel for the dynamically generated strict-recovery AnyTool
+# class ("tool_or_function"): a fresh class is built per call (its tool-union
+# type varies), so re-registration must be recognized as the same logical tool.
+_ANY_TOOL_MESSAGE_ORIGIN: Any = object()
+
+# Safety margin (in tokens) subtracted from the model context length when
+# shrinking chat history and/or the requested output length to fit, in case
+# our token-count estimates are off.
+CHAT_HISTORY_BUFFER = 300
+
+
+def _reject_json_constant(constant: str) -> None:
+    """Reject JavaScript numeric constants that are not valid JSON."""
+    raise ValueError(f"non-JSON numeric constant: {constant}")
+
+
+def _parse_json_float(value: str) -> float:
+    """Parse a JSON float while rejecting exponent overflow."""
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"non-finite JSON number: {value}")
+    return parsed
+
+
+def _is_identified_result(message: LLMMessage) -> bool:
+    """Whether a TOOL/FUNCTION result has its identifier and no call payload.
+
+    Such results must survive even with empty content so their calls can be
+    marked complete (issue #1063).
+    """
+    has_identifier = (
+        message.role == Role.TOOL and bool((message.tool_call_id or "").strip())
+    ) or (message.role == Role.FUNCTION and bool((message.name or "").strip()))
+    return has_identifier and message.function_call is None and not message.tool_calls
+
+
+def _llm_message_has_payload(message: LLMMessage) -> bool:
+    """Whether a message has the fields required for a valid history entry."""
+    return (
+        (message.content or "").strip() != ""
+        or message.function_call is not None
+        or bool(message.tool_calls)
+        or _is_identified_result(message)
+    )
+
+
+class ChatAgentConfig(AgentConfig):
+    """
+    Configuration for ChatAgent
+
+    Attributes:
+        system_message: system message to include in message sequence
+             (typically defines role and task of agent).
+             Used only if `task` is not specified in the constructor.
+        user_message: user message to include in message sequence.
+             Used only if `task` is not specified in the constructor.
+        use_tools: whether to use our own ToolMessages mechanism
+        handle_llm_no_tool (Any): desired agent_response when
+            LLM generates non-tool msg.
+        use_functions_api: whether to use functions/tools native to the LLM API
+                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
+        use_tools_api: When `use_functions_api` is True, if this is also True,
+            the OpenAI tool-call API is used, rather than the older/deprecated
+            function-call API. However the tool-call API has some tricky aspects,
+            hence we set this to False by default.
+        strict_recovery: whether to enable strict schema recovery when there
+            is a tool-generation error.
+        enable_orchestration_tool_handling: whether to enable handling of orchestration
+            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
+        output_format: When supported by the LLM (certain OpenAI LLMs
+            and local LLMs served by providers such as vLLM), ensures
+            that the output is a JSON matching the corresponding
+            schema via grammar-based decoding
+        handle_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for handling".
+        use_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for use" (by LLM) and
+            instructions on using T are added to the system message.
+        instructions_output_format: Controls whether we generate instructions for
+            `output_format` in the system message.
+        use_tools_on_output_format: Controls whether to automatically switch
+            to the Langroid-native tools mechanism when `output_format` is set.
+            Note that LLMs may generate tool calls which do not belong to
+            `output_format` even when strict JSON mode is enabled, so this should be
+            enabled when such tool calls are not desired.
+        output_format_include_defaults: Whether to include fields with default arguments
+            in the output schema
+        full_citations: Whether to show source reference citation + content for each
+            citation, or just the main reference citation.
+        search_for_tools_everywhere: Whether to search for tools everywhere,
+            or only in specific LLM response elements based on use_tools /
+            use_functions_api / use_tools_api config settings.
+        recognize_recipient_in_content: Whether to parse LLM response text content
+            for recipient routing patterns, specifically:
+            - ``TO[<recipient>]:<content>`` addressing format, and
+            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
+            When False, only structured routing via function_call/tool_call
+            ``recipient`` fields is recognized. Default is True.
+            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
+            which controls Task-level signals like DONE, PASS, and SEND_TO.
+            To fully disable all text-based routing, set both to False.
+        context_overflow_strategy: Strategy for handling context overflow when
+            message history exceeds model context length. Options:
+            - "truncate": Truncate content of early messages (preserves all messages
+              but with shortened content). This maintains the message sequence.
+            - "drop_turns": Drop complete conversation turns (USER + all responses
+              until next USER). More aggressive but cleaner for voice agents.
+            Default is "truncate" for backward compatibility.
+    """
+
+    system_message: str = "You are a helpful assistant."
+    user_message: Optional[str] = None
+    handle_llm_no_tool: Any = None
+    use_tools: bool = True
+    use_functions_api: bool = False
+    use_tools_api: bool = True
+    strict_recovery: bool = True
+    enable_orchestration_tool_handling: bool = True
+    output_format: Optional[type] = None
+    handle_output_format: bool = True
+    use_output_format: bool = True
+    instructions_output_format: bool = True
+    output_format_include_defaults: bool = True
+    use_tools_on_output_format: bool = True
+    full_citations: bool = True  # show source + content for each citation?
+    search_for_tools_everywhere: bool = True
+    recognize_recipient_in_content: bool = True
+    context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
+
+    def _set_fn_or_tools(self) -> None:
+        """
+        Enable Langroid Tool or OpenAI-like fn-calling,
+        depending on config settings.
+        """
+        if not self.use_functions_api or not self.use_tools:
+            return
+        if self.use_functions_api and self.use_tools:
+            logger.debug(
+                """
+                You have enabled both `use_tools` and `use_functions_api`.
+                Setting `use_functions_api` to False.
+                """
+            )
+            self.use_tools = True
+            self.use_functions_api = False
+
+
+class ChatAgent(Agent):
+    """
+    Chat Agent interacting with external env
+    (could be human, or external tools).
+    The agent (the LLM actually) is provided with an optional "Task Spec",
+    which is a sequence of `LLMMessage`s. These are used to initialize
+    the `task_messages` of the agent.
+    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
+    The `Agent` class mainly exists to hold various common methods and attributes.
+    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
+    `llm_response` method uses "chat mode" API (i.e. one that takes a
+    message sequence rather than a single message),
+    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
+    that takes a single message).
+    """
+
+    def __init__(
+        self,
+        config: ChatAgentConfig = ChatAgentConfig(),
+        task: Optional[List[LLMMessage]] = None,
+    ):
+        """
+        Chat-mode agent initialized with task spec as the initial message sequence
+        Args:
+            config: settings for the agent
+
+        """
+        super().__init__(config)
+        self.config: ChatAgentConfig = config
+        self.config._set_fn_or_tools()
+        self.message_history: List[LLMMessage] = []
+        # emit the attachment-token-estimate warning at most once per agent
+        self._attachment_tokens_warned: bool = False
+        self.init_state()
+        # An agent's "task" is defined by a system msg and an optional user msg;
+        # These are "priming" messages that kick off the agent's conversation.
+        self.system_message: str = self.config.system_message
+        self.user_message: str | None = self.config.user_message
+
+        if task is not None:
+            # if task contains a system msg, we override the config system msg
+            if len(task) > 0 and task[0].role == Role.SYSTEM:
+                self.system_message = task[0].content or ""
+            # if task contains a user msg, we override the config user msg
+            if len(task) > 1 and task[1].role == Role.USER:
+                self.user_message = task[1].content
+
+        # system-level instructions for using tools/functions:
+        # We maintain these as tools/functions are enabled/disabled,
+        # and whenever an LLM response is sought, these are used to
+        # recreate the system message (via `_create_system_and_tools_message`)
+        # each time, so it reflects the current set of enabled tools/functions.
+        # (a) these are general instructions on using certain tools/functions,
+        #   if they are specified in a ToolMessage class as a classmethod `instructions`
+        self.system_tool_instructions: str = ""
+        # (b) these are only for the builtin in Langroid TOOLS mechanism:
+        self.system_tool_format_instructions: str = ""
+
+        self.llm_functions_map: Dict[str, LLMFunctionSpec] = {}
+        self.llm_functions_handled: Set[str] = set()
+        self.llm_functions_usable: Set[str] = set()
+        self.llm_function_force: Optional[Dict[str, str]] = None
+
+        self.output_format: Optional[type[ToolMessage | BaseModel]] = None
+
+        self.saved_requests_and_tool_setings = self._requests_and_tool_settings()
+        # This variable is not None and equals a `ToolMessage` T, if and only if:
+        # (a) T has been set as the output_format of this agent, AND
+        # (b) T has been "enabled for use" ONLY for enforcing this output format, AND
+        # (c) T has NOT been explicitly "enabled for use" by this Agent.
+        self.enabled_use_output_format: Optional[type[ToolMessage]] = None
+        # As above but deals with "enabled for handling" instead of "enabled for use".
+        self.enabled_handling_output_format: Optional[type[ToolMessage]] = None
+        if config.output_format is not None:
+            self.set_output_format(config.output_format)
+        # instructions specifically related to enforcing `output_format`
+        self.output_format_instructions = ""
+
+        # controls whether to disable strict schemas for this agent if
+        # strict mode causes exception
+        self.disable_strict = False
+        # Tracks whether any strict tool is enabled; used to determine whether to set
+        # `self.disable_strict` on an exception
+        self.any_strict = False
+        # Tracks the set of tools on which we force-disable strict decoding
+        self.disable_strict_tools_set: set[str] = set()
+
+        # search for tools according to the agent configuration
+        if not config.search_for_tools_everywhere:
+            if config.use_functions_api:
+                if config.use_tools_api:
+                    self.search_for_tools = {SearchForTools.TOOLS.value}
+                else:
+                    self.search_for_tools = {SearchForTools.FUNCTIONS.value}
+            else:
+                self.search_for_tools = {SearchForTools.CONTENT.value}
+
+        if self.config.enable_orchestration_tool_handling:
+            # Only enable HANDLING by `agent_response`, NOT LLM generation of these.
+            # This is useful where tool-handlers or agent_response generate these
+            # tools, and need to be handled.
+            # We don't want enable orch tool GENERATION by default, since that
+            # might clutter-up the LLM system message unnecessarily.
+            from langroid.agent.tools.orchestration import (
+                AgentDoneTool,
+                AgentSendTool,
+                DonePassTool,
+                DoneTool,
+                ForwardTool,
+                PassTool,
+                ResultTool,
+                SendTool,
+            )
+
+            self.enable_message(ForwardTool, use=False, handle=True)
+            self.enable_message(DoneTool, use=False, handle=True)
+            self.enable_message(AgentDoneTool, use=False, handle=True)
+            self.enable_message(PassTool, use=False, handle=True)
+            self.enable_message(DonePassTool, use=False, handle=True)
+            self.enable_message(SendTool, use=False, handle=True)
+            self.enable_message(AgentSendTool, use=False, handle=True)
+            self.enable_message(ResultTool, use=False, handle=True)
+
+    def init_state(self) -> None:
+        """
+        Initialize the state of the agent. Just conversation state here,
+        but subclasses can override this to initialize other state.
+        """
+        super().init_state()
+        self.clear_history(0)
+        self.clear_dialog()
+
+    @staticmethod
+    def from_id(id: str) -> "ChatAgent":
+        """
+        Get an agent from its ID
+        Args:
+            agent_id (str): ID of the agent
+        Returns:
+            ChatAgent: The agent with the given ID
+        """
+        return cast(ChatAgent, Agent.from_id(id))
+
+    def clone(self, i: int = 0) -> "ChatAgent":
+        """Create i'th clone of this agent, ensuring tool use/handling is cloned.
+        Important: We assume all member variables are in the __init__ method here
+        and in the Agent class.
+        TODO: We are attempting to clone an agent after its state has been
+        changed in possibly many ways. Below is an imperfect solution. Caution advised.
+        Revisit later.
+        """
+        agent_cls = type(self)
+        # Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
+        # instead of deepcopy which loses subclass information
+        config_copy = self.config.model_copy(deep=True)
+        config_copy.name = f"{config_copy.name}-{i}"
+        new_agent = agent_cls(config_copy)
+        new_agent.system_tool_instructions = self.system_tool_instructions
+        new_agent.system_tool_format_instructions = self.system_tool_format_instructions
+        new_agent.llm_tools_map = self.llm_tools_map
+        new_agent.llm_tools_known = self.llm_tools_known
+        new_agent.llm_tools_handled = self.llm_tools_handled
+        new_agent.llm_tools_usable = self.llm_tools_usable
+        new_agent.llm_functions_map = self.llm_functions_map
+        new_agent.llm_functions_handled = self.llm_functions_handled
+        new_agent.llm_functions_usable = self.llm_functions_usable
+        new_agent.llm_function_force = self.llm_function_force
+        # Ensure each clone gets its own vecdb client when supported.
+        new_agent.vecdb = None if self.vecdb is None else self.vecdb.clone()
+        self._clone_extra_state(new_agent)
+        new_agent.id = ObjectRegistry.new_id()
+        if self.config.add_to_registry:
+            ObjectRegistry.register_object(new_agent)
+        return new_agent
+
+    def _clone_extra_state(self, new_agent: "ChatAgent") -> None:
+        """Hook for subclasses to copy additional state into clones."""
+
+    def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool:
+        """Should we enable strict mode for a given tool?"""
+        if isinstance(tool, str):
+            tool_class = self.llm_tools_map[tool]
+        else:
+            tool_class = tool
+        name = tool_class.default_value("request")
+        if name in self.disable_strict_tools_set or self.disable_strict:
+            return False
+        strict: Optional[bool] = tool_class.default_value("strict")
+        if strict is None:
+            strict = self._strict_tools_available()
+
+        return strict
+
+    def _fn_call_available(self) -> bool:
+        """Does this agent's LLM support function calling?"""
+        return self.llm is not None and self.llm.supports_functions_or_tools()
+
+    def _strict_tools_available(self) -> bool:
+        """Does this agent's LLM support strict tools?"""
+        return (
+            not self.disable_strict
+            and self.llm is not None
+            and isinstance(self.llm, OpenAIGPT)
+            and self.llm.config.parallel_tool_calls is False
+            and self.llm.supports_strict_tools
+        )
+
+    def _json_schema_available(self) -> bool:
+        """Does this agent's LLM support strict JSON schema output format?"""
+        return (
+            not self.disable_strict
+            and self.llm is not None
+            and isinstance(self.llm, OpenAIGPT)
+            and self.llm.supports_json_schema
+        )
+
+    def set_system_message(self, msg: str) -> None:
+        self.system_message = msg
+        if len(self.message_history) > 0:
+            # if there is message history, update the system message in it
+            self.message_history[0].content = msg
+
+    def set_user_message(self, msg: str) -> None:
+        self.user_message = msg
+
+    @property
+    def task_messages(self) -> List[LLMMessage]:
+        """
+        The task messages are the initial messages that define the task
+        of the agent. There will be at least a system message plus possibly a user msg.
+        Returns:
+            List[LLMMessage]: the task messages
+        """
+        msgs = [self._create_system_and_tools_message()]
+        if self.user_message:
+            msgs.append(LLMMessage(role=Role.USER, content=self.user_message))
+        return msgs
+
+    def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None:
+        id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
+        if msg.role == Role.TOOL:
+            # dropping tool result, so ADD the corresponding tool-call back
+            # to the list of pending calls!
+            id = msg.tool_call_id
+            if id in self.oai_tool_id2call:
+                self.oai_tool_calls.append(self.oai_tool_id2call[id])
+        elif msg.tool_calls is not None:
+            # dropping a msg with tool-calls, so DROP these from pending list
+            # as well as from id -> call map
+            for tool_call in msg.tool_calls:
+                if tool_call.id in id2idx:
+                    self.oai_tool_calls.pop(id2idx[tool_call.id])
+                if tool_call.id in self.oai_tool_id2call:
+                    del self.oai_tool_id2call[tool_call.id]
+
+    def clear_history(self, start: int = -2, end: int = -1) -> None:
+        """
+        Clear the message history, deleting  messages from index `start`,
+        up to index `end`.
+
+        Args:
+            start (int): index of first message to delete; default = -2
+                    (i.e. delete last 2 messages, typically these
+                    are the last user and assistant messages)
+            end (int): index of last message to delete; Default = -1
+                    (i.e. delete all messages up to the last one)
+        """
+        n = len(self.message_history)
+        if start < 0:
+            start = max(0, n + start)
+        end_ = n if end == -1 else end + 1
+        dropped = self.message_history[start:end_]
+        # consider the dropped msgs in REVERSE order, so we are
+        # carefully updating self.oai_tool_calls
+        for msg in reversed(dropped):
+            self._drop_msg_update_tool_calls(msg)
+            # clear out the chat document from the ObjectRegistry
+            ChatDocument.delete_id(msg.chat_document_id)
+        del self.message_history[start:end_]
+
+    def update_history(self, message: str, response: str) -> None:
+        """
+        Update the message history with the latest user message and LLM response.
+        Args:
+            message (str): user message
+            response: (str): LLM response
+        """
+        self.message_history.extend(
+            [
+                LLMMessage(role=Role.USER, content=message),
+                LLMMessage(role=Role.ASSISTANT, content=response),
+            ]
+        )
+
+    def export_history(self) -> str:
+        """Export message history as a portable, versioned JSON snapshot.
+
+        Returns:
+            A JSON string containing the current message history.
+        """
+        messages: List[Dict[str, Any]] = []
+        for message in self.message_history:
+            json.dumps(
+                message.model_dump(mode="python", exclude={"files"}),
+                allow_nan=False,
+                default=str,
+            )
+            data = message.model_dump(mode="json", exclude={"files"})
+            data["chat_document_id"] = ""
+            data["files"] = [
+                {
+                    "content_base64": base64.b64encode(file.content).decode("ascii"),
+                    "filename": file.filename,
+                    "mime_type": file.mime_type,
+                    "url": file.url,
+                    "detail": file.detail,
+                }
+                for file in message.files
+            ]
+            messages.append(data)
+        return json.dumps({"version": 1, "messages": messages}, allow_nan=False)
+
+    def import_history(
+        self,
+        snapshot: str,
+        max_size_bytes: int = 100 * 1024 * 1024,
+    ) -> None:
+        """Restore message history from :meth:`export_history` output.
+
+        Args:
+            snapshot: Versioned JSON snapshot to restore.
+            max_size_bytes: Maximum total decoded attachment size. Defaults to
+                100 MiB.
+
+        Raises:
+            ValueError: If the snapshot is malformed, has an unknown version,
+                starts with a non-system message, or exceeds ``max_size_bytes``.
+        """
+        try:
+            if max_size_bytes < 0:
+                raise ValueError("max_size_bytes must be non-negative")
+            payload = json.loads(
+                snapshot,
+                parse_constant=_reject_json_constant,
+                parse_float=_parse_json_float,
+            )
+            if (
+                not isinstance(payload, dict)
+                or type(payload.get("version")) is not int
+                or payload["version"] != 1
+            ):
+                raise ValueError("unsupported version")
+            raw_messages = payload.get("messages")
+            if not isinstance(raw_messages, list):
+                raise ValueError("messages must be a list")
+            if not raw_messages:
+                raise ValueError("messages must not be empty")
+
+            messages: List[LLMMessage] = []
+            total_attachment_bytes = 0
+            for raw_message in raw_messages:
+                if not isinstance(raw_message, dict):
+                    raise ValueError("message must be an object")
+                message_data = dict(raw_message)
+                raw_files = message_data.get("files", [])
+                if not isinstance(raw_files, list):
+                    raise ValueError("files must be a list")
+                files = []
+                for raw_file in raw_files:
+                    if not isinstance(raw_file, dict):
+                        raise ValueError("file must be an object")
+                    file_data = dict(raw_file)
+                    encoded_content = file_data.pop("content_base64")
+                    if not isinstance(encoded_content, str):
+                        raise ValueError("content_base64 must be a string")
+                    encoded_bytes = encoded_content.encode("ascii")
+                    padding = len(encoded_bytes) - len(encoded_bytes.rstrip(b"="))
+                    decoded_size = max(
+                        0,
+                        len(encoded_bytes) // 4 * 3 - min(padding, 2),
+                    )
+                    if total_attachment_bytes + decoded_size > max_size_bytes:
+                        raise ValueError(
+                            "decoded attachments exceed "
+                            f"max_size_bytes={max_size_bytes}"
+                        )
+                    content = base64.b64decode(encoded_bytes, validate=True)
+                    total_attachment_bytes += len(content)
+                    if total_attachment_bytes > max_size_bytes:
+                        raise ValueError(
+                            "decoded attachments exceed "
+                            f"max_size_bytes={max_size_bytes}"
+                        )
+                    files.append(FileAttachment(content=content, **file_data))
+                message_data["files"] = files
+                message_data["chat_document_id"] = ""
+                messages.append(LLMMessage.model_validate(message_data))
+            if messages[0].role != Role.SYSTEM:
+                raise ValueError("first message must have role 'system'")
+            seen_call_ids: Set[str] = set()
+            for message in messages:
+                if message.role in (Role.TOOL, Role.FUNCTION) and (
+                    message.function_call is not None or message.tool_calls is not None
+                ):
+                    raise ValueError("result messages must not contain call payloads")
+                if message.function_call is not None and message.role != Role.ASSISTANT:
+                    raise ValueError("function calls must have role 'assistant'")
+                if message.function_call is not None:
+                    if not message.function_call.name.strip():
+                        raise ValueError("function call names must be nonblank")
+                if message.tool_call_id is not None and message.role != Role.TOOL:
+                    raise ValueError("tool_call_id is only valid on tool results")
+                if message.role == Role.FUNCTION:
+                    name = message.name
+                    if name is None or not name or name != name.strip():
+                        raise ValueError(
+                            "function result name must be nonblank and normalized"
+                        )
+                if message.tool_calls is not None:
+                    if message.role != Role.ASSISTANT:
+                        raise ValueError("tool calls must have role 'assistant'")
+                    for call in message.tool_calls:
+                        if call.function is None:
+                            raise ValueError("tool calls must include a function")
+                        if not call.function.name.strip():
+                            raise ValueError("function call names must be nonblank")
+                        call_id = call.id
+                        if call_id is None or not call_id or call_id != call_id.strip():
+                            raise ValueError(
+                                "tool call IDs must be nonblank and normalized"
+                            )
+                        if call_id in seen_call_ids:
+                            raise ValueError("tool call IDs must be unique")
+                        seen_call_ids.add(call_id)
+                    if not message.tool_calls:
+                        message.tool_calls = None
+        except (
+            KeyError,
+            RecursionError,
+            TypeError,
+            UnicodeEncodeError,
+            ValueError,
+        ) as exc:
+            raise ValueError(f"Invalid history snapshot: {exc}") from exc
+
+        all_calls = {
+            call.id: call
+            for message in messages
+            for call in (message.tool_calls or [])
+            if call.id is not None
+        }
+        completed_call_ids = {
+            message.tool_call_id
+            for message in messages
+            if message.role == Role.TOOL and message.tool_call_id is not None
+        }
+        old_chat_document_ids = {
+            message.chat_document_id
+            for message in self.message_history
+            if message.chat_document_id
+        }
+        for chat_document_id in old_chat_document_ids:
+            ChatDocument.delete_id(chat_document_id)
+        self.message_history = messages
+        self.oai_tool_id2call = all_calls
+        self.oai_tool_calls = [
+            call
+            for call_id, call in all_calls.items()
+            if call_id not in completed_call_ids
+        ]
+
+    def tool_format_rules(self) -> str:
+        """
+        Specification of tool formatting rules
+        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
+        based on the currently enabled usable `ToolMessage`s
+
+        Returns:
+            str: formatting rules
+        """
+        # ONLY Usable tools (i.e. LLM-generation allowed),
+        usable_tool_classes: List[Type[ToolMessage]] = [
+            t
+            for t in list(self.llm_tools_map.values())
+            if t.default_value("request") in self.llm_tools_usable
+        ]
+
+        if len(usable_tool_classes) == 0:
+            return ""
+        format_instructions = "\n\n".join(
+            [
+                msg_cls.format_instructions(tool=self.config.use_tools)
+                for msg_cls in usable_tool_classes
+            ]
+        )
+        # if any of the enabled classes has json_group_instructions, then use that,
+        # else fall back to ToolMessage.json_group_instructions
+        for msg_cls in usable_tool_classes:
+            if hasattr(msg_cls, "json_group_instructions") and callable(
+                getattr(msg_cls, "json_group_instructions")
+            ):
+                return msg_cls.group_format_instructions().format(
+                    format_instructions=format_instructions
+                )
+        return ToolMessage.group_format_instructions().format(
+            format_instructions=format_instructions
+        )
+
+    def tool_instructions(self) -> str:
+        """
+        Instructions for tools or function-calls, for enabled and usable Tools.
+        These are inserted into system prompt regardless of whether we are using
+        our own ToolMessage mechanism or the LLM's function-call mechanism.
+
+        Returns:
+            str: concatenation of instructions for all usable tools
+        """
+        enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
+        if len(enabled_classes) == 0:
+            return ""
+        instructions = []
+        for msg_cls in enabled_classes:
+            if msg_cls.default_value("request") in self.llm_tools_usable:
+                class_instructions = ""
+                if hasattr(msg_cls, "instructions") and inspect.ismethod(
+                    msg_cls.instructions
+                ):
+                    class_instructions = msg_cls.instructions()
+                if (
+                    self.config.use_tools
+                    and hasattr(msg_cls, "langroid_tools_instructions")
+                    and inspect.ismethod(msg_cls.langroid_tools_instructions)
+                ):
+                    class_instructions += msg_cls.langroid_tools_instructions()
+                # example will be shown in tool_format_rules() when using TOOLs,
+                # so we don't need to show it here.
+                example = "" if self.config.use_tools else (msg_cls.usage_examples())
+                if example != "":
+                    example = "EXAMPLES:\n" + example
+                guidance = (
+                    ""
+                    if class_instructions == ""
+                    else ("GUIDANCE: " + class_instructions)
+                )
+                if guidance == "" and example == "":
+                    continue
+                instructions.append(
+                    textwrap.dedent(
+                        f"""
+                        TOOL: {msg_cls.default_value("request")}:
+                        {guidance}
+                        {example}
+                        """.lstrip()
+                    )
+                )
+        if len(instructions) == 0:
+            return ""
+        instructions_str = "\n\n".join(instructions)
+        return textwrap.dedent(
+            f"""
+            === GUIDELINES ON SOME TOOLS/FUNCTIONS USAGE ===
+            {instructions_str}
+            """.lstrip()
+        )
+
+    def augment_system_message(self, message: str) -> None:
+        """
+        Augment the system message with the given message.
+        Args:
+            message (str): system message
+        """
+        self.system_message += "\n\n" + message
+
+    def last_message_with_role(self, role: Role) -> LLMMessage | None:
+        """from `message_history`, return the last message with role `role`"""
+        n_role_msgs = len([m for m in self.message_history if m.role == role])
+        if n_role_msgs == 0:
+            return None
+        idx = self.nth_message_idx_with_role(role, n_role_msgs)
+        return self.message_history[idx]
+
+    def last_message_idx_with_role(self, role: Role) -> int:
+        """Index of last message in message_history, with specified role.
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+        indices_with_role = [
+            i for i, m in enumerate(self.message_history) if m.role == role
+        ]
+        if len(indices_with_role) == 0:
+            return -1
+        return indices_with_role[-1]
+
+    def nth_message_idx_with_role(self, role: Role, n: int) -> int:
+        """Index of `n`th message in message_history, with specified role.
+        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+        indices_with_role = [
+            i for i, m in enumerate(self.message_history) if m.role == role
+        ]
+
+        if len(indices_with_role) < n:
+            return -1
+        return indices_with_role[n - 1]
+
+    def update_last_message(self, message: str, role: str = Role.USER) -> None:
+        """
+        Update the last message that has role `role` in the message history.
+        Useful when we want to replace a long user prompt, that may contain context
+        documents plus a question, with just the question.
+        Args:
+            message (str): new message to replace with
+            role (str): role of message to replace
+        """
+        if len(self.message_history) == 0:
+            return
+        # find last message in self.message_history with role `role`
+        for i in range(len(self.message_history) - 1, -1, -1):
+            if self.message_history[i].role == role:
+                self.message_history[i].content = message
+                break
+
+    def delete_last_message(self, role: str = Role.USER) -> None:
+        """
+        Delete the last message that has role `role` from the message history.
+        Args:
+            role (str): role of message to delete
+        """
+        if len(self.message_history) == 0:
+            return
+        # find last message in self.message_history with role `role`
+        for i in range(len(self.message_history) - 1, -1, -1):
+            if self.message_history[i].role == role:
+                self.message_history.pop(i)
+                break
+
+    def _create_system_and_tools_message(self) -> LLMMessage:
+        """
+        (Re-)Create the system message for the LLM of the agent,
+        taking into account any tool instructions that have been added
+        after the agent was initialized.
+
+        The system message will consist of:
+        (a) the system message from the `task` arg in constructor, if any,
+            otherwise the default system message from the config
+        (b) the system tool instructions, if any
+        (c) the system json tool instructions, if any
+
+        Returns:
+            LLMMessage object
+        """
+        content = self.system_message
+        if self.system_tool_instructions != "":
+            content += "\n\n" + self.system_tool_instructions
+        if self.system_tool_format_instructions != "":
+            content += "\n\n" + self.system_tool_format_instructions
+        if self.output_format_instructions != "":
+            content += "\n\n" + self.output_format_instructions
+
+        # remove leading and trailing newlines and other whitespace
+        return LLMMessage(role=Role.SYSTEM, content=content.strip())
+
+    def handle_message_fallback(self, msg: str | ChatDocument) -> Any:
+        """
+        Fallback method for the "no-tools" scenario, i.e., the current `msg`
+        (presumably emitted by the LLM) does not have any tool that the agent
+        can handle.
+        NOTE: The `msg` may contain tools but either (a) the agent is not
+        enabled to handle them, or (b) there's an explicit `recipient` field
+        in the tool that doesn't match the agent's name.
+
+        Uses the self.config.non_tool_routing to determine the action to take.
+
+        This method can be overridden by subclasses, e.g.,
+        to create a "reminder" message when a tool is expected but the LLM "forgot"
+        to generate one.
+
+        Args:
+            msg (str | ChatDocument): The input msg to handle
+        Returns:
+            Any: The result of the handler method
+        """
+        if (
+            isinstance(msg, str)
+            or msg.metadata.sender != Entity.LLM
+            or self.config.handle_llm_no_tool is None
+            or self.has_only_unhandled_tools(msg)
+        ):
+            return None
+        # we ONLY use the `handle_llm_no_tool` config option when
+        # the msg is from LLM and does not contain ANY tools at all.
+        from langroid.agent.tools.orchestration import AgentDoneTool, ForwardTool
+
+        no_tool_option = self.config.handle_llm_no_tool
+        if no_tool_option in list(NonToolAction):
+            # in case the `no_tool_option` is one of the special NonToolAction vals
+            match self.config.handle_llm_no_tool:
+                case NonToolAction.FORWARD_USER:
+                    return ForwardTool(agent="User")
+                case NonToolAction.DONE:
+                    return AgentDoneTool(content=msg.content, tools=msg.tool_messages)
+        elif is_callable(no_tool_option):
+            return no_tool_option(msg)
+        # Otherwise just return `no_tool_option` as is:
+        # This can be any string, such as a specific nudge/reminder to the LLM,
+        # or even something like ResultTool etc.
+        return no_tool_option
+
+    def unhandled_tools(self) -> set[str]:
+        """The set of tools that are known but not handled.
+        Useful in task flow: an agent can refuse to accept an incoming msg
+        when it only has unhandled tools.
+        """
+        return self.llm_tools_known - self.llm_tools_handled
+
+    def enable_message(
+        self,
+        message_class: Optional[Type[ToolMessage] | List[Type[ToolMessage]]],
+        use: bool = True,
+        handle: bool = True,
+        force: bool = False,
+        require_recipient: bool = False,
+        include_defaults: bool = True,
+    ) -> None:
+        """
+        Add the tool (message class) to the agent, and enable either
+        - tool USE (i.e. the LLM can generate JSON to use this tool),
+        - tool HANDLING (i.e. the agent can handle JSON from this tool),
+
+        Args:
+            message_class: The ToolMessage class OR List of such classes to enable,
+                for USE, or HANDLING, or both.
+                If this is a list of ToolMessage classes, then the remain args are
+                applied to all classes.
+                Optional; if None, then apply the enabling to all tools in the
+                agent's toolset that have been enabled so far.
+            use: IF True, allow the agent (LLM) to use this tool (or all tools),
+                else disallow
+            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
+                tool (or all tools)
+            force: whether to FORCE the agent (LLM) to USE the specific
+                 tool represented by `message_class`.
+                 `force` is ignored if `message_class` is None.
+            require_recipient: whether to require that recipient be specified
+                when using the tool message (only applies if `use` is True).
+            include_defaults: whether to include fields that have default values,
+                in the "properties" section of the JSON format instructions.
+                (Normally the OpenAI completion API ignores these fields,
+                but the Assistant fn-calling seems to pay attn to these,
+                and if we don't want this, we should set this to False.)
+        """
+        if message_class is not None and isinstance(message_class, list):
+            for mc in message_class:
+                self.enable_message(
+                    mc,
+                    use=use,
+                    handle=handle,
+                    force=force,
+                    require_recipient=require_recipient,
+                    include_defaults=include_defaults,
+                )
+            return None
+
+        # Validate that use/handle are booleans, not accidentally passed tool classes
+        if isclass(use) or isclass(handle):
+            param = "use" if isclass(use) else "handle"
+            raise TypeError(
+                textwrap.dedent(
+                    f"""
+                    Invalid arguments to enable_message().
+                    It appears you passed multiple ToolMessage classes as separate
+                    arguments instead of as a list.
+
+                    Correct usage:
+                        agent.enable_message([Tool1, Tool2, Tool3])
+
+                    Incorrect usage:
+                        agent.enable_message(Tool1, Tool2, Tool3)
+
+                    The '{param}' parameter must be a boolean, not a class.
+                    """
+                )
+            )
+
+        if require_recipient and message_class is not None:
+            message_class = message_class.require_recipient()
+        if message_class is not None:
+            if not issubclass(message_class, ToolMessage):
+                raise ValueError("message_class must be a subclass of ToolMessage")
+            request = message_class.default_value("request")
+            existing_class = self.llm_tools_map.get(request)
+            existing_origin = (
+                existing_class.__dict__.get("__tool_message_origin__", existing_class)
+                if existing_class is not None
+                else None
+            )
+            message_origin = message_class.__dict__.get(
+                "__tool_message_origin__", message_class
+            )
+            if existing_class is not None and existing_origin is not message_origin:
+                raise ValueError(
+                    f"Tool request name {request!r} is already registered to "
+                    f"{existing_class.__name__}; cannot register "
+                    f"{message_class.__name__}"
+                )
+        if isinstance(message_class, XMLToolMessage):
+            # XMLToolMessage is not compatible with OpenAI's Tools/functions API,
+            # so we disable use of functions API, enable langroid-native Tools,
+            # which are prompt-based.
+            self.config.use_functions_api = False
+            self.config.use_tools = True
+        super().enable_message_handling(message_class)  # enables handling only
+        tools = self._get_tool_list(message_class)
+        if message_class is not None:
+            if request == "":
+                raise ValueError(
+                    f"""
+                    ToolMessage class {message_class} must have a non-empty
+                    'request' field if it is to be enabled as a tool.
+                    """
+                )
+            llm_function = message_class.llm_function_schema(defaults=include_defaults)
+            self.llm_functions_map[request] = llm_function
+            if force:
+                self.llm_function_force = dict(name=request)
+            else:
+                self.llm_function_force = None
+
+        for t in tools:
+            self.llm_tools_known.add(t)
+
+            if handle:
+                self.llm_tools_handled.add(t)
+                self.llm_functions_handled.add(t)
+
+                if (
+                    self.enabled_handling_output_format is not None
+                    and self.enabled_handling_output_format.name() == t
+                ):
+                    # `t` was designated as "enabled for handling" ONLY for
+                    # output_format enforcement, but we are explicitly ]
+                    # enabling it for handling here, so we set the variable to None.
+                    self.enabled_handling_output_format = None
+            else:
+                self.llm_tools_handled.discard(t)
+                self.llm_functions_handled.discard(t)
+
+            if use:
+                tool_class = self.llm_tools_map[t]
+                allow_llm_use = tool_class._allow_llm_use
+                if isinstance(allow_llm_use, ModelPrivateAttr):
+                    allow_llm_use = allow_llm_use.default
+                if allow_llm_use:
+                    self.llm_tools_usable.add(t)
+                    self.llm_functions_usable.add(t)
+                else:
+                    logger.warning(
+                        f"""
+                        ToolMessage class {tool_class} does not allow LLM use,
+                        because `_allow_llm_use=False` either in the Tool or a
+                        parent class of this tool;
+                        so not enabling LLM use for this tool!
+                        If you intended an LLM to use this tool,
+                        set `_allow_llm_use=True` when you define the tool.
+                        """
+                    )
+                if (
+                    self.enabled_use_output_format is not None
+                    and self.enabled_use_output_format.default_value("request") == t
+                ):
+                    # `t` was designated as "enabled for use" ONLY for output_format
+                    # enforcement, but we are explicitly enabling it for use here,
+                    # so we set the variable to None.
+                    self.enabled_use_output_format = None
+            else:
+                self.llm_tools_usable.discard(t)
+                self.llm_functions_usable.discard(t)
+
+        self._update_tool_instructions()
+
+    def _update_tool_instructions(self) -> None:
+        # Set tool instructions and JSON format instructions,
+        # in case Tools have been enabled/disabled.
+        if self.config.use_tools:
+            self.system_tool_format_instructions = self.tool_format_rules()
+        self.system_tool_instructions = self.tool_instructions()
+
+    def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]:
+        """
+        Returns the current set of enabled requests for inference and tools configs.
+        Used for restoring setings overriden by `set_output_format`.
+        """
+        return (
+            self.enabled_requests_for_inference,
+            self.config.use_functions_api,
+            self.config.use_tools,
+        )
+
+    @property
+    def all_llm_tools_known(self) -> set[str]:
+        """All known tools; we include `output_format` if it is a `ToolMessage`."""
+        known = self.llm_tools_known
+
+        if self.output_format is not None and issubclass(
+            self.output_format, ToolMessage
+        ):
+            return known.union({self.output_format.default_value("request")})
+
+        return known
+
+    def set_output_format(
+        self,
+        output_type: Optional[type],
+        force_tools: Optional[bool] = None,
+        use: Optional[bool] = None,
+        handle: Optional[bool] = None,
+        instructions: Optional[bool] = None,
+        is_copy: bool = False,
+    ) -> None:
+        """
+        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
+        switches to the native Langroid tools mechanism to ensure that no tool
+        calls not of `output_type` are generated. By default, `force_tools`
+        follows the `use_tools_on_output_format` parameter in the config.
+
+        If `output_type` is None, restores to the state prior to setting
+        `output_format`.
+
+        If `use`, we enable use of `output_type` when it is a subclass
+        of `ToolMesage`. Note that this primarily controls instruction
+        generation: the model will always generate `output_type` regardless
+        of whether `use` is set. Defaults to the `use_output_format`
+        parameter in the config. Similarly, handling of `output_type` is
+        controlled by `handle`, which defaults to the
+        `handle_output_format` parameter in the config.
+
+        `instructions` controls whether we generate instructions specifying
+        the output format schema. Defaults to the `instructions_output_format`
+        parameter in the config.
+
+        `is_copy` is set when called via `__getitem__`. In that case, we must
+        copy certain fields to ensure that we do not overwrite the main agent's
+        setings.
+        """
+        # Disable usage of an output format which was not specifically enabled
+        # by `enable_message`
+        if self.enabled_use_output_format is not None:
+            self.disable_message_use(self.enabled_use_output_format)
+            self.enabled_use_output_format = None
+
+        # Disable handling of an output format which did not specifically have
+        # handling enabled via `enable_message`
+        if self.enabled_handling_output_format is not None:
+            self.disable_message_handling(self.enabled_handling_output_format)
+            self.enabled_handling_output_format = None
+
+        # Reset any previous instructions
+        self.output_format_instructions = ""
+
+        if output_type is None:
+            self.output_format = None
+            (
+                requests_for_inference,
+                use_functions_api,
+                use_tools,
+            ) = self.saved_requests_and_tool_setings
+            self.config = self.config.model_copy()
+            self.enabled_requests_for_inference = requests_for_inference
+            self.config.use_functions_api = use_functions_api
+            self.config.use_tools = use_tools
+        else:
+            if force_tools is None:
+                force_tools = self.config.use_tools_on_output_format
+
+            if not any(
+                (isclass(output_type) and issubclass(output_type, t))
+                for t in [ToolMessage, BaseModel]
+            ):
+                output_type = get_pydantic_wrapper(output_type)
+
+            if self.output_format is None and force_tools:
+                self.saved_requests_and_tool_setings = (
+                    self._requests_and_tool_settings()
+                )
+
+            self.output_format = output_type
+            if issubclass(output_type, ToolMessage):
+                name = output_type.default_value("request")
+                if use is None:
+                    use = self.config.use_output_format
+
+                if handle is None:
+                    handle = self.config.handle_output_format
+
+                if use or handle:
+                    is_usable = name in self.llm_tools_usable.union(
+                        self.llm_functions_usable
+                    )
+                    is_handled = name in self.llm_tools_handled.union(
+                        self.llm_functions_handled
+                    )
+
+                    if is_copy:
+                        if use:
+                            # We must copy `llm_tools_usable` so the base agent
+                            # is unmodified
+                            self.llm_tools_usable = self.llm_tools_usable.copy()
+                            self.llm_functions_usable = self.llm_functions_usable.copy()
+                        if handle:
+                            # If handling the tool, do the same for `llm_tools_handled`
+                            self.llm_tools_handled = self.llm_tools_handled.copy()
+                            self.llm_functions_handled = (
+                                self.llm_functions_handled.copy()
+                            )
+                    # Enable `output_type`
+                    self.enable_message(
+                        output_type,
+                        # Do not override existing settings
+                        use=use or is_usable,
+                        handle=handle or is_handled,
+                    )
+
+                    # If the `output_type` ToilMessage was not already enabled for
+                    # use, this means we are ONLY enabling it for use specifically
+                    # for enforcing this output format, so we set the
+                    # `enabled_use_output_forma  to this output_type, to
+                    # record that it should be disabled when `output_format` is changed
+                    if not is_usable:
+                        self.enabled_use_output_format = output_type
+
+                    # (same reasoning as for use-enabling)
+                    if not is_handled:
+                        self.enabled_handling_output_format = output_type
+
+                generated_tool_instructions = name in self.llm_tools_usable.union(
+                    self.llm_functions_usable
+                )
+            else:
+                generated_tool_instructions = False
+
+            if instructions is None:
+                instructions = self.config.instructions_output_format
+            if issubclass(output_type, BaseModel) and instructions:
+                if generated_tool_instructions:
+                    # Already generated tool instructions as part of "enabling for use",
+                    # so only need to generate a reminder to use this tool.
+                    name = cast(ToolMessage, output_type).default_value("request")
+                    self.output_format_instructions = textwrap.dedent(
+                        f"""
+                        === OUTPUT FORMAT INSTRUCTIONS ===
+
+                        Please provide output using the `{name}` tool/function.
+                        """
+                    )
+                else:
+                    if issubclass(output_type, ToolMessage):
+                        output_format_schema = output_type.llm_function_schema(
+                            request=True,
+                            defaults=self.config.output_format_include_defaults,
+                        ).parameters
+                    else:
+                        output_format_schema = output_type.model_json_schema()
+
+                    format_schema_for_strict(output_format_schema)
+
+                    self.output_format_instructions = textwrap.dedent(
+                        f"""
+                        === OUTPUT FORMAT INSTRUCTIONS ===
+                        Please provide output as JSON with the following schema:
+
+                        {output_format_schema}
+                        """
+                    )
+
+            if force_tools:
+                if issubclass(output_type, ToolMessage):
+                    self.enabled_requests_for_inference = {
+                        output_type.default_value("request")
+                    }
+                if self.config.use_functions_api:
+                    self.config = self.config.model_copy()
+                    self.config.use_functions_api = False
+                    self.config.use_tools = True
+
+    def __getitem__(self, output_type: type) -> Self:
+        """
+        Returns a (shallow) copy of `self` with a forced output type.
+        """
+        clone = copy.copy(self)
+        clone.set_output_format(output_type, is_copy=True)
+        return clone
+
+    def disable_message_handling(
+        self,
+        message_class: Optional[Type[ToolMessage]] = None,
+    ) -> None:
+        """
+        Disable this agent from RESPONDING to a `message_class` (Tool). If
+            `message_class` is None, then disable this agent from responding to ALL.
+        Args:
+            message_class: The ToolMessage class to disable; Optional.
+        """
+        super().disable_message_handling(message_class)
+        for t in self._get_tool_list(message_class):
+            self.llm_tools_handled.discard(t)
+            self.llm_functions_handled.discard(t)
+
+    def disable_message_use(
+        self,
+        message_class: Optional[Type[ToolMessage]],
+    ) -> None:
+        """
+        Disable this agent from USING a message class (Tool).
+        If `message_class` is None, then disable this agent from USING ALL tools.
+        Args:
+            message_class: The ToolMessage class to disable.
+                If None, disable all.
+        """
+        for t in self._get_tool_list(message_class):
+            self.llm_tools_usable.discard(t)
+            self.llm_functions_usable.discard(t)
+
+        self._update_tool_instructions()
+
+    def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None:
+        """
+        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
+        Args:
+            message_class: The only ToolMessage class to allow
+        """
+        request = message_class.model_fields["request"].default
+        to_remove = [r for r in self.llm_tools_usable if r != request]
+        for r in to_remove:
+            self.llm_tools_usable.discard(r)
+            self.llm_functions_usable.discard(r)
+        self._update_tool_instructions()
+
+    def _load_output_format(self, message: ChatDocument) -> None:
+        """
+        If set, attempts to parse a value of type `self.output_format` from the message
+        contents or any tool/function call and assigns it to `content_any`.
+        """
+        if self.output_format is not None:
+            any_succeeded = False
+            attempts: list[str | LLMFunctionCall] = [
+                message.content,
+            ]
+
+            if message.function_call is not None:
+                attempts.append(message.function_call)
+
+            if message.oai_tool_calls is not None:
+                attempts.extend(
+                    [
+                        c.function
+                        for c in message.oai_tool_calls
+                        if c.function is not None
+                    ]
+                )
+
+            for attempt in attempts:
+                try:
+                    if isinstance(attempt, str):
+                        content = json.loads(attempt)
+                    else:
+                        if not (
+                            issubclass(self.output_format, ToolMessage)
+                            and attempt.name
+                            == self.output_format.default_value("request")
+                        ):
+                            continue
+
+                        content = attempt.arguments
+
+                    content_any = self.output_format.model_validate(content)
+
+                    if issubclass(self.output_format, PydanticWrapper):
+                        message.content_any = content_any.value  # type: ignore
+                    else:
+                        message.content_any = content_any
+                    any_succeeded = True
+                    break
+                except (ValidationError, json.JSONDecodeError):
+                    continue
+
+            if not any_succeeded:
+                self.disable_strict = True
+                logging.warning(
+                    """
+                    Validation error occured with strict output format enabled.
+                    Disabling strict mode.
+                    """
+                )
+
+    def get_tool_messages(
+        self,
+        msg: str | ChatDocument | None,
+        all_tools: bool = False,
+    ) -> List[ToolMessage]:
+        """
+        Extracts messages and tracks whether any errors occurred. If strict mode
+        was enabled, disables it for the tool, else triggers strict recovery.
+        """
+        self.tool_error = False
+        most_recent_sent_by_llm = (
+            len(self.message_history) > 0
+            and self.message_history[-1].role == Role.ASSISTANT
+        )
+        was_llm = most_recent_sent_by_llm or (
+            isinstance(msg, ChatDocument) and msg.metadata.sender == Entity.LLM
+        )
+        try:
+            tools = super().get_tool_messages(msg, all_tools)
+        except ValidationError as ve:
+            # Check if tool class was attached to the exception
+            if hasattr(ve, "tool_class") and ve.tool_class:
+                tool_class = ve.tool_class  # type: ignore
+                if issubclass(tool_class, ToolMessage):
+                    was_strict = (
+                        self.config.use_functions_api
+                        and self.config.use_tools_api
+                        and self._strict_mode_for_tool(tool_class)
+                    )
+                    # If the result of strict output for a tool using the
+                    # OpenAI tools API fails to parse, we infer that the
+                    # schema edits necessary for compatibility prevented
+                    # adherence to the underlying `ToolMessage` schema and
+                    # disable strict output for the tool
+                    if was_strict:
+                        name = tool_class.default_value("request")
+                        self.disable_strict_tools_set.add(name)
+                        logging.warning(
+                            f"""
+                            Validation error occured with strict tool format.
+                            Disabling strict mode for the {name} tool.
+                            """
+                        )
+                    else:
+                        # We will trigger the strict recovery mechanism to force
+                        # the LLM to correct its output, allowing us to parse
+                        if isinstance(msg, ChatDocument):
+                            self.tool_error = msg.metadata.sender == Entity.LLM
+                        else:
+                            self.tool_error = most_recent_sent_by_llm
+
+            if was_llm:
+                raise ve
+            else:
+                self.tool_error = False
+                return []
+
+        if not was_llm:
+            self.tool_error = False
+
+        return tools
+
+    def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None:
+        """
+        Returns a `ToolMessage` which wraps all enabled tools, excluding those
+        where strict recovery is disabled. Used in strict recovery.
+        """
+        possible_tools = tuple(
+            self.llm_tools_map[t]
+            for t in self.llm_tools_usable
+            if t not in self.disable_strict_tools_set
+        )
+        if len(possible_tools) == 0:
+            return None
+        any_tool_type = Union.__getitem__(possible_tools)  # type ignore
+
+        maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
+
+        class AnyTool(ToolMessage):
+            purpose: str = "To call a tool/function."
+            request: str = "tool_or_function"
+            tool: maybe_optional_type  # type: ignore
+
+            def response(self, agent: ChatAgent) -> None | str | ChatDocument:
+                # One-time use
+                agent.set_output_format(None)
+
+                if self.tool is None:
+                    return None
+
+                # As the ToolMessage schema accepts invalid
+                # `tool.request` values, reparse with the
+                # corresponding tool
+                request = self.tool.request
+                if request not in agent.llm_tools_map:
+                    return None
+                tool = agent.llm_tools_map[request].model_validate_json(
+                    self.tool.to_json()
+                )
+
+                return agent.handle_tool_message(tool)
+
+            async def response_async(
+                self, agent: ChatAgent
+            ) -> None | str | ChatDocument:
+                # One-time use
+                agent.set_output_format(None)
+
+                if self.tool is None:
+                    return None
+
+                # As the ToolMessage schema accepts invalid
+                # `tool.request` values, reparse with the
+                # corresponding tool
+                request = self.tool.request
+                if request not in agent.llm_tools_map:
+                    return None
+                tool = agent.llm_tools_map[request].model_validate_json(
+                    self.tool.to_json()
+                )
+
+                return await agent.handle_tool_message_async(tool)
+
+        # Every call builds a distinct class; share one origin so enabling a
+        # regenerated AnyTool under "tool_or_function" stays idempotent instead
+        # of tripping the same-name/different-tool registration guard.
+        AnyTool.__tool_message_origin__ = (  # type: ignore[attr-defined]
+            _ANY_TOOL_MESSAGE_ORIGIN
+        )
+        return AnyTool
+
+    def _strict_recovery_instructions(
+        self,
+        tool_type: Optional[type[ToolMessage]] = None,
+        optional: bool = True,
+    ) -> str:
+        """Returns instructions for strict recovery."""
+        optional_instructions = (
+            (
+                "\n"
+                + """
+        If you did NOT intend to do so, `tool` should be null.
+        """
+            )
+            if optional
+            else ""
+        )
+        response_prefix = "If you intended to make such a call, r" if optional else "R"
+        instruction_prefix = "If you do so, b" if optional else "B"
+
+        schema_instructions = (
+            f"""
+        The schema for `tool_or_function` is as follows:
+        {tool_type.llm_function_schema(defaults=True, request=True).parameters}
+        """
+            if tool_type
+            else ""
+        )
+
+        return textwrap.dedent(
+            f"""
+        Your previous attempt to make a tool/function call appears to have failed.
+        {response_prefix}espond with your desired tool/function. Do so with the
+        `tool_or_function` tool/function where `tool` is set to your intended call.
+        {schema_instructions}
+
+        {instruction_prefix}e sure that your corrected call matches your intention
+        in your previous request. For any field with a default value which
+        you did not intend to override in your previous attempt, be sure
+        to set that field to its default value. {optional_instructions}
+        """
+        )
+
+    def truncate_message(
+        self,
+        idx: int,
+        tokens: int = 5,
+        warning: str = "...[Contents truncated!]",
+        inplace: bool = True,
+    ) -> LLMMessage:
+        """
+        Truncate message at idx in msg history to `tokens` tokens.
+
+        If inplace is True, the message is truncated in place, else
+        it LEAVES the original message INTACT and returns a new message
+        """
+        if inplace:
+            llm_msg = self.message_history[idx]
+        else:
+            llm_msg = copy.deepcopy(self.message_history[idx])
+        if llm_msg.content is None or (
+            llm_msg.content == "" and _is_identified_result(llm_msg)
+        ):
+            return llm_msg
+        orig_content = llm_msg.content
+        new_content = (
+            self.parser.truncate_tokens(orig_content, tokens)
+            if self.parser is not None
+            else orig_content[: tokens * 4]  # approx truncation
+        )
+        llm_msg.content = new_content + "\n" + warning
+        return llm_msg
+
+    def _reduce_raw_tool_results(self, message: ChatDocument) -> None:
+        """
+        If message is the result of a ToolMessage that had
+        a `_max_retained_tokens` set to a non-None value, then we replace contents
+        with a placeholder message.
+        """
+        parent_message: ChatDocument | None = message.parent
+        tools = [] if parent_message is None else parent_message.tool_messages
+        truncate_tools = []
+        for t in tools:
+            max_retained_tokens = t._max_retained_tokens
+            if isinstance(max_retained_tokens, ModelPrivateAttr):
+                max_retained_tokens = max_retained_tokens.default
+            if max_retained_tokens is not None:
+                truncate_tools.append(t)
+        limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
+        if limiting_tool is not None:
+            max_retained_tokens = limiting_tool._max_retained_tokens
+            if isinstance(max_retained_tokens, ModelPrivateAttr):
+                max_retained_tokens = max_retained_tokens.default
+            if max_retained_tokens is not None:
+                tool_name = limiting_tool.default_value("request")
+                max_tokens: int = max_retained_tokens
+                truncation_warning = f"""
+                    The result of the {tool_name} tool were too large,
+                    and has been truncated to {max_tokens} tokens.
+                    To obtain the full result, the tool needs to be re-used.
+                """
+                self.truncate_message(
+                    message.metadata.msg_idx, max_tokens, truncation_warning
+                )
+
+    def llm_response(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> Optional[ChatDocument]:
+        """
+        Respond to a single user message, appended to the message history,
+        in "chat" mode
+        Args:
+            message (str|ChatDocument): message or ChatDocument object to respond to.
+                If None, use the self.task_messages
+        Returns:
+            LLM response as a ChatDocument object
+        """
+        if self.llm is None:
+            return None
+
+        # If enabled and a tool error occurred, we recover by generating the tool in
+        # strict json mode
+        if (
+            self.tool_error
+            and self.output_format is None
+            and self._json_schema_available()
+            and self.config.strict_recovery
+        ):
+            self.tool_error = False
+            AnyTool = self._get_any_tool_message()
+            if AnyTool is None:
+                return None
+            self.set_output_format(
+                AnyTool,
+                force_tools=True,
+                use=True,
+                handle=True,
+                instructions=True,
+            )
+            recovery_message = self._strict_recovery_instructions(AnyTool)
+            augmented_message = message
+            if augmented_message is None:
+                augmented_message = recovery_message
+            elif isinstance(augmented_message, str):
+                augmented_message = augmented_message + recovery_message
+            else:
+                augmented_message.content = augmented_message.content + recovery_message
+
+            # only use the augmented message for this one response...
+            result = self.llm_response(augmented_message)
+            # ... restore the original user message so that the AnyTool recover
+            # instructions don't persist in the message history
+            # (this can cause the LLM to use the AnyTool directly as a tool)
+            if message is None:
+                self.delete_last_message(role=Role.USER)
+            else:
+                msg = message if isinstance(message, str) else message.content
+                self.update_last_message(msg, role=Role.USER)
+            return result
+
+        hist, output_len = self._prep_llm_messages(message)
+        if len(hist) == 0:
+            return None
+        tool_choice = (
+            "auto"
+            if isinstance(message, str)
+            else (message.oai_tool_choice if message is not None else "auto")
+        )
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
+            try:
+                response = self.llm_response_messages(hist, output_len, tool_choice)
+            except openai.BadRequestError as e:
+                if self.any_strict:
+                    self.disable_strict = True
+                    self.set_output_format(None)
+                    logging.warning(
+                        f"""
+                        OpenAI BadRequestError raised with strict mode enabled.
+                        Message: {e.message}
+                        Disabling strict mode and retrying.
+                        """
+                    )
+                    return self.llm_response(message)
+                else:
+                    raise e
+        self.message_history.extend(ChatDocument.to_LLMMessage(response))
+        response.metadata.msg_idx = len(self.message_history) - 1
+        response.metadata.agent_id = self.id
+        if isinstance(message, ChatDocument):
+            self._reduce_raw_tool_results(message)
+        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
+        response.metadata.tool_ids = (
+            []
+            if isinstance(message, str)
+            else message.metadata.tool_ids if message is not None else []
+        )
+
+        return response
+
+    async def llm_response_async(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> Optional[ChatDocument]:
+        """
+        Async version of `llm_response`. See there for details.
+        """
+        if self.llm is None:
+            return None
+
+        # If enabled and a tool error occurred, we recover by generating the tool in
+        # strict json mode
+        if (
+            self.tool_error
+            and self.output_format is None
+            and self._json_schema_available()
+            and self.config.strict_recovery
+        ):
+            self.tool_error = False
+            AnyTool = self._get_any_tool_message()
+            self.set_output_format(
+                AnyTool,
+                force_tools=True,
+                use=True,
+                handle=True,
+                instructions=True,
+            )
+            recovery_message = self._strict_recovery_instructions(AnyTool)
+            augmented_message = message
+            if augmented_message is None:
+                augmented_message = recovery_message
+            elif isinstance(augmented_message, str):
+                augmented_message = augmented_message + recovery_message
+            else:
+                augmented_message.content = augmented_message.content + recovery_message
+
+            # only use the augmented message for this one response...
+            result = self.llm_response(augmented_message)
+            # ... restore the original user message so that the AnyTool recover
+            # instructions don't persist in the message history
+            # (this can cause the LLM to use the AnyTool directly as a tool)
+            if message is None:
+                self.delete_last_message(role=Role.USER)
+            else:
+                msg = message if isinstance(message, str) else message.content
+                self.update_last_message(msg, role=Role.USER)
+            return result
+
+        hist, output_len = self._prep_llm_messages(message)
+        if len(hist) == 0:
+            return None
+        tool_choice = (
+            "auto"
+            if isinstance(message, str)
+            else (message.oai_tool_choice if message is not None else "auto")
+        )
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
+            try:
+                response = await self.llm_response_messages_async(
+                    hist, output_len, tool_choice
+                )
+            except openai.BadRequestError as e:
+                if self.any_strict:
+                    self.disable_strict = True
+                    self.set_output_format(None)
+                    logging.warning(
+                        f"""
+                        OpenAI BadRequestError raised with strict mode enabled.
+                        Message: {e.message}
+                        Disabling strict mode and retrying.
+                        """
+                    )
+                    return await self.llm_response_async(message)
+                else:
+                    raise e
+        self.message_history.extend(ChatDocument.to_LLMMessage(response))
+        response.metadata.msg_idx = len(self.message_history) - 1
+        response.metadata.agent_id = self.id
+        if isinstance(message, ChatDocument):
+            self._reduce_raw_tool_results(message)
+        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
+        response.metadata.tool_ids = (
+            []
+            if isinstance(message, str)
+            else message.metadata.tool_ids if message is not None else []
+        )
+
+        return response
+
+    def init_message_history(self) -> None:
+        """
+        Initialize the message history with the system message and user message
+        """
+        self.message_history = [self._create_system_and_tools_message()]
+        if self.user_message:
+            self.message_history.append(
+                LLMMessage(role=Role.USER, content=self.user_message)
+            )
+
+    def _prep_llm_messages(
+        self,
+        message: Optional[str | ChatDocument] = None,
+        truncate: bool = True,
+    ) -> Tuple[List[LLMMessage], int]:
+        """
+        Prepare messages to be sent to self.llm_response_messages,
+            which is the main method that calls the LLM API to get a response.
+            If desired output tokens + message history exceeds the model context length,
+            then first the max output tokens is reduced to fit, and if that is not
+            possible, older messages may be truncated to accommodate at least
+            self.config.llm.min_output_tokens of output.
+
+        Returns:
+            Tuple[List[LLMMessage], int]: (messages, output_len)
+                messages = Full list of messages to send
+                output_len = max expected number of tokens in response
+        """
+
+        if (
+            not self.llm_can_respond(message)
+            or self.config.llm is None
+            or self.llm is None
+        ):
+            return [], 0
+
+        if message is None and len(self.message_history) > 0:
+            # this means agent has been used to get LLM response already,
+            # and so the last message is an "assistant" response.
+            # We delete this last assistant response and re-generate it.
+            self.clear_history(-1)
+            logger.warning(
+                "Re-generating the last assistant response since message is None"
+            )
+
+        if len(self.message_history) == 0:
+            # initial messages have not yet been loaded, so load them
+            self.init_message_history()
+
+            # for debugging, show the initial message history
+            if settings.debug:
+                print(
+                    f"""
+                [grey37]LLM Initial Msg History:
+                {escape(self.message_history_str())}
+                [/grey37]
+                """
+                )
+        else:
+            assert self.message_history[0].role == Role.SYSTEM
+            # update the system message with the latest tool instructions
+            self.message_history[0] = self._create_system_and_tools_message()
+
+        if message is not None:
+            if (
+                isinstance(message, str)
+                or message.id() != self.message_history[-1].chat_document_id
+            ):
+                # either the message is a str, or it is a fresh ChatDocument
+                # different from the last message in the history
+                llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
+                llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
+                # Canonicalize retained whitespace-only results before token counting.
+                for llm_msg in llm_msgs:
+                    if (
+                        _is_identified_result(llm_msg)
+                        and llm_msg.content is not None
+                        and llm_msg.content.strip() == ""
+                    ):
+                        llm_msg.content = ""
+                if len(llm_msgs) == 0:
+                    return [], 0
+                # process tools if any
+                done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
+                self.oai_tool_calls = [
+                    t for t in self.oai_tool_calls if t.id not in done_tools
+                ]
+                self.message_history.extend(llm_msgs)
+
+        hist = self.message_history
+        output_len = self.config.llm.model_max_output_tokens
+        if (
+            truncate
+            and output_len > self.llm.chat_context_length() - self.chat_num_tokens(hist)
+        ):
+            # chat + output > max context length,
+            # so first try to shorten requested output len to fit;
+            # use an extra margin of CHAT_HISTORY_BUFFER tokens
+            # in case our calcs are off (and to allow for some extra tokens)
+            output_len = (
+                self.llm.chat_context_length()
+                - self.chat_num_tokens(hist)
+                - CHAT_HISTORY_BUFFER
+            )
+            if output_len > self.config.llm.min_output_tokens:
+                logger.debug(
+                    f"""
+                    Chat Model context length is {self.llm.chat_context_length()},
+                    but the current message history is {self.chat_num_tokens(hist)}
+                    tokens long, which does not allow
+                    {self.config.llm.model_max_output_tokens} output tokens.
+                    Therefore we reduced `max_output_tokens` to {output_len} tokens,
+                    so they can fit within the model's context length
+                    """
+                )
+            else:
+                # unacceptably small output len, so compress early parts of
+                # conversation history based on the configured strategy
+                strategy = self.config.context_overflow_strategy
+
+                if strategy == "truncate":
+                    # Truncate content of individual messages while preserving
+                    # the message sequence (important for LLM APIs that require
+                    # alternating USER/ASSISTANT messages)
+                    msg_idx_to_compress = 1  # don't touch system msg
+                    # we will try compressing msg indices up to but not including
+                    # last user msg
+                    last_msg_idx_to_compress = (
+                        self.last_message_idx_with_role(
+                            role=Role.USER,
+                        )
+                        - 1
+                    )
+                    n_truncated = 0
+                    _target_tokens = (
+                        self.llm.chat_context_length()
+                        - self.config.llm.min_output_tokens
+                        - CHAT_HISTORY_BUFFER
+                    )
+                    # Truncation floor: never reduce a message's content below
+                    # this many tokens.
+                    _min_keep_tokens = 30
+                    _truncation_warning = "... [Contents truncated!]"
+
+                    def _content_tokens(text: str | None) -> int:
+                        """Token count of message *content* only.
+
+                        `truncate_message` only trims `message.content`, so
+                        using the full `_message_num_tokens` (which includes
+                        attachment payloads) would inflate the count and make
+                        the keep-target too large to ever converge, for
+                        messages carrying file attachments.
+                        """
+                        return (
+                            self.parser.num_tokens(text or "")
+                            if self.parser is not None
+                            # approx fallback, matches truncate_message
+                            else len(text or "") // 4
+                        )
+
+                    # Account for the warning that truncate_message appends
+                    # ("\n" + warning), so the final token count of a
+                    # truncated message does not exceed its keep-target.
+                    _warning_tokens = _content_tokens("\n" + _truncation_warning)
+                    # NOTE: loop termination is guaranteed:
+                    # msg_idx_to_compress strictly increases every iteration
+                    # (truncate or skip), and once it exceeds
+                    # last_msg_idx_to_compress a ValueError is raised. (The
+                    # token count need not decrease every iteration, so
+                    # termination rests on the index advancing.)
+                    while self.chat_num_tokens(hist) > _target_tokens:
+                        if msg_idx_to_compress > last_msg_idx_to_compress:
+                            # We want to preserve the first message (typically
+                            # system msg) and last message (user msg).
+                            raise ValueError(
+                                """
+                            The (message history + max_output_tokens) is longer than the
+                            max chat context length of this model, and we have tried
+                            reducing the requested max output tokens, as well as
+                            truncating early parts of the message history, to
+                            accommodate the model context length, but we have run out
+                            of msgs to truncate.
+
+                            HINT: In the `llm` field of your `ChatAgentConfig` object,
+                            which is of type `LLMConfig/OpenAIGPTConfig`, try
+                            - increasing `chat_context_length`
+                                (if accurate for the model), or
+                            - decreasing `max_output_tokens`
+                            """
+                            )
+                        _msg_tokens = _content_tokens(hist[msg_idx_to_compress].content)
+                        if _msg_tokens <= _min_keep_tokens + _warning_tokens:
+                            # Truncating this message cannot shrink the total:
+                            # its content is already at/below the keep-floor
+                            # plus the appended warning; leave it intact.
+                            msg_idx_to_compress += 1
+                            continue
+                        n_truncated += 1
+                        # Distribute the current excess evenly across the
+                        # remaining *compressible* messages, so each retains
+                        # as much content as possible instead of being
+                        # collapsed to the fixed 30-token floor. The excess is
+                        # recomputed every iteration, so the distribution
+                        # self-corrects as we move forward through the
+                        # history.
+                        _current_excess = self.chat_num_tokens(hist) - _target_tokens
+                        # Shrink capacity of each *later* message in the
+                        # compressible range: its content above the floor (net
+                        # of the appended warning). Non-positive entries are
+                        # the tiny messages the skip-check above will leave
+                        # untouched; they must not dilute the even share, so
+                        # only messages with positive capacity count toward
+                        # the denominator (plus this message, which passed the
+                        # skip-check and is therefore compressible).
+                        _later_capacities = [
+                            _content_tokens(m.content)
+                            - _min_keep_tokens
+                            - _warning_tokens
+                            for m in hist[
+                                msg_idx_to_compress + 1 : last_msg_idx_to_compress + 1
+                            ]
+                        ]
+                        _n_remaining = 1 + sum(1 for c in _later_capacities if c > 0)
+                        _even_share = math.ceil(_current_excess / _n_remaining)
+                        # Later messages can shed at most their capacity; this
+                        # message must absorb whatever they cannot, so that
+                        # this single forward pass reaches the target whenever
+                        # that is possible at all.
+                        _later_capacity = sum(c for c in _later_capacities if c > 0)
+                        _reduction = max(_even_share, _current_excess - _later_capacity)
+                        # Extra 2-token slack: re-encoding truncated content
+                        # plus the appended warning can merge/split tokens at
+                        # the boundary, so aim slightly below the target to
+                        # keep the achieved reduction from falling short.
+                        _keep_tokens = max(
+                            _min_keep_tokens,
+                            _msg_tokens - _reduction - _warning_tokens - 2,
+                        )
+                        # compress the msg at idx `msg_idx_to_compress`
+                        hist[msg_idx_to_compress] = self.truncate_message(
+                            msg_idx_to_compress,
+                            tokens=_keep_tokens,
+                            warning=_truncation_warning,
+                        )
+                        msg_idx_to_compress += 1
+
+                    output_len = min(
+                        self.config.llm.model_max_output_tokens,
+                        self.llm.chat_context_length()
+                        - self.chat_num_tokens(hist)
+                        - CHAT_HISTORY_BUFFER,
+                    )
+                    if output_len < self.config.llm.min_output_tokens:
+                        raise ValueError(
+                            f"""
+                            Tried to shorten prompt history for chat mode
+                            but even after truncating all messages except system msg
+                            and last (user) msg, the history token len
+                            {self.chat_num_tokens(hist)} is too long to accommodate
+                            the desired minimum output tokens
+                            {self.config.llm.min_output_tokens} within the
+                            model's context length {self.llm.chat_context_length()}.
+                            Please try shortening the system msg or user prompts,
+                            or adjust `config.llm.min_output_tokens` to be smaller.
+                            """
+                        )
+                    else:
+                        # we MUST have truncated at least one msg
+                        msg_tokens = self.chat_num_tokens()
+                        logger.warning(
+                            f"""
+                        Chat Model context length is {self.llm.chat_context_length()}
+                        tokens, but the current message history is {msg_tokens} tokens
+                        long, which does not allow
+                        {self.config.llm.model_max_output_tokens} output tokens.
+                        Therefore we truncated the first {n_truncated} messages
+                        in the conversation history so that history token
+                        length is reduced to {self.chat_num_tokens(hist)}, and
+                        we use `max_output_tokens = {output_len}`,
+                        so they can fit within the model's context length
+                        of {self.llm.chat_context_length()} tokens.
+                        """
+                        )
+
+                else:  # strategy == "drop_turns"
+                    # Drop complete conversation turns. A complete turn is defined
+                    # as a USER message followed by all messages until the next
+                    # USER message. This is more aggressive but cleaner for voice
+                    # agents with limited context.
+                    n_dropped_turns = 0
+                    while (
+                        self.chat_num_tokens(hist)
+                        > self.llm.chat_context_length()
+                        - self.config.llm.min_output_tokens
+                        - CHAT_HISTORY_BUFFER
+                    ):
+                        # Find the last USER message index
+                        last_user_idx = self.last_message_idx_with_role(role=Role.USER)
+                        if last_user_idx == -1:
+                            break
+
+                        # Find the first complete turn to drop (skip system message)
+                        first_user_idx = -1
+                        for i in range(1, last_user_idx):
+                            if hist[i].role == Role.USER:
+                                first_user_idx = i
+                                break
+                        if first_user_idx == -1:
+                            break
+
+                        # Find the end of this turn: last message before next USER
+                        next_user_idx = -1
+                        for i in range(first_user_idx + 1, last_user_idx + 1):
+                            if hist[i].role == Role.USER:
+                                next_user_idx = i
+                                break
+                        if next_user_idx == -1:
+                            break
+
+                        # Drop the turn
+                        self.clear_history(first_user_idx, next_user_idx - 1)
+                        n_dropped_turns += 1
+
+                    output_len = min(
+                        self.config.llm.model_max_output_tokens,
+                        self.llm.chat_context_length()
+                        - self.chat_num_tokens(hist)
+                        - CHAT_HISTORY_BUFFER,
+                    )
+                    if output_len < self.config.llm.min_output_tokens:
+                        raise ValueError(
+                            f"""
+                            Tried to shorten prompt history for chat mode
+                            but even after dropping complete turns except the system
+                            msg and last turn, the history token len
+                            {self.chat_num_tokens(hist)} is too long to accommodate
+                            the desired minimum output tokens
+                            {self.config.llm.min_output_tokens} within the
+                            model's context length {self.llm.chat_context_length()}.
+                            Please try shortening the system msg or user prompts,
+                            or adjust `config.llm.min_output_tokens` to be smaller.
+                            """
+                        )
+                    else:
+                        # we MUST have dropped at least one turn
+                        msg_tokens = self.chat_num_tokens()
+                        logger.warning(
+                            f"""
+                        Chat Model context length is {self.llm.chat_context_length()}
+                        tokens, but the current message history is {msg_tokens} tokens
+                        long, which does not allow
+                        {self.config.llm.model_max_output_tokens} output tokens.
+                        Therefore we dropped the first {n_dropped_turns} complete
+                        turn(s) from the conversation history so that history token
+                        length is reduced to {self.chat_num_tokens(hist)}, and
+                        we use `max_output_tokens = {output_len}`,
+                        so they can fit within the model's context length
+                        of {self.llm.chat_context_length()} tokens.
+                        """
+                        )
+
+        if isinstance(message, ChatDocument):
+            # record the position of the corresponding LLMMessage in
+            # the message_history
+            message.metadata.msg_idx = len(hist) - 1
+            message.metadata.agent_id = self.id
+        return hist, output_len
+
+    def _function_args(
+        self,
+    ) -> Tuple[
+        Optional[List[LLMFunctionSpec]],
+        str | Dict[str, str],
+        Optional[List[OpenAIToolSpec]],
+        Optional[Dict[str, Dict[str, str] | str]],
+        Optional[OpenAIJsonSchemaSpec],
+    ]:
+        """
+        Get function/tool spec/output format arguments for
+        OpenAI-compatible LLM API call
+        """
+        functions: Optional[List[LLMFunctionSpec]] = None
+        fun_call: str | Dict[str, str] = "none"
+        tools: Optional[List[OpenAIToolSpec]] = None
+        force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
+        self.any_strict = False
+        if self.config.use_functions_api and len(self.llm_functions_usable) > 0:
+            if not self.config.use_tools_api:
+                functions = [
+                    self.llm_functions_map[f] for f in self.llm_functions_usable
+                ]
+                fun_call = (
+                    "auto"
+                    if self.llm_function_force is None
+                    else self.llm_function_force
+                )
+            else:
+
+                def to_maybe_strict_spec(function: str) -> OpenAIToolSpec:
+                    spec = self.llm_functions_map[function]
+                    strict = self._strict_mode_for_tool(function)
+                    if strict:
+                        self.any_strict = True
+                        strict_spec = copy.deepcopy(spec)
+                        format_schema_for_strict(strict_spec.parameters)
+                    else:
+                        strict_spec = spec
+
+                    return OpenAIToolSpec(
+                        type="function",
+                        strict=strict,
+                        function=strict_spec,
+                    )
+
+                tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
+                force_tool = (
+                    None
+                    if self.llm_function_force is None
+                    else {
+                        "type": "function",
+                        "function": {"name": self.llm_function_force["name"]},
+                    }
+                )
+        output_format = None
+        if self.output_format is not None and self._json_schema_available():
+            self.any_strict = True
+            if issubclass(self.output_format, ToolMessage) and not issubclass(
+                self.output_format, XMLToolMessage
+            ):
+                spec = self.output_format.llm_function_schema(
+                    request=True,
+                    defaults=self.config.output_format_include_defaults,
+                )
+                format_schema_for_strict(spec.parameters)
+
+                output_format = OpenAIJsonSchemaSpec(
+                    # We always require that outputs strictly match the schema
+                    strict=True,
+                    function=spec,
+                )
+            elif issubclass(self.output_format, BaseModel):
+                param_spec = self.output_format.model_json_schema()
+                format_schema_for_strict(param_spec)
+
+                output_format = OpenAIJsonSchemaSpec(
+                    # We always require that outputs strictly match the schema
+                    strict=True,
+                    function=LLMFunctionSpec(
+                        name="json_output",
+                        description="Strict Json output format.",
+                        parameters=param_spec,
+                    ),
+                )
+
+        return functions, fun_call, tools, force_tool, output_format
+
+    def llm_response_messages(
+        self,
+        messages: List[LLMMessage],
+        output_len: Optional[int] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+    ) -> ChatDocument:
+        """
+        Respond to a series of messages, e.g. with OpenAI ChatCompletion
+        Args:
+            messages: seq of messages (with role, content fields) sent to LLM
+            output_len: max number of tokens expected in response.
+                    If None, use the LLM's default model_max_output_tokens.
+        Returns:
+            Document (i.e. with fields "content", "metadata")
+        """
+        assert self.config.llm is not None and self.llm is not None
+        output_len = output_len or self.config.llm.model_max_output_tokens
+        streamer = noop_fn
+        if self.llm.get_stream():
+            streamer = self.callbacks.start_llm_stream()
+        self.llm.config.streamer = streamer
+        with ExitStack() as stack:  # for conditionally using rich spinner
+            if not self.llm.get_stream() and not settings.quiet:
+                # show rich spinner only if not streaming!
+                # (Why? b/c the intent of showing a spinner is to "show progress",
+                # and we don't need to do that when streaming, since
+                # streaming output already shows progress.)
+                cm = status(
+                    "LLM responding to messages...",
+                    log_if_quiet=False,
+                )
+                stack.enter_context(cm)
+            if self.llm.get_stream() and not settings.quiet:
+                console.print(f"[green]{self.indent}", end="")
+            functions, fun_call, tools, force_tool, output_format = (
+                self._function_args()
+            )
+            assert self.llm is not None
+            response = self.llm.chat(
+                messages,
+                output_len,
+                tools=tools,
+                tool_choice=force_tool or tool_choice,
+                functions=functions,
+                function_call=fun_call,
+                response_format=output_format,
+            )
+        if self.llm.get_stream():
+            # Create temp ChatDocument for tool check, then clean up to avoid
+            # polluting ObjectRegistry (see PR #939 discussion)
+            temp_doc = ChatDocument.from_LLMResponse(
+                response,
+                displayed=True,
+                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+            )
+            self._call_callback_with_reasoning(
+                "finish_llm_stream",
+                reasoning=response.reasoning,
+                content=response.message or "",
+                tools_content=response.tools_content(),
+                is_tool=self.has_tool_message_attempt(temp_doc),
+            )
+            ObjectRegistry.remove(temp_doc.id())
+        self.llm.config.streamer = noop_fn
+        if response.cached:
+            self.callbacks.cancel_llm_stream()
+        self._render_llm_response(response)
+        self.update_token_usage(
+            response,  # .usage attrib is updated!
+            messages,
+            self.llm.get_stream(),
+            chat=True,
+            print_response_stats=self.config.show_stats and not settings.quiet,
+        )
+        chat_doc = ChatDocument.from_LLMResponse(
+            response,
+            displayed=True,
+            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+        )
+        self.oai_tool_calls = response.oai_tool_calls or []
+        self.oai_tool_id2call.update(
+            {t.id: t for t in self.oai_tool_calls if t.id is not None}
+        )
+
+        # If using strict output format, parse the output JSON
+        self._load_output_format(chat_doc)
+
+        return chat_doc
+
+    async def llm_response_messages_async(
+        self,
+        messages: List[LLMMessage],
+        output_len: Optional[int] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+    ) -> ChatDocument:
+        """
+        Async version of `llm_response_messages`. See there for details.
+        """
+        assert self.config.llm is not None and self.llm is not None
+        output_len = output_len or self.config.llm.model_max_output_tokens
+        functions, fun_call, tools, force_tool, output_format = self._function_args()
+        assert self.llm is not None
+
+        streamer_async = async_noop_fn
+        if self.llm.get_stream():
+            streamer_async = await self.callbacks.start_llm_stream_async()
+        self.llm.config.streamer_async = streamer_async
+
+        response = await self.llm.achat(
+            messages,
+            output_len,
+            tools=tools,
+            tool_choice=force_tool or tool_choice,
+            functions=functions,
+            function_call=fun_call,
+            response_format=output_format,
+        )
+        if self.llm.get_stream():
+            # Create temp ChatDocument for tool check, then clean up to avoid
+            # polluting ObjectRegistry (see PR #939 discussion)
+            temp_doc = ChatDocument.from_LLMResponse(
+                response,
+                displayed=True,
+                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+            )
+            self._call_callback_with_reasoning(
+                "finish_llm_stream",
+                reasoning=response.reasoning,
+                content=response.message or "",
+                tools_content=response.tools_content(),
+                is_tool=self.has_tool_message_attempt(temp_doc),
+            )
+            ObjectRegistry.remove(temp_doc.id())
+        self.llm.config.streamer_async = async_noop_fn
+        if response.cached:
+            self.callbacks.cancel_llm_stream()
+        self._render_llm_response(response)
+        self.update_token_usage(
+            response,  # .usage attrib is updated!
+            messages,
+            self.llm.get_stream(),
+            chat=True,
+            print_response_stats=self.config.show_stats and not settings.quiet,
+        )
+        chat_doc = ChatDocument.from_LLMResponse(
+            response,
+            displayed=True,
+            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+        )
+        self.oai_tool_calls = response.oai_tool_calls or []
+        self.oai_tool_id2call.update(
+            {t.id: t for t in self.oai_tool_calls if t.id is not None}
+        )
+
+        # If using strict output format, parse the output JSON
+        self._load_output_format(chat_doc)
+
+        return chat_doc
+
+    def _call_callback_with_reasoning(
+        self,
+        callback_name: str,
+        reasoning: str,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Call a callback method, only passing 'reasoning' if it accepts it.
+
+        This provides backward compatibility for custom callbacks that don't
+        have the 'reasoning' parameter in their signature.
+
+        Args:
+            callback_name: Name of the callback method (e.g., 'show_llm_response')
+            reasoning: The reasoning content to pass if supported
+            **kwargs: Other arguments to pass to the callback
+        """
+        callback = getattr(self.callbacks, callback_name, None)
+        if callback is None:
+            return
+
+        # Check if callback accepts 'reasoning' param or **kwargs
+        try:
+            sig = inspect.signature(callback)
+            params = sig.parameters
+            accepts_reasoning = "reasoning" in params or any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+            )
+        except (ValueError, TypeError):
+            # If we can't inspect the signature, assume it doesn't accept reasoning
+            accepts_reasoning = False
+
+        if accepts_reasoning:
+            callback(reasoning=reasoning, **kwargs)
+        else:
+            callback(**kwargs)
+
+    def _render_llm_response(
+        self, response: ChatDocument | LLMResponse, citation_only: bool = False
+    ) -> None:
+        is_cached = (
+            response.cached
+            if isinstance(response, LLMResponse)
+            else response.metadata.cached
+        )
+        if self.llm is None:
+            return
+        if not citation_only and (not self.llm.get_stream() or is_cached):
+            # We would have already displayed the msg "live" ONLY if
+            # streaming was enabled, AND we did not find a cached response.
+            # If we are here, it means the response has not yet been displayed.
+            cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
+            # Track whether we created a temp ChatDocument for cleanup
+            is_temp_doc = isinstance(response, LLMResponse)
+            chat_doc = (
+                response
+                if isinstance(response, ChatDocument)
+                else ChatDocument.from_LLMResponse(
+                    response,
+                    displayed=True,
+                    recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+                )
+            )
+            # TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
+            if not settings.quiet:
+                print(cached + "[green]" + escape(str(response)))
+            if isinstance(response, LLMResponse):
+                content = response.message or ""
+                tools_content = response.tools_content()
+            else:
+                content = response.content
+                tools_content = ""
+            reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
+            self._call_callback_with_reasoning(
+                "show_llm_response",
+                reasoning=reasoning,
+                content=content,
+                tools_content=tools_content,
+                is_tool=self.has_tool_message_attempt(chat_doc),
+                cached=is_cached,
+            )
+            # Clean up temp ChatDocument to avoid polluting ObjectRegistry
+            if is_temp_doc:
+                ObjectRegistry.remove(chat_doc.id())
+        if isinstance(response, LLMResponse):
+            # we are in the context immediately after an LLM responded,
+            # we won't have citations yet, so we're done
+            return
+        if response.metadata.has_citation:
+            citation = (
+                response.metadata.source_content
+                if self.config.full_citations
+                else response.metadata.source
+            )
+            if not settings.quiet:
+                print("[grey37]SOURCES:\n" + escape(citation) + "[/grey37]")
+            self._call_callback_with_reasoning(
+                "show_llm_response",
+                reasoning="",  # Citations don't have reasoning
+                content=str(citation),
+                tools_content="",
+                is_tool=False,
+                cached=False,
+                language="text",
+            )
+
+    def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument:
+        """
+        Get LLM response to `prompt` (which presumably includes the `message`
+        somewhere, along with possible large "context" passages),
+        but only include `message` as the USER message, and not the
+        full `prompt`, in the message history.
+        Args:
+            message: the original, relatively short, user request or query
+            prompt: the full prompt potentially containing `message` plus context
+
+        Returns:
+            Document object containing the response.
+        """
+        # we explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
+        self.update_last_message(message, role=Role.USER)
+        return answer_doc
+
+    async def _llm_response_temp_context_async(
+        self, message: str, prompt: str
+    ) -> ChatDocument:
+        """
+        Async version of `_llm_response_temp_context`. See there for details.
+        """
+        # we explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            answer_doc = cast(
+                ChatDocument,
+                await ChatAgent.llm_response_async(self, prompt),
+            )
+        self.update_last_message(message, role=Role.USER)
+        return answer_doc
+
+    def llm_response_forget(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> ChatDocument:
+        """
+        LLM Response to single message, and restore message_history.
+        In effect a "one-off" message & response that leaves agent
+        message history state intact.
+
+        Args:
+            message (str|ChatDocument): message to respond to.
+
+        Returns:
+            A Document object with the response.
+
+        """
+        # explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        n_msgs = len(self.message_history)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            response = cast(ChatDocument, ChatAgent.llm_response(self, message))
+        # If there is a response, then we will have two additional
+        # messages in the message history, i.e. the user message and the
+        # assistant response. We want to (carefully) remove these two messages.
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+
+        # If using strict output format, parse the output JSON
+        self._load_output_format(response)
+
+        return response
+
+    async def llm_response_forget_async(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> ChatDocument:
+        """
+        Async version of `llm_response_forget`. See there for details.
+        """
+        # explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        n_msgs = len(self.message_history)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            response = cast(
+                ChatDocument, await ChatAgent.llm_response_async(self, message)
+            )
+        # If there is a response, then we will have two additional
+        # messages in the message history, i.e. the user message and the
+        # assistant response. We want to (carefully) remove these two messages.
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+        return response
+
+    def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int:
+        """
+        Total number of tokens in the message history so far.
+
+        Args:
+            messages: if provided, compute the number of tokens in this list of
+                messages, rather than the current message history.
+        Returns:
+            int: number of tokens in message history
+        """
+        if self.parser is None:
+            raise ValueError(
+                "ChatAgent.parser is None. "
+                "You must set ChatAgent.parser "
+                "before calling chat_num_tokens()."
+            )
+        hist = messages if messages is not None else self.message_history
+        return sum([self._message_num_tokens(m) for m in hist])
+
+    def _message_num_tokens(self, message: LLMMessage) -> int:
+        """Count tokens for a message, including serialized user attachments."""
+        if self.parser is None:
+            raise ValueError(
+                "ChatAgent.parser is None. "
+                "You must set ChatAgent.parser "
+                "before calling _message_num_tokens()."
+            )
+
+        return self.parser.num_tokens(
+            message.content or ""
+        ) + self._attachment_num_tokens(message)
+
+    def _attachment_num_tokens(self, message: LLMMessage) -> int:
+        """
+        Estimate attachment contribution using the serialized payload
+        that is sent in the API request for user messages.
+        """
+        if self.parser is None or message.role != Role.USER or len(message.files) == 0:
+            return 0
+
+        model = self._chat_model_name_for_attachments()
+        n_tokens = sum(
+            self.parser.num_tokens(
+                json.dumps(
+                    attachment.to_dict(model),
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+            )
+            for attachment in message.files
+        )
+        if n_tokens > 0 and not self._attachment_tokens_warned:
+            self._attachment_tokens_warned = True
+            logger.warning(
+                "File attachment payloads are included in context-length "
+                "token accounting; this count is an estimate based on the "
+                "serialized (e.g. base64 data-URI) form of each attachment, "
+                "and may differ from the provider's own accounting."
+            )
+        return n_tokens
+
+    def _chat_model_name_for_attachments(self) -> str:
+        """Return the model name used for attachment serialization."""
+        if self.llm is None:
+            return self.config.llm.chat_model if self.config.llm is not None else ""
+
+        return cast(
+            str,
+            getattr(
+                self.llm,
+                "chat_model_orig",
+                getattr(
+                    getattr(self.llm, "config", None),
+                    "chat_model",
+                    self.config.llm.chat_model if self.config.llm is not None else "",
+                ),
+            ),
+        )
+
+    def message_history_str(self, i: Optional[int] = None) -> str:
+        """
+        Return a string representation of the message history
+        Args:
+            i: if provided, return only the i-th message when i is postive,
+                or last k messages when i = -k.
+        Returns:
+        """
+        if i is None:
+            return "\n".join([str(m) for m in self.message_history])
+        elif i > 0:
+            return str(self.message_history[i])
+        else:
+            return "\n".join([str(m) for m in self.message_history[i:]])
+
+    def __del__(self) -> None:
+        """
+        Cleanup method called when the ChatAgent is garbage collected.
+        Note: We don't close LLM clients here because they may be shared
+        across multiple agents when client caching is enabled.
+        The clients are managed centrally and cleaned up via atexit hooks.
+        """
+        # Previously we closed clients here, but this caused issues when
+        # multiple agents shared the same cached client instance.
+        # Clients are now managed centrally in langroid.language_models.client_cache
+        pass
 </file>
 
 <file path="mkdocs.yml">
@@ -95901,6 +95962,7 @@ nav:
       - Markdown, HTML Parsing: notes/markdown-html-parsing.md
       - Context-Overflow Handling: notes/context-overflow.md
       - Batch Processing: notes/batch-processing.md
+      - Attachment Token Preflight: notes/attachment-token-preflight.md
 
   - Examples:
     - Guide: examples/guide.md
@@ -95949,7 +96011,7 @@ extra_javascript:
 <file path="pyproject.toml">
 [project]
 name = "langroid"
-version = "0.65.16"
+version = "0.66.0"
 authors = [
     {name = "Prasad Chalasani", email = "pchalasani@gmail.com"},
 ]

--- a/llms.txt
+++ b/llms.txt
@@ -107,6 +107,7 @@ docs/
     pure-lambda-non-circular.png
   notes/
     async-streaming.md
+    attachment-token-preflight.md
     azure-openai-models.md
     batch-processing.md
     chat-history-snapshots.md
@@ -683,6 +684,7 @@ tests/
     test_arangodb_chat_agent.py
     test_arangodb.py
     test_async_handlers.py
+    test_attachment_token_accounting.py
     test_azure_openai.py
     test_batch_tasks_typed.py
     test_batch.py
@@ -73690,6 +73692,55 @@ the LLM will try its best to interpret what you want, and offer choices when con
     - Illustrates function-calling/tools and code-generation
 </file>
 
+<file path="docs/notes/attachment-token-preflight.md">
+# Attachment Token Preflight
+
+Before each LLM call, Langroid runs a local context-length preflight: it counts
+the tokens in the pending message history (`ChatAgent.chat_num_tokens()`) and,
+if needed, reduces the requested output length, truncates old messages, or
+drops old turns so the request fits the model's context window.
+
+Historically this preflight counted only each message's text `content`, ignoring
+`LLMMessage.files` (`FileAttachment` objects). But attachments ARE serialized
+into the actual API request — for Gemini and other OpenAI-compatible paths,
+`FileAttachment.to_dict()` turns an attached PDF or image into a `data:` URI
+containing the full base64 payload. A ~1.9 MB PDF becomes roughly 2.6 million
+base64 characters, so the local check could pass while the real payload was far
+larger (issue #996).
+
+## Behavior
+
+The preflight now includes an estimate for each attachment on `USER` messages:
+
+- Each attachment is serialized exactly as it would be for the API request
+  (`FileAttachment.to_dict(model)`), and the resulting JSON is tokenized with
+  the agent's parser, the same way message text is counted.
+- Attachments that are NOT inlined — e.g. a `FileAttachment` carrying an
+  `http(s)` URL, which is sent as the URL itself rather than base64 bytes —
+  contribute only the tokens of their small serialized form, not the size of
+  the remote file.
+- Messages with no attachments are counted exactly as before; token accounting
+  is unchanged for attachment-free histories.
+
+When attachments contribute to the count for an agent, a warning is logged once
+(per agent, not per message) noting that the count is an estimate.
+
+## How conservative is the estimate?
+
+The estimate measures the serialized request payload (base64 data URI plus the
+surrounding JSON), tokenized like ordinary text. Provider-side accounting may
+differ in either direction:
+
+- Providers that bill inlined files as text-like payload will be close to this
+  estimate.
+- Providers that convert files to their own internal representation (e.g.
+  per-page or per-image token charges) may count fewer or more tokens.
+
+The goal is to keep the local preflight from drastically *under*-estimating the
+request size when large files are attached, so context-window overflows are
+caught locally instead of surfacing as provider-side errors.
+</file>
+
 <file path="docs/notes/batch-processing.md">
 # Batch Processing
 
@@ -87930,6 +87981,110 @@ def test_strip_literals_and_comments() -> None:
     assert "RETURN" in _strip_literals_and_comments("FOR d IN users RETURN d")
 </file>
 
+<file path="tests/main/test_attachment_token_accounting.py">
+"""Tests for attachment-aware context-preflight token accounting (issue #996).
+
+The accounting itself (attachment payloads counted via their serialized
+API form) is covered in `test_prep_llm_message.py`; here we test the
+one-time warning emitted when attachments contribute to the token count,
+and that accounting without attachments is unchanged.
+"""
+
+import logging
+from typing import List
+
+import pytest
+from _pytest.logging import LogCaptureFixture
+
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.language_models.base import LLMMessage, Role
+from langroid.language_models.openai_gpt import OpenAIGPTConfig
+from langroid.parsing.file_attachment import FileAttachment
+
+LOGGER_NAME = "langroid.agent.chat_agent"
+
+
+@pytest.fixture
+def agent() -> ChatAgent:
+    """ChatAgent with a char-count parser; no live LLM needed."""
+    config = ChatAgentConfig(
+        system_message="System message",
+        llm=OpenAIGPTConfig(
+            chat_model="gemini/gemini-2.5-flash",
+            chat_context_length=16_000,
+        ),
+    )
+    agent = ChatAgent(config)
+
+    class MockParser:
+        def num_tokens(self, text: str) -> int:
+            return len(text)
+
+    agent.parser = MockParser()  # type: ignore[assignment]
+    return agent
+
+
+def _user_msg_with_attachment() -> LLMMessage:
+    attachment = FileAttachment.from_bytes(
+        content=b"pdf-bytes" * 20,
+        filename="dummy.pdf",
+    )
+    return LLMMessage(
+        role=Role.USER,
+        content="Question about the PDF",
+        files=[attachment],
+    )
+
+
+def _attachment_warnings(caplog: LogCaptureFixture) -> List[logging.LogRecord]:
+    return [r for r in caplog.records if "attachment" in r.getMessage().lower()]
+
+
+def test_attachment_warning_emitted_once(
+    agent: ChatAgent, caplog: LogCaptureFixture
+) -> None:
+    """Warning fires once per agent, even across repeated token counts."""
+    msg = _user_msg_with_attachment()
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        agent.chat_num_tokens([msg])
+        agent.chat_num_tokens([msg, msg])
+        agent.chat_num_tokens([msg])
+
+    warnings = _attachment_warnings(caplog)
+    assert len(warnings) == 1
+    assert "estimate" in warnings[0].getMessage().lower()
+
+
+def test_no_warning_without_attachments(
+    agent: ChatAgent, caplog: LogCaptureFixture
+) -> None:
+    """No attachments: no warning, and counting is content-only as before."""
+    msg = LLMMessage(role=Role.USER, content="Just text")
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        n_tokens = agent.chat_num_tokens([msg])
+
+    assert n_tokens == len("Just text")
+    assert _attachment_warnings(caplog) == []
+
+
+def test_no_warning_for_non_user_attachment(
+    agent: ChatAgent, caplog: LogCaptureFixture
+) -> None:
+    """Attachments on non-user messages are not serialized inline, so they
+    neither count nor warn."""
+    attachment = FileAttachment.from_bytes(content=b"x" * 100, filename="f.pdf")
+    msg = LLMMessage(
+        role=Role.ASSISTANT,
+        content="reply",
+        files=[attachment],
+    )
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        n_tokens = agent.chat_num_tokens([msg])
+
+    assert n_tokens == len("reply")
+    assert _attachment_warnings(caplog) == []
+</file>
+
 <file path="tests/main/test_batch.py">
 import asyncio
 import time
@@ -101592,6 +101747,886 @@ class ToolMessage(ABC, BaseModel):
         return schema
 </file>
 
+<file path="langroid/language_models/base.py">
+import json
+import logging
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from enum import Enum
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
+
+from langroid.cachedb.base import CacheDBConfig
+from langroid.cachedb.redis_cachedb import RedisCacheConfig
+from langroid.language_models.model_info import ModelInfo, get_model_info
+from langroid.parsing.agent_chats import parse_message
+from langroid.parsing.file_attachment import FileAttachment
+from langroid.parsing.parse_json import parse_imperfect_json, top_level_json_field
+from langroid.prompts.dialog import collate_chat_history
+from langroid.utils.configuration import settings
+from langroid.utils.output.printing import show_if_debug
+
+logger = logging.getLogger(__name__)
+
+
+def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+    pass
+
+
+async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+    pass
+
+
+FunctionCallTypes = Literal["none", "auto"]
+ToolChoiceTypes = Literal["none", "auto", "required"]
+ToolTypes = Literal["function"]
+
+DEFAULT_CONTEXT_LENGTH = 16_000
+
+
+class StreamEventType(Enum):
+    TEXT = 1
+    FUNC_NAME = 2
+    FUNC_ARGS = 3
+    TOOL_NAME = 4
+    TOOL_ARGS = 5
+    REASONING = 6
+
+
+class RetryParams(BaseSettings):
+    max_retries: int = 5
+    initial_delay: float = 1.0
+    exponential_base: float = 1.3
+    jitter: bool = True
+
+
+class LLMConfig(BaseSettings):
+    """
+    Common configuration for all language models.
+    """
+
+    type: str = "openai"
+    streamer: Optional[Callable[[Any], None]] = noop_fn
+    streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
+    api_base: str | None = None
+    formatter: None | str = None
+    # specify None if you want to use the full max output tokens of the model
+    max_output_tokens: int | None = 8192
+    timeout: int = 20  # timeout for API requests
+    chat_model: str = ""
+    completion_model: str = ""
+    temperature: float = 0.0
+    chat_context_length: int | None = None
+    async_stream_quiet: bool = False  # suppress streaming output in async mode?
+    completion_context_length: int | None = None
+    # if input length + max_output_tokens > context length of model,
+    # we will try shortening requested output
+    min_output_tokens: int = 64
+    use_completion_for_chat: bool = False  # use completion model for chat?
+    # use chat model for completion? For OpenAI models, this MUST be set to True!
+    use_chat_for_completion: bool = True
+    stream: bool = True  # stream output from API?
+    # TODO: we could have a `stream_reasoning` flag here to control whether to show
+    # reasoning output from reasoning models
+    cache_config: None | CacheDBConfig = RedisCacheConfig()
+    thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
+    retry_params: RetryParams = RetryParams()
+
+    @property
+    def model_max_output_tokens(self) -> int:
+        if self.max_output_tokens:
+            return self.max_output_tokens
+        # Build fallback names by progressively stripping provider prefixes
+        # (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
+        # succeeds even before OpenAIGPT.__init__ strips the prefix.
+        parts = self.chat_model.split("/")
+        fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
+        return get_model_info(self.chat_model, fallbacks).max_output_tokens
+
+
+class LLMFunctionCall(BaseModel):
+    """
+    Structure of LLM response indicating it "wants" to call a function.
+    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
+    """
+
+    name: str  # name of function to call
+    arguments: Optional[Dict[str, Any]] = None
+
+    @staticmethod
+    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall":
+        """
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+        fun_call = LLMFunctionCall(name=message["name"])
+        fun_args_str = message["arguments"]
+        # sometimes may be malformed with invalid indents,
+        # so we try to be safe by removing newlines.
+        if fun_args_str is not None:
+            fun_args_str = fun_args_str.replace("\n", "").strip()
+            dict_or_list = parse_imperfect_json(fun_args_str)
+
+            if not isinstance(dict_or_list, dict):
+                raise ValueError(
+                    f"""
+                        Invalid function args: {fun_args_str}
+                        parsed as {dict_or_list},
+                        which is not a valid dict.
+                        """
+                )
+            fun_args = dict_or_list
+        else:
+            fun_args = None
+        fun_call.arguments = fun_args
+
+        return fun_call
+
+    def __str__(self) -> str:
+        return "FUNC: " + json.dumps(self.model_dump(), indent=2)
+
+
+class LLMFunctionSpec(BaseModel):
+    """
+    Description of a function available for the LLM to use.
+    To be used when calling the LLM `chat()` method with the `functions` parameter.
+    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
+    """
+
+    name: str
+    description: str
+    parameters: Dict[str, Any]
+
+
+class OpenAIToolCall(BaseModel):
+    """
+    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
+    See https://platform.openai.com/docs/api-reference/chat/create
+
+    Attributes:
+        id: The id of the tool call.
+        type: The type of the tool call;
+            only "function" is currently possible (7/26/24).
+        function: The function call.
+    """
+
+    id: str | None = None
+    type: ToolTypes = "function"
+    function: LLMFunctionCall | None = None
+    extra_content: Dict[str, Any] | None = None
+
+    @staticmethod
+    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall":
+        """
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+        id = message["id"]
+        type = message["type"]
+        function = LLMFunctionCall.from_dict(message["function"])
+        extra_content = message.get("extra_content")
+        return OpenAIToolCall(
+            id=id, type=type, function=function, extra_content=extra_content
+        )
+
+    def __str__(self) -> str:
+        if self.function is None:
+            return ""
+        return "OAI-TOOL: " + json.dumps(self.function.model_dump(), indent=2)
+
+
+class OpenAIToolSpec(BaseModel):
+    type: ToolTypes
+    strict: Optional[bool] = None
+    function: LLMFunctionSpec
+
+
+class OpenAIJsonSchemaSpec(BaseModel):
+    strict: Optional[bool] = None
+    function: LLMFunctionSpec
+
+    def to_dict(self) -> Dict[str, Any]:
+        json_schema: Dict[str, Any] = {
+            "name": self.function.name,
+            "description": self.function.description,
+            "schema": self.function.parameters,
+        }
+        if self.strict is not None:
+            json_schema["strict"] = self.strict
+
+        return {
+            "type": "json_schema",
+            "json_schema": json_schema,
+        }
+
+
+class LLMTokenUsage(BaseModel):
+    """
+    Usage of tokens by an LLM.
+    """
+
+    prompt_tokens: int = 0
+    cached_tokens: int = 0
+    completion_tokens: int = 0
+    cost: float = 0.0
+    calls: int = 0  # how many API calls - not used as of 2025-04-04
+
+    def reset(self) -> None:
+        self.prompt_tokens = 0
+        self.cached_tokens = 0
+        self.completion_tokens = 0
+        self.cost = 0.0
+        self.calls = 0
+
+    def __str__(self) -> str:
+        return (
+            f"Tokens = "
+            f"(prompt {self.prompt_tokens}, cached {self.cached_tokens}, "
+            f"completion {self.completion_tokens}), "
+            f"Cost={self.cost}, Calls={self.calls}"
+        )
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+
+class Role(str, Enum):
+    """
+    Possible roles for a message in a chat.
+    """
+
+    USER = "user"
+    SYSTEM = "system"
+    ASSISTANT = "assistant"
+    FUNCTION = "function"
+    TOOL = "tool"
+
+
+class LLMMessage(BaseModel):
+    """
+    Class representing an entry in the msg-history sent to the LLM API.
+    It could be one of these:
+    - a user message
+    - an LLM ("Assistant") response
+    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
+    - a result or results from executing a fn or tool-call(s)
+    """
+
+    role: Role
+    name: Optional[str] = None
+    tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
+    tool_id: str = ""  # used by OpenAIAssistant
+    # None means "no content" (the model returned only a tool/function call).
+    # This is distinct from "" and is dropped from the API payload by api_dict;
+    # see api_dict for how a fully-empty message is handled per-API.
+    content: Optional[str] = None
+    files: List[FileAttachment] = []
+    function_call: Optional[LLMFunctionCall] = None
+    tool_calls: Optional[List[OpenAIToolCall]] = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    # link to corresponding chat document, for provenance/rewind purposes
+    chat_document_id: str = ""
+
+    def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]:
+        """
+        Convert to dictionary for API request, keeping ONLY
+        the fields that are expected in an API call!
+        E.g., DROP the tool_id, since it is only for use in the Assistant API,
+            not the completion API.
+
+        Args:
+            has_system_role: whether the message has a system role (if not,
+                set to "user" role)
+        Returns:
+            dict: dictionary representation of LLM message
+        """
+        d = self.model_dump()
+        files: List[FileAttachment] = d.pop("files")
+        if len(files) > 0 and self.role == Role.USER:
+            # In there are files, then content is an array of
+            # different content-parts
+            d["content"] = [
+                dict(
+                    type="text",
+                    text=self.content or "",
+                )
+            ] + [f.to_dict(model) for f in self.files]
+
+        # if there is a key k = "role" with value "system", change to "user"
+        # in case has_system_role is False
+        if not has_system_role and "role" in d and d["role"] == "system":
+            d["role"] = "user"
+            if d.get("content"):
+                d["content"] = "[ADDITIONAL SYSTEM MESSAGE:]\n\n" + d["content"]
+        # drop None values since API doesn't accept them (this omits `content`
+        # entirely when it is None, i.e. "no content")
+        dict_no_none = {k: v for k, v in d.items() if v is not None}
+        if "name" in dict_no_none and dict_no_none["name"] == "":
+            # OpenAI API does not like empty name
+            del dict_no_none["name"]
+        if "function_call" in dict_no_none:
+            # arguments must be a string
+            if "arguments" in dict_no_none["function_call"]:
+                dict_no_none["function_call"]["arguments"] = json.dumps(
+                    dict_no_none["function_call"]["arguments"]
+                )
+        if dict_no_none.get("tool_calls"):
+            # convert tool calls to API format
+            for tc in dict_no_none["tool_calls"]:
+                if "arguments" in tc["function"]:
+                    # arguments must be a string
+                    if tc["function"]["arguments"] is None:
+                        tc["function"]["arguments"] = "{}"
+                    else:
+                        tc["function"]["arguments"] = json.dumps(
+                            tc["function"]["arguments"]
+                        )
+                if "extra_content" in tc and tc["extra_content"] is None:
+                    del tc["extra_content"]
+        else:
+            # An empty tool-call list is not a call and conveys no useful API
+            # information. Omitting it also lets the empty-message fallback
+            # below produce a valid message.
+            dict_no_none.pop("tool_calls", None)
+        # A message with empty content (None was dropped above, or "") AND no
+        # tool/function call would be an entirely empty message, which some APIs
+        # (e.g. Gemini) reject; fall back to a single space in that case only.
+        # When there IS a tool/function call, empty content is fine (and Gemini
+        # 3.x in fact REQUIRES it — it rejects an assistant turn that carries
+        # both a call and non-empty text content).
+        has_call = bool(dict_no_none.get("tool_calls")) or (
+            dict_no_none.get("function_call") is not None
+        )
+        if not has_call and not dict_no_none.get("content"):
+            dict_no_none["content"] = " "
+        # IMPORTANT! drop fields that are not expected in API call
+        dict_no_none.pop("tool_id", None)
+        dict_no_none.pop("timestamp", None)
+        dict_no_none.pop("chat_document_id", None)
+        return dict_no_none
+
+    def __str__(self) -> str:
+        if self.function_call is not None:
+            content = "FUNC: " + json.dumps(self.function_call)
+        else:
+            content = self.content or ""
+        name_str = f" ({self.name})" if self.name else ""
+        return f"{self.role} {name_str}: {content}"
+
+
+class LLMResponse(BaseModel):
+    """
+    Class representing response from LLM.
+    """
+
+    # None means the model returned NO content (e.g. only a tool/function
+    # call), which is distinct from an empty string "". Preserving this
+    # distinction lets the message be faithfully reproduced downstream
+    # (see ChatDocument.content_is_none and LLMMessage.content).
+    message: Optional[str] = None
+    reasoning: str = ""  # optional reasoning text from reasoning models
+    # Original message text including inline thought signatures (e.g.
+    # <thinking>...</thinking>). Only set when reasoning was extracted
+    # from the message text via get_reasoning_final(); NOT set when
+    # reasoning comes from a separate API field (e.g. reasoning_content),
+    # since in that case the message text never contained thought tags.
+    message_with_reasoning: Optional[str] = None
+    # TODO tool_id needs to generalize to multi-tool calls
+    tool_id: str = ""  # used by OpenAIAssistant
+    oai_tool_calls: Optional[List[OpenAIToolCall]] = None
+    function_call: Optional[LLMFunctionCall] = None
+    usage: Optional[LLMTokenUsage] = None
+    cached: bool = False
+
+    def __str__(self) -> str:
+        if self.function_call is not None:
+            return str(self.function_call)
+        elif self.oai_tool_calls:
+            return "\n".join(str(tc) for tc in self.oai_tool_calls)
+        else:
+            return self.message or ""
+
+    def tools_content(self) -> str:
+        if self.function_call is not None:
+            return str(self.function_call)
+        elif self.oai_tool_calls:
+            return "\n".join(str(tc) for tc in self.oai_tool_calls)
+        else:
+            return ""
+
+    def to_LLMMessage(self) -> LLMMessage:
+        """Convert LLM response to an LLMMessage, to be included in the
+        message-list sent to the API.
+        This is currently NOT used in any significant way in the library, and is only
+        provided as a utility to construct a message list for the API when directly
+        working with an LLM object.
+
+        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
+        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
+        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
+        """
+        return LLMMessage(
+            role=Role.ASSISTANT,
+            content=self.message,
+            name=None if self.function_call is None else self.function_call.name,
+            function_call=self.function_call,
+            tool_calls=self.oai_tool_calls,
+        )
+
+    def get_recipient_and_message(
+        self,
+        recognize_recipient_in_content: bool = True,
+    ) -> Tuple[str, str]:
+        """
+        If `message` or `function_call` of an LLM response contains an explicit
+        recipient name, return this recipient name and `message` stripped
+        of the recipient name if specified.
+
+        Two cases:
+        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
+        (b) `message` is empty and function_call/tool_call with explicit `recipient`
+
+        Args:
+            recognize_recipient_in_content (bool): When True (default), parses
+                message text for ``TO[<recipient>]:<content>`` patterns and
+                top-level JSON ``{"recipient": "..."}`` fields. When False,
+                only function_call/tool_call ``recipient`` fields are checked.
+
+        Returns:
+            (str): name of recipient, which may be empty string if no recipient
+            (str): content of message
+
+        """
+
+        if self.function_call is not None:
+            # in this case we ignore message, since all information is in function_call
+            msg = ""
+            args = self.function_call.arguments
+            recipient = ""
+            if isinstance(args, dict):
+                recipient = args.get("recipient", "")
+            return recipient, msg
+        else:
+            msg = self.message or ""
+            if self.oai_tool_calls is not None:
+                # get the first tool that has a recipient field, if any
+                for tc in self.oai_tool_calls:
+                    if tc.function is not None and tc.function.arguments is not None:
+                        recipient = tc.function.arguments.get(
+                            "recipient"
+                        )  # type: ignore
+                        if recipient is not None and recipient != "":
+                            return recipient, ""
+
+        if not recognize_recipient_in_content:
+            return "", msg
+
+        # It's not a function or tool call, so continue looking to see
+        # if a recipient is specified in the message.
+
+        # First check if message contains "TO: <recipient> <content>"
+        recipient_name, content = parse_message(msg) if msg is not None else ("", "")
+        # check if there is a top level json that specifies 'recipient',
+        # and retain the entire message as content.
+        if recipient_name == "":
+            recipient_name = top_level_json_field(msg, "recipient") if msg else ""
+            content = msg
+        return recipient_name, content
+
+
+# Define an abstract base class for language models
+class LanguageModel(ABC):
+    """
+    Abstract base class for language models.
+    """
+
+    # usage cost by model, accumulates here
+    usage_cost_dict: Dict[str, LLMTokenUsage] = {}
+
+    def __init__(self, config: LLMConfig = LLMConfig()):
+        self.config = config
+        self.chat_model_orig = config.chat_model
+
+    @staticmethod
+    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]:
+        """
+        Create a language model.
+        Args:
+            config: configuration for language model
+        Returns: instance of language model
+        """
+        if type(config) is LLMConfig:
+            raise ValueError(
+                """
+                Cannot create a Language Model object from LLMConfig.
+                Please specify a specific subclass of LLMConfig e.g.,
+                OpenAIGPTConfig. If you are creating a ChatAgent from
+                a ChatAgentConfig, please specify the `llm` field of this config
+                as a specific subclass of LLMConfig, e.g., OpenAIGPTConfig.
+                """
+            )
+        from langroid.language_models.azure_openai import AzureGPT
+        from langroid.language_models.mock_lm import MockLM, MockLMConfig
+        from langroid.language_models.openai_gpt import OpenAIGPT
+
+        if config is None or config.type is None:
+            return None
+
+        if config.type == "mock":
+            return MockLM(cast(MockLMConfig, config))
+
+        openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
+
+        if config.type == "azure":
+            openai = AzureGPT
+        else:
+            openai = OpenAIGPT
+        cls = dict(
+            openai=openai,
+        ).get(config.type, openai)
+        return cls(config)  # type: ignore
+
+    @staticmethod
+    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]:
+        """
+        Given an even-length sequence of strings, split into a sequence of pairs
+
+        Args:
+            lst (List[str]): sequence of strings
+
+        Returns:
+            List[Tuple[str,str]]: sequence of pairs of strings
+        """
+        evens = lst[::2]
+        odds = lst[1::2]
+        return list(zip(evens, odds))
+
+    @staticmethod
+    def get_chat_history_components(
+        messages: List[LLMMessage],
+    ) -> Tuple[str, List[Tuple[str, str]], str]:
+        """
+        From the chat history, extract system prompt, user-assistant turns, and
+        final user msg.
+
+        Args:
+            messages (List[LLMMessage]): List of messages in the chat history
+
+        Returns:
+            Tuple[str, List[Tuple[str,str]], str]:
+                system prompt, user-assistant turns, final user msg
+
+        """
+        # Handle various degenerate cases
+        messages = [m for m in messages]  # copy
+        DUMMY_SYS_PROMPT = "You are a helpful assistant."
+        DUMMY_USER_PROMPT = "Follow the instructions above."
+        if len(messages) == 0 or messages[0].role != Role.SYSTEM:
+            logger.warning("No system msg, creating dummy system prompt")
+            messages.insert(0, LLMMessage(content=DUMMY_SYS_PROMPT, role=Role.SYSTEM))
+        system_prompt = messages[0].content or ""
+
+        # now we have messages = [Sys,...]
+        if len(messages) == 1:
+            logger.warning(
+                "Got only system message in chat history, creating dummy user prompt"
+            )
+            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, msg, ...]
+
+        if messages[1].role != Role.USER:
+            messages.insert(1, LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, user, ...]
+        if messages[-1].role != Role.USER:
+            logger.warning(
+                "Last message in chat history is not a user message,"
+                " creating dummy user prompt"
+            )
+            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, user, ..., user]
+        # so we omit the first and last elements and make pairs of user-asst messages
+        conversation = [m.content or "" for m in messages[1:-1]]
+        user_prompt = messages[-1].content or ""
+        pairs = LanguageModel.user_assistant_pairs(conversation)
+        return system_prompt, pairs, user_prompt
+
+    @abstractmethod
+    def set_stream(self, stream: bool) -> bool:
+        """Enable or disable streaming output from API.
+        Return previous value of stream."""
+        pass
+
+    @abstractmethod
+    def get_stream(self) -> bool:
+        """Get streaming status"""
+        pass
+
+    @abstractmethod
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        pass
+
+    @abstractmethod
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        pass
+
+    @abstractmethod
+    def chat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """
+        Get chat-completion response from LLM.
+
+        Args:
+            messages: message-history to send to the LLM
+            max_tokens: max tokens to generate
+            tools: tools available for the LLM to use in its response
+            tool_choice: tool call mode, one of "none", "auto", "required",
+                or a dict specifying a specific tool.
+            functions: functions available for LLM to call (deprecated)
+            function_call: function calling mode, "auto", "none", or a specific fn
+                    (deprecated)
+        """
+
+        pass
+
+    @abstractmethod
+    async def achat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """Async version of `chat`. See `chat` for details."""
+        pass
+
+    def __call__(self, prompt: str, max_tokens: int) -> LLMResponse:
+        return self.generate(prompt, max_tokens)
+
+    @staticmethod
+    def _fallback_model_names(model: str) -> List[str]:
+        parts = model.split("/")
+        fallbacks = []
+        for i in range(1, len(parts)):
+            fallbacks.append("/".join(parts[i:]))
+        return fallbacks
+
+    def info(self) -> ModelInfo:
+        """Info of relevant chat model"""
+        orig_model = (
+            self.config.completion_model
+            if self.config.use_completion_for_chat
+            else self.chat_model_orig
+        )
+        return get_model_info(orig_model, self._fallback_model_names(orig_model))
+
+    def completion_info(self) -> ModelInfo:
+        """Info of relevant completion model"""
+        orig_model = (
+            self.chat_model_orig
+            if self.config.use_chat_for_completion
+            else self.config.completion_model
+        )
+        return get_model_info(orig_model, self._fallback_model_names(orig_model))
+
+    def supports_functions_or_tools(self) -> bool:
+        """
+        Does this Model's API support "native" tool-calling, i.e.
+        can we call the API with arguments that contain a list of available tools,
+        and their schemas?
+        Note that, given the plethora of LLM provider APIs this determination is
+        imperfect at best, and leans towards returning True.
+        When the API calls fails with an error indicating tools are not supported,
+        then users are encouraged to use the Langroid-based prompt-based
+        ToolMessage mechanism, which works with ANY LLM. To enable this,
+        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
+        """
+        return self.info().has_tools
+
+    def chat_context_length(self) -> int:
+        return self.config.chat_context_length or DEFAULT_CONTEXT_LENGTH
+
+    def completion_context_length(self) -> int:
+        return self.config.completion_context_length or DEFAULT_CONTEXT_LENGTH
+
+    def chat_cost(self) -> Tuple[float, float, float]:
+        """
+        Return the cost per 1000 tokens for chat completions.
+
+        Returns:
+            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
+                per 1000 tokens
+        """
+        return (0.0, 0.0, 0.0)
+
+    def reset_usage_cost(self) -> None:
+        for mdl in [self.config.chat_model, self.config.completion_model]:
+            if mdl is None:
+                return
+            if mdl not in self.usage_cost_dict:
+                self.usage_cost_dict[mdl] = LLMTokenUsage()
+            counter = self.usage_cost_dict[mdl]
+            counter.reset()
+
+    def update_usage_cost(
+        self, chat: bool, prompts: int, completions: int, cost: float
+    ) -> None:
+        """
+        Update usage cost for this LLM.
+        Args:
+            chat (bool): whether to update for chat or completion model
+            prompts (int): number of tokens used for prompts
+            completions (int): number of tokens used for completions
+            cost (float): total token cost in USD
+        """
+        mdl = self.config.chat_model if chat else self.config.completion_model
+        if mdl is None:
+            return
+        if mdl not in self.usage_cost_dict:
+            self.usage_cost_dict[mdl] = LLMTokenUsage()
+        counter = self.usage_cost_dict[mdl]
+        counter.prompt_tokens += prompts
+        counter.completion_tokens += completions
+        counter.cost += cost
+        counter.calls += 1
+
+    @classmethod
+    def usage_cost_summary(cls) -> str:
+        s = ""
+        for model, counter in cls.usage_cost_dict.items():
+            s += f"{model}: {counter}\n"
+        return s
+
+    @classmethod
+    def tot_tokens_cost(cls) -> Tuple[int, float]:
+        """
+        Return total tokens used and total cost across all models.
+        """
+        total_tokens = 0
+        total_cost = 0.0
+        for counter in cls.usage_cost_dict.values():
+            total_tokens += counter.total_tokens
+            total_cost += counter.cost
+        return total_tokens, total_cost
+
+    def get_reasoning_final(self, message: str) -> Tuple[str, str]:
+        """Extract "reasoning" and "final answer" from an LLM response, if the
+        reasoning is found within configured delimiters, like <think>, </think>.
+        E.g.,
+        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
+
+        Args:
+            message (str): message from LLM
+
+        Returns:
+            Tuple[str, str]: reasoning, final answer
+        """
+        start, end = self.config.thought_delimiters
+        if start in message and end in message:
+            parts = message.split(start)
+            if len(parts) > 1:
+                reasoning, final = parts[1].split(end)
+                return reasoning, final
+        return "", message
+
+    def followup_to_standalone(
+        self, chat_history: List[Tuple[str, str]], question: str
+    ) -> str:
+        """
+        Given a chat history and a question, convert it to a standalone question.
+        Args:
+            chat_history: list of tuples of (question, answer)
+            query: follow-up question
+
+        Returns: standalone version of the question
+        """
+        history = collate_chat_history(chat_history)
+
+        prompt = f"""
+        You are an expert at understanding a CHAT HISTORY between an AI Assistant
+        and a User, and you are highly skilled in rephrasing the User's FOLLOW-UP
+        QUESTION/REQUEST as a STANDALONE QUESTION/REQUEST that can be understood
+        WITHOUT the context of the chat history.
+
+        Below is the CHAT HISTORY. When the User asks you to rephrase a
+        FOLLOW-UP QUESTION/REQUEST, your ONLY task is to simply return the
+        question REPHRASED as a STANDALONE QUESTION/REQUEST, without any additional
+        text or context.
+
+        <CHAT_HISTORY>
+        {history}
+        </CHAT_HISTORY>
+        """.strip()
+
+        follow_up_question = f"""
+        Please rephrase this as a stand-alone question or request:
+        <FOLLOW-UP-QUESTION-OR-REQUEST>
+        {question}
+        </FOLLOW-UP-QUESTION-OR-REQUEST>
+        """.strip()
+
+        show_if_debug(prompt, "FOLLOWUP->STANDALONE-PROMPT= ")
+        standalone = (
+            self.chat(
+                messages=[
+                    LLMMessage(role=Role.SYSTEM, content=prompt),
+                    LLMMessage(role=Role.USER, content=follow_up_question),
+                ],
+                max_tokens=1024,
+            ).message
+            or ""
+        )
+        standalone = standalone.strip()
+
+        show_if_debug(prompt, "FOLLOWUP->STANDALONE-RESPONSE= ")
+        return standalone
+
+
+class StreamingIfAllowed:
+    """Context to temporarily enable or disable streaming, if allowed globally via
+    `settings.stream`"""
+
+    def __init__(self, llm: LanguageModel, stream: bool = True):
+        self.llm = llm
+        self.stream = stream
+
+    def __enter__(self) -> None:
+        self.old_stream = self.llm.set_stream(settings.stream and self.stream)
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.llm.set_stream(self.old_stream)
+</file>
+
 <file path="langroid/parsing/parser.py">
 import logging
 import re
@@ -106519,2341 +107554,6 @@ def test_unresolvable_symlinks_are_skipped_without_aborting(
     make_bad(base)
 
     assert INSIDE in _all_text(loader(base))
-</file>
-
-<file path="tests/main/test_tool_messages.py">
-import itertools
-import json
-import random
-from typing import Any, List, Literal, Optional
-
-import pytest
-from pydantic import BaseModel, Field
-
-from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
-from langroid.agent.chat_document import ChatDocMetaData, ChatDocument
-from langroid.agent.task import Task
-from langroid.agent.tool_message import ToolMessage
-from langroid.agent.tools import DonePassTool, DoneTool
-from langroid.agent.tools.orchestration import (
-    AgentDoneTool,
-    FinalResultTool,
-    ResultTool,
-)
-from langroid.agent.xml_tool_message import XMLToolMessage
-from langroid.cachedb.redis_cachedb import RedisCacheConfig
-from langroid.language_models.base import (
-    LLMFunctionCall,
-    LLMFunctionSpec,
-    LLMMessage,
-    OpenAIJsonSchemaSpec,
-    OpenAIToolCall,
-    OpenAIToolSpec,
-    Role,
-)
-from langroid.language_models.mock_lm import MockLMConfig
-from langroid.language_models.openai_gpt import OpenAIGPTConfig
-from langroid.mytypes import Entity
-from langroid.parsing.parse_json import extract_top_level_json
-from langroid.parsing.parser import ParsingConfig
-from langroid.prompts.prompts_config import PromptsConfig
-from langroid.utils.configuration import Settings, set_global
-from langroid.utils.constants import DONE
-from langroid.utils.types import is_callable
-
-
-class CountryCapitalMessage(ToolMessage):
-    request: str = "country_capital"
-    purpose: str = "To check whether <city> is the capital of <country>."
-    country: str = "France"
-    city: str = "Paris"
-
-    @classmethod
-    def examples(cls) -> List["CountryCapitalMessage"]:
-        # illustrating two types of examples
-        return [
-            (
-                "Need to check if Paris is the capital of France",
-                cls(country="France", city="Paris"),
-            ),
-            cls(country="France", city="Marseille"),
-        ]
-
-
-class FileExistsMessage(ToolMessage):
-    request: str = "file_exists"
-    purpose: str = """
-    To check whether a certain <filename> is in the repo,
-    recursively if needed, as specified by <recurse>.
-    """
-    filename: str = Field(..., description="File name to check existence of")
-    recurse: bool = Field(..., description="Whether to recurse into subdirectories")
-
-    @classmethod
-    def examples(cls) -> List["FileExistsMessage"]:
-        return [
-            cls(filename="README.md", recurse=True),
-            cls(filename="Dockerfile", recurse=False),
-        ]
-
-
-class PythonVersionMessage(ToolMessage):
-    request: str = "python_version"
-    _handler: str = "tool_handler"
-    purpose: str = "To check which version of Python is needed."
-
-    @classmethod
-    def examples(cls) -> List["PythonVersionMessage"]:
-        return [
-            cls(),
-        ]
-
-
-class PresidentInfo(BaseModel):
-    name: str = Field(..., description="Name of the president")
-    elected: bool = Field(..., description="Whether the president is elected")
-
-
-class CountryInfo(BaseModel):
-    name: str = Field(..., description="Name of the country")
-    capital: str = Field(..., description="Capital city of the country")
-    president: PresidentInfo = Field(..., description="President of the country")
-
-
-class CountryPresidentTool(ToolMessage):
-    request: str = "country_president"
-    purpose: str = "To present info on a country and its president."
-
-    country_info: CountryInfo = Field(
-        ..., description="Information about the country and its president"
-    )
-    country_type: Literal["island", "landlocked", "coastal"] = Field(
-        ..., description="Type of the country, e.g. island, landlocked, coastal"
-    )
-
-    def handle(self) -> str:
-        # Return a simple sentence with all the info.
-        return (
-            f"{self.country_info.name} is a {self.country_type} country. "
-            f"The capital is {self.country_info.capital}. "
-            f"The president is {self.country_info.president.name} "
-            f"({'elected' if self.country_info.president.elected else 'not elected'})."
-        )
-
-
-DEFAULT_PY_VERSION = "3.9"
-
-
-class MessageHandlingAgent(ChatAgent):
-    def file_exists(self, message: FileExistsMessage) -> str:
-        return "yes" if message.filename == "requirements.txt" else "no"
-
-    def tool_handler(self, message: ToolMessage) -> str:
-        if message.request == "python_version":
-            return DEFAULT_PY_VERSION
-        else:
-            return "invalid tool name"
-
-    def country_capital(self, message: CountryCapitalMessage) -> str:
-        return (
-            "yes" if (message.city == "Paris" and message.country == "France") else "no"
-        )
-
-
-cfg = ChatAgentConfig(
-    name="test-langroid",
-    vecdb=None,
-    llm=OpenAIGPTConfig(
-        type="openai",
-        cache_config=RedisCacheConfig(fake=False),
-    ),
-    parsing=ParsingConfig(),
-    prompts=PromptsConfig(),
-    use_functions_api=False,
-    use_tools=True,
-    system_message="""
-    VERY IMPORTANT: IF you see a possibility of using a tool/function,
-    you MUST use it, and MUST NOT ASK IN NATURAL LANGUAGE.
-    """,
-)
-agent = MessageHandlingAgent(cfg)
-
-# Define the range of values each variable can have
-use_vals = [True, False]
-handle_vals = [True, False]
-force_vals = [True, False]
-message_classes = [None, FileExistsMessage, PythonVersionMessage]
-
-# Get the cartesian product
-cartesian_product = list(
-    itertools.product(message_classes, use_vals, handle_vals, force_vals)
-)
-
-agent.enable_message(FileExistsMessage)
-agent.enable_message(PythonVersionMessage)
-
-
-def test_tool_message_name():
-    assert FileExistsMessage.default_value("request") == FileExistsMessage.name()
-
-
-@pytest.mark.parametrize("msg_class", [None, FileExistsMessage, PythonVersionMessage])
-@pytest.mark.parametrize("use", [True, False])
-@pytest.mark.parametrize("handle", [True, False])
-@pytest.mark.parametrize("force", [True, False])
-def test_enable_message(
-    msg_class: Optional[ToolMessage], use: bool, handle: bool, force: bool
-):
-    agent.enable_message(msg_class, use=use, handle=handle, force=force)
-    usable_tools = agent.llm_tools_usable
-    tools = agent._get_tool_list(msg_class)
-    for tool in set(tools).intersection(usable_tools):
-        assert tool in agent.llm_tools_map
-        if msg_class is not None:
-            assert agent.llm_tools_map[tool] == msg_class
-            assert agent.llm_functions_map[tool] == msg_class.llm_function_schema()
-        assert (tool in agent.llm_tools_handled) == handle
-        assert (tool in agent.llm_tools_usable) == use
-        assert (tool in agent.llm_functions_handled) == handle
-        assert (tool in agent.llm_functions_usable) == use
-
-    if msg_class is not None:
-        assert (
-            agent.llm_function_force is not None
-            and agent.llm_function_force["name"] == tools[0]
-        ) == force
-
-
-@pytest.mark.parametrize("msg_class", [None, FileExistsMessage, PythonVersionMessage])
-def test_disable_message_handling(msg_class: Optional[ToolMessage]):
-    agent.enable_message([FileExistsMessage, PythonVersionMessage])
-    usable_tools = agent.llm_tools_usable.copy()
-
-    agent.disable_message_handling(msg_class)
-    tools = agent._get_tool_list(msg_class)
-    for tool in set(tools).intersection(usable_tools):
-        assert tool not in agent.llm_tools_handled
-        assert tool not in agent.llm_functions_handled
-        assert tool in agent.llm_tools_usable
-        assert tool in agent.llm_functions_usable
-
-
-@pytest.mark.parametrize("msg_class", [None, FileExistsMessage, PythonVersionMessage])
-def test_disable_message_use(msg_class: Optional[ToolMessage]):
-    agent.enable_message(FileExistsMessage)
-    agent.enable_message(PythonVersionMessage)
-    usable_tools = agent.llm_tools_usable.copy()
-
-    agent.disable_message_use(msg_class)
-    tools = agent._get_tool_list(msg_class)
-    for tool in set(tools).intersection(usable_tools):
-        assert tool not in agent.llm_tools_usable
-        assert tool not in agent.llm_functions_usable
-        assert tool in agent.llm_tools_handled
-        assert tool in agent.llm_functions_handled
-
-    # check that disabling tool-use works as expected:
-    # Tools part of sys msg should be updated, and
-    # LLM should not be able to use this tool
-    agent.disable_message_use(FileExistsMessage)
-    agent.disable_message_use(PythonVersionMessage)
-    response = agent.llm_response_forget("Is there a README.md file?")
-    assert agent.get_tool_messages(response) == []
-
-
-@pytest.mark.parametrize("msg_cls", [PythonVersionMessage, FileExistsMessage])
-def test_usage_instruction(msg_cls: ToolMessage):
-    usage = msg_cls.usage_examples()
-    jsons = extract_top_level_json(usage)
-    assert all(
-        json.loads(j)["request"] == msg_cls.default_value("request") for j in jsons
-    )
-
-
-NONE_MSG = "nothing to see here"
-
-FILE_EXISTS_MSG = """
-Ok, thank you.
-{
-"request": "file_exists",
-"filename": "test.txt",
-"recurse": true
-}
-Hope you can tell me!
-"""
-
-PYTHON_VERSION_MSG = """
-great, please tell me this --
-{
-"request": "python_version"
-}/if you know it
-"""
-
-
-def test_agent_handle_message():
-    """
-    Test whether messages are handled correctly, and that
-    message enabling/disabling works as expected.
-    """
-    agent.enable_message(FileExistsMessage)
-    agent.enable_message(PythonVersionMessage)
-    assert agent.handle_message(NONE_MSG) is None
-    assert agent.handle_message(FILE_EXISTS_MSG).content == "no"
-    assert agent.handle_message(PYTHON_VERSION_MSG).content == "3.9"
-
-    agent.disable_message_handling(FileExistsMessage)
-    assert agent.handle_message(FILE_EXISTS_MSG) is None
-    assert agent.handle_message(PYTHON_VERSION_MSG).content == "3.9"
-
-    agent.disable_message_handling(PythonVersionMessage)
-    assert agent.handle_message(FILE_EXISTS_MSG) is None
-    assert agent.handle_message(PYTHON_VERSION_MSG) is None
-
-    agent.enable_message(FileExistsMessage)
-    assert agent.handle_message(FILE_EXISTS_MSG).content == "no"
-    assert agent.handle_message(PYTHON_VERSION_MSG) is None
-
-    agent.enable_message(PythonVersionMessage)
-    assert agent.handle_message(FILE_EXISTS_MSG).content == "no"
-    assert agent.handle_message(PYTHON_VERSION_MSG).content == "3.9"
-
-
-BAD_FILE_EXISTS_MSG = """
-Ok, thank you.
-{
-"request": "file_exists"
-}
-Hope you can tell me!
-"""
-
-
-@pytest.mark.parametrize("as_string", [False, True])
-def test_handle_bad_tool_message(as_string: bool):
-    """
-    Test that a correct tool name with bad/missing args is
-            handled correctly, i.e. the agent returns a clear
-            error message to the LLM so it can try to fix it.
-
-    as_string: whether to pass the bad tool message as a string or as an LLM msg
-    """
-    agent.enable_message(FileExistsMessage)
-    assert agent.handle_message(NONE_MSG) is None
-    if as_string:
-        # set up a prior LLM-originated msg, to mock a scenario
-        # where the last msg was from LLM, prior to calling
-        # handle_message with the bad tool message -- we are trying to
-        # test that the error is raised correctly in this case
-        agent.llm_response("3+4=")
-        result = agent.handle_message(BAD_FILE_EXISTS_MSG)
-    else:
-        bad_tool_from_llm = agent.create_llm_response(BAD_FILE_EXISTS_MSG)
-        result = agent.handle_message(bad_tool_from_llm)
-    assert "file_exists" in result and "filename" in result and "required" in result
-
-
-@pytest.mark.parametrize("stream", [False, True])
-@pytest.mark.parametrize(
-    "use_functions_api",
-    [True, False],
-)
-@pytest.mark.parametrize(
-    "use_tools_api",
-    [True],  # ONLY test tools-api since OpenAI has deprecated functions-api
-)
-@pytest.mark.parametrize(
-    "message_class, prompt, result",
-    [
-        (
-            FileExistsMessage,
-            """
-            You have to find out whether the file 'requirements.txt' exists in the repo,
-            recursively exploring subdirectories if needed.
-            """,
-            "yes",
-        ),
-        (
-            PythonVersionMessage,
-            "Find out about the python version",
-            "3.9",
-        ),
-        (
-            CountryCapitalMessage,
-            "You have to check whether Paris is the capital of France",
-            "yes",
-        ),
-        (
-            CountryPresidentTool,  # test nested tool
-            """
-            Present this info about France and its president, in a structured format:
-            - Country: France
-            - Capital: Paris
-            - President: Emmanuel Macron (elected)
-            - Country Type: coastal
-            """,
-            "elected",
-        ),
-    ],
-)
-def test_llm_tool_message(
-    test_settings: Settings,
-    use_functions_api: bool,
-    use_tools_api: bool,
-    message_class: ToolMessage,
-    prompt: str,
-    result: str,
-    stream: bool,
-):
-    """
-    Test whether LLM is able to GENERATE message (tool) in required format, and the
-    agent handles the message correctly.
-    Args:
-        test_settings: test settings from conftest.py
-        use_functions_api: whether to use LLM's functions api or not
-            (i.e. use the langroid ToolMessage tools instead).
-        message_class: the message class (i.e. tool/function) to test
-        prompt: the prompt to use to induce the LLM to use the tool
-        result: the expected result from agent handling the tool-message
-    """
-    set_global(test_settings)
-    cfg.llm.stream = stream
-    agent = MessageHandlingAgent(cfg)
-    agent.config.use_functions_api = use_functions_api
-    agent.config.use_tools = not use_functions_api
-    agent.config.use_tools_api = use_tools_api
-
-    agent.enable_message(
-        [
-            FileExistsMessage,
-            PythonVersionMessage,
-            CountryCapitalMessage,
-            CountryPresidentTool,
-        ]
-    )
-
-    llm_msg = agent.llm_response_forget(prompt)
-    tool_name = message_class.name()
-    if use_functions_api:
-        if use_tools_api:
-            assert llm_msg.oai_tool_calls[0].function.name == tool_name
-        else:
-            assert llm_msg.function_call.name == tool_name
-
-    tools = agent.get_tool_messages(llm_msg)
-    assert len(tools) == 1
-    assert isinstance(tools[0], message_class)
-
-    agent_result = agent.handle_message(llm_msg).content
-
-    assert result.lower() in agent_result.lower()
-
-
-def test_llm_non_tool(test_settings: Settings):
-    """Having no tools enabled should result in a None handle_message result"""
-    agent = MessageHandlingAgent(cfg)
-    llm_msg = agent.llm_response_forget(
-        "Ask me to check what is the population of France."
-    ).content
-    agent_result = agent.handle_message(llm_msg)
-    assert agent_result is None
-
-
-# Test that malformed tool messages results in proper err msg
-class NumPair(BaseModel):
-    xval: int
-    yval: int
-
-
-class NabroskiTool(ToolMessage):
-    request: str = "nabroski"
-    purpose: str = "to request computing the Nabroski transform of <num_pair>"
-    num_pair: NumPair
-
-    def handle(self) -> str:
-        return str(3 * self.num_pair.xval + self.num_pair.yval)
-
-
-class CoriolisTool(ToolMessage):
-    """Tool for testing handling of optional arguments, with default values."""
-
-    request: str = "coriolis"
-    purpose: str = "to request computing the Coriolis transform of <cats> and <cows>"
-    cats: int
-    cows: int = 5
-
-    def handle(self) -> str:
-        # same as NabroskiTool result
-        return str(3 * self.cats + self.cows)
-
-
-wrong_nabroski_tool = """
-{
-"request": "nabroski",
-"num_pair": {
-    "xval": 1
-    }
-}
-"""
-
-
-@pytest.mark.parametrize("use_tools_api", [True])
-@pytest.mark.parametrize("use_functions_api", [True, False])
-@pytest.mark.parametrize("stream", [True, False])
-@pytest.mark.parametrize("strict_recovery", [True, False])
-@pytest.mark.parametrize("as_string", [True, False])
-def test_agent_malformed_tool(
-    test_settings: Settings,
-    use_tools_api: bool,
-    use_functions_api: bool,
-    stream: bool,
-    strict_recovery: bool,
-    as_string: bool,
-):
-    set_global(test_settings)
-    cfg = ChatAgentConfig(
-        use_tools=not use_functions_api,
-        use_functions_api=use_functions_api,
-        use_tools_api=use_tools_api,
-        strict_recovery=strict_recovery,
-    )
-    cfg.llm.stream = stream
-    agent = ChatAgent(cfg)
-    agent.enable_message(NabroskiTool)
-    if as_string:
-        # set up a prior LLM-originated msg, to mock a scenario
-        # where the last msg was from LLM, prior to calling
-        # handle_message with the bad tool message -- we are trying to
-        # test that the error is raised correctly in this case
-        agent.llm_response("3+4=")
-        response = agent.agent_response(wrong_nabroski_tool)
-    else:
-        bad_tool_from_llm = agent.create_llm_response(wrong_nabroski_tool)
-        response = agent.agent_response(bad_tool_from_llm)
-    # We expect an error msg containing certain specific field names
-    assert "num_pair" in response.content and "yval" in response.content
-
-
-class FruitPair(BaseModel):
-    pears: int
-    apples: int
-
-
-class EulerTool(ToolMessage):
-    request: str = "euler"
-    purpose: str = "to request computing the Euler transform of <fruit_pair>"
-    fruit_pair: FruitPair
-
-    def handle(self) -> str:
-        return str(2 * self.fruit_pair.pears - self.fruit_pair.apples)
-
-
-class BoilerTool(ToolMessage):
-    request: str = "boiler"
-    purpose: str = "to request computing the Boiler transform of <fruit_pair>"
-    fruit_pair: FruitPair
-
-    def handle(self) -> str:
-        return str(3 * self.fruit_pair.pears - 5 * self.fruit_pair.apples)
-
-
-class SumTool(ToolMessage):
-    request: str = "sum"
-    purpose: str = "to request computing the sum of <x> and <y>"
-    x: int
-    y: int
-
-    def handle(self) -> str:
-        return str(self.x + self.y)
-
-
-class GaussTool(ToolMessage):
-    request: str = "gauss"
-    purpose: str = "to request computing the Gauss transform of (<x>, <y>)"
-    xval: int
-    yval: int
-
-    def handle(self) -> str:
-        return str((self.xval + self.yval) * self.yval)
-
-
-class CoinFlipTool(ToolMessage):
-    request: str = "coin_flip"
-    purpose: str = "to request a random coin flip"
-
-    def handle(self) -> Literal["Heads", "Tails"]:
-        heads = random.random() > 0.5
-        return "Heads" if heads else "Tails"
-
-
-@pytest.mark.parametrize("use_tools_api", [True])
-@pytest.mark.parametrize("use_functions_api", [True, False])
-def test_agent_infer_tool(
-    test_settings: Settings,
-    use_functions_api: bool,
-    use_tools_api: bool,
-):
-    set_global(test_settings)
-    gauss_request = """{"xval": 1, "yval": 3}"""
-    boiler_or_euler_request = """{"fruit_pair": {"pears": 1, "apples": 3}}"""
-    euler_request = """{"request": "euler", "fruit_pair": {"pears": 1, "apples": 3}}"""
-    additional_args_request = """{"xval": 1, "yval": 3, "zval": 4}"""
-    additional_args_request_specified = """
-    {"request": "gauss", "xval": 1, "yval": 3, "zval": 4}
-    """
-    no_args_request = """{}"""
-    no_args_request_specified = """{"request": "coin_flip"}"""
-
-    cfg = ChatAgentConfig(
-        use_tools=not use_functions_api,
-        use_functions_api=use_functions_api,
-        use_tools_api=use_tools_api,
-    )
-    agent = ChatAgent(cfg)
-    agent.enable_message(
-        [
-            NabroskiTool,
-            GaussTool,
-            CoinFlipTool,
-            BoilerTool,
-        ]
-    )
-    agent.enable_message(EulerTool, handle=False)
-
-    # Boiler is the only option prior to enabling EulerTool handling
-    assert agent.agent_response(boiler_or_euler_request).content == "-12"
-
-    # Enable handling EulerTool, this makes nabrowski_or_euler_request ambiguous
-    agent.enable_message(EulerTool)
-    agent.enable_message(BoilerTool)
-
-    # Gauss is the only option
-    assert agent.agent_response(gauss_request).content == "12"
-
-    # Explicit requests are forwarded to the correct handler
-    assert agent.agent_response(euler_request).content == "-1"
-
-    # We cannot infer the correct tool if there exist multiple matches
-    assert agent.agent_response(boiler_or_euler_request) is None
-
-    # We do not infer tools where the request has additional arguments
-    assert agent.agent_response(additional_args_request) is None
-    # But additional args are acceptable when the tool is specified
-    assert agent.agent_response(additional_args_request_specified).content == "12"
-
-    # We do not infer tools with no args
-    assert agent.agent_response(no_args_request) is None
-    # Request must be specified
-    assert agent.agent_response(no_args_request_specified).content in ["Heads", "Tails"]
-
-
-@pytest.mark.parametrize("use_tools_api", [True])
-@pytest.mark.parametrize("use_functions_api", [True, False])
-def test_tool_no_llm_response(
-    test_settings: Settings,
-    use_functions_api: bool,
-    use_tools_api: bool,
-):
-    """Test that agent.llm_response does not respond to tool messages."""
-
-    set_global(test_settings)
-    cfg = ChatAgentConfig(
-        use_tools=not use_functions_api,
-        use_functions_api=use_functions_api,
-        use_tools_api=use_tools_api,
-    )
-    agent = ChatAgent(cfg)
-    agent.enable_message(NabroskiTool)
-    nabroski_tool = NabroskiTool(num_pair=NumPair(xval=1, yval=2)).to_json()
-    response = agent.llm_response(nabroski_tool)
-    assert response is None
-
-
-@pytest.mark.parametrize("stream", [True, False])
-@pytest.mark.parametrize("use_functions_api", [True, False])
-def test_tool_no_task(
-    test_settings: Settings,
-    use_functions_api: bool,
-    stream: bool,
-):
-    """Test tool handling without running task, i.e. directly using
-    agent.llm_response and agent.agent_response methods."""
-
-    set_global(test_settings)
-    cfg = ChatAgentConfig(
-        use_tools=not use_functions_api,
-        use_functions_api=use_functions_api,
-    )
-    cfg.llm.stream = stream
-    agent = ChatAgent(cfg)
-    agent.enable_message(NabroskiTool, use=True, handle=True)
-
-    response = agent.llm_response("What is Nabroski of 1 and 2?")
-    assert isinstance(agent.get_tool_messages(response)[0], NabroskiTool)
-    result = agent.agent_response(response)
-    assert result.content == "5"
-
-
-@pytest.mark.parametrize("use_tools_api", [True])
-@pytest.mark.parametrize("use_functions_api", [True, False])
-def test_tool_optional_args(
-    test_settings: Settings,
-    use_functions_api: bool,
-    use_tools_api: bool,
-):
-    """Test that ToolMessage where some args are optional (i.e. have default values)
-    works well, i.e. LLM is able to generate all args if needed, including optionals."""
-
-    set_global(test_settings)
-    cfg = ChatAgentConfig(
-        use_tools=not use_functions_api,
-        use_functions_api=use_functions_api,
-        use_tools_api=use_tools_api,
-    )
-    agent = ChatAgent(cfg)
-
-    agent.enable_message(CoriolisTool, use=True, handle=True)
-    response = agent.llm_response("What is the Coriolis transform of 1, 2?")
-    assert isinstance(agent.get_tool_messages(response)[0], CoriolisTool)
-    tool = agent.get_tool_messages(response)[0]
-    assert tool.cats == 1 and tool.cows == 2
-
-
-@pytest.mark.parametrize("tool", [NabroskiTool, CoriolisTool])
-@pytest.mark.parametrize("stream", [False, True])
-@pytest.mark.parametrize("use_tools_api", [True])
-@pytest.mark.parametrize("use_functions_api", [True, False])
-def test_llm_tool_task(
-    test_settings: Settings,
-    use_functions_api: bool,
-    use_tools_api: bool,
-    stream: bool,
-    tool: ToolMessage,
-):
-    """
-    Test "full life cycle" of tool, when using Task.run().
-
-    1. invoke LLM api with tool-spec
-    2. LLM generates tool
-    3. ChatAgent.agent_response handles tool, result added to ChatAgent msg history
-    5. invoke LLM api with tool result
-    """
-
-    set_global(test_settings)
-    llm_config = OpenAIGPTConfig(max_output_tokens=3_000, timeout=120)
-    cfg = ChatAgentConfig(
-        llm=llm_config,
-        use_tools=not use_functions_api,
-        use_functions_api=use_functions_api,
-        use_tools_api=use_tools_api,
-        system_message=f"""
-        You will be asked to compute a certain transform of two numbers,
-        using a tool/function-call that you have access to.
-        When you receive the answer from the tool, say {DONE} and show the answer.
-        DO NOT SAY {DONE} until you receive a specific result from the tool.
-        """,
-    )
-    agent = ChatAgent(cfg)
-    agent.enable_message(tool)
-    task = Task(agent, interactive=False)
-
-    request = tool.default_value("request")
-    result = task.run(f"What is the {request} transform of 3 and 5?")
-    assert "14" in result.content
-
-
-@pytest.mark.parametrize("stream", [False, True])
-@pytest.mark.parametrize("use_tools_api", [True])
-@pytest.mark.parametrize("use_functions_api", [True, False])
-def test_multi_tool(
-    test_settings: Settings,
-    use_functions_api: bool,
-    use_tools_api: bool,
-    stream: bool,
-):
-    """
-    Test "full life cycle" of tool, when using Task.run().
-
-    1. invoke LLM api with tool-spec
-    2. LLM generates tool
-    3. ChatAgent.agent_response handles tool, result added to ChatAgent msg history
-    5. invoke LLM api with tool result
-    """
-
-    set_global(test_settings)
-    cfg = ChatAgentConfig(
-        use_tools=not use_functions_api,
-        use_functions_api=use_functions_api,
-        use_tools_api=use_tools_api,
-        system_message=f"""
-        You will be asked to compute transforms of two numbers,
-        using tools/function-calls that you have access to.
-        When you are asked for MULTIPLE transforms, you MUST
-        use MULTIPLE tools/functions.
-        When you receive the answers from the tools, say {DONE} and show the answers.
-        """,
-    )
-    agent = ChatAgent(cfg)
-    agent.enable_message(NabroskiTool)
-    agent.enable_message(GaussTool)
-    task = Task(agent, interactive=False)
-
-    # First test without task; using individual methods
-    # ---
-
-    result = task.run(
-        """
-        Compute these:
-        (A) Nabroski transform of 3 and 5
-        (B) Gauss transform of 1 and 2
-        """
-    )
-    # Nabroski: 3*3 + 5 = 14
-    # Gauss: (1+2)*2 = 6
-    assert "14" in result.content and "6" in result.content
-
-
-@pytest.mark.parametrize("stream", [False, True])
-def test_oai_tool_choice(
-    test_settings: Settings,
-    stream: bool,
-):
-    """
-    Test tool_choice for OpenAI-like LLM APIs.
-    """
-
-    set_global(test_settings)
-    cfg = ChatAgentConfig(
-        use_tools=False,  # langroid tools
-        use_functions_api=True,  # openai tools/fns
-        use_tools_api=True,  # openai tools/fns
-        system_message=f"""
-        You will be asked to compute an operation or transform of two numbers,
-        either using your own knowledge, or
-        using a tool/function-call that you have access to.
-        When you have an answer, say {DONE} and show the answer.
-        """,
-    )
-    agent = ChatAgent(cfg)
-    agent.enable_message(SumTool)
-
-    chat_doc = agent.create_user_response("What is the sum of 3 and 5?")
-    chat_doc.oai_tool_choice = "auto"
-    response = agent.llm_response_forget(chat_doc)
-
-    # expect either SumTool or direct result without tool
-    assert "8" in response.content or isinstance(
-        agent.get_tool_messages(response)[0], SumTool
-    )
-
-    chat_doc = agent.create_user_response("What is the double of 5?")
-    chat_doc.oai_tool_choice = "none"
-    response = agent.llm_response_forget(chat_doc)
-    assert "10" in response.content
-
-    chat_doc = agent.create_user_response("What is the sum of 3 and 5?")
-    chat_doc.oai_tool_choice = "required"
-    response = agent.llm_response_forget(chat_doc)
-    assert isinstance(agent.get_tool_messages(response)[0], SumTool)
-
-    agent.enable_message(NabroskiTool, force=True)
-    response = agent.llm_response("What is the nabroski of 3 and 5?")
-    assert "nabroski" in response.content.lower() or isinstance(
-        agent.get_tool_messages(response)[0], NabroskiTool
-    )
-
-
-@pytest.mark.parametrize(
-    "result_type",
-    [
-        "final_tool",
-        "result_tool",
-        "agent_done",
-        "tool",
-        "int",
-        "list",
-        "dict",
-        "ChatDocument",
-        "pydantic",
-    ],
-)
-@pytest.mark.parametrize(
-    "tool_handler", ["notool", "handle", "response", "response_with_doc"]
-)
-def test_tool_handlers_and_results(result_type: str, tool_handler: str):
-    """Test various types of ToolMessage handlers, and check that they can
-    return arbitrary result types"""
-
-    class SpecialResult(BaseModel):
-        """To illustrating returning an arbitrary Pydantic object as a result"""
-
-        answer: int
-        details: str = "nothing"
-
-    def result_fn(x: int) -> Any:
-        match result_type:
-            case "int":
-                return x + 5
-            case "dict":
-                return {"answer": x + 5, "details": "something"}
-            case "list":
-                return [x + 5, x * 2]
-            case "ChatDocument":
-                return ChatDocument(
-                    content=str(x + 5),
-                    metadata=ChatDocMetaData(sender="Agent"),
-                )
-            case "pydantic":
-                return SpecialResult(answer=x + 5)
-            case "tool":
-                # return tool, to be handled by sub-task
-                return UberTool(x=x)
-            case "result_tool":
-                return ResultTool(answer=x + 5)
-            case "final_tool":
-                return FinalResultTool(
-                    special=SpecialResult(answer=x + 5),  # explicitly declared
-                    # arbitrary new fields that were not declared in the class...
-                    extra_special=SpecialResult(answer=x + 10),
-                    # ... does not need to be a Pydantic object
-                    arbitrary_obj=dict(answer=x + 15),
-                )
-            case "agent_done":
-                # pass on to parent, to handle with UberTool,
-                # which is NOT enabled for this agent
-                return AgentDoneTool(tools=[UberTool(x=x)])
-
-    class UberTool(ToolMessage):
-        request: str = "uber_tool"
-        purpose: str = "to request the 'uber' transform of a  number <x>"
-        x: int
-
-        def handle(self) -> Any:
-            return FinalResultTool(answer=self.x + 5)
-
-    class CoolToolWithHandle(ToolMessage):
-        request: str = "cool_tool"
-        purpose: str = "to request the 'cool' transform of a  number <x>"
-
-        x: int
-
-        def handle(self) -> Any:
-            return result_fn(self.x)
-
-    class MyAgent(ChatAgent):
-        def init_state(self) -> None:
-            super().init_state()
-            self.state: int = 100
-            self.sender: str = ""
-            self.llm_sent: bool = False
-
-        def llm_response(
-            self, message: Optional[str | ChatDocument] = None
-        ) -> Optional[ChatDocument]:
-            self.llm_sent = True
-            return super().llm_response(message)
-
-        def handle_message_fallback(
-            self, msg: str | ChatDocument
-        ) -> str | ChatDocument | None:
-            """Handle non-tool LLM response"""
-            if self.llm_sent:
-                x = int(msg.content)
-                return result_fn(x)
-
-    class CoolToolWithResponse(ToolMessage):
-        """To test that `response` handler works as expected,
-        and is able to read and modify agent state.
-        """
-
-        request: str = "cool_tool"
-        purpose: str = "to request the 'cool' transform of a  number <x>"
-
-        x: int
-
-        def response(self, agent: MyAgent) -> Any:
-            agent.state += 1
-            return result_fn(self.x)
-
-    class CoolToolWithResponseDoc(ToolMessage):
-        """
-        To test that `response` handler works as expected,
-        is able to read and modify agent state, and
-        when using a `chat_doc` argument, and is able to read values from it.
-        """
-
-        request: str = "cool_tool"
-        purpose: str = "to request the 'cool' transform of a  number <x>"
-
-        x: int
-
-        def response(self, agent: MyAgent, chat_doc: ChatDocument) -> Any:
-            agent.state += 1
-            agent.sender = chat_doc.metadata.sender
-            return result_fn(self.x)
-
-    match tool_handler:
-        case "handle":
-            tool_class = CoolToolWithHandle
-        case "response":
-            tool_class = CoolToolWithResponse
-        case "response_with_doc":
-            tool_class = CoolToolWithResponseDoc
-        case "notool":
-            tool_class = None
-
-    agent = MyAgent(
-        ChatAgentConfig(
-            name="Test",
-            # no need for a real LLM, use a mock
-            llm=MockLMConfig(
-                # mock LLM generating a CoolTool variant
-                response_fn=lambda x: (
-                    tool_class(x=int(x)).model_dump_json()
-                    if tool_class is not None
-                    else x
-                ),
-            ),
-        )
-    )
-    if tool_class is not None:
-        agent.enable_message(tool_class)
-
-    tool_result = result_type in ["final_tool", "agent_done", "tool", "result_tool"]
-    task = Task(
-        agent,
-        interactive=False,
-        # need to specify task done when result is not FinalResultTool
-        done_if_response=[] if tool_result else [Entity.AGENT],
-    )
-    result = task.run("3")
-    if tool_handler == "response":
-        assert agent.state == 101
-    if tool_handler == "response_with_doc":
-        assert agent.state == 101
-        assert agent.sender == "LLM"
-
-    if not tool_result:
-        # CoolTool handler returns a non-tool result containing 8, and
-        # we terminate task on agent_response, via done_if_response,
-        # so the result.content == 8
-        assert "8" in result.content
-    elif result_type == "result_tool":
-        # CoolTool handler/response returns a ResultTool containing answer == 8
-        tool = result.tool_messages[0]
-        assert isinstance(tool, ResultTool)
-        assert tool.answer == 8
-    else:
-        # When CoolTool handler returns a ToolMessage,
-        # test that it is handled correctly by sub-task or a parent.
-
-        another_agent = ChatAgent(
-            ChatAgentConfig(
-                name="Another",
-                llm=MockLMConfig(response_fn=lambda x: x),  # pass thru
-            )
-        )
-        another_agent.enable_message(UberTool)
-        another_task = Task(another_agent, interactive=False)
-        another_task.add_sub_task(task)
-        result = another_task.run("3")
-
-        if result_type == "final_tool":
-            # task's CoolTool handler returns FinalResultTool
-            # which short-circuits parent task and returns as a tool
-            # in tool_messages list of the final result
-            tool = result.tool_messages[0]
-            assert isinstance(tool, FinalResultTool)
-            assert isinstance(tool.special, SpecialResult)
-            assert tool.special.answer == 8
-            assert tool.extra_special.answer == 13
-            assert tool.arbitrary_obj["answer"] == 18
-        elif result_type == "agent_done":
-            # inner task's CoolTool handler returns a DoneTool containing
-            # UberTool, which is handled by the parent "another_agent"
-            # which returns a FinalResultTool containing answer == 8
-            tool = result.tool_messages[0]
-            assert isinstance(tool, FinalResultTool)
-            assert tool.answer == 8
-
-            # Now disable parent agent's handling of UberTool
-            another_agent.disable_message_handling(UberTool)
-            # another_task = Task(another_agent, interactive=False)
-            # another_task.add_sub_task(task)
-            result = another_task.run("3")
-            # parent task is unable to handle UberTool, so will stall and return None
-            assert result is None
-            another_agent.enable_message(UberTool)
-
-        elif result_type == "tool":
-            # inner Task CoolTool handler returns UberTool (with NO done signal),
-            # which it is unable to handle, so stalls and returns None,
-            # and so does parent another_task
-            assert result is None
-
-            # Now reverse it: make another_task a sub-task of task, and
-            # test handling UberTool returned by task handler, by sub-task another_task
-            another_task = Task(another_agent, interactive=False)
-            # task = Task(agent, interactive=False)
-            task.add_sub_task(another_task)
-            result = task.run("3")
-            tool = result.tool_messages[0]
-            assert isinstance(tool, FinalResultTool)
-            assert tool.answer == 8
-
-            another_agent.disable_message_handling(UberTool)
-            result = task.run("3")
-            # subtask stalls, parent stalls, returns None
-            assert result is None
-
-
-@pytest.mark.parametrize("llm_tool", ["pair", "final_tool"])
-@pytest.mark.parametrize("handler_result_type", ["agent_done", "final_tool"])
-@pytest.mark.parametrize("use_fn_api", [True, False])
-@pytest.mark.parametrize("use_tools_api", [True])
-def test_llm_end_with_tool(
-    handler_result_type: str,
-    llm_tool: str,
-    use_fn_api: bool,
-    use_tools_api: bool,
-):
-    """
-    Test that an LLM can directly or indirectly trigger task-end, and return a Tool as
-    result. There are 3 ways:
-    - case llm_tool == "final_tool":
-        LLM returns a Tool (llm_tool == "final_tool") derived from FinalResultTool,
-        with field(s) containing a structured Pydantic object -- in this case the task
-        ends immediately without any agent response handling the tool
-    - case llm_tool == "pair":
-        LLM returns a PairTool, which is handled by the agent, which returns either
-        - AgentDoneTool, with `tools` field set to [self], or
-        - FinalResultTool, with `result` field set to the PairTool
-    """
-
-    class Pair(BaseModel):
-        a: int
-        b: int
-
-    class PairTool(ToolMessage):
-        """Handle the LLM-generated tool, signal done or final-result and
-        return it as the result."""
-
-        request: str = "pair_tool"
-        purpose: str = "to return a <pair> of numbers"
-        pair: Pair
-
-        def handle(self) -> Any:
-            if handler_result_type == "final_tool":
-                # field name can be anything; `result` is just an example.
-                return FinalResultTool(result=self)
-            else:
-                return AgentDoneTool(tools=[self])
-
-    class FinalResultPairTool(FinalResultTool):
-        request: str = "final_result_pair_tool"
-        purpose: str = "Present final result <pair>"
-        pair: Pair
-        _allow_llm_use: bool = True
-
-    final_result_pair_tool_name = FinalResultPairTool.default_value("request")
-
-    class MyAgent(ChatAgent):
-        def init_state(self) -> None:
-            super().init_state()
-            self.numbers: List[int] = []
-
-        def user_response(
-            self,
-            msg: Optional[str | ChatDocument] = None,
-        ) -> Optional[ChatDocument]:
-            """Mock human user input: they start with 0, then increment by 1"""
-            last_num = self.numbers[-1] if self.numbers else 0
-            new_num = last_num + 1
-            self.numbers.append(new_num)
-            return self.create_user_response(content=str(new_num))
-
-    pair_tool_name = PairTool.default_value("request")
-
-    if llm_tool == "pair":
-        # LLM generates just PairTool , to be handled by its tool handler
-        system_message = f"""
-            Ask the user for their next number.
-            Once you have collected 2 distinct numbers, present these as a pair
-            using the TOOL: `{pair_tool_name}`.
-            """
-    else:
-        system_message = f"""
-            Ask the user for their next number.
-            Once you have collected 2 distinct numbers, present these as the
-            final result using the TOOL: `{final_result_pair_tool_name}`.
-        """
-
-    agent = MyAgent(
-        ChatAgentConfig(
-            name="MyAgent",
-            system_message=system_message,
-            use_functions_api=use_fn_api,
-            use_tools_api=use_tools_api,
-            use_tools=not use_fn_api,
-        )
-    )
-    if llm_tool == "pair":
-        agent.enable_message(PairTool)
-    else:
-        agent.enable_message(FinalResultPairTool)
-
-    # we are mocking user response, so need to set only_user_quits_root=False
-    # so that the done signal (AgentDoneTool or FinalResultTool) actually end the task.
-    task = Task(agent, interactive=True, only_user_quits_root=False)
-    result = task.run()
-    tool = result.tool_messages[0]
-    if llm_tool == "pair":
-        if handler_result_type == "final_tool":
-            assert isinstance(tool, FinalResultTool)
-            assert tool.result.pair.a == 1 and tool.result.pair.b == 2
-        else:
-            assert isinstance(tool, PairTool)
-            assert tool.pair.a == 1 and tool.pair.b == 2
-    else:
-        assert isinstance(tool, FinalResultPairTool)
-        assert tool.pair.a == 1 and tool.pair.b == 2
-
-
-def test_final_result_tool():
-    """Test that FinalResultTool can be returned by agent_response"""
-
-    class MyAgent(ChatAgent):
-        def agent_response(self, msg: str | ChatDocument) -> Any:
-            return FinalResultTool(answer="42")
-
-    agent = MyAgent(
-        ChatAgentConfig(
-            name="MyAgent",
-            llm=MockLMConfig(response_fn=lambda x: x),
-        )
-    )
-
-    task = Task(agent, interactive=False)[ToolMessage]
-    result = task.run("3")
-    assert isinstance(result, FinalResultTool)
-    assert result.answer == "42"
-
-
-@pytest.mark.parametrize("tool", ["none", "a", "aa", "b"])
-def test_agent_respond_only_tools(tool: str):
-    """
-    Test that we can have an agent that only responds to certain tools,
-    and no plain-text msgs, by setting ChatAgentConfig.respond_only_tools=True.
-    """
-
-    class ATool(ToolMessage):
-        request: str = "a_tool"
-        purpose: str = "to present a number <num>"
-        num: int
-
-        def handle(self) -> FinalResultTool:
-            return FinalResultTool(answer=self.num * 2)
-
-    class AATool(ToolMessage):
-        request: str = "aa_tool"
-        purpose: str = "to present a number <num>"
-        num: int
-
-        def handle(self) -> FinalResultTool:
-            return FinalResultTool(answer=self.num * 3)
-
-    class BTool(ToolMessage):
-        request: str = "b_tool"
-        purpose: str = "to present a number <num>"
-        num: int
-
-        def handle(self) -> FinalResultTool:
-            return FinalResultTool(answer=self.num * 4)
-
-    match tool:
-        case "a":
-            tool_class = ATool
-        case "aa":
-            tool_class = AATool
-        case "b":
-            tool_class = BTool
-        case "none":
-            tool_class = None
-
-    main_agent = ChatAgent(
-        ChatAgentConfig(
-            name="Main",
-            llm=MockLMConfig(
-                response_fn=lambda x: (
-                    tool_class(num=int(x)).model_dump_json()
-                    if tool_class is not None
-                    else x
-                ),
-            ),
-        )
-    )
-
-    if tool_class is not None:
-        main_agent.enable_message(tool_class, use=True, handle=False)
-
-    alice_agent = ChatAgent(
-        ChatAgentConfig(
-            name="Alice",
-            llm=MockLMConfig(response_fn=lambda x: x),
-            respond_tools_only=True,
-        )
-    )
-    alice_agent.enable_message([ATool, AATool], use=False, handle=True)
-
-    # class BobAgent(ChatAgent):
-    #     def handle_message_fallback(self, msg: str | ChatDocument) -> Any:
-    #         if isinstance(msg, str) or len(msg.tool_messages) == 0:
-    #             return AgentDoneTool(content="")
-
-    bob_agent = ChatAgent(
-        ChatAgentConfig(
-            name="Bob",
-            llm=MockLMConfig(response_fn=lambda x: x),
-            respond_tools_only=True,
-        )
-    )
-    bob_agent.enable_message([BTool], use=False, handle=True)
-
-    class FallbackAgent(ChatAgent):
-        def agent_response(self, msg: str | ChatDocument) -> Any:
-            return FinalResultTool(answer=int(msg.content) * 5)
-
-    fallback_agent = FallbackAgent(
-        ChatAgentConfig(
-            name="Fallback",
-            llm=None,
-        )
-    )
-    fallback_task = Task(fallback_agent, interactive=False)
-
-    main_task = Task(main_agent, interactive=False)[ToolMessage]
-    alice_task = Task(alice_agent, interactive=False)
-    bob_task = Task(bob_agent, interactive=False)
-
-    main_task.add_sub_task([alice_task, bob_task, fallback_task])
-    tool = main_task.run(3)
-
-    # Note: when Main generates a tool, task orchestrator will not allow
-    # Alice to respond at all when the tool is not handled by Alice,
-    # and similarly for Bob (this uses agent.has_only_unhandled_tools()).
-    # However when main generates a non-tool string,
-    # we want to ensure that the above handle_message_fallback methods
-    # effectively return a null msg (and not get into a stalled loop inside the agent),
-    # and is finally handled by the FallbackAgent
-    assert isinstance(tool, FinalResultTool)
-
-    match tool:
-        case "a":
-            assert tool.answer == "6"
-        case "aa":
-            assert tool.answer == "9"
-        case "b":
-            assert tool.answer == "12"
-        case "none":
-            assert tool.answer == "15"
-            assert alice_task.n_stalled_steps == 0
-            assert bob_task.n_stalled_steps == 0
-
-
-@pytest.mark.parametrize("use_fn_api", [True, False])
-@pytest.mark.parametrize("use_tools_api", [True])
-def test_structured_recovery(
-    test_settings: Settings,
-    use_fn_api: bool,
-    use_tools_api: bool,
-):
-    """
-    Test that structured fallback correctly recovers
-    from failed tool calls.
-    """
-    set_global(test_settings)
-
-    def simulate_failed_call(attempt: str | ChatDocument) -> str:
-        agent = ChatAgent(
-            ChatAgentConfig(
-                use_functions_api=use_fn_api,
-                use_tools_api=use_tools_api,
-                use_tools=not use_fn_api,
-                strict_recovery=True,
-                llm=OpenAIGPTConfig(
-                    supports_json_schema=True,
-                    supports_strict_tools=True,
-                ),
-            )
-        )
-        agent.enable_message(NabroskiTool)
-        agent.enable_message(CoriolisTool)
-        agent.enable_message(EulerTool)
-
-        agent.message_history = [
-            LLMMessage(
-                role=Role.SYSTEM,
-                content="You are a helpful assistant.",
-            ),
-            LLMMessage(
-                role=Role.USER,
-                content="""
-                Please give me an example of a Nabroski, Coriolis, or Euler call.
-                """,
-            ),
-            LLMMessage(
-                role=Role.ASSISTANT,
-                content=attempt if isinstance(attempt, str) else attempt.content,
-                tool_calls=None if isinstance(attempt, str) else attempt.oai_tool_calls,
-                function_call=(
-                    None if isinstance(attempt, str) else attempt.function_call
-                ),
-            ),
-        ]
-        if (
-            use_fn_api
-            and use_tools_api
-            and isinstance(attempt, ChatDocument)
-            and attempt.oai_tool_calls is not None
-        ):
-            # Inserting this since OpenAI API strictly requires a
-            # Role.TOOL msg immediately after an Assistant Tool call,
-            # before the next Assistant msg.
-            agent.message_history.extend(
-                [
-                    LLMMessage(
-                        role=Role.TOOL,
-                        tool_call_id=t.id,
-                        content="error",
-                    )
-                    for t in attempt.oai_tool_calls
-                ]
-            )
-
-        # Simulates bad tool attempt by the LLM
-        agent.handle_message(attempt)
-        assert agent.tool_error
-        response = agent.llm_response(
-            """
-            There was an error in your attempted tool/function call. Please correct it.
-            """
-        )
-        assert response is not None
-        result = agent.handle_message(response)
-        assert result is not None
-        if isinstance(result, ChatDocument):
-            return result.content
-
-        return result
-
-    def to_attempt(attempt: LLMFunctionCall) -> str | ChatDocument:
-        if not use_fn_api:
-            return json.dumps(
-                {
-                    "request": attempt.name,
-                    **(attempt.arguments or {}),
-                }
-            )
-
-        if use_tools_api:
-            return ChatDocument(
-                content="",
-                metadata=ChatDocMetaData(sender=Entity.LLM),
-                oai_tool_calls=[
-                    OpenAIToolCall(
-                        id="call-1234657",
-                        function=attempt,
-                    )
-                ],
-            )
-
-        return ChatDocument(
-            content="",
-            metadata=ChatDocMetaData(sender=Entity.LLM),
-            function_call=attempt,
-        )
-
-    # The name of the function is incorrect:
-    # The LLM should correct the request to "nabroski" in recovery
-    assert (
-        simulate_failed_call(
-            to_attempt(
-                LLMFunctionCall(
-                    name="__nabroski__",
-                    arguments={
-                        "xval": 1,
-                        "yval": 3,
-                    },
-                )
-            )
-        )
-        == "6"
-    )
-    # The LLM should correct the request to "nabroski" in recovery
-    assert (
-        simulate_failed_call(
-            to_attempt(
-                LLMFunctionCall(
-                    name="Nabroski-function",
-                    arguments={
-                        "xval": 2,
-                        "yval": 3,
-                    },
-                )
-            )
-        )
-        == "9"
-    )
-    # Strict fallback disables the default arguments, but the LLM
-    # should infer from context. In addition, the name of the
-    # function is incorrect (the LLM should infer "coriolis" in
-    # recovery) and the JSON output is malformed
-
-    # Note here we intentionally use "catss" as the arg to ensure that
-    # the tool-name inference doesn't work (see `maybe_parse` agent/base.py,
-    # there's a mechanism that infers the intended tool if the arguments are
-    # unambiguously for a specific tool) -- here since we use `catss` that
-    # mechanism fails, and we can do this test properly to focus on structured
-    # recovery. But `catss' is sufficiently similar to 'cats' that the
-    # intent-based recovery should work.
-    assert (
-        simulate_failed_call(
-            """
-        request ":coriolis"
-        arguments {"catss": 1} 
-        """
-        )
-        == "8"
-    )
-    # The LLM should correct the request to "coriolis" in recovery
-    # The LLM should infer the default argument from context
-    assert (
-        simulate_failed_call(
-            to_attempt(
-                LLMFunctionCall(
-                    name="Coriolis",
-                    arguments={
-                        "cats": 1,
-                    },
-                )
-            )
-        )
-        == "8"
-    )
-    # The LLM should infer "euler" in recovery
-    assert (
-        simulate_failed_call(
-            to_attempt(
-                LLMFunctionCall(
-                    name="EulerTool",
-                    arguments={
-                        "pears": 6,
-                        "apples": 4,
-                    },
-                )
-            )
-        )
-        == "8"
-    )
-
-
-@pytest.mark.parametrize("use_fn_api", [True, False])
-@pytest.mark.parametrize("use_tools_api", [True])
-@pytest.mark.parametrize("parallel_tool_calls", [True, False])
-def test_strict_fallback(
-    test_settings: Settings,
-    use_fn_api: bool,
-    use_tools_api: bool,
-    parallel_tool_calls: bool,
-):
-    """
-    Test that strict tool and structured output errors
-    are handled gracefully and are disabled if errors
-    are caused.
-    """
-    set_global(test_settings)
-
-    class BrokenStrictSchemaAgent(ChatAgent):
-        def _function_args(self) -> tuple[
-            Optional[List[LLMFunctionSpec]],
-            str | dict[str, str],
-            Optional[list[OpenAIToolSpec]],
-            Optional[dict[str, dict[str, str] | str]],
-            Optional[OpenAIJsonSchemaSpec],
-        ]:
-            """
-            Implements a broken version of the correct _function_args()
-            that ensures that the generated schemas are incompatible
-            with OpenAI's strict decoding implementation.
-
-            Specifically, removes the schema edits performed by
-            `format_schema_for_strict()` (e.g. setting "additionalProperties"
-            to False on all objects in the JSON schema).
-            """
-            functions, fun_call, tools, force_tool, output_format = (
-                super()._function_args()
-            )
-
-            # remove schema edits for strict
-            if tools is not None:
-                for t in tools:
-                    name = t.function.name
-                    t.function = self.llm_functions_map[name]
-
-            if self.output_format is not None and self._json_schema_available():
-                self.any_strict = True
-                if issubclass(self.output_format, ToolMessage) and not issubclass(
-                    self.output_format, XMLToolMessage
-                ):
-                    spec = self.output_format.llm_function_schema(
-                        request=True,
-                        defaults=self.config.output_format_include_defaults,
-                    )
-
-                    output_format = OpenAIJsonSchemaSpec(
-                        strict=True,
-                        function=spec,
-                    )
-                elif issubclass(self.output_format, BaseModel):
-                    param_spec = self.output_format.model_json_schema()
-
-                    output_format = OpenAIJsonSchemaSpec(
-                        strict=True,
-                        function=LLMFunctionSpec(
-                            name="json_output",
-                            description="Strict Json output format.",
-                            parameters=param_spec,
-                        ),
-                    )
-
-            return functions, fun_call, tools, force_tool, output_format
-
-    agent = BrokenStrictSchemaAgent(
-        ChatAgentConfig(
-            use_functions_api=use_fn_api,
-            use_tools_api=use_tools_api,
-            use_tools=not use_fn_api,
-            llm=OpenAIGPTConfig(
-                parallel_tool_calls=parallel_tool_calls,
-                supports_json_schema=True,
-                supports_strict_tools=True,
-            ),
-        )
-    )
-    agent.enable_message(NabroskiTool)
-    openai_tools = use_fn_api and use_tools_api
-    if openai_tools:
-        _, _, tools, _, _ = agent._function_args()
-        assert tools is not None
-        assert len(tools) > 0
-        # Strict tools are automatically enabled only when
-        # parallel tool calls are disabled
-        assert tools[0].strict == (not parallel_tool_calls)
-
-    response = agent.llm_response_forget(
-        """
-        What is the Nabroski transform of (1,3)? Use the
-        `nabroski` tool/function.
-        """
-    )
-    result = agent.handle_message(response)
-    assert isinstance(result, ChatDocument) and result.content == "6"
-    assert agent.disable_strict == (openai_tools and not parallel_tool_calls)
-
-    agent = BrokenStrictSchemaAgent(
-        ChatAgentConfig(
-            use_functions_api=use_fn_api,
-            use_tools_api=use_tools_api,
-            use_tools=not use_fn_api,
-            llm=OpenAIGPTConfig(
-                parallel_tool_calls=parallel_tool_calls,
-                supports_json_schema=True,
-                supports_strict_tools=True,
-            ),
-        )
-    )
-    structured_agent = agent[NabroskiTool]
-    response = structured_agent.llm_response_forget(
-        """
-        What is the Nabroski transform of (1,3)?
-        """
-    )
-    assert response is not None
-    assert structured_agent.disable_strict
-    assert not agent.disable_strict
-
-
-@pytest.mark.parametrize("use_fn_api", [True, False])
-@pytest.mark.parametrize("use_tools_api", [True])
-@pytest.mark.parametrize("parallel_tool_calls", [True, False])
-def test_strict_schema_mismatch(
-    use_fn_api: bool,
-    use_tools_api: bool,
-    parallel_tool_calls: bool,
-):
-    """
-    Test that validation errors triggered in strict result in disabled strict output.
-    """
-
-    def int_schema(request: str) -> dict[str, Any]:
-        return {
-            "type": "object",
-            "additionalProperties": False,
-            "properties": {
-                "x": {"type": "integer"},
-                "request": {"type": "string", "enum": [request]},
-            },
-            "required": ["x", "request"],
-        }
-
-    class WrongSchemaAgent(ChatAgent):
-        def _function_args(self) -> tuple[
-            Optional[List[LLMFunctionSpec]],
-            str | dict[str, str],
-            Optional[list[OpenAIToolSpec]],
-            Optional[dict[str, dict[str, str] | str]],
-            Optional[OpenAIJsonSchemaSpec],
-        ]:
-            """
-            Implements a broken version of the correct _function_args()
-            that replaces the output and all tool schemas with an
-            incorrect schema. Simulates mismatched schemas due to
-            schema edits.
-            """
-            functions, fun_call, tools, force_tool, output_format = (
-                super()._function_args()
-            )
-
-            # remove schema edits for strict
-            if tools is not None:
-                for t in tools:
-                    name = t.function.name
-                    t.function.parameters = int_schema(name)
-
-            if self.output_format is not None and self._json_schema_available():
-                output_format = OpenAIJsonSchemaSpec(
-                    strict=True,
-                    function=LLMFunctionSpec(
-                        name="json_output",
-                        description="Strict Json output format.",
-                        parameters=int_schema("json_output"),
-                    ),
-                )
-
-            return functions, fun_call, tools, force_tool, output_format
-
-    agent = WrongSchemaAgent(
-        ChatAgentConfig(
-            use_functions_api=use_fn_api,
-            use_tools_api=use_tools_api,
-            use_tools=not use_fn_api,
-            llm=OpenAIGPTConfig(
-                parallel_tool_calls=parallel_tool_calls,
-                supports_json_schema=True,
-                supports_strict_tools=True,
-            ),
-        )
-    )
-
-    class IntTool(ToolMessage):
-        request: str = "int_tool"
-        purpose: str = "To return an integer value"
-        x: int
-
-        def handle(self):
-            return self.x
-
-    class StrTool(ToolMessage):
-        request: str = "str_tool"
-        purpose: str = "To return an string value"
-        text: str
-
-        def handle(self):
-            return self.text
-
-    agent.enable_message(IntTool)
-    agent.enable_message(StrTool)
-    strict_openai_tools = use_fn_api and use_tools_api and not parallel_tool_calls
-    response = agent.llm_response_forget(
-        """
-        What is the smallest integer greater than pi? Use the
-        `int_tool` tool/function.
-        """
-    )
-    agent.handle_message(response)
-    assert "int_tool" not in agent.disable_strict_tools_set
-
-    agent.llm_response_forget(
-        """
-        Who is the president of France? Use the `str_tool` tool/function.
-        """
-    )
-    assert ("str_tool" in agent.disable_strict_tools_set) == strict_openai_tools
-
-    strict_agent = agent[IntTool]
-    strict_agent.llm_response_forget("What is the smallest integer greater than pi?")
-    assert not strict_agent.disable_strict
-
-    strict_agent = agent[StrTool]
-    strict_agent.llm_response_forget("Who is the president of France?")
-    assert strict_agent.disable_strict
-
-
-def test_reduce_raw_tool_result():
-    BIG_RESULT = "hello " * 50
-
-    class MyTool(ToolMessage):
-        request: str = "my_tool"
-        purpose: str = "to present a number <num>"
-        num: int
-        _max_result_tokens: int = 10
-        _max_retained_tokens: int = 2
-
-        def handle(self) -> str:
-            return BIG_RESULT
-
-    class MyAgent(ChatAgent):
-        def user_response(
-            self,
-            msg: Optional[str | ChatDocument] = None,
-        ) -> Optional[ChatDocument]:
-            """
-            Mock user_response method for testing
-            """
-            txt = msg if isinstance(msg, str) else msg.content
-            map = dict([("hello", "50"), ("3", "5")])
-            response = map.get(txt)
-            # return the increment of input number
-            return self.create_user_response(response)
-
-    # create dummy agent first, just to get small_result with truncation
-    agent = MyAgent(ChatAgentConfig())
-    # Handle ModelPrivateAttr for _max_result_tokens
-    max_result_tokens = MyTool._max_result_tokens
-    if hasattr(max_result_tokens, "default"):
-        max_result_tokens = max_result_tokens.default
-    small_result = agent._maybe_truncate_result(BIG_RESULT, max_result_tokens)
-
-    # now create the actual agent
-    agent = MyAgent(
-        ChatAgentConfig(
-            name="Test",
-            # no need for a real LLM, use a mock
-            llm=MockLMConfig(
-                response_dict={
-                    "1": MyTool(num=1).to_json(),
-                    small_result: "hello",
-                    "50": DoneTool(content="Finished").to_json(),
-                }
-            ),
-        )
-    )
-    agent.enable_message(MyTool)
-    task = Task(agent, interactive=True, only_user_quits_root=False)
-
-    result = task.run("1")
-    """
-    msg history:
-    
-    sys_msg
-    user: 1 -> 
-    LLM: MyTool(1) ->
-    agent: BIG_RESULT -> truncated to 10 tokens, as `small_result`
-    LLM: hello ->
-    user: 50 -> 
-    LLM: Done (Finished)
-    """
-    assert result.content == "Finished"
-    assert len(agent.message_history) == 7
-    tool_result = agent.message_history[3].content
-    # Handle ModelPrivateAttr for _max_retained_tokens
-    max_retained = MyTool._max_retained_tokens
-    if hasattr(max_retained, "default"):
-        max_retained = max_retained.default
-    assert "my_tool" in tool_result and str(max_retained) in tool_result
-
-
-def test_valid_structured_recovery():
-    """
-    Test that structured recovery is not triggered inappropriately
-    when agent response contains a JSON-like string.
-    """
-
-    class MyAgent(ChatAgent):
-        def agent_response(self, msg: str | ChatDocument) -> Any:
-            return "{'x': 1, 'y': 2}"
-
-    agent = MyAgent(
-        ChatAgentConfig(
-            llm=OpenAIGPTConfig(),
-            system_message="""Simply respond No for any input""",
-        )
-    )
-
-    # with no tool enabled
-    task = Task(agent, interactive=False)
-    result = task.run("3", turns=4)
-    # response-sequence: agent, llm, agent, llm -> done
-    assert "No" in result.content
-
-    # with a tool enabled
-    agent.enable_message(NabroskiTool)
-    task = Task(agent, interactive=False)
-    result = task.run("3", turns=4)
-    assert "No" in result.content
-
-
-@pytest.mark.parametrize(
-    "handle_no_tool",
-    [
-        None,
-        "user",
-        "done",
-        "are you finished?",
-        ResultTool(answer=42),
-        DonePassTool(),
-        lambda msg: AgentDoneTool(content=msg.content),
-    ],
-)
-def test_handle_llm_no_tool(handle_no_tool: Any):
-    """Verify that ChatAgentConfig.handle_llm_no_tool works as expected"""
-
-    def mock_llm_response(x: str) -> str:
-        match x:
-            case "1":
-                return SumTool(x=1, y=2).model_dump_json()
-            case "3":
-                return "4"
-            case "are you finished?":
-                return "DONE 5"
-
-    config = ChatAgentConfig(
-        handle_llm_no_tool=handle_no_tool,
-        llm=MockLMConfig(response_fn=mock_llm_response),
-    )
-    agent = ChatAgent(config)
-    agent.enable_message(SumTool)
-    task = Task(agent, interactive=False, default_human_response="q")
-    result = task.run("1")
-    if handle_no_tool is None:
-        # task gets stuck and returns None
-        assert result is None
-
-    if isinstance(handle_no_tool, str):
-        match handle_no_tool:
-            case "user":
-                # LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> User(4) -> q
-                assert result.content == "q"
-            case "done":
-                # LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> Done(4)
-                assert result.content == "4"
-            case "are you finished?":
-                # LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> LLM(DONE)
-                assert result.content == "5"
-
-    if isinstance(handle_no_tool, ResultTool):
-        # LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> ResultTool(4)
-        assert isinstance(result.tool_messages[0], ResultTool)
-        assert result.tool_messages[0].answer == 42
-    if is_callable(handle_no_tool):
-        # LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> AgentDoneTool(4) -> 4
-        assert result.content == "4"
-    if isinstance(handle_no_tool, DonePassTool):
-        # LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> DonePass
-        assert result.content == "4"
-
-
-class GetTimeTool(ToolMessage):
-    purpose: str = "Get current time"
-    request: str = "get_time"
-
-    def response(self, agent: ChatAgent) -> ChatDocument:
-        return agent.create_agent_response(
-            content=json.dumps(
-                {
-                    "time": "11:59:59",
-                    "date": "1999-12-31",
-                    "day_of_week": "Friday",
-                    "week_number": "52",
-                    "tzname": "America/New York",
-                }
-            ),
-            recipient=Entity.LLM,
-        )
-
-
-@pytest.mark.parametrize("use_fn_api", [True, False])
-@pytest.mark.parametrize("use_tools_api", [True])
-def test_strict_recovery_only_from_LLM(
-    use_fn_api: bool,
-    use_tools_api: bool,
-):
-    """
-    Test that structured fallback only occurs on messages
-    sent by the LLM.
-    """
-    was_tool_error = False
-
-    class TrackToolError(ChatAgent):
-        def llm_response(
-            self, message: Optional[str | ChatDocument] = None
-        ) -> Optional[ChatDocument]:
-            nonlocal was_tool_error
-            if self.tool_error:
-                was_tool_error = True
-            return super().llm_response(message)
-
-        async def llm_response_async(
-            self, message: Optional[str | ChatDocument] = None
-        ) -> Optional[ChatDocument]:
-            nonlocal was_tool_error
-            if self.tool_error:
-                was_tool_error = True
-            return await super().llm_response_async(message)
-
-    agent = TrackToolError(
-        ChatAgentConfig(
-            use_functions_api=use_fn_api,
-            use_tools_api=use_tools_api,
-            use_tools=not use_fn_api,
-            strict_recovery=True,
-            llm=OpenAIGPTConfig(
-                supports_json_schema=True,
-                supports_strict_tools=True,
-            ),
-            system_message="""
-            You are a helpful assistant.  Start by calling the
-            get_time tool. Then greet the user according to the time
-            of the day.
-            """,
-        )
-    )
-    agent.enable_message(GetTimeTool)
-    task = Task(agent, interactive=False)
-    task.run(turns=6)
-    assert not was_tool_error
-
-    agent.init_message_history()
-
-    content = json.dumps(
-        {
-            "time": "11:59:59",
-            "date": "1999-12-31",
-            "day_of_week": "Friday",
-            "week_number": "52",
-            "tzname": "America/New York",
-        }
-    )
-
-    agent.get_tool_messages(content)
-    assert not agent.tool_error
-
-    user_message = agent.create_user_response(content=content, recipient=Entity.LLM)
-    agent.get_tool_messages(user_message)
-    assert not agent.tool_error
-
-    agent_message = agent.create_agent_response(content=content, recipient=Entity.LLM)
-    agent.get_tool_messages(agent_message)
-    assert not agent.tool_error
-
-    agent.message_history.extend(ChatDocument.to_LLMMessage(agent_message))
-    agent.get_tool_messages(content)
-    assert not agent.tool_error
-
-    agent.message_history.extend(ChatDocument.to_LLMMessage(user_message))
-    agent.get_tool_messages(content)
-    assert not agent.tool_error
-
-
-@pytest.mark.parametrize("use_fn_api", [False, True])
-def test_tool_handler_invoking_llm(use_fn_api: bool):
-    """
-    Check that if a tool handler directly invokes llm_response,
-    it works as expected, especially with OpenAI Tools API
-    """
-
-    class MyAgent(ChatAgent):
-        def nabroski(self, msg: NabroskiTool):
-            ans = self.llm_response("What is 3+4?")
-            return AgentDoneTool(content=ans.content)
-
-    agent = MyAgent(
-        ChatAgentConfig(
-            use_functions_api=use_fn_api,
-            use_tools_api=use_fn_api,
-            use_tools=not use_fn_api,
-            handle_llm_no_tool=f"you FORGOT to use the tool `{NabroskiTool.name()}`",
-            system_message=f"""
-            When user asks you to compute the Nabroski transform of two numbers,
-            you MUST use the TOOL `{NabroskiTool.name()}` to do so, since you do NOT
-            know how to do it yourself.
-            """,
-        )
-    )
-    agent.enable_message(NabroskiTool)
-    task = Task(agent, interactive=False, single_round=False)
-    result = task.run(
-        f"""
-        Use the TOOL `{NabroskiTool.name()}` to compute the
-        Nabroski transform of 2 and 5.
-        """
-    )
-
-    assert "7" in result.content
-
-
-def test_enable_message_validates_arguments(test_settings: Settings):
-    """Test that enable_message raises TypeError when tool classes are passed
-    as separate arguments instead of as a list."""
-    set_global(test_settings)
-
-    class Tool1(ToolMessage):
-        request: str = "tool1"
-        purpose: str = "First tool"
-
-    class Tool2(ToolMessage):
-        request: str = "tool2"
-        purpose: str = "Second tool"
-
-    class Tool3(ToolMessage):
-        request: str = "tool3"
-        purpose: str = "Third tool"
-
-    agent = ChatAgent(
-        ChatAgentConfig(
-            llm=MockLMConfig(default_response="test"),
-        )
-    )
-
-    # This should raise TypeError because Tool2 is passed as 'use' parameter
-    with pytest.raises(TypeError, match="'use' parameter must be a boolean"):
-        agent.enable_message(Tool1, Tool2)  # type: ignore
-
-    # This should raise TypeError because Tool3 is passed as 'handle' parameter
-    with pytest.raises(TypeError, match="'handle' parameter must be a boolean"):
-        agent.enable_message(Tool1, True, Tool3)  # type: ignore
-
-    # This should work correctly - passing tools as a list
-    agent.enable_message([Tool1, Tool2, Tool3])
-    assert "tool1" in agent.llm_tools_usable
-    assert "tool2" in agent.llm_tools_usable
-    assert "tool3" in agent.llm_tools_usable
-
-
-def test_enable_message_rejects_distinct_classes_with_same_request() -> None:
-    """Different tool classes cannot silently replace the same request name."""
-
-    class FirstCollisionTool(ToolMessage):
-        request: str = "shared_request"
-        purpose: str = "First tool"
-
-    class SecondCollisionTool(ToolMessage):
-        request: str = "shared_request"
-        purpose: str = "Second tool"
-
-    class DerivedCollisionTool(FirstCollisionTool):
-        purpose: str = "Derived tool"
-
-    agent = ChatAgent(ChatAgentConfig(llm=None))
-    agent.enable_message(FirstCollisionTool)
-    agent.enable_message(FirstCollisionTool)
-
-    with pytest.raises(ValueError) as exc_info:
-        agent.enable_message(SecondCollisionTool)
-
-    message = str(exc_info.value)
-    assert "shared_request" in message
-    assert "FirstCollisionTool" in message
-    assert "SecondCollisionTool" in message
-    assert agent.llm_tools_map["shared_request"] is FirstCollisionTool
-
-    derived_agent = ChatAgent(ChatAgentConfig(llm=None))
-    derived_agent.enable_message(DerivedCollisionTool)
-    with pytest.raises(ValueError, match="shared_request"):
-        derived_agent.enable_message(FirstCollisionTool)
-    assert derived_agent.llm_tools_map["shared_request"] is DerivedCollisionTool
-
-    recipient_wrapper = FirstCollisionTool.require_recipient()
-
-    class DerivedRecipientCollisionTool(recipient_wrapper):  # type: ignore
-        purpose: str = "Derived recipient tool"
-
-    recipient_agent = ChatAgent(ChatAgentConfig(llm=None))
-    recipient_agent.enable_message(recipient_wrapper)
-    with pytest.raises(ValueError, match="shared_request"):
-        recipient_agent.enable_message(DerivedRecipientCollisionTool)
-    assert recipient_agent.llm_tools_map["shared_request"] is recipient_wrapper
-
-
-def test_enable_message_rejects_recipient_wrapper_subclass_origin() -> None:
-    """Recipient wrapping must preserve a subclass as a distinct tool origin."""
-
-    class OriginalTool(ToolMessage):
-        request: str = "recipient_collision"
-        purpose: str = "Original tool"
-
-    recipient_wrapper = OriginalTool.require_recipient()
-
-    class RecipientWrapperSubclass(recipient_wrapper):  # type: ignore
-        purpose: str = "Distinct recipient-wrapper subclass"
-
-    agent = ChatAgent(ChatAgentConfig(llm=None))
-    agent.enable_message(recipient_wrapper)
-
-    with pytest.raises(
-        ValueError,
-        match="Tool request name 'recipient_collision' is already registered",
-    ):
-        agent.enable_message(
-            RecipientWrapperSubclass,
-            require_recipient=True,
-        )
-
-    assert agent.llm_tools_map["recipient_collision"] is recipient_wrapper
-
-
-def test_any_tool_reenable_is_idempotent() -> None:
-    """Regenerated strict-recovery AnyTool must re-register without error.
-
-    `_get_any_tool_message()` builds a fresh class per call (its tool-union
-    varies with enabled tools), so two generations of "tool_or_function" are
-    distinct classes; the same-name registration guard must treat them as the
-    same logical tool (regression: SQLChatAgent strict recovery raised
-    "already registered to AnyTool; cannot register AnyTool").
-    """
-
-    class ToolA(ToolMessage):
-        request: str = "any_tool_idem_a"
-        purpose: str = "Tool A"
-
-    class ToolB(ToolMessage):
-        request: str = "any_tool_idem_b"
-        purpose: str = "Tool B"
-
-    agent = ChatAgent(ChatAgentConfig(llm=None))
-    agent.enable_message(ToolA)
-
-    any_tool_1 = agent._get_any_tool_message()
-    assert any_tool_1 is not None
-    agent.enable_message(any_tool_1, use=False, handle=True)
-
-    # enabling another tool changes the union => a distinct AnyTool class
-    agent.enable_message(ToolB)
-    any_tool_2 = agent._get_any_tool_message()
-    assert any_tool_2 is not None
-    assert any_tool_2 is not any_tool_1
-    agent.enable_message(any_tool_2, use=False, handle=True)  # must not raise
-
-    assert agent.llm_tools_map["tool_or_function"] is any_tool_2
-
-
-def test_multi_agent_tool_caching(test_settings: Settings):
-    """
-    Test that tool message caching is agent-specific.
-
-    When Agent A parses a ChatDocument and caches tool messages,
-    Agent B (with different tools) should NOT use A's cached results
-    and should re-parse the message with its own tool registry.
-    """
-    set_global(test_settings)
-
-    # Define two different tools
-    class ToolA(ToolMessage):
-        request: str = "tool_a"
-        purpose: str = "Tool for Agent A"
-        value: str = "a"
-
-    class ToolB(ToolMessage):
-        request: str = "tool_b"
-        purpose: str = "Tool for Agent B"
-        value: str = "b"
-
-    # Create two agents with different tool registries
-    agent_a = ChatAgent(
-        ChatAgentConfig(
-            name="AgentA",
-            llm=MockLMConfig(default_response="test"),
-        )
-    )
-    agent_a.enable_message(ToolA)
-
-    agent_b = ChatAgent(
-        ChatAgentConfig(
-            name="AgentB",
-            llm=MockLMConfig(default_response="test"),
-        )
-    )
-    agent_b.enable_message(ToolB)
-
-    # Create a ChatDocument containing ToolB (which only AgentB knows about)
-    tool_b_json = json.dumps({"request": "tool_b", "value": "test_value"})
-    chat_doc = ChatDocument(
-        content=tool_b_json,
-        metadata=ChatDocMetaData(
-            source=Entity.LLM,
-            sender=Entity.LLM,
-        ),
-    )
-
-    # Agent A parses - should find no tools it handles (ToolB is unknown to A)
-    tools_from_a = agent_a.get_tool_messages(chat_doc, all_tools=True)
-    assert len(tools_from_a) == 0
-
-    # Verify cache was set by Agent A
-    assert chat_doc.all_tool_messages is not None
-    assert chat_doc.all_tool_messages_agent_id == agent_a.id
-
-    # Agent B parses the SAME ChatDocument - should re-parse and find ToolB
-    # because the cache was set by a different agent
-    tools_from_b = agent_b.get_tool_messages(chat_doc, all_tools=True)
-    assert len(tools_from_b) == 1
-    assert tools_from_b[0].request == "tool_b"
-    assert tools_from_b[0].value == "test_value"
-
-    # Verify cache was updated by Agent B
-    assert chat_doc.all_tool_messages_agent_id == agent_b.id
-
-    # Agent B parsing again should use the cache (same agent)
-    tools_from_b_cached = agent_b.get_tool_messages(chat_doc, all_tools=True)
-    assert len(tools_from_b_cached) == 1
-    assert tools_from_b_cached[0].request == "tool_b"
-
-
-def test_nested_tool_message_schema_is_cleaned() -> None:
-    """A ToolMessage nested inside another ToolMessage lands in the schema's
-    ``$defs``, and must get the same cleanup the top-level tool gets: internal
-    fields (``purpose``, ``id``) and the ``exclude`` marker removed, and
-    ``request`` pinned to its constant via an ``enum``.
-
-    Regression guard for the Pydantic v1->v2 migration: v1 emitted nested-model
-    schemas under ``definitions`` while v2 uses ``$defs``. If the cleanup keys
-    off the wrong name it silently no-ops, leaking those internal fields (and an
-    unconstrained ``request``) into the schema sent to the LLM.
-    """
-
-    class Inner(ToolMessage):
-        request: str = "inner_tool"
-        purpose: str = "the inner purpose"
-        x: int
-
-    class Outer(ToolMessage):
-        request: str = "outer_tool"
-        purpose: str = "the outer purpose"
-        inner: Inner
-
-    params = Outer.llm_function_schema(request=True).parameters
-    assert "$defs" in params
-    inner_schema = params["$defs"]["Inner"]
-
-    # internal markers/fields must not leak to the LLM
-    assert "exclude" not in inner_schema
-    assert "purpose" not in inner_schema["properties"]
-    assert "id" not in inner_schema["properties"]
-
-    # `request` is pinned to its constant and required
-    assert inner_schema["properties"]["request"] == {
-        "type": "string",
-        "enum": ["inner_tool"],
-    }
-    assert "request" in inner_schema["required"]
 </file>
 
 <file path="tests/main/test_vector_stores.py">
@@ -115167,886 +113867,6 @@ LLMMessage.model_rebuild()
 ChatDocMetaData.model_rebuild()
 </file>
 
-<file path="langroid/language_models/base.py">
-import json
-import logging
-from abc import ABC, abstractmethod
-from datetime import datetime, timezone
-from enum import Enum
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
-
-from pydantic import BaseModel, Field
-from pydantic_settings import BaseSettings
-
-from langroid.cachedb.base import CacheDBConfig
-from langroid.cachedb.redis_cachedb import RedisCacheConfig
-from langroid.language_models.model_info import ModelInfo, get_model_info
-from langroid.parsing.agent_chats import parse_message
-from langroid.parsing.file_attachment import FileAttachment
-from langroid.parsing.parse_json import parse_imperfect_json, top_level_json_field
-from langroid.prompts.dialog import collate_chat_history
-from langroid.utils.configuration import settings
-from langroid.utils.output.printing import show_if_debug
-
-logger = logging.getLogger(__name__)
-
-
-def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
-    pass
-
-
-async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
-    pass
-
-
-FunctionCallTypes = Literal["none", "auto"]
-ToolChoiceTypes = Literal["none", "auto", "required"]
-ToolTypes = Literal["function"]
-
-DEFAULT_CONTEXT_LENGTH = 16_000
-
-
-class StreamEventType(Enum):
-    TEXT = 1
-    FUNC_NAME = 2
-    FUNC_ARGS = 3
-    TOOL_NAME = 4
-    TOOL_ARGS = 5
-    REASONING = 6
-
-
-class RetryParams(BaseSettings):
-    max_retries: int = 5
-    initial_delay: float = 1.0
-    exponential_base: float = 1.3
-    jitter: bool = True
-
-
-class LLMConfig(BaseSettings):
-    """
-    Common configuration for all language models.
-    """
-
-    type: str = "openai"
-    streamer: Optional[Callable[[Any], None]] = noop_fn
-    streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
-    api_base: str | None = None
-    formatter: None | str = None
-    # specify None if you want to use the full max output tokens of the model
-    max_output_tokens: int | None = 8192
-    timeout: int = 20  # timeout for API requests
-    chat_model: str = ""
-    completion_model: str = ""
-    temperature: float = 0.0
-    chat_context_length: int | None = None
-    async_stream_quiet: bool = False  # suppress streaming output in async mode?
-    completion_context_length: int | None = None
-    # if input length + max_output_tokens > context length of model,
-    # we will try shortening requested output
-    min_output_tokens: int = 64
-    use_completion_for_chat: bool = False  # use completion model for chat?
-    # use chat model for completion? For OpenAI models, this MUST be set to True!
-    use_chat_for_completion: bool = True
-    stream: bool = True  # stream output from API?
-    # TODO: we could have a `stream_reasoning` flag here to control whether to show
-    # reasoning output from reasoning models
-    cache_config: None | CacheDBConfig = RedisCacheConfig()
-    thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
-    retry_params: RetryParams = RetryParams()
-
-    @property
-    def model_max_output_tokens(self) -> int:
-        if self.max_output_tokens:
-            return self.max_output_tokens
-        # Build fallback names by progressively stripping provider prefixes
-        # (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
-        # succeeds even before OpenAIGPT.__init__ strips the prefix.
-        parts = self.chat_model.split("/")
-        fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
-        return get_model_info(self.chat_model, fallbacks).max_output_tokens
-
-
-class LLMFunctionCall(BaseModel):
-    """
-    Structure of LLM response indicating it "wants" to call a function.
-    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
-    """
-
-    name: str  # name of function to call
-    arguments: Optional[Dict[str, Any]] = None
-
-    @staticmethod
-    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall":
-        """
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-        fun_call = LLMFunctionCall(name=message["name"])
-        fun_args_str = message["arguments"]
-        # sometimes may be malformed with invalid indents,
-        # so we try to be safe by removing newlines.
-        if fun_args_str is not None:
-            fun_args_str = fun_args_str.replace("\n", "").strip()
-            dict_or_list = parse_imperfect_json(fun_args_str)
-
-            if not isinstance(dict_or_list, dict):
-                raise ValueError(
-                    f"""
-                        Invalid function args: {fun_args_str}
-                        parsed as {dict_or_list},
-                        which is not a valid dict.
-                        """
-                )
-            fun_args = dict_or_list
-        else:
-            fun_args = None
-        fun_call.arguments = fun_args
-
-        return fun_call
-
-    def __str__(self) -> str:
-        return "FUNC: " + json.dumps(self.model_dump(), indent=2)
-
-
-class LLMFunctionSpec(BaseModel):
-    """
-    Description of a function available for the LLM to use.
-    To be used when calling the LLM `chat()` method with the `functions` parameter.
-    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
-    """
-
-    name: str
-    description: str
-    parameters: Dict[str, Any]
-
-
-class OpenAIToolCall(BaseModel):
-    """
-    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
-    See https://platform.openai.com/docs/api-reference/chat/create
-
-    Attributes:
-        id: The id of the tool call.
-        type: The type of the tool call;
-            only "function" is currently possible (7/26/24).
-        function: The function call.
-    """
-
-    id: str | None = None
-    type: ToolTypes = "function"
-    function: LLMFunctionCall | None = None
-    extra_content: Dict[str, Any] | None = None
-
-    @staticmethod
-    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall":
-        """
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-        id = message["id"]
-        type = message["type"]
-        function = LLMFunctionCall.from_dict(message["function"])
-        extra_content = message.get("extra_content")
-        return OpenAIToolCall(
-            id=id, type=type, function=function, extra_content=extra_content
-        )
-
-    def __str__(self) -> str:
-        if self.function is None:
-            return ""
-        return "OAI-TOOL: " + json.dumps(self.function.model_dump(), indent=2)
-
-
-class OpenAIToolSpec(BaseModel):
-    type: ToolTypes
-    strict: Optional[bool] = None
-    function: LLMFunctionSpec
-
-
-class OpenAIJsonSchemaSpec(BaseModel):
-    strict: Optional[bool] = None
-    function: LLMFunctionSpec
-
-    def to_dict(self) -> Dict[str, Any]:
-        json_schema: Dict[str, Any] = {
-            "name": self.function.name,
-            "description": self.function.description,
-            "schema": self.function.parameters,
-        }
-        if self.strict is not None:
-            json_schema["strict"] = self.strict
-
-        return {
-            "type": "json_schema",
-            "json_schema": json_schema,
-        }
-
-
-class LLMTokenUsage(BaseModel):
-    """
-    Usage of tokens by an LLM.
-    """
-
-    prompt_tokens: int = 0
-    cached_tokens: int = 0
-    completion_tokens: int = 0
-    cost: float = 0.0
-    calls: int = 0  # how many API calls - not used as of 2025-04-04
-
-    def reset(self) -> None:
-        self.prompt_tokens = 0
-        self.cached_tokens = 0
-        self.completion_tokens = 0
-        self.cost = 0.0
-        self.calls = 0
-
-    def __str__(self) -> str:
-        return (
-            f"Tokens = "
-            f"(prompt {self.prompt_tokens}, cached {self.cached_tokens}, "
-            f"completion {self.completion_tokens}), "
-            f"Cost={self.cost}, Calls={self.calls}"
-        )
-
-    @property
-    def total_tokens(self) -> int:
-        return self.prompt_tokens + self.completion_tokens
-
-
-class Role(str, Enum):
-    """
-    Possible roles for a message in a chat.
-    """
-
-    USER = "user"
-    SYSTEM = "system"
-    ASSISTANT = "assistant"
-    FUNCTION = "function"
-    TOOL = "tool"
-
-
-class LLMMessage(BaseModel):
-    """
-    Class representing an entry in the msg-history sent to the LLM API.
-    It could be one of these:
-    - a user message
-    - an LLM ("Assistant") response
-    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
-    - a result or results from executing a fn or tool-call(s)
-    """
-
-    role: Role
-    name: Optional[str] = None
-    tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
-    tool_id: str = ""  # used by OpenAIAssistant
-    # None means "no content" (the model returned only a tool/function call).
-    # This is distinct from "" and is dropped from the API payload by api_dict;
-    # see api_dict for how a fully-empty message is handled per-API.
-    content: Optional[str] = None
-    files: List[FileAttachment] = []
-    function_call: Optional[LLMFunctionCall] = None
-    tool_calls: Optional[List[OpenAIToolCall]] = None
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    # link to corresponding chat document, for provenance/rewind purposes
-    chat_document_id: str = ""
-
-    def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]:
-        """
-        Convert to dictionary for API request, keeping ONLY
-        the fields that are expected in an API call!
-        E.g., DROP the tool_id, since it is only for use in the Assistant API,
-            not the completion API.
-
-        Args:
-            has_system_role: whether the message has a system role (if not,
-                set to "user" role)
-        Returns:
-            dict: dictionary representation of LLM message
-        """
-        d = self.model_dump()
-        files: List[FileAttachment] = d.pop("files")
-        if len(files) > 0 and self.role == Role.USER:
-            # In there are files, then content is an array of
-            # different content-parts
-            d["content"] = [
-                dict(
-                    type="text",
-                    text=self.content or "",
-                )
-            ] + [f.to_dict(model) for f in self.files]
-
-        # if there is a key k = "role" with value "system", change to "user"
-        # in case has_system_role is False
-        if not has_system_role and "role" in d and d["role"] == "system":
-            d["role"] = "user"
-            if d.get("content"):
-                d["content"] = "[ADDITIONAL SYSTEM MESSAGE:]\n\n" + d["content"]
-        # drop None values since API doesn't accept them (this omits `content`
-        # entirely when it is None, i.e. "no content")
-        dict_no_none = {k: v for k, v in d.items() if v is not None}
-        if "name" in dict_no_none and dict_no_none["name"] == "":
-            # OpenAI API does not like empty name
-            del dict_no_none["name"]
-        if "function_call" in dict_no_none:
-            # arguments must be a string
-            if "arguments" in dict_no_none["function_call"]:
-                dict_no_none["function_call"]["arguments"] = json.dumps(
-                    dict_no_none["function_call"]["arguments"]
-                )
-        if dict_no_none.get("tool_calls"):
-            # convert tool calls to API format
-            for tc in dict_no_none["tool_calls"]:
-                if "arguments" in tc["function"]:
-                    # arguments must be a string
-                    if tc["function"]["arguments"] is None:
-                        tc["function"]["arguments"] = "{}"
-                    else:
-                        tc["function"]["arguments"] = json.dumps(
-                            tc["function"]["arguments"]
-                        )
-                if "extra_content" in tc and tc["extra_content"] is None:
-                    del tc["extra_content"]
-        else:
-            # An empty tool-call list is not a call and conveys no useful API
-            # information. Omitting it also lets the empty-message fallback
-            # below produce a valid message.
-            dict_no_none.pop("tool_calls", None)
-        # A message with empty content (None was dropped above, or "") AND no
-        # tool/function call would be an entirely empty message, which some APIs
-        # (e.g. Gemini) reject; fall back to a single space in that case only.
-        # When there IS a tool/function call, empty content is fine (and Gemini
-        # 3.x in fact REQUIRES it — it rejects an assistant turn that carries
-        # both a call and non-empty text content).
-        has_call = bool(dict_no_none.get("tool_calls")) or (
-            dict_no_none.get("function_call") is not None
-        )
-        if not has_call and not dict_no_none.get("content"):
-            dict_no_none["content"] = " "
-        # IMPORTANT! drop fields that are not expected in API call
-        dict_no_none.pop("tool_id", None)
-        dict_no_none.pop("timestamp", None)
-        dict_no_none.pop("chat_document_id", None)
-        return dict_no_none
-
-    def __str__(self) -> str:
-        if self.function_call is not None:
-            content = "FUNC: " + json.dumps(self.function_call)
-        else:
-            content = self.content or ""
-        name_str = f" ({self.name})" if self.name else ""
-        return f"{self.role} {name_str}: {content}"
-
-
-class LLMResponse(BaseModel):
-    """
-    Class representing response from LLM.
-    """
-
-    # None means the model returned NO content (e.g. only a tool/function
-    # call), which is distinct from an empty string "". Preserving this
-    # distinction lets the message be faithfully reproduced downstream
-    # (see ChatDocument.content_is_none and LLMMessage.content).
-    message: Optional[str] = None
-    reasoning: str = ""  # optional reasoning text from reasoning models
-    # Original message text including inline thought signatures (e.g.
-    # <thinking>...</thinking>). Only set when reasoning was extracted
-    # from the message text via get_reasoning_final(); NOT set when
-    # reasoning comes from a separate API field (e.g. reasoning_content),
-    # since in that case the message text never contained thought tags.
-    message_with_reasoning: Optional[str] = None
-    # TODO tool_id needs to generalize to multi-tool calls
-    tool_id: str = ""  # used by OpenAIAssistant
-    oai_tool_calls: Optional[List[OpenAIToolCall]] = None
-    function_call: Optional[LLMFunctionCall] = None
-    usage: Optional[LLMTokenUsage] = None
-    cached: bool = False
-
-    def __str__(self) -> str:
-        if self.function_call is not None:
-            return str(self.function_call)
-        elif self.oai_tool_calls:
-            return "\n".join(str(tc) for tc in self.oai_tool_calls)
-        else:
-            return self.message or ""
-
-    def tools_content(self) -> str:
-        if self.function_call is not None:
-            return str(self.function_call)
-        elif self.oai_tool_calls:
-            return "\n".join(str(tc) for tc in self.oai_tool_calls)
-        else:
-            return ""
-
-    def to_LLMMessage(self) -> LLMMessage:
-        """Convert LLM response to an LLMMessage, to be included in the
-        message-list sent to the API.
-        This is currently NOT used in any significant way in the library, and is only
-        provided as a utility to construct a message list for the API when directly
-        working with an LLM object.
-
-        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
-        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
-        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
-        """
-        return LLMMessage(
-            role=Role.ASSISTANT,
-            content=self.message,
-            name=None if self.function_call is None else self.function_call.name,
-            function_call=self.function_call,
-            tool_calls=self.oai_tool_calls,
-        )
-
-    def get_recipient_and_message(
-        self,
-        recognize_recipient_in_content: bool = True,
-    ) -> Tuple[str, str]:
-        """
-        If `message` or `function_call` of an LLM response contains an explicit
-        recipient name, return this recipient name and `message` stripped
-        of the recipient name if specified.
-
-        Two cases:
-        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
-        (b) `message` is empty and function_call/tool_call with explicit `recipient`
-
-        Args:
-            recognize_recipient_in_content (bool): When True (default), parses
-                message text for ``TO[<recipient>]:<content>`` patterns and
-                top-level JSON ``{"recipient": "..."}`` fields. When False,
-                only function_call/tool_call ``recipient`` fields are checked.
-
-        Returns:
-            (str): name of recipient, which may be empty string if no recipient
-            (str): content of message
-
-        """
-
-        if self.function_call is not None:
-            # in this case we ignore message, since all information is in function_call
-            msg = ""
-            args = self.function_call.arguments
-            recipient = ""
-            if isinstance(args, dict):
-                recipient = args.get("recipient", "")
-            return recipient, msg
-        else:
-            msg = self.message or ""
-            if self.oai_tool_calls is not None:
-                # get the first tool that has a recipient field, if any
-                for tc in self.oai_tool_calls:
-                    if tc.function is not None and tc.function.arguments is not None:
-                        recipient = tc.function.arguments.get(
-                            "recipient"
-                        )  # type: ignore
-                        if recipient is not None and recipient != "":
-                            return recipient, ""
-
-        if not recognize_recipient_in_content:
-            return "", msg
-
-        # It's not a function or tool call, so continue looking to see
-        # if a recipient is specified in the message.
-
-        # First check if message contains "TO: <recipient> <content>"
-        recipient_name, content = parse_message(msg) if msg is not None else ("", "")
-        # check if there is a top level json that specifies 'recipient',
-        # and retain the entire message as content.
-        if recipient_name == "":
-            recipient_name = top_level_json_field(msg, "recipient") if msg else ""
-            content = msg
-        return recipient_name, content
-
-
-# Define an abstract base class for language models
-class LanguageModel(ABC):
-    """
-    Abstract base class for language models.
-    """
-
-    # usage cost by model, accumulates here
-    usage_cost_dict: Dict[str, LLMTokenUsage] = {}
-
-    def __init__(self, config: LLMConfig = LLMConfig()):
-        self.config = config
-        self.chat_model_orig = config.chat_model
-
-    @staticmethod
-    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]:
-        """
-        Create a language model.
-        Args:
-            config: configuration for language model
-        Returns: instance of language model
-        """
-        if type(config) is LLMConfig:
-            raise ValueError(
-                """
-                Cannot create a Language Model object from LLMConfig.
-                Please specify a specific subclass of LLMConfig e.g.,
-                OpenAIGPTConfig. If you are creating a ChatAgent from
-                a ChatAgentConfig, please specify the `llm` field of this config
-                as a specific subclass of LLMConfig, e.g., OpenAIGPTConfig.
-                """
-            )
-        from langroid.language_models.azure_openai import AzureGPT
-        from langroid.language_models.mock_lm import MockLM, MockLMConfig
-        from langroid.language_models.openai_gpt import OpenAIGPT
-
-        if config is None or config.type is None:
-            return None
-
-        if config.type == "mock":
-            return MockLM(cast(MockLMConfig, config))
-
-        openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
-
-        if config.type == "azure":
-            openai = AzureGPT
-        else:
-            openai = OpenAIGPT
-        cls = dict(
-            openai=openai,
-        ).get(config.type, openai)
-        return cls(config)  # type: ignore
-
-    @staticmethod
-    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]:
-        """
-        Given an even-length sequence of strings, split into a sequence of pairs
-
-        Args:
-            lst (List[str]): sequence of strings
-
-        Returns:
-            List[Tuple[str,str]]: sequence of pairs of strings
-        """
-        evens = lst[::2]
-        odds = lst[1::2]
-        return list(zip(evens, odds))
-
-    @staticmethod
-    def get_chat_history_components(
-        messages: List[LLMMessage],
-    ) -> Tuple[str, List[Tuple[str, str]], str]:
-        """
-        From the chat history, extract system prompt, user-assistant turns, and
-        final user msg.
-
-        Args:
-            messages (List[LLMMessage]): List of messages in the chat history
-
-        Returns:
-            Tuple[str, List[Tuple[str,str]], str]:
-                system prompt, user-assistant turns, final user msg
-
-        """
-        # Handle various degenerate cases
-        messages = [m for m in messages]  # copy
-        DUMMY_SYS_PROMPT = "You are a helpful assistant."
-        DUMMY_USER_PROMPT = "Follow the instructions above."
-        if len(messages) == 0 or messages[0].role != Role.SYSTEM:
-            logger.warning("No system msg, creating dummy system prompt")
-            messages.insert(0, LLMMessage(content=DUMMY_SYS_PROMPT, role=Role.SYSTEM))
-        system_prompt = messages[0].content or ""
-
-        # now we have messages = [Sys,...]
-        if len(messages) == 1:
-            logger.warning(
-                "Got only system message in chat history, creating dummy user prompt"
-            )
-            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, msg, ...]
-
-        if messages[1].role != Role.USER:
-            messages.insert(1, LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, user, ...]
-        if messages[-1].role != Role.USER:
-            logger.warning(
-                "Last message in chat history is not a user message,"
-                " creating dummy user prompt"
-            )
-            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, user, ..., user]
-        # so we omit the first and last elements and make pairs of user-asst messages
-        conversation = [m.content or "" for m in messages[1:-1]]
-        user_prompt = messages[-1].content or ""
-        pairs = LanguageModel.user_assistant_pairs(conversation)
-        return system_prompt, pairs, user_prompt
-
-    @abstractmethod
-    def set_stream(self, stream: bool) -> bool:
-        """Enable or disable streaming output from API.
-        Return previous value of stream."""
-        pass
-
-    @abstractmethod
-    def get_stream(self) -> bool:
-        """Get streaming status"""
-        pass
-
-    @abstractmethod
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        pass
-
-    @abstractmethod
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        pass
-
-    @abstractmethod
-    def chat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """
-        Get chat-completion response from LLM.
-
-        Args:
-            messages: message-history to send to the LLM
-            max_tokens: max tokens to generate
-            tools: tools available for the LLM to use in its response
-            tool_choice: tool call mode, one of "none", "auto", "required",
-                or a dict specifying a specific tool.
-            functions: functions available for LLM to call (deprecated)
-            function_call: function calling mode, "auto", "none", or a specific fn
-                    (deprecated)
-        """
-
-        pass
-
-    @abstractmethod
-    async def achat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """Async version of `chat`. See `chat` for details."""
-        pass
-
-    def __call__(self, prompt: str, max_tokens: int) -> LLMResponse:
-        return self.generate(prompt, max_tokens)
-
-    @staticmethod
-    def _fallback_model_names(model: str) -> List[str]:
-        parts = model.split("/")
-        fallbacks = []
-        for i in range(1, len(parts)):
-            fallbacks.append("/".join(parts[i:]))
-        return fallbacks
-
-    def info(self) -> ModelInfo:
-        """Info of relevant chat model"""
-        orig_model = (
-            self.config.completion_model
-            if self.config.use_completion_for_chat
-            else self.chat_model_orig
-        )
-        return get_model_info(orig_model, self._fallback_model_names(orig_model))
-
-    def completion_info(self) -> ModelInfo:
-        """Info of relevant completion model"""
-        orig_model = (
-            self.chat_model_orig
-            if self.config.use_chat_for_completion
-            else self.config.completion_model
-        )
-        return get_model_info(orig_model, self._fallback_model_names(orig_model))
-
-    def supports_functions_or_tools(self) -> bool:
-        """
-        Does this Model's API support "native" tool-calling, i.e.
-        can we call the API with arguments that contain a list of available tools,
-        and their schemas?
-        Note that, given the plethora of LLM provider APIs this determination is
-        imperfect at best, and leans towards returning True.
-        When the API calls fails with an error indicating tools are not supported,
-        then users are encouraged to use the Langroid-based prompt-based
-        ToolMessage mechanism, which works with ANY LLM. To enable this,
-        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
-        """
-        return self.info().has_tools
-
-    def chat_context_length(self) -> int:
-        return self.config.chat_context_length or DEFAULT_CONTEXT_LENGTH
-
-    def completion_context_length(self) -> int:
-        return self.config.completion_context_length or DEFAULT_CONTEXT_LENGTH
-
-    def chat_cost(self) -> Tuple[float, float, float]:
-        """
-        Return the cost per 1000 tokens for chat completions.
-
-        Returns:
-            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
-                per 1000 tokens
-        """
-        return (0.0, 0.0, 0.0)
-
-    def reset_usage_cost(self) -> None:
-        for mdl in [self.config.chat_model, self.config.completion_model]:
-            if mdl is None:
-                return
-            if mdl not in self.usage_cost_dict:
-                self.usage_cost_dict[mdl] = LLMTokenUsage()
-            counter = self.usage_cost_dict[mdl]
-            counter.reset()
-
-    def update_usage_cost(
-        self, chat: bool, prompts: int, completions: int, cost: float
-    ) -> None:
-        """
-        Update usage cost for this LLM.
-        Args:
-            chat (bool): whether to update for chat or completion model
-            prompts (int): number of tokens used for prompts
-            completions (int): number of tokens used for completions
-            cost (float): total token cost in USD
-        """
-        mdl = self.config.chat_model if chat else self.config.completion_model
-        if mdl is None:
-            return
-        if mdl not in self.usage_cost_dict:
-            self.usage_cost_dict[mdl] = LLMTokenUsage()
-        counter = self.usage_cost_dict[mdl]
-        counter.prompt_tokens += prompts
-        counter.completion_tokens += completions
-        counter.cost += cost
-        counter.calls += 1
-
-    @classmethod
-    def usage_cost_summary(cls) -> str:
-        s = ""
-        for model, counter in cls.usage_cost_dict.items():
-            s += f"{model}: {counter}\n"
-        return s
-
-    @classmethod
-    def tot_tokens_cost(cls) -> Tuple[int, float]:
-        """
-        Return total tokens used and total cost across all models.
-        """
-        total_tokens = 0
-        total_cost = 0.0
-        for counter in cls.usage_cost_dict.values():
-            total_tokens += counter.total_tokens
-            total_cost += counter.cost
-        return total_tokens, total_cost
-
-    def get_reasoning_final(self, message: str) -> Tuple[str, str]:
-        """Extract "reasoning" and "final answer" from an LLM response, if the
-        reasoning is found within configured delimiters, like <think>, </think>.
-        E.g.,
-        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
-
-        Args:
-            message (str): message from LLM
-
-        Returns:
-            Tuple[str, str]: reasoning, final answer
-        """
-        start, end = self.config.thought_delimiters
-        if start in message and end in message:
-            parts = message.split(start)
-            if len(parts) > 1:
-                reasoning, final = parts[1].split(end)
-                return reasoning, final
-        return "", message
-
-    def followup_to_standalone(
-        self, chat_history: List[Tuple[str, str]], question: str
-    ) -> str:
-        """
-        Given a chat history and a question, convert it to a standalone question.
-        Args:
-            chat_history: list of tuples of (question, answer)
-            query: follow-up question
-
-        Returns: standalone version of the question
-        """
-        history = collate_chat_history(chat_history)
-
-        prompt = f"""
-        You are an expert at understanding a CHAT HISTORY between an AI Assistant
-        and a User, and you are highly skilled in rephrasing the User's FOLLOW-UP
-        QUESTION/REQUEST as a STANDALONE QUESTION/REQUEST that can be understood
-        WITHOUT the context of the chat history.
-
-        Below is the CHAT HISTORY. When the User asks you to rephrase a
-        FOLLOW-UP QUESTION/REQUEST, your ONLY task is to simply return the
-        question REPHRASED as a STANDALONE QUESTION/REQUEST, without any additional
-        text or context.
-
-        <CHAT_HISTORY>
-        {history}
-        </CHAT_HISTORY>
-        """.strip()
-
-        follow_up_question = f"""
-        Please rephrase this as a stand-alone question or request:
-        <FOLLOW-UP-QUESTION-OR-REQUEST>
-        {question}
-        </FOLLOW-UP-QUESTION-OR-REQUEST>
-        """.strip()
-
-        show_if_debug(prompt, "FOLLOWUP->STANDALONE-PROMPT= ")
-        standalone = (
-            self.chat(
-                messages=[
-                    LLMMessage(role=Role.SYSTEM, content=prompt),
-                    LLMMessage(role=Role.USER, content=follow_up_question),
-                ],
-                max_tokens=1024,
-            ).message
-            or ""
-        )
-        standalone = standalone.strip()
-
-        show_if_debug(prompt, "FOLLOWUP->STANDALONE-RESPONSE= ")
-        return standalone
-
-
-class StreamingIfAllowed:
-    """Context to temporarily enable or disable streaming, if allowed globally via
-    `settings.stream`"""
-
-    def __init__(self, llm: LanguageModel, stream: bool = True):
-        self.llm = llm
-        self.stream = stream
-
-    def __enter__(self) -> None:
-        self.old_stream = self.llm.set_stream(settings.stream and self.stream)
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self.llm.set_stream(self.old_stream)
-</file>
-
 <file path="langroid/language_models/client_cache.py">
 """
 Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
@@ -120433,6 +118253,2341 @@ def test_self_referential_model_param_breaks_ref_cycle() -> None:
     inst = tool_model(root={"val": 1, "child": {"val": 2}})
     assert inst.root.val == 1
     assert inst.root.child == {"val": 2}
+</file>
+
+<file path="tests/main/test_tool_messages.py">
+import itertools
+import json
+import random
+from typing import Any, List, Literal, Optional
+
+import pytest
+from pydantic import BaseModel, Field
+
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.agent.chat_document import ChatDocMetaData, ChatDocument
+from langroid.agent.task import Task
+from langroid.agent.tool_message import ToolMessage
+from langroid.agent.tools import DonePassTool, DoneTool
+from langroid.agent.tools.orchestration import (
+    AgentDoneTool,
+    FinalResultTool,
+    ResultTool,
+)
+from langroid.agent.xml_tool_message import XMLToolMessage
+from langroid.cachedb.redis_cachedb import RedisCacheConfig
+from langroid.language_models.base import (
+    LLMFunctionCall,
+    LLMFunctionSpec,
+    LLMMessage,
+    OpenAIJsonSchemaSpec,
+    OpenAIToolCall,
+    OpenAIToolSpec,
+    Role,
+)
+from langroid.language_models.mock_lm import MockLMConfig
+from langroid.language_models.openai_gpt import OpenAIGPTConfig
+from langroid.mytypes import Entity
+from langroid.parsing.parse_json import extract_top_level_json
+from langroid.parsing.parser import ParsingConfig
+from langroid.prompts.prompts_config import PromptsConfig
+from langroid.utils.configuration import Settings, set_global
+from langroid.utils.constants import DONE
+from langroid.utils.types import is_callable
+
+
+class CountryCapitalMessage(ToolMessage):
+    request: str = "country_capital"
+    purpose: str = "To check whether <city> is the capital of <country>."
+    country: str = "France"
+    city: str = "Paris"
+
+    @classmethod
+    def examples(cls) -> List["CountryCapitalMessage"]:
+        # illustrating two types of examples
+        return [
+            (
+                "Need to check if Paris is the capital of France",
+                cls(country="France", city="Paris"),
+            ),
+            cls(country="France", city="Marseille"),
+        ]
+
+
+class FileExistsMessage(ToolMessage):
+    request: str = "file_exists"
+    purpose: str = """
+    To check whether a certain <filename> is in the repo,
+    recursively if needed, as specified by <recurse>.
+    """
+    filename: str = Field(..., description="File name to check existence of")
+    recurse: bool = Field(..., description="Whether to recurse into subdirectories")
+
+    @classmethod
+    def examples(cls) -> List["FileExistsMessage"]:
+        return [
+            cls(filename="README.md", recurse=True),
+            cls(filename="Dockerfile", recurse=False),
+        ]
+
+
+class PythonVersionMessage(ToolMessage):
+    request: str = "python_version"
+    _handler: str = "tool_handler"
+    purpose: str = "To check which version of Python is needed."
+
+    @classmethod
+    def examples(cls) -> List["PythonVersionMessage"]:
+        return [
+            cls(),
+        ]
+
+
+class PresidentInfo(BaseModel):
+    name: str = Field(..., description="Name of the president")
+    elected: bool = Field(..., description="Whether the president is elected")
+
+
+class CountryInfo(BaseModel):
+    name: str = Field(..., description="Name of the country")
+    capital: str = Field(..., description="Capital city of the country")
+    president: PresidentInfo = Field(..., description="President of the country")
+
+
+class CountryPresidentTool(ToolMessage):
+    request: str = "country_president"
+    purpose: str = "To present info on a country and its president."
+
+    country_info: CountryInfo = Field(
+        ..., description="Information about the country and its president"
+    )
+    country_type: Literal["island", "landlocked", "coastal"] = Field(
+        ..., description="Type of the country, e.g. island, landlocked, coastal"
+    )
+
+    def handle(self) -> str:
+        # Return a simple sentence with all the info.
+        return (
+            f"{self.country_info.name} is a {self.country_type} country. "
+            f"The capital is {self.country_info.capital}. "
+            f"The president is {self.country_info.president.name} "
+            f"({'elected' if self.country_info.president.elected else 'not elected'})."
+        )
+
+
+DEFAULT_PY_VERSION = "3.9"
+
+
+class MessageHandlingAgent(ChatAgent):
+    def file_exists(self, message: FileExistsMessage) -> str:
+        return "yes" if message.filename == "requirements.txt" else "no"
+
+    def tool_handler(self, message: ToolMessage) -> str:
+        if message.request == "python_version":
+            return DEFAULT_PY_VERSION
+        else:
+            return "invalid tool name"
+
+    def country_capital(self, message: CountryCapitalMessage) -> str:
+        return (
+            "yes" if (message.city == "Paris" and message.country == "France") else "no"
+        )
+
+
+cfg = ChatAgentConfig(
+    name="test-langroid",
+    vecdb=None,
+    llm=OpenAIGPTConfig(
+        type="openai",
+        cache_config=RedisCacheConfig(fake=False),
+    ),
+    parsing=ParsingConfig(),
+    prompts=PromptsConfig(),
+    use_functions_api=False,
+    use_tools=True,
+    system_message="""
+    VERY IMPORTANT: IF you see a possibility of using a tool/function,
+    you MUST use it, and MUST NOT ASK IN NATURAL LANGUAGE.
+    """,
+)
+agent = MessageHandlingAgent(cfg)
+
+# Define the range of values each variable can have
+use_vals = [True, False]
+handle_vals = [True, False]
+force_vals = [True, False]
+message_classes = [None, FileExistsMessage, PythonVersionMessage]
+
+# Get the cartesian product
+cartesian_product = list(
+    itertools.product(message_classes, use_vals, handle_vals, force_vals)
+)
+
+agent.enable_message(FileExistsMessage)
+agent.enable_message(PythonVersionMessage)
+
+
+def test_tool_message_name():
+    assert FileExistsMessage.default_value("request") == FileExistsMessage.name()
+
+
+@pytest.mark.parametrize("msg_class", [None, FileExistsMessage, PythonVersionMessage])
+@pytest.mark.parametrize("use", [True, False])
+@pytest.mark.parametrize("handle", [True, False])
+@pytest.mark.parametrize("force", [True, False])
+def test_enable_message(
+    msg_class: Optional[ToolMessage], use: bool, handle: bool, force: bool
+):
+    agent.enable_message(msg_class, use=use, handle=handle, force=force)
+    usable_tools = agent.llm_tools_usable
+    tools = agent._get_tool_list(msg_class)
+    for tool in set(tools).intersection(usable_tools):
+        assert tool in agent.llm_tools_map
+        if msg_class is not None:
+            assert agent.llm_tools_map[tool] == msg_class
+            assert agent.llm_functions_map[tool] == msg_class.llm_function_schema()
+        assert (tool in agent.llm_tools_handled) == handle
+        assert (tool in agent.llm_tools_usable) == use
+        assert (tool in agent.llm_functions_handled) == handle
+        assert (tool in agent.llm_functions_usable) == use
+
+    if msg_class is not None:
+        assert (
+            agent.llm_function_force is not None
+            and agent.llm_function_force["name"] == tools[0]
+        ) == force
+
+
+@pytest.mark.parametrize("msg_class", [None, FileExistsMessage, PythonVersionMessage])
+def test_disable_message_handling(msg_class: Optional[ToolMessage]):
+    agent.enable_message([FileExistsMessage, PythonVersionMessage])
+    usable_tools = agent.llm_tools_usable.copy()
+
+    agent.disable_message_handling(msg_class)
+    tools = agent._get_tool_list(msg_class)
+    for tool in set(tools).intersection(usable_tools):
+        assert tool not in agent.llm_tools_handled
+        assert tool not in agent.llm_functions_handled
+        assert tool in agent.llm_tools_usable
+        assert tool in agent.llm_functions_usable
+
+
+@pytest.mark.parametrize("msg_class", [None, FileExistsMessage, PythonVersionMessage])
+def test_disable_message_use(msg_class: Optional[ToolMessage]):
+    agent.enable_message(FileExistsMessage)
+    agent.enable_message(PythonVersionMessage)
+    usable_tools = agent.llm_tools_usable.copy()
+
+    agent.disable_message_use(msg_class)
+    tools = agent._get_tool_list(msg_class)
+    for tool in set(tools).intersection(usable_tools):
+        assert tool not in agent.llm_tools_usable
+        assert tool not in agent.llm_functions_usable
+        assert tool in agent.llm_tools_handled
+        assert tool in agent.llm_functions_handled
+
+    # check that disabling tool-use works as expected:
+    # Tools part of sys msg should be updated, and
+    # LLM should not be able to use this tool
+    agent.disable_message_use(FileExistsMessage)
+    agent.disable_message_use(PythonVersionMessage)
+    response = agent.llm_response_forget("Is there a README.md file?")
+    assert agent.get_tool_messages(response) == []
+
+
+@pytest.mark.parametrize("msg_cls", [PythonVersionMessage, FileExistsMessage])
+def test_usage_instruction(msg_cls: ToolMessage):
+    usage = msg_cls.usage_examples()
+    jsons = extract_top_level_json(usage)
+    assert all(
+        json.loads(j)["request"] == msg_cls.default_value("request") for j in jsons
+    )
+
+
+NONE_MSG = "nothing to see here"
+
+FILE_EXISTS_MSG = """
+Ok, thank you.
+{
+"request": "file_exists",
+"filename": "test.txt",
+"recurse": true
+}
+Hope you can tell me!
+"""
+
+PYTHON_VERSION_MSG = """
+great, please tell me this --
+{
+"request": "python_version"
+}/if you know it
+"""
+
+
+def test_agent_handle_message():
+    """
+    Test whether messages are handled correctly, and that
+    message enabling/disabling works as expected.
+    """
+    agent.enable_message(FileExistsMessage)
+    agent.enable_message(PythonVersionMessage)
+    assert agent.handle_message(NONE_MSG) is None
+    assert agent.handle_message(FILE_EXISTS_MSG).content == "no"
+    assert agent.handle_message(PYTHON_VERSION_MSG).content == "3.9"
+
+    agent.disable_message_handling(FileExistsMessage)
+    assert agent.handle_message(FILE_EXISTS_MSG) is None
+    assert agent.handle_message(PYTHON_VERSION_MSG).content == "3.9"
+
+    agent.disable_message_handling(PythonVersionMessage)
+    assert agent.handle_message(FILE_EXISTS_MSG) is None
+    assert agent.handle_message(PYTHON_VERSION_MSG) is None
+
+    agent.enable_message(FileExistsMessage)
+    assert agent.handle_message(FILE_EXISTS_MSG).content == "no"
+    assert agent.handle_message(PYTHON_VERSION_MSG) is None
+
+    agent.enable_message(PythonVersionMessage)
+    assert agent.handle_message(FILE_EXISTS_MSG).content == "no"
+    assert agent.handle_message(PYTHON_VERSION_MSG).content == "3.9"
+
+
+BAD_FILE_EXISTS_MSG = """
+Ok, thank you.
+{
+"request": "file_exists"
+}
+Hope you can tell me!
+"""
+
+
+@pytest.mark.parametrize("as_string", [False, True])
+def test_handle_bad_tool_message(as_string: bool):
+    """
+    Test that a correct tool name with bad/missing args is
+            handled correctly, i.e. the agent returns a clear
+            error message to the LLM so it can try to fix it.
+
+    as_string: whether to pass the bad tool message as a string or as an LLM msg
+    """
+    agent.enable_message(FileExistsMessage)
+    assert agent.handle_message(NONE_MSG) is None
+    if as_string:
+        # set up a prior LLM-originated msg, to mock a scenario
+        # where the last msg was from LLM, prior to calling
+        # handle_message with the bad tool message -- we are trying to
+        # test that the error is raised correctly in this case
+        agent.llm_response("3+4=")
+        result = agent.handle_message(BAD_FILE_EXISTS_MSG)
+    else:
+        bad_tool_from_llm = agent.create_llm_response(BAD_FILE_EXISTS_MSG)
+        result = agent.handle_message(bad_tool_from_llm)
+    assert "file_exists" in result and "filename" in result and "required" in result
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize(
+    "use_functions_api",
+    [True, False],
+)
+@pytest.mark.parametrize(
+    "use_tools_api",
+    [True],  # ONLY test tools-api since OpenAI has deprecated functions-api
+)
+@pytest.mark.parametrize(
+    "message_class, prompt, result",
+    [
+        (
+            FileExistsMessage,
+            """
+            You have to find out whether the file 'requirements.txt' exists in the repo,
+            recursively exploring subdirectories if needed.
+            """,
+            "yes",
+        ),
+        (
+            PythonVersionMessage,
+            "Find out about the python version",
+            "3.9",
+        ),
+        (
+            CountryCapitalMessage,
+            "You have to check whether Paris is the capital of France",
+            "yes",
+        ),
+        (
+            CountryPresidentTool,  # test nested tool
+            """
+            Present this info about France and its president, in a structured format:
+            - Country: France
+            - Capital: Paris
+            - President: Emmanuel Macron (elected)
+            - Country Type: coastal
+            """,
+            "elected",
+        ),
+    ],
+)
+def test_llm_tool_message(
+    test_settings: Settings,
+    use_functions_api: bool,
+    use_tools_api: bool,
+    message_class: ToolMessage,
+    prompt: str,
+    result: str,
+    stream: bool,
+):
+    """
+    Test whether LLM is able to GENERATE message (tool) in required format, and the
+    agent handles the message correctly.
+    Args:
+        test_settings: test settings from conftest.py
+        use_functions_api: whether to use LLM's functions api or not
+            (i.e. use the langroid ToolMessage tools instead).
+        message_class: the message class (i.e. tool/function) to test
+        prompt: the prompt to use to induce the LLM to use the tool
+        result: the expected result from agent handling the tool-message
+    """
+    set_global(test_settings)
+    cfg.llm.stream = stream
+    agent = MessageHandlingAgent(cfg)
+    agent.config.use_functions_api = use_functions_api
+    agent.config.use_tools = not use_functions_api
+    agent.config.use_tools_api = use_tools_api
+
+    agent.enable_message(
+        [
+            FileExistsMessage,
+            PythonVersionMessage,
+            CountryCapitalMessage,
+            CountryPresidentTool,
+        ]
+    )
+
+    llm_msg = agent.llm_response_forget(prompt)
+    tool_name = message_class.name()
+    if use_functions_api:
+        if use_tools_api:
+            assert llm_msg.oai_tool_calls[0].function.name == tool_name
+        else:
+            assert llm_msg.function_call.name == tool_name
+
+    tools = agent.get_tool_messages(llm_msg)
+    assert len(tools) == 1
+    assert isinstance(tools[0], message_class)
+
+    agent_result = agent.handle_message(llm_msg).content
+
+    assert result.lower() in agent_result.lower()
+
+
+def test_llm_non_tool(test_settings: Settings):
+    """Having no tools enabled should result in a None handle_message result"""
+    agent = MessageHandlingAgent(cfg)
+    llm_msg = agent.llm_response_forget(
+        "Ask me to check what is the population of France."
+    ).content
+    agent_result = agent.handle_message(llm_msg)
+    assert agent_result is None
+
+
+# Test that malformed tool messages results in proper err msg
+class NumPair(BaseModel):
+    xval: int
+    yval: int
+
+
+class NabroskiTool(ToolMessage):
+    request: str = "nabroski"
+    purpose: str = "to request computing the Nabroski transform of <num_pair>"
+    num_pair: NumPair
+
+    def handle(self) -> str:
+        return str(3 * self.num_pair.xval + self.num_pair.yval)
+
+
+class CoriolisTool(ToolMessage):
+    """Tool for testing handling of optional arguments, with default values."""
+
+    request: str = "coriolis"
+    purpose: str = "to request computing the Coriolis transform of <cats> and <cows>"
+    cats: int
+    cows: int = 5
+
+    def handle(self) -> str:
+        # same as NabroskiTool result
+        return str(3 * self.cats + self.cows)
+
+
+wrong_nabroski_tool = """
+{
+"request": "nabroski",
+"num_pair": {
+    "xval": 1
+    }
+}
+"""
+
+
+@pytest.mark.parametrize("use_tools_api", [True])
+@pytest.mark.parametrize("use_functions_api", [True, False])
+@pytest.mark.parametrize("stream", [True, False])
+@pytest.mark.parametrize("strict_recovery", [True, False])
+@pytest.mark.parametrize("as_string", [True, False])
+def test_agent_malformed_tool(
+    test_settings: Settings,
+    use_tools_api: bool,
+    use_functions_api: bool,
+    stream: bool,
+    strict_recovery: bool,
+    as_string: bool,
+):
+    set_global(test_settings)
+    cfg = ChatAgentConfig(
+        use_tools=not use_functions_api,
+        use_functions_api=use_functions_api,
+        use_tools_api=use_tools_api,
+        strict_recovery=strict_recovery,
+    )
+    cfg.llm.stream = stream
+    agent = ChatAgent(cfg)
+    agent.enable_message(NabroskiTool)
+    if as_string:
+        # set up a prior LLM-originated msg, to mock a scenario
+        # where the last msg was from LLM, prior to calling
+        # handle_message with the bad tool message -- we are trying to
+        # test that the error is raised correctly in this case
+        agent.llm_response("3+4=")
+        response = agent.agent_response(wrong_nabroski_tool)
+    else:
+        bad_tool_from_llm = agent.create_llm_response(wrong_nabroski_tool)
+        response = agent.agent_response(bad_tool_from_llm)
+    # We expect an error msg containing certain specific field names
+    assert "num_pair" in response.content and "yval" in response.content
+
+
+class FruitPair(BaseModel):
+    pears: int
+    apples: int
+
+
+class EulerTool(ToolMessage):
+    request: str = "euler"
+    purpose: str = "to request computing the Euler transform of <fruit_pair>"
+    fruit_pair: FruitPair
+
+    def handle(self) -> str:
+        return str(2 * self.fruit_pair.pears - self.fruit_pair.apples)
+
+
+class BoilerTool(ToolMessage):
+    request: str = "boiler"
+    purpose: str = "to request computing the Boiler transform of <fruit_pair>"
+    fruit_pair: FruitPair
+
+    def handle(self) -> str:
+        return str(3 * self.fruit_pair.pears - 5 * self.fruit_pair.apples)
+
+
+class SumTool(ToolMessage):
+    request: str = "sum"
+    purpose: str = "to request computing the sum of <x> and <y>"
+    x: int
+    y: int
+
+    def handle(self) -> str:
+        return str(self.x + self.y)
+
+
+class GaussTool(ToolMessage):
+    request: str = "gauss"
+    purpose: str = "to request computing the Gauss transform of (<x>, <y>)"
+    xval: int
+    yval: int
+
+    def handle(self) -> str:
+        return str((self.xval + self.yval) * self.yval)
+
+
+class CoinFlipTool(ToolMessage):
+    request: str = "coin_flip"
+    purpose: str = "to request a random coin flip"
+
+    def handle(self) -> Literal["Heads", "Tails"]:
+        heads = random.random() > 0.5
+        return "Heads" if heads else "Tails"
+
+
+@pytest.mark.parametrize("use_tools_api", [True])
+@pytest.mark.parametrize("use_functions_api", [True, False])
+def test_agent_infer_tool(
+    test_settings: Settings,
+    use_functions_api: bool,
+    use_tools_api: bool,
+):
+    set_global(test_settings)
+    gauss_request = """{"xval": 1, "yval": 3}"""
+    boiler_or_euler_request = """{"fruit_pair": {"pears": 1, "apples": 3}}"""
+    euler_request = """{"request": "euler", "fruit_pair": {"pears": 1, "apples": 3}}"""
+    additional_args_request = """{"xval": 1, "yval": 3, "zval": 4}"""
+    additional_args_request_specified = """
+    {"request": "gauss", "xval": 1, "yval": 3, "zval": 4}
+    """
+    no_args_request = """{}"""
+    no_args_request_specified = """{"request": "coin_flip"}"""
+
+    cfg = ChatAgentConfig(
+        use_tools=not use_functions_api,
+        use_functions_api=use_functions_api,
+        use_tools_api=use_tools_api,
+    )
+    agent = ChatAgent(cfg)
+    agent.enable_message(
+        [
+            NabroskiTool,
+            GaussTool,
+            CoinFlipTool,
+            BoilerTool,
+        ]
+    )
+    agent.enable_message(EulerTool, handle=False)
+
+    # Boiler is the only option prior to enabling EulerTool handling
+    assert agent.agent_response(boiler_or_euler_request).content == "-12"
+
+    # Enable handling EulerTool, this makes nabrowski_or_euler_request ambiguous
+    agent.enable_message(EulerTool)
+    agent.enable_message(BoilerTool)
+
+    # Gauss is the only option
+    assert agent.agent_response(gauss_request).content == "12"
+
+    # Explicit requests are forwarded to the correct handler
+    assert agent.agent_response(euler_request).content == "-1"
+
+    # We cannot infer the correct tool if there exist multiple matches
+    assert agent.agent_response(boiler_or_euler_request) is None
+
+    # We do not infer tools where the request has additional arguments
+    assert agent.agent_response(additional_args_request) is None
+    # But additional args are acceptable when the tool is specified
+    assert agent.agent_response(additional_args_request_specified).content == "12"
+
+    # We do not infer tools with no args
+    assert agent.agent_response(no_args_request) is None
+    # Request must be specified
+    assert agent.agent_response(no_args_request_specified).content in ["Heads", "Tails"]
+
+
+@pytest.mark.parametrize("use_tools_api", [True])
+@pytest.mark.parametrize("use_functions_api", [True, False])
+def test_tool_no_llm_response(
+    test_settings: Settings,
+    use_functions_api: bool,
+    use_tools_api: bool,
+):
+    """Test that agent.llm_response does not respond to tool messages."""
+
+    set_global(test_settings)
+    cfg = ChatAgentConfig(
+        use_tools=not use_functions_api,
+        use_functions_api=use_functions_api,
+        use_tools_api=use_tools_api,
+    )
+    agent = ChatAgent(cfg)
+    agent.enable_message(NabroskiTool)
+    nabroski_tool = NabroskiTool(num_pair=NumPair(xval=1, yval=2)).to_json()
+    response = agent.llm_response(nabroski_tool)
+    assert response is None
+
+
+@pytest.mark.parametrize("stream", [True, False])
+@pytest.mark.parametrize("use_functions_api", [True, False])
+def test_tool_no_task(
+    test_settings: Settings,
+    use_functions_api: bool,
+    stream: bool,
+):
+    """Test tool handling without running task, i.e. directly using
+    agent.llm_response and agent.agent_response methods."""
+
+    set_global(test_settings)
+    cfg = ChatAgentConfig(
+        use_tools=not use_functions_api,
+        use_functions_api=use_functions_api,
+    )
+    cfg.llm.stream = stream
+    agent = ChatAgent(cfg)
+    agent.enable_message(NabroskiTool, use=True, handle=True)
+
+    response = agent.llm_response("What is Nabroski of 1 and 2?")
+    assert isinstance(agent.get_tool_messages(response)[0], NabroskiTool)
+    result = agent.agent_response(response)
+    assert result.content == "5"
+
+
+@pytest.mark.parametrize("use_tools_api", [True])
+@pytest.mark.parametrize("use_functions_api", [True, False])
+def test_tool_optional_args(
+    test_settings: Settings,
+    use_functions_api: bool,
+    use_tools_api: bool,
+):
+    """Test that ToolMessage where some args are optional (i.e. have default values)
+    works well, i.e. LLM is able to generate all args if needed, including optionals."""
+
+    set_global(test_settings)
+    cfg = ChatAgentConfig(
+        use_tools=not use_functions_api,
+        use_functions_api=use_functions_api,
+        use_tools_api=use_tools_api,
+    )
+    agent = ChatAgent(cfg)
+
+    agent.enable_message(CoriolisTool, use=True, handle=True)
+    response = agent.llm_response("What is the Coriolis transform of 1, 2?")
+    assert isinstance(agent.get_tool_messages(response)[0], CoriolisTool)
+    tool = agent.get_tool_messages(response)[0]
+    assert tool.cats == 1 and tool.cows == 2
+
+
+@pytest.mark.parametrize("tool", [NabroskiTool, CoriolisTool])
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("use_tools_api", [True])
+@pytest.mark.parametrize("use_functions_api", [True, False])
+def test_llm_tool_task(
+    test_settings: Settings,
+    use_functions_api: bool,
+    use_tools_api: bool,
+    stream: bool,
+    tool: ToolMessage,
+):
+    """
+    Test "full life cycle" of tool, when using Task.run().
+
+    1. invoke LLM api with tool-spec
+    2. LLM generates tool
+    3. ChatAgent.agent_response handles tool, result added to ChatAgent msg history
+    5. invoke LLM api with tool result
+    """
+
+    set_global(test_settings)
+    llm_config = OpenAIGPTConfig(max_output_tokens=3_000, timeout=120)
+    cfg = ChatAgentConfig(
+        llm=llm_config,
+        use_tools=not use_functions_api,
+        use_functions_api=use_functions_api,
+        use_tools_api=use_tools_api,
+        system_message=f"""
+        You will be asked to compute a certain transform of two numbers,
+        using a tool/function-call that you have access to.
+        When you receive the answer from the tool, say {DONE} and show the answer.
+        DO NOT SAY {DONE} until you receive a specific result from the tool.
+        """,
+    )
+    agent = ChatAgent(cfg)
+    agent.enable_message(tool)
+    task = Task(agent, interactive=False)
+
+    request = tool.default_value("request")
+    result = task.run(f"What is the {request} transform of 3 and 5?")
+    assert "14" in result.content
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("use_tools_api", [True])
+@pytest.mark.parametrize("use_functions_api", [True, False])
+def test_multi_tool(
+    test_settings: Settings,
+    use_functions_api: bool,
+    use_tools_api: bool,
+    stream: bool,
+):
+    """
+    Test "full life cycle" of tool, when using Task.run().
+
+    1. invoke LLM api with tool-spec
+    2. LLM generates tool
+    3. ChatAgent.agent_response handles tool, result added to ChatAgent msg history
+    5. invoke LLM api with tool result
+    """
+
+    set_global(test_settings)
+    cfg = ChatAgentConfig(
+        use_tools=not use_functions_api,
+        use_functions_api=use_functions_api,
+        use_tools_api=use_tools_api,
+        system_message=f"""
+        You will be asked to compute transforms of two numbers,
+        using tools/function-calls that you have access to.
+        When you are asked for MULTIPLE transforms, you MUST
+        use MULTIPLE tools/functions.
+        When you receive the answers from the tools, say {DONE} and show the answers.
+        """,
+    )
+    agent = ChatAgent(cfg)
+    agent.enable_message(NabroskiTool)
+    agent.enable_message(GaussTool)
+    task = Task(agent, interactive=False)
+
+    # First test without task; using individual methods
+    # ---
+
+    result = task.run(
+        """
+        Compute these:
+        (A) Nabroski transform of 3 and 5
+        (B) Gauss transform of 1 and 2
+        """
+    )
+    # Nabroski: 3*3 + 5 = 14
+    # Gauss: (1+2)*2 = 6
+    assert "14" in result.content and "6" in result.content
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_oai_tool_choice(
+    test_settings: Settings,
+    stream: bool,
+):
+    """
+    Test tool_choice for OpenAI-like LLM APIs.
+    """
+
+    set_global(test_settings)
+    cfg = ChatAgentConfig(
+        use_tools=False,  # langroid tools
+        use_functions_api=True,  # openai tools/fns
+        use_tools_api=True,  # openai tools/fns
+        system_message=f"""
+        You will be asked to compute an operation or transform of two numbers,
+        either using your own knowledge, or
+        using a tool/function-call that you have access to.
+        When you have an answer, say {DONE} and show the answer.
+        """,
+    )
+    agent = ChatAgent(cfg)
+    agent.enable_message(SumTool)
+
+    chat_doc = agent.create_user_response("What is the sum of 3 and 5?")
+    chat_doc.oai_tool_choice = "auto"
+    response = agent.llm_response_forget(chat_doc)
+
+    # expect either SumTool or direct result without tool
+    assert "8" in response.content or isinstance(
+        agent.get_tool_messages(response)[0], SumTool
+    )
+
+    chat_doc = agent.create_user_response("What is the double of 5?")
+    chat_doc.oai_tool_choice = "none"
+    response = agent.llm_response_forget(chat_doc)
+    assert "10" in response.content
+
+    chat_doc = agent.create_user_response("What is the sum of 3 and 5?")
+    chat_doc.oai_tool_choice = "required"
+    response = agent.llm_response_forget(chat_doc)
+    assert isinstance(agent.get_tool_messages(response)[0], SumTool)
+
+    agent.enable_message(NabroskiTool, force=True)
+    response = agent.llm_response("What is the nabroski of 3 and 5?")
+    assert "nabroski" in response.content.lower() or isinstance(
+        agent.get_tool_messages(response)[0], NabroskiTool
+    )
+
+
+@pytest.mark.parametrize(
+    "result_type",
+    [
+        "final_tool",
+        "result_tool",
+        "agent_done",
+        "tool",
+        "int",
+        "list",
+        "dict",
+        "ChatDocument",
+        "pydantic",
+    ],
+)
+@pytest.mark.parametrize(
+    "tool_handler", ["notool", "handle", "response", "response_with_doc"]
+)
+def test_tool_handlers_and_results(result_type: str, tool_handler: str):
+    """Test various types of ToolMessage handlers, and check that they can
+    return arbitrary result types"""
+
+    class SpecialResult(BaseModel):
+        """To illustrating returning an arbitrary Pydantic object as a result"""
+
+        answer: int
+        details: str = "nothing"
+
+    def result_fn(x: int) -> Any:
+        match result_type:
+            case "int":
+                return x + 5
+            case "dict":
+                return {"answer": x + 5, "details": "something"}
+            case "list":
+                return [x + 5, x * 2]
+            case "ChatDocument":
+                return ChatDocument(
+                    content=str(x + 5),
+                    metadata=ChatDocMetaData(sender="Agent"),
+                )
+            case "pydantic":
+                return SpecialResult(answer=x + 5)
+            case "tool":
+                # return tool, to be handled by sub-task
+                return UberTool(x=x)
+            case "result_tool":
+                return ResultTool(answer=x + 5)
+            case "final_tool":
+                return FinalResultTool(
+                    special=SpecialResult(answer=x + 5),  # explicitly declared
+                    # arbitrary new fields that were not declared in the class...
+                    extra_special=SpecialResult(answer=x + 10),
+                    # ... does not need to be a Pydantic object
+                    arbitrary_obj=dict(answer=x + 15),
+                )
+            case "agent_done":
+                # pass on to parent, to handle with UberTool,
+                # which is NOT enabled for this agent
+                return AgentDoneTool(tools=[UberTool(x=x)])
+
+    class UberTool(ToolMessage):
+        request: str = "uber_tool"
+        purpose: str = "to request the 'uber' transform of a  number <x>"
+        x: int
+
+        def handle(self) -> Any:
+            return FinalResultTool(answer=self.x + 5)
+
+    class CoolToolWithHandle(ToolMessage):
+        request: str = "cool_tool"
+        purpose: str = "to request the 'cool' transform of a  number <x>"
+
+        x: int
+
+        def handle(self) -> Any:
+            return result_fn(self.x)
+
+    class MyAgent(ChatAgent):
+        def init_state(self) -> None:
+            super().init_state()
+            self.state: int = 100
+            self.sender: str = ""
+            self.llm_sent: bool = False
+
+        def llm_response(
+            self, message: Optional[str | ChatDocument] = None
+        ) -> Optional[ChatDocument]:
+            self.llm_sent = True
+            return super().llm_response(message)
+
+        def handle_message_fallback(
+            self, msg: str | ChatDocument
+        ) -> str | ChatDocument | None:
+            """Handle non-tool LLM response"""
+            if self.llm_sent:
+                x = int(msg.content)
+                return result_fn(x)
+
+    class CoolToolWithResponse(ToolMessage):
+        """To test that `response` handler works as expected,
+        and is able to read and modify agent state.
+        """
+
+        request: str = "cool_tool"
+        purpose: str = "to request the 'cool' transform of a  number <x>"
+
+        x: int
+
+        def response(self, agent: MyAgent) -> Any:
+            agent.state += 1
+            return result_fn(self.x)
+
+    class CoolToolWithResponseDoc(ToolMessage):
+        """
+        To test that `response` handler works as expected,
+        is able to read and modify agent state, and
+        when using a `chat_doc` argument, and is able to read values from it.
+        """
+
+        request: str = "cool_tool"
+        purpose: str = "to request the 'cool' transform of a  number <x>"
+
+        x: int
+
+        def response(self, agent: MyAgent, chat_doc: ChatDocument) -> Any:
+            agent.state += 1
+            agent.sender = chat_doc.metadata.sender
+            return result_fn(self.x)
+
+    match tool_handler:
+        case "handle":
+            tool_class = CoolToolWithHandle
+        case "response":
+            tool_class = CoolToolWithResponse
+        case "response_with_doc":
+            tool_class = CoolToolWithResponseDoc
+        case "notool":
+            tool_class = None
+
+    agent = MyAgent(
+        ChatAgentConfig(
+            name="Test",
+            # no need for a real LLM, use a mock
+            llm=MockLMConfig(
+                # mock LLM generating a CoolTool variant
+                response_fn=lambda x: (
+                    tool_class(x=int(x)).model_dump_json()
+                    if tool_class is not None
+                    else x
+                ),
+            ),
+        )
+    )
+    if tool_class is not None:
+        agent.enable_message(tool_class)
+
+    tool_result = result_type in ["final_tool", "agent_done", "tool", "result_tool"]
+    task = Task(
+        agent,
+        interactive=False,
+        # need to specify task done when result is not FinalResultTool
+        done_if_response=[] if tool_result else [Entity.AGENT],
+    )
+    result = task.run("3")
+    if tool_handler == "response":
+        assert agent.state == 101
+    if tool_handler == "response_with_doc":
+        assert agent.state == 101
+        assert agent.sender == "LLM"
+
+    if not tool_result:
+        # CoolTool handler returns a non-tool result containing 8, and
+        # we terminate task on agent_response, via done_if_response,
+        # so the result.content == 8
+        assert "8" in result.content
+    elif result_type == "result_tool":
+        # CoolTool handler/response returns a ResultTool containing answer == 8
+        tool = result.tool_messages[0]
+        assert isinstance(tool, ResultTool)
+        assert tool.answer == 8
+    else:
+        # When CoolTool handler returns a ToolMessage,
+        # test that it is handled correctly by sub-task or a parent.
+
+        another_agent = ChatAgent(
+            ChatAgentConfig(
+                name="Another",
+                llm=MockLMConfig(response_fn=lambda x: x),  # pass thru
+            )
+        )
+        another_agent.enable_message(UberTool)
+        another_task = Task(another_agent, interactive=False)
+        another_task.add_sub_task(task)
+        result = another_task.run("3")
+
+        if result_type == "final_tool":
+            # task's CoolTool handler returns FinalResultTool
+            # which short-circuits parent task and returns as a tool
+            # in tool_messages list of the final result
+            tool = result.tool_messages[0]
+            assert isinstance(tool, FinalResultTool)
+            assert isinstance(tool.special, SpecialResult)
+            assert tool.special.answer == 8
+            assert tool.extra_special.answer == 13
+            assert tool.arbitrary_obj["answer"] == 18
+        elif result_type == "agent_done":
+            # inner task's CoolTool handler returns a DoneTool containing
+            # UberTool, which is handled by the parent "another_agent"
+            # which returns a FinalResultTool containing answer == 8
+            tool = result.tool_messages[0]
+            assert isinstance(tool, FinalResultTool)
+            assert tool.answer == 8
+
+            # Now disable parent agent's handling of UberTool
+            another_agent.disable_message_handling(UberTool)
+            # another_task = Task(another_agent, interactive=False)
+            # another_task.add_sub_task(task)
+            result = another_task.run("3")
+            # parent task is unable to handle UberTool, so will stall and return None
+            assert result is None
+            another_agent.enable_message(UberTool)
+
+        elif result_type == "tool":
+            # inner Task CoolTool handler returns UberTool (with NO done signal),
+            # which it is unable to handle, so stalls and returns None,
+            # and so does parent another_task
+            assert result is None
+
+            # Now reverse it: make another_task a sub-task of task, and
+            # test handling UberTool returned by task handler, by sub-task another_task
+            another_task = Task(another_agent, interactive=False)
+            # task = Task(agent, interactive=False)
+            task.add_sub_task(another_task)
+            result = task.run("3")
+            tool = result.tool_messages[0]
+            assert isinstance(tool, FinalResultTool)
+            assert tool.answer == 8
+
+            another_agent.disable_message_handling(UberTool)
+            result = task.run("3")
+            # subtask stalls, parent stalls, returns None
+            assert result is None
+
+
+@pytest.mark.parametrize("llm_tool", ["pair", "final_tool"])
+@pytest.mark.parametrize("handler_result_type", ["agent_done", "final_tool"])
+@pytest.mark.parametrize("use_fn_api", [True, False])
+@pytest.mark.parametrize("use_tools_api", [True])
+def test_llm_end_with_tool(
+    handler_result_type: str,
+    llm_tool: str,
+    use_fn_api: bool,
+    use_tools_api: bool,
+):
+    """
+    Test that an LLM can directly or indirectly trigger task-end, and return a Tool as
+    result. There are 3 ways:
+    - case llm_tool == "final_tool":
+        LLM returns a Tool (llm_tool == "final_tool") derived from FinalResultTool,
+        with field(s) containing a structured Pydantic object -- in this case the task
+        ends immediately without any agent response handling the tool
+    - case llm_tool == "pair":
+        LLM returns a PairTool, which is handled by the agent, which returns either
+        - AgentDoneTool, with `tools` field set to [self], or
+        - FinalResultTool, with `result` field set to the PairTool
+    """
+
+    class Pair(BaseModel):
+        a: int
+        b: int
+
+    class PairTool(ToolMessage):
+        """Handle the LLM-generated tool, signal done or final-result and
+        return it as the result."""
+
+        request: str = "pair_tool"
+        purpose: str = "to return a <pair> of numbers"
+        pair: Pair
+
+        def handle(self) -> Any:
+            if handler_result_type == "final_tool":
+                # field name can be anything; `result` is just an example.
+                return FinalResultTool(result=self)
+            else:
+                return AgentDoneTool(tools=[self])
+
+    class FinalResultPairTool(FinalResultTool):
+        request: str = "final_result_pair_tool"
+        purpose: str = "Present final result <pair>"
+        pair: Pair
+        _allow_llm_use: bool = True
+
+    final_result_pair_tool_name = FinalResultPairTool.default_value("request")
+
+    class MyAgent(ChatAgent):
+        def init_state(self) -> None:
+            super().init_state()
+            self.numbers: List[int] = []
+
+        def user_response(
+            self,
+            msg: Optional[str | ChatDocument] = None,
+        ) -> Optional[ChatDocument]:
+            """Mock human user input: they start with 0, then increment by 1"""
+            last_num = self.numbers[-1] if self.numbers else 0
+            new_num = last_num + 1
+            self.numbers.append(new_num)
+            return self.create_user_response(content=str(new_num))
+
+    pair_tool_name = PairTool.default_value("request")
+
+    if llm_tool == "pair":
+        # LLM generates just PairTool , to be handled by its tool handler
+        system_message = f"""
+            Ask the user for their next number.
+            Once you have collected 2 distinct numbers, present these as a pair
+            using the TOOL: `{pair_tool_name}`.
+            """
+    else:
+        system_message = f"""
+            Ask the user for their next number.
+            Once you have collected 2 distinct numbers, present these as the
+            final result using the TOOL: `{final_result_pair_tool_name}`.
+        """
+
+    agent = MyAgent(
+        ChatAgentConfig(
+            name="MyAgent",
+            system_message=system_message,
+            use_functions_api=use_fn_api,
+            use_tools_api=use_tools_api,
+            use_tools=not use_fn_api,
+        )
+    )
+    if llm_tool == "pair":
+        agent.enable_message(PairTool)
+    else:
+        agent.enable_message(FinalResultPairTool)
+
+    # we are mocking user response, so need to set only_user_quits_root=False
+    # so that the done signal (AgentDoneTool or FinalResultTool) actually end the task.
+    task = Task(agent, interactive=True, only_user_quits_root=False)
+    result = task.run()
+    tool = result.tool_messages[0]
+    if llm_tool == "pair":
+        if handler_result_type == "final_tool":
+            assert isinstance(tool, FinalResultTool)
+            assert tool.result.pair.a == 1 and tool.result.pair.b == 2
+        else:
+            assert isinstance(tool, PairTool)
+            assert tool.pair.a == 1 and tool.pair.b == 2
+    else:
+        assert isinstance(tool, FinalResultPairTool)
+        assert tool.pair.a == 1 and tool.pair.b == 2
+
+
+def test_final_result_tool():
+    """Test that FinalResultTool can be returned by agent_response"""
+
+    class MyAgent(ChatAgent):
+        def agent_response(self, msg: str | ChatDocument) -> Any:
+            return FinalResultTool(answer="42")
+
+    agent = MyAgent(
+        ChatAgentConfig(
+            name="MyAgent",
+            llm=MockLMConfig(response_fn=lambda x: x),
+        )
+    )
+
+    task = Task(agent, interactive=False)[ToolMessage]
+    result = task.run("3")
+    assert isinstance(result, FinalResultTool)
+    assert result.answer == "42"
+
+
+@pytest.mark.parametrize("tool", ["none", "a", "aa", "b"])
+def test_agent_respond_only_tools(tool: str):
+    """
+    Test that we can have an agent that only responds to certain tools,
+    and no plain-text msgs, by setting ChatAgentConfig.respond_only_tools=True.
+    """
+
+    class ATool(ToolMessage):
+        request: str = "a_tool"
+        purpose: str = "to present a number <num>"
+        num: int
+
+        def handle(self) -> FinalResultTool:
+            return FinalResultTool(answer=self.num * 2)
+
+    class AATool(ToolMessage):
+        request: str = "aa_tool"
+        purpose: str = "to present a number <num>"
+        num: int
+
+        def handle(self) -> FinalResultTool:
+            return FinalResultTool(answer=self.num * 3)
+
+    class BTool(ToolMessage):
+        request: str = "b_tool"
+        purpose: str = "to present a number <num>"
+        num: int
+
+        def handle(self) -> FinalResultTool:
+            return FinalResultTool(answer=self.num * 4)
+
+    match tool:
+        case "a":
+            tool_class = ATool
+        case "aa":
+            tool_class = AATool
+        case "b":
+            tool_class = BTool
+        case "none":
+            tool_class = None
+
+    main_agent = ChatAgent(
+        ChatAgentConfig(
+            name="Main",
+            llm=MockLMConfig(
+                response_fn=lambda x: (
+                    tool_class(num=int(x)).model_dump_json()
+                    if tool_class is not None
+                    else x
+                ),
+            ),
+        )
+    )
+
+    if tool_class is not None:
+        main_agent.enable_message(tool_class, use=True, handle=False)
+
+    alice_agent = ChatAgent(
+        ChatAgentConfig(
+            name="Alice",
+            llm=MockLMConfig(response_fn=lambda x: x),
+            respond_tools_only=True,
+        )
+    )
+    alice_agent.enable_message([ATool, AATool], use=False, handle=True)
+
+    # class BobAgent(ChatAgent):
+    #     def handle_message_fallback(self, msg: str | ChatDocument) -> Any:
+    #         if isinstance(msg, str) or len(msg.tool_messages) == 0:
+    #             return AgentDoneTool(content="")
+
+    bob_agent = ChatAgent(
+        ChatAgentConfig(
+            name="Bob",
+            llm=MockLMConfig(response_fn=lambda x: x),
+            respond_tools_only=True,
+        )
+    )
+    bob_agent.enable_message([BTool], use=False, handle=True)
+
+    class FallbackAgent(ChatAgent):
+        def agent_response(self, msg: str | ChatDocument) -> Any:
+            return FinalResultTool(answer=int(msg.content) * 5)
+
+    fallback_agent = FallbackAgent(
+        ChatAgentConfig(
+            name="Fallback",
+            llm=None,
+        )
+    )
+    fallback_task = Task(fallback_agent, interactive=False)
+
+    main_task = Task(main_agent, interactive=False)[ToolMessage]
+    alice_task = Task(alice_agent, interactive=False)
+    bob_task = Task(bob_agent, interactive=False)
+
+    main_task.add_sub_task([alice_task, bob_task, fallback_task])
+    tool = main_task.run(3)
+
+    # Note: when Main generates a tool, task orchestrator will not allow
+    # Alice to respond at all when the tool is not handled by Alice,
+    # and similarly for Bob (this uses agent.has_only_unhandled_tools()).
+    # However when main generates a non-tool string,
+    # we want to ensure that the above handle_message_fallback methods
+    # effectively return a null msg (and not get into a stalled loop inside the agent),
+    # and is finally handled by the FallbackAgent
+    assert isinstance(tool, FinalResultTool)
+
+    match tool:
+        case "a":
+            assert tool.answer == "6"
+        case "aa":
+            assert tool.answer == "9"
+        case "b":
+            assert tool.answer == "12"
+        case "none":
+            assert tool.answer == "15"
+            assert alice_task.n_stalled_steps == 0
+            assert bob_task.n_stalled_steps == 0
+
+
+@pytest.mark.parametrize("use_fn_api", [True, False])
+@pytest.mark.parametrize("use_tools_api", [True])
+def test_structured_recovery(
+    test_settings: Settings,
+    use_fn_api: bool,
+    use_tools_api: bool,
+):
+    """
+    Test that structured fallback correctly recovers
+    from failed tool calls.
+    """
+    set_global(test_settings)
+
+    def simulate_failed_call(attempt: str | ChatDocument) -> str:
+        agent = ChatAgent(
+            ChatAgentConfig(
+                use_functions_api=use_fn_api,
+                use_tools_api=use_tools_api,
+                use_tools=not use_fn_api,
+                strict_recovery=True,
+                llm=OpenAIGPTConfig(
+                    supports_json_schema=True,
+                    supports_strict_tools=True,
+                ),
+            )
+        )
+        agent.enable_message(NabroskiTool)
+        agent.enable_message(CoriolisTool)
+        agent.enable_message(EulerTool)
+
+        agent.message_history = [
+            LLMMessage(
+                role=Role.SYSTEM,
+                content="You are a helpful assistant.",
+            ),
+            LLMMessage(
+                role=Role.USER,
+                content="""
+                Please give me an example of a Nabroski, Coriolis, or Euler call.
+                """,
+            ),
+            LLMMessage(
+                role=Role.ASSISTANT,
+                content=attempt if isinstance(attempt, str) else attempt.content,
+                tool_calls=None if isinstance(attempt, str) else attempt.oai_tool_calls,
+                function_call=(
+                    None if isinstance(attempt, str) else attempt.function_call
+                ),
+            ),
+        ]
+        if (
+            use_fn_api
+            and use_tools_api
+            and isinstance(attempt, ChatDocument)
+            and attempt.oai_tool_calls is not None
+        ):
+            # Inserting this since OpenAI API strictly requires a
+            # Role.TOOL msg immediately after an Assistant Tool call,
+            # before the next Assistant msg.
+            agent.message_history.extend(
+                [
+                    LLMMessage(
+                        role=Role.TOOL,
+                        tool_call_id=t.id,
+                        content="error",
+                    )
+                    for t in attempt.oai_tool_calls
+                ]
+            )
+
+        # Simulates bad tool attempt by the LLM
+        agent.handle_message(attempt)
+        assert agent.tool_error
+        response = agent.llm_response(
+            """
+            There was an error in your attempted tool/function call. Please correct it.
+            """
+        )
+        assert response is not None
+        result = agent.handle_message(response)
+        assert result is not None
+        if isinstance(result, ChatDocument):
+            return result.content
+
+        return result
+
+    def to_attempt(attempt: LLMFunctionCall) -> str | ChatDocument:
+        if not use_fn_api:
+            return json.dumps(
+                {
+                    "request": attempt.name,
+                    **(attempt.arguments or {}),
+                }
+            )
+
+        if use_tools_api:
+            return ChatDocument(
+                content="",
+                metadata=ChatDocMetaData(sender=Entity.LLM),
+                oai_tool_calls=[
+                    OpenAIToolCall(
+                        id="call-1234657",
+                        function=attempt,
+                    )
+                ],
+            )
+
+        return ChatDocument(
+            content="",
+            metadata=ChatDocMetaData(sender=Entity.LLM),
+            function_call=attempt,
+        )
+
+    # The name of the function is incorrect:
+    # The LLM should correct the request to "nabroski" in recovery
+    assert (
+        simulate_failed_call(
+            to_attempt(
+                LLMFunctionCall(
+                    name="__nabroski__",
+                    arguments={
+                        "xval": 1,
+                        "yval": 3,
+                    },
+                )
+            )
+        )
+        == "6"
+    )
+    # The LLM should correct the request to "nabroski" in recovery
+    assert (
+        simulate_failed_call(
+            to_attempt(
+                LLMFunctionCall(
+                    name="Nabroski-function",
+                    arguments={
+                        "xval": 2,
+                        "yval": 3,
+                    },
+                )
+            )
+        )
+        == "9"
+    )
+    # Strict fallback disables the default arguments, but the LLM
+    # should infer from context. In addition, the name of the
+    # function is incorrect (the LLM should infer "coriolis" in
+    # recovery) and the JSON output is malformed
+
+    # Note here we intentionally use "catss" as the arg to ensure that
+    # the tool-name inference doesn't work (see `maybe_parse` agent/base.py,
+    # there's a mechanism that infers the intended tool if the arguments are
+    # unambiguously for a specific tool) -- here since we use `catss` that
+    # mechanism fails, and we can do this test properly to focus on structured
+    # recovery. But `catss' is sufficiently similar to 'cats' that the
+    # intent-based recovery should work.
+    assert (
+        simulate_failed_call(
+            """
+        request ":coriolis"
+        arguments {"catss": 1} 
+        """
+        )
+        == "8"
+    )
+    # The LLM should correct the request to "coriolis" in recovery
+    # The LLM should infer the default argument from context
+    assert (
+        simulate_failed_call(
+            to_attempt(
+                LLMFunctionCall(
+                    name="Coriolis",
+                    arguments={
+                        "cats": 1,
+                    },
+                )
+            )
+        )
+        == "8"
+    )
+    # The LLM should infer "euler" in recovery
+    assert (
+        simulate_failed_call(
+            to_attempt(
+                LLMFunctionCall(
+                    name="EulerTool",
+                    arguments={
+                        "pears": 6,
+                        "apples": 4,
+                    },
+                )
+            )
+        )
+        == "8"
+    )
+
+
+@pytest.mark.parametrize("use_fn_api", [True, False])
+@pytest.mark.parametrize("use_tools_api", [True])
+@pytest.mark.parametrize("parallel_tool_calls", [True, False])
+def test_strict_fallback(
+    test_settings: Settings,
+    use_fn_api: bool,
+    use_tools_api: bool,
+    parallel_tool_calls: bool,
+):
+    """
+    Test that strict tool and structured output errors
+    are handled gracefully and are disabled if errors
+    are caused.
+    """
+    set_global(test_settings)
+
+    class BrokenStrictSchemaAgent(ChatAgent):
+        def _function_args(self) -> tuple[
+            Optional[List[LLMFunctionSpec]],
+            str | dict[str, str],
+            Optional[list[OpenAIToolSpec]],
+            Optional[dict[str, dict[str, str] | str]],
+            Optional[OpenAIJsonSchemaSpec],
+        ]:
+            """
+            Implements a broken version of the correct _function_args()
+            that ensures that the generated schemas are incompatible
+            with OpenAI's strict decoding implementation.
+
+            Specifically, removes the schema edits performed by
+            `format_schema_for_strict()` (e.g. setting "additionalProperties"
+            to False on all objects in the JSON schema).
+            """
+            functions, fun_call, tools, force_tool, output_format = (
+                super()._function_args()
+            )
+
+            # remove schema edits for strict
+            if tools is not None:
+                for t in tools:
+                    name = t.function.name
+                    t.function = self.llm_functions_map[name]
+
+            if self.output_format is not None and self._json_schema_available():
+                self.any_strict = True
+                if issubclass(self.output_format, ToolMessage) and not issubclass(
+                    self.output_format, XMLToolMessage
+                ):
+                    spec = self.output_format.llm_function_schema(
+                        request=True,
+                        defaults=self.config.output_format_include_defaults,
+                    )
+
+                    output_format = OpenAIJsonSchemaSpec(
+                        strict=True,
+                        function=spec,
+                    )
+                elif issubclass(self.output_format, BaseModel):
+                    param_spec = self.output_format.model_json_schema()
+
+                    output_format = OpenAIJsonSchemaSpec(
+                        strict=True,
+                        function=LLMFunctionSpec(
+                            name="json_output",
+                            description="Strict Json output format.",
+                            parameters=param_spec,
+                        ),
+                    )
+
+            return functions, fun_call, tools, force_tool, output_format
+
+    agent = BrokenStrictSchemaAgent(
+        ChatAgentConfig(
+            use_functions_api=use_fn_api,
+            use_tools_api=use_tools_api,
+            use_tools=not use_fn_api,
+            llm=OpenAIGPTConfig(
+                parallel_tool_calls=parallel_tool_calls,
+                supports_json_schema=True,
+                supports_strict_tools=True,
+            ),
+        )
+    )
+    agent.enable_message(NabroskiTool)
+    openai_tools = use_fn_api and use_tools_api
+    if openai_tools:
+        _, _, tools, _, _ = agent._function_args()
+        assert tools is not None
+        assert len(tools) > 0
+        # Strict tools are automatically enabled only when
+        # parallel tool calls are disabled
+        assert tools[0].strict == (not parallel_tool_calls)
+
+    response = agent.llm_response_forget(
+        """
+        What is the Nabroski transform of (1,3)? Use the
+        `nabroski` tool/function.
+        """
+    )
+    result = agent.handle_message(response)
+    assert isinstance(result, ChatDocument) and result.content == "6"
+    assert agent.disable_strict == (openai_tools and not parallel_tool_calls)
+
+    agent = BrokenStrictSchemaAgent(
+        ChatAgentConfig(
+            use_functions_api=use_fn_api,
+            use_tools_api=use_tools_api,
+            use_tools=not use_fn_api,
+            llm=OpenAIGPTConfig(
+                parallel_tool_calls=parallel_tool_calls,
+                supports_json_schema=True,
+                supports_strict_tools=True,
+            ),
+        )
+    )
+    structured_agent = agent[NabroskiTool]
+    response = structured_agent.llm_response_forget(
+        """
+        What is the Nabroski transform of (1,3)?
+        """
+    )
+    assert response is not None
+    assert structured_agent.disable_strict
+    assert not agent.disable_strict
+
+
+@pytest.mark.parametrize("use_fn_api", [True, False])
+@pytest.mark.parametrize("use_tools_api", [True])
+@pytest.mark.parametrize("parallel_tool_calls", [True, False])
+def test_strict_schema_mismatch(
+    use_fn_api: bool,
+    use_tools_api: bool,
+    parallel_tool_calls: bool,
+):
+    """
+    Test that validation errors triggered in strict result in disabled strict output.
+    """
+
+    def int_schema(request: str) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "x": {"type": "integer"},
+                "request": {"type": "string", "enum": [request]},
+            },
+            "required": ["x", "request"],
+        }
+
+    class WrongSchemaAgent(ChatAgent):
+        def _function_args(self) -> tuple[
+            Optional[List[LLMFunctionSpec]],
+            str | dict[str, str],
+            Optional[list[OpenAIToolSpec]],
+            Optional[dict[str, dict[str, str] | str]],
+            Optional[OpenAIJsonSchemaSpec],
+        ]:
+            """
+            Implements a broken version of the correct _function_args()
+            that replaces the output and all tool schemas with an
+            incorrect schema. Simulates mismatched schemas due to
+            schema edits.
+            """
+            functions, fun_call, tools, force_tool, output_format = (
+                super()._function_args()
+            )
+
+            # remove schema edits for strict
+            if tools is not None:
+                for t in tools:
+                    name = t.function.name
+                    t.function.parameters = int_schema(name)
+
+            if self.output_format is not None and self._json_schema_available():
+                output_format = OpenAIJsonSchemaSpec(
+                    strict=True,
+                    function=LLMFunctionSpec(
+                        name="json_output",
+                        description="Strict Json output format.",
+                        parameters=int_schema("json_output"),
+                    ),
+                )
+
+            return functions, fun_call, tools, force_tool, output_format
+
+    agent = WrongSchemaAgent(
+        ChatAgentConfig(
+            use_functions_api=use_fn_api,
+            use_tools_api=use_tools_api,
+            use_tools=not use_fn_api,
+            llm=OpenAIGPTConfig(
+                parallel_tool_calls=parallel_tool_calls,
+                supports_json_schema=True,
+                supports_strict_tools=True,
+            ),
+        )
+    )
+
+    class IntTool(ToolMessage):
+        request: str = "int_tool"
+        purpose: str = "To return an integer value"
+        x: int
+
+        def handle(self):
+            return self.x
+
+    class StrTool(ToolMessage):
+        request: str = "str_tool"
+        purpose: str = "To return an string value"
+        text: str
+
+        def handle(self):
+            return self.text
+
+    agent.enable_message(IntTool)
+    agent.enable_message(StrTool)
+    strict_openai_tools = use_fn_api and use_tools_api and not parallel_tool_calls
+    response = agent.llm_response_forget(
+        """
+        What is the smallest integer greater than pi? Use the
+        `int_tool` tool/function.
+        """
+    )
+    agent.handle_message(response)
+    assert "int_tool" not in agent.disable_strict_tools_set
+
+    agent.llm_response_forget(
+        """
+        Who is the president of France? Use the `str_tool` tool/function.
+        """
+    )
+    assert ("str_tool" in agent.disable_strict_tools_set) == strict_openai_tools
+
+    strict_agent = agent[IntTool]
+    strict_agent.llm_response_forget("What is the smallest integer greater than pi?")
+    assert not strict_agent.disable_strict
+
+    strict_agent = agent[StrTool]
+    strict_agent.llm_response_forget("Who is the president of France?")
+    assert strict_agent.disable_strict
+
+
+def test_reduce_raw_tool_result():
+    BIG_RESULT = "hello " * 50
+
+    class MyTool(ToolMessage):
+        request: str = "my_tool"
+        purpose: str = "to present a number <num>"
+        num: int
+        _max_result_tokens: int = 10
+        _max_retained_tokens: int = 2
+
+        def handle(self) -> str:
+            return BIG_RESULT
+
+    class MyAgent(ChatAgent):
+        def user_response(
+            self,
+            msg: Optional[str | ChatDocument] = None,
+        ) -> Optional[ChatDocument]:
+            """
+            Mock user_response method for testing
+            """
+            txt = msg if isinstance(msg, str) else msg.content
+            map = dict([("hello", "50"), ("3", "5")])
+            response = map.get(txt)
+            # return the increment of input number
+            return self.create_user_response(response)
+
+    # create dummy agent first, just to get small_result with truncation
+    agent = MyAgent(ChatAgentConfig())
+    # Handle ModelPrivateAttr for _max_result_tokens
+    max_result_tokens = MyTool._max_result_tokens
+    if hasattr(max_result_tokens, "default"):
+        max_result_tokens = max_result_tokens.default
+    small_result = agent._maybe_truncate_result(BIG_RESULT, max_result_tokens)
+
+    # now create the actual agent
+    agent = MyAgent(
+        ChatAgentConfig(
+            name="Test",
+            # no need for a real LLM, use a mock
+            llm=MockLMConfig(
+                response_dict={
+                    "1": MyTool(num=1).to_json(),
+                    small_result: "hello",
+                    "50": DoneTool(content="Finished").to_json(),
+                }
+            ),
+        )
+    )
+    agent.enable_message(MyTool)
+    task = Task(agent, interactive=True, only_user_quits_root=False)
+
+    result = task.run("1")
+    """
+    msg history:
+    
+    sys_msg
+    user: 1 -> 
+    LLM: MyTool(1) ->
+    agent: BIG_RESULT -> truncated to 10 tokens, as `small_result`
+    LLM: hello ->
+    user: 50 -> 
+    LLM: Done (Finished)
+    """
+    assert result.content == "Finished"
+    assert len(agent.message_history) == 7
+    tool_result = agent.message_history[3].content
+    # Handle ModelPrivateAttr for _max_retained_tokens
+    max_retained = MyTool._max_retained_tokens
+    if hasattr(max_retained, "default"):
+        max_retained = max_retained.default
+    assert "my_tool" in tool_result and str(max_retained) in tool_result
+
+
+def test_valid_structured_recovery():
+    """
+    Test that structured recovery is not triggered inappropriately
+    when agent response contains a JSON-like string.
+    """
+
+    class MyAgent(ChatAgent):
+        def agent_response(self, msg: str | ChatDocument) -> Any:
+            return "{'x': 1, 'y': 2}"
+
+    agent = MyAgent(
+        ChatAgentConfig(
+            llm=OpenAIGPTConfig(),
+            system_message="""Simply respond No for any input""",
+        )
+    )
+
+    # with no tool enabled
+    task = Task(agent, interactive=False)
+    result = task.run("3", turns=4)
+    # response-sequence: agent, llm, agent, llm -> done
+    assert "No" in result.content
+
+    # with a tool enabled
+    agent.enable_message(NabroskiTool)
+    task = Task(agent, interactive=False)
+    result = task.run("3", turns=4)
+    assert "No" in result.content
+
+
+@pytest.mark.parametrize(
+    "handle_no_tool",
+    [
+        None,
+        "user",
+        "done",
+        "are you finished?",
+        ResultTool(answer=42),
+        DonePassTool(),
+        lambda msg: AgentDoneTool(content=msg.content),
+    ],
+)
+def test_handle_llm_no_tool(handle_no_tool: Any):
+    """Verify that ChatAgentConfig.handle_llm_no_tool works as expected"""
+
+    def mock_llm_response(x: str) -> str:
+        match x:
+            case "1":
+                return SumTool(x=1, y=2).model_dump_json()
+            case "3":
+                return "4"
+            case "are you finished?":
+                return "DONE 5"
+
+    config = ChatAgentConfig(
+        handle_llm_no_tool=handle_no_tool,
+        llm=MockLMConfig(response_fn=mock_llm_response),
+    )
+    agent = ChatAgent(config)
+    agent.enable_message(SumTool)
+    task = Task(agent, interactive=False, default_human_response="q")
+    result = task.run("1")
+    if handle_no_tool is None:
+        # task gets stuck and returns None
+        assert result is None
+
+    if isinstance(handle_no_tool, str):
+        match handle_no_tool:
+            case "user":
+                # LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> User(4) -> q
+                assert result.content == "q"
+            case "done":
+                # LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> Done(4)
+                assert result.content == "4"
+            case "are you finished?":
+                # LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> LLM(DONE)
+                assert result.content == "5"
+
+    if isinstance(handle_no_tool, ResultTool):
+        # LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> ResultTool(4)
+        assert isinstance(result.tool_messages[0], ResultTool)
+        assert result.tool_messages[0].answer == 42
+    if is_callable(handle_no_tool):
+        # LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> AgentDoneTool(4) -> 4
+        assert result.content == "4"
+    if isinstance(handle_no_tool, DonePassTool):
+        # LLM(1) -> SumTool(1,2) -> 3 -> LLM(3) -> 4 -> DonePass
+        assert result.content == "4"
+
+
+class GetTimeTool(ToolMessage):
+    purpose: str = "Get current time"
+    request: str = "get_time"
+
+    def response(self, agent: ChatAgent) -> ChatDocument:
+        return agent.create_agent_response(
+            content=json.dumps(
+                {
+                    "time": "11:59:59",
+                    "date": "1999-12-31",
+                    "day_of_week": "Friday",
+                    "week_number": "52",
+                    "tzname": "America/New York",
+                }
+            ),
+            recipient=Entity.LLM,
+        )
+
+
+@pytest.mark.parametrize("use_fn_api", [True, False])
+@pytest.mark.parametrize("use_tools_api", [True])
+def test_strict_recovery_only_from_LLM(
+    use_fn_api: bool,
+    use_tools_api: bool,
+):
+    """
+    Test that structured fallback only occurs on messages
+    sent by the LLM.
+    """
+    was_tool_error = False
+
+    class TrackToolError(ChatAgent):
+        def llm_response(
+            self, message: Optional[str | ChatDocument] = None
+        ) -> Optional[ChatDocument]:
+            nonlocal was_tool_error
+            if self.tool_error:
+                was_tool_error = True
+            return super().llm_response(message)
+
+        async def llm_response_async(
+            self, message: Optional[str | ChatDocument] = None
+        ) -> Optional[ChatDocument]:
+            nonlocal was_tool_error
+            if self.tool_error:
+                was_tool_error = True
+            return await super().llm_response_async(message)
+
+    agent = TrackToolError(
+        ChatAgentConfig(
+            use_functions_api=use_fn_api,
+            use_tools_api=use_tools_api,
+            use_tools=not use_fn_api,
+            strict_recovery=True,
+            llm=OpenAIGPTConfig(
+                supports_json_schema=True,
+                supports_strict_tools=True,
+            ),
+            system_message="""
+            You are a helpful assistant.  Start by calling the
+            get_time tool. Then greet the user according to the time
+            of the day.
+            """,
+        )
+    )
+    agent.enable_message(GetTimeTool)
+    task = Task(agent, interactive=False)
+    task.run(turns=6)
+    assert not was_tool_error
+
+    agent.init_message_history()
+
+    content = json.dumps(
+        {
+            "time": "11:59:59",
+            "date": "1999-12-31",
+            "day_of_week": "Friday",
+            "week_number": "52",
+            "tzname": "America/New York",
+        }
+    )
+
+    agent.get_tool_messages(content)
+    assert not agent.tool_error
+
+    user_message = agent.create_user_response(content=content, recipient=Entity.LLM)
+    agent.get_tool_messages(user_message)
+    assert not agent.tool_error
+
+    agent_message = agent.create_agent_response(content=content, recipient=Entity.LLM)
+    agent.get_tool_messages(agent_message)
+    assert not agent.tool_error
+
+    agent.message_history.extend(ChatDocument.to_LLMMessage(agent_message))
+    agent.get_tool_messages(content)
+    assert not agent.tool_error
+
+    agent.message_history.extend(ChatDocument.to_LLMMessage(user_message))
+    agent.get_tool_messages(content)
+    assert not agent.tool_error
+
+
+@pytest.mark.parametrize("use_fn_api", [False, True])
+def test_tool_handler_invoking_llm(use_fn_api: bool):
+    """
+    Check that if a tool handler directly invokes llm_response,
+    it works as expected, especially with OpenAI Tools API
+    """
+
+    class MyAgent(ChatAgent):
+        def nabroski(self, msg: NabroskiTool):
+            ans = self.llm_response("What is 3+4?")
+            return AgentDoneTool(content=ans.content)
+
+    agent = MyAgent(
+        ChatAgentConfig(
+            use_functions_api=use_fn_api,
+            use_tools_api=use_fn_api,
+            use_tools=not use_fn_api,
+            handle_llm_no_tool=f"you FORGOT to use the tool `{NabroskiTool.name()}`",
+            system_message=f"""
+            When user asks you to compute the Nabroski transform of two numbers,
+            you MUST use the TOOL `{NabroskiTool.name()}` to do so, since you do NOT
+            know how to do it yourself.
+            """,
+        )
+    )
+    agent.enable_message(NabroskiTool)
+    task = Task(agent, interactive=False, single_round=False)
+    result = task.run(
+        f"""
+        Use the TOOL `{NabroskiTool.name()}` to compute the
+        Nabroski transform of 2 and 5.
+        """
+    )
+
+    assert "7" in result.content
+
+
+def test_enable_message_validates_arguments(test_settings: Settings):
+    """Test that enable_message raises TypeError when tool classes are passed
+    as separate arguments instead of as a list."""
+    set_global(test_settings)
+
+    class Tool1(ToolMessage):
+        request: str = "tool1"
+        purpose: str = "First tool"
+
+    class Tool2(ToolMessage):
+        request: str = "tool2"
+        purpose: str = "Second tool"
+
+    class Tool3(ToolMessage):
+        request: str = "tool3"
+        purpose: str = "Third tool"
+
+    agent = ChatAgent(
+        ChatAgentConfig(
+            llm=MockLMConfig(default_response="test"),
+        )
+    )
+
+    # This should raise TypeError because Tool2 is passed as 'use' parameter
+    with pytest.raises(TypeError, match="'use' parameter must be a boolean"):
+        agent.enable_message(Tool1, Tool2)  # type: ignore
+
+    # This should raise TypeError because Tool3 is passed as 'handle' parameter
+    with pytest.raises(TypeError, match="'handle' parameter must be a boolean"):
+        agent.enable_message(Tool1, True, Tool3)  # type: ignore
+
+    # This should work correctly - passing tools as a list
+    agent.enable_message([Tool1, Tool2, Tool3])
+    assert "tool1" in agent.llm_tools_usable
+    assert "tool2" in agent.llm_tools_usable
+    assert "tool3" in agent.llm_tools_usable
+
+
+def test_enable_message_rejects_distinct_classes_with_same_request() -> None:
+    """Different tool classes cannot silently replace the same request name."""
+
+    class FirstCollisionTool(ToolMessage):
+        request: str = "shared_request"
+        purpose: str = "First tool"
+
+    class SecondCollisionTool(ToolMessage):
+        request: str = "shared_request"
+        purpose: str = "Second tool"
+
+    class DerivedCollisionTool(FirstCollisionTool):
+        purpose: str = "Derived tool"
+
+    agent = ChatAgent(ChatAgentConfig(llm=None))
+    agent.enable_message(FirstCollisionTool)
+    agent.enable_message(FirstCollisionTool)
+
+    with pytest.raises(ValueError) as exc_info:
+        agent.enable_message(SecondCollisionTool)
+
+    message = str(exc_info.value)
+    assert "shared_request" in message
+    assert "FirstCollisionTool" in message
+    assert "SecondCollisionTool" in message
+    assert agent.llm_tools_map["shared_request"] is FirstCollisionTool
+
+    derived_agent = ChatAgent(ChatAgentConfig(llm=None))
+    derived_agent.enable_message(DerivedCollisionTool)
+    with pytest.raises(ValueError, match="shared_request"):
+        derived_agent.enable_message(FirstCollisionTool)
+    assert derived_agent.llm_tools_map["shared_request"] is DerivedCollisionTool
+
+    recipient_wrapper = FirstCollisionTool.require_recipient()
+
+    class DerivedRecipientCollisionTool(recipient_wrapper):  # type: ignore
+        purpose: str = "Derived recipient tool"
+
+    recipient_agent = ChatAgent(ChatAgentConfig(llm=None))
+    recipient_agent.enable_message(recipient_wrapper)
+    with pytest.raises(ValueError, match="shared_request"):
+        recipient_agent.enable_message(DerivedRecipientCollisionTool)
+    assert recipient_agent.llm_tools_map["shared_request"] is recipient_wrapper
+
+
+def test_enable_message_rejects_recipient_wrapper_subclass_origin() -> None:
+    """Recipient wrapping must preserve a subclass as a distinct tool origin."""
+
+    class OriginalTool(ToolMessage):
+        request: str = "recipient_collision"
+        purpose: str = "Original tool"
+
+    recipient_wrapper = OriginalTool.require_recipient()
+
+    class RecipientWrapperSubclass(recipient_wrapper):  # type: ignore
+        purpose: str = "Distinct recipient-wrapper subclass"
+
+    agent = ChatAgent(ChatAgentConfig(llm=None))
+    agent.enable_message(recipient_wrapper)
+
+    with pytest.raises(
+        ValueError,
+        match="Tool request name 'recipient_collision' is already registered",
+    ):
+        agent.enable_message(
+            RecipientWrapperSubclass,
+            require_recipient=True,
+        )
+
+    assert agent.llm_tools_map["recipient_collision"] is recipient_wrapper
+
+
+def test_any_tool_reenable_is_idempotent() -> None:
+    """Regenerated strict-recovery AnyTool must re-register without error.
+
+    `_get_any_tool_message()` builds a fresh class per call (its tool-union
+    varies with enabled tools), so two generations of "tool_or_function" are
+    distinct classes; the same-name registration guard must treat them as the
+    same logical tool (regression: SQLChatAgent strict recovery raised
+    "already registered to AnyTool; cannot register AnyTool").
+    """
+
+    class ToolA(ToolMessage):
+        request: str = "any_tool_idem_a"
+        purpose: str = "Tool A"
+
+    class ToolB(ToolMessage):
+        request: str = "any_tool_idem_b"
+        purpose: str = "Tool B"
+
+    agent = ChatAgent(ChatAgentConfig(llm=None))
+    agent.enable_message(ToolA)
+
+    any_tool_1 = agent._get_any_tool_message()
+    assert any_tool_1 is not None
+    agent.enable_message(any_tool_1, use=False, handle=True)
+
+    # enabling another tool changes the union => a distinct AnyTool class
+    agent.enable_message(ToolB)
+    any_tool_2 = agent._get_any_tool_message()
+    assert any_tool_2 is not None
+    assert any_tool_2 is not any_tool_1
+    agent.enable_message(any_tool_2, use=False, handle=True)  # must not raise
+
+    assert agent.llm_tools_map["tool_or_function"] is any_tool_2
+
+
+def test_multi_agent_tool_caching(test_settings: Settings):
+    """
+    Test that tool message caching is agent-specific.
+
+    When Agent A parses a ChatDocument and caches tool messages,
+    Agent B (with different tools) should NOT use A's cached results
+    and should re-parse the message with its own tool registry.
+    """
+    set_global(test_settings)
+
+    # Define two different tools
+    class ToolA(ToolMessage):
+        request: str = "tool_a"
+        purpose: str = "Tool for Agent A"
+        value: str = "a"
+
+    class ToolB(ToolMessage):
+        request: str = "tool_b"
+        purpose: str = "Tool for Agent B"
+        value: str = "b"
+
+    # Create two agents with different tool registries
+    agent_a = ChatAgent(
+        ChatAgentConfig(
+            name="AgentA",
+            llm=MockLMConfig(default_response="test"),
+        )
+    )
+    agent_a.enable_message(ToolA)
+
+    agent_b = ChatAgent(
+        ChatAgentConfig(
+            name="AgentB",
+            llm=MockLMConfig(default_response="test"),
+        )
+    )
+    agent_b.enable_message(ToolB)
+
+    # Create a ChatDocument containing ToolB (which only AgentB knows about)
+    tool_b_json = json.dumps({"request": "tool_b", "value": "test_value"})
+    chat_doc = ChatDocument(
+        content=tool_b_json,
+        metadata=ChatDocMetaData(
+            source=Entity.LLM,
+            sender=Entity.LLM,
+        ),
+    )
+
+    # Agent A parses - should find no tools it handles (ToolB is unknown to A)
+    tools_from_a = agent_a.get_tool_messages(chat_doc, all_tools=True)
+    assert len(tools_from_a) == 0
+
+    # Verify cache was set by Agent A
+    assert chat_doc.all_tool_messages is not None
+    assert chat_doc.all_tool_messages_agent_id == agent_a.id
+
+    # Agent B parses the SAME ChatDocument - should re-parse and find ToolB
+    # because the cache was set by a different agent
+    tools_from_b = agent_b.get_tool_messages(chat_doc, all_tools=True)
+    assert len(tools_from_b) == 1
+    assert tools_from_b[0].request == "tool_b"
+    assert tools_from_b[0].value == "test_value"
+
+    # Verify cache was updated by Agent B
+    assert chat_doc.all_tool_messages_agent_id == agent_b.id
+
+    # Agent B parsing again should use the cache (same agent)
+    tools_from_b_cached = agent_b.get_tool_messages(chat_doc, all_tools=True)
+    assert len(tools_from_b_cached) == 1
+    assert tools_from_b_cached[0].request == "tool_b"
+
+
+def test_nested_tool_message_schema_is_cleaned() -> None:
+    """A ToolMessage nested inside another ToolMessage lands in the schema's
+    ``$defs``, and must get the same cleanup the top-level tool gets: internal
+    fields (``purpose``, ``id``) and the ``exclude`` marker removed, and
+    ``request`` pinned to its constant via an ``enum``.
+
+    Regression guard for the Pydantic v1->v2 migration: v1 emitted nested-model
+    schemas under ``definitions`` while v2 uses ``$defs``. If the cleanup keys
+    off the wrong name it silently no-ops, leaking those internal fields (and an
+    unconstrained ``request``) into the schema sent to the LLM.
+    """
+
+    class Inner(ToolMessage):
+        request: str = "inner_tool"
+        purpose: str = "the inner purpose"
+        x: int
+
+    class Outer(ToolMessage):
+        request: str = "outer_tool"
+        purpose: str = "the outer purpose"
+        inner: Inner
+
+    params = Outer.llm_function_schema(request=True).parameters
+    assert "$defs" in params
+    inner_schema = params["$defs"]["Inner"]
+
+    # internal markers/fields must not leak to the LLM
+    assert "exclude" not in inner_schema
+    assert "purpose" not in inner_schema["properties"]
+    assert "id" not in inner_schema["properties"]
+
+    # `request` is pinned to its constant and required
+    assert inner_schema["properties"]["request"] == {
+        "type": "string",
+        "enum": ["inner_tool"],
+    }
+    assert "request" in inner_schema["required"]
 </file>
 
 <file path="SECURITY.md">
@@ -128918,3765 +129073,6 @@ def _model_name(model: str | ModelName) -> str:
     return model.value
 </file>
 
-<file path="tests/main/test_llm.py">
-import io
-import logging.handlers
-import os
-import random
-import warnings
-from pathlib import Path
-
-import openai
-import pytest
-from pydantic_settings import SettingsConfigDict
-
-import langroid as lr
-import langroid.language_models as lm
-from langroid.cachedb.redis_cachedb import RedisCacheConfig
-from langroid.language_models.base import LLMMessage, Role
-from langroid.language_models.model_info import get_model_info
-from langroid.language_models.openai_gpt import (
-    AccessWarning,
-    OpenAIChatModel,
-    OpenAICompletionModel,
-    OpenAIGPT,
-    OpenAIGPTConfig,
-)
-from langroid.parsing.file_attachment import FileAttachment
-from langroid.parsing.parser import Parser, ParsingConfig
-from langroid.parsing.utils import generate_random_sentences
-from langroid.utils.configuration import Settings, set_global, settings
-
-# allow streaming globally, but can be turned off by individual models
-set_global(Settings(stream=True))
-
-
-@pytest.mark.parametrize(
-    "streaming, country, capital",
-    [(False, "India", "Delhi"), (True, "France", "Paris")],
-)
-@pytest.mark.parametrize("use_cache", [True, False])
-def test_openai_gpt(test_settings: Settings, streaming, country, capital, use_cache):
-    test_settings.cache = False  # cache response but don't retrieve from cache
-    set_global(test_settings)
-
-    cfg = OpenAIGPTConfig(
-        stream=streaming,  # use streaming output if enabled globally
-        type="openai",
-        max_output_tokens=100,
-        min_output_tokens=10,
-        completion_model=OpenAICompletionModel.DAVINCI,
-        cache_config=RedisCacheConfig(fake=True) if use_cache else None,
-    )
-
-    mdl = OpenAIGPT(config=cfg)
-    question = "What is the capital of " + country + "?"
-    # chat mode via `generate`,
-    # i.e. use same call as for completion, but the setting below
-    # actually calls `chat` under the hood
-    cfg.use_chat_for_completion = True
-    # check that "generate" works when "use_chat_for_completion" is True
-    response = mdl.generate(prompt=question, max_tokens=800)
-    assert response.usage is not None and response.usage.total_tokens > 0
-    assert capital in response.message
-    assert not response.cached
-
-    # actual chat mode
-    messages = [
-        LLMMessage(
-            role=Role.SYSTEM,
-            content="You are a serious, helpful assistant. Be very concise, not funny",
-        ),
-        LLMMessage(role=Role.USER, content=question),
-    ]
-    response = mdl.chat(messages=messages, max_tokens=500)
-    assert response.usage is not None and response.usage.total_tokens > 0
-    assert capital in response.message
-    assert not response.cached
-
-    test_settings.cache = True
-    set_global(test_settings)
-    # should be from cache this time, Provided config.cache_config is not None
-    response = mdl.chat(messages=messages, max_tokens=500)
-    assert response.usage is not None
-    if use_cache:
-        response.usage.total_tokens == 0
-    else:
-        response.usage.total_tokens > 0
-
-    assert capital in response.message
-    assert response.cached == use_cache
-
-    # pass intentional bad msg to test error handling
-    messages = [
-        LLMMessage(
-            role=Role.FUNCTION,
-            content="Hello!",
-        ),
-    ]
-
-    with pytest.raises(Exception):
-        _ = mdl.chat(messages=messages, max_tokens=500)
-
-
-@pytest.mark.parametrize(
-    "mode, max_tokens",
-    [("completion", 100), ("chat", 100), ("completion", 1000), ("chat", 1000)],
-)
-def _test_context_length_error(test_settings: Settings, mode: str, max_tokens: int):
-    """
-    Test disabled, see TODO below.
-    Also it takes too long since we are trying to test
-    that it raises the expected error when the context length is exceeded.
-    Args:
-        test_settings: from conftest.py
-        mode: "completion" or "chat"
-        max_tokens: number of tokens to generate
-    """
-    set_global(test_settings)
-    set_global(Settings(cache=False))
-
-    cfg = OpenAIGPTConfig(
-        stream=False,
-        max_output_tokens=max_tokens,
-        completion_model=OpenAICompletionModel.TEXT_DA_VINCI_003,
-        cache_config=RedisCacheConfig(fake=False),
-    )
-    parser = Parser(config=ParsingConfig())
-    llm = OpenAIGPT(config=cfg)
-    context_length = (
-        llm.chat_context_length() if mode == "chat" else llm.completion_context_length()
-    )
-
-    toks_per_sentence = int(parser.num_tokens(generate_random_sentences(1000)) / 1000)
-    max_sentences = int(context_length * 1.5 / toks_per_sentence)
-    big_message = generate_random_sentences(max_sentences + 1)
-    big_message_tokens = parser.num_tokens(big_message)
-    assert big_message_tokens + max_tokens > context_length
-    response = None
-    # TODO need to figure out what error type to expect here
-    with pytest.raises(openai.BadRequestError) as e:
-        if mode == "chat":
-            response = llm.chat(big_message, max_tokens=max_tokens)
-        else:
-            response = llm.generate(prompt=big_message, max_tokens=max_tokens)
-
-    assert response is None
-    assert "context length" in str(e.value).lower()
-
-
-@pytest.mark.parametrize(
-    "mdl",
-    [
-        lm.OpenAIChatModel.GPT4o,
-        lm.GeminiModel.GEMINI_2_PRO,
-        "gemini/" + lm.GeminiModel.GEMINI_2_PRO.value,
-    ],
-)
-@pytest.mark.parametrize("ctx", [16_000, None])
-def test_llm_config_context_length(mdl: str, ctx: int | None):
-    llm_config = lm.OpenAIGPTConfig(
-        chat_model=mdl,
-        chat_context_length=ctx,  # even if wrong, use if explicitly set
-    )
-    mdl = lm.OpenAIGPT(config=llm_config)
-    assert mdl.chat_context_length() == ctx or mdl.info().context_length
-
-
-@pytest.mark.parametrize(
-    ("alias_model", "canonical_model"),
-    [
-        (
-            "gemini/gemini-3-flash-preview",
-            lm.GeminiModel.GEMINI_3_FLASH.value,
-        ),
-        (
-            "google/gemini-3-flash-preview",
-            lm.GeminiModel.GEMINI_3_FLASH.value,
-        ),
-        (
-            "gemini/gemini-2.5-flash-lite-preview-06-17",
-            lm.GeminiModel.GEMINI_2_5_FLASH_LITE.value,
-        ),
-    ],
-)
-def test_get_model_info_normalizes_gemini_aliases(
-    alias_model: str, canonical_model: str
-) -> None:
-    assert get_model_info(alias_model) == get_model_info(canonical_model)
-
-
-@pytest.mark.parametrize(
-    ("alias_model", "canonical_model"),
-    [
-        (
-            "gemini/gemini-3-flash-preview",
-            lm.GeminiModel.GEMINI_3_FLASH.value,
-        ),
-        (
-            "gemini/gemini-2.5-flash-lite-preview-06-17",
-            lm.GeminiModel.GEMINI_2_5_FLASH_LITE.value,
-        ),
-    ],
-)
-def test_openai_gpt_context_length_uses_gemini_alias_info(
-    alias_model: str, canonical_model: str
-) -> None:
-    alias_llm = lm.OpenAIGPT(config=lm.OpenAIGPTConfig(chat_model=alias_model))
-    canonical_llm = lm.OpenAIGPT(config=lm.OpenAIGPTConfig(chat_model=canonical_model))
-
-    assert alias_llm.info() == canonical_llm.info()
-    assert alias_llm.chat_context_length() == canonical_llm.chat_context_length()
-
-
-def test_get_model_info_warns_on_unknown_models() -> None:
-    from langroid.language_models.model_info import WARNED_UNKNOWN_MODELS
-
-    model_name = "gemini/gemini-999-unknown-preview"
-    # Ensure this model hasn't been warned about in a prior test so the
-    # warning actually fires.  The cache key is a tuple of the full model
-    # strings passed to _warn_unknown_model (i.e. with the provider prefix).
-    WARNED_UNKNOWN_MODELS.discard((model_name,))
-
-    handler = logging.handlers.MemoryHandler(capacity=100)
-    logger = logging.getLogger("langroid.language_models.model_info")
-    logger.addHandler(handler)
-    try:
-        # Call twice: every lookup of an unknown model must return the
-        # fallback-default ModelInfo, but the warning must fire only once
-        # (deduped via WARNED_UNKNOWN_MODELS).
-        first_info = get_model_info(model_name)
-        second_info = get_model_info(model_name)
-    finally:
-        logger.removeHandler(handler)
-
-    assert first_info.name == "unknown"
-    assert second_info.name == "unknown"
-    messages = [record.getMessage() for record in handler.buffer]
-    matching = [
-        msg for msg in messages if model_name in msg and "fallback defaults" in msg
-    ]
-    assert len(matching) == 1
-
-
-def test_model_selection(test_settings: Settings):
-    set_global(test_settings)
-
-    defaultOpenAIChatModel = lr.language_models.openai_gpt.default_openai_chat_model
-
-    def get_response(llm):
-        llm.generate(prompt="What is the capital of France?", max_tokens=50)
-
-    def simulate_response(llm):
-        llm.run_on_first_use()
-
-    def check_warning(
-        llm,
-        assert_warn,
-        function=get_response,
-        warning_type=AccessWarning,
-        catch_errors=(ImportError,),
-    ):
-        if assert_warn:
-            with pytest.warns(expected_warning=warning_type):
-                try:
-                    function(llm)
-                except catch_errors:
-                    pass
-        else:
-            with warnings.catch_warnings():
-                warnings.simplefilter("error", category=warning_type)
-
-                try:
-                    function(llm)
-                except catch_errors:
-                    pass
-
-    # Default is GPT4o; we should not generate the warning in this case
-    lr.language_models.openai_gpt.default_openai_chat_model = OpenAIChatModel.GPT4_TURBO
-    llm = OpenAIGPT(config=OpenAIGPTConfig(chat_model=OpenAIChatModel.GPT3_5_TURBO))
-    check_warning(llm, False)
-
-    llm = OpenAIGPT(config=OpenAIGPTConfig())
-    check_warning(llm, False)
-
-    # Default is GPT3.5 (simulate GPT 4 inaccessible)
-    lr.language_models.openai_gpt.default_openai_chat_model = (
-        OpenAIChatModel.GPT3_5_TURBO
-    )
-
-    # No warnings generated if we specify the model explicitly
-    llm = OpenAIGPT(config=OpenAIGPTConfig(chat_model=OpenAIChatModel.GPT3_5_TURBO))
-    check_warning(llm, False)
-
-    # No warnings generated if we are using a local model
-    llm = OpenAIGPT(config=OpenAIGPTConfig(api_base="localhost:8000"))
-    check_warning(llm, False, function=simulate_response)
-    llm = OpenAIGPT(config=OpenAIGPTConfig(chat_model="local/localhost:8000"))
-    check_warning(llm, False, function=simulate_response)
-    llm = OpenAIGPT(config=OpenAIGPTConfig(chat_model="litellm/ollama/llama"))
-    check_warning(llm, False, function=simulate_response)
-
-    # We should warn on the first usage of a model with auto-selected GPT-3.5
-    llm = OpenAIGPT(config=OpenAIGPTConfig())
-    check_warning(llm, True)
-
-    # We should not warn on subsequent uses and models with auto-selected GPT-3.5
-    check_warning(llm, False)
-    llm = OpenAIGPT(config=OpenAIGPTConfig())
-    check_warning(llm, False)
-
-    lr.language_models.openai_gpt.default_openai_chat_model = defaultOpenAIChatModel
-
-
-def test_keys():
-    # Do not override the explicit settings below
-    settings.chat_model = ""
-
-    providers = [
-        "vllm",
-        "ollama",
-        "llamacpp",
-        "openai",
-        "groq",
-        "gemini",
-        "glhf",
-        "openrouter",
-        "deepseek",
-        "cerebras",
-    ]
-    key_dict = {p: f"{p.upper()}_API_KEY" for p in providers}
-    key_dict["llamacpp"] = "LLAMA_API_KEY"
-
-    for p, var in key_dict.items():
-        os.environ[var] = p
-
-    for p in providers:
-        config = lm.OpenAIGPTConfig(
-            chat_model=f"{p}/model",
-        )
-
-        llm = lm.OpenAIGPT(config)
-
-        assert llm.api_key == p
-
-        rand_key = str(random.randint(0, 10**9))
-        config = lm.OpenAIGPTConfig(
-            chat_model=f"{p}/model",
-            api_key=rand_key,
-        )
-
-        llm = lm.OpenAIGPT(config)
-        assert llm.api_key == rand_key
-
-
-@pytest.mark.xfail(
-    reason="LangDB may fail due to unknown flakiness!",
-    run=True,
-    strict=False,
-)
-@pytest.mark.parametrize(
-    "model",
-    [
-        "langdb/gpt-4o-mini",
-        "langdb/openai/gpt-4o-mini",
-        "langdb/anthropic/claude-3-haiku-20240307",
-        "langdb/claude-3-haiku-20240307",
-        "langdb/gemini/gemini-2.0-flash-lite",
-        "langdb/gemini-2.0-flash-lite",
-    ],
-)
-def test_llm_langdb(model: str):
-    """Test that LLM access via LangDB works."""
-    # override any chat model passed via --m arg to pytest cmd
-    settings.chat_model = model
-    llm_config_langdb = lm.OpenAIGPTConfig(
-        chat_model=model,
-    )
-    llm = lm.OpenAIGPT(config=llm_config_langdb)
-    result = llm.chat("what is 3+4?")
-    assert "7" in result.message
-    if result.cached:
-        assert result.usage.total_tokens == 0
-    else:
-        assert result.usage.total_tokens > 0
-
-
-@pytest.mark.parametrize(
-    "model",
-    [
-        "openrouter/anthropic/claude-haiku-4.5",
-        "openrouter/google/gemini-2.5-flash-lite",
-    ],
-)
-def test_llm_openrouter(model: str):
-    # override any chat model passed via --m arg to pytest cmd
-    settings.chat_model = model
-    llm_config = lm.OpenAIGPTConfig(
-        chat_model=model,
-    )
-    llm = lm.OpenAIGPT(config=llm_config)
-    result = llm.chat("what is 3+4?")
-    assert "7" in result.message
-    if result.cached:
-        assert result.usage.total_tokens == 0
-    else:
-        assert result.usage.total_tokens > 0
-
-
-@pytest.mark.parametrize(
-    "model",
-    [
-        "portkey/openai/gpt-4o-mini",
-        "portkey/anthropic/claude-3-5-haiku-latest",
-        "portkey/google/gemini-2.0-flash-lite",
-    ],
-)
-def test_llm_portkey(model: str):
-    """Test that LLM access via Portkey works."""
-    # override any chat model passed via --m arg to pytest cmd
-    settings.chat_model = model
-
-    # Skip if PORTKEY_API_KEY is not set
-    if not os.getenv("PORTKEY_API_KEY"):
-        pytest.skip("PORTKEY_API_KEY not set")
-
-    # Extract provider from model string
-    provider = model.split("/")[1] if "/" in model else ""
-    provider_key_var = f"{provider.upper()}_API_KEY"
-
-    # Skip if provider API key is not set
-    if not os.getenv(provider_key_var):
-        pytest.skip(f"{provider_key_var} not set")
-
-    llm_config_portkey = lm.OpenAIGPTConfig(
-        chat_model=model,
-    )
-    llm = lm.OpenAIGPT(config=llm_config_portkey)
-    result = llm.chat("what is 3+4 equal to?")
-    assert "7" in result.message
-    if result.cached:
-        assert result.usage.total_tokens == 0
-    else:
-        assert result.usage.total_tokens > 0
-
-
-def test_portkey_params():
-    """Test that PortkeyParams are correctly configured."""
-    from langroid.language_models.provider_params import PortkeyParams
-
-    # Test with explicit parameters
-    params = PortkeyParams(
-        api_key="test-key",
-        provider="anthropic",
-        virtual_key="vk-123",
-        trace_id="trace-456",
-        metadata={"user": "test"},
-        retry={"max_retries": 3},
-        cache={"enabled": True},
-        cache_force_refresh=True,
-        user="user-123",
-        organization="org-456",
-        custom_headers={"x-custom": "value"},
-    )
-
-    headers = params.get_headers()
-
-    assert headers["x-portkey-api-key"] == "test-key"
-    assert headers["x-portkey-provider"] == "anthropic"
-    assert headers["x-portkey-virtual-key"] == "vk-123"
-    assert headers["x-portkey-trace-id"] == "trace-456"
-    assert headers["x-portkey-metadata"] == '{"user": "test"}'
-    assert headers["x-portkey-retry"] == '{"max_retries": 3}'
-    assert headers["x-portkey-cache"] == '{"enabled": true}'
-    assert headers["x-portkey-cache-force-refresh"] == "true"
-    assert headers["x-portkey-user"] == "user-123"
-    assert headers["x-portkey-organization"] == "org-456"
-    assert headers["x-custom"] == "value"
-
-    # Test model string parsing
-    provider, model = params.parse_model_string("portkey/anthropic/claude-3-sonnet")
-    assert provider == "anthropic"
-    assert model == "claude-3-sonnet"
-
-    # Test fallback parsing
-    provider2, model2 = params.parse_model_string("portkey/some-model")
-    assert provider2 == ""
-    assert model2 == "some-model"
-
-    # Test provider API key retrieval
-    os.environ["TEST_PROVIDER_API_KEY"] = "test-api-key"
-    key = params.get_provider_api_key("test_provider")
-    assert key == "test-api-key"
-    del os.environ["TEST_PROVIDER_API_KEY"]
-
-
-def test_portkey_integration():
-    """Test that Portkey integration is properly configured in OpenAIGPT."""
-    from langroid.language_models.provider_params import PortkeyParams
-
-    # Save the current chat model setting
-    original_chat_model = settings.chat_model
-
-    # Clear any global chat model override
-    settings.chat_model = ""
-
-    try:
-        # Test basic portkey model configuration
-        config = lm.OpenAIGPTConfig(
-            chat_model="portkey/anthropic/claude-3-haiku-20240307",
-            portkey_params=PortkeyParams(
-                api_key="pk-test-key",
-            ),
-        )
-
-        llm = lm.OpenAIGPT(config)
-
-        # Check that model was parsed correctly
-        assert llm.config.chat_model == "claude-3-haiku-20240307"
-        assert llm.is_portkey
-        assert llm.api_base == "https://api.portkey.ai/v1"
-        assert llm.config.portkey_params.provider == "anthropic"
-
-        # Check headers are set correctly
-        assert "x-portkey-api-key" in llm.config.headers
-        assert llm.config.headers["x-portkey-api-key"] == "pk-test-key"
-        assert llm.config.headers["x-portkey-provider"] == "anthropic"
-
-    finally:
-        # Restore original chat model setting
-        settings.chat_model = original_chat_model
-
-
-def test_gemini_api_base():
-    """Test that Gemini api_base is configurable for Vertex AI support."""
-    from langroid.language_models.openai_gpt import GEMINI_BASE_URL
-
-    original_chat_model = settings.chat_model
-    settings.chat_model = ""
-
-    # Save and clear env vars that could interfere
-    saved_openai_api_base = os.environ.pop("OPENAI_API_BASE", None)
-    saved_gemini_api_base = os.environ.pop("GEMINI_API_BASE", None)
-
-    try:
-        # Default: api_base should be GEMINI_BASE_URL
-        config = lm.OpenAIGPTConfig(
-            chat_model="gemini/gemini-2.0-flash",
-        )
-        llm = lm.OpenAIGPT(config)
-        assert llm.is_gemini
-        assert llm.config.chat_model == "gemini-2.0-flash"
-        assert llm.api_base == GEMINI_BASE_URL
-
-        # Custom api_base: should override default (e.g. Vertex AI endpoint)
-        vertex_url = "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project/locations/us-central1/endpoints/openapi"
-        config = lm.OpenAIGPTConfig(
-            chat_model="gemini/gemini-2.0-flash",
-            api_base=vertex_url,
-        )
-        llm = lm.OpenAIGPT(config)
-        assert llm.is_gemini
-        assert llm.api_base == vertex_url
-
-        # Empty string api_base: should fall back to default
-        config = lm.OpenAIGPTConfig(
-            chat_model="gemini/gemini-2.0-flash",
-            api_base="",
-        )
-        llm = lm.OpenAIGPT(config)
-        assert llm.is_gemini
-        assert llm.api_base == GEMINI_BASE_URL
-
-        # None api_base: should fall back to default
-        config = lm.OpenAIGPTConfig(
-            chat_model="gemini/gemini-2.0-flash",
-            api_base=None,
-        )
-        llm = lm.OpenAIGPT(config)
-        assert llm.is_gemini
-        assert llm.api_base == GEMINI_BASE_URL
-
-        # OPENAI_API_BASE env var should NOT leak into Gemini api_base
-        os.environ["OPENAI_API_BASE"] = "http://localhost:8000/v1"
-        config = lm.OpenAIGPTConfig(
-            chat_model="gemini/gemini-2.0-flash",
-        )
-        llm = lm.OpenAIGPT(config)
-        assert llm.is_gemini
-        assert llm.api_base == GEMINI_BASE_URL
-        os.environ.pop("OPENAI_API_BASE")
-
-        # GEMINI_API_BASE env var should be used (e.g. Vertex AI)
-        os.environ["GEMINI_API_BASE"] = vertex_url
-        config = lm.OpenAIGPTConfig(
-            chat_model="gemini/gemini-2.0-flash",
-        )
-        llm = lm.OpenAIGPT(config)
-        assert llm.is_gemini
-        assert llm.api_base == vertex_url
-        os.environ.pop("GEMINI_API_BASE")
-
-        # GEMINI_API_BASE should take priority over OPENAI_API_BASE
-        os.environ["OPENAI_API_BASE"] = "http://localhost:8000/v1"
-        os.environ["GEMINI_API_BASE"] = vertex_url
-        config = lm.OpenAIGPTConfig(
-            chat_model="gemini/gemini-2.0-flash",
-        )
-        llm = lm.OpenAIGPT(config)
-        assert llm.is_gemini
-        assert llm.api_base == vertex_url
-        os.environ.pop("OPENAI_API_BASE")
-        os.environ.pop("GEMINI_API_BASE")
-    finally:
-        settings.chat_model = original_chat_model
-        # Restore original env vars
-        if saved_openai_api_base is not None:
-            os.environ["OPENAI_API_BASE"] = saved_openai_api_base
-        if saved_gemini_api_base is not None:
-            os.environ["GEMINI_API_BASE"] = saved_gemini_api_base
-
-
-def test_gemini_google_prefix(monkeypatch):
-    """`google/`-prefixed Gemini models route to the Gemini API (issue #995)."""
-    from langroid.language_models.openai_gpt import GEMINI_BASE_URL
-
-    monkeypatch.setattr(settings, "chat_model", "")
-    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
-    monkeypatch.delenv("GEMINI_API_BASE", raising=False)
-    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
-    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
-
-    for chat_model in ("gemini/gemini-2.0-flash", "google/gemini-2.0-flash"):
-        llm = lm.OpenAIGPT(lm.OpenAIGPTConfig(chat_model=chat_model))
-        assert llm.is_gemini
-        assert llm.config.chat_model == "gemini-2.0-flash"
-        assert llm.api_base == GEMINI_BASE_URL
-        assert llm.api_key == "gemini-key"
-
-
-def test_gemini_ignores_last_case_variant_openai_api_base(monkeypatch):
-    """Gemini routing follows pydantic's last-wins env case normalization."""
-    from langroid.language_models.openai_gpt import GEMINI_BASE_URL
-
-    monkeypatch.setattr(settings, "chat_model", "")
-    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
-    monkeypatch.delenv("openai_api_base", raising=False)
-    monkeypatch.delenv("GEMINI_API_BASE", raising=False)
-    monkeypatch.setenv("OPENAI_API_BASE", "https://first.example/v1")
-    monkeypatch.setenv("openai_api_base", "https://last.example/v1")
-
-    llm = lm.OpenAIGPT(lm.OpenAIGPTConfig(chat_model="google/gemini-2.0-flash"))
-
-    assert llm.is_gemini
-    assert llm.api_base == GEMINI_BASE_URL
-
-
-@pytest.mark.parametrize(
-    "chat_model",
-    ("google/gemma-3-27b-it", "google/text-bison-001"),
-)
-def test_non_gemini_google_model_is_not_rerouted(monkeypatch, chat_model):
-    """Non-Gemini Google models retain caller routing and credentials."""
-    monkeypatch.setattr(settings, "chat_model", "")
-    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
-    monkeypatch.delenv("GEMINI_API_BASE", raising=False)
-    monkeypatch.setenv("GEMINI_API_KEY", "ambient-gemini-key")
-    caller_api_key = "caller-api-key"
-
-    llm = lm.OpenAIGPT(
-        lm.OpenAIGPTConfig(chat_model=chat_model, api_key=caller_api_key)
-    )
-
-    assert not llm.is_gemini
-    assert llm.config.chat_model == chat_model
-    assert llm.api_base is None
-    assert llm.api_key == caller_api_key
-
-
-@pytest.mark.parametrize(
-    "chat_model",
-    ("gemini/gemini-2.0-flash", "google/gemini-2.0-flash"),
-)
-@pytest.mark.parametrize(
-    "openai_api_base, explicit_api_base",
-    (
-        ("https://openai-env.example/v1", "https://caller.example/v1"),
-        ("https://shared.example/v1", "https://shared.example/v1"),
-    ),
-)
-def test_gemini_alias_preserves_explicit_api_base(
-    monkeypatch, chat_model, openai_api_base, explicit_api_base
-):
-    """Gemini aliases retain an explicitly configured API base."""
-    monkeypatch.setattr(settings, "chat_model", "")
-    monkeypatch.setenv("OPENAI_API_BASE", openai_api_base)
-    monkeypatch.setenv("GEMINI_API_BASE", "https://gemini-env.example/v1")
-
-    llm = lm.OpenAIGPT(
-        lm.OpenAIGPTConfig(
-            chat_model=chat_model,
-            api_base=explicit_api_base,
-        )
-    )
-
-    assert llm.is_gemini
-    assert llm.api_base == explicit_api_base
-    expected_model = (
-        chat_model if chat_model.startswith("google/") else "gemini-2.0-flash"
-    )
-    assert llm.config.chat_model == expected_model
-
-
-@pytest.mark.parametrize(
-    "chat_model",
-    ("gemini/gemini-2.0-flash", "google/gemini-2.0-flash"),
-)
-def test_gemini_model_copy_preserves_explicit_api_base(monkeypatch, chat_model):
-    """Gemini configs copied with an API base retain the caller endpoint."""
-    monkeypatch.setattr(settings, "chat_model", "")
-    monkeypatch.setenv("GEMINI_API_BASE", "https://gemini-env.example/v1")
-    custom_base = "https://caller.example/v1"
-    config = lm.OpenAIGPTConfig(chat_model=chat_model).model_copy(
-        update={"api_base": custom_base}
-    )
-
-    llm = lm.OpenAIGPT(config)
-
-    assert llm.is_gemini
-    assert llm.api_base == custom_base
-
-
-@pytest.mark.parametrize(
-    "chat_model",
-    ("gemini/gemini-2.0-flash", "google/gemini-2.0-flash"),
-)
-def test_gemini_assignment_preserves_explicit_api_base(monkeypatch, chat_model):
-    """Gemini configs assigned an API base retain the caller endpoint."""
-    monkeypatch.setattr(settings, "chat_model", "")
-    monkeypatch.setenv("GEMINI_API_BASE", "https://gemini-env.example/v1")
-    custom_base = "https://caller.example/v1"
-    config = lm.OpenAIGPTConfig(chat_model=chat_model)
-    config.api_base = custom_base
-
-    llm = lm.OpenAIGPT(config)
-
-    assert llm.is_gemini
-    assert llm.api_base == custom_base
-
-
-def test_gemini_dynamic_config_preserves_api_base(monkeypatch):
-    """Dynamically prefixed Gemini settings retain their API base."""
-    monkeypatch.setattr(settings, "chat_model", "")
-    monkeypatch.setenv("VERTEX_API_BASE", "https://vertex.example/v1")
-    monkeypatch.setenv("GEMINI_API_BASE", "https://gemini-env.example/v1")
-    vertex_config = lm.OpenAIGPTConfig.create("vertex")
-
-    llm = lm.OpenAIGPT(vertex_config(chat_model="google/gemini-2.0-flash"))
-
-    assert llm.is_gemini
-    assert llm.api_base == "https://vertex.example/v1"
-    assert llm.config.chat_model == "google/gemini-2.0-flash"
-
-
-def test_followup_standalone():
-    """Test that followup_to_standalone works."""
-
-    llm = OpenAIGPT(OpenAIGPTConfig())
-    dialog = [
-        ("Is 5 a prime number?", "yes"),
-        ("Is 10 a prime number?", "no"),
-    ]
-    followup = "What about 11?"
-    response = llm.followup_to_standalone(dialog, followup)
-    assert response is not None
-    assert "prime" in response.lower() and "11" in response
-
-
-def test_llm_pdf_attachment():
-    """Test sending a PDF file attachment to the LLM."""
-
-    # Path to the test PDF file
-    pdf_path = Path("tests/main/data/dummy.pdf")
-
-    # Create a FileAttachment from the PDF file
-    attachment = FileAttachment.from_path(pdf_path)
-
-    # Verify the attachment properties
-    assert attachment.mime_type == "application/pdf"
-    assert attachment.filename == "dummy.pdf"
-
-    # Create messages with the attachment
-    messages = [
-        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
-        LLMMessage(
-            role=Role.USER, content="What's title of the paper?", files=[attachment]
-        ),
-    ]
-
-    # Set up the LLM with a suitable model that supports PDFs
-    llm = OpenAIGPT(OpenAIGPTConfig(max_output_tokens=1000))
-
-    # Get response from the LLM
-    response = llm.chat(messages=messages)
-
-    assert response is not None
-    assert response.message is not None
-    assert "Supply Chain" in response.message
-
-    # follow-up question
-    messages += [
-        LLMMessage(role=Role.ASSISTANT, content="Supply Chain"),
-        LLMMessage(role=Role.USER, content="Who is the first author?"),
-    ]
-    response = llm.chat(messages=messages)
-    assert response is not None
-    assert response.message is not None
-    assert "Takio" in response.message
-
-
-@pytest.mark.xfail(
-    reason="Multi-file attachments may not work yet",
-    run=True,
-    strict=False,
-)
-def test_llm_multi_pdf_attachments():
-
-    # Path to the test PDF file
-    pdf_path = Path("tests/main/data/dummy.pdf")
-
-    # Create a FileAttachment from the PDF file
-    attachment = FileAttachment.from_path(pdf_path)
-
-    # multiple attachments
-    pdf_path2 = Path("tests/main/data/sample-test.pdf")
-
-    # Create a FileAttachment from the PDF file
-    attachment2 = FileAttachment.from_path(pdf_path2)
-
-    messages = [
-        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
-        LLMMessage(
-            role=Role.USER,
-            content="How many pages are in the Supply Chain paper?",
-            files=[attachment2, attachment],
-        ),
-    ]
-    # Set up the LLM with a suitable model that supports PDFs
-    llm = OpenAIGPT(OpenAIGPTConfig(max_output_tokens=1000))
-
-    response = llm.chat(messages=messages)
-    print(response.message)
-    assert any(x in response.message for x in ["4", "four"])
-
-    # follow-up question
-    messages += [
-        LLMMessage(role=Role.ASSISTANT, content="4 pages"),
-        LLMMessage(
-            role=Role.USER,
-            content="""
-            How many columns are in the table in the 
-            document that is NOT about Supply Chain?
-            """,
-        ),
-    ]
-    response = llm.chat(messages=messages)
-    assert any(x in response.message for x in ["3", "three"])
-
-
-def test_llm_pdf_bytes_and_split():
-    """Test sending PDF files to LLM as bytes and split into pages."""
-
-    # Path to the test PDF file
-    pdf_path = Path("tests/main/data/dummy.pdf")
-
-    # Test creating attachment from bytes
-    with open(pdf_path, "rb") as f:
-        pdf_bytes = f.read()
-
-    attachment_from_bytes = FileAttachment.from_bytes(
-        content=pdf_bytes,
-        filename="supply_chain_paper.pdf",
-    )
-
-    messages = [
-        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
-        LLMMessage(
-            role=Role.USER,
-            content="Who is the first author of this paper?",
-            files=[attachment_from_bytes],
-        ),
-    ]
-
-    llm = OpenAIGPT(OpenAIGPTConfig(max_output_tokens=100))
-    response = llm.chat(messages=messages)
-
-    assert response is not None
-    assert "Takio" in response.message
-
-    # Test creating attachment from file-like object
-    pdf_io = io.BytesIO(pdf_bytes)
-    attachment_from_io = FileAttachment.from_io(
-        file_obj=pdf_io,
-        filename="paper_from_io.pdf",
-    )
-
-    messages = [
-        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
-        LLMMessage(
-            role=Role.USER,
-            content="What is the title of this paper?",
-            files=[attachment_from_io],
-        ),
-    ]
-
-    response = llm.chat(messages=messages)
-    assert "Supply Chain" in response.message
-
-    # Test splitting PDF into pages and sending individual pages
-    import fitz
-
-    doc = fitz.open(pdf_path)
-    page_attachments = []
-
-    for i, page in enumerate(doc):
-        # Extract page as PDF
-        page_pdf = io.BytesIO()
-        page_doc = fitz.open()
-        page_doc.insert_pdf(doc, from_page=i, to_page=i)
-        page_doc.save(page_pdf)
-        page_pdf.seek(0)
-
-        # Create attachment for this page
-        page_attachment = FileAttachment.from_io(
-            file_obj=page_pdf,
-            filename=f"page_{i+1}.pdf",
-        )
-        page_attachments.append(page_attachment)
-
-    # Send just the first page
-    messages = [
-        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
-        LLMMessage(
-            role=Role.USER,
-            content="Based on just this page, what is this document about?",
-            files=[page_attachments[0]],
-        ),
-    ]
-
-    response = llm.chat(messages=messages)
-    assert "supply chain" in response.message.lower()
-
-    # Test with multiple pages as separate attachments
-    messages = [
-        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
-        LLMMessage(
-            role=Role.USER,
-            content="I'm sending you pages from a paper. "
-            "How many figures are shown across all pages?",
-            files=page_attachments,
-        ),
-    ]
-
-    response = llm.chat(messages=messages)
-    assert response is not None
-    assert any(
-        x in response.message.lower() for x in ["figure", "diagram", "illustration"]
-    )
-
-
-@pytest.mark.parametrize(
-    "path",
-    [
-        "tests/main/data/color-shape-series.jpg",
-        "tests/main/data/color-shape-series.png",
-        "tests/main/data/color-shape-series.pdf",
-        "https://upload.wikimedia.org/wikipedia/commons/1/18/Seriation_task_w_shapes.jpg",
-    ],
-)
-def test_llm_image_input(path: str):
-    attachment = FileAttachment.from_path(path, detail="low")
-
-    messages = [
-        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
-        LLMMessage(
-            role=Role.USER,
-            content="How many squares are here?",
-            files=[attachment],
-        ),
-    ]
-    # Set up the LLM with a suitable model that supports PDFs
-    llm = OpenAIGPT(OpenAIGPTConfig(max_output_tokens=500))
-
-    response = llm.chat(messages=messages)
-    print(response.message)
-    assert any(x in response.message for x in ["three", "3"])
-
-
-def test_litellm_model_key():
-    """
-    Test that passing in explicit api_key works with `litellm/*` models
-    """
-    model = "litellm/anthropic/claude-3-5-haiku-latest"
-    # disable any chat model passed via --m arg to pytest cmd
-    settings.chat_model = model
-
-    class CustomOpenAIGPTConfig(lm.OpenAIGPTConfig):
-        """OpenAI config that doesn't auto-load from environment variables."""
-
-        # Disable environment prefix to prevent auto-loading
-        model_config = SettingsConfigDict(env_prefix="")
-
-    llm_config = CustomOpenAIGPTConfig(
-        chat_model=model,
-        api_key=os.getenv("ANTHROPIC_API_KEY", ""),
-    )
-    llm = lm.OpenAIGPT(config=llm_config)
-    print(f"\nTesting with model: {llm.chat_model_orig} => {llm.config.chat_model}")
-    response = llm.chat("What is 3+4?")
-    assert "7" in response.message
-</file>
-
-<file path="langroid/agent/chat_agent.py">
-import base64
-import copy
-import inspect
-import json
-import logging
-import math
-import textwrap
-from contextlib import ExitStack
-from inspect import isclass
-from typing import (
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Self,
-    Set,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
-
-import openai
-from pydantic import BaseModel, ValidationError
-from pydantic.fields import ModelPrivateAttr
-from rich import print
-from rich.console import Console
-from rich.markup import escape
-
-from langroid.agent.base import (
-    Agent,
-    AgentConfig,
-    SearchForTools,
-    async_noop_fn,
-    noop_fn,
-)
-from langroid.agent.chat_document import ChatDocument
-from langroid.agent.tool_message import (
-    ToolMessage,
-    format_schema_for_strict,
-)
-from langroid.agent.xml_tool_message import XMLToolMessage
-from langroid.language_models.base import (
-    LLMFunctionCall,
-    LLMFunctionSpec,
-    LLMMessage,
-    LLMResponse,
-    OpenAIJsonSchemaSpec,
-    OpenAIToolSpec,
-    Role,
-    StreamingIfAllowed,
-    ToolChoiceTypes,
-)
-from langroid.language_models.openai_gpt import OpenAIGPT
-from langroid.mytypes import Entity, NonToolAction
-from langroid.parsing.file_attachment import FileAttachment
-from langroid.utils.configuration import settings
-from langroid.utils.object_registry import ObjectRegistry
-from langroid.utils.output import status
-from langroid.utils.pydantic_utils import PydanticWrapper, get_pydantic_wrapper
-from langroid.utils.types import is_callable
-
-console = Console()
-
-logger = logging.getLogger(__name__)
-
-# Stable origin sentinel for the dynamically generated strict-recovery AnyTool
-# class ("tool_or_function"): a fresh class is built per call (its tool-union
-# type varies), so re-registration must be recognized as the same logical tool.
-_ANY_TOOL_MESSAGE_ORIGIN: Any = object()
-
-# Safety margin (in tokens) subtracted from the model context length when
-# shrinking chat history and/or the requested output length to fit, in case
-# our token-count estimates are off.
-CHAT_HISTORY_BUFFER = 300
-
-
-def _reject_json_constant(constant: str) -> None:
-    """Reject JavaScript numeric constants that are not valid JSON."""
-    raise ValueError(f"non-JSON numeric constant: {constant}")
-
-
-def _parse_json_float(value: str) -> float:
-    """Parse a JSON float while rejecting exponent overflow."""
-    parsed = float(value)
-    if not math.isfinite(parsed):
-        raise ValueError(f"non-finite JSON number: {value}")
-    return parsed
-
-
-def _is_identified_result(message: LLMMessage) -> bool:
-    """Whether a TOOL/FUNCTION result has its identifier and no call payload.
-
-    Such results must survive even with empty content so their calls can be
-    marked complete (issue #1063).
-    """
-    has_identifier = (
-        message.role == Role.TOOL and bool((message.tool_call_id or "").strip())
-    ) or (message.role == Role.FUNCTION and bool((message.name or "").strip()))
-    return has_identifier and message.function_call is None and not message.tool_calls
-
-
-def _llm_message_has_payload(message: LLMMessage) -> bool:
-    """Whether a message has the fields required for a valid history entry."""
-    return (
-        (message.content or "").strip() != ""
-        or message.function_call is not None
-        or bool(message.tool_calls)
-        or _is_identified_result(message)
-    )
-
-
-class ChatAgentConfig(AgentConfig):
-    """
-    Configuration for ChatAgent
-
-    Attributes:
-        system_message: system message to include in message sequence
-             (typically defines role and task of agent).
-             Used only if `task` is not specified in the constructor.
-        user_message: user message to include in message sequence.
-             Used only if `task` is not specified in the constructor.
-        use_tools: whether to use our own ToolMessages mechanism
-        handle_llm_no_tool (Any): desired agent_response when
-            LLM generates non-tool msg.
-        use_functions_api: whether to use functions/tools native to the LLM API
-                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
-        use_tools_api: When `use_functions_api` is True, if this is also True,
-            the OpenAI tool-call API is used, rather than the older/deprecated
-            function-call API. However the tool-call API has some tricky aspects,
-            hence we set this to False by default.
-        strict_recovery: whether to enable strict schema recovery when there
-            is a tool-generation error.
-        enable_orchestration_tool_handling: whether to enable handling of orchestration
-            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
-        output_format: When supported by the LLM (certain OpenAI LLMs
-            and local LLMs served by providers such as vLLM), ensures
-            that the output is a JSON matching the corresponding
-            schema via grammar-based decoding
-        handle_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for handling".
-        use_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for use" (by LLM) and
-            instructions on using T are added to the system message.
-        instructions_output_format: Controls whether we generate instructions for
-            `output_format` in the system message.
-        use_tools_on_output_format: Controls whether to automatically switch
-            to the Langroid-native tools mechanism when `output_format` is set.
-            Note that LLMs may generate tool calls which do not belong to
-            `output_format` even when strict JSON mode is enabled, so this should be
-            enabled when such tool calls are not desired.
-        output_format_include_defaults: Whether to include fields with default arguments
-            in the output schema
-        full_citations: Whether to show source reference citation + content for each
-            citation, or just the main reference citation.
-        search_for_tools_everywhere: Whether to search for tools everywhere,
-            or only in specific LLM response elements based on use_tools /
-            use_functions_api / use_tools_api config settings.
-        recognize_recipient_in_content: Whether to parse LLM response text content
-            for recipient routing patterns, specifically:
-            - ``TO[<recipient>]:<content>`` addressing format, and
-            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
-            When False, only structured routing via function_call/tool_call
-            ``recipient`` fields is recognized. Default is True.
-            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
-            which controls Task-level signals like DONE, PASS, and SEND_TO.
-            To fully disable all text-based routing, set both to False.
-        context_overflow_strategy: Strategy for handling context overflow when
-            message history exceeds model context length. Options:
-            - "truncate": Truncate content of early messages (preserves all messages
-              but with shortened content). This maintains the message sequence.
-            - "drop_turns": Drop complete conversation turns (USER + all responses
-              until next USER). More aggressive but cleaner for voice agents.
-            Default is "truncate" for backward compatibility.
-    """
-
-    system_message: str = "You are a helpful assistant."
-    user_message: Optional[str] = None
-    handle_llm_no_tool: Any = None
-    use_tools: bool = True
-    use_functions_api: bool = False
-    use_tools_api: bool = True
-    strict_recovery: bool = True
-    enable_orchestration_tool_handling: bool = True
-    output_format: Optional[type] = None
-    handle_output_format: bool = True
-    use_output_format: bool = True
-    instructions_output_format: bool = True
-    output_format_include_defaults: bool = True
-    use_tools_on_output_format: bool = True
-    full_citations: bool = True  # show source + content for each citation?
-    search_for_tools_everywhere: bool = True
-    recognize_recipient_in_content: bool = True
-    context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
-
-    def _set_fn_or_tools(self) -> None:
-        """
-        Enable Langroid Tool or OpenAI-like fn-calling,
-        depending on config settings.
-        """
-        if not self.use_functions_api or not self.use_tools:
-            return
-        if self.use_functions_api and self.use_tools:
-            logger.debug(
-                """
-                You have enabled both `use_tools` and `use_functions_api`.
-                Setting `use_functions_api` to False.
-                """
-            )
-            self.use_tools = True
-            self.use_functions_api = False
-
-
-class ChatAgent(Agent):
-    """
-    Chat Agent interacting with external env
-    (could be human, or external tools).
-    The agent (the LLM actually) is provided with an optional "Task Spec",
-    which is a sequence of `LLMMessage`s. These are used to initialize
-    the `task_messages` of the agent.
-    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
-    The `Agent` class mainly exists to hold various common methods and attributes.
-    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
-    `llm_response` method uses "chat mode" API (i.e. one that takes a
-    message sequence rather than a single message),
-    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
-    that takes a single message).
-    """
-
-    def __init__(
-        self,
-        config: ChatAgentConfig = ChatAgentConfig(),
-        task: Optional[List[LLMMessage]] = None,
-    ):
-        """
-        Chat-mode agent initialized with task spec as the initial message sequence
-        Args:
-            config: settings for the agent
-
-        """
-        super().__init__(config)
-        self.config: ChatAgentConfig = config
-        self.config._set_fn_or_tools()
-        self.message_history: List[LLMMessage] = []
-        self.init_state()
-        # An agent's "task" is defined by a system msg and an optional user msg;
-        # These are "priming" messages that kick off the agent's conversation.
-        self.system_message: str = self.config.system_message
-        self.user_message: str | None = self.config.user_message
-
-        if task is not None:
-            # if task contains a system msg, we override the config system msg
-            if len(task) > 0 and task[0].role == Role.SYSTEM:
-                self.system_message = task[0].content or ""
-            # if task contains a user msg, we override the config user msg
-            if len(task) > 1 and task[1].role == Role.USER:
-                self.user_message = task[1].content
-
-        # system-level instructions for using tools/functions:
-        # We maintain these as tools/functions are enabled/disabled,
-        # and whenever an LLM response is sought, these are used to
-        # recreate the system message (via `_create_system_and_tools_message`)
-        # each time, so it reflects the current set of enabled tools/functions.
-        # (a) these are general instructions on using certain tools/functions,
-        #   if they are specified in a ToolMessage class as a classmethod `instructions`
-        self.system_tool_instructions: str = ""
-        # (b) these are only for the builtin in Langroid TOOLS mechanism:
-        self.system_tool_format_instructions: str = ""
-
-        self.llm_functions_map: Dict[str, LLMFunctionSpec] = {}
-        self.llm_functions_handled: Set[str] = set()
-        self.llm_functions_usable: Set[str] = set()
-        self.llm_function_force: Optional[Dict[str, str]] = None
-
-        self.output_format: Optional[type[ToolMessage | BaseModel]] = None
-
-        self.saved_requests_and_tool_setings = self._requests_and_tool_settings()
-        # This variable is not None and equals a `ToolMessage` T, if and only if:
-        # (a) T has been set as the output_format of this agent, AND
-        # (b) T has been "enabled for use" ONLY for enforcing this output format, AND
-        # (c) T has NOT been explicitly "enabled for use" by this Agent.
-        self.enabled_use_output_format: Optional[type[ToolMessage]] = None
-        # As above but deals with "enabled for handling" instead of "enabled for use".
-        self.enabled_handling_output_format: Optional[type[ToolMessage]] = None
-        if config.output_format is not None:
-            self.set_output_format(config.output_format)
-        # instructions specifically related to enforcing `output_format`
-        self.output_format_instructions = ""
-
-        # controls whether to disable strict schemas for this agent if
-        # strict mode causes exception
-        self.disable_strict = False
-        # Tracks whether any strict tool is enabled; used to determine whether to set
-        # `self.disable_strict` on an exception
-        self.any_strict = False
-        # Tracks the set of tools on which we force-disable strict decoding
-        self.disable_strict_tools_set: set[str] = set()
-
-        # search for tools according to the agent configuration
-        if not config.search_for_tools_everywhere:
-            if config.use_functions_api:
-                if config.use_tools_api:
-                    self.search_for_tools = {SearchForTools.TOOLS.value}
-                else:
-                    self.search_for_tools = {SearchForTools.FUNCTIONS.value}
-            else:
-                self.search_for_tools = {SearchForTools.CONTENT.value}
-
-        if self.config.enable_orchestration_tool_handling:
-            # Only enable HANDLING by `agent_response`, NOT LLM generation of these.
-            # This is useful where tool-handlers or agent_response generate these
-            # tools, and need to be handled.
-            # We don't want enable orch tool GENERATION by default, since that
-            # might clutter-up the LLM system message unnecessarily.
-            from langroid.agent.tools.orchestration import (
-                AgentDoneTool,
-                AgentSendTool,
-                DonePassTool,
-                DoneTool,
-                ForwardTool,
-                PassTool,
-                ResultTool,
-                SendTool,
-            )
-
-            self.enable_message(ForwardTool, use=False, handle=True)
-            self.enable_message(DoneTool, use=False, handle=True)
-            self.enable_message(AgentDoneTool, use=False, handle=True)
-            self.enable_message(PassTool, use=False, handle=True)
-            self.enable_message(DonePassTool, use=False, handle=True)
-            self.enable_message(SendTool, use=False, handle=True)
-            self.enable_message(AgentSendTool, use=False, handle=True)
-            self.enable_message(ResultTool, use=False, handle=True)
-
-    def init_state(self) -> None:
-        """
-        Initialize the state of the agent. Just conversation state here,
-        but subclasses can override this to initialize other state.
-        """
-        super().init_state()
-        self.clear_history(0)
-        self.clear_dialog()
-
-    @staticmethod
-    def from_id(id: str) -> "ChatAgent":
-        """
-        Get an agent from its ID
-        Args:
-            agent_id (str): ID of the agent
-        Returns:
-            ChatAgent: The agent with the given ID
-        """
-        return cast(ChatAgent, Agent.from_id(id))
-
-    def clone(self, i: int = 0) -> "ChatAgent":
-        """Create i'th clone of this agent, ensuring tool use/handling is cloned.
-        Important: We assume all member variables are in the __init__ method here
-        and in the Agent class.
-        TODO: We are attempting to clone an agent after its state has been
-        changed in possibly many ways. Below is an imperfect solution. Caution advised.
-        Revisit later.
-        """
-        agent_cls = type(self)
-        # Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
-        # instead of deepcopy which loses subclass information
-        config_copy = self.config.model_copy(deep=True)
-        config_copy.name = f"{config_copy.name}-{i}"
-        new_agent = agent_cls(config_copy)
-        new_agent.system_tool_instructions = self.system_tool_instructions
-        new_agent.system_tool_format_instructions = self.system_tool_format_instructions
-        new_agent.llm_tools_map = self.llm_tools_map
-        new_agent.llm_tools_known = self.llm_tools_known
-        new_agent.llm_tools_handled = self.llm_tools_handled
-        new_agent.llm_tools_usable = self.llm_tools_usable
-        new_agent.llm_functions_map = self.llm_functions_map
-        new_agent.llm_functions_handled = self.llm_functions_handled
-        new_agent.llm_functions_usable = self.llm_functions_usable
-        new_agent.llm_function_force = self.llm_function_force
-        # Ensure each clone gets its own vecdb client when supported.
-        new_agent.vecdb = None if self.vecdb is None else self.vecdb.clone()
-        self._clone_extra_state(new_agent)
-        new_agent.id = ObjectRegistry.new_id()
-        if self.config.add_to_registry:
-            ObjectRegistry.register_object(new_agent)
-        return new_agent
-
-    def _clone_extra_state(self, new_agent: "ChatAgent") -> None:
-        """Hook for subclasses to copy additional state into clones."""
-
-    def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool:
-        """Should we enable strict mode for a given tool?"""
-        if isinstance(tool, str):
-            tool_class = self.llm_tools_map[tool]
-        else:
-            tool_class = tool
-        name = tool_class.default_value("request")
-        if name in self.disable_strict_tools_set or self.disable_strict:
-            return False
-        strict: Optional[bool] = tool_class.default_value("strict")
-        if strict is None:
-            strict = self._strict_tools_available()
-
-        return strict
-
-    def _fn_call_available(self) -> bool:
-        """Does this agent's LLM support function calling?"""
-        return self.llm is not None and self.llm.supports_functions_or_tools()
-
-    def _strict_tools_available(self) -> bool:
-        """Does this agent's LLM support strict tools?"""
-        return (
-            not self.disable_strict
-            and self.llm is not None
-            and isinstance(self.llm, OpenAIGPT)
-            and self.llm.config.parallel_tool_calls is False
-            and self.llm.supports_strict_tools
-        )
-
-    def _json_schema_available(self) -> bool:
-        """Does this agent's LLM support strict JSON schema output format?"""
-        return (
-            not self.disable_strict
-            and self.llm is not None
-            and isinstance(self.llm, OpenAIGPT)
-            and self.llm.supports_json_schema
-        )
-
-    def set_system_message(self, msg: str) -> None:
-        self.system_message = msg
-        if len(self.message_history) > 0:
-            # if there is message history, update the system message in it
-            self.message_history[0].content = msg
-
-    def set_user_message(self, msg: str) -> None:
-        self.user_message = msg
-
-    @property
-    def task_messages(self) -> List[LLMMessage]:
-        """
-        The task messages are the initial messages that define the task
-        of the agent. There will be at least a system message plus possibly a user msg.
-        Returns:
-            List[LLMMessage]: the task messages
-        """
-        msgs = [self._create_system_and_tools_message()]
-        if self.user_message:
-            msgs.append(LLMMessage(role=Role.USER, content=self.user_message))
-        return msgs
-
-    def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None:
-        id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
-        if msg.role == Role.TOOL:
-            # dropping tool result, so ADD the corresponding tool-call back
-            # to the list of pending calls!
-            id = msg.tool_call_id
-            if id in self.oai_tool_id2call:
-                self.oai_tool_calls.append(self.oai_tool_id2call[id])
-        elif msg.tool_calls is not None:
-            # dropping a msg with tool-calls, so DROP these from pending list
-            # as well as from id -> call map
-            for tool_call in msg.tool_calls:
-                if tool_call.id in id2idx:
-                    self.oai_tool_calls.pop(id2idx[tool_call.id])
-                if tool_call.id in self.oai_tool_id2call:
-                    del self.oai_tool_id2call[tool_call.id]
-
-    def clear_history(self, start: int = -2, end: int = -1) -> None:
-        """
-        Clear the message history, deleting  messages from index `start`,
-        up to index `end`.
-
-        Args:
-            start (int): index of first message to delete; default = -2
-                    (i.e. delete last 2 messages, typically these
-                    are the last user and assistant messages)
-            end (int): index of last message to delete; Default = -1
-                    (i.e. delete all messages up to the last one)
-        """
-        n = len(self.message_history)
-        if start < 0:
-            start = max(0, n + start)
-        end_ = n if end == -1 else end + 1
-        dropped = self.message_history[start:end_]
-        # consider the dropped msgs in REVERSE order, so we are
-        # carefully updating self.oai_tool_calls
-        for msg in reversed(dropped):
-            self._drop_msg_update_tool_calls(msg)
-            # clear out the chat document from the ObjectRegistry
-            ChatDocument.delete_id(msg.chat_document_id)
-        del self.message_history[start:end_]
-
-    def update_history(self, message: str, response: str) -> None:
-        """
-        Update the message history with the latest user message and LLM response.
-        Args:
-            message (str): user message
-            response: (str): LLM response
-        """
-        self.message_history.extend(
-            [
-                LLMMessage(role=Role.USER, content=message),
-                LLMMessage(role=Role.ASSISTANT, content=response),
-            ]
-        )
-
-    def export_history(self) -> str:
-        """Export message history as a portable, versioned JSON snapshot.
-
-        Returns:
-            A JSON string containing the current message history.
-        """
-        messages: List[Dict[str, Any]] = []
-        for message in self.message_history:
-            json.dumps(
-                message.model_dump(mode="python", exclude={"files"}),
-                allow_nan=False,
-                default=str,
-            )
-            data = message.model_dump(mode="json", exclude={"files"})
-            data["chat_document_id"] = ""
-            data["files"] = [
-                {
-                    "content_base64": base64.b64encode(file.content).decode("ascii"),
-                    "filename": file.filename,
-                    "mime_type": file.mime_type,
-                    "url": file.url,
-                    "detail": file.detail,
-                }
-                for file in message.files
-            ]
-            messages.append(data)
-        return json.dumps({"version": 1, "messages": messages}, allow_nan=False)
-
-    def import_history(
-        self,
-        snapshot: str,
-        max_size_bytes: int = 100 * 1024 * 1024,
-    ) -> None:
-        """Restore message history from :meth:`export_history` output.
-
-        Args:
-            snapshot: Versioned JSON snapshot to restore.
-            max_size_bytes: Maximum total decoded attachment size. Defaults to
-                100 MiB.
-
-        Raises:
-            ValueError: If the snapshot is malformed, has an unknown version,
-                starts with a non-system message, or exceeds ``max_size_bytes``.
-        """
-        try:
-            if max_size_bytes < 0:
-                raise ValueError("max_size_bytes must be non-negative")
-            payload = json.loads(
-                snapshot,
-                parse_constant=_reject_json_constant,
-                parse_float=_parse_json_float,
-            )
-            if (
-                not isinstance(payload, dict)
-                or type(payload.get("version")) is not int
-                or payload["version"] != 1
-            ):
-                raise ValueError("unsupported version")
-            raw_messages = payload.get("messages")
-            if not isinstance(raw_messages, list):
-                raise ValueError("messages must be a list")
-            if not raw_messages:
-                raise ValueError("messages must not be empty")
-
-            messages: List[LLMMessage] = []
-            total_attachment_bytes = 0
-            for raw_message in raw_messages:
-                if not isinstance(raw_message, dict):
-                    raise ValueError("message must be an object")
-                message_data = dict(raw_message)
-                raw_files = message_data.get("files", [])
-                if not isinstance(raw_files, list):
-                    raise ValueError("files must be a list")
-                files = []
-                for raw_file in raw_files:
-                    if not isinstance(raw_file, dict):
-                        raise ValueError("file must be an object")
-                    file_data = dict(raw_file)
-                    encoded_content = file_data.pop("content_base64")
-                    if not isinstance(encoded_content, str):
-                        raise ValueError("content_base64 must be a string")
-                    encoded_bytes = encoded_content.encode("ascii")
-                    padding = len(encoded_bytes) - len(encoded_bytes.rstrip(b"="))
-                    decoded_size = max(
-                        0,
-                        len(encoded_bytes) // 4 * 3 - min(padding, 2),
-                    )
-                    if total_attachment_bytes + decoded_size > max_size_bytes:
-                        raise ValueError(
-                            "decoded attachments exceed "
-                            f"max_size_bytes={max_size_bytes}"
-                        )
-                    content = base64.b64decode(encoded_bytes, validate=True)
-                    total_attachment_bytes += len(content)
-                    if total_attachment_bytes > max_size_bytes:
-                        raise ValueError(
-                            "decoded attachments exceed "
-                            f"max_size_bytes={max_size_bytes}"
-                        )
-                    files.append(FileAttachment(content=content, **file_data))
-                message_data["files"] = files
-                message_data["chat_document_id"] = ""
-                messages.append(LLMMessage.model_validate(message_data))
-            if messages[0].role != Role.SYSTEM:
-                raise ValueError("first message must have role 'system'")
-            seen_call_ids: Set[str] = set()
-            for message in messages:
-                if message.role in (Role.TOOL, Role.FUNCTION) and (
-                    message.function_call is not None or message.tool_calls is not None
-                ):
-                    raise ValueError("result messages must not contain call payloads")
-                if message.function_call is not None and message.role != Role.ASSISTANT:
-                    raise ValueError("function calls must have role 'assistant'")
-                if message.function_call is not None:
-                    if not message.function_call.name.strip():
-                        raise ValueError("function call names must be nonblank")
-                if message.tool_call_id is not None and message.role != Role.TOOL:
-                    raise ValueError("tool_call_id is only valid on tool results")
-                if message.role == Role.FUNCTION:
-                    name = message.name
-                    if name is None or not name or name != name.strip():
-                        raise ValueError(
-                            "function result name must be nonblank and normalized"
-                        )
-                if message.tool_calls is not None:
-                    if message.role != Role.ASSISTANT:
-                        raise ValueError("tool calls must have role 'assistant'")
-                    for call in message.tool_calls:
-                        if call.function is None:
-                            raise ValueError("tool calls must include a function")
-                        if not call.function.name.strip():
-                            raise ValueError("function call names must be nonblank")
-                        call_id = call.id
-                        if call_id is None or not call_id or call_id != call_id.strip():
-                            raise ValueError(
-                                "tool call IDs must be nonblank and normalized"
-                            )
-                        if call_id in seen_call_ids:
-                            raise ValueError("tool call IDs must be unique")
-                        seen_call_ids.add(call_id)
-                    if not message.tool_calls:
-                        message.tool_calls = None
-        except (
-            KeyError,
-            RecursionError,
-            TypeError,
-            UnicodeEncodeError,
-            ValueError,
-        ) as exc:
-            raise ValueError(f"Invalid history snapshot: {exc}") from exc
-
-        all_calls = {
-            call.id: call
-            for message in messages
-            for call in (message.tool_calls or [])
-            if call.id is not None
-        }
-        completed_call_ids = {
-            message.tool_call_id
-            for message in messages
-            if message.role == Role.TOOL and message.tool_call_id is not None
-        }
-        old_chat_document_ids = {
-            message.chat_document_id
-            for message in self.message_history
-            if message.chat_document_id
-        }
-        for chat_document_id in old_chat_document_ids:
-            ChatDocument.delete_id(chat_document_id)
-        self.message_history = messages
-        self.oai_tool_id2call = all_calls
-        self.oai_tool_calls = [
-            call
-            for call_id, call in all_calls.items()
-            if call_id not in completed_call_ids
-        ]
-
-    def tool_format_rules(self) -> str:
-        """
-        Specification of tool formatting rules
-        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
-        based on the currently enabled usable `ToolMessage`s
-
-        Returns:
-            str: formatting rules
-        """
-        # ONLY Usable tools (i.e. LLM-generation allowed),
-        usable_tool_classes: List[Type[ToolMessage]] = [
-            t
-            for t in list(self.llm_tools_map.values())
-            if t.default_value("request") in self.llm_tools_usable
-        ]
-
-        if len(usable_tool_classes) == 0:
-            return ""
-        format_instructions = "\n\n".join(
-            [
-                msg_cls.format_instructions(tool=self.config.use_tools)
-                for msg_cls in usable_tool_classes
-            ]
-        )
-        # if any of the enabled classes has json_group_instructions, then use that,
-        # else fall back to ToolMessage.json_group_instructions
-        for msg_cls in usable_tool_classes:
-            if hasattr(msg_cls, "json_group_instructions") and callable(
-                getattr(msg_cls, "json_group_instructions")
-            ):
-                return msg_cls.group_format_instructions().format(
-                    format_instructions=format_instructions
-                )
-        return ToolMessage.group_format_instructions().format(
-            format_instructions=format_instructions
-        )
-
-    def tool_instructions(self) -> str:
-        """
-        Instructions for tools or function-calls, for enabled and usable Tools.
-        These are inserted into system prompt regardless of whether we are using
-        our own ToolMessage mechanism or the LLM's function-call mechanism.
-
-        Returns:
-            str: concatenation of instructions for all usable tools
-        """
-        enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
-        if len(enabled_classes) == 0:
-            return ""
-        instructions = []
-        for msg_cls in enabled_classes:
-            if msg_cls.default_value("request") in self.llm_tools_usable:
-                class_instructions = ""
-                if hasattr(msg_cls, "instructions") and inspect.ismethod(
-                    msg_cls.instructions
-                ):
-                    class_instructions = msg_cls.instructions()
-                if (
-                    self.config.use_tools
-                    and hasattr(msg_cls, "langroid_tools_instructions")
-                    and inspect.ismethod(msg_cls.langroid_tools_instructions)
-                ):
-                    class_instructions += msg_cls.langroid_tools_instructions()
-                # example will be shown in tool_format_rules() when using TOOLs,
-                # so we don't need to show it here.
-                example = "" if self.config.use_tools else (msg_cls.usage_examples())
-                if example != "":
-                    example = "EXAMPLES:\n" + example
-                guidance = (
-                    ""
-                    if class_instructions == ""
-                    else ("GUIDANCE: " + class_instructions)
-                )
-                if guidance == "" and example == "":
-                    continue
-                instructions.append(
-                    textwrap.dedent(
-                        f"""
-                        TOOL: {msg_cls.default_value("request")}:
-                        {guidance}
-                        {example}
-                        """.lstrip()
-                    )
-                )
-        if len(instructions) == 0:
-            return ""
-        instructions_str = "\n\n".join(instructions)
-        return textwrap.dedent(
-            f"""
-            === GUIDELINES ON SOME TOOLS/FUNCTIONS USAGE ===
-            {instructions_str}
-            """.lstrip()
-        )
-
-    def augment_system_message(self, message: str) -> None:
-        """
-        Augment the system message with the given message.
-        Args:
-            message (str): system message
-        """
-        self.system_message += "\n\n" + message
-
-    def last_message_with_role(self, role: Role) -> LLMMessage | None:
-        """from `message_history`, return the last message with role `role`"""
-        n_role_msgs = len([m for m in self.message_history if m.role == role])
-        if n_role_msgs == 0:
-            return None
-        idx = self.nth_message_idx_with_role(role, n_role_msgs)
-        return self.message_history[idx]
-
-    def last_message_idx_with_role(self, role: Role) -> int:
-        """Index of last message in message_history, with specified role.
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-        indices_with_role = [
-            i for i, m in enumerate(self.message_history) if m.role == role
-        ]
-        if len(indices_with_role) == 0:
-            return -1
-        return indices_with_role[-1]
-
-    def nth_message_idx_with_role(self, role: Role, n: int) -> int:
-        """Index of `n`th message in message_history, with specified role.
-        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-        indices_with_role = [
-            i for i, m in enumerate(self.message_history) if m.role == role
-        ]
-
-        if len(indices_with_role) < n:
-            return -1
-        return indices_with_role[n - 1]
-
-    def update_last_message(self, message: str, role: str = Role.USER) -> None:
-        """
-        Update the last message that has role `role` in the message history.
-        Useful when we want to replace a long user prompt, that may contain context
-        documents plus a question, with just the question.
-        Args:
-            message (str): new message to replace with
-            role (str): role of message to replace
-        """
-        if len(self.message_history) == 0:
-            return
-        # find last message in self.message_history with role `role`
-        for i in range(len(self.message_history) - 1, -1, -1):
-            if self.message_history[i].role == role:
-                self.message_history[i].content = message
-                break
-
-    def delete_last_message(self, role: str = Role.USER) -> None:
-        """
-        Delete the last message that has role `role` from the message history.
-        Args:
-            role (str): role of message to delete
-        """
-        if len(self.message_history) == 0:
-            return
-        # find last message in self.message_history with role `role`
-        for i in range(len(self.message_history) - 1, -1, -1):
-            if self.message_history[i].role == role:
-                self.message_history.pop(i)
-                break
-
-    def _create_system_and_tools_message(self) -> LLMMessage:
-        """
-        (Re-)Create the system message for the LLM of the agent,
-        taking into account any tool instructions that have been added
-        after the agent was initialized.
-
-        The system message will consist of:
-        (a) the system message from the `task` arg in constructor, if any,
-            otherwise the default system message from the config
-        (b) the system tool instructions, if any
-        (c) the system json tool instructions, if any
-
-        Returns:
-            LLMMessage object
-        """
-        content = self.system_message
-        if self.system_tool_instructions != "":
-            content += "\n\n" + self.system_tool_instructions
-        if self.system_tool_format_instructions != "":
-            content += "\n\n" + self.system_tool_format_instructions
-        if self.output_format_instructions != "":
-            content += "\n\n" + self.output_format_instructions
-
-        # remove leading and trailing newlines and other whitespace
-        return LLMMessage(role=Role.SYSTEM, content=content.strip())
-
-    def handle_message_fallback(self, msg: str | ChatDocument) -> Any:
-        """
-        Fallback method for the "no-tools" scenario, i.e., the current `msg`
-        (presumably emitted by the LLM) does not have any tool that the agent
-        can handle.
-        NOTE: The `msg` may contain tools but either (a) the agent is not
-        enabled to handle them, or (b) there's an explicit `recipient` field
-        in the tool that doesn't match the agent's name.
-
-        Uses the self.config.non_tool_routing to determine the action to take.
-
-        This method can be overridden by subclasses, e.g.,
-        to create a "reminder" message when a tool is expected but the LLM "forgot"
-        to generate one.
-
-        Args:
-            msg (str | ChatDocument): The input msg to handle
-        Returns:
-            Any: The result of the handler method
-        """
-        if (
-            isinstance(msg, str)
-            or msg.metadata.sender != Entity.LLM
-            or self.config.handle_llm_no_tool is None
-            or self.has_only_unhandled_tools(msg)
-        ):
-            return None
-        # we ONLY use the `handle_llm_no_tool` config option when
-        # the msg is from LLM and does not contain ANY tools at all.
-        from langroid.agent.tools.orchestration import AgentDoneTool, ForwardTool
-
-        no_tool_option = self.config.handle_llm_no_tool
-        if no_tool_option in list(NonToolAction):
-            # in case the `no_tool_option` is one of the special NonToolAction vals
-            match self.config.handle_llm_no_tool:
-                case NonToolAction.FORWARD_USER:
-                    return ForwardTool(agent="User")
-                case NonToolAction.DONE:
-                    return AgentDoneTool(content=msg.content, tools=msg.tool_messages)
-        elif is_callable(no_tool_option):
-            return no_tool_option(msg)
-        # Otherwise just return `no_tool_option` as is:
-        # This can be any string, such as a specific nudge/reminder to the LLM,
-        # or even something like ResultTool etc.
-        return no_tool_option
-
-    def unhandled_tools(self) -> set[str]:
-        """The set of tools that are known but not handled.
-        Useful in task flow: an agent can refuse to accept an incoming msg
-        when it only has unhandled tools.
-        """
-        return self.llm_tools_known - self.llm_tools_handled
-
-    def enable_message(
-        self,
-        message_class: Optional[Type[ToolMessage] | List[Type[ToolMessage]]],
-        use: bool = True,
-        handle: bool = True,
-        force: bool = False,
-        require_recipient: bool = False,
-        include_defaults: bool = True,
-    ) -> None:
-        """
-        Add the tool (message class) to the agent, and enable either
-        - tool USE (i.e. the LLM can generate JSON to use this tool),
-        - tool HANDLING (i.e. the agent can handle JSON from this tool),
-
-        Args:
-            message_class: The ToolMessage class OR List of such classes to enable,
-                for USE, or HANDLING, or both.
-                If this is a list of ToolMessage classes, then the remain args are
-                applied to all classes.
-                Optional; if None, then apply the enabling to all tools in the
-                agent's toolset that have been enabled so far.
-            use: IF True, allow the agent (LLM) to use this tool (or all tools),
-                else disallow
-            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
-                tool (or all tools)
-            force: whether to FORCE the agent (LLM) to USE the specific
-                 tool represented by `message_class`.
-                 `force` is ignored if `message_class` is None.
-            require_recipient: whether to require that recipient be specified
-                when using the tool message (only applies if `use` is True).
-            include_defaults: whether to include fields that have default values,
-                in the "properties" section of the JSON format instructions.
-                (Normally the OpenAI completion API ignores these fields,
-                but the Assistant fn-calling seems to pay attn to these,
-                and if we don't want this, we should set this to False.)
-        """
-        if message_class is not None and isinstance(message_class, list):
-            for mc in message_class:
-                self.enable_message(
-                    mc,
-                    use=use,
-                    handle=handle,
-                    force=force,
-                    require_recipient=require_recipient,
-                    include_defaults=include_defaults,
-                )
-            return None
-
-        # Validate that use/handle are booleans, not accidentally passed tool classes
-        if isclass(use) or isclass(handle):
-            param = "use" if isclass(use) else "handle"
-            raise TypeError(
-                textwrap.dedent(
-                    f"""
-                    Invalid arguments to enable_message().
-                    It appears you passed multiple ToolMessage classes as separate
-                    arguments instead of as a list.
-
-                    Correct usage:
-                        agent.enable_message([Tool1, Tool2, Tool3])
-
-                    Incorrect usage:
-                        agent.enable_message(Tool1, Tool2, Tool3)
-
-                    The '{param}' parameter must be a boolean, not a class.
-                    """
-                )
-            )
-
-        if require_recipient and message_class is not None:
-            message_class = message_class.require_recipient()
-        if message_class is not None:
-            if not issubclass(message_class, ToolMessage):
-                raise ValueError("message_class must be a subclass of ToolMessage")
-            request = message_class.default_value("request")
-            existing_class = self.llm_tools_map.get(request)
-            existing_origin = (
-                existing_class.__dict__.get("__tool_message_origin__", existing_class)
-                if existing_class is not None
-                else None
-            )
-            message_origin = message_class.__dict__.get(
-                "__tool_message_origin__", message_class
-            )
-            if existing_class is not None and existing_origin is not message_origin:
-                raise ValueError(
-                    f"Tool request name {request!r} is already registered to "
-                    f"{existing_class.__name__}; cannot register "
-                    f"{message_class.__name__}"
-                )
-        if isinstance(message_class, XMLToolMessage):
-            # XMLToolMessage is not compatible with OpenAI's Tools/functions API,
-            # so we disable use of functions API, enable langroid-native Tools,
-            # which are prompt-based.
-            self.config.use_functions_api = False
-            self.config.use_tools = True
-        super().enable_message_handling(message_class)  # enables handling only
-        tools = self._get_tool_list(message_class)
-        if message_class is not None:
-            if request == "":
-                raise ValueError(
-                    f"""
-                    ToolMessage class {message_class} must have a non-empty
-                    'request' field if it is to be enabled as a tool.
-                    """
-                )
-            llm_function = message_class.llm_function_schema(defaults=include_defaults)
-            self.llm_functions_map[request] = llm_function
-            if force:
-                self.llm_function_force = dict(name=request)
-            else:
-                self.llm_function_force = None
-
-        for t in tools:
-            self.llm_tools_known.add(t)
-
-            if handle:
-                self.llm_tools_handled.add(t)
-                self.llm_functions_handled.add(t)
-
-                if (
-                    self.enabled_handling_output_format is not None
-                    and self.enabled_handling_output_format.name() == t
-                ):
-                    # `t` was designated as "enabled for handling" ONLY for
-                    # output_format enforcement, but we are explicitly ]
-                    # enabling it for handling here, so we set the variable to None.
-                    self.enabled_handling_output_format = None
-            else:
-                self.llm_tools_handled.discard(t)
-                self.llm_functions_handled.discard(t)
-
-            if use:
-                tool_class = self.llm_tools_map[t]
-                allow_llm_use = tool_class._allow_llm_use
-                if isinstance(allow_llm_use, ModelPrivateAttr):
-                    allow_llm_use = allow_llm_use.default
-                if allow_llm_use:
-                    self.llm_tools_usable.add(t)
-                    self.llm_functions_usable.add(t)
-                else:
-                    logger.warning(
-                        f"""
-                        ToolMessage class {tool_class} does not allow LLM use,
-                        because `_allow_llm_use=False` either in the Tool or a
-                        parent class of this tool;
-                        so not enabling LLM use for this tool!
-                        If you intended an LLM to use this tool,
-                        set `_allow_llm_use=True` when you define the tool.
-                        """
-                    )
-                if (
-                    self.enabled_use_output_format is not None
-                    and self.enabled_use_output_format.default_value("request") == t
-                ):
-                    # `t` was designated as "enabled for use" ONLY for output_format
-                    # enforcement, but we are explicitly enabling it for use here,
-                    # so we set the variable to None.
-                    self.enabled_use_output_format = None
-            else:
-                self.llm_tools_usable.discard(t)
-                self.llm_functions_usable.discard(t)
-
-        self._update_tool_instructions()
-
-    def _update_tool_instructions(self) -> None:
-        # Set tool instructions and JSON format instructions,
-        # in case Tools have been enabled/disabled.
-        if self.config.use_tools:
-            self.system_tool_format_instructions = self.tool_format_rules()
-        self.system_tool_instructions = self.tool_instructions()
-
-    def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]:
-        """
-        Returns the current set of enabled requests for inference and tools configs.
-        Used for restoring setings overriden by `set_output_format`.
-        """
-        return (
-            self.enabled_requests_for_inference,
-            self.config.use_functions_api,
-            self.config.use_tools,
-        )
-
-    @property
-    def all_llm_tools_known(self) -> set[str]:
-        """All known tools; we include `output_format` if it is a `ToolMessage`."""
-        known = self.llm_tools_known
-
-        if self.output_format is not None and issubclass(
-            self.output_format, ToolMessage
-        ):
-            return known.union({self.output_format.default_value("request")})
-
-        return known
-
-    def set_output_format(
-        self,
-        output_type: Optional[type],
-        force_tools: Optional[bool] = None,
-        use: Optional[bool] = None,
-        handle: Optional[bool] = None,
-        instructions: Optional[bool] = None,
-        is_copy: bool = False,
-    ) -> None:
-        """
-        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
-        switches to the native Langroid tools mechanism to ensure that no tool
-        calls not of `output_type` are generated. By default, `force_tools`
-        follows the `use_tools_on_output_format` parameter in the config.
-
-        If `output_type` is None, restores to the state prior to setting
-        `output_format`.
-
-        If `use`, we enable use of `output_type` when it is a subclass
-        of `ToolMesage`. Note that this primarily controls instruction
-        generation: the model will always generate `output_type` regardless
-        of whether `use` is set. Defaults to the `use_output_format`
-        parameter in the config. Similarly, handling of `output_type` is
-        controlled by `handle`, which defaults to the
-        `handle_output_format` parameter in the config.
-
-        `instructions` controls whether we generate instructions specifying
-        the output format schema. Defaults to the `instructions_output_format`
-        parameter in the config.
-
-        `is_copy` is set when called via `__getitem__`. In that case, we must
-        copy certain fields to ensure that we do not overwrite the main agent's
-        setings.
-        """
-        # Disable usage of an output format which was not specifically enabled
-        # by `enable_message`
-        if self.enabled_use_output_format is not None:
-            self.disable_message_use(self.enabled_use_output_format)
-            self.enabled_use_output_format = None
-
-        # Disable handling of an output format which did not specifically have
-        # handling enabled via `enable_message`
-        if self.enabled_handling_output_format is not None:
-            self.disable_message_handling(self.enabled_handling_output_format)
-            self.enabled_handling_output_format = None
-
-        # Reset any previous instructions
-        self.output_format_instructions = ""
-
-        if output_type is None:
-            self.output_format = None
-            (
-                requests_for_inference,
-                use_functions_api,
-                use_tools,
-            ) = self.saved_requests_and_tool_setings
-            self.config = self.config.model_copy()
-            self.enabled_requests_for_inference = requests_for_inference
-            self.config.use_functions_api = use_functions_api
-            self.config.use_tools = use_tools
-        else:
-            if force_tools is None:
-                force_tools = self.config.use_tools_on_output_format
-
-            if not any(
-                (isclass(output_type) and issubclass(output_type, t))
-                for t in [ToolMessage, BaseModel]
-            ):
-                output_type = get_pydantic_wrapper(output_type)
-
-            if self.output_format is None and force_tools:
-                self.saved_requests_and_tool_setings = (
-                    self._requests_and_tool_settings()
-                )
-
-            self.output_format = output_type
-            if issubclass(output_type, ToolMessage):
-                name = output_type.default_value("request")
-                if use is None:
-                    use = self.config.use_output_format
-
-                if handle is None:
-                    handle = self.config.handle_output_format
-
-                if use or handle:
-                    is_usable = name in self.llm_tools_usable.union(
-                        self.llm_functions_usable
-                    )
-                    is_handled = name in self.llm_tools_handled.union(
-                        self.llm_functions_handled
-                    )
-
-                    if is_copy:
-                        if use:
-                            # We must copy `llm_tools_usable` so the base agent
-                            # is unmodified
-                            self.llm_tools_usable = self.llm_tools_usable.copy()
-                            self.llm_functions_usable = self.llm_functions_usable.copy()
-                        if handle:
-                            # If handling the tool, do the same for `llm_tools_handled`
-                            self.llm_tools_handled = self.llm_tools_handled.copy()
-                            self.llm_functions_handled = (
-                                self.llm_functions_handled.copy()
-                            )
-                    # Enable `output_type`
-                    self.enable_message(
-                        output_type,
-                        # Do not override existing settings
-                        use=use or is_usable,
-                        handle=handle or is_handled,
-                    )
-
-                    # If the `output_type` ToilMessage was not already enabled for
-                    # use, this means we are ONLY enabling it for use specifically
-                    # for enforcing this output format, so we set the
-                    # `enabled_use_output_forma  to this output_type, to
-                    # record that it should be disabled when `output_format` is changed
-                    if not is_usable:
-                        self.enabled_use_output_format = output_type
-
-                    # (same reasoning as for use-enabling)
-                    if not is_handled:
-                        self.enabled_handling_output_format = output_type
-
-                generated_tool_instructions = name in self.llm_tools_usable.union(
-                    self.llm_functions_usable
-                )
-            else:
-                generated_tool_instructions = False
-
-            if instructions is None:
-                instructions = self.config.instructions_output_format
-            if issubclass(output_type, BaseModel) and instructions:
-                if generated_tool_instructions:
-                    # Already generated tool instructions as part of "enabling for use",
-                    # so only need to generate a reminder to use this tool.
-                    name = cast(ToolMessage, output_type).default_value("request")
-                    self.output_format_instructions = textwrap.dedent(
-                        f"""
-                        === OUTPUT FORMAT INSTRUCTIONS ===
-
-                        Please provide output using the `{name}` tool/function.
-                        """
-                    )
-                else:
-                    if issubclass(output_type, ToolMessage):
-                        output_format_schema = output_type.llm_function_schema(
-                            request=True,
-                            defaults=self.config.output_format_include_defaults,
-                        ).parameters
-                    else:
-                        output_format_schema = output_type.model_json_schema()
-
-                    format_schema_for_strict(output_format_schema)
-
-                    self.output_format_instructions = textwrap.dedent(
-                        f"""
-                        === OUTPUT FORMAT INSTRUCTIONS ===
-                        Please provide output as JSON with the following schema:
-
-                        {output_format_schema}
-                        """
-                    )
-
-            if force_tools:
-                if issubclass(output_type, ToolMessage):
-                    self.enabled_requests_for_inference = {
-                        output_type.default_value("request")
-                    }
-                if self.config.use_functions_api:
-                    self.config = self.config.model_copy()
-                    self.config.use_functions_api = False
-                    self.config.use_tools = True
-
-    def __getitem__(self, output_type: type) -> Self:
-        """
-        Returns a (shallow) copy of `self` with a forced output type.
-        """
-        clone = copy.copy(self)
-        clone.set_output_format(output_type, is_copy=True)
-        return clone
-
-    def disable_message_handling(
-        self,
-        message_class: Optional[Type[ToolMessage]] = None,
-    ) -> None:
-        """
-        Disable this agent from RESPONDING to a `message_class` (Tool). If
-            `message_class` is None, then disable this agent from responding to ALL.
-        Args:
-            message_class: The ToolMessage class to disable; Optional.
-        """
-        super().disable_message_handling(message_class)
-        for t in self._get_tool_list(message_class):
-            self.llm_tools_handled.discard(t)
-            self.llm_functions_handled.discard(t)
-
-    def disable_message_use(
-        self,
-        message_class: Optional[Type[ToolMessage]],
-    ) -> None:
-        """
-        Disable this agent from USING a message class (Tool).
-        If `message_class` is None, then disable this agent from USING ALL tools.
-        Args:
-            message_class: The ToolMessage class to disable.
-                If None, disable all.
-        """
-        for t in self._get_tool_list(message_class):
-            self.llm_tools_usable.discard(t)
-            self.llm_functions_usable.discard(t)
-
-        self._update_tool_instructions()
-
-    def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None:
-        """
-        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
-        Args:
-            message_class: The only ToolMessage class to allow
-        """
-        request = message_class.model_fields["request"].default
-        to_remove = [r for r in self.llm_tools_usable if r != request]
-        for r in to_remove:
-            self.llm_tools_usable.discard(r)
-            self.llm_functions_usable.discard(r)
-        self._update_tool_instructions()
-
-    def _load_output_format(self, message: ChatDocument) -> None:
-        """
-        If set, attempts to parse a value of type `self.output_format` from the message
-        contents or any tool/function call and assigns it to `content_any`.
-        """
-        if self.output_format is not None:
-            any_succeeded = False
-            attempts: list[str | LLMFunctionCall] = [
-                message.content,
-            ]
-
-            if message.function_call is not None:
-                attempts.append(message.function_call)
-
-            if message.oai_tool_calls is not None:
-                attempts.extend(
-                    [
-                        c.function
-                        for c in message.oai_tool_calls
-                        if c.function is not None
-                    ]
-                )
-
-            for attempt in attempts:
-                try:
-                    if isinstance(attempt, str):
-                        content = json.loads(attempt)
-                    else:
-                        if not (
-                            issubclass(self.output_format, ToolMessage)
-                            and attempt.name
-                            == self.output_format.default_value("request")
-                        ):
-                            continue
-
-                        content = attempt.arguments
-
-                    content_any = self.output_format.model_validate(content)
-
-                    if issubclass(self.output_format, PydanticWrapper):
-                        message.content_any = content_any.value  # type: ignore
-                    else:
-                        message.content_any = content_any
-                    any_succeeded = True
-                    break
-                except (ValidationError, json.JSONDecodeError):
-                    continue
-
-            if not any_succeeded:
-                self.disable_strict = True
-                logging.warning(
-                    """
-                    Validation error occured with strict output format enabled.
-                    Disabling strict mode.
-                    """
-                )
-
-    def get_tool_messages(
-        self,
-        msg: str | ChatDocument | None,
-        all_tools: bool = False,
-    ) -> List[ToolMessage]:
-        """
-        Extracts messages and tracks whether any errors occurred. If strict mode
-        was enabled, disables it for the tool, else triggers strict recovery.
-        """
-        self.tool_error = False
-        most_recent_sent_by_llm = (
-            len(self.message_history) > 0
-            and self.message_history[-1].role == Role.ASSISTANT
-        )
-        was_llm = most_recent_sent_by_llm or (
-            isinstance(msg, ChatDocument) and msg.metadata.sender == Entity.LLM
-        )
-        try:
-            tools = super().get_tool_messages(msg, all_tools)
-        except ValidationError as ve:
-            # Check if tool class was attached to the exception
-            if hasattr(ve, "tool_class") and ve.tool_class:
-                tool_class = ve.tool_class  # type: ignore
-                if issubclass(tool_class, ToolMessage):
-                    was_strict = (
-                        self.config.use_functions_api
-                        and self.config.use_tools_api
-                        and self._strict_mode_for_tool(tool_class)
-                    )
-                    # If the result of strict output for a tool using the
-                    # OpenAI tools API fails to parse, we infer that the
-                    # schema edits necessary for compatibility prevented
-                    # adherence to the underlying `ToolMessage` schema and
-                    # disable strict output for the tool
-                    if was_strict:
-                        name = tool_class.default_value("request")
-                        self.disable_strict_tools_set.add(name)
-                        logging.warning(
-                            f"""
-                            Validation error occured with strict tool format.
-                            Disabling strict mode for the {name} tool.
-                            """
-                        )
-                    else:
-                        # We will trigger the strict recovery mechanism to force
-                        # the LLM to correct its output, allowing us to parse
-                        if isinstance(msg, ChatDocument):
-                            self.tool_error = msg.metadata.sender == Entity.LLM
-                        else:
-                            self.tool_error = most_recent_sent_by_llm
-
-            if was_llm:
-                raise ve
-            else:
-                self.tool_error = False
-                return []
-
-        if not was_llm:
-            self.tool_error = False
-
-        return tools
-
-    def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None:
-        """
-        Returns a `ToolMessage` which wraps all enabled tools, excluding those
-        where strict recovery is disabled. Used in strict recovery.
-        """
-        possible_tools = tuple(
-            self.llm_tools_map[t]
-            for t in self.llm_tools_usable
-            if t not in self.disable_strict_tools_set
-        )
-        if len(possible_tools) == 0:
-            return None
-        any_tool_type = Union.__getitem__(possible_tools)  # type ignore
-
-        maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
-
-        class AnyTool(ToolMessage):
-            purpose: str = "To call a tool/function."
-            request: str = "tool_or_function"
-            tool: maybe_optional_type  # type: ignore
-
-            def response(self, agent: ChatAgent) -> None | str | ChatDocument:
-                # One-time use
-                agent.set_output_format(None)
-
-                if self.tool is None:
-                    return None
-
-                # As the ToolMessage schema accepts invalid
-                # `tool.request` values, reparse with the
-                # corresponding tool
-                request = self.tool.request
-                if request not in agent.llm_tools_map:
-                    return None
-                tool = agent.llm_tools_map[request].model_validate_json(
-                    self.tool.to_json()
-                )
-
-                return agent.handle_tool_message(tool)
-
-            async def response_async(
-                self, agent: ChatAgent
-            ) -> None | str | ChatDocument:
-                # One-time use
-                agent.set_output_format(None)
-
-                if self.tool is None:
-                    return None
-
-                # As the ToolMessage schema accepts invalid
-                # `tool.request` values, reparse with the
-                # corresponding tool
-                request = self.tool.request
-                if request not in agent.llm_tools_map:
-                    return None
-                tool = agent.llm_tools_map[request].model_validate_json(
-                    self.tool.to_json()
-                )
-
-                return await agent.handle_tool_message_async(tool)
-
-        # Every call builds a distinct class; share one origin so enabling a
-        # regenerated AnyTool under "tool_or_function" stays idempotent instead
-        # of tripping the same-name/different-tool registration guard.
-        AnyTool.__tool_message_origin__ = (  # type: ignore[attr-defined]
-            _ANY_TOOL_MESSAGE_ORIGIN
-        )
-        return AnyTool
-
-    def _strict_recovery_instructions(
-        self,
-        tool_type: Optional[type[ToolMessage]] = None,
-        optional: bool = True,
-    ) -> str:
-        """Returns instructions for strict recovery."""
-        optional_instructions = (
-            (
-                "\n"
-                + """
-        If you did NOT intend to do so, `tool` should be null.
-        """
-            )
-            if optional
-            else ""
-        )
-        response_prefix = "If you intended to make such a call, r" if optional else "R"
-        instruction_prefix = "If you do so, b" if optional else "B"
-
-        schema_instructions = (
-            f"""
-        The schema for `tool_or_function` is as follows:
-        {tool_type.llm_function_schema(defaults=True, request=True).parameters}
-        """
-            if tool_type
-            else ""
-        )
-
-        return textwrap.dedent(
-            f"""
-        Your previous attempt to make a tool/function call appears to have failed.
-        {response_prefix}espond with your desired tool/function. Do so with the
-        `tool_or_function` tool/function where `tool` is set to your intended call.
-        {schema_instructions}
-
-        {instruction_prefix}e sure that your corrected call matches your intention
-        in your previous request. For any field with a default value which
-        you did not intend to override in your previous attempt, be sure
-        to set that field to its default value. {optional_instructions}
-        """
-        )
-
-    def truncate_message(
-        self,
-        idx: int,
-        tokens: int = 5,
-        warning: str = "...[Contents truncated!]",
-        inplace: bool = True,
-    ) -> LLMMessage:
-        """
-        Truncate message at idx in msg history to `tokens` tokens.
-
-        If inplace is True, the message is truncated in place, else
-        it LEAVES the original message INTACT and returns a new message
-        """
-        if inplace:
-            llm_msg = self.message_history[idx]
-        else:
-            llm_msg = copy.deepcopy(self.message_history[idx])
-        if llm_msg.content is None or (
-            llm_msg.content == "" and _is_identified_result(llm_msg)
-        ):
-            return llm_msg
-        orig_content = llm_msg.content
-        new_content = (
-            self.parser.truncate_tokens(orig_content, tokens)
-            if self.parser is not None
-            else orig_content[: tokens * 4]  # approx truncation
-        )
-        llm_msg.content = new_content + "\n" + warning
-        return llm_msg
-
-    def _reduce_raw_tool_results(self, message: ChatDocument) -> None:
-        """
-        If message is the result of a ToolMessage that had
-        a `_max_retained_tokens` set to a non-None value, then we replace contents
-        with a placeholder message.
-        """
-        parent_message: ChatDocument | None = message.parent
-        tools = [] if parent_message is None else parent_message.tool_messages
-        truncate_tools = []
-        for t in tools:
-            max_retained_tokens = t._max_retained_tokens
-            if isinstance(max_retained_tokens, ModelPrivateAttr):
-                max_retained_tokens = max_retained_tokens.default
-            if max_retained_tokens is not None:
-                truncate_tools.append(t)
-        limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
-        if limiting_tool is not None:
-            max_retained_tokens = limiting_tool._max_retained_tokens
-            if isinstance(max_retained_tokens, ModelPrivateAttr):
-                max_retained_tokens = max_retained_tokens.default
-            if max_retained_tokens is not None:
-                tool_name = limiting_tool.default_value("request")
-                max_tokens: int = max_retained_tokens
-                truncation_warning = f"""
-                    The result of the {tool_name} tool were too large,
-                    and has been truncated to {max_tokens} tokens.
-                    To obtain the full result, the tool needs to be re-used.
-                """
-                self.truncate_message(
-                    message.metadata.msg_idx, max_tokens, truncation_warning
-                )
-
-    def llm_response(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> Optional[ChatDocument]:
-        """
-        Respond to a single user message, appended to the message history,
-        in "chat" mode
-        Args:
-            message (str|ChatDocument): message or ChatDocument object to respond to.
-                If None, use the self.task_messages
-        Returns:
-            LLM response as a ChatDocument object
-        """
-        if self.llm is None:
-            return None
-
-        # If enabled and a tool error occurred, we recover by generating the tool in
-        # strict json mode
-        if (
-            self.tool_error
-            and self.output_format is None
-            and self._json_schema_available()
-            and self.config.strict_recovery
-        ):
-            self.tool_error = False
-            AnyTool = self._get_any_tool_message()
-            if AnyTool is None:
-                return None
-            self.set_output_format(
-                AnyTool,
-                force_tools=True,
-                use=True,
-                handle=True,
-                instructions=True,
-            )
-            recovery_message = self._strict_recovery_instructions(AnyTool)
-            augmented_message = message
-            if augmented_message is None:
-                augmented_message = recovery_message
-            elif isinstance(augmented_message, str):
-                augmented_message = augmented_message + recovery_message
-            else:
-                augmented_message.content = augmented_message.content + recovery_message
-
-            # only use the augmented message for this one response...
-            result = self.llm_response(augmented_message)
-            # ... restore the original user message so that the AnyTool recover
-            # instructions don't persist in the message history
-            # (this can cause the LLM to use the AnyTool directly as a tool)
-            if message is None:
-                self.delete_last_message(role=Role.USER)
-            else:
-                msg = message if isinstance(message, str) else message.content
-                self.update_last_message(msg, role=Role.USER)
-            return result
-
-        hist, output_len = self._prep_llm_messages(message)
-        if len(hist) == 0:
-            return None
-        tool_choice = (
-            "auto"
-            if isinstance(message, str)
-            else (message.oai_tool_choice if message is not None else "auto")
-        )
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
-            try:
-                response = self.llm_response_messages(hist, output_len, tool_choice)
-            except openai.BadRequestError as e:
-                if self.any_strict:
-                    self.disable_strict = True
-                    self.set_output_format(None)
-                    logging.warning(
-                        f"""
-                        OpenAI BadRequestError raised with strict mode enabled.
-                        Message: {e.message}
-                        Disabling strict mode and retrying.
-                        """
-                    )
-                    return self.llm_response(message)
-                else:
-                    raise e
-        self.message_history.extend(ChatDocument.to_LLMMessage(response))
-        response.metadata.msg_idx = len(self.message_history) - 1
-        response.metadata.agent_id = self.id
-        if isinstance(message, ChatDocument):
-            self._reduce_raw_tool_results(message)
-        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
-        response.metadata.tool_ids = (
-            []
-            if isinstance(message, str)
-            else message.metadata.tool_ids if message is not None else []
-        )
-
-        return response
-
-    async def llm_response_async(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> Optional[ChatDocument]:
-        """
-        Async version of `llm_response`. See there for details.
-        """
-        if self.llm is None:
-            return None
-
-        # If enabled and a tool error occurred, we recover by generating the tool in
-        # strict json mode
-        if (
-            self.tool_error
-            and self.output_format is None
-            and self._json_schema_available()
-            and self.config.strict_recovery
-        ):
-            self.tool_error = False
-            AnyTool = self._get_any_tool_message()
-            self.set_output_format(
-                AnyTool,
-                force_tools=True,
-                use=True,
-                handle=True,
-                instructions=True,
-            )
-            recovery_message = self._strict_recovery_instructions(AnyTool)
-            augmented_message = message
-            if augmented_message is None:
-                augmented_message = recovery_message
-            elif isinstance(augmented_message, str):
-                augmented_message = augmented_message + recovery_message
-            else:
-                augmented_message.content = augmented_message.content + recovery_message
-
-            # only use the augmented message for this one response...
-            result = self.llm_response(augmented_message)
-            # ... restore the original user message so that the AnyTool recover
-            # instructions don't persist in the message history
-            # (this can cause the LLM to use the AnyTool directly as a tool)
-            if message is None:
-                self.delete_last_message(role=Role.USER)
-            else:
-                msg = message if isinstance(message, str) else message.content
-                self.update_last_message(msg, role=Role.USER)
-            return result
-
-        hist, output_len = self._prep_llm_messages(message)
-        if len(hist) == 0:
-            return None
-        tool_choice = (
-            "auto"
-            if isinstance(message, str)
-            else (message.oai_tool_choice if message is not None else "auto")
-        )
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
-            try:
-                response = await self.llm_response_messages_async(
-                    hist, output_len, tool_choice
-                )
-            except openai.BadRequestError as e:
-                if self.any_strict:
-                    self.disable_strict = True
-                    self.set_output_format(None)
-                    logging.warning(
-                        f"""
-                        OpenAI BadRequestError raised with strict mode enabled.
-                        Message: {e.message}
-                        Disabling strict mode and retrying.
-                        """
-                    )
-                    return await self.llm_response_async(message)
-                else:
-                    raise e
-        self.message_history.extend(ChatDocument.to_LLMMessage(response))
-        response.metadata.msg_idx = len(self.message_history) - 1
-        response.metadata.agent_id = self.id
-        if isinstance(message, ChatDocument):
-            self._reduce_raw_tool_results(message)
-        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
-        response.metadata.tool_ids = (
-            []
-            if isinstance(message, str)
-            else message.metadata.tool_ids if message is not None else []
-        )
-
-        return response
-
-    def init_message_history(self) -> None:
-        """
-        Initialize the message history with the system message and user message
-        """
-        self.message_history = [self._create_system_and_tools_message()]
-        if self.user_message:
-            self.message_history.append(
-                LLMMessage(role=Role.USER, content=self.user_message)
-            )
-
-    def _prep_llm_messages(
-        self,
-        message: Optional[str | ChatDocument] = None,
-        truncate: bool = True,
-    ) -> Tuple[List[LLMMessage], int]:
-        """
-        Prepare messages to be sent to self.llm_response_messages,
-            which is the main method that calls the LLM API to get a response.
-            If desired output tokens + message history exceeds the model context length,
-            then first the max output tokens is reduced to fit, and if that is not
-            possible, older messages may be truncated to accommodate at least
-            self.config.llm.min_output_tokens of output.
-
-        Returns:
-            Tuple[List[LLMMessage], int]: (messages, output_len)
-                messages = Full list of messages to send
-                output_len = max expected number of tokens in response
-        """
-
-        if (
-            not self.llm_can_respond(message)
-            or self.config.llm is None
-            or self.llm is None
-        ):
-            return [], 0
-
-        if message is None and len(self.message_history) > 0:
-            # this means agent has been used to get LLM response already,
-            # and so the last message is an "assistant" response.
-            # We delete this last assistant response and re-generate it.
-            self.clear_history(-1)
-            logger.warning(
-                "Re-generating the last assistant response since message is None"
-            )
-
-        if len(self.message_history) == 0:
-            # initial messages have not yet been loaded, so load them
-            self.init_message_history()
-
-            # for debugging, show the initial message history
-            if settings.debug:
-                print(
-                    f"""
-                [grey37]LLM Initial Msg History:
-                {escape(self.message_history_str())}
-                [/grey37]
-                """
-                )
-        else:
-            assert self.message_history[0].role == Role.SYSTEM
-            # update the system message with the latest tool instructions
-            self.message_history[0] = self._create_system_and_tools_message()
-
-        if message is not None:
-            if (
-                isinstance(message, str)
-                or message.id() != self.message_history[-1].chat_document_id
-            ):
-                # either the message is a str, or it is a fresh ChatDocument
-                # different from the last message in the history
-                llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
-                llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
-                # Canonicalize retained whitespace-only results before token counting.
-                for llm_msg in llm_msgs:
-                    if (
-                        _is_identified_result(llm_msg)
-                        and llm_msg.content is not None
-                        and llm_msg.content.strip() == ""
-                    ):
-                        llm_msg.content = ""
-                if len(llm_msgs) == 0:
-                    return [], 0
-                # process tools if any
-                done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
-                self.oai_tool_calls = [
-                    t for t in self.oai_tool_calls if t.id not in done_tools
-                ]
-                self.message_history.extend(llm_msgs)
-
-        hist = self.message_history
-        output_len = self.config.llm.model_max_output_tokens
-        if (
-            truncate
-            and output_len > self.llm.chat_context_length() - self.chat_num_tokens(hist)
-        ):
-            # chat + output > max context length,
-            # so first try to shorten requested output len to fit;
-            # use an extra margin of CHAT_HISTORY_BUFFER tokens
-            # in case our calcs are off (and to allow for some extra tokens)
-            output_len = (
-                self.llm.chat_context_length()
-                - self.chat_num_tokens(hist)
-                - CHAT_HISTORY_BUFFER
-            )
-            if output_len > self.config.llm.min_output_tokens:
-                logger.debug(
-                    f"""
-                    Chat Model context length is {self.llm.chat_context_length()},
-                    but the current message history is {self.chat_num_tokens(hist)}
-                    tokens long, which does not allow
-                    {self.config.llm.model_max_output_tokens} output tokens.
-                    Therefore we reduced `max_output_tokens` to {output_len} tokens,
-                    so they can fit within the model's context length
-                    """
-                )
-            else:
-                # unacceptably small output len, so compress early parts of
-                # conversation history based on the configured strategy
-                strategy = self.config.context_overflow_strategy
-
-                if strategy == "truncate":
-                    # Truncate content of individual messages while preserving
-                    # the message sequence (important for LLM APIs that require
-                    # alternating USER/ASSISTANT messages)
-                    msg_idx_to_compress = 1  # don't touch system msg
-                    # we will try compressing msg indices up to but not including
-                    # last user msg
-                    last_msg_idx_to_compress = (
-                        self.last_message_idx_with_role(
-                            role=Role.USER,
-                        )
-                        - 1
-                    )
-                    n_truncated = 0
-                    _target_tokens = (
-                        self.llm.chat_context_length()
-                        - self.config.llm.min_output_tokens
-                        - CHAT_HISTORY_BUFFER
-                    )
-                    # Truncation floor: never reduce a message's content below
-                    # this many tokens.
-                    _min_keep_tokens = 30
-                    _truncation_warning = "... [Contents truncated!]"
-
-                    def _content_tokens(text: str | None) -> int:
-                        """Token count of message *content* only.
-
-                        `truncate_message` only trims `message.content`, so
-                        using the full `_message_num_tokens` (which includes
-                        attachment payloads) would inflate the count and make
-                        the keep-target too large to ever converge, for
-                        messages carrying file attachments.
-                        """
-                        return (
-                            self.parser.num_tokens(text or "")
-                            if self.parser is not None
-                            # approx fallback, matches truncate_message
-                            else len(text or "") // 4
-                        )
-
-                    # Account for the warning that truncate_message appends
-                    # ("\n" + warning), so the final token count of a
-                    # truncated message does not exceed its keep-target.
-                    _warning_tokens = _content_tokens("\n" + _truncation_warning)
-                    # NOTE: loop termination is guaranteed:
-                    # msg_idx_to_compress strictly increases every iteration
-                    # (truncate or skip), and once it exceeds
-                    # last_msg_idx_to_compress a ValueError is raised. (The
-                    # token count need not decrease every iteration, so
-                    # termination rests on the index advancing.)
-                    while self.chat_num_tokens(hist) > _target_tokens:
-                        if msg_idx_to_compress > last_msg_idx_to_compress:
-                            # We want to preserve the first message (typically
-                            # system msg) and last message (user msg).
-                            raise ValueError(
-                                """
-                            The (message history + max_output_tokens) is longer than the
-                            max chat context length of this model, and we have tried
-                            reducing the requested max output tokens, as well as
-                            truncating early parts of the message history, to
-                            accommodate the model context length, but we have run out
-                            of msgs to truncate.
-
-                            HINT: In the `llm` field of your `ChatAgentConfig` object,
-                            which is of type `LLMConfig/OpenAIGPTConfig`, try
-                            - increasing `chat_context_length`
-                                (if accurate for the model), or
-                            - decreasing `max_output_tokens`
-                            """
-                            )
-                        _msg_tokens = _content_tokens(hist[msg_idx_to_compress].content)
-                        if _msg_tokens <= _min_keep_tokens + _warning_tokens:
-                            # Truncating this message cannot shrink the total:
-                            # its content is already at/below the keep-floor
-                            # plus the appended warning; leave it intact.
-                            msg_idx_to_compress += 1
-                            continue
-                        n_truncated += 1
-                        # Distribute the current excess evenly across the
-                        # remaining *compressible* messages, so each retains
-                        # as much content as possible instead of being
-                        # collapsed to the fixed 30-token floor. The excess is
-                        # recomputed every iteration, so the distribution
-                        # self-corrects as we move forward through the
-                        # history.
-                        _current_excess = self.chat_num_tokens(hist) - _target_tokens
-                        # Shrink capacity of each *later* message in the
-                        # compressible range: its content above the floor (net
-                        # of the appended warning). Non-positive entries are
-                        # the tiny messages the skip-check above will leave
-                        # untouched; they must not dilute the even share, so
-                        # only messages with positive capacity count toward
-                        # the denominator (plus this message, which passed the
-                        # skip-check and is therefore compressible).
-                        _later_capacities = [
-                            _content_tokens(m.content)
-                            - _min_keep_tokens
-                            - _warning_tokens
-                            for m in hist[
-                                msg_idx_to_compress + 1 : last_msg_idx_to_compress + 1
-                            ]
-                        ]
-                        _n_remaining = 1 + sum(1 for c in _later_capacities if c > 0)
-                        _even_share = math.ceil(_current_excess / _n_remaining)
-                        # Later messages can shed at most their capacity; this
-                        # message must absorb whatever they cannot, so that
-                        # this single forward pass reaches the target whenever
-                        # that is possible at all.
-                        _later_capacity = sum(c for c in _later_capacities if c > 0)
-                        _reduction = max(_even_share, _current_excess - _later_capacity)
-                        # Extra 2-token slack: re-encoding truncated content
-                        # plus the appended warning can merge/split tokens at
-                        # the boundary, so aim slightly below the target to
-                        # keep the achieved reduction from falling short.
-                        _keep_tokens = max(
-                            _min_keep_tokens,
-                            _msg_tokens - _reduction - _warning_tokens - 2,
-                        )
-                        # compress the msg at idx `msg_idx_to_compress`
-                        hist[msg_idx_to_compress] = self.truncate_message(
-                            msg_idx_to_compress,
-                            tokens=_keep_tokens,
-                            warning=_truncation_warning,
-                        )
-                        msg_idx_to_compress += 1
-
-                    output_len = min(
-                        self.config.llm.model_max_output_tokens,
-                        self.llm.chat_context_length()
-                        - self.chat_num_tokens(hist)
-                        - CHAT_HISTORY_BUFFER,
-                    )
-                    if output_len < self.config.llm.min_output_tokens:
-                        raise ValueError(
-                            f"""
-                            Tried to shorten prompt history for chat mode
-                            but even after truncating all messages except system msg
-                            and last (user) msg, the history token len
-                            {self.chat_num_tokens(hist)} is too long to accommodate
-                            the desired minimum output tokens
-                            {self.config.llm.min_output_tokens} within the
-                            model's context length {self.llm.chat_context_length()}.
-                            Please try shortening the system msg or user prompts,
-                            or adjust `config.llm.min_output_tokens` to be smaller.
-                            """
-                        )
-                    else:
-                        # we MUST have truncated at least one msg
-                        msg_tokens = self.chat_num_tokens()
-                        logger.warning(
-                            f"""
-                        Chat Model context length is {self.llm.chat_context_length()}
-                        tokens, but the current message history is {msg_tokens} tokens
-                        long, which does not allow
-                        {self.config.llm.model_max_output_tokens} output tokens.
-                        Therefore we truncated the first {n_truncated} messages
-                        in the conversation history so that history token
-                        length is reduced to {self.chat_num_tokens(hist)}, and
-                        we use `max_output_tokens = {output_len}`,
-                        so they can fit within the model's context length
-                        of {self.llm.chat_context_length()} tokens.
-                        """
-                        )
-
-                else:  # strategy == "drop_turns"
-                    # Drop complete conversation turns. A complete turn is defined
-                    # as a USER message followed by all messages until the next
-                    # USER message. This is more aggressive but cleaner for voice
-                    # agents with limited context.
-                    n_dropped_turns = 0
-                    while (
-                        self.chat_num_tokens(hist)
-                        > self.llm.chat_context_length()
-                        - self.config.llm.min_output_tokens
-                        - CHAT_HISTORY_BUFFER
-                    ):
-                        # Find the last USER message index
-                        last_user_idx = self.last_message_idx_with_role(role=Role.USER)
-                        if last_user_idx == -1:
-                            break
-
-                        # Find the first complete turn to drop (skip system message)
-                        first_user_idx = -1
-                        for i in range(1, last_user_idx):
-                            if hist[i].role == Role.USER:
-                                first_user_idx = i
-                                break
-                        if first_user_idx == -1:
-                            break
-
-                        # Find the end of this turn: last message before next USER
-                        next_user_idx = -1
-                        for i in range(first_user_idx + 1, last_user_idx + 1):
-                            if hist[i].role == Role.USER:
-                                next_user_idx = i
-                                break
-                        if next_user_idx == -1:
-                            break
-
-                        # Drop the turn
-                        self.clear_history(first_user_idx, next_user_idx - 1)
-                        n_dropped_turns += 1
-
-                    output_len = min(
-                        self.config.llm.model_max_output_tokens,
-                        self.llm.chat_context_length()
-                        - self.chat_num_tokens(hist)
-                        - CHAT_HISTORY_BUFFER,
-                    )
-                    if output_len < self.config.llm.min_output_tokens:
-                        raise ValueError(
-                            f"""
-                            Tried to shorten prompt history for chat mode
-                            but even after dropping complete turns except the system
-                            msg and last turn, the history token len
-                            {self.chat_num_tokens(hist)} is too long to accommodate
-                            the desired minimum output tokens
-                            {self.config.llm.min_output_tokens} within the
-                            model's context length {self.llm.chat_context_length()}.
-                            Please try shortening the system msg or user prompts,
-                            or adjust `config.llm.min_output_tokens` to be smaller.
-                            """
-                        )
-                    else:
-                        # we MUST have dropped at least one turn
-                        msg_tokens = self.chat_num_tokens()
-                        logger.warning(
-                            f"""
-                        Chat Model context length is {self.llm.chat_context_length()}
-                        tokens, but the current message history is {msg_tokens} tokens
-                        long, which does not allow
-                        {self.config.llm.model_max_output_tokens} output tokens.
-                        Therefore we dropped the first {n_dropped_turns} complete
-                        turn(s) from the conversation history so that history token
-                        length is reduced to {self.chat_num_tokens(hist)}, and
-                        we use `max_output_tokens = {output_len}`,
-                        so they can fit within the model's context length
-                        of {self.llm.chat_context_length()} tokens.
-                        """
-                        )
-
-        if isinstance(message, ChatDocument):
-            # record the position of the corresponding LLMMessage in
-            # the message_history
-            message.metadata.msg_idx = len(hist) - 1
-            message.metadata.agent_id = self.id
-        return hist, output_len
-
-    def _function_args(
-        self,
-    ) -> Tuple[
-        Optional[List[LLMFunctionSpec]],
-        str | Dict[str, str],
-        Optional[List[OpenAIToolSpec]],
-        Optional[Dict[str, Dict[str, str] | str]],
-        Optional[OpenAIJsonSchemaSpec],
-    ]:
-        """
-        Get function/tool spec/output format arguments for
-        OpenAI-compatible LLM API call
-        """
-        functions: Optional[List[LLMFunctionSpec]] = None
-        fun_call: str | Dict[str, str] = "none"
-        tools: Optional[List[OpenAIToolSpec]] = None
-        force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
-        self.any_strict = False
-        if self.config.use_functions_api and len(self.llm_functions_usable) > 0:
-            if not self.config.use_tools_api:
-                functions = [
-                    self.llm_functions_map[f] for f in self.llm_functions_usable
-                ]
-                fun_call = (
-                    "auto"
-                    if self.llm_function_force is None
-                    else self.llm_function_force
-                )
-            else:
-
-                def to_maybe_strict_spec(function: str) -> OpenAIToolSpec:
-                    spec = self.llm_functions_map[function]
-                    strict = self._strict_mode_for_tool(function)
-                    if strict:
-                        self.any_strict = True
-                        strict_spec = copy.deepcopy(spec)
-                        format_schema_for_strict(strict_spec.parameters)
-                    else:
-                        strict_spec = spec
-
-                    return OpenAIToolSpec(
-                        type="function",
-                        strict=strict,
-                        function=strict_spec,
-                    )
-
-                tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
-                force_tool = (
-                    None
-                    if self.llm_function_force is None
-                    else {
-                        "type": "function",
-                        "function": {"name": self.llm_function_force["name"]},
-                    }
-                )
-        output_format = None
-        if self.output_format is not None and self._json_schema_available():
-            self.any_strict = True
-            if issubclass(self.output_format, ToolMessage) and not issubclass(
-                self.output_format, XMLToolMessage
-            ):
-                spec = self.output_format.llm_function_schema(
-                    request=True,
-                    defaults=self.config.output_format_include_defaults,
-                )
-                format_schema_for_strict(spec.parameters)
-
-                output_format = OpenAIJsonSchemaSpec(
-                    # We always require that outputs strictly match the schema
-                    strict=True,
-                    function=spec,
-                )
-            elif issubclass(self.output_format, BaseModel):
-                param_spec = self.output_format.model_json_schema()
-                format_schema_for_strict(param_spec)
-
-                output_format = OpenAIJsonSchemaSpec(
-                    # We always require that outputs strictly match the schema
-                    strict=True,
-                    function=LLMFunctionSpec(
-                        name="json_output",
-                        description="Strict Json output format.",
-                        parameters=param_spec,
-                    ),
-                )
-
-        return functions, fun_call, tools, force_tool, output_format
-
-    def llm_response_messages(
-        self,
-        messages: List[LLMMessage],
-        output_len: Optional[int] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-    ) -> ChatDocument:
-        """
-        Respond to a series of messages, e.g. with OpenAI ChatCompletion
-        Args:
-            messages: seq of messages (with role, content fields) sent to LLM
-            output_len: max number of tokens expected in response.
-                    If None, use the LLM's default model_max_output_tokens.
-        Returns:
-            Document (i.e. with fields "content", "metadata")
-        """
-        assert self.config.llm is not None and self.llm is not None
-        output_len = output_len or self.config.llm.model_max_output_tokens
-        streamer = noop_fn
-        if self.llm.get_stream():
-            streamer = self.callbacks.start_llm_stream()
-        self.llm.config.streamer = streamer
-        with ExitStack() as stack:  # for conditionally using rich spinner
-            if not self.llm.get_stream() and not settings.quiet:
-                # show rich spinner only if not streaming!
-                # (Why? b/c the intent of showing a spinner is to "show progress",
-                # and we don't need to do that when streaming, since
-                # streaming output already shows progress.)
-                cm = status(
-                    "LLM responding to messages...",
-                    log_if_quiet=False,
-                )
-                stack.enter_context(cm)
-            if self.llm.get_stream() and not settings.quiet:
-                console.print(f"[green]{self.indent}", end="")
-            functions, fun_call, tools, force_tool, output_format = (
-                self._function_args()
-            )
-            assert self.llm is not None
-            response = self.llm.chat(
-                messages,
-                output_len,
-                tools=tools,
-                tool_choice=force_tool or tool_choice,
-                functions=functions,
-                function_call=fun_call,
-                response_format=output_format,
-            )
-        if self.llm.get_stream():
-            # Create temp ChatDocument for tool check, then clean up to avoid
-            # polluting ObjectRegistry (see PR #939 discussion)
-            temp_doc = ChatDocument.from_LLMResponse(
-                response,
-                displayed=True,
-                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-            )
-            self._call_callback_with_reasoning(
-                "finish_llm_stream",
-                reasoning=response.reasoning,
-                content=response.message or "",
-                tools_content=response.tools_content(),
-                is_tool=self.has_tool_message_attempt(temp_doc),
-            )
-            ObjectRegistry.remove(temp_doc.id())
-        self.llm.config.streamer = noop_fn
-        if response.cached:
-            self.callbacks.cancel_llm_stream()
-        self._render_llm_response(response)
-        self.update_token_usage(
-            response,  # .usage attrib is updated!
-            messages,
-            self.llm.get_stream(),
-            chat=True,
-            print_response_stats=self.config.show_stats and not settings.quiet,
-        )
-        chat_doc = ChatDocument.from_LLMResponse(
-            response,
-            displayed=True,
-            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-        )
-        self.oai_tool_calls = response.oai_tool_calls or []
-        self.oai_tool_id2call.update(
-            {t.id: t for t in self.oai_tool_calls if t.id is not None}
-        )
-
-        # If using strict output format, parse the output JSON
-        self._load_output_format(chat_doc)
-
-        return chat_doc
-
-    async def llm_response_messages_async(
-        self,
-        messages: List[LLMMessage],
-        output_len: Optional[int] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-    ) -> ChatDocument:
-        """
-        Async version of `llm_response_messages`. See there for details.
-        """
-        assert self.config.llm is not None and self.llm is not None
-        output_len = output_len or self.config.llm.model_max_output_tokens
-        functions, fun_call, tools, force_tool, output_format = self._function_args()
-        assert self.llm is not None
-
-        streamer_async = async_noop_fn
-        if self.llm.get_stream():
-            streamer_async = await self.callbacks.start_llm_stream_async()
-        self.llm.config.streamer_async = streamer_async
-
-        response = await self.llm.achat(
-            messages,
-            output_len,
-            tools=tools,
-            tool_choice=force_tool or tool_choice,
-            functions=functions,
-            function_call=fun_call,
-            response_format=output_format,
-        )
-        if self.llm.get_stream():
-            # Create temp ChatDocument for tool check, then clean up to avoid
-            # polluting ObjectRegistry (see PR #939 discussion)
-            temp_doc = ChatDocument.from_LLMResponse(
-                response,
-                displayed=True,
-                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-            )
-            self._call_callback_with_reasoning(
-                "finish_llm_stream",
-                reasoning=response.reasoning,
-                content=response.message or "",
-                tools_content=response.tools_content(),
-                is_tool=self.has_tool_message_attempt(temp_doc),
-            )
-            ObjectRegistry.remove(temp_doc.id())
-        self.llm.config.streamer_async = async_noop_fn
-        if response.cached:
-            self.callbacks.cancel_llm_stream()
-        self._render_llm_response(response)
-        self.update_token_usage(
-            response,  # .usage attrib is updated!
-            messages,
-            self.llm.get_stream(),
-            chat=True,
-            print_response_stats=self.config.show_stats and not settings.quiet,
-        )
-        chat_doc = ChatDocument.from_LLMResponse(
-            response,
-            displayed=True,
-            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-        )
-        self.oai_tool_calls = response.oai_tool_calls or []
-        self.oai_tool_id2call.update(
-            {t.id: t for t in self.oai_tool_calls if t.id is not None}
-        )
-
-        # If using strict output format, parse the output JSON
-        self._load_output_format(chat_doc)
-
-        return chat_doc
-
-    def _call_callback_with_reasoning(
-        self,
-        callback_name: str,
-        reasoning: str,
-        **kwargs: Any,
-    ) -> None:
-        """
-        Call a callback method, only passing 'reasoning' if it accepts it.
-
-        This provides backward compatibility for custom callbacks that don't
-        have the 'reasoning' parameter in their signature.
-
-        Args:
-            callback_name: Name of the callback method (e.g., 'show_llm_response')
-            reasoning: The reasoning content to pass if supported
-            **kwargs: Other arguments to pass to the callback
-        """
-        callback = getattr(self.callbacks, callback_name, None)
-        if callback is None:
-            return
-
-        # Check if callback accepts 'reasoning' param or **kwargs
-        try:
-            sig = inspect.signature(callback)
-            params = sig.parameters
-            accepts_reasoning = "reasoning" in params or any(
-                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-            )
-        except (ValueError, TypeError):
-            # If we can't inspect the signature, assume it doesn't accept reasoning
-            accepts_reasoning = False
-
-        if accepts_reasoning:
-            callback(reasoning=reasoning, **kwargs)
-        else:
-            callback(**kwargs)
-
-    def _render_llm_response(
-        self, response: ChatDocument | LLMResponse, citation_only: bool = False
-    ) -> None:
-        is_cached = (
-            response.cached
-            if isinstance(response, LLMResponse)
-            else response.metadata.cached
-        )
-        if self.llm is None:
-            return
-        if not citation_only and (not self.llm.get_stream() or is_cached):
-            # We would have already displayed the msg "live" ONLY if
-            # streaming was enabled, AND we did not find a cached response.
-            # If we are here, it means the response has not yet been displayed.
-            cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
-            # Track whether we created a temp ChatDocument for cleanup
-            is_temp_doc = isinstance(response, LLMResponse)
-            chat_doc = (
-                response
-                if isinstance(response, ChatDocument)
-                else ChatDocument.from_LLMResponse(
-                    response,
-                    displayed=True,
-                    recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-                )
-            )
-            # TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
-            if not settings.quiet:
-                print(cached + "[green]" + escape(str(response)))
-            if isinstance(response, LLMResponse):
-                content = response.message or ""
-                tools_content = response.tools_content()
-            else:
-                content = response.content
-                tools_content = ""
-            reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
-            self._call_callback_with_reasoning(
-                "show_llm_response",
-                reasoning=reasoning,
-                content=content,
-                tools_content=tools_content,
-                is_tool=self.has_tool_message_attempt(chat_doc),
-                cached=is_cached,
-            )
-            # Clean up temp ChatDocument to avoid polluting ObjectRegistry
-            if is_temp_doc:
-                ObjectRegistry.remove(chat_doc.id())
-        if isinstance(response, LLMResponse):
-            # we are in the context immediately after an LLM responded,
-            # we won't have citations yet, so we're done
-            return
-        if response.metadata.has_citation:
-            citation = (
-                response.metadata.source_content
-                if self.config.full_citations
-                else response.metadata.source
-            )
-            if not settings.quiet:
-                print("[grey37]SOURCES:\n" + escape(citation) + "[/grey37]")
-            self._call_callback_with_reasoning(
-                "show_llm_response",
-                reasoning="",  # Citations don't have reasoning
-                content=str(citation),
-                tools_content="",
-                is_tool=False,
-                cached=False,
-                language="text",
-            )
-
-    def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument:
-        """
-        Get LLM response to `prompt` (which presumably includes the `message`
-        somewhere, along with possible large "context" passages),
-        but only include `message` as the USER message, and not the
-        full `prompt`, in the message history.
-        Args:
-            message: the original, relatively short, user request or query
-            prompt: the full prompt potentially containing `message` plus context
-
-        Returns:
-            Document object containing the response.
-        """
-        # we explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
-        self.update_last_message(message, role=Role.USER)
-        return answer_doc
-
-    async def _llm_response_temp_context_async(
-        self, message: str, prompt: str
-    ) -> ChatDocument:
-        """
-        Async version of `_llm_response_temp_context`. See there for details.
-        """
-        # we explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            answer_doc = cast(
-                ChatDocument,
-                await ChatAgent.llm_response_async(self, prompt),
-            )
-        self.update_last_message(message, role=Role.USER)
-        return answer_doc
-
-    def llm_response_forget(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> ChatDocument:
-        """
-        LLM Response to single message, and restore message_history.
-        In effect a "one-off" message & response that leaves agent
-        message history state intact.
-
-        Args:
-            message (str|ChatDocument): message to respond to.
-
-        Returns:
-            A Document object with the response.
-
-        """
-        # explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        n_msgs = len(self.message_history)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            response = cast(ChatDocument, ChatAgent.llm_response(self, message))
-        # If there is a response, then we will have two additional
-        # messages in the message history, i.e. the user message and the
-        # assistant response. We want to (carefully) remove these two messages.
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-
-        # If using strict output format, parse the output JSON
-        self._load_output_format(response)
-
-        return response
-
-    async def llm_response_forget_async(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> ChatDocument:
-        """
-        Async version of `llm_response_forget`. See there for details.
-        """
-        # explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        n_msgs = len(self.message_history)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            response = cast(
-                ChatDocument, await ChatAgent.llm_response_async(self, message)
-            )
-        # If there is a response, then we will have two additional
-        # messages in the message history, i.e. the user message and the
-        # assistant response. We want to (carefully) remove these two messages.
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-        return response
-
-    def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int:
-        """
-        Total number of tokens in the message history so far.
-
-        Args:
-            messages: if provided, compute the number of tokens in this list of
-                messages, rather than the current message history.
-        Returns:
-            int: number of tokens in message history
-        """
-        if self.parser is None:
-            raise ValueError(
-                "ChatAgent.parser is None. "
-                "You must set ChatAgent.parser "
-                "before calling chat_num_tokens()."
-            )
-        hist = messages if messages is not None else self.message_history
-        return sum([self._message_num_tokens(m) for m in hist])
-
-    def _message_num_tokens(self, message: LLMMessage) -> int:
-        """Count tokens for a message, including serialized user attachments."""
-        if self.parser is None:
-            raise ValueError(
-                "ChatAgent.parser is None. "
-                "You must set ChatAgent.parser "
-                "before calling _message_num_tokens()."
-            )
-
-        return self.parser.num_tokens(
-            message.content or ""
-        ) + self._attachment_num_tokens(message)
-
-    def _attachment_num_tokens(self, message: LLMMessage) -> int:
-        """
-        Estimate attachment contribution using the serialized payload
-        that is sent in the API request for user messages.
-        """
-        if self.parser is None or message.role != Role.USER or len(message.files) == 0:
-            return 0
-
-        model = self._chat_model_name_for_attachments()
-        return sum(
-            self.parser.num_tokens(
-                json.dumps(
-                    attachment.to_dict(model),
-                    separators=(",", ":"),
-                    sort_keys=True,
-                )
-            )
-            for attachment in message.files
-        )
-
-    def _chat_model_name_for_attachments(self) -> str:
-        """Return the model name used for attachment serialization."""
-        if self.llm is None:
-            return self.config.llm.chat_model if self.config.llm is not None else ""
-
-        return cast(
-            str,
-            getattr(
-                self.llm,
-                "chat_model_orig",
-                getattr(
-                    getattr(self.llm, "config", None),
-                    "chat_model",
-                    self.config.llm.chat_model if self.config.llm is not None else "",
-                ),
-            ),
-        )
-
-    def message_history_str(self, i: Optional[int] = None) -> str:
-        """
-        Return a string representation of the message history
-        Args:
-            i: if provided, return only the i-th message when i is postive,
-                or last k messages when i = -k.
-        Returns:
-        """
-        if i is None:
-            return "\n".join([str(m) for m in self.message_history])
-        elif i > 0:
-            return str(self.message_history[i])
-        else:
-            return "\n".join([str(m) for m in self.message_history[i:]])
-
-    def __del__(self) -> None:
-        """
-        Cleanup method called when the ChatAgent is garbage collected.
-        Note: We don't close LLM clients here because they may be shared
-        across multiple agents when client caching is enabled.
-        The clients are managed centrally and cleaned up via atexit hooks.
-        """
-        # Previously we closed clients here, but this caused issues when
-        # multiple agents shared the same cached client instance.
-        # Clients are now managed centrally in langroid.language_models.client_cache
-        pass
-</file>
-
 <file path="langroid/language_models/openai_gpt.py">
 import hashlib
 import json
@@ -135275,13 +131671,3783 @@ class OpenAIGPT(LanguageModel):
         return self._process_chat_completion_response(cached, response_dict)
 </file>
 
+<file path="tests/main/test_llm.py">
+import io
+import logging.handlers
+import os
+import random
+import warnings
+from pathlib import Path
+
+import openai
+import pytest
+from pydantic_settings import SettingsConfigDict
+
+import langroid as lr
+import langroid.language_models as lm
+from langroid.cachedb.redis_cachedb import RedisCacheConfig
+from langroid.language_models.base import LLMMessage, Role
+from langroid.language_models.model_info import get_model_info
+from langroid.language_models.openai_gpt import (
+    AccessWarning,
+    OpenAIChatModel,
+    OpenAICompletionModel,
+    OpenAIGPT,
+    OpenAIGPTConfig,
+)
+from langroid.parsing.file_attachment import FileAttachment
+from langroid.parsing.parser import Parser, ParsingConfig
+from langroid.parsing.utils import generate_random_sentences
+from langroid.utils.configuration import Settings, set_global, settings
+
+# allow streaming globally, but can be turned off by individual models
+set_global(Settings(stream=True))
+
+
+@pytest.mark.parametrize(
+    "streaming, country, capital",
+    [(False, "India", "Delhi"), (True, "France", "Paris")],
+)
+@pytest.mark.parametrize("use_cache", [True, False])
+def test_openai_gpt(test_settings: Settings, streaming, country, capital, use_cache):
+    test_settings.cache = False  # cache response but don't retrieve from cache
+    set_global(test_settings)
+
+    cfg = OpenAIGPTConfig(
+        stream=streaming,  # use streaming output if enabled globally
+        type="openai",
+        max_output_tokens=100,
+        min_output_tokens=10,
+        completion_model=OpenAICompletionModel.DAVINCI,
+        cache_config=RedisCacheConfig(fake=True) if use_cache else None,
+    )
+
+    mdl = OpenAIGPT(config=cfg)
+    question = "What is the capital of " + country + "?"
+    # chat mode via `generate`,
+    # i.e. use same call as for completion, but the setting below
+    # actually calls `chat` under the hood
+    cfg.use_chat_for_completion = True
+    # check that "generate" works when "use_chat_for_completion" is True
+    response = mdl.generate(prompt=question, max_tokens=800)
+    assert response.usage is not None and response.usage.total_tokens > 0
+    assert capital in response.message
+    assert not response.cached
+
+    # actual chat mode
+    messages = [
+        LLMMessage(
+            role=Role.SYSTEM,
+            content="You are a serious, helpful assistant. Be very concise, not funny",
+        ),
+        LLMMessage(role=Role.USER, content=question),
+    ]
+    response = mdl.chat(messages=messages, max_tokens=500)
+    assert response.usage is not None and response.usage.total_tokens > 0
+    assert capital in response.message
+    assert not response.cached
+
+    test_settings.cache = True
+    set_global(test_settings)
+    # should be from cache this time, Provided config.cache_config is not None
+    response = mdl.chat(messages=messages, max_tokens=500)
+    assert response.usage is not None
+    if use_cache:
+        response.usage.total_tokens == 0
+    else:
+        response.usage.total_tokens > 0
+
+    assert capital in response.message
+    assert response.cached == use_cache
+
+    # pass intentional bad msg to test error handling
+    messages = [
+        LLMMessage(
+            role=Role.FUNCTION,
+            content="Hello!",
+        ),
+    ]
+
+    with pytest.raises(Exception):
+        _ = mdl.chat(messages=messages, max_tokens=500)
+
+
+@pytest.mark.parametrize(
+    "mode, max_tokens",
+    [("completion", 100), ("chat", 100), ("completion", 1000), ("chat", 1000)],
+)
+def _test_context_length_error(test_settings: Settings, mode: str, max_tokens: int):
+    """
+    Test disabled, see TODO below.
+    Also it takes too long since we are trying to test
+    that it raises the expected error when the context length is exceeded.
+    Args:
+        test_settings: from conftest.py
+        mode: "completion" or "chat"
+        max_tokens: number of tokens to generate
+    """
+    set_global(test_settings)
+    set_global(Settings(cache=False))
+
+    cfg = OpenAIGPTConfig(
+        stream=False,
+        max_output_tokens=max_tokens,
+        completion_model=OpenAICompletionModel.TEXT_DA_VINCI_003,
+        cache_config=RedisCacheConfig(fake=False),
+    )
+    parser = Parser(config=ParsingConfig())
+    llm = OpenAIGPT(config=cfg)
+    context_length = (
+        llm.chat_context_length() if mode == "chat" else llm.completion_context_length()
+    )
+
+    toks_per_sentence = int(parser.num_tokens(generate_random_sentences(1000)) / 1000)
+    max_sentences = int(context_length * 1.5 / toks_per_sentence)
+    big_message = generate_random_sentences(max_sentences + 1)
+    big_message_tokens = parser.num_tokens(big_message)
+    assert big_message_tokens + max_tokens > context_length
+    response = None
+    # TODO need to figure out what error type to expect here
+    with pytest.raises(openai.BadRequestError) as e:
+        if mode == "chat":
+            response = llm.chat(big_message, max_tokens=max_tokens)
+        else:
+            response = llm.generate(prompt=big_message, max_tokens=max_tokens)
+
+    assert response is None
+    assert "context length" in str(e.value).lower()
+
+
+@pytest.mark.parametrize(
+    "mdl",
+    [
+        lm.OpenAIChatModel.GPT4o,
+        lm.GeminiModel.GEMINI_2_PRO,
+        "gemini/" + lm.GeminiModel.GEMINI_2_PRO.value,
+    ],
+)
+@pytest.mark.parametrize("ctx", [16_000, None])
+def test_llm_config_context_length(mdl: str, ctx: int | None):
+    llm_config = lm.OpenAIGPTConfig(
+        chat_model=mdl,
+        chat_context_length=ctx,  # even if wrong, use if explicitly set
+    )
+    mdl = lm.OpenAIGPT(config=llm_config)
+    assert mdl.chat_context_length() == ctx or mdl.info().context_length
+
+
+@pytest.mark.parametrize(
+    ("alias_model", "canonical_model"),
+    [
+        (
+            "gemini/gemini-3-flash-preview",
+            lm.GeminiModel.GEMINI_3_FLASH.value,
+        ),
+        (
+            "google/gemini-3-flash-preview",
+            lm.GeminiModel.GEMINI_3_FLASH.value,
+        ),
+        (
+            "gemini/gemini-2.5-flash-lite-preview-06-17",
+            lm.GeminiModel.GEMINI_2_5_FLASH_LITE.value,
+        ),
+    ],
+)
+def test_get_model_info_normalizes_gemini_aliases(
+    alias_model: str, canonical_model: str
+) -> None:
+    assert get_model_info(alias_model) == get_model_info(canonical_model)
+
+
+@pytest.mark.parametrize(
+    ("alias_model", "canonical_model"),
+    [
+        (
+            "gemini/gemini-3-flash-preview",
+            lm.GeminiModel.GEMINI_3_FLASH.value,
+        ),
+        (
+            "gemini/gemini-2.5-flash-lite-preview-06-17",
+            lm.GeminiModel.GEMINI_2_5_FLASH_LITE.value,
+        ),
+    ],
+)
+def test_openai_gpt_context_length_uses_gemini_alias_info(
+    alias_model: str, canonical_model: str
+) -> None:
+    alias_llm = lm.OpenAIGPT(config=lm.OpenAIGPTConfig(chat_model=alias_model))
+    canonical_llm = lm.OpenAIGPT(config=lm.OpenAIGPTConfig(chat_model=canonical_model))
+
+    assert alias_llm.info() == canonical_llm.info()
+    assert alias_llm.chat_context_length() == canonical_llm.chat_context_length()
+
+
+def test_get_model_info_warns_on_unknown_models() -> None:
+    from langroid.language_models.model_info import WARNED_UNKNOWN_MODELS
+
+    model_name = "gemini/gemini-999-unknown-preview"
+    # Ensure this model hasn't been warned about in a prior test so the
+    # warning actually fires.  The cache key is a tuple of the full model
+    # strings passed to _warn_unknown_model (i.e. with the provider prefix).
+    WARNED_UNKNOWN_MODELS.discard((model_name,))
+
+    handler = logging.handlers.MemoryHandler(capacity=100)
+    logger = logging.getLogger("langroid.language_models.model_info")
+    logger.addHandler(handler)
+    try:
+        # Call twice: every lookup of an unknown model must return the
+        # fallback-default ModelInfo, but the warning must fire only once
+        # (deduped via WARNED_UNKNOWN_MODELS).
+        first_info = get_model_info(model_name)
+        second_info = get_model_info(model_name)
+    finally:
+        logger.removeHandler(handler)
+
+    assert first_info.name == "unknown"
+    assert second_info.name == "unknown"
+    messages = [record.getMessage() for record in handler.buffer]
+    matching = [
+        msg for msg in messages if model_name in msg and "fallback defaults" in msg
+    ]
+    assert len(matching) == 1
+
+
+def test_model_selection(test_settings: Settings):
+    set_global(test_settings)
+
+    defaultOpenAIChatModel = lr.language_models.openai_gpt.default_openai_chat_model
+
+    def get_response(llm):
+        llm.generate(prompt="What is the capital of France?", max_tokens=50)
+
+    def simulate_response(llm):
+        llm.run_on_first_use()
+
+    def check_warning(
+        llm,
+        assert_warn,
+        function=get_response,
+        warning_type=AccessWarning,
+        catch_errors=(ImportError,),
+    ):
+        if assert_warn:
+            with pytest.warns(expected_warning=warning_type):
+                try:
+                    function(llm)
+                except catch_errors:
+                    pass
+        else:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", category=warning_type)
+
+                try:
+                    function(llm)
+                except catch_errors:
+                    pass
+
+    # Default is GPT4o; we should not generate the warning in this case
+    lr.language_models.openai_gpt.default_openai_chat_model = OpenAIChatModel.GPT4_TURBO
+    llm = OpenAIGPT(config=OpenAIGPTConfig(chat_model=OpenAIChatModel.GPT3_5_TURBO))
+    check_warning(llm, False)
+
+    llm = OpenAIGPT(config=OpenAIGPTConfig())
+    check_warning(llm, False)
+
+    # Default is GPT3.5 (simulate GPT 4 inaccessible)
+    lr.language_models.openai_gpt.default_openai_chat_model = (
+        OpenAIChatModel.GPT3_5_TURBO
+    )
+
+    # No warnings generated if we specify the model explicitly
+    llm = OpenAIGPT(config=OpenAIGPTConfig(chat_model=OpenAIChatModel.GPT3_5_TURBO))
+    check_warning(llm, False)
+
+    # No warnings generated if we are using a local model
+    llm = OpenAIGPT(config=OpenAIGPTConfig(api_base="localhost:8000"))
+    check_warning(llm, False, function=simulate_response)
+    llm = OpenAIGPT(config=OpenAIGPTConfig(chat_model="local/localhost:8000"))
+    check_warning(llm, False, function=simulate_response)
+    llm = OpenAIGPT(config=OpenAIGPTConfig(chat_model="litellm/ollama/llama"))
+    check_warning(llm, False, function=simulate_response)
+
+    # We should warn on the first usage of a model with auto-selected GPT-3.5
+    llm = OpenAIGPT(config=OpenAIGPTConfig())
+    check_warning(llm, True)
+
+    # We should not warn on subsequent uses and models with auto-selected GPT-3.5
+    check_warning(llm, False)
+    llm = OpenAIGPT(config=OpenAIGPTConfig())
+    check_warning(llm, False)
+
+    lr.language_models.openai_gpt.default_openai_chat_model = defaultOpenAIChatModel
+
+
+def test_keys():
+    # Do not override the explicit settings below
+    settings.chat_model = ""
+
+    providers = [
+        "vllm",
+        "ollama",
+        "llamacpp",
+        "openai",
+        "groq",
+        "gemini",
+        "glhf",
+        "openrouter",
+        "deepseek",
+        "cerebras",
+    ]
+    key_dict = {p: f"{p.upper()}_API_KEY" for p in providers}
+    key_dict["llamacpp"] = "LLAMA_API_KEY"
+
+    for p, var in key_dict.items():
+        os.environ[var] = p
+
+    for p in providers:
+        config = lm.OpenAIGPTConfig(
+            chat_model=f"{p}/model",
+        )
+
+        llm = lm.OpenAIGPT(config)
+
+        assert llm.api_key == p
+
+        rand_key = str(random.randint(0, 10**9))
+        config = lm.OpenAIGPTConfig(
+            chat_model=f"{p}/model",
+            api_key=rand_key,
+        )
+
+        llm = lm.OpenAIGPT(config)
+        assert llm.api_key == rand_key
+
+
+@pytest.mark.xfail(
+    reason="LangDB may fail due to unknown flakiness!",
+    run=True,
+    strict=False,
+)
+@pytest.mark.parametrize(
+    "model",
+    [
+        "langdb/gpt-4o-mini",
+        "langdb/openai/gpt-4o-mini",
+        "langdb/anthropic/claude-3-haiku-20240307",
+        "langdb/claude-3-haiku-20240307",
+        "langdb/gemini/gemini-2.0-flash-lite",
+        "langdb/gemini-2.0-flash-lite",
+    ],
+)
+def test_llm_langdb(model: str):
+    """Test that LLM access via LangDB works."""
+    # override any chat model passed via --m arg to pytest cmd
+    settings.chat_model = model
+    llm_config_langdb = lm.OpenAIGPTConfig(
+        chat_model=model,
+    )
+    llm = lm.OpenAIGPT(config=llm_config_langdb)
+    result = llm.chat("what is 3+4?")
+    assert "7" in result.message
+    if result.cached:
+        assert result.usage.total_tokens == 0
+    else:
+        assert result.usage.total_tokens > 0
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "openrouter/anthropic/claude-haiku-4.5",
+        "openrouter/google/gemini-2.5-flash-lite",
+    ],
+)
+def test_llm_openrouter(model: str):
+    # override any chat model passed via --m arg to pytest cmd
+    settings.chat_model = model
+    llm_config = lm.OpenAIGPTConfig(
+        chat_model=model,
+    )
+    llm = lm.OpenAIGPT(config=llm_config)
+    result = llm.chat("what is 3+4?")
+    assert "7" in result.message
+    if result.cached:
+        assert result.usage.total_tokens == 0
+    else:
+        assert result.usage.total_tokens > 0
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "portkey/openai/gpt-4o-mini",
+        "portkey/anthropic/claude-3-5-haiku-latest",
+        "portkey/google/gemini-2.0-flash-lite",
+    ],
+)
+def test_llm_portkey(model: str):
+    """Test that LLM access via Portkey works."""
+    # override any chat model passed via --m arg to pytest cmd
+    settings.chat_model = model
+
+    # Skip if PORTKEY_API_KEY is not set
+    if not os.getenv("PORTKEY_API_KEY"):
+        pytest.skip("PORTKEY_API_KEY not set")
+
+    # Extract provider from model string
+    provider = model.split("/")[1] if "/" in model else ""
+    provider_key_var = f"{provider.upper()}_API_KEY"
+
+    # Skip if provider API key is not set
+    if not os.getenv(provider_key_var):
+        pytest.skip(f"{provider_key_var} not set")
+
+    llm_config_portkey = lm.OpenAIGPTConfig(
+        chat_model=model,
+    )
+    llm = lm.OpenAIGPT(config=llm_config_portkey)
+    result = llm.chat("what is 3+4 equal to?")
+    assert "7" in result.message
+    if result.cached:
+        assert result.usage.total_tokens == 0
+    else:
+        assert result.usage.total_tokens > 0
+
+
+def test_portkey_params():
+    """Test that PortkeyParams are correctly configured."""
+    from langroid.language_models.provider_params import PortkeyParams
+
+    # Test with explicit parameters
+    params = PortkeyParams(
+        api_key="test-key",
+        provider="anthropic",
+        virtual_key="vk-123",
+        trace_id="trace-456",
+        metadata={"user": "test"},
+        retry={"max_retries": 3},
+        cache={"enabled": True},
+        cache_force_refresh=True,
+        user="user-123",
+        organization="org-456",
+        custom_headers={"x-custom": "value"},
+    )
+
+    headers = params.get_headers()
+
+    assert headers["x-portkey-api-key"] == "test-key"
+    assert headers["x-portkey-provider"] == "anthropic"
+    assert headers["x-portkey-virtual-key"] == "vk-123"
+    assert headers["x-portkey-trace-id"] == "trace-456"
+    assert headers["x-portkey-metadata"] == '{"user": "test"}'
+    assert headers["x-portkey-retry"] == '{"max_retries": 3}'
+    assert headers["x-portkey-cache"] == '{"enabled": true}'
+    assert headers["x-portkey-cache-force-refresh"] == "true"
+    assert headers["x-portkey-user"] == "user-123"
+    assert headers["x-portkey-organization"] == "org-456"
+    assert headers["x-custom"] == "value"
+
+    # Test model string parsing
+    provider, model = params.parse_model_string("portkey/anthropic/claude-3-sonnet")
+    assert provider == "anthropic"
+    assert model == "claude-3-sonnet"
+
+    # Test fallback parsing
+    provider2, model2 = params.parse_model_string("portkey/some-model")
+    assert provider2 == ""
+    assert model2 == "some-model"
+
+    # Test provider API key retrieval
+    os.environ["TEST_PROVIDER_API_KEY"] = "test-api-key"
+    key = params.get_provider_api_key("test_provider")
+    assert key == "test-api-key"
+    del os.environ["TEST_PROVIDER_API_KEY"]
+
+
+def test_portkey_integration():
+    """Test that Portkey integration is properly configured in OpenAIGPT."""
+    from langroid.language_models.provider_params import PortkeyParams
+
+    # Save the current chat model setting
+    original_chat_model = settings.chat_model
+
+    # Clear any global chat model override
+    settings.chat_model = ""
+
+    try:
+        # Test basic portkey model configuration
+        config = lm.OpenAIGPTConfig(
+            chat_model="portkey/anthropic/claude-3-haiku-20240307",
+            portkey_params=PortkeyParams(
+                api_key="pk-test-key",
+            ),
+        )
+
+        llm = lm.OpenAIGPT(config)
+
+        # Check that model was parsed correctly
+        assert llm.config.chat_model == "claude-3-haiku-20240307"
+        assert llm.is_portkey
+        assert llm.api_base == "https://api.portkey.ai/v1"
+        assert llm.config.portkey_params.provider == "anthropic"
+
+        # Check headers are set correctly
+        assert "x-portkey-api-key" in llm.config.headers
+        assert llm.config.headers["x-portkey-api-key"] == "pk-test-key"
+        assert llm.config.headers["x-portkey-provider"] == "anthropic"
+
+    finally:
+        # Restore original chat model setting
+        settings.chat_model = original_chat_model
+
+
+def test_gemini_api_base():
+    """Test that Gemini api_base is configurable for Vertex AI support."""
+    from langroid.language_models.openai_gpt import GEMINI_BASE_URL
+
+    original_chat_model = settings.chat_model
+    settings.chat_model = ""
+
+    # Save and clear env vars that could interfere
+    saved_openai_api_base = os.environ.pop("OPENAI_API_BASE", None)
+    saved_gemini_api_base = os.environ.pop("GEMINI_API_BASE", None)
+
+    try:
+        # Default: api_base should be GEMINI_BASE_URL
+        config = lm.OpenAIGPTConfig(
+            chat_model="gemini/gemini-2.0-flash",
+        )
+        llm = lm.OpenAIGPT(config)
+        assert llm.is_gemini
+        assert llm.config.chat_model == "gemini-2.0-flash"
+        assert llm.api_base == GEMINI_BASE_URL
+
+        # Custom api_base: should override default (e.g. Vertex AI endpoint)
+        vertex_url = "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project/locations/us-central1/endpoints/openapi"
+        config = lm.OpenAIGPTConfig(
+            chat_model="gemini/gemini-2.0-flash",
+            api_base=vertex_url,
+        )
+        llm = lm.OpenAIGPT(config)
+        assert llm.is_gemini
+        assert llm.api_base == vertex_url
+
+        # Empty string api_base: should fall back to default
+        config = lm.OpenAIGPTConfig(
+            chat_model="gemini/gemini-2.0-flash",
+            api_base="",
+        )
+        llm = lm.OpenAIGPT(config)
+        assert llm.is_gemini
+        assert llm.api_base == GEMINI_BASE_URL
+
+        # None api_base: should fall back to default
+        config = lm.OpenAIGPTConfig(
+            chat_model="gemini/gemini-2.0-flash",
+            api_base=None,
+        )
+        llm = lm.OpenAIGPT(config)
+        assert llm.is_gemini
+        assert llm.api_base == GEMINI_BASE_URL
+
+        # OPENAI_API_BASE env var should NOT leak into Gemini api_base
+        os.environ["OPENAI_API_BASE"] = "http://localhost:8000/v1"
+        config = lm.OpenAIGPTConfig(
+            chat_model="gemini/gemini-2.0-flash",
+        )
+        llm = lm.OpenAIGPT(config)
+        assert llm.is_gemini
+        assert llm.api_base == GEMINI_BASE_URL
+        os.environ.pop("OPENAI_API_BASE")
+
+        # GEMINI_API_BASE env var should be used (e.g. Vertex AI)
+        os.environ["GEMINI_API_BASE"] = vertex_url
+        config = lm.OpenAIGPTConfig(
+            chat_model="gemini/gemini-2.0-flash",
+        )
+        llm = lm.OpenAIGPT(config)
+        assert llm.is_gemini
+        assert llm.api_base == vertex_url
+        os.environ.pop("GEMINI_API_BASE")
+
+        # GEMINI_API_BASE should take priority over OPENAI_API_BASE
+        os.environ["OPENAI_API_BASE"] = "http://localhost:8000/v1"
+        os.environ["GEMINI_API_BASE"] = vertex_url
+        config = lm.OpenAIGPTConfig(
+            chat_model="gemini/gemini-2.0-flash",
+        )
+        llm = lm.OpenAIGPT(config)
+        assert llm.is_gemini
+        assert llm.api_base == vertex_url
+        os.environ.pop("OPENAI_API_BASE")
+        os.environ.pop("GEMINI_API_BASE")
+    finally:
+        settings.chat_model = original_chat_model
+        # Restore original env vars
+        if saved_openai_api_base is not None:
+            os.environ["OPENAI_API_BASE"] = saved_openai_api_base
+        if saved_gemini_api_base is not None:
+            os.environ["GEMINI_API_BASE"] = saved_gemini_api_base
+
+
+def test_gemini_google_prefix(monkeypatch):
+    """`google/`-prefixed Gemini models route to the Gemini API (issue #995)."""
+    from langroid.language_models.openai_gpt import GEMINI_BASE_URL
+
+    monkeypatch.setattr(settings, "chat_model", "")
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.delenv("GEMINI_API_BASE", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
+
+    for chat_model in ("gemini/gemini-2.0-flash", "google/gemini-2.0-flash"):
+        llm = lm.OpenAIGPT(lm.OpenAIGPTConfig(chat_model=chat_model))
+        assert llm.is_gemini
+        assert llm.config.chat_model == "gemini-2.0-flash"
+        assert llm.api_base == GEMINI_BASE_URL
+        assert llm.api_key == "gemini-key"
+
+
+def test_gemini_ignores_last_case_variant_openai_api_base(monkeypatch):
+    """Gemini routing follows pydantic's last-wins env case normalization."""
+    from langroid.language_models.openai_gpt import GEMINI_BASE_URL
+
+    monkeypatch.setattr(settings, "chat_model", "")
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.delenv("openai_api_base", raising=False)
+    monkeypatch.delenv("GEMINI_API_BASE", raising=False)
+    monkeypatch.setenv("OPENAI_API_BASE", "https://first.example/v1")
+    monkeypatch.setenv("openai_api_base", "https://last.example/v1")
+
+    llm = lm.OpenAIGPT(lm.OpenAIGPTConfig(chat_model="google/gemini-2.0-flash"))
+
+    assert llm.is_gemini
+    assert llm.api_base == GEMINI_BASE_URL
+
+
+@pytest.mark.parametrize(
+    "chat_model",
+    ("google/gemma-3-27b-it", "google/text-bison-001"),
+)
+def test_non_gemini_google_model_is_not_rerouted(monkeypatch, chat_model):
+    """Non-Gemini Google models retain caller routing and credentials."""
+    monkeypatch.setattr(settings, "chat_model", "")
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.delenv("GEMINI_API_BASE", raising=False)
+    monkeypatch.setenv("GEMINI_API_KEY", "ambient-gemini-key")
+    caller_api_key = "caller-api-key"
+
+    llm = lm.OpenAIGPT(
+        lm.OpenAIGPTConfig(chat_model=chat_model, api_key=caller_api_key)
+    )
+
+    assert not llm.is_gemini
+    assert llm.config.chat_model == chat_model
+    assert llm.api_base is None
+    assert llm.api_key == caller_api_key
+
+
+@pytest.mark.parametrize(
+    "chat_model",
+    ("gemini/gemini-2.0-flash", "google/gemini-2.0-flash"),
+)
+@pytest.mark.parametrize(
+    "openai_api_base, explicit_api_base",
+    (
+        ("https://openai-env.example/v1", "https://caller.example/v1"),
+        ("https://shared.example/v1", "https://shared.example/v1"),
+    ),
+)
+def test_gemini_alias_preserves_explicit_api_base(
+    monkeypatch, chat_model, openai_api_base, explicit_api_base
+):
+    """Gemini aliases retain an explicitly configured API base."""
+    monkeypatch.setattr(settings, "chat_model", "")
+    monkeypatch.setenv("OPENAI_API_BASE", openai_api_base)
+    monkeypatch.setenv("GEMINI_API_BASE", "https://gemini-env.example/v1")
+
+    llm = lm.OpenAIGPT(
+        lm.OpenAIGPTConfig(
+            chat_model=chat_model,
+            api_base=explicit_api_base,
+        )
+    )
+
+    assert llm.is_gemini
+    assert llm.api_base == explicit_api_base
+    expected_model = (
+        chat_model if chat_model.startswith("google/") else "gemini-2.0-flash"
+    )
+    assert llm.config.chat_model == expected_model
+
+
+@pytest.mark.parametrize(
+    "chat_model",
+    ("gemini/gemini-2.0-flash", "google/gemini-2.0-flash"),
+)
+def test_gemini_model_copy_preserves_explicit_api_base(monkeypatch, chat_model):
+    """Gemini configs copied with an API base retain the caller endpoint."""
+    monkeypatch.setattr(settings, "chat_model", "")
+    monkeypatch.setenv("GEMINI_API_BASE", "https://gemini-env.example/v1")
+    custom_base = "https://caller.example/v1"
+    config = lm.OpenAIGPTConfig(chat_model=chat_model).model_copy(
+        update={"api_base": custom_base}
+    )
+
+    llm = lm.OpenAIGPT(config)
+
+    assert llm.is_gemini
+    assert llm.api_base == custom_base
+
+
+@pytest.mark.parametrize(
+    "chat_model",
+    ("gemini/gemini-2.0-flash", "google/gemini-2.0-flash"),
+)
+def test_gemini_assignment_preserves_explicit_api_base(monkeypatch, chat_model):
+    """Gemini configs assigned an API base retain the caller endpoint."""
+    monkeypatch.setattr(settings, "chat_model", "")
+    monkeypatch.setenv("GEMINI_API_BASE", "https://gemini-env.example/v1")
+    custom_base = "https://caller.example/v1"
+    config = lm.OpenAIGPTConfig(chat_model=chat_model)
+    config.api_base = custom_base
+
+    llm = lm.OpenAIGPT(config)
+
+    assert llm.is_gemini
+    assert llm.api_base == custom_base
+
+
+def test_gemini_dynamic_config_preserves_api_base(monkeypatch):
+    """Dynamically prefixed Gemini settings retain their API base."""
+    monkeypatch.setattr(settings, "chat_model", "")
+    monkeypatch.setenv("VERTEX_API_BASE", "https://vertex.example/v1")
+    monkeypatch.setenv("GEMINI_API_BASE", "https://gemini-env.example/v1")
+    vertex_config = lm.OpenAIGPTConfig.create("vertex")
+
+    llm = lm.OpenAIGPT(vertex_config(chat_model="google/gemini-2.0-flash"))
+
+    assert llm.is_gemini
+    assert llm.api_base == "https://vertex.example/v1"
+    assert llm.config.chat_model == "google/gemini-2.0-flash"
+
+
+def test_followup_standalone():
+    """Test that followup_to_standalone works."""
+
+    llm = OpenAIGPT(OpenAIGPTConfig())
+    dialog = [
+        ("Is 5 a prime number?", "yes"),
+        ("Is 10 a prime number?", "no"),
+    ]
+    followup = "What about 11?"
+    response = llm.followup_to_standalone(dialog, followup)
+    assert response is not None
+    assert "prime" in response.lower() and "11" in response
+
+
+def test_llm_pdf_attachment():
+    """Test sending a PDF file attachment to the LLM."""
+
+    # Path to the test PDF file
+    pdf_path = Path("tests/main/data/dummy.pdf")
+
+    # Create a FileAttachment from the PDF file
+    attachment = FileAttachment.from_path(pdf_path)
+
+    # Verify the attachment properties
+    assert attachment.mime_type == "application/pdf"
+    assert attachment.filename == "dummy.pdf"
+
+    # Create messages with the attachment
+    messages = [
+        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
+        LLMMessage(
+            role=Role.USER, content="What's title of the paper?", files=[attachment]
+        ),
+    ]
+
+    # Set up the LLM with a suitable model that supports PDFs
+    llm = OpenAIGPT(OpenAIGPTConfig(max_output_tokens=1000))
+
+    # Get response from the LLM
+    response = llm.chat(messages=messages)
+
+    assert response is not None
+    assert response.message is not None
+    assert "Supply Chain" in response.message
+
+    # follow-up question
+    messages += [
+        LLMMessage(role=Role.ASSISTANT, content="Supply Chain"),
+        LLMMessage(role=Role.USER, content="Who is the first author?"),
+    ]
+    response = llm.chat(messages=messages)
+    assert response is not None
+    assert response.message is not None
+    assert "Takio" in response.message
+
+
+@pytest.mark.xfail(
+    reason="Multi-file attachments may not work yet",
+    run=True,
+    strict=False,
+)
+def test_llm_multi_pdf_attachments():
+
+    # Path to the test PDF file
+    pdf_path = Path("tests/main/data/dummy.pdf")
+
+    # Create a FileAttachment from the PDF file
+    attachment = FileAttachment.from_path(pdf_path)
+
+    # multiple attachments
+    pdf_path2 = Path("tests/main/data/sample-test.pdf")
+
+    # Create a FileAttachment from the PDF file
+    attachment2 = FileAttachment.from_path(pdf_path2)
+
+    messages = [
+        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
+        LLMMessage(
+            role=Role.USER,
+            content="How many pages are in the Supply Chain paper?",
+            files=[attachment2, attachment],
+        ),
+    ]
+    # Set up the LLM with a suitable model that supports PDFs
+    llm = OpenAIGPT(OpenAIGPTConfig(max_output_tokens=1000))
+
+    response = llm.chat(messages=messages)
+    print(response.message)
+    assert any(x in response.message for x in ["4", "four"])
+
+    # follow-up question
+    messages += [
+        LLMMessage(role=Role.ASSISTANT, content="4 pages"),
+        LLMMessage(
+            role=Role.USER,
+            content="""
+            How many columns are in the table in the 
+            document that is NOT about Supply Chain?
+            """,
+        ),
+    ]
+    response = llm.chat(messages=messages)
+    assert any(x in response.message for x in ["3", "three"])
+
+
+def test_llm_pdf_bytes_and_split():
+    """Test sending PDF files to LLM as bytes and split into pages."""
+
+    # Path to the test PDF file
+    pdf_path = Path("tests/main/data/dummy.pdf")
+
+    # Test creating attachment from bytes
+    with open(pdf_path, "rb") as f:
+        pdf_bytes = f.read()
+
+    attachment_from_bytes = FileAttachment.from_bytes(
+        content=pdf_bytes,
+        filename="supply_chain_paper.pdf",
+    )
+
+    messages = [
+        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
+        LLMMessage(
+            role=Role.USER,
+            content="Who is the first author of this paper?",
+            files=[attachment_from_bytes],
+        ),
+    ]
+
+    llm = OpenAIGPT(OpenAIGPTConfig(max_output_tokens=100))
+    response = llm.chat(messages=messages)
+
+    assert response is not None
+    assert "Takio" in response.message
+
+    # Test creating attachment from file-like object
+    pdf_io = io.BytesIO(pdf_bytes)
+    attachment_from_io = FileAttachment.from_io(
+        file_obj=pdf_io,
+        filename="paper_from_io.pdf",
+    )
+
+    messages = [
+        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
+        LLMMessage(
+            role=Role.USER,
+            content="What is the title of this paper?",
+            files=[attachment_from_io],
+        ),
+    ]
+
+    response = llm.chat(messages=messages)
+    assert "Supply Chain" in response.message
+
+    # Test splitting PDF into pages and sending individual pages
+    import fitz
+
+    doc = fitz.open(pdf_path)
+    page_attachments = []
+
+    for i, page in enumerate(doc):
+        # Extract page as PDF
+        page_pdf = io.BytesIO()
+        page_doc = fitz.open()
+        page_doc.insert_pdf(doc, from_page=i, to_page=i)
+        page_doc.save(page_pdf)
+        page_pdf.seek(0)
+
+        # Create attachment for this page
+        page_attachment = FileAttachment.from_io(
+            file_obj=page_pdf,
+            filename=f"page_{i+1}.pdf",
+        )
+        page_attachments.append(page_attachment)
+
+    # Send just the first page
+    messages = [
+        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
+        LLMMessage(
+            role=Role.USER,
+            content="Based on just this page, what is this document about?",
+            files=[page_attachments[0]],
+        ),
+    ]
+
+    response = llm.chat(messages=messages)
+    assert "supply chain" in response.message.lower()
+
+    # Test with multiple pages as separate attachments
+    messages = [
+        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
+        LLMMessage(
+            role=Role.USER,
+            content="I'm sending you pages from a paper. "
+            "How many figures are shown across all pages?",
+            files=page_attachments,
+        ),
+    ]
+
+    response = llm.chat(messages=messages)
+    assert response is not None
+    assert any(
+        x in response.message.lower() for x in ["figure", "diagram", "illustration"]
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "tests/main/data/color-shape-series.jpg",
+        "tests/main/data/color-shape-series.png",
+        "tests/main/data/color-shape-series.pdf",
+        "https://upload.wikimedia.org/wikipedia/commons/1/18/Seriation_task_w_shapes.jpg",
+    ],
+)
+def test_llm_image_input(path: str):
+    attachment = FileAttachment.from_path(path, detail="low")
+
+    messages = [
+        LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
+        LLMMessage(
+            role=Role.USER,
+            content="How many squares are here?",
+            files=[attachment],
+        ),
+    ]
+    # Set up the LLM with a suitable model that supports PDFs
+    llm = OpenAIGPT(OpenAIGPTConfig(max_output_tokens=500))
+
+    response = llm.chat(messages=messages)
+    print(response.message)
+    assert any(x in response.message for x in ["three", "3"])
+
+
+def test_litellm_model_key():
+    """
+    Test that passing in explicit api_key works with `litellm/*` models
+    """
+    model = "litellm/anthropic/claude-3-5-haiku-latest"
+    # disable any chat model passed via --m arg to pytest cmd
+    settings.chat_model = model
+
+    class CustomOpenAIGPTConfig(lm.OpenAIGPTConfig):
+        """OpenAI config that doesn't auto-load from environment variables."""
+
+        # Disable environment prefix to prevent auto-loading
+        model_config = SettingsConfigDict(env_prefix="")
+
+    llm_config = CustomOpenAIGPTConfig(
+        chat_model=model,
+        api_key=os.getenv("ANTHROPIC_API_KEY", ""),
+    )
+    llm = lm.OpenAIGPT(config=llm_config)
+    print(f"\nTesting with model: {llm.chat_model_orig} => {llm.config.chat_model}")
+    response = llm.chat("What is 3+4?")
+    assert "7" in response.message
+</file>
+
 <file path=".pre-commit-config.yaml">
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.16.0
+  rev: v0.16.4
   hooks:
     - id: ruff
+</file>
+
+<file path="langroid/agent/chat_agent.py">
+import base64
+import copy
+import inspect
+import json
+import logging
+import math
+import textwrap
+from contextlib import ExitStack
+from inspect import isclass
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Self,
+    Set,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+import openai
+from pydantic import BaseModel, ValidationError
+from pydantic.fields import ModelPrivateAttr
+from rich import print
+from rich.console import Console
+from rich.markup import escape
+
+from langroid.agent.base import (
+    Agent,
+    AgentConfig,
+    SearchForTools,
+    async_noop_fn,
+    noop_fn,
+)
+from langroid.agent.chat_document import ChatDocument
+from langroid.agent.tool_message import (
+    ToolMessage,
+    format_schema_for_strict,
+)
+from langroid.agent.xml_tool_message import XMLToolMessage
+from langroid.language_models.base import (
+    LLMFunctionCall,
+    LLMFunctionSpec,
+    LLMMessage,
+    LLMResponse,
+    OpenAIJsonSchemaSpec,
+    OpenAIToolSpec,
+    Role,
+    StreamingIfAllowed,
+    ToolChoiceTypes,
+)
+from langroid.language_models.openai_gpt import OpenAIGPT
+from langroid.mytypes import Entity, NonToolAction
+from langroid.parsing.file_attachment import FileAttachment
+from langroid.utils.configuration import settings
+from langroid.utils.object_registry import ObjectRegistry
+from langroid.utils.output import status
+from langroid.utils.pydantic_utils import PydanticWrapper, get_pydantic_wrapper
+from langroid.utils.types import is_callable
+
+console = Console()
+
+logger = logging.getLogger(__name__)
+
+# Stable origin sentinel for the dynamically generated strict-recovery AnyTool
+# class ("tool_or_function"): a fresh class is built per call (its tool-union
+# type varies), so re-registration must be recognized as the same logical tool.
+_ANY_TOOL_MESSAGE_ORIGIN: Any = object()
+
+# Safety margin (in tokens) subtracted from the model context length when
+# shrinking chat history and/or the requested output length to fit, in case
+# our token-count estimates are off.
+CHAT_HISTORY_BUFFER = 300
+
+
+def _reject_json_constant(constant: str) -> None:
+    """Reject JavaScript numeric constants that are not valid JSON."""
+    raise ValueError(f"non-JSON numeric constant: {constant}")
+
+
+def _parse_json_float(value: str) -> float:
+    """Parse a JSON float while rejecting exponent overflow."""
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"non-finite JSON number: {value}")
+    return parsed
+
+
+def _is_identified_result(message: LLMMessage) -> bool:
+    """Whether a TOOL/FUNCTION result has its identifier and no call payload.
+
+    Such results must survive even with empty content so their calls can be
+    marked complete (issue #1063).
+    """
+    has_identifier = (
+        message.role == Role.TOOL and bool((message.tool_call_id or "").strip())
+    ) or (message.role == Role.FUNCTION and bool((message.name or "").strip()))
+    return has_identifier and message.function_call is None and not message.tool_calls
+
+
+def _llm_message_has_payload(message: LLMMessage) -> bool:
+    """Whether a message has the fields required for a valid history entry."""
+    return (
+        (message.content or "").strip() != ""
+        or message.function_call is not None
+        or bool(message.tool_calls)
+        or _is_identified_result(message)
+    )
+
+
+class ChatAgentConfig(AgentConfig):
+    """
+    Configuration for ChatAgent
+
+    Attributes:
+        system_message: system message to include in message sequence
+             (typically defines role and task of agent).
+             Used only if `task` is not specified in the constructor.
+        user_message: user message to include in message sequence.
+             Used only if `task` is not specified in the constructor.
+        use_tools: whether to use our own ToolMessages mechanism
+        handle_llm_no_tool (Any): desired agent_response when
+            LLM generates non-tool msg.
+        use_functions_api: whether to use functions/tools native to the LLM API
+                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
+        use_tools_api: When `use_functions_api` is True, if this is also True,
+            the OpenAI tool-call API is used, rather than the older/deprecated
+            function-call API. However the tool-call API has some tricky aspects,
+            hence we set this to False by default.
+        strict_recovery: whether to enable strict schema recovery when there
+            is a tool-generation error.
+        enable_orchestration_tool_handling: whether to enable handling of orchestration
+            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
+        output_format: When supported by the LLM (certain OpenAI LLMs
+            and local LLMs served by providers such as vLLM), ensures
+            that the output is a JSON matching the corresponding
+            schema via grammar-based decoding
+        handle_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for handling".
+        use_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for use" (by LLM) and
+            instructions on using T are added to the system message.
+        instructions_output_format: Controls whether we generate instructions for
+            `output_format` in the system message.
+        use_tools_on_output_format: Controls whether to automatically switch
+            to the Langroid-native tools mechanism when `output_format` is set.
+            Note that LLMs may generate tool calls which do not belong to
+            `output_format` even when strict JSON mode is enabled, so this should be
+            enabled when such tool calls are not desired.
+        output_format_include_defaults: Whether to include fields with default arguments
+            in the output schema
+        full_citations: Whether to show source reference citation + content for each
+            citation, or just the main reference citation.
+        search_for_tools_everywhere: Whether to search for tools everywhere,
+            or only in specific LLM response elements based on use_tools /
+            use_functions_api / use_tools_api config settings.
+        recognize_recipient_in_content: Whether to parse LLM response text content
+            for recipient routing patterns, specifically:
+            - ``TO[<recipient>]:<content>`` addressing format, and
+            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
+            When False, only structured routing via function_call/tool_call
+            ``recipient`` fields is recognized. Default is True.
+            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
+            which controls Task-level signals like DONE, PASS, and SEND_TO.
+            To fully disable all text-based routing, set both to False.
+        context_overflow_strategy: Strategy for handling context overflow when
+            message history exceeds model context length. Options:
+            - "truncate": Truncate content of early messages (preserves all messages
+              but with shortened content). This maintains the message sequence.
+            - "drop_turns": Drop complete conversation turns (USER + all responses
+              until next USER). More aggressive but cleaner for voice agents.
+            Default is "truncate" for backward compatibility.
+    """
+
+    system_message: str = "You are a helpful assistant."
+    user_message: Optional[str] = None
+    handle_llm_no_tool: Any = None
+    use_tools: bool = True
+    use_functions_api: bool = False
+    use_tools_api: bool = True
+    strict_recovery: bool = True
+    enable_orchestration_tool_handling: bool = True
+    output_format: Optional[type] = None
+    handle_output_format: bool = True
+    use_output_format: bool = True
+    instructions_output_format: bool = True
+    output_format_include_defaults: bool = True
+    use_tools_on_output_format: bool = True
+    full_citations: bool = True  # show source + content for each citation?
+    search_for_tools_everywhere: bool = True
+    recognize_recipient_in_content: bool = True
+    context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
+
+    def _set_fn_or_tools(self) -> None:
+        """
+        Enable Langroid Tool or OpenAI-like fn-calling,
+        depending on config settings.
+        """
+        if not self.use_functions_api or not self.use_tools:
+            return
+        if self.use_functions_api and self.use_tools:
+            logger.debug(
+                """
+                You have enabled both `use_tools` and `use_functions_api`.
+                Setting `use_functions_api` to False.
+                """
+            )
+            self.use_tools = True
+            self.use_functions_api = False
+
+
+class ChatAgent(Agent):
+    """
+    Chat Agent interacting with external env
+    (could be human, or external tools).
+    The agent (the LLM actually) is provided with an optional "Task Spec",
+    which is a sequence of `LLMMessage`s. These are used to initialize
+    the `task_messages` of the agent.
+    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
+    The `Agent` class mainly exists to hold various common methods and attributes.
+    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
+    `llm_response` method uses "chat mode" API (i.e. one that takes a
+    message sequence rather than a single message),
+    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
+    that takes a single message).
+    """
+
+    def __init__(
+        self,
+        config: ChatAgentConfig = ChatAgentConfig(),
+        task: Optional[List[LLMMessage]] = None,
+    ):
+        """
+        Chat-mode agent initialized with task spec as the initial message sequence
+        Args:
+            config: settings for the agent
+
+        """
+        super().__init__(config)
+        self.config: ChatAgentConfig = config
+        self.config._set_fn_or_tools()
+        self.message_history: List[LLMMessage] = []
+        # emit the attachment-token-estimate warning at most once per agent
+        self._attachment_tokens_warned: bool = False
+        self.init_state()
+        # An agent's "task" is defined by a system msg and an optional user msg;
+        # These are "priming" messages that kick off the agent's conversation.
+        self.system_message: str = self.config.system_message
+        self.user_message: str | None = self.config.user_message
+
+        if task is not None:
+            # if task contains a system msg, we override the config system msg
+            if len(task) > 0 and task[0].role == Role.SYSTEM:
+                self.system_message = task[0].content or ""
+            # if task contains a user msg, we override the config user msg
+            if len(task) > 1 and task[1].role == Role.USER:
+                self.user_message = task[1].content
+
+        # system-level instructions for using tools/functions:
+        # We maintain these as tools/functions are enabled/disabled,
+        # and whenever an LLM response is sought, these are used to
+        # recreate the system message (via `_create_system_and_tools_message`)
+        # each time, so it reflects the current set of enabled tools/functions.
+        # (a) these are general instructions on using certain tools/functions,
+        #   if they are specified in a ToolMessage class as a classmethod `instructions`
+        self.system_tool_instructions: str = ""
+        # (b) these are only for the builtin in Langroid TOOLS mechanism:
+        self.system_tool_format_instructions: str = ""
+
+        self.llm_functions_map: Dict[str, LLMFunctionSpec] = {}
+        self.llm_functions_handled: Set[str] = set()
+        self.llm_functions_usable: Set[str] = set()
+        self.llm_function_force: Optional[Dict[str, str]] = None
+
+        self.output_format: Optional[type[ToolMessage | BaseModel]] = None
+
+        self.saved_requests_and_tool_setings = self._requests_and_tool_settings()
+        # This variable is not None and equals a `ToolMessage` T, if and only if:
+        # (a) T has been set as the output_format of this agent, AND
+        # (b) T has been "enabled for use" ONLY for enforcing this output format, AND
+        # (c) T has NOT been explicitly "enabled for use" by this Agent.
+        self.enabled_use_output_format: Optional[type[ToolMessage]] = None
+        # As above but deals with "enabled for handling" instead of "enabled for use".
+        self.enabled_handling_output_format: Optional[type[ToolMessage]] = None
+        if config.output_format is not None:
+            self.set_output_format(config.output_format)
+        # instructions specifically related to enforcing `output_format`
+        self.output_format_instructions = ""
+
+        # controls whether to disable strict schemas for this agent if
+        # strict mode causes exception
+        self.disable_strict = False
+        # Tracks whether any strict tool is enabled; used to determine whether to set
+        # `self.disable_strict` on an exception
+        self.any_strict = False
+        # Tracks the set of tools on which we force-disable strict decoding
+        self.disable_strict_tools_set: set[str] = set()
+
+        # search for tools according to the agent configuration
+        if not config.search_for_tools_everywhere:
+            if config.use_functions_api:
+                if config.use_tools_api:
+                    self.search_for_tools = {SearchForTools.TOOLS.value}
+                else:
+                    self.search_for_tools = {SearchForTools.FUNCTIONS.value}
+            else:
+                self.search_for_tools = {SearchForTools.CONTENT.value}
+
+        if self.config.enable_orchestration_tool_handling:
+            # Only enable HANDLING by `agent_response`, NOT LLM generation of these.
+            # This is useful where tool-handlers or agent_response generate these
+            # tools, and need to be handled.
+            # We don't want enable orch tool GENERATION by default, since that
+            # might clutter-up the LLM system message unnecessarily.
+            from langroid.agent.tools.orchestration import (
+                AgentDoneTool,
+                AgentSendTool,
+                DonePassTool,
+                DoneTool,
+                ForwardTool,
+                PassTool,
+                ResultTool,
+                SendTool,
+            )
+
+            self.enable_message(ForwardTool, use=False, handle=True)
+            self.enable_message(DoneTool, use=False, handle=True)
+            self.enable_message(AgentDoneTool, use=False, handle=True)
+            self.enable_message(PassTool, use=False, handle=True)
+            self.enable_message(DonePassTool, use=False, handle=True)
+            self.enable_message(SendTool, use=False, handle=True)
+            self.enable_message(AgentSendTool, use=False, handle=True)
+            self.enable_message(ResultTool, use=False, handle=True)
+
+    def init_state(self) -> None:
+        """
+        Initialize the state of the agent. Just conversation state here,
+        but subclasses can override this to initialize other state.
+        """
+        super().init_state()
+        self.clear_history(0)
+        self.clear_dialog()
+
+    @staticmethod
+    def from_id(id: str) -> "ChatAgent":
+        """
+        Get an agent from its ID
+        Args:
+            agent_id (str): ID of the agent
+        Returns:
+            ChatAgent: The agent with the given ID
+        """
+        return cast(ChatAgent, Agent.from_id(id))
+
+    def clone(self, i: int = 0) -> "ChatAgent":
+        """Create i'th clone of this agent, ensuring tool use/handling is cloned.
+        Important: We assume all member variables are in the __init__ method here
+        and in the Agent class.
+        TODO: We are attempting to clone an agent after its state has been
+        changed in possibly many ways. Below is an imperfect solution. Caution advised.
+        Revisit later.
+        """
+        agent_cls = type(self)
+        # Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
+        # instead of deepcopy which loses subclass information
+        config_copy = self.config.model_copy(deep=True)
+        config_copy.name = f"{config_copy.name}-{i}"
+        new_agent = agent_cls(config_copy)
+        new_agent.system_tool_instructions = self.system_tool_instructions
+        new_agent.system_tool_format_instructions = self.system_tool_format_instructions
+        new_agent.llm_tools_map = self.llm_tools_map
+        new_agent.llm_tools_known = self.llm_tools_known
+        new_agent.llm_tools_handled = self.llm_tools_handled
+        new_agent.llm_tools_usable = self.llm_tools_usable
+        new_agent.llm_functions_map = self.llm_functions_map
+        new_agent.llm_functions_handled = self.llm_functions_handled
+        new_agent.llm_functions_usable = self.llm_functions_usable
+        new_agent.llm_function_force = self.llm_function_force
+        # Ensure each clone gets its own vecdb client when supported.
+        new_agent.vecdb = None if self.vecdb is None else self.vecdb.clone()
+        self._clone_extra_state(new_agent)
+        new_agent.id = ObjectRegistry.new_id()
+        if self.config.add_to_registry:
+            ObjectRegistry.register_object(new_agent)
+        return new_agent
+
+    def _clone_extra_state(self, new_agent: "ChatAgent") -> None:
+        """Hook for subclasses to copy additional state into clones."""
+
+    def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool:
+        """Should we enable strict mode for a given tool?"""
+        if isinstance(tool, str):
+            tool_class = self.llm_tools_map[tool]
+        else:
+            tool_class = tool
+        name = tool_class.default_value("request")
+        if name in self.disable_strict_tools_set or self.disable_strict:
+            return False
+        strict: Optional[bool] = tool_class.default_value("strict")
+        if strict is None:
+            strict = self._strict_tools_available()
+
+        return strict
+
+    def _fn_call_available(self) -> bool:
+        """Does this agent's LLM support function calling?"""
+        return self.llm is not None and self.llm.supports_functions_or_tools()
+
+    def _strict_tools_available(self) -> bool:
+        """Does this agent's LLM support strict tools?"""
+        return (
+            not self.disable_strict
+            and self.llm is not None
+            and isinstance(self.llm, OpenAIGPT)
+            and self.llm.config.parallel_tool_calls is False
+            and self.llm.supports_strict_tools
+        )
+
+    def _json_schema_available(self) -> bool:
+        """Does this agent's LLM support strict JSON schema output format?"""
+        return (
+            not self.disable_strict
+            and self.llm is not None
+            and isinstance(self.llm, OpenAIGPT)
+            and self.llm.supports_json_schema
+        )
+
+    def set_system_message(self, msg: str) -> None:
+        self.system_message = msg
+        if len(self.message_history) > 0:
+            # if there is message history, update the system message in it
+            self.message_history[0].content = msg
+
+    def set_user_message(self, msg: str) -> None:
+        self.user_message = msg
+
+    @property
+    def task_messages(self) -> List[LLMMessage]:
+        """
+        The task messages are the initial messages that define the task
+        of the agent. There will be at least a system message plus possibly a user msg.
+        Returns:
+            List[LLMMessage]: the task messages
+        """
+        msgs = [self._create_system_and_tools_message()]
+        if self.user_message:
+            msgs.append(LLMMessage(role=Role.USER, content=self.user_message))
+        return msgs
+
+    def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None:
+        id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
+        if msg.role == Role.TOOL:
+            # dropping tool result, so ADD the corresponding tool-call back
+            # to the list of pending calls!
+            id = msg.tool_call_id
+            if id in self.oai_tool_id2call:
+                self.oai_tool_calls.append(self.oai_tool_id2call[id])
+        elif msg.tool_calls is not None:
+            # dropping a msg with tool-calls, so DROP these from pending list
+            # as well as from id -> call map
+            for tool_call in msg.tool_calls:
+                if tool_call.id in id2idx:
+                    self.oai_tool_calls.pop(id2idx[tool_call.id])
+                if tool_call.id in self.oai_tool_id2call:
+                    del self.oai_tool_id2call[tool_call.id]
+
+    def clear_history(self, start: int = -2, end: int = -1) -> None:
+        """
+        Clear the message history, deleting  messages from index `start`,
+        up to index `end`.
+
+        Args:
+            start (int): index of first message to delete; default = -2
+                    (i.e. delete last 2 messages, typically these
+                    are the last user and assistant messages)
+            end (int): index of last message to delete; Default = -1
+                    (i.e. delete all messages up to the last one)
+        """
+        n = len(self.message_history)
+        if start < 0:
+            start = max(0, n + start)
+        end_ = n if end == -1 else end + 1
+        dropped = self.message_history[start:end_]
+        # consider the dropped msgs in REVERSE order, so we are
+        # carefully updating self.oai_tool_calls
+        for msg in reversed(dropped):
+            self._drop_msg_update_tool_calls(msg)
+            # clear out the chat document from the ObjectRegistry
+            ChatDocument.delete_id(msg.chat_document_id)
+        del self.message_history[start:end_]
+
+    def update_history(self, message: str, response: str) -> None:
+        """
+        Update the message history with the latest user message and LLM response.
+        Args:
+            message (str): user message
+            response: (str): LLM response
+        """
+        self.message_history.extend(
+            [
+                LLMMessage(role=Role.USER, content=message),
+                LLMMessage(role=Role.ASSISTANT, content=response),
+            ]
+        )
+
+    def export_history(self) -> str:
+        """Export message history as a portable, versioned JSON snapshot.
+
+        Returns:
+            A JSON string containing the current message history.
+        """
+        messages: List[Dict[str, Any]] = []
+        for message in self.message_history:
+            json.dumps(
+                message.model_dump(mode="python", exclude={"files"}),
+                allow_nan=False,
+                default=str,
+            )
+            data = message.model_dump(mode="json", exclude={"files"})
+            data["chat_document_id"] = ""
+            data["files"] = [
+                {
+                    "content_base64": base64.b64encode(file.content).decode("ascii"),
+                    "filename": file.filename,
+                    "mime_type": file.mime_type,
+                    "url": file.url,
+                    "detail": file.detail,
+                }
+                for file in message.files
+            ]
+            messages.append(data)
+        return json.dumps({"version": 1, "messages": messages}, allow_nan=False)
+
+    def import_history(
+        self,
+        snapshot: str,
+        max_size_bytes: int = 100 * 1024 * 1024,
+    ) -> None:
+        """Restore message history from :meth:`export_history` output.
+
+        Args:
+            snapshot: Versioned JSON snapshot to restore.
+            max_size_bytes: Maximum total decoded attachment size. Defaults to
+                100 MiB.
+
+        Raises:
+            ValueError: If the snapshot is malformed, has an unknown version,
+                starts with a non-system message, or exceeds ``max_size_bytes``.
+        """
+        try:
+            if max_size_bytes < 0:
+                raise ValueError("max_size_bytes must be non-negative")
+            payload = json.loads(
+                snapshot,
+                parse_constant=_reject_json_constant,
+                parse_float=_parse_json_float,
+            )
+            if (
+                not isinstance(payload, dict)
+                or type(payload.get("version")) is not int
+                or payload["version"] != 1
+            ):
+                raise ValueError("unsupported version")
+            raw_messages = payload.get("messages")
+            if not isinstance(raw_messages, list):
+                raise ValueError("messages must be a list")
+            if not raw_messages:
+                raise ValueError("messages must not be empty")
+
+            messages: List[LLMMessage] = []
+            total_attachment_bytes = 0
+            for raw_message in raw_messages:
+                if not isinstance(raw_message, dict):
+                    raise ValueError("message must be an object")
+                message_data = dict(raw_message)
+                raw_files = message_data.get("files", [])
+                if not isinstance(raw_files, list):
+                    raise ValueError("files must be a list")
+                files = []
+                for raw_file in raw_files:
+                    if not isinstance(raw_file, dict):
+                        raise ValueError("file must be an object")
+                    file_data = dict(raw_file)
+                    encoded_content = file_data.pop("content_base64")
+                    if not isinstance(encoded_content, str):
+                        raise ValueError("content_base64 must be a string")
+                    encoded_bytes = encoded_content.encode("ascii")
+                    padding = len(encoded_bytes) - len(encoded_bytes.rstrip(b"="))
+                    decoded_size = max(
+                        0,
+                        len(encoded_bytes) // 4 * 3 - min(padding, 2),
+                    )
+                    if total_attachment_bytes + decoded_size > max_size_bytes:
+                        raise ValueError(
+                            "decoded attachments exceed "
+                            f"max_size_bytes={max_size_bytes}"
+                        )
+                    content = base64.b64decode(encoded_bytes, validate=True)
+                    total_attachment_bytes += len(content)
+                    if total_attachment_bytes > max_size_bytes:
+                        raise ValueError(
+                            "decoded attachments exceed "
+                            f"max_size_bytes={max_size_bytes}"
+                        )
+                    files.append(FileAttachment(content=content, **file_data))
+                message_data["files"] = files
+                message_data["chat_document_id"] = ""
+                messages.append(LLMMessage.model_validate(message_data))
+            if messages[0].role != Role.SYSTEM:
+                raise ValueError("first message must have role 'system'")
+            seen_call_ids: Set[str] = set()
+            for message in messages:
+                if message.role in (Role.TOOL, Role.FUNCTION) and (
+                    message.function_call is not None or message.tool_calls is not None
+                ):
+                    raise ValueError("result messages must not contain call payloads")
+                if message.function_call is not None and message.role != Role.ASSISTANT:
+                    raise ValueError("function calls must have role 'assistant'")
+                if message.function_call is not None:
+                    if not message.function_call.name.strip():
+                        raise ValueError("function call names must be nonblank")
+                if message.tool_call_id is not None and message.role != Role.TOOL:
+                    raise ValueError("tool_call_id is only valid on tool results")
+                if message.role == Role.FUNCTION:
+                    name = message.name
+                    if name is None or not name or name != name.strip():
+                        raise ValueError(
+                            "function result name must be nonblank and normalized"
+                        )
+                if message.tool_calls is not None:
+                    if message.role != Role.ASSISTANT:
+                        raise ValueError("tool calls must have role 'assistant'")
+                    for call in message.tool_calls:
+                        if call.function is None:
+                            raise ValueError("tool calls must include a function")
+                        if not call.function.name.strip():
+                            raise ValueError("function call names must be nonblank")
+                        call_id = call.id
+                        if call_id is None or not call_id or call_id != call_id.strip():
+                            raise ValueError(
+                                "tool call IDs must be nonblank and normalized"
+                            )
+                        if call_id in seen_call_ids:
+                            raise ValueError("tool call IDs must be unique")
+                        seen_call_ids.add(call_id)
+                    if not message.tool_calls:
+                        message.tool_calls = None
+        except (
+            KeyError,
+            RecursionError,
+            TypeError,
+            UnicodeEncodeError,
+            ValueError,
+        ) as exc:
+            raise ValueError(f"Invalid history snapshot: {exc}") from exc
+
+        all_calls = {
+            call.id: call
+            for message in messages
+            for call in (message.tool_calls or [])
+            if call.id is not None
+        }
+        completed_call_ids = {
+            message.tool_call_id
+            for message in messages
+            if message.role == Role.TOOL and message.tool_call_id is not None
+        }
+        old_chat_document_ids = {
+            message.chat_document_id
+            for message in self.message_history
+            if message.chat_document_id
+        }
+        for chat_document_id in old_chat_document_ids:
+            ChatDocument.delete_id(chat_document_id)
+        self.message_history = messages
+        self.oai_tool_id2call = all_calls
+        self.oai_tool_calls = [
+            call
+            for call_id, call in all_calls.items()
+            if call_id not in completed_call_ids
+        ]
+
+    def tool_format_rules(self) -> str:
+        """
+        Specification of tool formatting rules
+        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
+        based on the currently enabled usable `ToolMessage`s
+
+        Returns:
+            str: formatting rules
+        """
+        # ONLY Usable tools (i.e. LLM-generation allowed),
+        usable_tool_classes: List[Type[ToolMessage]] = [
+            t
+            for t in list(self.llm_tools_map.values())
+            if t.default_value("request") in self.llm_tools_usable
+        ]
+
+        if len(usable_tool_classes) == 0:
+            return ""
+        format_instructions = "\n\n".join(
+            [
+                msg_cls.format_instructions(tool=self.config.use_tools)
+                for msg_cls in usable_tool_classes
+            ]
+        )
+        # if any of the enabled classes has json_group_instructions, then use that,
+        # else fall back to ToolMessage.json_group_instructions
+        for msg_cls in usable_tool_classes:
+            if hasattr(msg_cls, "json_group_instructions") and callable(
+                getattr(msg_cls, "json_group_instructions")
+            ):
+                return msg_cls.group_format_instructions().format(
+                    format_instructions=format_instructions
+                )
+        return ToolMessage.group_format_instructions().format(
+            format_instructions=format_instructions
+        )
+
+    def tool_instructions(self) -> str:
+        """
+        Instructions for tools or function-calls, for enabled and usable Tools.
+        These are inserted into system prompt regardless of whether we are using
+        our own ToolMessage mechanism or the LLM's function-call mechanism.
+
+        Returns:
+            str: concatenation of instructions for all usable tools
+        """
+        enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
+        if len(enabled_classes) == 0:
+            return ""
+        instructions = []
+        for msg_cls in enabled_classes:
+            if msg_cls.default_value("request") in self.llm_tools_usable:
+                class_instructions = ""
+                if hasattr(msg_cls, "instructions") and inspect.ismethod(
+                    msg_cls.instructions
+                ):
+                    class_instructions = msg_cls.instructions()
+                if (
+                    self.config.use_tools
+                    and hasattr(msg_cls, "langroid_tools_instructions")
+                    and inspect.ismethod(msg_cls.langroid_tools_instructions)
+                ):
+                    class_instructions += msg_cls.langroid_tools_instructions()
+                # example will be shown in tool_format_rules() when using TOOLs,
+                # so we don't need to show it here.
+                example = "" if self.config.use_tools else (msg_cls.usage_examples())
+                if example != "":
+                    example = "EXAMPLES:\n" + example
+                guidance = (
+                    ""
+                    if class_instructions == ""
+                    else ("GUIDANCE: " + class_instructions)
+                )
+                if guidance == "" and example == "":
+                    continue
+                instructions.append(
+                    textwrap.dedent(
+                        f"""
+                        TOOL: {msg_cls.default_value("request")}:
+                        {guidance}
+                        {example}
+                        """.lstrip()
+                    )
+                )
+        if len(instructions) == 0:
+            return ""
+        instructions_str = "\n\n".join(instructions)
+        return textwrap.dedent(
+            f"""
+            === GUIDELINES ON SOME TOOLS/FUNCTIONS USAGE ===
+            {instructions_str}
+            """.lstrip()
+        )
+
+    def augment_system_message(self, message: str) -> None:
+        """
+        Augment the system message with the given message.
+        Args:
+            message (str): system message
+        """
+        self.system_message += "\n\n" + message
+
+    def last_message_with_role(self, role: Role) -> LLMMessage | None:
+        """from `message_history`, return the last message with role `role`"""
+        n_role_msgs = len([m for m in self.message_history if m.role == role])
+        if n_role_msgs == 0:
+            return None
+        idx = self.nth_message_idx_with_role(role, n_role_msgs)
+        return self.message_history[idx]
+
+    def last_message_idx_with_role(self, role: Role) -> int:
+        """Index of last message in message_history, with specified role.
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+        indices_with_role = [
+            i for i, m in enumerate(self.message_history) if m.role == role
+        ]
+        if len(indices_with_role) == 0:
+            return -1
+        return indices_with_role[-1]
+
+    def nth_message_idx_with_role(self, role: Role, n: int) -> int:
+        """Index of `n`th message in message_history, with specified role.
+        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+        indices_with_role = [
+            i for i, m in enumerate(self.message_history) if m.role == role
+        ]
+
+        if len(indices_with_role) < n:
+            return -1
+        return indices_with_role[n - 1]
+
+    def update_last_message(self, message: str, role: str = Role.USER) -> None:
+        """
+        Update the last message that has role `role` in the message history.
+        Useful when we want to replace a long user prompt, that may contain context
+        documents plus a question, with just the question.
+        Args:
+            message (str): new message to replace with
+            role (str): role of message to replace
+        """
+        if len(self.message_history) == 0:
+            return
+        # find last message in self.message_history with role `role`
+        for i in range(len(self.message_history) - 1, -1, -1):
+            if self.message_history[i].role == role:
+                self.message_history[i].content = message
+                break
+
+    def delete_last_message(self, role: str = Role.USER) -> None:
+        """
+        Delete the last message that has role `role` from the message history.
+        Args:
+            role (str): role of message to delete
+        """
+        if len(self.message_history) == 0:
+            return
+        # find last message in self.message_history with role `role`
+        for i in range(len(self.message_history) - 1, -1, -1):
+            if self.message_history[i].role == role:
+                self.message_history.pop(i)
+                break
+
+    def _create_system_and_tools_message(self) -> LLMMessage:
+        """
+        (Re-)Create the system message for the LLM of the agent,
+        taking into account any tool instructions that have been added
+        after the agent was initialized.
+
+        The system message will consist of:
+        (a) the system message from the `task` arg in constructor, if any,
+            otherwise the default system message from the config
+        (b) the system tool instructions, if any
+        (c) the system json tool instructions, if any
+
+        Returns:
+            LLMMessage object
+        """
+        content = self.system_message
+        if self.system_tool_instructions != "":
+            content += "\n\n" + self.system_tool_instructions
+        if self.system_tool_format_instructions != "":
+            content += "\n\n" + self.system_tool_format_instructions
+        if self.output_format_instructions != "":
+            content += "\n\n" + self.output_format_instructions
+
+        # remove leading and trailing newlines and other whitespace
+        return LLMMessage(role=Role.SYSTEM, content=content.strip())
+
+    def handle_message_fallback(self, msg: str | ChatDocument) -> Any:
+        """
+        Fallback method for the "no-tools" scenario, i.e., the current `msg`
+        (presumably emitted by the LLM) does not have any tool that the agent
+        can handle.
+        NOTE: The `msg` may contain tools but either (a) the agent is not
+        enabled to handle them, or (b) there's an explicit `recipient` field
+        in the tool that doesn't match the agent's name.
+
+        Uses the self.config.non_tool_routing to determine the action to take.
+
+        This method can be overridden by subclasses, e.g.,
+        to create a "reminder" message when a tool is expected but the LLM "forgot"
+        to generate one.
+
+        Args:
+            msg (str | ChatDocument): The input msg to handle
+        Returns:
+            Any: The result of the handler method
+        """
+        if (
+            isinstance(msg, str)
+            or msg.metadata.sender != Entity.LLM
+            or self.config.handle_llm_no_tool is None
+            or self.has_only_unhandled_tools(msg)
+        ):
+            return None
+        # we ONLY use the `handle_llm_no_tool` config option when
+        # the msg is from LLM and does not contain ANY tools at all.
+        from langroid.agent.tools.orchestration import AgentDoneTool, ForwardTool
+
+        no_tool_option = self.config.handle_llm_no_tool
+        if no_tool_option in list(NonToolAction):
+            # in case the `no_tool_option` is one of the special NonToolAction vals
+            match self.config.handle_llm_no_tool:
+                case NonToolAction.FORWARD_USER:
+                    return ForwardTool(agent="User")
+                case NonToolAction.DONE:
+                    return AgentDoneTool(content=msg.content, tools=msg.tool_messages)
+        elif is_callable(no_tool_option):
+            return no_tool_option(msg)
+        # Otherwise just return `no_tool_option` as is:
+        # This can be any string, such as a specific nudge/reminder to the LLM,
+        # or even something like ResultTool etc.
+        return no_tool_option
+
+    def unhandled_tools(self) -> set[str]:
+        """The set of tools that are known but not handled.
+        Useful in task flow: an agent can refuse to accept an incoming msg
+        when it only has unhandled tools.
+        """
+        return self.llm_tools_known - self.llm_tools_handled
+
+    def enable_message(
+        self,
+        message_class: Optional[Type[ToolMessage] | List[Type[ToolMessage]]],
+        use: bool = True,
+        handle: bool = True,
+        force: bool = False,
+        require_recipient: bool = False,
+        include_defaults: bool = True,
+    ) -> None:
+        """
+        Add the tool (message class) to the agent, and enable either
+        - tool USE (i.e. the LLM can generate JSON to use this tool),
+        - tool HANDLING (i.e. the agent can handle JSON from this tool),
+
+        Args:
+            message_class: The ToolMessage class OR List of such classes to enable,
+                for USE, or HANDLING, or both.
+                If this is a list of ToolMessage classes, then the remain args are
+                applied to all classes.
+                Optional; if None, then apply the enabling to all tools in the
+                agent's toolset that have been enabled so far.
+            use: IF True, allow the agent (LLM) to use this tool (or all tools),
+                else disallow
+            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
+                tool (or all tools)
+            force: whether to FORCE the agent (LLM) to USE the specific
+                 tool represented by `message_class`.
+                 `force` is ignored if `message_class` is None.
+            require_recipient: whether to require that recipient be specified
+                when using the tool message (only applies if `use` is True).
+            include_defaults: whether to include fields that have default values,
+                in the "properties" section of the JSON format instructions.
+                (Normally the OpenAI completion API ignores these fields,
+                but the Assistant fn-calling seems to pay attn to these,
+                and if we don't want this, we should set this to False.)
+        """
+        if message_class is not None and isinstance(message_class, list):
+            for mc in message_class:
+                self.enable_message(
+                    mc,
+                    use=use,
+                    handle=handle,
+                    force=force,
+                    require_recipient=require_recipient,
+                    include_defaults=include_defaults,
+                )
+            return None
+
+        # Validate that use/handle are booleans, not accidentally passed tool classes
+        if isclass(use) or isclass(handle):
+            param = "use" if isclass(use) else "handle"
+            raise TypeError(
+                textwrap.dedent(
+                    f"""
+                    Invalid arguments to enable_message().
+                    It appears you passed multiple ToolMessage classes as separate
+                    arguments instead of as a list.
+
+                    Correct usage:
+                        agent.enable_message([Tool1, Tool2, Tool3])
+
+                    Incorrect usage:
+                        agent.enable_message(Tool1, Tool2, Tool3)
+
+                    The '{param}' parameter must be a boolean, not a class.
+                    """
+                )
+            )
+
+        if require_recipient and message_class is not None:
+            message_class = message_class.require_recipient()
+        if message_class is not None:
+            if not issubclass(message_class, ToolMessage):
+                raise ValueError("message_class must be a subclass of ToolMessage")
+            request = message_class.default_value("request")
+            existing_class = self.llm_tools_map.get(request)
+            existing_origin = (
+                existing_class.__dict__.get("__tool_message_origin__", existing_class)
+                if existing_class is not None
+                else None
+            )
+            message_origin = message_class.__dict__.get(
+                "__tool_message_origin__", message_class
+            )
+            if existing_class is not None and existing_origin is not message_origin:
+                raise ValueError(
+                    f"Tool request name {request!r} is already registered to "
+                    f"{existing_class.__name__}; cannot register "
+                    f"{message_class.__name__}"
+                )
+        if isinstance(message_class, XMLToolMessage):
+            # XMLToolMessage is not compatible with OpenAI's Tools/functions API,
+            # so we disable use of functions API, enable langroid-native Tools,
+            # which are prompt-based.
+            self.config.use_functions_api = False
+            self.config.use_tools = True
+        super().enable_message_handling(message_class)  # enables handling only
+        tools = self._get_tool_list(message_class)
+        if message_class is not None:
+            if request == "":
+                raise ValueError(
+                    f"""
+                    ToolMessage class {message_class} must have a non-empty
+                    'request' field if it is to be enabled as a tool.
+                    """
+                )
+            llm_function = message_class.llm_function_schema(defaults=include_defaults)
+            self.llm_functions_map[request] = llm_function
+            if force:
+                self.llm_function_force = dict(name=request)
+            else:
+                self.llm_function_force = None
+
+        for t in tools:
+            self.llm_tools_known.add(t)
+
+            if handle:
+                self.llm_tools_handled.add(t)
+                self.llm_functions_handled.add(t)
+
+                if (
+                    self.enabled_handling_output_format is not None
+                    and self.enabled_handling_output_format.name() == t
+                ):
+                    # `t` was designated as "enabled for handling" ONLY for
+                    # output_format enforcement, but we are explicitly ]
+                    # enabling it for handling here, so we set the variable to None.
+                    self.enabled_handling_output_format = None
+            else:
+                self.llm_tools_handled.discard(t)
+                self.llm_functions_handled.discard(t)
+
+            if use:
+                tool_class = self.llm_tools_map[t]
+                allow_llm_use = tool_class._allow_llm_use
+                if isinstance(allow_llm_use, ModelPrivateAttr):
+                    allow_llm_use = allow_llm_use.default
+                if allow_llm_use:
+                    self.llm_tools_usable.add(t)
+                    self.llm_functions_usable.add(t)
+                else:
+                    logger.warning(
+                        f"""
+                        ToolMessage class {tool_class} does not allow LLM use,
+                        because `_allow_llm_use=False` either in the Tool or a
+                        parent class of this tool;
+                        so not enabling LLM use for this tool!
+                        If you intended an LLM to use this tool,
+                        set `_allow_llm_use=True` when you define the tool.
+                        """
+                    )
+                if (
+                    self.enabled_use_output_format is not None
+                    and self.enabled_use_output_format.default_value("request") == t
+                ):
+                    # `t` was designated as "enabled for use" ONLY for output_format
+                    # enforcement, but we are explicitly enabling it for use here,
+                    # so we set the variable to None.
+                    self.enabled_use_output_format = None
+            else:
+                self.llm_tools_usable.discard(t)
+                self.llm_functions_usable.discard(t)
+
+        self._update_tool_instructions()
+
+    def _update_tool_instructions(self) -> None:
+        # Set tool instructions and JSON format instructions,
+        # in case Tools have been enabled/disabled.
+        if self.config.use_tools:
+            self.system_tool_format_instructions = self.tool_format_rules()
+        self.system_tool_instructions = self.tool_instructions()
+
+    def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]:
+        """
+        Returns the current set of enabled requests for inference and tools configs.
+        Used for restoring setings overriden by `set_output_format`.
+        """
+        return (
+            self.enabled_requests_for_inference,
+            self.config.use_functions_api,
+            self.config.use_tools,
+        )
+
+    @property
+    def all_llm_tools_known(self) -> set[str]:
+        """All known tools; we include `output_format` if it is a `ToolMessage`."""
+        known = self.llm_tools_known
+
+        if self.output_format is not None and issubclass(
+            self.output_format, ToolMessage
+        ):
+            return known.union({self.output_format.default_value("request")})
+
+        return known
+
+    def set_output_format(
+        self,
+        output_type: Optional[type],
+        force_tools: Optional[bool] = None,
+        use: Optional[bool] = None,
+        handle: Optional[bool] = None,
+        instructions: Optional[bool] = None,
+        is_copy: bool = False,
+    ) -> None:
+        """
+        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
+        switches to the native Langroid tools mechanism to ensure that no tool
+        calls not of `output_type` are generated. By default, `force_tools`
+        follows the `use_tools_on_output_format` parameter in the config.
+
+        If `output_type` is None, restores to the state prior to setting
+        `output_format`.
+
+        If `use`, we enable use of `output_type` when it is a subclass
+        of `ToolMesage`. Note that this primarily controls instruction
+        generation: the model will always generate `output_type` regardless
+        of whether `use` is set. Defaults to the `use_output_format`
+        parameter in the config. Similarly, handling of `output_type` is
+        controlled by `handle`, which defaults to the
+        `handle_output_format` parameter in the config.
+
+        `instructions` controls whether we generate instructions specifying
+        the output format schema. Defaults to the `instructions_output_format`
+        parameter in the config.
+
+        `is_copy` is set when called via `__getitem__`. In that case, we must
+        copy certain fields to ensure that we do not overwrite the main agent's
+        setings.
+        """
+        # Disable usage of an output format which was not specifically enabled
+        # by `enable_message`
+        if self.enabled_use_output_format is not None:
+            self.disable_message_use(self.enabled_use_output_format)
+            self.enabled_use_output_format = None
+
+        # Disable handling of an output format which did not specifically have
+        # handling enabled via `enable_message`
+        if self.enabled_handling_output_format is not None:
+            self.disable_message_handling(self.enabled_handling_output_format)
+            self.enabled_handling_output_format = None
+
+        # Reset any previous instructions
+        self.output_format_instructions = ""
+
+        if output_type is None:
+            self.output_format = None
+            (
+                requests_for_inference,
+                use_functions_api,
+                use_tools,
+            ) = self.saved_requests_and_tool_setings
+            self.config = self.config.model_copy()
+            self.enabled_requests_for_inference = requests_for_inference
+            self.config.use_functions_api = use_functions_api
+            self.config.use_tools = use_tools
+        else:
+            if force_tools is None:
+                force_tools = self.config.use_tools_on_output_format
+
+            if not any(
+                (isclass(output_type) and issubclass(output_type, t))
+                for t in [ToolMessage, BaseModel]
+            ):
+                output_type = get_pydantic_wrapper(output_type)
+
+            if self.output_format is None and force_tools:
+                self.saved_requests_and_tool_setings = (
+                    self._requests_and_tool_settings()
+                )
+
+            self.output_format = output_type
+            if issubclass(output_type, ToolMessage):
+                name = output_type.default_value("request")
+                if use is None:
+                    use = self.config.use_output_format
+
+                if handle is None:
+                    handle = self.config.handle_output_format
+
+                if use or handle:
+                    is_usable = name in self.llm_tools_usable.union(
+                        self.llm_functions_usable
+                    )
+                    is_handled = name in self.llm_tools_handled.union(
+                        self.llm_functions_handled
+                    )
+
+                    if is_copy:
+                        if use:
+                            # We must copy `llm_tools_usable` so the base agent
+                            # is unmodified
+                            self.llm_tools_usable = self.llm_tools_usable.copy()
+                            self.llm_functions_usable = self.llm_functions_usable.copy()
+                        if handle:
+                            # If handling the tool, do the same for `llm_tools_handled`
+                            self.llm_tools_handled = self.llm_tools_handled.copy()
+                            self.llm_functions_handled = (
+                                self.llm_functions_handled.copy()
+                            )
+                    # Enable `output_type`
+                    self.enable_message(
+                        output_type,
+                        # Do not override existing settings
+                        use=use or is_usable,
+                        handle=handle or is_handled,
+                    )
+
+                    # If the `output_type` ToilMessage was not already enabled for
+                    # use, this means we are ONLY enabling it for use specifically
+                    # for enforcing this output format, so we set the
+                    # `enabled_use_output_forma  to this output_type, to
+                    # record that it should be disabled when `output_format` is changed
+                    if not is_usable:
+                        self.enabled_use_output_format = output_type
+
+                    # (same reasoning as for use-enabling)
+                    if not is_handled:
+                        self.enabled_handling_output_format = output_type
+
+                generated_tool_instructions = name in self.llm_tools_usable.union(
+                    self.llm_functions_usable
+                )
+            else:
+                generated_tool_instructions = False
+
+            if instructions is None:
+                instructions = self.config.instructions_output_format
+            if issubclass(output_type, BaseModel) and instructions:
+                if generated_tool_instructions:
+                    # Already generated tool instructions as part of "enabling for use",
+                    # so only need to generate a reminder to use this tool.
+                    name = cast(ToolMessage, output_type).default_value("request")
+                    self.output_format_instructions = textwrap.dedent(
+                        f"""
+                        === OUTPUT FORMAT INSTRUCTIONS ===
+
+                        Please provide output using the `{name}` tool/function.
+                        """
+                    )
+                else:
+                    if issubclass(output_type, ToolMessage):
+                        output_format_schema = output_type.llm_function_schema(
+                            request=True,
+                            defaults=self.config.output_format_include_defaults,
+                        ).parameters
+                    else:
+                        output_format_schema = output_type.model_json_schema()
+
+                    format_schema_for_strict(output_format_schema)
+
+                    self.output_format_instructions = textwrap.dedent(
+                        f"""
+                        === OUTPUT FORMAT INSTRUCTIONS ===
+                        Please provide output as JSON with the following schema:
+
+                        {output_format_schema}
+                        """
+                    )
+
+            if force_tools:
+                if issubclass(output_type, ToolMessage):
+                    self.enabled_requests_for_inference = {
+                        output_type.default_value("request")
+                    }
+                if self.config.use_functions_api:
+                    self.config = self.config.model_copy()
+                    self.config.use_functions_api = False
+                    self.config.use_tools = True
+
+    def __getitem__(self, output_type: type) -> Self:
+        """
+        Returns a (shallow) copy of `self` with a forced output type.
+        """
+        clone = copy.copy(self)
+        clone.set_output_format(output_type, is_copy=True)
+        return clone
+
+    def disable_message_handling(
+        self,
+        message_class: Optional[Type[ToolMessage]] = None,
+    ) -> None:
+        """
+        Disable this agent from RESPONDING to a `message_class` (Tool). If
+            `message_class` is None, then disable this agent from responding to ALL.
+        Args:
+            message_class: The ToolMessage class to disable; Optional.
+        """
+        super().disable_message_handling(message_class)
+        for t in self._get_tool_list(message_class):
+            self.llm_tools_handled.discard(t)
+            self.llm_functions_handled.discard(t)
+
+    def disable_message_use(
+        self,
+        message_class: Optional[Type[ToolMessage]],
+    ) -> None:
+        """
+        Disable this agent from USING a message class (Tool).
+        If `message_class` is None, then disable this agent from USING ALL tools.
+        Args:
+            message_class: The ToolMessage class to disable.
+                If None, disable all.
+        """
+        for t in self._get_tool_list(message_class):
+            self.llm_tools_usable.discard(t)
+            self.llm_functions_usable.discard(t)
+
+        self._update_tool_instructions()
+
+    def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None:
+        """
+        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
+        Args:
+            message_class: The only ToolMessage class to allow
+        """
+        request = message_class.model_fields["request"].default
+        to_remove = [r for r in self.llm_tools_usable if r != request]
+        for r in to_remove:
+            self.llm_tools_usable.discard(r)
+            self.llm_functions_usable.discard(r)
+        self._update_tool_instructions()
+
+    def _load_output_format(self, message: ChatDocument) -> None:
+        """
+        If set, attempts to parse a value of type `self.output_format` from the message
+        contents or any tool/function call and assigns it to `content_any`.
+        """
+        if self.output_format is not None:
+            any_succeeded = False
+            attempts: list[str | LLMFunctionCall] = [
+                message.content,
+            ]
+
+            if message.function_call is not None:
+                attempts.append(message.function_call)
+
+            if message.oai_tool_calls is not None:
+                attempts.extend(
+                    [
+                        c.function
+                        for c in message.oai_tool_calls
+                        if c.function is not None
+                    ]
+                )
+
+            for attempt in attempts:
+                try:
+                    if isinstance(attempt, str):
+                        content = json.loads(attempt)
+                    else:
+                        if not (
+                            issubclass(self.output_format, ToolMessage)
+                            and attempt.name
+                            == self.output_format.default_value("request")
+                        ):
+                            continue
+
+                        content = attempt.arguments
+
+                    content_any = self.output_format.model_validate(content)
+
+                    if issubclass(self.output_format, PydanticWrapper):
+                        message.content_any = content_any.value  # type: ignore
+                    else:
+                        message.content_any = content_any
+                    any_succeeded = True
+                    break
+                except (ValidationError, json.JSONDecodeError):
+                    continue
+
+            if not any_succeeded:
+                self.disable_strict = True
+                logging.warning(
+                    """
+                    Validation error occured with strict output format enabled.
+                    Disabling strict mode.
+                    """
+                )
+
+    def get_tool_messages(
+        self,
+        msg: str | ChatDocument | None,
+        all_tools: bool = False,
+    ) -> List[ToolMessage]:
+        """
+        Extracts messages and tracks whether any errors occurred. If strict mode
+        was enabled, disables it for the tool, else triggers strict recovery.
+        """
+        self.tool_error = False
+        most_recent_sent_by_llm = (
+            len(self.message_history) > 0
+            and self.message_history[-1].role == Role.ASSISTANT
+        )
+        was_llm = most_recent_sent_by_llm or (
+            isinstance(msg, ChatDocument) and msg.metadata.sender == Entity.LLM
+        )
+        try:
+            tools = super().get_tool_messages(msg, all_tools)
+        except ValidationError as ve:
+            # Check if tool class was attached to the exception
+            if hasattr(ve, "tool_class") and ve.tool_class:
+                tool_class = ve.tool_class  # type: ignore
+                if issubclass(tool_class, ToolMessage):
+                    was_strict = (
+                        self.config.use_functions_api
+                        and self.config.use_tools_api
+                        and self._strict_mode_for_tool(tool_class)
+                    )
+                    # If the result of strict output for a tool using the
+                    # OpenAI tools API fails to parse, we infer that the
+                    # schema edits necessary for compatibility prevented
+                    # adherence to the underlying `ToolMessage` schema and
+                    # disable strict output for the tool
+                    if was_strict:
+                        name = tool_class.default_value("request")
+                        self.disable_strict_tools_set.add(name)
+                        logging.warning(
+                            f"""
+                            Validation error occured with strict tool format.
+                            Disabling strict mode for the {name} tool.
+                            """
+                        )
+                    else:
+                        # We will trigger the strict recovery mechanism to force
+                        # the LLM to correct its output, allowing us to parse
+                        if isinstance(msg, ChatDocument):
+                            self.tool_error = msg.metadata.sender == Entity.LLM
+                        else:
+                            self.tool_error = most_recent_sent_by_llm
+
+            if was_llm:
+                raise ve
+            else:
+                self.tool_error = False
+                return []
+
+        if not was_llm:
+            self.tool_error = False
+
+        return tools
+
+    def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None:
+        """
+        Returns a `ToolMessage` which wraps all enabled tools, excluding those
+        where strict recovery is disabled. Used in strict recovery.
+        """
+        possible_tools = tuple(
+            self.llm_tools_map[t]
+            for t in self.llm_tools_usable
+            if t not in self.disable_strict_tools_set
+        )
+        if len(possible_tools) == 0:
+            return None
+        any_tool_type = Union.__getitem__(possible_tools)  # type ignore
+
+        maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
+
+        class AnyTool(ToolMessage):
+            purpose: str = "To call a tool/function."
+            request: str = "tool_or_function"
+            tool: maybe_optional_type  # type: ignore
+
+            def response(self, agent: ChatAgent) -> None | str | ChatDocument:
+                # One-time use
+                agent.set_output_format(None)
+
+                if self.tool is None:
+                    return None
+
+                # As the ToolMessage schema accepts invalid
+                # `tool.request` values, reparse with the
+                # corresponding tool
+                request = self.tool.request
+                if request not in agent.llm_tools_map:
+                    return None
+                tool = agent.llm_tools_map[request].model_validate_json(
+                    self.tool.to_json()
+                )
+
+                return agent.handle_tool_message(tool)
+
+            async def response_async(
+                self, agent: ChatAgent
+            ) -> None | str | ChatDocument:
+                # One-time use
+                agent.set_output_format(None)
+
+                if self.tool is None:
+                    return None
+
+                # As the ToolMessage schema accepts invalid
+                # `tool.request` values, reparse with the
+                # corresponding tool
+                request = self.tool.request
+                if request not in agent.llm_tools_map:
+                    return None
+                tool = agent.llm_tools_map[request].model_validate_json(
+                    self.tool.to_json()
+                )
+
+                return await agent.handle_tool_message_async(tool)
+
+        # Every call builds a distinct class; share one origin so enabling a
+        # regenerated AnyTool under "tool_or_function" stays idempotent instead
+        # of tripping the same-name/different-tool registration guard.
+        AnyTool.__tool_message_origin__ = (  # type: ignore[attr-defined]
+            _ANY_TOOL_MESSAGE_ORIGIN
+        )
+        return AnyTool
+
+    def _strict_recovery_instructions(
+        self,
+        tool_type: Optional[type[ToolMessage]] = None,
+        optional: bool = True,
+    ) -> str:
+        """Returns instructions for strict recovery."""
+        optional_instructions = (
+            (
+                "\n"
+                + """
+        If you did NOT intend to do so, `tool` should be null.
+        """
+            )
+            if optional
+            else ""
+        )
+        response_prefix = "If you intended to make such a call, r" if optional else "R"
+        instruction_prefix = "If you do so, b" if optional else "B"
+
+        schema_instructions = (
+            f"""
+        The schema for `tool_or_function` is as follows:
+        {tool_type.llm_function_schema(defaults=True, request=True).parameters}
+        """
+            if tool_type
+            else ""
+        )
+
+        return textwrap.dedent(
+            f"""
+        Your previous attempt to make a tool/function call appears to have failed.
+        {response_prefix}espond with your desired tool/function. Do so with the
+        `tool_or_function` tool/function where `tool` is set to your intended call.
+        {schema_instructions}
+
+        {instruction_prefix}e sure that your corrected call matches your intention
+        in your previous request. For any field with a default value which
+        you did not intend to override in your previous attempt, be sure
+        to set that field to its default value. {optional_instructions}
+        """
+        )
+
+    def truncate_message(
+        self,
+        idx: int,
+        tokens: int = 5,
+        warning: str = "...[Contents truncated!]",
+        inplace: bool = True,
+    ) -> LLMMessage:
+        """
+        Truncate message at idx in msg history to `tokens` tokens.
+
+        If inplace is True, the message is truncated in place, else
+        it LEAVES the original message INTACT and returns a new message
+        """
+        if inplace:
+            llm_msg = self.message_history[idx]
+        else:
+            llm_msg = copy.deepcopy(self.message_history[idx])
+        if llm_msg.content is None or (
+            llm_msg.content == "" and _is_identified_result(llm_msg)
+        ):
+            return llm_msg
+        orig_content = llm_msg.content
+        new_content = (
+            self.parser.truncate_tokens(orig_content, tokens)
+            if self.parser is not None
+            else orig_content[: tokens * 4]  # approx truncation
+        )
+        llm_msg.content = new_content + "\n" + warning
+        return llm_msg
+
+    def _reduce_raw_tool_results(self, message: ChatDocument) -> None:
+        """
+        If message is the result of a ToolMessage that had
+        a `_max_retained_tokens` set to a non-None value, then we replace contents
+        with a placeholder message.
+        """
+        parent_message: ChatDocument | None = message.parent
+        tools = [] if parent_message is None else parent_message.tool_messages
+        truncate_tools = []
+        for t in tools:
+            max_retained_tokens = t._max_retained_tokens
+            if isinstance(max_retained_tokens, ModelPrivateAttr):
+                max_retained_tokens = max_retained_tokens.default
+            if max_retained_tokens is not None:
+                truncate_tools.append(t)
+        limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
+        if limiting_tool is not None:
+            max_retained_tokens = limiting_tool._max_retained_tokens
+            if isinstance(max_retained_tokens, ModelPrivateAttr):
+                max_retained_tokens = max_retained_tokens.default
+            if max_retained_tokens is not None:
+                tool_name = limiting_tool.default_value("request")
+                max_tokens: int = max_retained_tokens
+                truncation_warning = f"""
+                    The result of the {tool_name} tool were too large,
+                    and has been truncated to {max_tokens} tokens.
+                    To obtain the full result, the tool needs to be re-used.
+                """
+                self.truncate_message(
+                    message.metadata.msg_idx, max_tokens, truncation_warning
+                )
+
+    def llm_response(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> Optional[ChatDocument]:
+        """
+        Respond to a single user message, appended to the message history,
+        in "chat" mode
+        Args:
+            message (str|ChatDocument): message or ChatDocument object to respond to.
+                If None, use the self.task_messages
+        Returns:
+            LLM response as a ChatDocument object
+        """
+        if self.llm is None:
+            return None
+
+        # If enabled and a tool error occurred, we recover by generating the tool in
+        # strict json mode
+        if (
+            self.tool_error
+            and self.output_format is None
+            and self._json_schema_available()
+            and self.config.strict_recovery
+        ):
+            self.tool_error = False
+            AnyTool = self._get_any_tool_message()
+            if AnyTool is None:
+                return None
+            self.set_output_format(
+                AnyTool,
+                force_tools=True,
+                use=True,
+                handle=True,
+                instructions=True,
+            )
+            recovery_message = self._strict_recovery_instructions(AnyTool)
+            augmented_message = message
+            if augmented_message is None:
+                augmented_message = recovery_message
+            elif isinstance(augmented_message, str):
+                augmented_message = augmented_message + recovery_message
+            else:
+                augmented_message.content = augmented_message.content + recovery_message
+
+            # only use the augmented message for this one response...
+            result = self.llm_response(augmented_message)
+            # ... restore the original user message so that the AnyTool recover
+            # instructions don't persist in the message history
+            # (this can cause the LLM to use the AnyTool directly as a tool)
+            if message is None:
+                self.delete_last_message(role=Role.USER)
+            else:
+                msg = message if isinstance(message, str) else message.content
+                self.update_last_message(msg, role=Role.USER)
+            return result
+
+        hist, output_len = self._prep_llm_messages(message)
+        if len(hist) == 0:
+            return None
+        tool_choice = (
+            "auto"
+            if isinstance(message, str)
+            else (message.oai_tool_choice if message is not None else "auto")
+        )
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
+            try:
+                response = self.llm_response_messages(hist, output_len, tool_choice)
+            except openai.BadRequestError as e:
+                if self.any_strict:
+                    self.disable_strict = True
+                    self.set_output_format(None)
+                    logging.warning(
+                        f"""
+                        OpenAI BadRequestError raised with strict mode enabled.
+                        Message: {e.message}
+                        Disabling strict mode and retrying.
+                        """
+                    )
+                    return self.llm_response(message)
+                else:
+                    raise e
+        self.message_history.extend(ChatDocument.to_LLMMessage(response))
+        response.metadata.msg_idx = len(self.message_history) - 1
+        response.metadata.agent_id = self.id
+        if isinstance(message, ChatDocument):
+            self._reduce_raw_tool_results(message)
+        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
+        response.metadata.tool_ids = (
+            []
+            if isinstance(message, str)
+            else message.metadata.tool_ids if message is not None else []
+        )
+
+        return response
+
+    async def llm_response_async(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> Optional[ChatDocument]:
+        """
+        Async version of `llm_response`. See there for details.
+        """
+        if self.llm is None:
+            return None
+
+        # If enabled and a tool error occurred, we recover by generating the tool in
+        # strict json mode
+        if (
+            self.tool_error
+            and self.output_format is None
+            and self._json_schema_available()
+            and self.config.strict_recovery
+        ):
+            self.tool_error = False
+            AnyTool = self._get_any_tool_message()
+            self.set_output_format(
+                AnyTool,
+                force_tools=True,
+                use=True,
+                handle=True,
+                instructions=True,
+            )
+            recovery_message = self._strict_recovery_instructions(AnyTool)
+            augmented_message = message
+            if augmented_message is None:
+                augmented_message = recovery_message
+            elif isinstance(augmented_message, str):
+                augmented_message = augmented_message + recovery_message
+            else:
+                augmented_message.content = augmented_message.content + recovery_message
+
+            # only use the augmented message for this one response...
+            result = self.llm_response(augmented_message)
+            # ... restore the original user message so that the AnyTool recover
+            # instructions don't persist in the message history
+            # (this can cause the LLM to use the AnyTool directly as a tool)
+            if message is None:
+                self.delete_last_message(role=Role.USER)
+            else:
+                msg = message if isinstance(message, str) else message.content
+                self.update_last_message(msg, role=Role.USER)
+            return result
+
+        hist, output_len = self._prep_llm_messages(message)
+        if len(hist) == 0:
+            return None
+        tool_choice = (
+            "auto"
+            if isinstance(message, str)
+            else (message.oai_tool_choice if message is not None else "auto")
+        )
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
+            try:
+                response = await self.llm_response_messages_async(
+                    hist, output_len, tool_choice
+                )
+            except openai.BadRequestError as e:
+                if self.any_strict:
+                    self.disable_strict = True
+                    self.set_output_format(None)
+                    logging.warning(
+                        f"""
+                        OpenAI BadRequestError raised with strict mode enabled.
+                        Message: {e.message}
+                        Disabling strict mode and retrying.
+                        """
+                    )
+                    return await self.llm_response_async(message)
+                else:
+                    raise e
+        self.message_history.extend(ChatDocument.to_LLMMessage(response))
+        response.metadata.msg_idx = len(self.message_history) - 1
+        response.metadata.agent_id = self.id
+        if isinstance(message, ChatDocument):
+            self._reduce_raw_tool_results(message)
+        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
+        response.metadata.tool_ids = (
+            []
+            if isinstance(message, str)
+            else message.metadata.tool_ids if message is not None else []
+        )
+
+        return response
+
+    def init_message_history(self) -> None:
+        """
+        Initialize the message history with the system message and user message
+        """
+        self.message_history = [self._create_system_and_tools_message()]
+        if self.user_message:
+            self.message_history.append(
+                LLMMessage(role=Role.USER, content=self.user_message)
+            )
+
+    def _prep_llm_messages(
+        self,
+        message: Optional[str | ChatDocument] = None,
+        truncate: bool = True,
+    ) -> Tuple[List[LLMMessage], int]:
+        """
+        Prepare messages to be sent to self.llm_response_messages,
+            which is the main method that calls the LLM API to get a response.
+            If desired output tokens + message history exceeds the model context length,
+            then first the max output tokens is reduced to fit, and if that is not
+            possible, older messages may be truncated to accommodate at least
+            self.config.llm.min_output_tokens of output.
+
+        Returns:
+            Tuple[List[LLMMessage], int]: (messages, output_len)
+                messages = Full list of messages to send
+                output_len = max expected number of tokens in response
+        """
+
+        if (
+            not self.llm_can_respond(message)
+            or self.config.llm is None
+            or self.llm is None
+        ):
+            return [], 0
+
+        if message is None and len(self.message_history) > 0:
+            # this means agent has been used to get LLM response already,
+            # and so the last message is an "assistant" response.
+            # We delete this last assistant response and re-generate it.
+            self.clear_history(-1)
+            logger.warning(
+                "Re-generating the last assistant response since message is None"
+            )
+
+        if len(self.message_history) == 0:
+            # initial messages have not yet been loaded, so load them
+            self.init_message_history()
+
+            # for debugging, show the initial message history
+            if settings.debug:
+                print(
+                    f"""
+                [grey37]LLM Initial Msg History:
+                {escape(self.message_history_str())}
+                [/grey37]
+                """
+                )
+        else:
+            assert self.message_history[0].role == Role.SYSTEM
+            # update the system message with the latest tool instructions
+            self.message_history[0] = self._create_system_and_tools_message()
+
+        if message is not None:
+            if (
+                isinstance(message, str)
+                or message.id() != self.message_history[-1].chat_document_id
+            ):
+                # either the message is a str, or it is a fresh ChatDocument
+                # different from the last message in the history
+                llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
+                llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
+                # Canonicalize retained whitespace-only results before token counting.
+                for llm_msg in llm_msgs:
+                    if (
+                        _is_identified_result(llm_msg)
+                        and llm_msg.content is not None
+                        and llm_msg.content.strip() == ""
+                    ):
+                        llm_msg.content = ""
+                if len(llm_msgs) == 0:
+                    return [], 0
+                # process tools if any
+                done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
+                self.oai_tool_calls = [
+                    t for t in self.oai_tool_calls if t.id not in done_tools
+                ]
+                self.message_history.extend(llm_msgs)
+
+        hist = self.message_history
+        output_len = self.config.llm.model_max_output_tokens
+        if (
+            truncate
+            and output_len > self.llm.chat_context_length() - self.chat_num_tokens(hist)
+        ):
+            # chat + output > max context length,
+            # so first try to shorten requested output len to fit;
+            # use an extra margin of CHAT_HISTORY_BUFFER tokens
+            # in case our calcs are off (and to allow for some extra tokens)
+            output_len = (
+                self.llm.chat_context_length()
+                - self.chat_num_tokens(hist)
+                - CHAT_HISTORY_BUFFER
+            )
+            if output_len > self.config.llm.min_output_tokens:
+                logger.debug(
+                    f"""
+                    Chat Model context length is {self.llm.chat_context_length()},
+                    but the current message history is {self.chat_num_tokens(hist)}
+                    tokens long, which does not allow
+                    {self.config.llm.model_max_output_tokens} output tokens.
+                    Therefore we reduced `max_output_tokens` to {output_len} tokens,
+                    so they can fit within the model's context length
+                    """
+                )
+            else:
+                # unacceptably small output len, so compress early parts of
+                # conversation history based on the configured strategy
+                strategy = self.config.context_overflow_strategy
+
+                if strategy == "truncate":
+                    # Truncate content of individual messages while preserving
+                    # the message sequence (important for LLM APIs that require
+                    # alternating USER/ASSISTANT messages)
+                    msg_idx_to_compress = 1  # don't touch system msg
+                    # we will try compressing msg indices up to but not including
+                    # last user msg
+                    last_msg_idx_to_compress = (
+                        self.last_message_idx_with_role(
+                            role=Role.USER,
+                        )
+                        - 1
+                    )
+                    n_truncated = 0
+                    _target_tokens = (
+                        self.llm.chat_context_length()
+                        - self.config.llm.min_output_tokens
+                        - CHAT_HISTORY_BUFFER
+                    )
+                    # Truncation floor: never reduce a message's content below
+                    # this many tokens.
+                    _min_keep_tokens = 30
+                    _truncation_warning = "... [Contents truncated!]"
+
+                    def _content_tokens(text: str | None) -> int:
+                        """Token count of message *content* only.
+
+                        `truncate_message` only trims `message.content`, so
+                        using the full `_message_num_tokens` (which includes
+                        attachment payloads) would inflate the count and make
+                        the keep-target too large to ever converge, for
+                        messages carrying file attachments.
+                        """
+                        return (
+                            self.parser.num_tokens(text or "")
+                            if self.parser is not None
+                            # approx fallback, matches truncate_message
+                            else len(text or "") // 4
+                        )
+
+                    # Account for the warning that truncate_message appends
+                    # ("\n" + warning), so the final token count of a
+                    # truncated message does not exceed its keep-target.
+                    _warning_tokens = _content_tokens("\n" + _truncation_warning)
+                    # NOTE: loop termination is guaranteed:
+                    # msg_idx_to_compress strictly increases every iteration
+                    # (truncate or skip), and once it exceeds
+                    # last_msg_idx_to_compress a ValueError is raised. (The
+                    # token count need not decrease every iteration, so
+                    # termination rests on the index advancing.)
+                    while self.chat_num_tokens(hist) > _target_tokens:
+                        if msg_idx_to_compress > last_msg_idx_to_compress:
+                            # We want to preserve the first message (typically
+                            # system msg) and last message (user msg).
+                            raise ValueError(
+                                """
+                            The (message history + max_output_tokens) is longer than the
+                            max chat context length of this model, and we have tried
+                            reducing the requested max output tokens, as well as
+                            truncating early parts of the message history, to
+                            accommodate the model context length, but we have run out
+                            of msgs to truncate.
+
+                            HINT: In the `llm` field of your `ChatAgentConfig` object,
+                            which is of type `LLMConfig/OpenAIGPTConfig`, try
+                            - increasing `chat_context_length`
+                                (if accurate for the model), or
+                            - decreasing `max_output_tokens`
+                            """
+                            )
+                        _msg_tokens = _content_tokens(hist[msg_idx_to_compress].content)
+                        if _msg_tokens <= _min_keep_tokens + _warning_tokens:
+                            # Truncating this message cannot shrink the total:
+                            # its content is already at/below the keep-floor
+                            # plus the appended warning; leave it intact.
+                            msg_idx_to_compress += 1
+                            continue
+                        n_truncated += 1
+                        # Distribute the current excess evenly across the
+                        # remaining *compressible* messages, so each retains
+                        # as much content as possible instead of being
+                        # collapsed to the fixed 30-token floor. The excess is
+                        # recomputed every iteration, so the distribution
+                        # self-corrects as we move forward through the
+                        # history.
+                        _current_excess = self.chat_num_tokens(hist) - _target_tokens
+                        # Shrink capacity of each *later* message in the
+                        # compressible range: its content above the floor (net
+                        # of the appended warning). Non-positive entries are
+                        # the tiny messages the skip-check above will leave
+                        # untouched; they must not dilute the even share, so
+                        # only messages with positive capacity count toward
+                        # the denominator (plus this message, which passed the
+                        # skip-check and is therefore compressible).
+                        _later_capacities = [
+                            _content_tokens(m.content)
+                            - _min_keep_tokens
+                            - _warning_tokens
+                            for m in hist[
+                                msg_idx_to_compress + 1 : last_msg_idx_to_compress + 1
+                            ]
+                        ]
+                        _n_remaining = 1 + sum(1 for c in _later_capacities if c > 0)
+                        _even_share = math.ceil(_current_excess / _n_remaining)
+                        # Later messages can shed at most their capacity; this
+                        # message must absorb whatever they cannot, so that
+                        # this single forward pass reaches the target whenever
+                        # that is possible at all.
+                        _later_capacity = sum(c for c in _later_capacities if c > 0)
+                        _reduction = max(_even_share, _current_excess - _later_capacity)
+                        # Extra 2-token slack: re-encoding truncated content
+                        # plus the appended warning can merge/split tokens at
+                        # the boundary, so aim slightly below the target to
+                        # keep the achieved reduction from falling short.
+                        _keep_tokens = max(
+                            _min_keep_tokens,
+                            _msg_tokens - _reduction - _warning_tokens - 2,
+                        )
+                        # compress the msg at idx `msg_idx_to_compress`
+                        hist[msg_idx_to_compress] = self.truncate_message(
+                            msg_idx_to_compress,
+                            tokens=_keep_tokens,
+                            warning=_truncation_warning,
+                        )
+                        msg_idx_to_compress += 1
+
+                    output_len = min(
+                        self.config.llm.model_max_output_tokens,
+                        self.llm.chat_context_length()
+                        - self.chat_num_tokens(hist)
+                        - CHAT_HISTORY_BUFFER,
+                    )
+                    if output_len < self.config.llm.min_output_tokens:
+                        raise ValueError(
+                            f"""
+                            Tried to shorten prompt history for chat mode
+                            but even after truncating all messages except system msg
+                            and last (user) msg, the history token len
+                            {self.chat_num_tokens(hist)} is too long to accommodate
+                            the desired minimum output tokens
+                            {self.config.llm.min_output_tokens} within the
+                            model's context length {self.llm.chat_context_length()}.
+                            Please try shortening the system msg or user prompts,
+                            or adjust `config.llm.min_output_tokens` to be smaller.
+                            """
+                        )
+                    else:
+                        # we MUST have truncated at least one msg
+                        msg_tokens = self.chat_num_tokens()
+                        logger.warning(
+                            f"""
+                        Chat Model context length is {self.llm.chat_context_length()}
+                        tokens, but the current message history is {msg_tokens} tokens
+                        long, which does not allow
+                        {self.config.llm.model_max_output_tokens} output tokens.
+                        Therefore we truncated the first {n_truncated} messages
+                        in the conversation history so that history token
+                        length is reduced to {self.chat_num_tokens(hist)}, and
+                        we use `max_output_tokens = {output_len}`,
+                        so they can fit within the model's context length
+                        of {self.llm.chat_context_length()} tokens.
+                        """
+                        )
+
+                else:  # strategy == "drop_turns"
+                    # Drop complete conversation turns. A complete turn is defined
+                    # as a USER message followed by all messages until the next
+                    # USER message. This is more aggressive but cleaner for voice
+                    # agents with limited context.
+                    n_dropped_turns = 0
+                    while (
+                        self.chat_num_tokens(hist)
+                        > self.llm.chat_context_length()
+                        - self.config.llm.min_output_tokens
+                        - CHAT_HISTORY_BUFFER
+                    ):
+                        # Find the last USER message index
+                        last_user_idx = self.last_message_idx_with_role(role=Role.USER)
+                        if last_user_idx == -1:
+                            break
+
+                        # Find the first complete turn to drop (skip system message)
+                        first_user_idx = -1
+                        for i in range(1, last_user_idx):
+                            if hist[i].role == Role.USER:
+                                first_user_idx = i
+                                break
+                        if first_user_idx == -1:
+                            break
+
+                        # Find the end of this turn: last message before next USER
+                        next_user_idx = -1
+                        for i in range(first_user_idx + 1, last_user_idx + 1):
+                            if hist[i].role == Role.USER:
+                                next_user_idx = i
+                                break
+                        if next_user_idx == -1:
+                            break
+
+                        # Drop the turn
+                        self.clear_history(first_user_idx, next_user_idx - 1)
+                        n_dropped_turns += 1
+
+                    output_len = min(
+                        self.config.llm.model_max_output_tokens,
+                        self.llm.chat_context_length()
+                        - self.chat_num_tokens(hist)
+                        - CHAT_HISTORY_BUFFER,
+                    )
+                    if output_len < self.config.llm.min_output_tokens:
+                        raise ValueError(
+                            f"""
+                            Tried to shorten prompt history for chat mode
+                            but even after dropping complete turns except the system
+                            msg and last turn, the history token len
+                            {self.chat_num_tokens(hist)} is too long to accommodate
+                            the desired minimum output tokens
+                            {self.config.llm.min_output_tokens} within the
+                            model's context length {self.llm.chat_context_length()}.
+                            Please try shortening the system msg or user prompts,
+                            or adjust `config.llm.min_output_tokens` to be smaller.
+                            """
+                        )
+                    else:
+                        # we MUST have dropped at least one turn
+                        msg_tokens = self.chat_num_tokens()
+                        logger.warning(
+                            f"""
+                        Chat Model context length is {self.llm.chat_context_length()}
+                        tokens, but the current message history is {msg_tokens} tokens
+                        long, which does not allow
+                        {self.config.llm.model_max_output_tokens} output tokens.
+                        Therefore we dropped the first {n_dropped_turns} complete
+                        turn(s) from the conversation history so that history token
+                        length is reduced to {self.chat_num_tokens(hist)}, and
+                        we use `max_output_tokens = {output_len}`,
+                        so they can fit within the model's context length
+                        of {self.llm.chat_context_length()} tokens.
+                        """
+                        )
+
+        if isinstance(message, ChatDocument):
+            # record the position of the corresponding LLMMessage in
+            # the message_history
+            message.metadata.msg_idx = len(hist) - 1
+            message.metadata.agent_id = self.id
+        return hist, output_len
+
+    def _function_args(
+        self,
+    ) -> Tuple[
+        Optional[List[LLMFunctionSpec]],
+        str | Dict[str, str],
+        Optional[List[OpenAIToolSpec]],
+        Optional[Dict[str, Dict[str, str] | str]],
+        Optional[OpenAIJsonSchemaSpec],
+    ]:
+        """
+        Get function/tool spec/output format arguments for
+        OpenAI-compatible LLM API call
+        """
+        functions: Optional[List[LLMFunctionSpec]] = None
+        fun_call: str | Dict[str, str] = "none"
+        tools: Optional[List[OpenAIToolSpec]] = None
+        force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
+        self.any_strict = False
+        if self.config.use_functions_api and len(self.llm_functions_usable) > 0:
+            if not self.config.use_tools_api:
+                functions = [
+                    self.llm_functions_map[f] for f in self.llm_functions_usable
+                ]
+                fun_call = (
+                    "auto"
+                    if self.llm_function_force is None
+                    else self.llm_function_force
+                )
+            else:
+
+                def to_maybe_strict_spec(function: str) -> OpenAIToolSpec:
+                    spec = self.llm_functions_map[function]
+                    strict = self._strict_mode_for_tool(function)
+                    if strict:
+                        self.any_strict = True
+                        strict_spec = copy.deepcopy(spec)
+                        format_schema_for_strict(strict_spec.parameters)
+                    else:
+                        strict_spec = spec
+
+                    return OpenAIToolSpec(
+                        type="function",
+                        strict=strict,
+                        function=strict_spec,
+                    )
+
+                tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
+                force_tool = (
+                    None
+                    if self.llm_function_force is None
+                    else {
+                        "type": "function",
+                        "function": {"name": self.llm_function_force["name"]},
+                    }
+                )
+        output_format = None
+        if self.output_format is not None and self._json_schema_available():
+            self.any_strict = True
+            if issubclass(self.output_format, ToolMessage) and not issubclass(
+                self.output_format, XMLToolMessage
+            ):
+                spec = self.output_format.llm_function_schema(
+                    request=True,
+                    defaults=self.config.output_format_include_defaults,
+                )
+                format_schema_for_strict(spec.parameters)
+
+                output_format = OpenAIJsonSchemaSpec(
+                    # We always require that outputs strictly match the schema
+                    strict=True,
+                    function=spec,
+                )
+            elif issubclass(self.output_format, BaseModel):
+                param_spec = self.output_format.model_json_schema()
+                format_schema_for_strict(param_spec)
+
+                output_format = OpenAIJsonSchemaSpec(
+                    # We always require that outputs strictly match the schema
+                    strict=True,
+                    function=LLMFunctionSpec(
+                        name="json_output",
+                        description="Strict Json output format.",
+                        parameters=param_spec,
+                    ),
+                )
+
+        return functions, fun_call, tools, force_tool, output_format
+
+    def llm_response_messages(
+        self,
+        messages: List[LLMMessage],
+        output_len: Optional[int] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+    ) -> ChatDocument:
+        """
+        Respond to a series of messages, e.g. with OpenAI ChatCompletion
+        Args:
+            messages: seq of messages (with role, content fields) sent to LLM
+            output_len: max number of tokens expected in response.
+                    If None, use the LLM's default model_max_output_tokens.
+        Returns:
+            Document (i.e. with fields "content", "metadata")
+        """
+        assert self.config.llm is not None and self.llm is not None
+        output_len = output_len or self.config.llm.model_max_output_tokens
+        streamer = noop_fn
+        if self.llm.get_stream():
+            streamer = self.callbacks.start_llm_stream()
+        self.llm.config.streamer = streamer
+        with ExitStack() as stack:  # for conditionally using rich spinner
+            if not self.llm.get_stream() and not settings.quiet:
+                # show rich spinner only if not streaming!
+                # (Why? b/c the intent of showing a spinner is to "show progress",
+                # and we don't need to do that when streaming, since
+                # streaming output already shows progress.)
+                cm = status(
+                    "LLM responding to messages...",
+                    log_if_quiet=False,
+                )
+                stack.enter_context(cm)
+            if self.llm.get_stream() and not settings.quiet:
+                console.print(f"[green]{self.indent}", end="")
+            functions, fun_call, tools, force_tool, output_format = (
+                self._function_args()
+            )
+            assert self.llm is not None
+            response = self.llm.chat(
+                messages,
+                output_len,
+                tools=tools,
+                tool_choice=force_tool or tool_choice,
+                functions=functions,
+                function_call=fun_call,
+                response_format=output_format,
+            )
+        if self.llm.get_stream():
+            # Create temp ChatDocument for tool check, then clean up to avoid
+            # polluting ObjectRegistry (see PR #939 discussion)
+            temp_doc = ChatDocument.from_LLMResponse(
+                response,
+                displayed=True,
+                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+            )
+            self._call_callback_with_reasoning(
+                "finish_llm_stream",
+                reasoning=response.reasoning,
+                content=response.message or "",
+                tools_content=response.tools_content(),
+                is_tool=self.has_tool_message_attempt(temp_doc),
+            )
+            ObjectRegistry.remove(temp_doc.id())
+        self.llm.config.streamer = noop_fn
+        if response.cached:
+            self.callbacks.cancel_llm_stream()
+        self._render_llm_response(response)
+        self.update_token_usage(
+            response,  # .usage attrib is updated!
+            messages,
+            self.llm.get_stream(),
+            chat=True,
+            print_response_stats=self.config.show_stats and not settings.quiet,
+        )
+        chat_doc = ChatDocument.from_LLMResponse(
+            response,
+            displayed=True,
+            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+        )
+        self.oai_tool_calls = response.oai_tool_calls or []
+        self.oai_tool_id2call.update(
+            {t.id: t for t in self.oai_tool_calls if t.id is not None}
+        )
+
+        # If using strict output format, parse the output JSON
+        self._load_output_format(chat_doc)
+
+        return chat_doc
+
+    async def llm_response_messages_async(
+        self,
+        messages: List[LLMMessage],
+        output_len: Optional[int] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+    ) -> ChatDocument:
+        """
+        Async version of `llm_response_messages`. See there for details.
+        """
+        assert self.config.llm is not None and self.llm is not None
+        output_len = output_len or self.config.llm.model_max_output_tokens
+        functions, fun_call, tools, force_tool, output_format = self._function_args()
+        assert self.llm is not None
+
+        streamer_async = async_noop_fn
+        if self.llm.get_stream():
+            streamer_async = await self.callbacks.start_llm_stream_async()
+        self.llm.config.streamer_async = streamer_async
+
+        response = await self.llm.achat(
+            messages,
+            output_len,
+            tools=tools,
+            tool_choice=force_tool or tool_choice,
+            functions=functions,
+            function_call=fun_call,
+            response_format=output_format,
+        )
+        if self.llm.get_stream():
+            # Create temp ChatDocument for tool check, then clean up to avoid
+            # polluting ObjectRegistry (see PR #939 discussion)
+            temp_doc = ChatDocument.from_LLMResponse(
+                response,
+                displayed=True,
+                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+            )
+            self._call_callback_with_reasoning(
+                "finish_llm_stream",
+                reasoning=response.reasoning,
+                content=response.message or "",
+                tools_content=response.tools_content(),
+                is_tool=self.has_tool_message_attempt(temp_doc),
+            )
+            ObjectRegistry.remove(temp_doc.id())
+        self.llm.config.streamer_async = async_noop_fn
+        if response.cached:
+            self.callbacks.cancel_llm_stream()
+        self._render_llm_response(response)
+        self.update_token_usage(
+            response,  # .usage attrib is updated!
+            messages,
+            self.llm.get_stream(),
+            chat=True,
+            print_response_stats=self.config.show_stats and not settings.quiet,
+        )
+        chat_doc = ChatDocument.from_LLMResponse(
+            response,
+            displayed=True,
+            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+        )
+        self.oai_tool_calls = response.oai_tool_calls or []
+        self.oai_tool_id2call.update(
+            {t.id: t for t in self.oai_tool_calls if t.id is not None}
+        )
+
+        # If using strict output format, parse the output JSON
+        self._load_output_format(chat_doc)
+
+        return chat_doc
+
+    def _call_callback_with_reasoning(
+        self,
+        callback_name: str,
+        reasoning: str,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Call a callback method, only passing 'reasoning' if it accepts it.
+
+        This provides backward compatibility for custom callbacks that don't
+        have the 'reasoning' parameter in their signature.
+
+        Args:
+            callback_name: Name of the callback method (e.g., 'show_llm_response')
+            reasoning: The reasoning content to pass if supported
+            **kwargs: Other arguments to pass to the callback
+        """
+        callback = getattr(self.callbacks, callback_name, None)
+        if callback is None:
+            return
+
+        # Check if callback accepts 'reasoning' param or **kwargs
+        try:
+            sig = inspect.signature(callback)
+            params = sig.parameters
+            accepts_reasoning = "reasoning" in params or any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+            )
+        except (ValueError, TypeError):
+            # If we can't inspect the signature, assume it doesn't accept reasoning
+            accepts_reasoning = False
+
+        if accepts_reasoning:
+            callback(reasoning=reasoning, **kwargs)
+        else:
+            callback(**kwargs)
+
+    def _render_llm_response(
+        self, response: ChatDocument | LLMResponse, citation_only: bool = False
+    ) -> None:
+        is_cached = (
+            response.cached
+            if isinstance(response, LLMResponse)
+            else response.metadata.cached
+        )
+        if self.llm is None:
+            return
+        if not citation_only and (not self.llm.get_stream() or is_cached):
+            # We would have already displayed the msg "live" ONLY if
+            # streaming was enabled, AND we did not find a cached response.
+            # If we are here, it means the response has not yet been displayed.
+            cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
+            # Track whether we created a temp ChatDocument for cleanup
+            is_temp_doc = isinstance(response, LLMResponse)
+            chat_doc = (
+                response
+                if isinstance(response, ChatDocument)
+                else ChatDocument.from_LLMResponse(
+                    response,
+                    displayed=True,
+                    recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+                )
+            )
+            # TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
+            if not settings.quiet:
+                print(cached + "[green]" + escape(str(response)))
+            if isinstance(response, LLMResponse):
+                content = response.message or ""
+                tools_content = response.tools_content()
+            else:
+                content = response.content
+                tools_content = ""
+            reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
+            self._call_callback_with_reasoning(
+                "show_llm_response",
+                reasoning=reasoning,
+                content=content,
+                tools_content=tools_content,
+                is_tool=self.has_tool_message_attempt(chat_doc),
+                cached=is_cached,
+            )
+            # Clean up temp ChatDocument to avoid polluting ObjectRegistry
+            if is_temp_doc:
+                ObjectRegistry.remove(chat_doc.id())
+        if isinstance(response, LLMResponse):
+            # we are in the context immediately after an LLM responded,
+            # we won't have citations yet, so we're done
+            return
+        if response.metadata.has_citation:
+            citation = (
+                response.metadata.source_content
+                if self.config.full_citations
+                else response.metadata.source
+            )
+            if not settings.quiet:
+                print("[grey37]SOURCES:\n" + escape(citation) + "[/grey37]")
+            self._call_callback_with_reasoning(
+                "show_llm_response",
+                reasoning="",  # Citations don't have reasoning
+                content=str(citation),
+                tools_content="",
+                is_tool=False,
+                cached=False,
+                language="text",
+            )
+
+    def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument:
+        """
+        Get LLM response to `prompt` (which presumably includes the `message`
+        somewhere, along with possible large "context" passages),
+        but only include `message` as the USER message, and not the
+        full `prompt`, in the message history.
+        Args:
+            message: the original, relatively short, user request or query
+            prompt: the full prompt potentially containing `message` plus context
+
+        Returns:
+            Document object containing the response.
+        """
+        # we explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
+        self.update_last_message(message, role=Role.USER)
+        return answer_doc
+
+    async def _llm_response_temp_context_async(
+        self, message: str, prompt: str
+    ) -> ChatDocument:
+        """
+        Async version of `_llm_response_temp_context`. See there for details.
+        """
+        # we explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            answer_doc = cast(
+                ChatDocument,
+                await ChatAgent.llm_response_async(self, prompt),
+            )
+        self.update_last_message(message, role=Role.USER)
+        return answer_doc
+
+    def llm_response_forget(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> ChatDocument:
+        """
+        LLM Response to single message, and restore message_history.
+        In effect a "one-off" message & response that leaves agent
+        message history state intact.
+
+        Args:
+            message (str|ChatDocument): message to respond to.
+
+        Returns:
+            A Document object with the response.
+
+        """
+        # explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        n_msgs = len(self.message_history)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            response = cast(ChatDocument, ChatAgent.llm_response(self, message))
+        # If there is a response, then we will have two additional
+        # messages in the message history, i.e. the user message and the
+        # assistant response. We want to (carefully) remove these two messages.
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+
+        # If using strict output format, parse the output JSON
+        self._load_output_format(response)
+
+        return response
+
+    async def llm_response_forget_async(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> ChatDocument:
+        """
+        Async version of `llm_response_forget`. See there for details.
+        """
+        # explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        n_msgs = len(self.message_history)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            response = cast(
+                ChatDocument, await ChatAgent.llm_response_async(self, message)
+            )
+        # If there is a response, then we will have two additional
+        # messages in the message history, i.e. the user message and the
+        # assistant response. We want to (carefully) remove these two messages.
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+        return response
+
+    def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int:
+        """
+        Total number of tokens in the message history so far.
+
+        Args:
+            messages: if provided, compute the number of tokens in this list of
+                messages, rather than the current message history.
+        Returns:
+            int: number of tokens in message history
+        """
+        if self.parser is None:
+            raise ValueError(
+                "ChatAgent.parser is None. "
+                "You must set ChatAgent.parser "
+                "before calling chat_num_tokens()."
+            )
+        hist = messages if messages is not None else self.message_history
+        return sum([self._message_num_tokens(m) for m in hist])
+
+    def _message_num_tokens(self, message: LLMMessage) -> int:
+        """Count tokens for a message, including serialized user attachments."""
+        if self.parser is None:
+            raise ValueError(
+                "ChatAgent.parser is None. "
+                "You must set ChatAgent.parser "
+                "before calling _message_num_tokens()."
+            )
+
+        return self.parser.num_tokens(
+            message.content or ""
+        ) + self._attachment_num_tokens(message)
+
+    def _attachment_num_tokens(self, message: LLMMessage) -> int:
+        """
+        Estimate attachment contribution using the serialized payload
+        that is sent in the API request for user messages.
+        """
+        if self.parser is None or message.role != Role.USER or len(message.files) == 0:
+            return 0
+
+        model = self._chat_model_name_for_attachments()
+        n_tokens = sum(
+            self.parser.num_tokens(
+                json.dumps(
+                    attachment.to_dict(model),
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+            )
+            for attachment in message.files
+        )
+        if n_tokens > 0 and not self._attachment_tokens_warned:
+            self._attachment_tokens_warned = True
+            logger.warning(
+                "File attachment payloads are included in context-length "
+                "token accounting; this count is an estimate based on the "
+                "serialized (e.g. base64 data-URI) form of each attachment, "
+                "and may differ from the provider's own accounting."
+            )
+        return n_tokens
+
+    def _chat_model_name_for_attachments(self) -> str:
+        """Return the model name used for attachment serialization."""
+        if self.llm is None:
+            return self.config.llm.chat_model if self.config.llm is not None else ""
+
+        return cast(
+            str,
+            getattr(
+                self.llm,
+                "chat_model_orig",
+                getattr(
+                    getattr(self.llm, "config", None),
+                    "chat_model",
+                    self.config.llm.chat_model if self.config.llm is not None else "",
+                ),
+            ),
+        )
+
+    def message_history_str(self, i: Optional[int] = None) -> str:
+        """
+        Return a string representation of the message history
+        Args:
+            i: if provided, return only the i-th message when i is postive,
+                or last k messages when i = -k.
+        Returns:
+        """
+        if i is None:
+            return "\n".join([str(m) for m in self.message_history])
+        elif i > 0:
+            return str(self.message_history[i])
+        else:
+            return "\n".join([str(m) for m in self.message_history[i:]])
+
+    def __del__(self) -> None:
+        """
+        Cleanup method called when the ChatAgent is garbage collected.
+        Note: We don't close LLM clients here because they may be shared
+        across multiple agents when client caching is enabled.
+        The clients are managed centrally and cleaned up via atexit hooks.
+        """
+        # Previously we closed clients here, but this caused issues when
+        # multiple agents shared the same cached client instance.
+        # Clients are now managed centrally in langroid.language_models.client_cache
+        pass
 </file>
 
 <file path="mkdocs.yml">
@@ -135436,6 +135602,7 @@ nav:
       - Markdown, HTML Parsing: notes/markdown-html-parsing.md
       - Context-Overflow Handling: notes/context-overflow.md
       - Batch Processing: notes/batch-processing.md
+      - Attachment Token Preflight: notes/attachment-token-preflight.md
 
   - Examples:
     - Guide: examples/guide.md
@@ -135484,7 +135651,7 @@ extra_javascript:
 <file path="pyproject.toml">
 [project]
 name = "langroid"
-version = "0.65.16"
+version = "0.66.0"
 authors = [
     {name = "Prasad Chalasani", email = "pchalasani@gmail.com"},
 ]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
       - Markdown, HTML Parsing: notes/markdown-html-parsing.md
       - Context-Overflow Handling: notes/context-overflow.md
       - Batch Processing: notes/batch-processing.md
+      - Attachment Token Preflight: notes/attachment-token-preflight.md
 
   - Examples:
     - Guide: examples/guide.md

--- a/tests/main/test_attachment_token_accounting.py
+++ b/tests/main/test_attachment_token_accounting.py
@@ -1,0 +1,101 @@
+"""Tests for attachment-aware context-preflight token accounting (issue #996).
+
+The accounting itself (attachment payloads counted via their serialized
+API form) is covered in `test_prep_llm_message.py`; here we test the
+one-time warning emitted when attachments contribute to the token count,
+and that accounting without attachments is unchanged.
+"""
+
+import logging
+from typing import List
+
+import pytest
+from _pytest.logging import LogCaptureFixture
+
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.language_models.base import LLMMessage, Role
+from langroid.language_models.openai_gpt import OpenAIGPTConfig
+from langroid.parsing.file_attachment import FileAttachment
+
+LOGGER_NAME = "langroid.agent.chat_agent"
+
+
+@pytest.fixture
+def agent() -> ChatAgent:
+    """ChatAgent with a char-count parser; no live LLM needed."""
+    config = ChatAgentConfig(
+        system_message="System message",
+        llm=OpenAIGPTConfig(
+            chat_model="gemini/gemini-2.5-flash",
+            chat_context_length=16_000,
+        ),
+    )
+    agent = ChatAgent(config)
+
+    class MockParser:
+        def num_tokens(self, text: str) -> int:
+            return len(text)
+
+    agent.parser = MockParser()  # type: ignore[assignment]
+    return agent
+
+
+def _user_msg_with_attachment() -> LLMMessage:
+    attachment = FileAttachment.from_bytes(
+        content=b"pdf-bytes" * 20,
+        filename="dummy.pdf",
+    )
+    return LLMMessage(
+        role=Role.USER,
+        content="Question about the PDF",
+        files=[attachment],
+    )
+
+
+def _attachment_warnings(caplog: LogCaptureFixture) -> List[logging.LogRecord]:
+    return [r for r in caplog.records if "attachment" in r.getMessage().lower()]
+
+
+def test_attachment_warning_emitted_once(
+    agent: ChatAgent, caplog: LogCaptureFixture
+) -> None:
+    """Warning fires once per agent, even across repeated token counts."""
+    msg = _user_msg_with_attachment()
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        agent.chat_num_tokens([msg])
+        agent.chat_num_tokens([msg, msg])
+        agent.chat_num_tokens([msg])
+
+    warnings = _attachment_warnings(caplog)
+    assert len(warnings) == 1
+    assert "estimate" in warnings[0].getMessage().lower()
+
+
+def test_no_warning_without_attachments(
+    agent: ChatAgent, caplog: LogCaptureFixture
+) -> None:
+    """No attachments: no warning, and counting is content-only as before."""
+    msg = LLMMessage(role=Role.USER, content="Just text")
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        n_tokens = agent.chat_num_tokens([msg])
+
+    assert n_tokens == len("Just text")
+    assert _attachment_warnings(caplog) == []
+
+
+def test_no_warning_for_non_user_attachment(
+    agent: ChatAgent, caplog: LogCaptureFixture
+) -> None:
+    """Attachments on non-user messages are not serialized inline, so they
+    neither count nor warn."""
+    attachment = FileAttachment.from_bytes(content=b"x" * 100, filename="f.pdf")
+    msg = LLMMessage(
+        role=Role.ASSISTANT,
+        content="reply",
+        files=[attachment],
+    )
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        n_tokens = agent.chat_num_tokens([msg])
+
+    assert n_tokens == len("reply")
+    assert _attachment_warnings(caplog) == []


### PR DESCRIPTION
Closes #996.

The core attachment-aware accounting landed in PR #998 (`_attachment_num_tokens()` serializes each USER-message `FileAttachment` exactly as the API request would and tokenizes that). This PR completes the remaining spec items from the issue:

- A once-per-agent warning when attachments contribute tokens to the context preflight, noting the count is an estimate of the serialized payload.
- Tests: warning fires exactly once across repeated `chat_num_tokens()` calls; content-only counting is unchanged when no attachments are present; non-USER-message attachments neither count nor warn.
- `docs/notes/attachment-token-preflight.md` documenting the behavior, including that URL-backed attachments contribute only their small serialized form.
- Regenerated `llms*.txt` bundles.

Verification: 55 passed in the touched suites plus existing chat-agent and file-attachment suites; `make check` clean (black/ruff/mypy).