### PR TITLE
fix(security): add per-provider env_prefix to all vector-store configs (#1078)

### DIFF
--- a/docs/notes/vecstore-env-prefix.md
+++ b/docs/notes/vecstore-env-prefix.md
@@ -1,0 +1,80 @@
+# Vector-Store Config Env-Var Prefixes
+
+Vector-store configs are `pydantic-settings` classes, which means their
+fields can be set via environment variables. Prior to this change (see
+issue #1078), `VectorStoreConfig` and its subclasses declared **no
+`env_prefix`**, so every field name was itself a case-insensitive
+environment variable. A bare `HOST`, `PORT`, `CLOUD`, `TIMEOUT`,
+`BATCH_SIZE`, `STORAGE_PATH`, `COLLECTION_NAME`, or `FULL_EVAL` in the
+environment silently overrode the default for *every* vector-store
+config:
+
+```bash
+HOST=evil.example.com PORT=9999 FULL_EVAL=true \
+  python -c "from langroid.vector_store.qdrantdb import QdrantDBConfig; \
+             c = QdrantDBConfig(); print(c.host, c.port, c.full_eval)"
+# old behavior: evil.example.com 9999 True
+```
+
+This was dangerous for two reasons:
+
+- `HOST` and `PORT` are routinely set by shells, containers, and CI
+  systems, so vector-store clients could silently point at the wrong
+  server.
+- `FULL_EVAL=true` disabled the code-injection guard (see
+  [code-injection-protection](code-injection-protection.md)) with no
+  explicit opt-in anywhere in the user's code.
+
+## New behavior
+
+Each vector-store config now has its own env prefix, consistent with
+the rest of the codebase (`OPENAI_`, `AZURE_OPENAI_`, `NEO4J_`, ...):
+
+| Config class        | Env prefix     |
+|---------------------|----------------|
+| `VectorStoreConfig` | `VECDB_`       |
+| `QdrantDBConfig`    | `QDRANT_`      |
+| `ChromaDBConfig`    | `CHROMA_`      |
+| `LanceDBConfig`     | `LANCEDB_`     |
+| `PineconeDBConfig`  | `PINECONE_`    |
+| `PostgresDBConfig`  | `POSTGRES_`    |
+| `MeiliSearchConfig` | `MEILISEARCH_` |
+| `WeaviateDBConfig`  | `WEAVIATE_`    |
+
+Bare env vars (`HOST`, `FULL_EVAL`, ...) are now ignored by all of
+these configs. To set a field via the environment, use the prefix of
+the specific config class, e.g. `QDRANT_HOST=my.qdrant.example` or
+`QDRANT_FULL_EVAL=true` for `QdrantDBConfig`. Every provider subclass
+in langroid overrides the prefix with its own, so within langroid
+`VECDB_*` vars affect only direct `VectorStoreConfig` instances.
+However, pydantic inherits `model_config`, so a third-party subclass
+of `VectorStoreConfig` that does not set its own `env_prefix` will
+read `VECDB_*` vars.
+
+A `tcp://...` value in a `*_PORT` env var (the format Kubernetes
+service links inject, e.g. `QDRANT_PORT=tcp://10.0.0.8:6333` from a
+service named `qdrant` with `enableServiceLinks` on) is ignored with a
+warning and the default port is used; any other non-integer port value
+fails validation as usual.
+
+Explicit constructor arguments always take priority over environment
+values (standard `pydantic-settings` precedence):
+
+```python
+config = QdrantDBConfig(host="10.0.0.5")  # wins over QDRANT_HOST
+```
+
+## Migration
+
+If you (deliberately) relied on bare env vars to configure a
+vector store, rename them with the appropriate prefix from the table
+above, e.g. `COLLECTION_NAME=mydocs` becomes
+`QDRANT_COLLECTION_NAME=mydocs`.
+
+Env vars read via `os.getenv` outside the config classes are
+unaffected, e.g. `QDRANT_API_KEY`, `PINECONE_API_KEY`,
+`MEILISEARCH_API_KEY`, `MEILISEARCH_API_URL`, `WEAVIATE_API_KEY`, and
+`WEAVIATE_API_URL` keep their existing meanings. Note that the
+`QDRANT_*` and `PINECONE_*` prefixes overlap with those existing
+names, but the config classes have no `api_key`/`api_url` fields, so
+extra prefixed vars are ignored.

--- a/docs/notes/vecstore-env-prefix.md
+++ b/docs/notes/vecstore-env-prefix.md
@@ -51,11 +51,14 @@ However, pydantic inherits `model_config`, so a third-party subclass
 of `VectorStoreConfig` that does not set its own `env_prefix` will
 read `VECDB_*` vars.
 
-A `tcp://...` value in a `*_PORT` env var (the format Kubernetes
-service links inject, e.g. `QDRANT_PORT=tcp://10.0.0.8:6333` from a
-service named `qdrant` with `enableServiceLinks` on) is ignored with a
-warning and the default port is used; any other non-integer port value
-fails validation as usual.
+A `port` value coming from the *environment* that matches the exact
+Kubernetes service-link format `tcp://<host>:<digits>` (e.g.
+`QDRANT_PORT=tcp://10.0.0.8:6333`, injected into every pod by a
+service named `qdrant` when `enableServiceLinks` is on) is ignored
+with a warning and the default port is used. This exception applies
+only to the env settings source and only to that full format:
+malformed `tcp://` junk in the environment, and any `tcp://...` value
+passed explicitly to the constructor, fail validation as usual.
 
 Explicit constructor arguments always take priority over environment
 values (standard `pydantic-settings` precedence):

--- a/langroid/utils/configuration.py
+++ b/langroid/utils/configuration.py
@@ -132,8 +132,12 @@ def set_env(settings_instance: BaseSettings) -> None:
     """
     Set environment variables from a BaseSettings instance.
 
-    Each field in the settings is written to os.environ.
+    Each field in the settings is written to os.environ, under the name
+    the settings class itself reads: `<env_prefix><FIELD_NAME_UPPER>`,
+    or the field's explicit alias (which, per pydantic-settings
+    semantics, is the full env name and is not prefixed).
     """
+    env_prefix = settings_instance.model_config.get("env_prefix", "")
     for field_name, field in settings_instance.__class__.model_fields.items():
-        env_var_name = field.alias or field_name.upper()
+        env_var_name = field.alias or f"{env_prefix}{field_name.upper()}"
         os.environ[env_var_name] = str(settings_instance.model_dump()[field_name])

--- a/langroid/vector_store/base.py
+++ b/langroid/vector_store/base.py
@@ -1,12 +1,17 @@
 import copy
 import logging
+import re
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
 
 import numpy as np
 import pandas as pd
-from pydantic import field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic.fields import FieldInfo
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
 
 from langroid.embedding_models.base import EmbeddingModel, EmbeddingModelsConfig
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
@@ -19,6 +24,48 @@ from langroid.utils.pandas_utils import safe_eval_globals, sanitize_command, str
 from langroid.utils.pydantic_utils import flatten_dict
 
 logger = logging.getLogger(__name__)
+
+# the exact shape Kubernetes service links inject, e.g. tcp://10.0.0.8:6333
+# (\Z, not $: $ would match before a trailing newline, silently
+# discarding a value that should fail validation)
+_SERVICE_LINK_PORT_RE = re.compile(r"^tcp://\S+:\d+\Z")
+
+
+class _ServiceLinkPortFilter(PydanticBaseSettingsSource):
+    """Env-source wrapper dropping k8s/docker service-link `port` values.
+
+    With `enableServiceLinks` (on by default in Kubernetes), a service
+    named e.g. `qdrant` injects `QDRANT_PORT=tcp://IP:PORT` into every
+    pod, which would otherwise fail integer validation of the `port`
+    field. If the wrapped env source yields a `port` string matching
+    exactly that format, it is dropped (with a warning) so the class
+    default applies. Any other value — including malformed `tcp://`
+    junk, or a `tcp://` value passed to the constructor (which never
+    goes through this source) — still fails validation as usual.
+    """
+
+    def __init__(self, wrapped: PydanticBaseSettingsSource) -> None:
+        super().__init__(wrapped.settings_cls)
+        self._wrapped = wrapped
+
+    def get_field_value(
+        self, field: FieldInfo, field_name: str
+    ) -> Tuple[Any, str, bool]:
+        return self._wrapped.get_field_value(field, field_name)
+
+    def __call__(self) -> Dict[str, Any]:
+        values = self._wrapped()
+        port = values.get("port")
+        if isinstance(port, str) and _SERVICE_LINK_PORT_RE.match(port):
+            default = self.settings_cls.model_fields["port"].default
+            logger.warning(
+                f"Ignoring port value {port!r} from the environment: it "
+                f"looks like a Kubernetes/Docker service-link artifact "
+                f"(an injected <SERVICE>_PORT env var); using default "
+                f"port {default} instead."
+            )
+            values = {k: v for k, v in values.items() if k != "port"}
+        return values
 
 
 class VectorStoreConfig(BaseSettings):
@@ -47,27 +94,26 @@ class VectorStoreConfig(BaseSettings):
     # compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
     full_eval: bool = False  # runs eval without sanitization. Use only on trusted input
 
-    @field_validator("port", mode="before")
     @classmethod
-    def _ignore_service_link_port(cls, v: Any) -> Any:
-        """Ignore Kubernetes/Docker service-link `tcp://...` port values.
+    def settings_customise_sources(
+        cls,
+        settings_cls: Type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> Tuple[PydanticBaseSettingsSource, ...]:
+        """Wrap the env source to drop k8s service-link `port` values.
 
-        With `enableServiceLinks` (on by default in Kubernetes), a
-        service named e.g. `qdrant` injects `QDRANT_PORT=tcp://IP:PORT`
-        into every pod, which would otherwise fail integer validation
-        of the `port` field. Only this exact format is forgiven; any
-        other invalid value still fails validation as usual.
+        Source precedence is unchanged (init beats env, etc.); only the
+        env source is filtered — see `_ServiceLinkPortFilter`.
         """
-        if isinstance(v, str) and v.startswith("tcp://"):
-            default = cls.model_fields["port"].default
-            logger.warning(
-                f"Ignoring port value {v!r}: it looks like a "
-                f"Kubernetes/Docker service-link artifact (an injected "
-                f"<SERVICE>_PORT env var); using default port "
-                f"{default} instead."
-            )
-            return default
-        return v
+        return (
+            init_settings,
+            _ServiceLinkPortFilter(env_settings),
+            dotenv_settings,
+            file_secret_settings,
+        )
 
 
 class VectorStore(ABC):

--- a/langroid/vector_store/base.py
+++ b/langroid/vector_store/base.py
@@ -1,11 +1,12 @@
 import copy
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Sequence, Tuple, Type
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
 
 import numpy as np
 import pandas as pd
-from pydantic_settings import BaseSettings
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from langroid.embedding_models.base import EmbeddingModel, EmbeddingModelsConfig
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
@@ -21,6 +22,12 @@ logger = logging.getLogger(__name__)
 
 
 class VectorStoreConfig(BaseSettings):
+    # Without a prefix, every field name would itself be a
+    # case-insensitive env var (e.g. a bare HOST, PORT, or FULL_EVAL
+    # in the environment would silently override defaults); subclasses
+    # each set their own prefix (QDRANT_, LANCEDB_, ...).
+    model_config = SettingsConfigDict(env_prefix="VECDB_")
+
     type: str = ""  # deprecated, keeping it for backward compatibility
     collection_name: str | None = "temp"
     replace_collection: bool = False  # replace collection if it already exists
@@ -39,6 +46,28 @@ class VectorStoreConfig(BaseSettings):
     metadata_class: Type[DocMetaData] = DocMetaData
     # compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
     full_eval: bool = False  # runs eval without sanitization. Use only on trusted input
+
+    @field_validator("port", mode="before")
+    @classmethod
+    def _ignore_service_link_port(cls, v: Any) -> Any:
+        """Ignore Kubernetes/Docker service-link `tcp://...` port values.
+
+        With `enableServiceLinks` (on by default in Kubernetes), a
+        service named e.g. `qdrant` injects `QDRANT_PORT=tcp://IP:PORT`
+        into every pod, which would otherwise fail integer validation
+        of the `port` field. Only this exact format is forgiven; any
+        other invalid value still fails validation as usual.
+        """
+        if isinstance(v, str) and v.startswith("tcp://"):
+            default = cls.model_fields["port"].default
+            logger.warning(
+                f"Ignoring port value {v!r}: it looks like a "
+                f"Kubernetes/Docker service-link artifact (an injected "
+                f"<SERVICE>_PORT env var); using default port "
+                f"{default} instead."
+            )
+            return default
+        return v
 
 
 class VectorStore(ABC):

--- a/langroid/vector_store/chromadb.py
+++ b/langroid/vector_store/chromadb.py
@@ -2,6 +2,8 @@ import json
 import logging
 from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
 
+from pydantic_settings import SettingsConfigDict
+
 from langroid.embedding_models.base import (
     EmbeddingModelsConfig,
 )
@@ -16,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 
 class ChromaDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="CHROMA_")
+
     collection_name: str = "temp"
     storage_path: str = ".chroma/data"
     distance: Literal["cosine", "l2", "ip"] = "cosine"

--- a/langroid/vector_store/lancedb.py
+++ b/langroid/vector_store/lancedb.py
@@ -20,6 +20,8 @@ from pydantic import BaseModel, ValidationError, create_model
 if TYPE_CHECKING:
     from lancedb.query import LanceVectorQueryBuilder
 
+from pydantic_settings import SettingsConfigDict
+
 from langroid.embedding_models.base import (
     EmbeddingModelsConfig,
 )
@@ -45,6 +47,8 @@ logger = logging.getLogger(__name__)
 
 
 class LanceDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="LANCEDB_")
+
     cloud: bool = False
     collection_name: str | None = "temp"
     storage_path: str = ".lancedb/data"

--- a/langroid/vector_store/meilisearch.py
+++ b/langroid/vector_store/meilisearch.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
     from meilisearch_python_sdk.models.documents import DocumentsInfo
 
 
+from pydantic_settings import SettingsConfigDict
+
 from langroid.exceptions import LangroidImportError
 from langroid.mytypes import DocMetaData, Document
 from langroid.utils.configuration import settings
@@ -30,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 
 class MeiliSearchConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="MEILISEARCH_")
+
     cloud: bool = False
     collection_name: str | None = None
     primary_key: str = "id"

--- a/langroid/vector_store/pineconedb.py
+++ b/langroid/vector_store/pineconedb.py
@@ -19,6 +19,7 @@ from dotenv import load_dotenv
 
 # import dataclass
 from pydantic import BaseModel
+from pydantic_settings import SettingsConfigDict
 
 from langroid import LangroidImportError
 from langroid.mytypes import Document
@@ -55,6 +56,8 @@ class IndexMeta:
 
 
 class PineconeDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="PINECONE_")
+
     cloud: bool = True
     collection_name: str | None = "temp"
     spec: ServerlessSpec = ServerlessSpec(cloud="aws", region="us-east-1")

--- a/langroid/vector_store/postgres.py
+++ b/langroid/vector_store/postgres.py
@@ -5,6 +5,8 @@ import os
 import uuid
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
+from pydantic_settings import SettingsConfigDict
+
 from langroid.embedding_models.base import (
     EmbeddingModelsConfig,
 )
@@ -47,6 +49,8 @@ def _quote_ident(name: str) -> str:
 
 
 class PostgresDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="POSTGRES_")
+
     collection_name: str = "embeddings"
     cloud: bool = False
     docker: bool = True

--- a/langroid/vector_store/qdrantdb.py
+++ b/langroid/vector_store/qdrantdb.py
@@ -7,6 +7,7 @@ import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, TypeVar
 
 from dotenv import load_dotenv
+from pydantic_settings import SettingsConfigDict
 
 from langroid.embedding_models.base import (
     EmbeddingModelsConfig,
@@ -49,6 +50,8 @@ def is_valid_uuid(uuid_to_test: str) -> bool:
 
 
 class QdrantDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="QDRANT_")
+
     cloud: bool = True
     docker: bool = False
     collection_name: str | None = "temp"

--- a/langroid/vector_store/weaviatedb.py
+++ b/langroid/vector_store/weaviatedb.py
@@ -4,6 +4,7 @@ import re
 from typing import Any, List, Optional, Sequence, Tuple
 
 from dotenv import load_dotenv
+from pydantic_settings import SettingsConfigDict
 
 from langroid.embedding_models.base import (
     EmbeddingModelsConfig,
@@ -28,6 +29,8 @@ class VectorDistances:
 
 
 class WeaviateDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="WEAVIATE_")
+
     collection_name: str | None = "temp"
     embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
     distance: str = VectorDistances.COSINE

--- a/llms-compressed.txt
+++ b/llms-compressed.txt
@@ -156,6 +156,7 @@ docs/
     tool-message-handler.md
     twitter-search.md
     url_loader.md
+    vecstore-env-prefix.md
     weaviate.md
     xml-tools.md
   overrides/
@@ -792,6 +793,7 @@ tests/
     test_tool_origin_taint.py
     test_tool_taint_laundering.py
     test_url_loader.py
+    test_vecstore_env_prefix.py
     test_vector_stores.py
     test_web_search_tools.py
     test_xml_tool_message.py
@@ -5194,6 +5196,207 @@ config = OpenAIGPTConfig(
 - Implements singleton pattern with lazy initialization
 - Automatically cleans up clients on program exit via atexit hooks
 - Compatible with both sync and async OpenAI clients
+</file>
+
+<file path="docs/notes/openai-http-client.md">
+# OpenAI HTTP Client Configuration
+
+When using OpenAI models through Langroid in corporate environments or behind proxies, you may encounter SSL certificate verification errors. Langroid provides three flexible options to configure the HTTP client used for OpenAI API calls.
+
+## Configuration Options
+
+### 1. Simple SSL Verification Bypass
+
+The quickest solution for development or trusted environments:
+
+```python
+import langroid.language_models as lm
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_verify_ssl=False  # Disables SSL certificate verification
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+!!! warning "Security Notice"
+    Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks. Only use this in trusted environments.
+
+### 2. HTTP Client Configuration Dictionary
+
+For common scenarios like proxies or custom certificates, use a configuration dictionary:
+
+```python
+import langroid.language_models as lm
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_config={
+        "verify": False,  # Or path to CA bundle: "/path/to/ca-bundle.pem"
+        "proxy": "http://proxy.company.com:8080",
+        "timeout": 30.0,
+        "headers": {
+            "User-Agent": "MyApp/1.0"
+        }
+    }
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+**Benefits**: This approach enables client caching, improving performance when creating multiple agents.
+
+### 3. Custom HTTP Client Factory
+
+For advanced scenarios requiring dynamic behavior or custom authentication:
+
+```python
+import langroid.language_models as lm
+from httpx import Client
+
+def create_custom_client():
+    """Factory function to create a custom HTTP client."""
+    client = Client(
+        verify="/path/to/corporate-ca-bundle.pem",
+        proxies={
+            "http": "http://proxy.corp.com:8080",
+            "https": "http://proxy.corp.com:8080"
+        },
+        timeout=30.0
+    )
+
+    # Add custom event hooks for logging
+    def log_request(request):
+        print(f"API Request: {request.method} {request.url}")
+
+    client.event_hooks = {"request": [log_request]}
+
+    return client
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_factory=create_custom_client
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+If you are using `async` methods, return a tuple of `(Client, AsyncClient)` from your factory:
+
+```python
+from httpx import AsyncClient, Client
+
+def create_custom_client():
+    """Factory function to create a custom sync and async HTTP clients."""
+    client_args = {
+        "verify": "/path/to/corporate-ca-bundle.pem",
+        "proxy": "http://proxy.corp.com:8080",
+        "timeout": 30.0,
+    }
+    client = Client(**client_args)
+    async_client = AsyncClient(**client_args)
+
+    return client, async_client
+```
+
+**Note**: Custom factories bypass client caching. Each `OpenAIGPT` instance creates a new client.
+
+## Priority Order
+
+When multiple options are specified, they are applied in this order:
+1. `http_client_factory` (highest priority)
+2. `http_client_config`
+3. `http_verify_ssl` (lowest priority)
+
+## Common Use Cases
+
+### Corporate Proxy with Custom CA Certificate
+
+```python
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_config={
+        "verify": "/path/to/corporate-ca-bundle.pem",
+        "proxies": {
+            "http": "http://proxy.corp.com:8080",
+            "https": "https://proxy.corp.com:8443"
+        }
+    }
+)
+```
+
+### Debugging API Calls
+
+```python
+def debug_client_factory():
+    from httpx import Client
+
+    client = Client(verify=False)
+
+    def log_response(response):
+        print(f"Status: {response.status_code}")
+        print(f"Headers: {response.headers}")
+
+    client.event_hooks = {
+        "response": [log_response]
+    }
+
+    return client
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_factory=debug_client_factory
+)
+```
+
+### Local Development with Self-Signed Certificates
+
+```python
+# For local OpenAI-compatible APIs
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    api_base="https://localhost:8443/v1",
+    http_verify_ssl=False
+)
+```
+
+
+## Best Practices
+
+1. **Use the simplest option that meets your needs**:
+   - Development/testing: `http_verify_ssl=False`
+   - Corporate environments: `http_client_config` with proper CA bundle
+   - Complex requirements: `http_client_factory`
+
+2. **Prefer configuration over factories for better performance** - configured clients are cached and reused
+
+3. **Always use proper CA certificates in production** instead of disabling SSL verification
+
+4. **Test your configuration** with a simple API call before deploying:
+   ```python
+   llm = lm.OpenAIGPT(config)
+   response = llm.chat("Hello")
+   print(response.content)
+   ```
+
+## Troubleshooting
+
+### SSL Certificate Errors
+```
+ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
+```
+**Solution**: Use one of the three configuration options above.
+
+
+### Proxy Connection Issues
+- Verify proxy URL format: `http://proxy:port` or `https://proxy:port`
+- Check if proxy requires authentication
+- Ensure proxy allows connections to `api.openai.com`
+
+## See Also
+
+- [OpenAI API Reference](https://platform.openai.com/docs/api-reference) - Official OpenAI documentation
 </file>
 
 <file path="docs/notes/overview.md">
@@ -33669,116 +33872,6 @@ logged = True
 __all__ = [
 </file>
 
-<file path="langroid/utils/configuration.py">
-# Global reentrant lock to serialize any modifications to the global settings.
-_global_lock = threading.RLock()
-⋮----
-class Settings(BaseSettings)
-⋮----
-debug: bool = False  # show debug messages?
-max_turns: int = -1  # maximum number of turns in a task (to avoid inf loop)
-progress: bool = False  # show progress spinners/bars?
-stream: bool = True  # stream output?
-cache: bool = True  # use cache?
-cache_type: Literal["redis", "fakeredis", "none"] = "redis"  # cache type
-chat_model: str = ""  # language model name, e.g. litellm/ollama/llama2
-quiet: bool = False  # quiet mode (i.e. suppress all output)?
-notebook: bool = False  # running in a notebook?
-⋮----
-model_config = SettingsConfigDict(extra="forbid")
-⋮----
-# Load environment variables from .env file.
-⋮----
-# The global (default) settings instance.
-# This is updated by update_global_settings() and set_global().
-_global_settings = Settings()
-⋮----
-# Thread-local storage for temporary (per-thread) settings overrides.
-_thread_local = threading.local()
-⋮----
-class SettingsProxy
-⋮----
-"""
-    A proxy for the settings that returns a thread‐local override if set,
-    or else falls back to the global settings.
-    """
-⋮----
-def __getattr__(self, name: str) -> Any
-⋮----
-# If the calling thread has set an override, use that.
-⋮----
-def __setattr__(self, name: str, value: Any) -> None
-⋮----
-# All writes go to the global settings.
-⋮----
-def update(self, new_settings: Settings) -> None
-⋮----
-def dict(self) -> Dict[str, Any]
-⋮----
-# Return a dict view of the settings as seen by the caller.
-# Note that temporary overrides are not “merged” with global settings.
-⋮----
-settings = SettingsProxy()
-⋮----
-def update_global_settings(cfg: BaseSettings, keys: List[str]) -> None
-⋮----
-"""
-    Update global settings so that modules can later access them via, e.g.,
-
-        from langroid.utils.configuration import settings
-        if settings.debug: ...
-
-    This updates the global default.
-    """
-config_dict = cfg.model_dump()
-filtered_config = {key: config_dict[key] for key in keys if key in config_dict}
-new_settings = Settings(**filtered_config)
-⋮----
-def set_global(key_vals: Settings) -> None
-⋮----
-"""
-    Update the global settings object.
-    """
-⋮----
-@contextmanager
-def temporary_settings(temp_settings: Settings) -> Iterator[None]
-⋮----
-"""
-    Temporarily override the settings for the calling thread.
-
-    Within the context, any access to "settings" will use the provided temporary
-    settings. Once the context is exited, the thread reverts to the global settings.
-    """
-saved = getattr(_thread_local, "override", None)
-⋮----
-@contextmanager
-def quiet_mode(quiet: bool = True) -> Iterator[None]
-⋮----
-"""
-    Temporarily override settings.quiet for the current thread.
-    This implementation builds on the thread‑local temporary_settings context manager.
-    The effective quiet mode is merged:
-    if quiet is already True (from an outer context),
-    then it remains True even if a nested context passes quiet=False.
-    """
-current_effective = (
-⋮----
-)  # get the current thread's effective settings
-# Create a new settings instance from the current effective state.
-temp = Settings(**current_effective)
-# Merge the new flag: once quiet is enabled, it stays enabled.
-⋮----
-def set_env(settings_instance: BaseSettings) -> None
-⋮----
-"""
-    Set environment variables from a BaseSettings instance.
-
-    Each field in the settings is written to os.environ.
-    """
-⋮----
-env_var_name = field.alias or field_name.upper()
-</file>
-
 <file path="langroid/utils/constants.py">
 # Define the ANSI escape sequences for various colors and reset
 class Colors(BaseModel)
@@ -46162,207 +46255,6 @@ matches = agent.vecdb.similar_texts_with_scores(
 ```
 </file>
 
-<file path="docs/notes/openai-http-client.md">
-# OpenAI HTTP Client Configuration
-
-When using OpenAI models through Langroid in corporate environments or behind proxies, you may encounter SSL certificate verification errors. Langroid provides three flexible options to configure the HTTP client used for OpenAI API calls.
-
-## Configuration Options
-
-### 1. Simple SSL Verification Bypass
-
-The quickest solution for development or trusted environments:
-
-```python
-import langroid.language_models as lm
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_verify_ssl=False  # Disables SSL certificate verification
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-!!! warning "Security Notice"
-    Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks. Only use this in trusted environments.
-
-### 2. HTTP Client Configuration Dictionary
-
-For common scenarios like proxies or custom certificates, use a configuration dictionary:
-
-```python
-import langroid.language_models as lm
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_config={
-        "verify": False,  # Or path to CA bundle: "/path/to/ca-bundle.pem"
-        "proxy": "http://proxy.company.com:8080",
-        "timeout": 30.0,
-        "headers": {
-            "User-Agent": "MyApp/1.0"
-        }
-    }
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-**Benefits**: This approach enables client caching, improving performance when creating multiple agents.
-
-### 3. Custom HTTP Client Factory
-
-For advanced scenarios requiring dynamic behavior or custom authentication:
-
-```python
-import langroid.language_models as lm
-from httpx import Client
-
-def create_custom_client():
-    """Factory function to create a custom HTTP client."""
-    client = Client(
-        verify="/path/to/corporate-ca-bundle.pem",
-        proxies={
-            "http": "http://proxy.corp.com:8080",
-            "https": "http://proxy.corp.com:8080"
-        },
-        timeout=30.0
-    )
-
-    # Add custom event hooks for logging
-    def log_request(request):
-        print(f"API Request: {request.method} {request.url}")
-
-    client.event_hooks = {"request": [log_request]}
-
-    return client
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_factory=create_custom_client
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-If you are using `async` methods, return a tuple of `(Client, AsyncClient)` from your factory:
-
-```python
-from httpx import AsyncClient, Client
-
-def create_custom_client():
-    """Factory function to create a custom sync and async HTTP clients."""
-    client_args = {
-        "verify": "/path/to/corporate-ca-bundle.pem",
-        "proxy": "http://proxy.corp.com:8080",
-        "timeout": 30.0,
-    }
-    client = Client(**client_args)
-    async_client = AsyncClient(**client_args)
-
-    return client, async_client
-```
-
-**Note**: Custom factories bypass client caching. Each `OpenAIGPT` instance creates a new client.
-
-## Priority Order
-
-When multiple options are specified, they are applied in this order:
-1. `http_client_factory` (highest priority)
-2. `http_client_config`
-3. `http_verify_ssl` (lowest priority)
-
-## Common Use Cases
-
-### Corporate Proxy with Custom CA Certificate
-
-```python
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_config={
-        "verify": "/path/to/corporate-ca-bundle.pem",
-        "proxies": {
-            "http": "http://proxy.corp.com:8080",
-            "https": "https://proxy.corp.com:8443"
-        }
-    }
-)
-```
-
-### Debugging API Calls
-
-```python
-def debug_client_factory():
-    from httpx import Client
-
-    client = Client(verify=False)
-
-    def log_response(response):
-        print(f"Status: {response.status_code}")
-        print(f"Headers: {response.headers}")
-
-    client.event_hooks = {
-        "response": [log_response]
-    }
-
-    return client
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_factory=debug_client_factory
-)
-```
-
-### Local Development with Self-Signed Certificates
-
-```python
-# For local OpenAI-compatible APIs
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    api_base="https://localhost:8443/v1",
-    http_verify_ssl=False
-)
-```
-
-
-## Best Practices
-
-1. **Use the simplest option that meets your needs**:
-   - Development/testing: `http_verify_ssl=False`
-   - Corporate environments: `http_client_config` with proper CA bundle
-   - Complex requirements: `http_client_factory`
-
-2. **Prefer configuration over factories for better performance** - configured clients are cached and reused
-
-3. **Always use proper CA certificates in production** instead of disabling SSL verification
-
-4. **Test your configuration** with a simple API call before deploying:
-   ```python
-   llm = lm.OpenAIGPT(config)
-   response = llm.chat("Hello")
-   print(response.content)
-   ```
-
-## Troubleshooting
-
-### SSL Certificate Errors
-```
-ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
-```
-**Solution**: Use one of the three configuration options above.
-
-
-### Proxy Connection Issues
-- Verify proxy URL format: `http://proxy:port` or `https://proxy:port`
-- Check if proxy requires authentication
-- Ensure proxy allows connections to `api.openai.com`
-
-## See Also
-
-- [OpenAI API Reference](https://platform.openai.com/docs/api-reference) - Official OpenAI documentation
-</file>
-
 <file path="docs/notes/rotating-api-keys.md">
 # Rotating / Short-Lived API Keys
 
@@ -51929,6 +51821,120 @@ result = WebSearchResult(
 link=None,  # skip HTTP fetch; Seltz already provides content
 </file>
 
+<file path="langroid/utils/configuration.py">
+# Global reentrant lock to serialize any modifications to the global settings.
+_global_lock = threading.RLock()
+⋮----
+class Settings(BaseSettings)
+⋮----
+debug: bool = False  # show debug messages?
+max_turns: int = -1  # maximum number of turns in a task (to avoid inf loop)
+progress: bool = False  # show progress spinners/bars?
+stream: bool = True  # stream output?
+cache: bool = True  # use cache?
+cache_type: Literal["redis", "fakeredis", "none"] = "redis"  # cache type
+chat_model: str = ""  # language model name, e.g. litellm/ollama/llama2
+quiet: bool = False  # quiet mode (i.e. suppress all output)?
+notebook: bool = False  # running in a notebook?
+⋮----
+model_config = SettingsConfigDict(extra="forbid")
+⋮----
+# Load environment variables from .env file.
+⋮----
+# The global (default) settings instance.
+# This is updated by update_global_settings() and set_global().
+_global_settings = Settings()
+⋮----
+# Thread-local storage for temporary (per-thread) settings overrides.
+_thread_local = threading.local()
+⋮----
+class SettingsProxy
+⋮----
+"""
+    A proxy for the settings that returns a thread‐local override if set,
+    or else falls back to the global settings.
+    """
+⋮----
+def __getattr__(self, name: str) -> Any
+⋮----
+# If the calling thread has set an override, use that.
+⋮----
+def __setattr__(self, name: str, value: Any) -> None
+⋮----
+# All writes go to the global settings.
+⋮----
+def update(self, new_settings: Settings) -> None
+⋮----
+def dict(self) -> Dict[str, Any]
+⋮----
+# Return a dict view of the settings as seen by the caller.
+# Note that temporary overrides are not “merged” with global settings.
+⋮----
+settings = SettingsProxy()
+⋮----
+def update_global_settings(cfg: BaseSettings, keys: List[str]) -> None
+⋮----
+"""
+    Update global settings so that modules can later access them via, e.g.,
+
+        from langroid.utils.configuration import settings
+        if settings.debug: ...
+
+    This updates the global default.
+    """
+config_dict = cfg.model_dump()
+filtered_config = {key: config_dict[key] for key in keys if key in config_dict}
+new_settings = Settings(**filtered_config)
+⋮----
+def set_global(key_vals: Settings) -> None
+⋮----
+"""
+    Update the global settings object.
+    """
+⋮----
+@contextmanager
+def temporary_settings(temp_settings: Settings) -> Iterator[None]
+⋮----
+"""
+    Temporarily override the settings for the calling thread.
+
+    Within the context, any access to "settings" will use the provided temporary
+    settings. Once the context is exited, the thread reverts to the global settings.
+    """
+saved = getattr(_thread_local, "override", None)
+⋮----
+@contextmanager
+def quiet_mode(quiet: bool = True) -> Iterator[None]
+⋮----
+"""
+    Temporarily override settings.quiet for the current thread.
+    This implementation builds on the thread‑local temporary_settings context manager.
+    The effective quiet mode is merged:
+    if quiet is already True (from an outer context),
+    then it remains True even if a nested context passes quiet=False.
+    """
+current_effective = (
+⋮----
+)  # get the current thread's effective settings
+# Create a new settings instance from the current effective state.
+temp = Settings(**current_effective)
+# Merge the new flag: once quiet is enabled, it stays enabled.
+⋮----
+def set_env(settings_instance: BaseSettings) -> None
+⋮----
+"""
+    Set environment variables from a BaseSettings instance.
+
+    Each field in the settings is written to os.environ, under the name
+    the settings class itself reads: `<env_prefix><FIELD_NAME_UPPER>`,
+    or the field's explicit alias (which, per pydantic-settings
+    semantics, is the full env name and is not prefixed).
+    """
+env_prefix = settings_instance.model_config.get("env_prefix", "")
+⋮----
+env_var_name = field.alias or f"{env_prefix}{field_name.upper()}"
+</file>
+
 <file path="langroid/utils/pandas_utils.py">
 COMMON_USE_DF_METHODS = {
 ⋮----
@@ -52656,472 +52662,6 @@ chromadb  # silence linters
 postgres  # silence linters
 </file>
 
-<file path="langroid/vector_store/chromadb.py">
-logger = logging.getLogger(__name__)
-⋮----
-class ChromaDBConfig(VectorStoreConfig)
-⋮----
-collection_name: str = "temp"
-storage_path: str = ".chroma/data"
-distance: Literal["cosine", "l2", "ip"] = "cosine"
-construction_ef: int = 100
-search_ef: int = 100
-max_neighbors: int = 16
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-host: str = "127.0.0.1"
-port: int = 6333
-⋮----
-class ChromaDB(VectorStore)
-⋮----
-def __init__(self, config: ChromaDBConfig | None = None)
-⋮----
-config = config if config is not None else ChromaDBConfig()
-⋮----
-# chroma_db_impl="duckdb+parquet",
-# is_persistent=bool(config.storage_path),
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""Clear all collections in the vector store with the given prefix."""
-⋮----
-coll = [c for c in self.client.list_collections() if c.name.startswith(prefix)]
-⋮----
-n_empty_deletes = 0
-n_non_empty_deletes = 0
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-colls = self.client.list_collections()
-n_deletes = 0
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""
-        List non-empty collections in the vector store.
-        Args:
-            empty (bool, optional): Whether to list empty collections.
-        Returns:
-            List[str]: List of non-empty collection names.
-        """
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""
-        Create a collection in the vector store, optionally replacing an existing
-            collection if `replace` is True.
-        Args:
-            collection_name (str): Name of the collection to create or replace.
-            replace (bool, optional): Whether to replace an existing collection.
-                Defaults to False.
-
-        """
-⋮----
-# we could expose other configs, see:
-# https://docs.trychroma.com/docs/collections/configure
-⋮----
-def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-contents: List[str] = [document.content for document in documents]
-# convert metadatas to dicts so chroma can handle them
-metadata_dicts: List[dict[str, Any]] = [
-⋮----
-# chroma does not handle non-atomic types in metadata
-⋮----
-ids = [str(d.id()) for d in documents]
-⋮----
-colls = self.list_collections(empty=True)
-⋮----
-# embedding_models=embedding_models,
-⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-filter = json.loads(where) if where else None
-results = self.collection.get(
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-# get them one by one since chroma mangles the order of the results
-# when fetched from a list of ids.
-results = [
-final_results = {}
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-n = self.collection.count()
-⋮----
-results = self.collection.query(
-docs = self._docs_from_results(results)
-# chroma distances are 1 - cosine.
-scores = [1 - s for s in results["distances"][0]]
-⋮----
-def _docs_from_results(self, results: Dict[str, Any]) -> List[Document]
-⋮----
-"""
-        Helper function to convert results from ChromaDB to a list of Documents
-        Args:
-            results (dict): results from ChromaDB
-
-        Returns:
-            List[Document]: list of Documents
-        """
-⋮----
-contents = results["documents"][0]
-⋮----
-metadatas = results["metadatas"][0]
-⋮----
-# restore the stringified list of window_ids into the original List[str]
-⋮----
-docs = [
-</file>
-
-<file path="langroid/vector_store/lancedb.py">
-has_lancedb = True
-⋮----
-has_lancedb = False
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-class LanceDBConfig(VectorStoreConfig)
-⋮----
-cloud: bool = False
-collection_name: str | None = "temp"
-storage_path: str = ".lancedb/data"
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-distance: str = "cosine"
-⋮----
-class LanceDB(VectorStore)
-⋮----
-def __init__(self, config: LanceDBConfig | None = None)
-⋮----
-config = config if config is not None else LanceDBConfig()
-⋮----
-self.is_from_dataframe = False  # were docs ingested from a dataframe?
-self.df_metadata_columns: List[str] = []  # metadata columns from dataframe
-⋮----
-new_storage_path = config.storage_path + ".new"
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-coll_names = self.list_collections()
-n_deletes = 0
-⋮----
-nr = self.client.open_table(name).head(1).shape[0]
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""Clear all collections with the given prefix."""
-⋮----
-coll_names = [
-⋮----
-n_empty_deletes = 0
-n_non_empty_deletes = 0
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""
-        Returns:
-            List of collection names that have at least one vector.
-
-        Args:
-            empty (bool, optional): Whether to include empty collections.
-        """
-colls = self.client.table_names(limit=None)
-⋮----
-if empty:  # include empty tbls
-return colls  # type: ignore
-counts = [self.client.open_table(coll).head(1).shape[0] for coll in colls]
-⋮----
-def _create_lance_schema(self, doc_cls: Type[Document]) -> Type[BaseModel]
-⋮----
-"""
-        NOTE: NOT USED, but leaving it here as it may be useful.
-
-        Create a subclass of LanceModel with fields:
-         - id (str)
-         - Vector field that has dims equal to
-            the embedding dimension of the embedding model, and a data field of type
-            DocClass.
-         - other fields from doc_cls
-
-        Args:
-            doc_cls (Type[Document]): A Pydantic model which should be a subclass of
-                Document, to be used as the type for the data field.
-
-        Returns:
-            Type[BaseModel]: A new Pydantic model subclassing from LanceModel.
-
-        Raises:
-            ValueError: If `n` is not a non-negative integer or if `DocClass` is not a
-                subclass of Document.
-        """
-⋮----
-n = self.embedding_dim
-⋮----
-# Prepare fields for the new model
-fields = {"id": (str, ...), "vector": (Vector(n), ...)}
-⋮----
-sorted_fields = dict(
-# Add both statically and dynamically defined fields from doc_cls
-⋮----
-field_type = field.annotation if hasattr(field, "annotation") else field
-⋮----
-# Create the new model with dynamic fields
-NewModel = create_model(
-⋮----
-)  # type: ignore
-return NewModel  # type: ignore
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-colls = self.list_collections(empty=True)
-⋮----
-embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-coll_name = self.config.collection_name
-⋮----
-# self._maybe_set_doc_class_schema(documents[0])
-table_exists = False
-⋮----
-# collection exists and  is not empty:
-# if replace_collection is True, we'll overwrite the existing collection,
-# else we'll append to it.
-⋮----
-table_exists = True
-⋮----
-ids = [str(d.id()) for d in documents]
-# don't insert all at once, batch in chunks of b,
-# else we get an API error
-b = self.config.batch_size
-⋮----
-def make_batches() -> Generator[List[Dict[str, Any]], None, None]
-⋮----
-batch = [
-⋮----
-tbl = self.client.open_table(coll_name)
-⋮----
-batch_gen = make_batches()
-batch = next(batch_gen)
-# use first batch to create table...
-tbl = self.client.create_table(
-# ... and add the rest
-⋮----
-"""
-        Add a dataframe to the collection.
-        Args:
-            df (pd.DataFrame): A dataframe
-            content (str): The name of the column in the dataframe that contains the
-                text content to be embedded using the embedding model.
-            metadata (List[str]): A list of column names in the dataframe that contain
-                metadata to be stored in the database. Defaults to [].
-        """
-⋮----
-actual_metadata = metadata.copy()
-self.df_metadata_columns = actual_metadata  # could be updated below
-# get content column
-content_values = df[content].values.tolist()
-embedding_vecs = self.embedding_fn(content_values)
-⋮----
-# add vector column
-⋮----
-# rename content column to "content", leave existing column intact
-df = df.rename(columns={content: "content"}, inplace=False)
-⋮----
-docs = dataframe_to_documents(df, content="content", metadata=metadata)
-ids = [str(d.id()) for d in docs]
-⋮----
-# collection either doesn't exist or is empty, so replace it
-# and set new schema from df
-⋮----
-doc_cls = dataframe_to_document_model(
-self.config.document_class = doc_cls  # type: ignore
-⋮----
-# collection exists and is not empty, so append to it
-tbl = self.client.open_table(self.config.collection_name)
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-df = result.to_pandas()
-⋮----
-records = result.to_arrow().to_pylist()
-⋮----
-def _records_to_docs(self, records: List[Dict[str, Any]]) -> List[Document]
-⋮----
-docs = [self.config.document_class(**rec) for rec in records]
-⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-pre_result = tbl.search(None).where(where or None).limit(None)
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-_ids = [str(id) for id in ids]
-⋮----
-docs = []
-⋮----
-results = self._lance_result_to_docs(tbl.search().where(f"id == '{_id}'"))
-⋮----
-embedding = self.embedding_fn([text])[0]
-⋮----
-result = (
-docs = self._lance_result_to_docs(result)
-# note _distance is 1 - cosine
-⋮----
-scores = [
-⋮----
-scores = [1 - rec["_distance"] for rec in result.to_arrow().to_pylist()]
-⋮----
-doc_score_pairs = list(zip(docs, scores))
-</file>
-
-<file path="langroid/vector_store/meilisearch.py">
-"""
-MeiliSearch as a pure document store, without its
-(experimental) vector-store functionality.
-We aim to use MeiliSearch for fast lexical search.
-Note that what we call "Collection" in Langroid is referred to as
-"Index" in MeiliSearch. Each data-store has its own terminology,
-but for uniformity we use the Langroid terminology here.
-"""
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-class MeiliSearchConfig(VectorStoreConfig)
-⋮----
-cloud: bool = False
-collection_name: str | None = None
-primary_key: str = "id"
-port: int = 7700
-⋮----
-class MeiliSearch(VectorStore)
-⋮----
-def __init__(self, config: MeiliSearchConfig | None = None)
-⋮----
-config = config if config is not None else MeiliSearchConfig()
-⋮----
-# Note: Only create collection if a non-null collection name is provided.
-# This is useful to delay creation of db until we have a suitable
-# collection name (e.g. we could get it from the url or folder path).
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-"""All collections are treated as non-empty in MeiliSearch, so this is a
-        no-op"""
-⋮----
-async def _async_delete_indices(self, uids: List[str]) -> List[bool]
-⋮----
-"""Delete any indicecs in `uids` that exist.
-        Returns list of bools indicating whether the index has been deleted"""
-⋮----
-result = await asyncio.gather(
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""Delete all indices whose names start with `prefix`"""
-⋮----
-coll_names = [c for c in self.list_collections() if c.startswith(prefix)]
-deletes = asyncio.run(self._async_delete_indices(coll_names))
-n_deletes = sum(deletes)
-⋮----
-def _list_all_collections(self) -> List[str]
-⋮----
-"""
-        List all collections, including empty ones.
-        Returns:
-            List of collection names.
-        """
-⋮----
-async def _async_get_indexes(self) -> List[AsyncIndex]
-⋮----
-indexes = await client.get_indexes(limit=10_000)
-return [] if indexes is None else indexes  # type: ignore
-⋮----
-async def _async_get_index(self, index_uid: str) -> "AsyncIndex"
-⋮----
-index = await client.get_index(index_uid)
-return index  # type: ignore
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""
-        Returns:
-            List of index names stored. We treat any existing index as non-empty.
-        """
-indexes = asyncio.run(self._async_get_indexes())
-⋮----
-async def _async_create_index(self, collection_name: str) -> "AsyncIndex"
-⋮----
-index = await client.create_index(
-⋮----
-async def _async_delete_index(self, collection_name: str) -> bool
-⋮----
-"""Delete index if it exists. Returns True iff index was deleted"""
-⋮----
-result = await client.delete_index_if_exists(uid=collection_name)
-return result  # type: ignore
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""
-        Create a collection with the given name, optionally replacing an existing
-            collection if `replace` is True.
-        Args:
-            collection_name (str): Name of the collection to create.
-            replace (bool): Whether to replace an existing collection
-                with the same name. Defaults to False.
-        """
-⋮----
-collections = self.list_collections()
-⋮----
-collection_info = asyncio.run(self._async_get_index(collection_name))
-⋮----
-level = logger.getEffectiveLevel()
-⋮----
-index = client.index(collection_name)
-⋮----
-def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-colls = self._list_all_collections()
-⋮----
-docs = [
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-def _to_int_or_uuid(self, id: str) -> int | str
-⋮----
-async def _async_get_documents(self, where: str = "") -> "DocumentsInfo"
-⋮----
-filter = [] if where is None else where
-⋮----
-index = client.index(self.config.collection_name)
-documents = await index.get_documents(limit=10_000, filter=filter)
-⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-docs = asyncio.run(self._async_get_documents(where))
-⋮----
-doc_results = docs.results
-⋮----
-async def _async_get_documents_by_ids(self, ids: List[str]) -> List[Dict[str, Any]]
-⋮----
-documents = await asyncio.gather(*[index.get_document(id) for id in ids])
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-docs = asyncio.run(self._async_get_documents_by_ids(ids))
-⋮----
-results = await index.search(
-return results.hits  # type: ignore
-⋮----
-neighbors: int = 0,  # ignored
-⋮----
-_docs = asyncio.run(self._async_search(text, k, filter))  # type: ignore
-⋮----
-scores = [h["_rankingScore"] for h in _docs]
-⋮----
-doc_score_pairs = list(zip(docs, scores))
-</file>
-
 <file path="langroid/vector_store/milvusdb.py">
 logger = logging.getLogger(__name__)
 ⋮----
@@ -53304,348 +52844,6 @@ comparisons = " or ".join(
 ⋮----
 @staticmethod
     def _format_filter_value(value: Any) -> str
-</file>
-
-<file path="langroid/vector_store/pineconedb.py">
-# import dataclass
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-has_pinecone: bool = True
-⋮----
-class ServerlessSpec(BaseModel)
-⋮----
-"""
-            Fallback Serverless specification configuration to avoid import errors.
-            """
-⋮----
-cloud: str
-region: str
-⋮----
-PineconeApiException = Any  # type: ignore
-Pinecone = Any  # type: ignore
-has_pinecone = False
-⋮----
-@dataclass(frozen=True)
-class IndexMeta
-⋮----
-name: str
-total_vector_count: int
-⋮----
-class PineconeDBConfig(VectorStoreConfig)
-⋮----
-cloud: bool = True
-collection_name: str | None = "temp"
-spec: ServerlessSpec = ServerlessSpec(cloud="aws", region="us-east-1")
-deletion_protection: Literal["enabled", "disabled"] | None = None
-metric: str = "cosine"
-pagination_size: int = 100
-⋮----
-class PineconeDB(VectorStore)
-⋮----
-def __init__(self, config: PineconeDBConfig | None = None)
-⋮----
-config = config if config is not None else PineconeDBConfig()
-⋮----
-key = os.getenv("PINECONE_API_KEY")
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-indexes = self._list_index_metas(empty=True)
-n_deletes = 0
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""
-        Returns:
-            Number of Pinecone indexes that were deleted
-
-        Args:
-            really: Optional[bool] - whether to really delete all Pinecone collections
-            prefix: Optional[str] - string to match potential Pinecone
-                indexes for deletion
-        """
-⋮----
-indexes = [
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""
-        Returns:
-            List of Pinecone indices that have at least one vector.
-
-        Args:
-            empty: Optional[bool] - whether to include empty collections
-        """
-indexes = self.client.list_indexes()
-res: List[str] = []
-⋮----
-index_meta = self.client.Index(name=index)
-⋮----
-def _list_index_metas(self, empty: bool = False) -> List[IndexMeta]
-⋮----
-"""
-        Returns:
-            List of objects describing Pinecone indices
-
-        Args:
-            empty: Optional[bool] - whether to include empty collections
-        """
-⋮----
-res = []
-⋮----
-index_meta = self._fetch_index_meta(index)
-⋮----
-def _fetch_index_meta(self, index_name: str) -> IndexMeta
-⋮----
-"""
-        Returns:
-            A dataclass describing the input Index by name and vector count
-            to save a bit on index description calls
-
-        Args:
-            index_name: str - Name of the index in Pinecone
-        """
-⋮----
-index = self.client.Index(name=index_name)
-stats = index.describe_index_stats()
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""
-        Create a collection with the given name, optionally replacing an existing
-        collection if `replace` is True.
-
-        Args:
-            collection_name: str - Configuration of the collection to create.
-            replace: Optional[Bool] - Whether to replace an existing collection
-                with the same name. Defaults to False.
-        """
-pattern = re.compile(r"^[a-z0-9-]+$")
-⋮----
-index = self.client.Index(name=collection_name)
-⋮----
-status = self.client.describe_index(name=collection_name)
-⋮----
-payload = {
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-def add_documents(self, documents: Sequence[Document], namespace: str = "") -> None
-⋮----
-document_dicts = [doc.model_dump() for doc in documents]
-document_ids = [doc.id() for doc in documents]
-embedding_vectors = self.embedding_fn([doc.content for doc in documents])
-vectors = [
-⋮----
-index = self.client.Index(name=self.config.collection_name)
-batch_size = self.config.batch_size
-⋮----
-"""
-        Returns:
-            All documents for the collection currently defined in
-            the configuration object
-
-        Args:
-            prefix: str - document id prefix to search for
-            namespace: str - partition of vectors to search within the index
-        """
-⋮----
-docs = []
-⋮----
-request_filters: Dict[str, Union[str, int]] = {
-⋮----
-response = index.list_paginated(**request_filters)
-vectors = response.get("vectors", [])
-⋮----
-pagination_token = response.get("pagination", {}).get("next", None)
-⋮----
-"""
-        Returns:
-            Fetches document text embedded in Pinecone index metadata
-
-        Args:
-            ids: List[str] - vector data object ids to retrieve
-            namespace: str - partition of vectors to search within the index
-        """
-⋮----
-records = index.fetch(ids=ids, namespace=namespace)
-⋮----
-records = index.fetch(ids=ids)
-⋮----
-id_mapping = {key: value for key, value in records["vectors"].items()}
-ordered_payloads = [id_mapping[_id] for _id in ids if _id in id_mapping]
-⋮----
-vector_search_request = {
-⋮----
-response = index.query(**vector_search_request)
-doc_score_pairs = [
-⋮----
-max_score = max([pair[1] for pair in doc_score_pairs])
-⋮----
-def transform_pinecone_vector(self, metadata_dict: Dict[str, Any]) -> Document
-⋮----
-"""
-        Parses the metadata response from the Pinecone vector query and
-        formats it into a dictionary that can be parsed by the Document class
-        associated with the PineconeDBConfig class
-
-        Returns:
-            Well formed dictionary object to be transformed into a Document
-
-        Args:
-            metadata_dict: Dict - the metadata dictionary from the Pinecone
-                vector query match
-        """
-</file>
-
-<file path="langroid/vector_store/weaviatedb.py">
-logger = logging.getLogger(__name__)
-⋮----
-class VectorDistances
-⋮----
-"""
-    Fallback class when weaviate is not installed, to avoid import errors.
-    """
-⋮----
-COSINE: str = "cosine"
-DOTPRODUCT: str = "dot"
-L2: str = "l2"
-⋮----
-class WeaviateDBConfig(VectorStoreConfig)
-⋮----
-collection_name: str | None = "temp"
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-distance: str = VectorDistances.COSINE
-cloud: bool = False
-docker: bool = False
-host: str = "127.0.0.1"
-port: int = 8080
-storage_path: str = ".weaviate_embedded/data"
-⋮----
-class WeaviateDB(VectorStore)
-⋮----
-def __init__(self, config: WeaviateDBConfig | None = None)
-⋮----
-config = config if config is not None else WeaviateDBConfig()
-⋮----
-key = os.getenv("WEAVIATE_API_KEY")
-url = os.getenv("WEAVIATE_API_URL")
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-colls = self.client.collections.list_all()
-n_deletes = 0
-⋮----
-val = self.client.collections.get(coll_name)
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-non_empty_colls = [
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-coll_names = [
-⋮----
-n_empty_deletes = 0
-n_non_empty_deletes = 0
-⋮----
-info = self.client.collections.get(name)
-points_count = len(info)
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-collection_name = WeaviateDB.validate_and_format_collection_name(
-⋮----
-coll = self.client.collections.get(name=collection_name)
-⋮----
-vector_index_config = Configure.VectorIndex.hnsw(
-⋮----
-vectorizer_config = Configure.Vectorizer.text2vec_openai(
-⋮----
-vectorizer_config = None
-⋮----
-collection_info = self.client.collections.create(
-collection_info = self.client.collections.get(name=collection_name)
-⋮----
-level = logger.getEffectiveLevel()
-⋮----
-def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-colls = self.list_collections(empty=True)
-⋮----
-document_dicts = [doc.model_dump() for doc in documents]
-embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-⋮----
-coll_name = self.client.collections.get(self.config.collection_name)
-⋮----
-id = doc_dict["metadata"].pop("id", None)
-⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-# cannot use filter as client does not support json type queries
-coll = self.client.collections.get(self.config.collection_name)
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-docs = []
-⋮----
-result = coll_name.query.fetch_objects(
-⋮----
-id_to_doc = {}
-⋮----
-doc = self.weaviate_obj_to_doc(item)
-⋮----
-# Reconstruct the list of documents in the original order of input ids
-docs = [id_to_doc[id] for id in ids if id in id_to_doc]
-⋮----
-embedding = self.embedding_fn([text])[0]
-⋮----
-response = coll.query.near_vector(
-maybe_distances = [item.metadata.distance for item in response.objects]
-similarities = [0 if d is None else 1 - d for d in maybe_distances]
-docs = [self.weaviate_obj_to_doc(item) for item in response.objects]
-⋮----
-def _create_valid_uuid_id(self, id: str) -> Any
-⋮----
-id = get_valid_uuid(id)
-⋮----
-def weaviate_obj_to_doc(self, input_object: Any) -> Document
-⋮----
-content = input_object.properties.get("content", "")
-metadata_dict = input_object.properties.get("metadata", {})
-⋮----
-window_ids = metadata_dict.pop("window_ids", [])
-window_ids = [str(uuid) for uuid in window_ids]
-⋮----
-# Ensure the id is a valid UUID string
-id_value = get_valid_uuid(input_object.uuid)
-⋮----
-metadata = DocMetaData(id=id_value, window_ids=window_ids, **metadata_dict)
-⋮----
-@staticmethod
-    def validate_and_format_collection_name(name: str) -> str
-⋮----
-"""
-        Formats the collection name to comply with Weaviate's naming rules:
-        - Name must start with a capital letter.
-        - Name can only contain letters, numbers, and underscores.
-        - Replaces invalid characters with underscores.
-        """
-⋮----
-formatted_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
-⋮----
-# Ensure the first letter is capitalized
-⋮----
-formatted_name = formatted_name.capitalize()
-⋮----
-# Check if the name now meets the criteria
-⋮----
-def __del__(self) -> None
-⋮----
-# Gracefully close the connection with local client
 </file>
 
 <file path="tests/main/sql_chat/test_sql_chat_agent.py">
@@ -58685,6 +57883,92 @@ follow_up = agent.agent_response(laundered)
 text = "" if follow_up is None else follow_up.content
 </file>
 
+<file path="docs/notes/vecstore-env-prefix.md">
+# Vector-Store Config Env-Var Prefixes
+
+Vector-store configs are `pydantic-settings` classes, which means their
+fields can be set via environment variables. Prior to this change (see
+issue #1078), `VectorStoreConfig` and its subclasses declared **no
+`env_prefix`**, so every field name was itself a case-insensitive
+environment variable. A bare `HOST`, `PORT`, `CLOUD`, `TIMEOUT`,
+`BATCH_SIZE`, `STORAGE_PATH`, `COLLECTION_NAME`, or `FULL_EVAL` in the
+environment silently overrode the default for *every* vector-store
+config:
+
+```bash
+HOST=evil.example.com PORT=9999 FULL_EVAL=true \
+  python -c "from langroid.vector_store.qdrantdb import QdrantDBConfig; \
+             c = QdrantDBConfig(); print(c.host, c.port, c.full_eval)"
+# old behavior: evil.example.com 9999 True
+```
+
+This was dangerous for two reasons:
+
+- `HOST` and `PORT` are routinely set by shells, containers, and CI
+  systems, so vector-store clients could silently point at the wrong
+  server.
+- `FULL_EVAL=true` disabled the code-injection guard (see
+  [code-injection-protection](code-injection-protection.md)) with no
+  explicit opt-in anywhere in the user's code.
+
+## New behavior
+
+Each vector-store config now has its own env prefix, consistent with
+the rest of the codebase (`OPENAI_`, `AZURE_OPENAI_`, `NEO4J_`, ...):
+
+| Config class        | Env prefix     |
+|---------------------|----------------|
+| `VectorStoreConfig` | `VECDB_`       |
+| `QdrantDBConfig`    | `QDRANT_`      |
+| `ChromaDBConfig`    | `CHROMA_`      |
+| `LanceDBConfig`     | `LANCEDB_`     |
+| `PineconeDBConfig`  | `PINECONE_`    |
+| `PostgresDBConfig`  | `POSTGRES_`    |
+| `MeiliSearchConfig` | `MEILISEARCH_` |
+| `WeaviateDBConfig`  | `WEAVIATE_`    |
+
+Bare env vars (`HOST`, `FULL_EVAL`, ...) are now ignored by all of
+these configs. To set a field via the environment, use the prefix of
+the specific config class, e.g. `QDRANT_HOST=my.qdrant.example` or
+`QDRANT_FULL_EVAL=true` for `QdrantDBConfig`. Every provider subclass
+in langroid overrides the prefix with its own, so within langroid
+`VECDB_*` vars affect only direct `VectorStoreConfig` instances.
+However, pydantic inherits `model_config`, so a third-party subclass
+of `VectorStoreConfig` that does not set its own `env_prefix` will
+read `VECDB_*` vars.
+
+A `port` value coming from the *environment* that matches the exact
+Kubernetes service-link format `tcp://<host>:<digits>` (e.g.
+`QDRANT_PORT=tcp://10.0.0.8:6333`, injected into every pod by a
+service named `qdrant` when `enableServiceLinks` is on) is ignored
+with a warning and the default port is used. This exception applies
+only to the env settings source and only to that full format:
+malformed `tcp://` junk in the environment, and any `tcp://...` value
+passed explicitly to the constructor, fail validation as usual.
+
+Explicit constructor arguments always take priority over environment
+values (standard `pydantic-settings` precedence):
+
+```python
+config = QdrantDBConfig(host="10.0.0.5")  # wins over QDRANT_HOST
+```
+
+## Migration
+
+If you (deliberately) relied on bare env vars to configure a
+vector store, rename them with the appropriate prefix from the table
+above, e.g. `COLLECTION_NAME=mydocs` becomes
+`QDRANT_COLLECTION_NAME=mydocs`.
+
+Env vars read via `os.getenv` outside the config classes are
+unaffected, e.g. `QDRANT_API_KEY`, `PINECONE_API_KEY`,
+`MEILISEARCH_API_KEY`, `MEILISEARCH_API_URL`, `WEAVIATE_API_KEY`, and
+`WEAVIATE_API_URL` keep their existing meanings. Note that the
+`QDRANT_*` and `PINECONE_*` prefixes overlap with those existing
+names, but the config classes have no `api_key`/`api_url` fields, so
+extra prefixed vars are ignored.
+</file>
+
 <file path="docs/tutorials/non-openai-llms.md">
 # Using Langroid with Non-OpenAI LLMs
 
@@ -60958,574 +60242,160 @@ contents = ""
 path = file["path"]
 </file>
 
-<file path="langroid/vector_store/base.py">
+<file path="langroid/vector_store/chromadb.py">
 logger = logging.getLogger(__name__)
 ⋮----
-class VectorStoreConfig(BaseSettings)
+class ChromaDBConfig(VectorStoreConfig)
 ⋮----
-type: str = ""  # deprecated, keeping it for backward compatibility
-collection_name: str | None = "temp"
-replace_collection: bool = False  # replace collection if it already exists
-storage_path: str = ".qdrant/data"
-cloud: bool = False
-batch_size: int = 200
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig(
-embedding_model: Optional[EmbeddingModel] = None
-timeout: int = 60
+model_config = SettingsConfigDict(env_prefix="CHROMA_")
+⋮----
+collection_name: str = "temp"
+storage_path: str = ".chroma/data"
+distance: Literal["cosine", "l2", "ip"] = "cosine"
+construction_ef: int = 100
+search_ef: int = 100
+max_neighbors: int = 16
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
 host: str = "127.0.0.1"
 port: int = 6333
-# used when parsing search results back as Document objects
-document_class: Type[Document] = Document
-metadata_class: Type[DocMetaData] = DocMetaData
-# compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
-full_eval: bool = False  # runs eval without sanitization. Use only on trusted input
 ⋮----
-class VectorStore(ABC)
+class ChromaDB(VectorStore)
 ⋮----
-"""
-    Abstract base class for a vector store.
-    """
+def __init__(self, config: ChromaDBConfig | None = None)
 ⋮----
-def __init__(self, config: VectorStoreConfig)
+config = config if config is not None else ChromaDBConfig()
 ⋮----
-@staticmethod
-    def create(config: VectorStoreConfig) -> Optional["VectorStore"]
-⋮----
-@property
-    def embedding_dim(self) -> int
-⋮----
-def clone(self) -> "VectorStore"
-⋮----
-"""Return a vector-store clone suitable for agent cloning.
-
-        The default implementation deep-copies the configuration, reuses any
-        existing embedding model, and instantiates a fresh store of the same
-        type. Subclasses can override when sharing the instance is required
-        (e.g., embedded/local stores that rely on file locks).
-        """
-⋮----
-config_class = self.config.__class__
-config_data = self.config.model_dump(mode="python")
-⋮----
-config_copy = config_class.model_validate(config_data)
-⋮----
-# Preserve the calculated collection contents without forcing replaces
-⋮----
-config_copy.replace_collection = False  # type: ignore[attr-defined]
-cloned_embedding: Optional[EmbeddingModel] = None
-⋮----
-cloned_embedding = self.embedding_model.clone()  # type: ignore[attr-defined]
-⋮----
-cloned_store = type(self)(config_copy)  # type: ignore[call-arg]
-⋮----
-# Some stores might not honour replace_collection; ensure same collection
-⋮----
-@abstractmethod
-    def clear_empty_collections(self) -> int
-⋮----
-"""Clear all empty collections in the vector store.
-        Returns the number of collections deleted.
-        """
-⋮----
-@abstractmethod
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""
-        Clear all collections in the vector store.
-
-        Args:
-            really (bool, optional): Whether to really clear all collections.
-                Defaults to False.
-            prefix (str, optional): Prefix of collections to clear.
-        Returns:
-            int: Number of collections deleted.
-        """
-⋮----
-@abstractmethod
-    def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""List all collections in the vector store
-        (only non empty collections if empty=False).
-        """
-⋮----
-def set_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""
-        Set the current collection to the given collection name.
-        Args:
-            collection_name (str): Name of the collection.
-            replace (bool, optional): Whether to replace the collection if it
-                already exists. Defaults to False.
-        """
-⋮----
-@abstractmethod
-    def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""Create a collection with the given name.
-        Args:
-            collection_name (str): Name of the collection.
-            replace (bool, optional): Whether to replace the
-                collection if it already exists. Defaults to False.
-        """
-⋮----
-@abstractmethod
-    def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-def compute_from_docs(self, docs: List[Document], calc: str) -> str
-⋮----
-"""Compute a result on a set of documents,
-        using a dataframe calc string like `df.groupby('state')['income'].mean()`.
-
-        If full_eval is False (default), the input expression is sanitized to prevent
-        most common code injection attack vectors.
-        If full_eval is True, sanitization is bypassed - use only with trusted input!
-        """
-# convert each doc to a dict, using dotted paths for nested fields
-dicts = [flatten_dict(doc.model_dump(by_alias=True)) for doc in docs]
-df = pd.DataFrame(dicts)
-⋮----
-# SECURITY MITIGATION: Eval input is sanitized to prevent most common
-# code injection attack vectors when full_eval is False. The globals
-# dict also restricts ``__builtins__`` so that even with
-# ``full_eval=True`` the expression cannot reach
-# ``__import__``/``eval``/``exec`` via Python's implicit builtin
-# injection (GHSA-q9p7-wqxg-mrhc).
-vars = {"df": df}
-⋮----
-calc = sanitize_command(calc)
-code = compile(calc, "<calc>", "eval")
-result = eval(code, safe_eval_globals(vars), {})
-⋮----
-# return error message so LLM can fix the calc string if needed
-err = f"""
-⋮----
-# Pd.eval sometimes fails on a perfectly valid exprn like
-# df.loc[..., 'column'] with a KeyError.
-⋮----
-def maybe_add_ids(self, documents: Sequence[Document]) -> None
-⋮----
-"""Add ids to metadata if absent, since some
-        vecdbs don't like having blank ids."""
-⋮----
-"""
-        Find k most similar texts to the given text, in terms of vector distance metric
-        (e.g., cosine similarity).
-
-        Args:
-            text (str): The text to find similar texts for.
-            k (int, optional): Number of similar texts to retrieve. Defaults to 1.
-            where (Optional[str], optional): Where clause to filter the search.
-
-        Returns:
-            List[Tuple[Document,float]]: List of (Document, score) tuples.
-
-        """
-⋮----
-"""
-        In each doc's metadata, there may be a window_ids field indicating
-        the ids of the chunks around the current chunk.
-        These window_ids may overlap, so we
-        - coalesce each overlapping groups into a single window (maintaining ordering),
-        - create a new document for each part, preserving metadata,
-
-        We may have stored a longer set of window_ids than we need during chunking.
-        Now, we just want `neighbors` on each side of the center of the window_ids list.
-
-        Args:
-            docs_scores (List[Tuple[Document, float]]): List of pairs of documents
-                to add context windows to together with their match scores.
-            neighbors (int, optional): Number of neighbors on "each side" of match to
-                retrieve. Defaults to 0.
-                "Each side" here means before and after the match,
-                in the original text.
-
-        Returns:
-            List[Tuple[Document, float]]: List of (Document, score) tuples.
-        """
-# We return a larger context around each match, i.e.
-# a window of `neighbors` on each side of the match.
-docs = [d for d, s in docs_scores]
-scores = [s for d, s in docs_scores]
-⋮----
-doc_chunks = [d for d in docs if d.metadata.is_chunk]
-⋮----
-window_ids_list = []
-id2metadata = {}
-# id -> highest score of a doc it appears in
-id2max_score: Dict[int | str, float] = {}
-⋮----
-window_ids = d.metadata.window_ids
-⋮----
-window_ids = [d.id()]
-⋮----
-n = len(window_ids)
-chunk_idx = window_ids.index(d.id())
-neighbor_ids = window_ids[
-⋮----
-# window_ids could be from different docs,
-# and they may overlap, so we coalesce overlapping groups into
-# separate windows.
-window_ids_list = self.remove_overlaps(window_ids_list)
-final_docs = []
-final_scores = []
-⋮----
-metadata = copy.deepcopy(id2metadata[w[0]])
-⋮----
-document = Document(
-# make a fresh id since content is in general different
-⋮----
-@staticmethod
-    def remove_overlaps(windows: List[List[str]]) -> List[List[str]]
-⋮----
-"""
-        Given a collection of windows, where each window is a sequence of ids,
-        identify groups of overlapping windows, and for each overlapping group,
-        order the chunk-ids using topological sort so they appear in the original
-        order in the text.
-
-        Args:
-            windows (List[int|str]): List of windows, where each window is a
-                sequence of ids.
-
-        Returns:
-            List[int|str]: List of windows, where each window is a sequence of ids,
-                and no two windows overlap.
-        """
-ids = set(id for w in windows for id in w)
-# id -> {win -> # pos}
-id2win2pos: Dict[str, Dict[int, int]] = {id: {} for id in ids}
-⋮----
-n = len(windows)
-# relation between windows:
-order = np.zeros((n, n), dtype=np.int8)
-⋮----
-id = list(set(w).intersection(x))[0]  # any common id
-⋮----
-order[i, j] = -1  # win i is before win j
-⋮----
-order[i, j] = 1  # win i is after win j
-⋮----
-# find groups of windows that overlap, like connected components in a graph
-groups = components(np.abs(order))
-⋮----
-# order the chunk-ids in each group using topological sort
-new_windows = []
-⋮----
-# find total ordering among windows in group based on order matrix
-# (this is a topological sort)
-_g = np.array(g)
-order_matrix = order[_g][:, _g]
-ordered_window_indices = topological_sort(order_matrix)
-ordered_window_ids = [windows[i] for i in _g[ordered_window_indices]]
-flattened = [id for w in ordered_window_ids for id in w]
-flattened_deduped = list(dict.fromkeys(flattened))
-# Note we are not going to split these, and instead we'll return
-# larger windows from concatenating the connected groups.
-# This ensures context is retained for LLM q/a
-⋮----
-@abstractmethod
-    def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-"""
-        Get all documents in the current collection, possibly filtered by `where`.
-        """
-⋮----
-@abstractmethod
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-"""
-        Get documents by their ids.
-        Args:
-            ids (List[str]): List of document ids.
-
-        Returns:
-            List[Document]: List of documents
-        """
-⋮----
-@abstractmethod
-    def delete_collection(self, collection_name: str) -> None
-⋮----
-def show_if_debug(self, doc_score_pairs: List[Tuple[Document, float]]) -> None
-</file>
-
-<file path="langroid/vector_store/postgres.py">
-has_postgres: bool = True
-⋮----
-Engine = Any  # type: ignore
-Connection = Any  # type: ignore
-has_postgres = False
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-def _quote_ident(name: str) -> str
-⋮----
-"""Quote a SQL identifier (table/index name) for use in raw DDL, so a name
-    containing characters that are invalid in an unquoted identifier -- e.g.
-    the ``-`` in a pytest-xdist worker suffix like ``mycollection-gw1`` -- does
-    not produce a syntax error. Embedded double-quotes are escaped per the SQL
-    standard.
-    """
-⋮----
-class PostgresDBConfig(VectorStoreConfig)
-⋮----
-collection_name: str = "embeddings"
-cloud: bool = False
-docker: bool = True
-host: str = "127.0.0.1"
-port: int = 5432
-replace_collection: bool = False
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-pool_size: int = 10
-max_overflow: int = 20
-hnsw_m: int = 16
-hnsw_ef_construction: int = 200
-⋮----
-class PostgresDB(VectorStore)
-⋮----
-def __init__(self, config: PostgresDBConfig | None = None)
-⋮----
-config = config if config is not None else PostgresDBConfig()
-⋮----
-def _create_engine(self) -> Engine
-⋮----
-"""Creates a SQLAlchemy engine based on the configuration."""
-⋮----
-connection_string: str | None = None  # Ensure variable is always defined
-⋮----
-connection_string = os.getenv("POSTGRES_CONNECTION_STRING")
-⋮----
-connection_string = connection_string.replace(
-⋮----
-username = os.getenv("POSTGRES_USER", "postgres")
-password = os.getenv("POSTGRES_PASSWORD", "postgres")
-database = os.getenv("POSTGRES_DB", "langroid")
-⋮----
-connection_string = (
-self.config.cloud = False  # Ensures cloud is disabled if using Docker
-⋮----
-def _setup_table(self) -> None
-⋮----
-# Create HNSW index for embeddings column if it doesn't exist.
-# This index enables efficient nearest-neighbor search using cosine similarity.
-# PostgreSQL automatically builds the index after creation;
-# no manual step required.
-# Read more about pgvector hnsw index here:
-# https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw
-⋮----
-index_name = f"hnsw_index_{self.config.collection_name}_embedding"
-⋮----
-create_index_query = text(
-⋮----
-def index_exists(self, connection: Connection, index_name: str) -> bool
-⋮----
-"""Check if an index exists."""
-query = text(
-result = connection.execute(query).scalar()
-⋮----
-@staticmethod
-    def _create_vector_extension(conn: Engine) -> None
-⋮----
-# The number is a unique identifier used to lock a specific resource
-# during transaction. Any 64-bit integer can be used for advisory locks.
-# Acquire advisory lock to ensure atomic, isolated setup
-# and prevent race conditions.
-⋮----
-statement = text(
-⋮----
-def set_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-inspector = inspect(self.engine)
-table_exists = collection_name in inspector.get_table_names()
-⋮----
-def list_collections(self, empty: bool = True) -> List[str]
-⋮----
-table_names = inspector.get_table_names()
-⋮----
-collections = []
-⋮----
-table = Table(table_name, self.metadata, autoload_with=self.engine)
-⋮----
-# Efficiently check for non-emptiness
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-"""
-        Deletes a collection and its associated HNSW index, handling metadata
-        synchronization issues.
-        """
-⋮----
-index_name = f"hnsw_index_{collection_name}_embedding"
-drop_index_query = text(
-⋮----
-# 3. Now, drop the table using SQLAlchemy
-table = Table(collection_name, self.metadata)
-⋮----
-# 4. Refresh metadata again after dropping the table
+# chroma_db_impl="duckdb+parquet",
+# is_persistent=bool(config.storage_path),
 ⋮----
 def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
 ⋮----
-deleted_count = 0
+"""Clear all collections in the vector store with the given prefix."""
 ⋮----
-# Use delete_collection to handle index and table deletion
+coll = [c for c in self.client.list_collections() if c.name.startswith(prefix)]
+⋮----
+n_empty_deletes = 0
+n_non_empty_deletes = 0
 ⋮----
 def clear_empty_collections(self) -> int
 ⋮----
-# Efficiently check for emptiness without fetching all rows
+colls = self.client.list_collections()
+n_deletes = 0
 ⋮----
-session.commit()  # Commit is likely not needed here
+def list_collections(self, empty: bool = False) -> List[str]
 ⋮----
-def _parse_embedding_store_record(self, res: Any) -> Dict[str, Any]
+"""
+        List non-empty collections in the vector store.
+        Args:
+            empty (bool, optional): Whether to list empty collections.
+        Returns:
+            List[str]: List of non-empty collection names.
+        """
 ⋮----
-metadata = res.cmetadata or {}
+def create_collection(self, collection_name: str, replace: bool = False) -> None
 ⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
+"""
+        Create a collection in the vector store, optionally replacing an existing
+            collection if `replace` is True.
+        Args:
+            collection_name (str): Name of the collection to create or replace.
+            replace (bool, optional): Whether to replace an existing collection.
+                Defaults to False.
+
+        """
 ⋮----
-query = session.query(self.embeddings_table)
-⋮----
-# Apply 'where' clause if provided
-⋮----
-where_json = json.loads(where)
-query = query.filter(
-⋮----
-return []  # Return empty list or handle error as appropriate
-⋮----
-results = query.all()
-documents = [
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-# Add a CASE statement to preserve the order of IDs
-case_stmt = case(
-⋮----
-query = (
-⋮----
-.order_by(case_stmt)  # Order by the CASE statement
+# we could expose other configs, see:
+# https://docs.trychroma.com/docs/collections/configure
 ⋮----
 def add_documents(self, documents: Sequence[Document]) -> None
 ⋮----
-embeddings = self.embedding_fn([doc.content for doc in documents])
+contents: List[str] = [document.content for document in documents]
+# convert metadatas to dicts so chroma can handle them
+metadata_dicts: List[dict[str, Any]] = [
 ⋮----
-batch_size = self.config.batch_size
+# chroma does not handle non-atomic types in metadata
 ⋮----
-batch_docs = documents[i : i + batch_size]
-batch_embeddings = embeddings[i : i + batch_size]
+ids = [str(d.id()) for d in documents]
 ⋮----
-new_records = [
+colls = self.list_collections(empty=True)
 ⋮----
-stmt = insert(self.embeddings_table).values(new_records)
+# embedding_models=embedding_models,
 ⋮----
-@staticmethod
-    def _id_to_uuid(id: str, obj: object) -> str
+def get_all_documents(self, where: str = "") -> List[Document]
 ⋮----
-doc_id = str(uuid.UUID(id))
+filter = json.loads(where) if where else None
+results = self.collection.get(
 ⋮----
-obj_repr = repr(obj)
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
 ⋮----
-obj_hash = hashlib.sha256(obj_repr.encode()).hexdigest()
+# get them one by one since chroma mangles the order of the results
+# when fetched from a list of ids.
+results = [
+final_results = {}
 ⋮----
-combined = f"{id}-{obj_hash}"
+def delete_collection(self, collection_name: str) -> None
 ⋮----
-doc_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, combined))
+n = self.collection.count()
 ⋮----
-neighbors: int = 1,  # Parameter not used in this implementation
+results = self.collection.query(
+docs = self._docs_from_results(results)
+# chroma distances are 1 - cosine.
+scores = [1 - s for s in results["distances"][0]]
 ⋮----
-embedding = self.embedding_fn([query])[0]
+def _docs_from_results(self, results: Dict[str, Any]) -> List[Document]
 ⋮----
-# Calculate the score (1 - cosine_distance) and label it as "score"
-score = (
-⋮----
-json_query = json.loads(where)
-⋮----
-results = (
-⋮----
-score,  # Select the calculated score
-⋮----
-.order_by(score.desc())  # Order by score in descending order
-⋮----
-documents_with_scores = [
-⋮----
-result.score,  # Use the score from the query result
-</file>
+"""
+        Helper function to convert results from ChromaDB to a list of Documents
+        Args:
+            results (dict): results from ChromaDB
 
-<file path="langroid/vector_store/qdrantdb.py">
-logger = logging.getLogger(__name__)
-⋮----
-T = TypeVar("T")
-⋮----
-def from_optional(x: Optional[T], default: T) -> T
-⋮----
-def is_valid_uuid(uuid_to_test: str) -> bool
-⋮----
-"""
-    Check if a given string is a valid UUID.
-    """
-⋮----
-uuid_obj = uuid.UUID(uuid_to_test)
-⋮----
-# Check for valid unsigned 64-bit integer
-⋮----
-int_value = int(uuid_to_test)
-⋮----
-class QdrantDBConfig(VectorStoreConfig)
-⋮----
-cloud: bool = True
-docker: bool = False
-collection_name: str | None = "temp"
-storage_path: str = ".qdrant/data"
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-use_sparse_embeddings: bool = False
-sparse_embedding_model: str = "naver/splade-v3-distilbert"
-sparse_limit: int = 3
-distance: str = "cosine"
-⋮----
-class QdrantDB(VectorStore)
-⋮----
-def __init__(self, config: QdrantDBConfig | None = None)
-⋮----
-config = config if config is not None else QdrantDBConfig()
-⋮----
-self.sparse_tokenizer = AutoTokenizer.from_pretrained(  # type: ignore
-⋮----
-key = os.getenv("QDRANT_API_KEY")
-url = os.getenv("QDRANT_API_URL")
-⋮----
-new_storage_path = config.storage_path + ".new"
-⋮----
-# Note: Only create collection if a non-null collection name is provided.
-# This is useful to delay creation of vecdb until we have a suitable
-# collection name (e.g. we could get it from the url or folder path).
-⋮----
-def clone(self) -> "QdrantDB"
-⋮----
-"""Create an independent Qdrant client when running against Qdrant Cloud."""
-⋮----
-cloned = super().clone()
-⋮----
-def close(self) -> None
-⋮----
-"""
-        Close the QdrantDB client and release any resources (e.g., file locks).
-        This is especially important for local storage to release the .lock file.
+        Returns:
+            List[Document]: list of Documents
         """
 ⋮----
-# QdrantLocal has a close method that releases the lock
+contents = results["documents"][0]
 ⋮----
-def __enter__(self) -> "QdrantDB"
+metadatas = results["metadatas"][0]
 ⋮----
-"""Context manager entry."""
+# restore the stringified list of window_ids into the original List[str]
 ⋮----
-def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
+docs = [
+</file>
+
+<file path="langroid/vector_store/lancedb.py">
+has_lancedb = True
 ⋮----
-"""Context manager exit - ensure cleanup even if an exception occurred."""
+has_lancedb = False
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+class LanceDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="LANCEDB_")
+⋮----
+cloud: bool = False
+collection_name: str | None = "temp"
+storage_path: str = ".lancedb/data"
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+distance: str = "cosine"
+⋮----
+class LanceDB(VectorStore)
+⋮----
+def __init__(self, config: LanceDBConfig | None = None)
+⋮----
+config = config if config is not None else LanceDBConfig()
+⋮----
+self.is_from_dataframe = False  # were docs ingested from a dataframe?
+self.df_metadata_columns: List[str] = []  # metadata columns from dataframe
+⋮----
+new_storage_path = config.storage_path + ".new"
 ⋮----
 def clear_empty_collections(self) -> int
 ⋮----
 coll_names = self.list_collections()
 n_deletes = 0
 ⋮----
-info = self.client.get_collection(collection_name=name)
+nr = self.client.open_table(name).head(1).shape[0]
 ⋮----
 def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
 ⋮----
@@ -61536,8 +60406,6 @@ coll_names = [
 n_empty_deletes = 0
 n_non_empty_deletes = 0
 ⋮----
-points_count = from_optional(info.points_count, 0)
-⋮----
 def list_collections(self, empty: bool = False) -> List[str]
 ⋮----
 """
@@ -61547,10 +60415,242 @@ def list_collections(self, empty: bool = False) -> List[str]
         Args:
             empty (bool, optional): Whether to include empty collections.
         """
+colls = self.client.table_names(limit=None)
 ⋮----
-colls = list(self.client.get_collections())[0][1]
+if empty:  # include empty tbls
+return colls  # type: ignore
+counts = [self.client.open_table(coll).head(1).shape[0] for coll in colls]
 ⋮----
-counts = []
+def _create_lance_schema(self, doc_cls: Type[Document]) -> Type[BaseModel]
+⋮----
+"""
+        NOTE: NOT USED, but leaving it here as it may be useful.
+
+        Create a subclass of LanceModel with fields:
+         - id (str)
+         - Vector field that has dims equal to
+            the embedding dimension of the embedding model, and a data field of type
+            DocClass.
+         - other fields from doc_cls
+
+        Args:
+            doc_cls (Type[Document]): A Pydantic model which should be a subclass of
+                Document, to be used as the type for the data field.
+
+        Returns:
+            Type[BaseModel]: A new Pydantic model subclassing from LanceModel.
+
+        Raises:
+            ValueError: If `n` is not a non-negative integer or if `DocClass` is not a
+                subclass of Document.
+        """
+⋮----
+n = self.embedding_dim
+⋮----
+# Prepare fields for the new model
+fields = {"id": (str, ...), "vector": (Vector(n), ...)}
+⋮----
+sorted_fields = dict(
+# Add both statically and dynamically defined fields from doc_cls
+⋮----
+field_type = field.annotation if hasattr(field, "annotation") else field
+⋮----
+# Create the new model with dynamic fields
+NewModel = create_model(
+⋮----
+)  # type: ignore
+return NewModel  # type: ignore
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+colls = self.list_collections(empty=True)
+⋮----
+embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+coll_name = self.config.collection_name
+⋮----
+# self._maybe_set_doc_class_schema(documents[0])
+table_exists = False
+⋮----
+# collection exists and  is not empty:
+# if replace_collection is True, we'll overwrite the existing collection,
+# else we'll append to it.
+⋮----
+table_exists = True
+⋮----
+ids = [str(d.id()) for d in documents]
+# don't insert all at once, batch in chunks of b,
+# else we get an API error
+b = self.config.batch_size
+⋮----
+def make_batches() -> Generator[List[Dict[str, Any]], None, None]
+⋮----
+batch = [
+⋮----
+tbl = self.client.open_table(coll_name)
+⋮----
+batch_gen = make_batches()
+batch = next(batch_gen)
+# use first batch to create table...
+tbl = self.client.create_table(
+# ... and add the rest
+⋮----
+"""
+        Add a dataframe to the collection.
+        Args:
+            df (pd.DataFrame): A dataframe
+            content (str): The name of the column in the dataframe that contains the
+                text content to be embedded using the embedding model.
+            metadata (List[str]): A list of column names in the dataframe that contain
+                metadata to be stored in the database. Defaults to [].
+        """
+⋮----
+actual_metadata = metadata.copy()
+self.df_metadata_columns = actual_metadata  # could be updated below
+# get content column
+content_values = df[content].values.tolist()
+embedding_vecs = self.embedding_fn(content_values)
+⋮----
+# add vector column
+⋮----
+# rename content column to "content", leave existing column intact
+df = df.rename(columns={content: "content"}, inplace=False)
+⋮----
+docs = dataframe_to_documents(df, content="content", metadata=metadata)
+ids = [str(d.id()) for d in docs]
+⋮----
+# collection either doesn't exist or is empty, so replace it
+# and set new schema from df
+⋮----
+doc_cls = dataframe_to_document_model(
+self.config.document_class = doc_cls  # type: ignore
+⋮----
+# collection exists and is not empty, so append to it
+tbl = self.client.open_table(self.config.collection_name)
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+df = result.to_pandas()
+⋮----
+records = result.to_arrow().to_pylist()
+⋮----
+def _records_to_docs(self, records: List[Dict[str, Any]]) -> List[Document]
+⋮----
+docs = [self.config.document_class(**rec) for rec in records]
+⋮----
+def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+pre_result = tbl.search(None).where(where or None).limit(None)
+⋮----
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+_ids = [str(id) for id in ids]
+⋮----
+docs = []
+⋮----
+results = self._lance_result_to_docs(tbl.search().where(f"id == '{_id}'"))
+⋮----
+embedding = self.embedding_fn([text])[0]
+⋮----
+result = (
+docs = self._lance_result_to_docs(result)
+# note _distance is 1 - cosine
+⋮----
+scores = [
+⋮----
+scores = [1 - rec["_distance"] for rec in result.to_arrow().to_pylist()]
+⋮----
+doc_score_pairs = list(zip(docs, scores))
+</file>
+
+<file path="langroid/vector_store/meilisearch.py">
+"""
+MeiliSearch as a pure document store, without its
+(experimental) vector-store functionality.
+We aim to use MeiliSearch for fast lexical search.
+Note that what we call "Collection" in Langroid is referred to as
+"Index" in MeiliSearch. Each data-store has its own terminology,
+but for uniformity we use the Langroid terminology here.
+"""
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+class MeiliSearchConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="MEILISEARCH_")
+⋮----
+cloud: bool = False
+collection_name: str | None = None
+primary_key: str = "id"
+port: int = 7700
+⋮----
+class MeiliSearch(VectorStore)
+⋮----
+def __init__(self, config: MeiliSearchConfig | None = None)
+⋮----
+config = config if config is not None else MeiliSearchConfig()
+⋮----
+# Note: Only create collection if a non-null collection name is provided.
+# This is useful to delay creation of db until we have a suitable
+# collection name (e.g. we could get it from the url or folder path).
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+"""All collections are treated as non-empty in MeiliSearch, so this is a
+        no-op"""
+⋮----
+async def _async_delete_indices(self, uids: List[str]) -> List[bool]
+⋮----
+"""Delete any indicecs in `uids` that exist.
+        Returns list of bools indicating whether the index has been deleted"""
+⋮----
+result = await asyncio.gather(
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+"""Delete all indices whose names start with `prefix`"""
+⋮----
+coll_names = [c for c in self.list_collections() if c.startswith(prefix)]
+deletes = asyncio.run(self._async_delete_indices(coll_names))
+n_deletes = sum(deletes)
+⋮----
+def _list_all_collections(self) -> List[str]
+⋮----
+"""
+        List all collections, including empty ones.
+        Returns:
+            List of collection names.
+        """
+⋮----
+async def _async_get_indexes(self) -> List[AsyncIndex]
+⋮----
+indexes = await client.get_indexes(limit=10_000)
+return [] if indexes is None else indexes  # type: ignore
+⋮----
+async def _async_get_index(self, index_uid: str) -> "AsyncIndex"
+⋮----
+index = await client.get_index(index_uid)
+return index  # type: ignore
+⋮----
+def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+"""
+        Returns:
+            List of index names stored. We treat any existing index as non-empty.
+        """
+indexes = asyncio.run(self._async_get_indexes())
+⋮----
+async def _async_create_index(self, collection_name: str) -> "AsyncIndex"
+⋮----
+index = await client.create_index(
+⋮----
+async def _async_delete_index(self, collection_name: str) -> bool
+⋮----
+"""Delete index if it exists. Returns True iff index was deleted"""
+⋮----
+result = await client.delete_index_if_exists(uid=collection_name)
+return result  # type: ignore
 ⋮----
 def create_collection(self, collection_name: str, replace: bool = False) -> None
 ⋮----
@@ -61563,120 +60663,401 @@ def create_collection(self, collection_name: str, replace: bool = False) -> None
                 with the same name. Defaults to False.
         """
 ⋮----
-coll = self.client.get_collection(collection_name=collection_name)
+collections = self.list_collections()
 ⋮----
-vectors_config = {
-sparse_vectors_config = None
-⋮----
-sparse_vectors_config = {
-⋮----
-collection_info = self.client.get_collection(collection_name=collection_name)
+collection_info = asyncio.run(self._async_get_index(collection_name))
 ⋮----
 level = logger.getEffectiveLevel()
 ⋮----
-def get_sparse_embeddings(self, inputs: List[str]) -> List["SparseVector"]
-⋮----
-tokens = self.sparse_tokenizer(
-output = self.sparse_model(**tokens)
-vectors = torch.max(
-sparse_embeddings = []
-⋮----
-cols = vec.nonzero().squeeze().cpu().tolist()
-weights = vec[cols].cpu().tolist()
+index = client.index(collection_name)
 ⋮----
 def add_documents(self, documents: Sequence[Document]) -> None
 ⋮----
-# Add id to metadata if not already present
+colls = self._list_all_collections()
 ⋮----
-# Fix the ids due to qdrant finickiness
-⋮----
-colls = self.list_collections(empty=True)
-⋮----
-document_dicts = [doc.model_dump() for doc in documents]
-embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-sparse_embedding_vecs = self.get_sparse_embeddings(
-⋮----
-ids = [self._to_int_or_uuid(d.id()) for d in documents]
-# don't insert all at once, batch in chunks of b,
-# else we get an API error
-b = self.config.batch_size
-⋮----
-vectors: Dict[str, Embeddings | List[SparseVector]] = {
-⋮----
-coll_found: bool = False
-⋮----
-# poll until collection is ready
-⋮----
-coll_found = True
+docs = [
 ⋮----
 def delete_collection(self, collection_name: str) -> None
 ⋮----
 def _to_int_or_uuid(self, id: str) -> int | str
 ⋮----
-int_val = int(id)
+async def _async_get_documents(self, where: str = "") -> "DocumentsInfo"
 ⋮----
-# If doc_id is already a valid UUID, return it as is
+filter = [] if where is None else where
 ⋮----
-# Otherwise, generate a UUID from the doc_id
-# Convert doc_id to string if it's not already
-id_str = str(id)
-⋮----
-# Hash the document ID using SHA-1
-hash_object = hashlib.sha1(id_str.encode())
-hash_digest = hash_object.hexdigest()
-⋮----
-# Truncate or manipulate the hash to fit into a UUID (128 bits)
-uuid_str = hash_digest[:32]
-⋮----
-# Format this string into a UUID format
-formatted_uuid = uuid.UUID(uuid_str)
+index = client.index(self.config.collection_name)
+documents = await index.get_documents(limit=10_000, filter=filter)
 ⋮----
 def get_all_documents(self, where: str = "") -> List[Document]
 ⋮----
-docs = []
-offset = 0
-filter = Filter() if where == "" else Filter.model_validate(json.loads(where))
+docs = asyncio.run(self._async_get_documents(where))
 ⋮----
-limit=10_000,  # try getting all at once, if not we keep paging
+doc_results = docs.results
 ⋮----
-self.config.document_class(**record.payload)  # type: ignore
+async def _async_get_documents_by_ids(self, ids: List[str]) -> List[Dict[str, Any]]
 ⋮----
-# ignore
-⋮----
-offset = next_page_offset  # type: ignore
+documents = await asyncio.gather(*[index.get_document(id) for id in ids])
 ⋮----
 def get_documents_by_ids(self, ids: List[str]) -> List[Document]
 ⋮----
-_ids = [self._to_int_or_uuid(id) for id in ids]
-records = self.client.retrieve(
-# Note the records may NOT be in the order of the ids,
-# so we re-order them here.
-id2payload = {record.id: record.payload for record in records}
-ordered_payloads = [id2payload[id] for id in _ids if id in id2payload]
-docs = [Document(**payload) for payload in ordered_payloads]  # type: ignore
+docs = asyncio.run(self._async_get_documents_by_ids(ids))
 ⋮----
-embedding = self.embedding_fn([text])[0]
-# TODO filter may not work yet
+results = await index.search(
+return results.hits  # type: ignore
 ⋮----
-filter = Filter()
+neighbors: int = 0,  # ignored
 ⋮----
-filter = Filter.model_validate(json.loads(where))
-requests = [
+_docs = asyncio.run(self._async_search(text, k, filter))  # type: ignore
 ⋮----
-sparse_embedding = self.get_sparse_embeddings([text])[0]
-⋮----
-search_result_lists: List[List[ScoredPoint]] = self.client.search_batch(
-⋮----
-search_result = [
-⋮----
-]  # 2D list -> 1D list
-scores = [match.score for match in search_result if match is not None]
-docs = [
-⋮----
-self.config.document_class(**(match.payload))  # type: ignore
+scores = [h["_rankingScore"] for h in _docs]
 ⋮----
 doc_score_pairs = list(zip(docs, scores))
-max_score = max(ds[1] for ds in doc_score_pairs)
+</file>
+
+<file path="langroid/vector_store/pineconedb.py">
+# import dataclass
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+has_pinecone: bool = True
+⋮----
+class ServerlessSpec(BaseModel)
+⋮----
+"""
+            Fallback Serverless specification configuration to avoid import errors.
+            """
+⋮----
+cloud: str
+region: str
+⋮----
+PineconeApiException = Any  # type: ignore
+Pinecone = Any  # type: ignore
+has_pinecone = False
+⋮----
+@dataclass(frozen=True)
+class IndexMeta
+⋮----
+name: str
+total_vector_count: int
+⋮----
+class PineconeDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="PINECONE_")
+⋮----
+cloud: bool = True
+collection_name: str | None = "temp"
+spec: ServerlessSpec = ServerlessSpec(cloud="aws", region="us-east-1")
+deletion_protection: Literal["enabled", "disabled"] | None = None
+metric: str = "cosine"
+pagination_size: int = 100
+⋮----
+class PineconeDB(VectorStore)
+⋮----
+def __init__(self, config: PineconeDBConfig | None = None)
+⋮----
+config = config if config is not None else PineconeDBConfig()
+⋮----
+key = os.getenv("PINECONE_API_KEY")
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+indexes = self._list_index_metas(empty=True)
+n_deletes = 0
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+"""
+        Returns:
+            Number of Pinecone indexes that were deleted
+
+        Args:
+            really: Optional[bool] - whether to really delete all Pinecone collections
+            prefix: Optional[str] - string to match potential Pinecone
+                indexes for deletion
+        """
+⋮----
+indexes = [
+⋮----
+def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+"""
+        Returns:
+            List of Pinecone indices that have at least one vector.
+
+        Args:
+            empty: Optional[bool] - whether to include empty collections
+        """
+indexes = self.client.list_indexes()
+res: List[str] = []
+⋮----
+index_meta = self.client.Index(name=index)
+⋮----
+def _list_index_metas(self, empty: bool = False) -> List[IndexMeta]
+⋮----
+"""
+        Returns:
+            List of objects describing Pinecone indices
+
+        Args:
+            empty: Optional[bool] - whether to include empty collections
+        """
+⋮----
+res = []
+⋮----
+index_meta = self._fetch_index_meta(index)
+⋮----
+def _fetch_index_meta(self, index_name: str) -> IndexMeta
+⋮----
+"""
+        Returns:
+            A dataclass describing the input Index by name and vector count
+            to save a bit on index description calls
+
+        Args:
+            index_name: str - Name of the index in Pinecone
+        """
+⋮----
+index = self.client.Index(name=index_name)
+stats = index.describe_index_stats()
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+"""
+        Create a collection with the given name, optionally replacing an existing
+        collection if `replace` is True.
+
+        Args:
+            collection_name: str - Configuration of the collection to create.
+            replace: Optional[Bool] - Whether to replace an existing collection
+                with the same name. Defaults to False.
+        """
+pattern = re.compile(r"^[a-z0-9-]+$")
+⋮----
+index = self.client.Index(name=collection_name)
+⋮----
+status = self.client.describe_index(name=collection_name)
+⋮----
+payload = {
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+def add_documents(self, documents: Sequence[Document], namespace: str = "") -> None
+⋮----
+document_dicts = [doc.model_dump() for doc in documents]
+document_ids = [doc.id() for doc in documents]
+embedding_vectors = self.embedding_fn([doc.content for doc in documents])
+vectors = [
+⋮----
+index = self.client.Index(name=self.config.collection_name)
+batch_size = self.config.batch_size
+⋮----
+"""
+        Returns:
+            All documents for the collection currently defined in
+            the configuration object
+
+        Args:
+            prefix: str - document id prefix to search for
+            namespace: str - partition of vectors to search within the index
+        """
+⋮----
+docs = []
+⋮----
+request_filters: Dict[str, Union[str, int]] = {
+⋮----
+response = index.list_paginated(**request_filters)
+vectors = response.get("vectors", [])
+⋮----
+pagination_token = response.get("pagination", {}).get("next", None)
+⋮----
+"""
+        Returns:
+            Fetches document text embedded in Pinecone index metadata
+
+        Args:
+            ids: List[str] - vector data object ids to retrieve
+            namespace: str - partition of vectors to search within the index
+        """
+⋮----
+records = index.fetch(ids=ids, namespace=namespace)
+⋮----
+records = index.fetch(ids=ids)
+⋮----
+id_mapping = {key: value for key, value in records["vectors"].items()}
+ordered_payloads = [id_mapping[_id] for _id in ids if _id in id_mapping]
+⋮----
+vector_search_request = {
+⋮----
+response = index.query(**vector_search_request)
+doc_score_pairs = [
+⋮----
+max_score = max([pair[1] for pair in doc_score_pairs])
+⋮----
+def transform_pinecone_vector(self, metadata_dict: Dict[str, Any]) -> Document
+⋮----
+"""
+        Parses the metadata response from the Pinecone vector query and
+        formats it into a dictionary that can be parsed by the Document class
+        associated with the PineconeDBConfig class
+
+        Returns:
+            Well formed dictionary object to be transformed into a Document
+
+        Args:
+            metadata_dict: Dict - the metadata dictionary from the Pinecone
+                vector query match
+        """
+</file>
+
+<file path="langroid/vector_store/weaviatedb.py">
+logger = logging.getLogger(__name__)
+⋮----
+class VectorDistances
+⋮----
+"""
+    Fallback class when weaviate is not installed, to avoid import errors.
+    """
+⋮----
+COSINE: str = "cosine"
+DOTPRODUCT: str = "dot"
+L2: str = "l2"
+⋮----
+class WeaviateDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="WEAVIATE_")
+⋮----
+collection_name: str | None = "temp"
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+distance: str = VectorDistances.COSINE
+cloud: bool = False
+docker: bool = False
+host: str = "127.0.0.1"
+port: int = 8080
+storage_path: str = ".weaviate_embedded/data"
+⋮----
+class WeaviateDB(VectorStore)
+⋮----
+def __init__(self, config: WeaviateDBConfig | None = None)
+⋮----
+config = config if config is not None else WeaviateDBConfig()
+⋮----
+key = os.getenv("WEAVIATE_API_KEY")
+url = os.getenv("WEAVIATE_API_URL")
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+colls = self.client.collections.list_all()
+n_deletes = 0
+⋮----
+val = self.client.collections.get(coll_name)
+⋮----
+def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+non_empty_colls = [
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+coll_names = [
+⋮----
+n_empty_deletes = 0
+n_non_empty_deletes = 0
+⋮----
+info = self.client.collections.get(name)
+points_count = len(info)
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+collection_name = WeaviateDB.validate_and_format_collection_name(
+⋮----
+coll = self.client.collections.get(name=collection_name)
+⋮----
+vector_index_config = Configure.VectorIndex.hnsw(
+⋮----
+vectorizer_config = Configure.Vectorizer.text2vec_openai(
+⋮----
+vectorizer_config = None
+⋮----
+collection_info = self.client.collections.create(
+collection_info = self.client.collections.get(name=collection_name)
+⋮----
+level = logger.getEffectiveLevel()
+⋮----
+def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+colls = self.list_collections(empty=True)
+⋮----
+document_dicts = [doc.model_dump() for doc in documents]
+embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+⋮----
+coll_name = self.client.collections.get(self.config.collection_name)
+⋮----
+id = doc_dict["metadata"].pop("id", None)
+⋮----
+def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+# cannot use filter as client does not support json type queries
+coll = self.client.collections.get(self.config.collection_name)
+⋮----
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+docs = []
+⋮----
+result = coll_name.query.fetch_objects(
+⋮----
+id_to_doc = {}
+⋮----
+doc = self.weaviate_obj_to_doc(item)
+⋮----
+# Reconstruct the list of documents in the original order of input ids
+docs = [id_to_doc[id] for id in ids if id in id_to_doc]
+⋮----
+embedding = self.embedding_fn([text])[0]
+⋮----
+response = coll.query.near_vector(
+maybe_distances = [item.metadata.distance for item in response.objects]
+similarities = [0 if d is None else 1 - d for d in maybe_distances]
+docs = [self.weaviate_obj_to_doc(item) for item in response.objects]
+⋮----
+def _create_valid_uuid_id(self, id: str) -> Any
+⋮----
+id = get_valid_uuid(id)
+⋮----
+def weaviate_obj_to_doc(self, input_object: Any) -> Document
+⋮----
+content = input_object.properties.get("content", "")
+metadata_dict = input_object.properties.get("metadata", {})
+⋮----
+window_ids = metadata_dict.pop("window_ids", [])
+window_ids = [str(uuid) for uuid in window_ids]
+⋮----
+# Ensure the id is a valid UUID string
+id_value = get_valid_uuid(input_object.uuid)
+⋮----
+metadata = DocMetaData(id=id_value, window_ids=window_ids, **metadata_dict)
+⋮----
+@staticmethod
+    def validate_and_format_collection_name(name: str) -> str
+⋮----
+"""
+        Formats the collection name to comply with Weaviate's naming rules:
+        - Name must start with a capital letter.
+        - Name can only contain letters, numbers, and underscores.
+        - Replaces invalid characters with underscores.
+        """
+⋮----
+formatted_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+⋮----
+# Ensure the first letter is capitalized
+⋮----
+formatted_name = formatted_name.capitalize()
+⋮----
+# Check if the name now meets the criteria
+⋮----
+def __del__(self) -> None
+⋮----
+# Gracefully close the connection with local client
 </file>
 
 <file path="tests/main/test_arangodb_chat_agent.py">
@@ -62657,6 +62038,120 @@ def _mutual_loop(base: Path) -> None
     ``Path.resolve()`` raises ``RuntimeError`` -- not ``OSError`` -- on a
     symlink loop, which otherwise propagates out of the walk and kills the run.
     """
+</file>
+
+<file path="tests/main/test_vecstore_env_prefix.py">
+"""Tests for env-var prefixes on vector-store configs (issue #1078).
+
+`VectorStoreConfig` extends `BaseSettings`, so without an `env_prefix`
+every field name was itself a case-insensitive environment variable:
+a bare `HOST`, `PORT`, or worst `FULL_EVAL` in the environment silently
+overrode the default for every vector-store config. These tests assert
+that bare env vars no longer leak in, that properly prefixed env vars
+(`VECDB_*` for the base config, `QDRANT_*` etc. per provider) do work,
+and that explicit constructor arguments beat env values.
+
+No live vector-store connections are needed: config construction only.
+"""
+⋮----
+ALL_CONFIGS: list[Type[VectorStoreConfig]] = [
+⋮----
+# provider config -> (its env prefix, a str field to probe with)
+PREFIXED_CASES: list[tuple[Type[VectorStoreConfig], str, str]] = [
+⋮----
+# every field name these tests assert on, in env-var (upper) form
+FIELD_VARS: list[str] = [
+⋮----
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None
+⋮----
+"""Remove ambient bare and prefixed env vars before each test.
+
+    A runner may legitimately have e.g. `POSTGRES_HOST` set (docker/CI)
+    or a stray `QDRANT_FULL_EVAL`; without this cleanup those would make
+    the default-value assertions below fail spuriously. Runs before each
+    test body, so tests that intentionally `setenv` still work.
+    """
+prefixes = [""] + [prefix for _, prefix, _ in PREFIXED_CASES]
+⋮----
+"""Bare (unprefixed) env vars must not override config defaults."""
+⋮----
+defaults = config_cls.model_fields
+config = config_cls()
+⋮----
+"""Env vars with the class's own prefix DO override defaults."""
+⋮----
+"""Explicit constructor kwargs take priority over prefixed env vars."""
+⋮----
+config = config_cls(**{field: "explicit", "full_eval": False})
+⋮----
+"""One provider's prefixed env vars must not affect other providers."""
+⋮----
+"""A k8s/docker service-link `tcp://...` port is ignored with a warning.
+
+    With `enableServiceLinks` (on by default in Kubernetes), a service
+    named e.g. `qdrant` injects `QDRANT_PORT=tcp://10.0.0.8:6333` into
+    every pod; construction must succeed with the default port.
+    """
+⋮----
+default_port = config_cls.model_fields["port"].default
+⋮----
+"""Only the `tcp://` service-link format is forgiven; other junk fails."""
+⋮----
+"""A `tcp://` value NOT matching the full service-link shape fails.
+
+    Only `tcp://<host>:<digits>` (the exact k8s injection format) is
+    forgiven; malformed `tcp://` junk must fail validation loudly.
+    """
+⋮----
+def test_constructor_tcp_port_still_fails() -> None
+⋮----
+"""The service-link exception applies to the env source ONLY.
+
+    An explicit constructor value is a programming error, not a k8s
+    artifact, so it must fail validation rather than be silently
+    replaced with the default.
+    """
+⋮----
+QdrantDBConfig(port="tcp://10.0.0.8:6333")  # type: ignore[arg-type]
+⋮----
+def test_valid_env_port_still_works(monkeypatch: pytest.MonkeyPatch) -> None
+⋮----
+"""A normal numeric prefixed port env var is honored as before."""
+⋮----
+def test_valid_constructor_port_still_works() -> None
+⋮----
+"""A normal explicit constructor port is honored as before."""
+⋮----
+"""A service-link-like value with a trailing newline fails validation.
+
+    The full-format check must anchor at the true end of the string
+    (`\\Z`), not `$` (which matches before a trailing newline), so this
+    value is NOT silently discarded.
+    """
+⋮----
+"""`set_env` writes names a fresh config actually reads back.
+
+    `set_env` used to write bare upper-cased field names (`HOST`),
+    which prefixed configs no longer read; it must write
+    `<PREFIX><FIELD>` (e.g. `QDRANT_HOST`).
+    """
+config = QdrantDBConfig(host="example.internal")
+# pre-register every var set_env will write, so monkeypatch teardown
+# restores each to its original (absent) state after the test
+⋮----
+name = field.alias or f"QDRANT_{field_name.upper()}"
+⋮----
+# pre-existing set_env limitation, unrelated to prefixes: complex
+# fields (nested configs, classes) are written as non-JSON python
+# reprs the env source cannot parse back; clear them so the fresh
+# construction below exercises the simple fields
+⋮----
+"""A settings class without env_prefix still gets bare var names."""
+⋮----
+class PlainSettings(BaseSettings)
+⋮----
+some_field: str = "default"
 </file>
 
 <file path="tests/main/test_vector_stores.py">
@@ -68039,6 +67534,441 @@ page_no = 0
         """
 </file>
 
+<file path="langroid/vector_store/postgres.py">
+has_postgres: bool = True
+⋮----
+Engine = Any  # type: ignore
+Connection = Any  # type: ignore
+has_postgres = False
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+def _quote_ident(name: str) -> str
+⋮----
+"""Quote a SQL identifier (table/index name) for use in raw DDL, so a name
+    containing characters that are invalid in an unquoted identifier -- e.g.
+    the ``-`` in a pytest-xdist worker suffix like ``mycollection-gw1`` -- does
+    not produce a syntax error. Embedded double-quotes are escaped per the SQL
+    standard.
+    """
+⋮----
+class PostgresDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="POSTGRES_")
+⋮----
+collection_name: str = "embeddings"
+cloud: bool = False
+docker: bool = True
+host: str = "127.0.0.1"
+port: int = 5432
+replace_collection: bool = False
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+pool_size: int = 10
+max_overflow: int = 20
+hnsw_m: int = 16
+hnsw_ef_construction: int = 200
+⋮----
+class PostgresDB(VectorStore)
+⋮----
+def __init__(self, config: PostgresDBConfig | None = None)
+⋮----
+config = config if config is not None else PostgresDBConfig()
+⋮----
+def _create_engine(self) -> Engine
+⋮----
+"""Creates a SQLAlchemy engine based on the configuration."""
+⋮----
+connection_string: str | None = None  # Ensure variable is always defined
+⋮----
+connection_string = os.getenv("POSTGRES_CONNECTION_STRING")
+⋮----
+connection_string = connection_string.replace(
+⋮----
+username = os.getenv("POSTGRES_USER", "postgres")
+password = os.getenv("POSTGRES_PASSWORD", "postgres")
+database = os.getenv("POSTGRES_DB", "langroid")
+⋮----
+connection_string = (
+self.config.cloud = False  # Ensures cloud is disabled if using Docker
+⋮----
+def _setup_table(self) -> None
+⋮----
+# Create HNSW index for embeddings column if it doesn't exist.
+# This index enables efficient nearest-neighbor search using cosine similarity.
+# PostgreSQL automatically builds the index after creation;
+# no manual step required.
+# Read more about pgvector hnsw index here:
+# https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw
+⋮----
+index_name = f"hnsw_index_{self.config.collection_name}_embedding"
+⋮----
+create_index_query = text(
+⋮----
+def index_exists(self, connection: Connection, index_name: str) -> bool
+⋮----
+"""Check if an index exists."""
+query = text(
+result = connection.execute(query).scalar()
+⋮----
+@staticmethod
+    def _create_vector_extension(conn: Engine) -> None
+⋮----
+# The number is a unique identifier used to lock a specific resource
+# during transaction. Any 64-bit integer can be used for advisory locks.
+# Acquire advisory lock to ensure atomic, isolated setup
+# and prevent race conditions.
+⋮----
+statement = text(
+⋮----
+def set_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+inspector = inspect(self.engine)
+table_exists = collection_name in inspector.get_table_names()
+⋮----
+def list_collections(self, empty: bool = True) -> List[str]
+⋮----
+table_names = inspector.get_table_names()
+⋮----
+collections = []
+⋮----
+table = Table(table_name, self.metadata, autoload_with=self.engine)
+⋮----
+# Efficiently check for non-emptiness
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+"""
+        Deletes a collection and its associated HNSW index, handling metadata
+        synchronization issues.
+        """
+⋮----
+index_name = f"hnsw_index_{collection_name}_embedding"
+drop_index_query = text(
+⋮----
+# 3. Now, drop the table using SQLAlchemy
+table = Table(collection_name, self.metadata)
+⋮----
+# 4. Refresh metadata again after dropping the table
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+deleted_count = 0
+⋮----
+# Use delete_collection to handle index and table deletion
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+# Efficiently check for emptiness without fetching all rows
+⋮----
+session.commit()  # Commit is likely not needed here
+⋮----
+def _parse_embedding_store_record(self, res: Any) -> Dict[str, Any]
+⋮----
+metadata = res.cmetadata or {}
+⋮----
+def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+query = session.query(self.embeddings_table)
+⋮----
+# Apply 'where' clause if provided
+⋮----
+where_json = json.loads(where)
+query = query.filter(
+⋮----
+return []  # Return empty list or handle error as appropriate
+⋮----
+results = query.all()
+documents = [
+⋮----
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+# Add a CASE statement to preserve the order of IDs
+case_stmt = case(
+⋮----
+query = (
+⋮----
+.order_by(case_stmt)  # Order by the CASE statement
+⋮----
+def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+embeddings = self.embedding_fn([doc.content for doc in documents])
+⋮----
+batch_size = self.config.batch_size
+⋮----
+batch_docs = documents[i : i + batch_size]
+batch_embeddings = embeddings[i : i + batch_size]
+⋮----
+new_records = [
+⋮----
+stmt = insert(self.embeddings_table).values(new_records)
+⋮----
+@staticmethod
+    def _id_to_uuid(id: str, obj: object) -> str
+⋮----
+doc_id = str(uuid.UUID(id))
+⋮----
+obj_repr = repr(obj)
+⋮----
+obj_hash = hashlib.sha256(obj_repr.encode()).hexdigest()
+⋮----
+combined = f"{id}-{obj_hash}"
+⋮----
+doc_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, combined))
+⋮----
+neighbors: int = 1,  # Parameter not used in this implementation
+⋮----
+embedding = self.embedding_fn([query])[0]
+⋮----
+# Calculate the score (1 - cosine_distance) and label it as "score"
+score = (
+⋮----
+json_query = json.loads(where)
+⋮----
+results = (
+⋮----
+score,  # Select the calculated score
+⋮----
+.order_by(score.desc())  # Order by score in descending order
+⋮----
+documents_with_scores = [
+⋮----
+result.score,  # Use the score from the query result
+</file>
+
+<file path="langroid/vector_store/qdrantdb.py">
+logger = logging.getLogger(__name__)
+⋮----
+T = TypeVar("T")
+⋮----
+def from_optional(x: Optional[T], default: T) -> T
+⋮----
+def is_valid_uuid(uuid_to_test: str) -> bool
+⋮----
+"""
+    Check if a given string is a valid UUID.
+    """
+⋮----
+uuid_obj = uuid.UUID(uuid_to_test)
+⋮----
+# Check for valid unsigned 64-bit integer
+⋮----
+int_value = int(uuid_to_test)
+⋮----
+class QdrantDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="QDRANT_")
+⋮----
+cloud: bool = True
+docker: bool = False
+collection_name: str | None = "temp"
+storage_path: str = ".qdrant/data"
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+use_sparse_embeddings: bool = False
+sparse_embedding_model: str = "naver/splade-v3-distilbert"
+sparse_limit: int = 3
+distance: str = "cosine"
+⋮----
+class QdrantDB(VectorStore)
+⋮----
+def __init__(self, config: QdrantDBConfig | None = None)
+⋮----
+config = config if config is not None else QdrantDBConfig()
+⋮----
+self.sparse_tokenizer = AutoTokenizer.from_pretrained(  # type: ignore
+⋮----
+key = os.getenv("QDRANT_API_KEY")
+url = os.getenv("QDRANT_API_URL")
+⋮----
+new_storage_path = config.storage_path + ".new"
+⋮----
+# Note: Only create collection if a non-null collection name is provided.
+# This is useful to delay creation of vecdb until we have a suitable
+# collection name (e.g. we could get it from the url or folder path).
+⋮----
+def clone(self) -> "QdrantDB"
+⋮----
+"""Create an independent Qdrant client when running against Qdrant Cloud."""
+⋮----
+cloned = super().clone()
+⋮----
+def close(self) -> None
+⋮----
+"""
+        Close the QdrantDB client and release any resources (e.g., file locks).
+        This is especially important for local storage to release the .lock file.
+        """
+⋮----
+# QdrantLocal has a close method that releases the lock
+⋮----
+def __enter__(self) -> "QdrantDB"
+⋮----
+"""Context manager entry."""
+⋮----
+def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
+⋮----
+"""Context manager exit - ensure cleanup even if an exception occurred."""
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+coll_names = self.list_collections()
+n_deletes = 0
+⋮----
+info = self.client.get_collection(collection_name=name)
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+"""Clear all collections with the given prefix."""
+⋮----
+coll_names = [
+⋮----
+n_empty_deletes = 0
+n_non_empty_deletes = 0
+⋮----
+points_count = from_optional(info.points_count, 0)
+⋮----
+def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+"""
+        Returns:
+            List of collection names that have at least one vector.
+
+        Args:
+            empty (bool, optional): Whether to include empty collections.
+        """
+⋮----
+colls = list(self.client.get_collections())[0][1]
+⋮----
+counts = []
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+"""
+        Create a collection with the given name, optionally replacing an existing
+            collection if `replace` is True.
+        Args:
+            collection_name (str): Name of the collection to create.
+            replace (bool): Whether to replace an existing collection
+                with the same name. Defaults to False.
+        """
+⋮----
+coll = self.client.get_collection(collection_name=collection_name)
+⋮----
+vectors_config = {
+sparse_vectors_config = None
+⋮----
+sparse_vectors_config = {
+⋮----
+collection_info = self.client.get_collection(collection_name=collection_name)
+⋮----
+level = logger.getEffectiveLevel()
+⋮----
+def get_sparse_embeddings(self, inputs: List[str]) -> List["SparseVector"]
+⋮----
+tokens = self.sparse_tokenizer(
+output = self.sparse_model(**tokens)
+vectors = torch.max(
+sparse_embeddings = []
+⋮----
+cols = vec.nonzero().squeeze().cpu().tolist()
+weights = vec[cols].cpu().tolist()
+⋮----
+def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+# Add id to metadata if not already present
+⋮----
+# Fix the ids due to qdrant finickiness
+⋮----
+colls = self.list_collections(empty=True)
+⋮----
+document_dicts = [doc.model_dump() for doc in documents]
+embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+sparse_embedding_vecs = self.get_sparse_embeddings(
+⋮----
+ids = [self._to_int_or_uuid(d.id()) for d in documents]
+# don't insert all at once, batch in chunks of b,
+# else we get an API error
+b = self.config.batch_size
+⋮----
+vectors: Dict[str, Embeddings | List[SparseVector]] = {
+⋮----
+coll_found: bool = False
+⋮----
+# poll until collection is ready
+⋮----
+coll_found = True
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+def _to_int_or_uuid(self, id: str) -> int | str
+⋮----
+int_val = int(id)
+⋮----
+# If doc_id is already a valid UUID, return it as is
+⋮----
+# Otherwise, generate a UUID from the doc_id
+# Convert doc_id to string if it's not already
+id_str = str(id)
+⋮----
+# Hash the document ID using SHA-1
+hash_object = hashlib.sha1(id_str.encode())
+hash_digest = hash_object.hexdigest()
+⋮----
+# Truncate or manipulate the hash to fit into a UUID (128 bits)
+uuid_str = hash_digest[:32]
+⋮----
+# Format this string into a UUID format
+formatted_uuid = uuid.UUID(uuid_str)
+⋮----
+def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+docs = []
+offset = 0
+filter = Filter() if where == "" else Filter.model_validate(json.loads(where))
+⋮----
+limit=10_000,  # try getting all at once, if not we keep paging
+⋮----
+self.config.document_class(**record.payload)  # type: ignore
+⋮----
+# ignore
+⋮----
+offset = next_page_offset  # type: ignore
+⋮----
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+_ids = [self._to_int_or_uuid(id) for id in ids]
+records = self.client.retrieve(
+# Note the records may NOT be in the order of the ids,
+# so we re-order them here.
+id2payload = {record.id: record.payload for record in records}
+ordered_payloads = [id2payload[id] for id in _ids if id in id2payload]
+docs = [Document(**payload) for payload in ordered_payloads]  # type: ignore
+⋮----
+embedding = self.embedding_fn([text])[0]
+# TODO filter may not work yet
+⋮----
+filter = Filter()
+⋮----
+filter = Filter.model_validate(json.loads(where))
+requests = [
+⋮----
+sparse_embedding = self.get_sparse_embeddings([text])[0]
+⋮----
+search_result_lists: List[List[ScoredPoint]] = self.client.search_batch(
+⋮----
+search_result = [
+⋮----
+]  # 2D list -> 1D list
+scores = [match.score for match in search_result if match is not None]
+docs = [
+⋮----
+self.config.document_class(**(match.payload))  # type: ignore
+⋮----
+doc_score_pairs = list(zip(docs, scores))
+max_score = max(ds[1] for ds in doc_score_pairs)
+</file>
+
 <file path="tests/main/test_mcp_tools.py">
 # note we use pydantic v2 to define MCP server
 from pydantic import (  # keep - need pydantic v2 for MCP server
@@ -70179,6 +70109,1447 @@ it, and if it was a denylist gap it is out of scope.
 
 Security fixes ship in the latest release. Please upgrade to the current
 version of `langroid` rather than requesting backports.
+</file>
+
+<file path="langroid/language_models/openai_gpt.py">
+OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
+⋮----
+OLLAMA_BASE_URL = "http://localhost:11434/v1"
+⋮----
+DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+# Provider prefixes that route to the Gemini OpenAI-compatible API.
+GEMINI_MODEL_PREFIXES = ("gemini/", "google/gemini-")
+GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+OLLAMA_API_KEY = "ollama"
+⋮----
+VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
+LLAMACPP_API_KEY = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
+⋮----
+openai_chat_model_pref_list = [
+⋮----
+openai_completion_model_pref_list = [
+⋮----
+available_models = set(map(lambda m: m.id, OpenAI().models.list()))
+⋮----
+available_models = set()
+⋮----
+default_openai_chat_model = next(
+default_openai_completion_model = next(
+⋮----
+class AccessWarning(Warning)
+⋮----
+@cache
+def gpt_3_5_warning() -> None
+⋮----
+@cache
+def parallel_strict_warning() -> None
+⋮----
+def noop() -> None
+⋮----
+"""Does nothing."""
+⋮----
+class OpenAICallParams(BaseModel)
+⋮----
+"""
+    Various params that can be sent to an OpenAI API chat-completion call.
+    When specified, any param here overrides the one with same name in the
+    OpenAIGPTConfig.
+    See OpenAI API Reference for details on the params:
+    https://platform.openai.com/docs/api-reference/chat
+    """
+⋮----
+max_tokens: int | None = None
+temperature: float | None = None
+frequency_penalty: float | None = None  # between -2 and 2
+presence_penalty: float | None = None  # between -2 and 2
+response_format: Dict[str, str] | None = None
+logit_bias: Dict[int, float] | None = None  # token_id -> bias
+logprobs: bool | None = None
+top_p: float | None = None
+reasoning_effort: str | None = None  # or "low" or "high" or "medium"
+top_logprobs: int | None = None  # if int, requires logprobs=True
+n: int | None = None  # how many completions to generate (n > 1 is NOT handled now)
+stop: str | List[str] | None = None  # (list of) stop sequence(s)
+seed: int | None = None
+user: str | None = None  # user id for tracking
+extra_body: Dict[str, Any] | None = None  # additional params for API request body
+⋮----
+def to_dict_exclude_none(self) -> Dict[str, Any]
+⋮----
+class LiteLLMProxyConfig(BaseSettings)
+⋮----
+"""Configuration for LiteLLM proxy connection."""
+⋮----
+api_key: str = ""  # read from env var LITELLM_API_KEY if set
+api_base: str = ""  # read from env var LITELLM_API_BASE if set
+⋮----
+model_config = SettingsConfigDict(env_prefix="LITELLM_")
+⋮----
+class OpenAIGPTConfig(LLMConfig)
+⋮----
+"""
+    Class for any LLM with an OpenAI-like API: besides the OpenAI models this includes:
+    (a) locally-served models behind an OpenAI-compatible API
+    (b) non-local models, using a proxy adaptor lib like litellm that provides
+        an OpenAI-compatible API.
+    (We could rename this class to OpenAILikeConfig, but we keep it as-is for now)
+
+    Important Note:
+    Due to the `env_prefix = "OPENAI_"` defined below,
+    all of the fields below can be set AND OVERRIDDEN via env vars,
+    # by upper-casing the name and prefixing with OPENAI_, e.g.
+    # OPENAI_MAX_OUTPUT_TOKENS=1000.
+    # If any of these is defined in this way in the environment
+    # (either via explicit setenv or export or via .env file + load_dotenv()),
+    # the environment variable takes precedence over the value in the config.
+    """
+⋮----
+type: str = "openai"
+api_key: str = DUMMY_API_KEY
+# Callable returning a fresh API key/bearer token, for endpoints that
+# authenticate with short-lived rotating credentials (e.g. Vertex AI
+# OAuth tokens, Azure Entra ID). Resolved per-request by the OpenAI
+# client, and excluded from the client-cache key (the cache is keyed on
+# the provider's identity), so rotating tokens neither go stale nor grow
+# the cache. Takes precedence over `api_key`. Only supported for models
+# served via an OpenAI-compatible endpoint (not Groq/Cerebras/litellm).
+# See docs/notes/rotating-api-keys.md.
+api_key_provider: Optional[Callable[[], str]] = None
+organization: str = ""
+api_base: str | None = None  # used for local or other non-OpenAI models
+litellm: bool = False  # use litellm api?
+litellm_proxy: LiteLLMProxyConfig = LiteLLMProxyConfig()
+ollama: bool = False  # use ollama's OpenAI-compatible endpoint?
+min_output_tokens: int = 1
+use_chat_for_completion: bool = True  # do not change this, for OpenAI models!
+timeout: int = 20
+temperature: float = 0.2
+seed: int | None = 42
+params: OpenAICallParams | None = None
+use_cached_client: bool = (
+⋮----
+True  # Whether to reuse cached clients (prevents resource exhaustion)
+⋮----
+# these can be any model name that is served at an OpenAI-compatible API end point
+chat_model: str = default_openai_chat_model
+chat_model_orig: Optional[str] = None
+completion_model: str = default_openai_completion_model
+run_on_first_use: Callable[[], None] = noop
+parallel_tool_calls: Optional[bool] = None
+# Supports constrained decoding which enforces that the output of the LLM
+# adheres to a JSON schema
+supports_json_schema: Optional[bool] = None
+# Supports strict decoding for the generation of tool calls with
+# the OpenAI Tools API; this ensures that the generated tools
+# adhere to the provided schema.
+supports_strict_tools: Optional[bool] = None
+# a string that roughly matches a HuggingFace chat_template,
+# e.g. "mistral-instruct-v0.2 (a fuzzy search is done to find the closest match)
+formatter: str | None = None
+hf_formatter: HFFormatter | None = None
+langdb_params: LangDBParams = LangDBParams()
+portkey_params: PortkeyParams = PortkeyParams()
+headers: Dict[str, str] = {}
+http_client_factory: Optional[Callable[[], Any]] = (
+⋮----
+None  # Factory: returns Client or (Client, AsyncClient)
+⋮----
+http_verify_ssl: bool = True  # Simple flag for SSL verification
+http_client_config: Optional[Dict[str, Any]] = None  # Config dict for httpx.Client
+_api_base_was_supplied: bool = False
+⋮----
+def __init__(self, **kwargs) -> None:  # type: ignore
+⋮----
+api_base_was_supplied = "api_base" in kwargs
+local_model = "api_base" in kwargs and kwargs["api_base"] is not None
+⋮----
+chat_model = kwargs.get("chat_model", "")
+local_prefixes = ["local/", "litellm/", "ollama/", "vllm/", "llamacpp/"]
+⋮----
+local_model = True
+⋮----
+warn_gpt_3_5 = (
+⋮----
+existing_hook = kwargs.get("run_on_first_use", noop)
+⋮----
+def with_warning() -> None
+⋮----
+env_prefix = self.model_config.get("env_prefix")
+env_api_base_name = f"{env_prefix}API_BASE"
+env_api_base = os.getenv(env_api_base_name)
+⋮----
+case_insensitive_env = {
+env_api_base = case_insensitive_env.get(env_api_base_name.lower())
+api_base_was_supplied = api_base_was_supplied or (
+⋮----
+model_config = SettingsConfigDict(env_prefix="OPENAI_")
+⋮----
+def __setattr__(self, name: str, value: Any) -> None
+⋮----
+"""Track API bases assigned after config construction."""
+⋮----
+"""
+        Copy config while preserving nested model instances and subclasses.
+
+        Important: Avoid reconstructing via `model_dump` as that coerces nested
+        models to their annotated base types (dropping subclass-only fields).
+        Instead, defer to Pydantic's native `model_copy`, which keeps nested
+        `BaseModel` instances (and their concrete subclasses) intact.
+
+        An `api_base` supplied through `update` is caller configuration, so the
+        copy must retain that provenance for provider-specific routing.
+        """
+# Delegate to BaseSettings/BaseModel implementation to preserve types
+copied = super().model_copy(update=update, deep=deep)
+⋮----
+return copied  # type: ignore[return-value]
+⋮----
+def _validate_litellm(self) -> None
+⋮----
+"""
+        When using liteLLM, validate whether all env vars required by the model
+        have been set.
+        """
+⋮----
+litellm.drop_params = True  # drop un-supported params without crashing
+⋮----
+self.seed = None  # some local mdls don't support seed
+⋮----
+keys_dict = litellm.utils.validate_environment(self.chat_model)
+missing_keys = keys_dict.get("missing_keys", [])
+⋮----
+@classmethod
+    def create(cls, prefix: str) -> Type["OpenAIGPTConfig"]
+⋮----
+"""Create a config class whose params can be set via a desired
+        prefix from the .env file or env vars.
+        E.g., using
+        ```python
+        OllamaConfig = OpenAIGPTConfig.create("ollama")
+        ollama_config = OllamaConfig()
+        ```
+        you can have a group of params prefixed by "OLLAMA_", to be used
+        with models served via `ollama`.
+        This way, you can maintain several setting-groups in your .env file,
+        one per model type.
+        """
+⋮----
+class DynamicConfig(OpenAIGPTConfig)
+⋮----
+class OpenAIResponse(BaseModel)
+⋮----
+"""OpenAI response model, either completion or chat."""
+⋮----
+choices: List[Dict]  # type: ignore
+usage: Dict  # type: ignore
+⋮----
+def litellm_logging_fn(model_call_dict: Dict[str, Any]) -> None
+⋮----
+"""Logging function for litellm"""
+⋮----
+api_input_dict = model_call_dict.get("additional_args", {}).get(
+⋮----
+text = escape(json.dumps(api_input_dict, indent=2))
+⋮----
+# Define a class for OpenAI GPT models that extends the base class
+class OpenAIGPT(LanguageModel)
+⋮----
+"""
+    Class for OpenAI LLMs
+    """
+⋮----
+client: OpenAI | Groq | Cerebras | None
+async_client: AsyncOpenAI | AsyncGroq | AsyncCerebras | None
+⋮----
+def __init__(self, config: OpenAIGPTConfig = OpenAIGPTConfig())
+⋮----
+"""
+        Args:
+            config: configuration for openai-gpt model
+        """
+# copy the config to avoid modifying the original; deep to decouple
+# nested models while preserving their concrete subclasses
+# The api_key_provider must NOT be deep-copied: the client cache is
+# keyed on its identity (so a copy would defeat cache sharing), and it
+# may hold non-copyable state (e.g. a threading.Lock). Clear it in a
+# shallow copy first, then restore the original callable afterwards.
+api_key_provider = config.api_key_provider
+⋮----
+config = config.model_copy(update={"api_key_provider": None})
+config = config.model_copy(deep=True)
+⋮----
+# save original model name such as `provider/model` before
+# we strip out the `provider` - we retain the original in
+# case some params are specific to a provider.
+⋮----
+# Run the first time the model is used
+⋮----
+# global override of chat_model,
+# to allow quick testing with other models
+⋮----
+# there is a formatter specified, e.g.
+# "litellm/ollama/mistral//hf" or
+# "local/localhost:8000/v1//mistral-instruct-v0.2"
+formatter = parts[1]
+⋮----
+# e.g. "litellm/ollama/mistral//hf" -> "litellm/ollama/mistral"
+formatter = find_hf_formatter(self.config.chat_model)
+⋮----
+# e.g. "mistral"
+⋮----
+# e.g. "local/localhost:8000/v1//mistral-instruct-v0.2"
+⋮----
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", DUMMY_API_KEY)
+⋮----
+# if model name starts with "litellm",
+# set the actual model name by stripping the "litellm/" prefix
+# and set the litellm flag to True
+⋮----
+# e.g. litellm/ollama/mistral
+⋮----
+# strip the "litellm/" prefix
+# e.g. litellm/ollama/llama2 => ollama/llama2
+⋮----
+# expect this to be of the form "local/localhost:8000/v1",
+# depending on how the model is launched locally.
+# In this case the model served locally behind an OpenAI-compatible API
+# so we can just use `openai.*` methods directly,
+# and don't need a adaptor library like litellm
+⋮----
+self.config.seed = None  # some models raise an error when seed is set
+# Extract the api_base from the model name after the "local/" prefix
+⋮----
+# use api_base from config if set, else fall back on OLLAMA_BASE_URL
+⋮----
+# If api_base is unset we use OpenAI's endpoint, which supports
+# these features (with JSON schema restricted to a limited set of models)
+⋮----
+# if we're overriding chat model globally, set completion model to same
+⋮----
+# we want to format chats -> completions using this specific formatter
+⋮----
+# use groq-specific client
+⋮----
+# Create new clients without caching
+⋮----
+# use cerebras-specific client
+⋮----
+# TODO there is not async client, so should we do anything here?
+⋮----
+# in these cases, there's no specific client: OpenAI python client suffices
+⋮----
+# Prefer caller config, then Gemini env, then the default.
+gemini_api_base = os.getenv("GEMINI_API_BASE", "")
+explicit_api_base = (
+⋮----
+# Honor caller-supplied base URL (e.g. regional endpoints,
+# proxies) instead of always forcing the default.
+openai_api_base = os.getenv("OPENAI_API_BASE")
+⋮----
+# Only overwrite with MINIMAX_API_KEY when it is actually
+# set, so users who intentionally put their MiniMax key in
+# OPENAI_API_KEY are not silently downgraded to a dummy key.
+minimax_key = os.getenv("MINIMAX_API_KEY", "")
+⋮----
+# Recompute capabilities now that the prefix has been stripped
+# and self.info() can find the model in MODEL_INFO.
+⋮----
+project_id = self.config.langdb_params.project_id
+⋮----
+params = self.config.langdb_params
+⋮----
+# Parse the model string and extract provider/model
+⋮----
+# Set Portkey base URL
+⋮----
+# Set API key - use provider's API key from env if available
+⋮----
+# Add Portkey-specific headers
+⋮----
+# Sanitize the API key: strip leading/trailing whitespace
+# (including stray newlines from .env files or CI secrets).
+⋮----
+# Create http_client if needed - Priority order:
+# 1. http_client_factory (most flexibility, not cacheable)
+# 2. http_client_config (cacheable, moderate flexibility)
+# 3. http_verify_ssl=False (cacheable, simple SSL bypass)
+http_client = None
+async_http_client = None
+http_client_config_used = None
+⋮----
+# Use the factory to create http_client (not cacheable)
+http_client = self.config.http_client_factory()
+⋮----
+# set async_http_client to None - so that it will
+# be created later
+⋮----
+# Use config dict (cacheable)
+http_client_config_used = self.config.http_client_config
+⋮----
+# Simple SSL bypass (cacheable)
+http_client_config_used = {"verify": False}
+⋮----
+# With an api_key_provider, hand the callable itself to the
+# OpenAI client, which resolves a fresh token on each request.
+openai_api_key: Union[str, Callable[[], str]] = (
+⋮----
+client_kwargs: Dict[str, Any] = dict(
+⋮----
+# Create http_client from config for non-cached scenario
+⋮----
+async_client_kwargs: Dict[str, Any] = dict(
+⋮----
+# AsyncOpenAI awaits its api_key callable
+⋮----
+# Create async http_client from config for non-cached scenario
+⋮----
+use_cache = self.config.cache_config is not None
+⋮----
+# switch to fresh redis config if needed
+⋮----
+# force use of fake redis if global cache_type is "fakeredis"
+⋮----
+def _openai_api_call_params(self, kwargs: Dict[str, Any]) -> Dict[str, Any]
+⋮----
+"""
+        Prep the params to be sent to the OpenAI API
+        (or any OpenAI-compatible API, e.g. from Ooba or LmStudio)
+        for chat-completion.
+
+        Order of priority:
+        - (1) Params (mainly max_tokens) in the chat/achat/generate/agenerate call
+                (these are passed in via kwargs)
+        - (2) Params in OpenAIGPTConfig.params (of class OpenAICallParams)
+        - (3) Specific Params in OpenAIGPTConfig (just temperature for now)
+        """
+params = dict(
+⋮----
+def is_openai_chat_model(self) -> bool
+⋮----
+openai_chat_models = [e.value for e in OpenAIChatModel]
+⋮----
+def is_openai_completion_model(self) -> bool
+⋮----
+openai_completion_models = [e.value for e in OpenAICompletionModel]
+⋮----
+def is_gemini_model(self) -> bool
+⋮----
+"""Are we using the gemini OpenAI-compatible API?"""
+⋮----
+def is_deepseek_model(self) -> bool
+⋮----
+deepseek_models = [e.value for e in DeepSeekModel]
+⋮----
+def is_minimax_model(self) -> bool
+⋮----
+"""Are we using the MiniMax OpenAI-compatible API?"""
+minimax_models = [e.value for e in MiniMaxModel]
+⋮----
+def unsupported_params(self) -> List[str]
+⋮----
+"""
+        List of params that are not supported by the current model
+        """
+unsupported = set(self.info().unsupported_params)
+⋮----
+def rename_params(self) -> Dict[str, str]
+⋮----
+"""
+        Map of param name -> new name for specific models.
+        Currently main troublemaker is o1* series.
+        """
+⋮----
+def chat_context_length(self) -> int
+⋮----
+"""
+        Context-length for chat-completion models/endpoints.
+        Get it from the config if explicitly given,
+         otherwise use model_info based on model name, and fall back to
+         generic model_info if there's no match.
+        """
+⋮----
+def completion_context_length(self) -> int
+⋮----
+"""
+        Context-length for completion models/endpoints.
+        Get it from the config if explicitly given,
+         otherwise use model_info based on model name, and fall back to
+         generic model_info if there's no match.
+        """
+⋮----
+def chat_cost(self) -> Tuple[float, float, float]
+⋮----
+"""
+        (Prompt, Cached, Generation) cost per 1000 tokens, for chat-completion
+        models/endpoints.
+        Get it from the dict, otherwise fail-over to general method
+        """
+info = self.info()
+cached_cost_per_million = info.cached_cost_per_million
+⋮----
+cached_cost_per_million = info.input_cost_per_million
+⋮----
+def set_stream(self, stream: bool) -> bool
+⋮----
+"""Enable or disable streaming output from API.
+        Args:
+            stream: enable streaming output from API
+        Returns: previous value of stream
+        """
+tmp = self.config.stream
+⋮----
+def get_stream(self) -> bool
+⋮----
+"""Get streaming status."""
+⋮----
+"""Separate inline reasoning from text tokens in a streaming chunk.
+
+        When models embed thinking inside content (e.g. <think>...</think>)
+        rather than using a separate reasoning field, this splits the chunk
+        into text-only and reasoning-only portions for proper streamer routing.
+
+        Returns (text_tokens, reasoning_tokens, in_reasoning).
+        """
+text_tokens = event_text
+reasoning_tokens = event_reasoning
+⋮----
+remaining = event_text
+⋮----
+text_tokens = ""
+⋮----
+text_tokens = before
+remaining = after
+in_reasoning = True
+⋮----
+reasoning_tokens = before
+in_reasoning = False
+⋮----
+reasoning_tokens = remaining
+⋮----
+"""Process state vars while processing a streaming API response.
+            Returns a tuple consisting of:
+        - is_break: whether to break out of the loop
+        - has_function: whether the response contains a function_call
+        - function_name: name of the function
+        - function_args: args of the function
+        - completion: completion text
+        - reasoning: reasoning text
+        - usage: usage dict
+        """
+# convert event obj (of type ChatCompletionChunk) to dict so rest of code,
+# which expects dicts, works as it did before switching to openai v1.x
+⋮----
+event = event.model_dump()
+⋮----
+usage = event.get("usage", {}) or {}
+choices = event.get("choices", [{}])
+⋮----
+choices = [{}]
+⋮----
+# we have a "usage" chunk, and empty choices, so we're done
+# ASSUMPTION: a usage chunk ONLY arrives AFTER all normal completion text!
+# If any API does not follow this, we need to change this code.
+⋮----
+event_args = ""
+event_fn_name = ""
+event_tool_deltas: Optional[List[Dict[str, Any]]] = None
+silent = settings.quiet
+# The first two events in the stream of Azure OpenAI is useless.
+# In the 1st: choices list is empty, in the 2nd: the dict delta has null content
+⋮----
+delta = choices[0].get("delta", {}) or {}
+# capture both content and reasoning_content
+event_text = delta.get("content", "")
+event_reasoning = delta.get(
+⋮----
+event_fn_name = delta["function_call"]["name"]
+⋮----
+event_args = delta["function_call"]["arguments"]
+⋮----
+# it's a list of deltas, usually just one
+event_tool_deltas = delta["tool_calls"]
+⋮----
+event_text = choices[0]["text"]
+event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
+⋮----
+finish_reason = choices[0].get("finish_reason", "")
+⋮----
+filter_names = [
+event_text = (
+⋮----
+function_name = event_fn_name
+has_function = True
+⋮----
+# print out streaming tool calls, if not async
+⋮----
+tool_fn_name = td["function"]["name"]
+⋮----
+tool_fn_args = td["function"]["arguments"]
+⋮----
+# show this delta in the stream
+is_break = finish_reason in [
+# for function_call, finish_reason does not necessarily
+# contain "function_call" as mentioned in the docs.
+# So we check for "stop" or "function_call" here.
+⋮----
+# we got usage chunk, and empty choices, so we're done
+⋮----
+silent = self.config.async_stream_quiet or settings.quiet
+⋮----
+is_break = choices[0].get("finish_reason", "") in [
+⋮----
+def _stream_response(  # type: ignore
+⋮----
+"""
+        Grab and print streaming response from API.
+        Args:
+            response: event-sequence emitted by API
+            chat: whether in chat-mode (or else completion-mode)
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                Dict version of OpenAIResponse object (with choices, usage)
+
+        """
+completion = ""
+reasoning = ""
+function_args = ""
+function_name = ""
+⋮----
+has_function = False
+tool_deltas: List[Dict[str, Any]] = []
+token_usage: Dict[str, int] = {}
+done: bool = False
+in_reasoning: bool = False  # Track if we're inside reasoning delimiters
+content_present = False
+⋮----
+event_dict = event if isinstance(event, dict) else event.model_dump()
+choices = event_dict.get("choices") or []
+⋮----
+delta = choices[0].get("delta") or {}
+content_present = content_present or (
+⋮----
+# capture the token usage when non-empty
+token_usage = usage
+⋮----
+# if not streaming, then we don't wait for last "usage" chunk
+⋮----
+# mark done, so we quit after the last "usage" chunk
+done = True
+⋮----
+# TODO- get usage info in stream mode (?)
+⋮----
+async def _stream_response_async(  # type: ignore
+⋮----
+"""
+        Grab and print streaming response from API.
+        Args:
+            response: event-sequence emitted by API
+            chat: whether in chat-mode (or else completion-mode)
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                OpenAIResponse object (with choices, usage)
+
+        """
+⋮----
+# mark done, so we quit after the next "usage" chunk
+⋮----
+"""
+        Convert accumulated tool-call deltas to OpenAIToolCall objects.
+        Adapted from this excellent code:
+         https://community.openai.com/t/help-for-function-calls-with-streaming/627170/2
+
+        Args:
+            tools: list of tool deltas received from streaming API
+
+        Returns:
+            str: plain text corresponding to tool calls that failed to parse
+            List[OpenAIToolCall]: list of OpenAIToolCall objects
+            List[Dict[str, Any]]: list of tool dicts
+                (to reconstruct OpenAI API response, so it can be cached)
+        """
+# Initialize a dictionary with default values
+⋮----
+# idx -> dict repr of tool
+# (used to simulate OpenAIResponse object later, and also to
+# accumulate function args as strings)
+idx2tool_dict: Dict[str, Dict[str, Any]] = defaultdict(
+⋮----
+# (try to) parse the fn args of each tool
+contents: List[str] = []
+good_indices = []
+id2args: Dict[str, None | Dict[str, Any]] = {}
+⋮----
+# used to build tool_calls_list below
+id2args[tool_dict["id"]] = args_dict or None  # if {}, store as None
+⋮----
+# remove the failed tool calls
+idx2tool_dict = {
+⋮----
+# create OpenAIToolCall list
+tool_calls_list = [
+⋮----
+@staticmethod
+    def _parse_function_args(args: str) -> Tuple[str, Dict[str, Any]]
+⋮----
+"""
+        Try to parse the `args` string as function args.
+
+        Args:
+            args: string containing function args
+
+        Returns:
+            Tuple of content, function name and args dict.
+            If parsing unsuccessful, returns the original string as content,
+            else returns the args dict.
+        """
+content = ""
+args_dict = {}
+⋮----
+stripped_fn_args = args.strip()
+dict_or_list = parse_imperfect_json(stripped_fn_args)
+⋮----
+args_dict = dict_or_list
+⋮----
+content = args
+⋮----
+"""
+        Create an LLMResponse object from the streaming API response.
+
+        Args:
+            chat: whether in chat-mode (or else completion-mode)
+            tool_deltas: list of tool deltas received from streaming API
+            has_function: whether the response contains a function_call
+            completion: completion text
+            reasoning: reasoning text
+            function_args: string representing function args
+            function_name: name of the function
+            usage: token usage dict
+            content_present: whether a stream delta explicitly contained content
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                Dict version of OpenAIResponse object (with choices, usage)
+                    (this is needed so we can cache the response, as if it were
+                    a non-streaming response)
+        """
+# check if function_call args are valid, if not,
+# treat this as a normal msg, not a function call
+args: Dict[str, Any] = {}
+⋮----
+completion = completion + content
+⋮----
+# mock openai response so we can cache it
+⋮----
+content_present = True
+has_valid_call = len(tool_dicts) > 0 or has_function
+response_content = (
+msg: Dict[str, Any] = dict(
+⋮----
+function_call = LLMFunctionCall(name=function_name)
+function_call_dict = function_call.model_dump()
+⋮----
+# non-chat mode has no function_call
+msg = dict(text=completion)
+response_content = completion
+# TODO: Ignoring reasoning content for non-chat models
+⋮----
+# create an OpenAIResponse object so we can cache it as if it were
+# a non-streaming response
+openai_response = OpenAIResponse(
+# Track whether we extracted inline thought tags from the text.
+# Only set message_with_reasoning when get_reasoning_final()
+# actually finds and extracts inline tags (e.g. <think>...</think>).
+# When reasoning is already provided via a separate API field
+# (e.g. reasoning_content), the message text doesn't contain
+# thought signatures, so there's nothing extra to preserve.
+message_with_reasoning = None
+message: str | None
+⋮----
+# some LLM APIs may not return a separate reasoning field,
+# and the reasoning may be included in the message content
+# within delimiters like <think> ... </think>
+⋮----
+# Inline tags were found and extracted; preserve the
+# original text so it can be restored in message history.
+message_with_reasoning = response_content
+⋮----
+message = response_content
+⋮----
+prompt_tokens = usage.get("prompt_tokens", 0)
+prompt_tokens_details: Any = usage.get("prompt_tokens_details", {})
+cached_tokens = (
+completion_tokens = usage.get("completion_tokens", 0)
+⋮----
+# don't allow empty list [] here
+⋮----
+def _cache_store(self, k: str, v: Any) -> None
+⋮----
+def _cache_lookup(self, fn_name: str, **kwargs: Dict[str, Any]) -> Tuple[str, Any]
+⋮----
+return "", None  # no cache, return empty key and None result
+# Use the kwargs as the cache key
+sorted_kwargs_str = str(sorted(kwargs.items()))
+raw_key = f"{fn_name}:{sorted_kwargs_str}"
+⋮----
+# Hash the key to a fixed length using SHA256
+hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
+⋮----
+# when caching disabled, return the hashed_key and none result
+⋮----
+# Try to get the result from the cache
+⋮----
+cached_val = self.cache.retrieve(hashed_key)
+⋮----
+def _cost_chat_model(self, prompt: int, cached: int, completion: int) -> float
+⋮----
+price = self.chat_cost()
+⋮----
+"""
+        Extracts token usage from ``response`` and computes cost, only when NOT
+        in streaming mode, since the LLM API (OpenAI currently) was not
+        populating the usage fields in streaming mode (but as of Sep 2024, streaming
+        responses include  usage info as well, so we should update the code
+        to directly use usage information from the streaming response, which is more
+        accurate, esp with "thinking" LLMs like o1 series which consume
+        thinking tokens).
+        In streaming mode, these are set to zero for
+        now, and will be updated later by the fn ``update_token_usage``.
+        """
+cost = 0.0
+prompt_tokens = 0
+cached_tokens = 0
+completion_tokens = 0
+⋮----
+usage = response.get("usage")
+⋮----
+prompt_tokens = usage.get("prompt_tokens") or 0
+prompt_tokens_details = usage.get("prompt_tokens_details", {}) or {}
+cached_tokens = prompt_tokens_details.get("cached_tokens") or 0
+completion_tokens = usage.get("completion_tokens") or 0
+cost = self._cost_chat_model(
+⋮----
+def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+# Catch HTTP-level API errors (400, 401, 403, 404, 422, 429, 5xx)
+# without traceback — these originate server-side and a local
+# stack trace adds no diagnostic value.
+# Note: APIConnectionError/APITimeoutError are intentionally NOT
+# caught here so they fall through to the generic handler below,
+# where the full traceback aids in diagnosing local network issues.
+⋮----
+# log and re-raise exception
+⋮----
+def _generate(self, prompt: str, max_tokens: int) -> LLMResponse
+⋮----
+@retry_with_exponential_backoff
+        def completions_with_backoff(**kwargs):  # type: ignore
+⋮----
+cached = False
+⋮----
+cached = True
+⋮----
+completion_call = litellm_completion
+⋮----
+completion_call = self.client.completions.create
+⋮----
+# If it's not in the cache, call the API
+result = completion_call(**kwargs)
+⋮----
+kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
+⋮----
+# TODO this is a temp fix, we should really be using a proper completion fn
+# that takes a pre-formatted prompt, rather than mocking it as a sys msg.
+⋮----
+else:  # any other OpenAI-compatible endpoint
+⋮----
+args = dict(
+⋮----
+max_tokens=max_tokens,  # for output/completion
+⋮----
+args = self._openai_api_call_params(args)
+⋮----
+# assume response is an actual response rather than a streaming event
+⋮----
+response = response.model_dump()
+⋮----
+msg = (response["choices"][0]["message"]["content"] or "").strip()
+⋮----
+msg = (response["choices"][0]["text"] or "").strip()
+⋮----
+async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+# Catch HTTP-level API errors (see comment in generate() above).
+⋮----
+async def _agenerate(self, prompt: str, max_tokens: int) -> LLMResponse
+⋮----
+# note we typically will not have self.config.stream = True
+# when issuing several api calls concurrently/asynchronously.
+# The calling fn should use the context `with Streaming(..., False)` to
+# disable streaming.
+⋮----
+# WARNING: .Completion.* endpoints are deprecated,
+# and as of Sep 2023 only legacy models will work here,
+# e.g. text-davinci-003, text-ada-001.
+⋮----
+@async_retry_with_exponential_backoff
+        async def completions_with_backoff(**kwargs):  # type: ignore
+⋮----
+# TODO this may not work: text_completion is not async,
+# and we didn't find an async version in litellm
+⋮----
+acompletion_call = (
+⋮----
+result = await acompletion_call(**kwargs)
+⋮----
+# only makes sense for non-OpenAI models
+⋮----
+messages = [
+prompt = self.config.hf_formatter.format(messages)
+⋮----
+# turn off streaming for async calls
+⋮----
+# only makes sense for local models, where we are trying to
+# convert a chat dialog msg-sequence to a simple completion prompt.
+⋮----
+formatter = HFFormatter(
+⋮----
+prompt = formatter.format(messages)
+⋮----
+result = await self._achat(
+⋮----
+def _chat_completions_with_backoff_body(self, **kwargs):  # type: ignore
+⋮----
+completion_call = self.client.chat.completions.create
+⋮----
+# If streaming, cannot cache result
+# since it is a generator. Instead,
+# we hold on to the hashed_key and
+# cache the result later
+⋮----
+# Test if this is a stream with an exception by
+# trying to get first chunk: Some providers like LiteLLM
+# produce a valid stream object `result` instead of throwing a
+# rate-limit error, and if we don't catch it here,
+# we end up returning an empty response and not
+# using the retry mechanism in the decorator.
+⋮----
+# try to get the first chunk to check for errors
+test_iter = iter(result)
+first_chunk = next(test_iter)
+# If we get here without error, recreate the stream
+result = chain([first_chunk], test_iter)
+⋮----
+# Empty stream is fine
+⋮----
+# Propagate any errors in the stream
+⋮----
+def _chat_completions_with_backoff(self, **kwargs):  # type: ignore
+⋮----
+retry_func = retry_with_exponential_backoff(
+⋮----
+async def _achat_completions_with_backoff_body(self, **kwargs):  # type: ignore
+⋮----
+acompletion_call = litellm_acompletion
+⋮----
+acompletion_call = self.async_client.chat.completions.create
+⋮----
+# Try to peek at the first chunk to immediately catch any errors
+# Store the original result (the stream)
+original_stream = result
+⋮----
+# Manually create and advance the iterator to check for errors
+stream_iter = original_stream.__aiter__()
+⋮----
+# This will raise an exception if the stream is invalid
+first_chunk = await anext(stream_iter)
+⋮----
+# If we reach here, the stream started successfully
+# Now recreate a fresh stream from the original API result
+# Otherwise, return a new stream that yields the first chunk
+# and remaining items
+async def combined_stream():  # type: ignore
+⋮----
+result = combined_stream()  # type: ignore
+⋮----
+# Empty stream is normal - nothing to do
+⋮----
+# Any exception here should be raised to trigger the retry mechanism
+⋮----
+async def _achat_completions_with_backoff(self, **kwargs):  # type: ignore
+⋮----
+retry_func = async_retry_with_exponential_backoff(
+⋮----
+"""Prepare args for LLM chat-completion API call"""
+⋮----
+llm_messages = [
+⋮----
+llm_messages = messages
+⋮----
+# TODO: we will unconditionally insert a dummy user msg
+# if the only msg is a system msg.
+# We could make this conditional on ModelInfo.needs_first_user_message
+⋮----
+# some LLMs, notable Gemini as of 12/11/24,
+# require the first message to be from the user,
+# so insert a dummy user msg if needed.
+⋮----
+chat_model = self.config.chat_model
+⋮----
+args: Dict[str, Any] = dict(
+⋮----
+# groq fails when we include stream_options in the request
+⋮----
+# get token-usage numbers in stream mode from OpenAI API,
+# and possibly other OpenAI-compatible APIs.
+⋮----
+# only include functions-related args if functions are provided
+# since the OpenAI API will throw an error if `functions` is None or []
+⋮----
+# some models e.g. o1-mini (as of sep 2024) don't support some params,
+# like temperature and stream, so we need to remove them.
+⋮----
+param_rename_map = self.rename_params()
+⋮----
+# finally, get rid of extra_body params exclusive to certain models
+# Only apply allowlist restrictions for known models.
+# Unknown/custom models are allowed to use all params by default.
+is_known_model = self.info().name != "unknown"
+extra_params = args.get("extra_body", {})
+⋮----
+# openAI response will look like this:
+"""
+        {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1677652288,
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "name": "",
+                    "content": "\n\nHello there, how may I help you?",
+                    "reasoning_content": "Okay, let's see here, hmmm...",
+                    "function_call": {
+                        "name": "fun_name",
+                        "arguments: {
+                            "arg1": "val1",
+                            "arg2": "val2"
+                        }
+                    },
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 12,
+                "total_tokens": 21
+            }
+        }
+        """
+choices = response.get("choices")
+⋮----
+message = choices[0].get("message", {})
+⋮----
+message = {}
+⋮----
+content = message.get("content")
+reasoning = message.get("reasoning_content", "")
+⋮----
+message_with_reasoning = content
+⋮----
+msg = content
+⋮----
+fun_call = None
+⋮----
+fun_call = LLMFunctionCall.from_dict(message["function_call"])
+⋮----
+args_str = message["function_call"]["arguments"] or ""
+msg_str = message["content"] or ""
+msg = msg_str + args_str
+oai_tool_calls = None
+⋮----
+oai_tool_calls = []
+⋮----
+tool_call = OpenAIToolCall.from_dict(tool_call_dict)
+⋮----
+serialized_tool_call = json.dumps(tool_call_dict)
+msg = (msg or "") + ("\n" if msg else "") + serialized_tool_call
+⋮----
+# None (no content, e.g. a tool-call-only response) is preserved as
+# None rather than coerced to "", so the distinction survives
+# downstream (see LLMMessage.content / ChatDocument.content_is_none).
+⋮----
+oai_tool_calls=oai_tool_calls or None,  # don't allow empty list [] here
+⋮----
+"""
+        ChatCompletion API call to OpenAI.
+        Args:
+            messages: list of messages  to send to the API, typically
+                represents back and forth dialogue between user and LLM, but could
+                also include "function"-role messages. If messages is a string,
+                it is assumed to be a user message.
+            max_tokens: max output tokens to generate
+            functions: list of LLMFunction specs available to the LLM, to possibly
+                use in its response
+            function_call: controls how the LLM uses `functions`:
+                - "auto": LLM decides whether to use `functions` or not,
+                - "none": LLM blocked from using any function
+                - a dict of {"name": "function_name"} which forces the LLM to use
+                    the specified function.
+        Returns:
+            LLMResponse object
+        """
+args = self._prep_chat_completion(
+cached, hashed_key, response = self._chat_completions_with_backoff(**args)  # type: ignore
+⋮----
+return llm_response  # type: ignore
+⋮----
+response_dict = response
+⋮----
+response_dict = response.model_dump()
+⋮----
+"""
+        Async version of _chat(). See that function for details.
+        """
+⋮----
+cached, hashed_key, response = await self._achat_completions_with_backoff(  # type: ignore
+</file>
+
+<file path="langroid/vector_store/base.py">
+logger = logging.getLogger(__name__)
+⋮----
+# the exact shape Kubernetes service links inject, e.g. tcp://10.0.0.8:6333
+# (\Z, not $: $ would match before a trailing newline, silently
+# discarding a value that should fail validation)
+_SERVICE_LINK_PORT_RE = re.compile(r"^tcp://\S+:\d+\Z")
+⋮----
+class _ServiceLinkPortFilter(PydanticBaseSettingsSource)
+⋮----
+"""Env-source wrapper dropping k8s/docker service-link `port` values.
+
+    With `enableServiceLinks` (on by default in Kubernetes), a service
+    named e.g. `qdrant` injects `QDRANT_PORT=tcp://IP:PORT` into every
+    pod, which would otherwise fail integer validation of the `port`
+    field. If the wrapped env source yields a `port` string matching
+    exactly that format, it is dropped (with a warning) so the class
+    default applies. Any other value — including malformed `tcp://`
+    junk, or a `tcp://` value passed to the constructor (which never
+    goes through this source) — still fails validation as usual.
+    """
+⋮----
+def __init__(self, wrapped: PydanticBaseSettingsSource) -> None
+⋮----
+def __call__(self) -> Dict[str, Any]
+⋮----
+values = self._wrapped()
+port = values.get("port")
+⋮----
+default = self.settings_cls.model_fields["port"].default
+⋮----
+values = {k: v for k, v in values.items() if k != "port"}
+⋮----
+class VectorStoreConfig(BaseSettings)
+⋮----
+# Without a prefix, every field name would itself be a
+# case-insensitive env var (e.g. a bare HOST, PORT, or FULL_EVAL
+# in the environment would silently override defaults); subclasses
+# each set their own prefix (QDRANT_, LANCEDB_, ...).
+model_config = SettingsConfigDict(env_prefix="VECDB_")
+⋮----
+type: str = ""  # deprecated, keeping it for backward compatibility
+collection_name: str | None = "temp"
+replace_collection: bool = False  # replace collection if it already exists
+storage_path: str = ".qdrant/data"
+cloud: bool = False
+batch_size: int = 200
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig(
+embedding_model: Optional[EmbeddingModel] = None
+timeout: int = 60
+host: str = "127.0.0.1"
+port: int = 6333
+# used when parsing search results back as Document objects
+document_class: Type[Document] = Document
+metadata_class: Type[DocMetaData] = DocMetaData
+# compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
+full_eval: bool = False  # runs eval without sanitization. Use only on trusted input
+⋮----
+"""Wrap the env source to drop k8s service-link `port` values.
+
+        Source precedence is unchanged (init beats env, etc.); only the
+        env source is filtered — see `_ServiceLinkPortFilter`.
+        """
+⋮----
+class VectorStore(ABC)
+⋮----
+"""
+    Abstract base class for a vector store.
+    """
+⋮----
+def __init__(self, config: VectorStoreConfig)
+⋮----
+@staticmethod
+    def create(config: VectorStoreConfig) -> Optional["VectorStore"]
+⋮----
+@property
+    def embedding_dim(self) -> int
+⋮----
+def clone(self) -> "VectorStore"
+⋮----
+"""Return a vector-store clone suitable for agent cloning.
+
+        The default implementation deep-copies the configuration, reuses any
+        existing embedding model, and instantiates a fresh store of the same
+        type. Subclasses can override when sharing the instance is required
+        (e.g., embedded/local stores that rely on file locks).
+        """
+⋮----
+config_class = self.config.__class__
+config_data = self.config.model_dump(mode="python")
+⋮----
+config_copy = config_class.model_validate(config_data)
+⋮----
+# Preserve the calculated collection contents without forcing replaces
+⋮----
+config_copy.replace_collection = False  # type: ignore[attr-defined]
+cloned_embedding: Optional[EmbeddingModel] = None
+⋮----
+cloned_embedding = self.embedding_model.clone()  # type: ignore[attr-defined]
+⋮----
+cloned_store = type(self)(config_copy)  # type: ignore[call-arg]
+⋮----
+# Some stores might not honour replace_collection; ensure same collection
+⋮----
+@abstractmethod
+    def clear_empty_collections(self) -> int
+⋮----
+"""Clear all empty collections in the vector store.
+        Returns the number of collections deleted.
+        """
+⋮----
+@abstractmethod
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+"""
+        Clear all collections in the vector store.
+
+        Args:
+            really (bool, optional): Whether to really clear all collections.
+                Defaults to False.
+            prefix (str, optional): Prefix of collections to clear.
+        Returns:
+            int: Number of collections deleted.
+        """
+⋮----
+@abstractmethod
+    def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+"""List all collections in the vector store
+        (only non empty collections if empty=False).
+        """
+⋮----
+def set_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+"""
+        Set the current collection to the given collection name.
+        Args:
+            collection_name (str): Name of the collection.
+            replace (bool, optional): Whether to replace the collection if it
+                already exists. Defaults to False.
+        """
+⋮----
+@abstractmethod
+    def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+"""Create a collection with the given name.
+        Args:
+            collection_name (str): Name of the collection.
+            replace (bool, optional): Whether to replace the
+                collection if it already exists. Defaults to False.
+        """
+⋮----
+@abstractmethod
+    def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+def compute_from_docs(self, docs: List[Document], calc: str) -> str
+⋮----
+"""Compute a result on a set of documents,
+        using a dataframe calc string like `df.groupby('state')['income'].mean()`.
+
+        If full_eval is False (default), the input expression is sanitized to prevent
+        most common code injection attack vectors.
+        If full_eval is True, sanitization is bypassed - use only with trusted input!
+        """
+# convert each doc to a dict, using dotted paths for nested fields
+dicts = [flatten_dict(doc.model_dump(by_alias=True)) for doc in docs]
+df = pd.DataFrame(dicts)
+⋮----
+# SECURITY MITIGATION: Eval input is sanitized to prevent most common
+# code injection attack vectors when full_eval is False. The globals
+# dict also restricts ``__builtins__`` so that even with
+# ``full_eval=True`` the expression cannot reach
+# ``__import__``/``eval``/``exec`` via Python's implicit builtin
+# injection (GHSA-q9p7-wqxg-mrhc).
+vars = {"df": df}
+⋮----
+calc = sanitize_command(calc)
+code = compile(calc, "<calc>", "eval")
+result = eval(code, safe_eval_globals(vars), {})
+⋮----
+# return error message so LLM can fix the calc string if needed
+err = f"""
+⋮----
+# Pd.eval sometimes fails on a perfectly valid exprn like
+# df.loc[..., 'column'] with a KeyError.
+⋮----
+def maybe_add_ids(self, documents: Sequence[Document]) -> None
+⋮----
+"""Add ids to metadata if absent, since some
+        vecdbs don't like having blank ids."""
+⋮----
+"""
+        Find k most similar texts to the given text, in terms of vector distance metric
+        (e.g., cosine similarity).
+
+        Args:
+            text (str): The text to find similar texts for.
+            k (int, optional): Number of similar texts to retrieve. Defaults to 1.
+            where (Optional[str], optional): Where clause to filter the search.
+
+        Returns:
+            List[Tuple[Document,float]]: List of (Document, score) tuples.
+
+        """
+⋮----
+"""
+        In each doc's metadata, there may be a window_ids field indicating
+        the ids of the chunks around the current chunk.
+        These window_ids may overlap, so we
+        - coalesce each overlapping groups into a single window (maintaining ordering),
+        - create a new document for each part, preserving metadata,
+
+        We may have stored a longer set of window_ids than we need during chunking.
+        Now, we just want `neighbors` on each side of the center of the window_ids list.
+
+        Args:
+            docs_scores (List[Tuple[Document, float]]): List of pairs of documents
+                to add context windows to together with their match scores.
+            neighbors (int, optional): Number of neighbors on "each side" of match to
+                retrieve. Defaults to 0.
+                "Each side" here means before and after the match,
+                in the original text.
+
+        Returns:
+            List[Tuple[Document, float]]: List of (Document, score) tuples.
+        """
+# We return a larger context around each match, i.e.
+# a window of `neighbors` on each side of the match.
+docs = [d for d, s in docs_scores]
+scores = [s for d, s in docs_scores]
+⋮----
+doc_chunks = [d for d in docs if d.metadata.is_chunk]
+⋮----
+window_ids_list = []
+id2metadata = {}
+# id -> highest score of a doc it appears in
+id2max_score: Dict[int | str, float] = {}
+⋮----
+window_ids = d.metadata.window_ids
+⋮----
+window_ids = [d.id()]
+⋮----
+n = len(window_ids)
+chunk_idx = window_ids.index(d.id())
+neighbor_ids = window_ids[
+⋮----
+# window_ids could be from different docs,
+# and they may overlap, so we coalesce overlapping groups into
+# separate windows.
+window_ids_list = self.remove_overlaps(window_ids_list)
+final_docs = []
+final_scores = []
+⋮----
+metadata = copy.deepcopy(id2metadata[w[0]])
+⋮----
+document = Document(
+# make a fresh id since content is in general different
+⋮----
+@staticmethod
+    def remove_overlaps(windows: List[List[str]]) -> List[List[str]]
+⋮----
+"""
+        Given a collection of windows, where each window is a sequence of ids,
+        identify groups of overlapping windows, and for each overlapping group,
+        order the chunk-ids using topological sort so they appear in the original
+        order in the text.
+
+        Args:
+            windows (List[int|str]): List of windows, where each window is a
+                sequence of ids.
+
+        Returns:
+            List[int|str]: List of windows, where each window is a sequence of ids,
+                and no two windows overlap.
+        """
+ids = set(id for w in windows for id in w)
+# id -> {win -> # pos}
+id2win2pos: Dict[str, Dict[int, int]] = {id: {} for id in ids}
+⋮----
+n = len(windows)
+# relation between windows:
+order = np.zeros((n, n), dtype=np.int8)
+⋮----
+id = list(set(w).intersection(x))[0]  # any common id
+⋮----
+order[i, j] = -1  # win i is before win j
+⋮----
+order[i, j] = 1  # win i is after win j
+⋮----
+# find groups of windows that overlap, like connected components in a graph
+groups = components(np.abs(order))
+⋮----
+# order the chunk-ids in each group using topological sort
+new_windows = []
+⋮----
+# find total ordering among windows in group based on order matrix
+# (this is a topological sort)
+_g = np.array(g)
+order_matrix = order[_g][:, _g]
+ordered_window_indices = topological_sort(order_matrix)
+ordered_window_ids = [windows[i] for i in _g[ordered_window_indices]]
+flattened = [id for w in ordered_window_ids for id in w]
+flattened_deduped = list(dict.fromkeys(flattened))
+# Note we are not going to split these, and instead we'll return
+# larger windows from concatenating the connected groups.
+# This ensures context is retained for LLM q/a
+⋮----
+@abstractmethod
+    def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+"""
+        Get all documents in the current collection, possibly filtered by `where`.
+        """
+⋮----
+@abstractmethod
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+"""
+        Get documents by their ids.
+        Args:
+            ids (List[str]): List of document ids.
+
+        Returns:
+            List[Document]: List of documents
+        """
+⋮----
+@abstractmethod
+    def delete_collection(self, collection_name: str) -> None
+⋮----
+def show_if_debug(self, doc_score_pairs: List[Tuple[Document, float]]) -> None
 </file>
 
 <file path="tests/main/sql_chat/test_sql_chat_security.py">
@@ -73936,1115 +75307,6 @@ model_names = tuple(_model_name(model) for model in models)
 def _model_name(model: str | ModelName) -> str
 </file>
 
-<file path="langroid/language_models/openai_gpt.py">
-OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
-⋮----
-OLLAMA_BASE_URL = "http://localhost:11434/v1"
-⋮----
-DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
-# Provider prefixes that route to the Gemini OpenAI-compatible API.
-GEMINI_MODEL_PREFIXES = ("gemini/", "google/gemini-")
-GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
-MINIMAX_BASE_URL = "https://api.minimax.io/v1"
-OLLAMA_API_KEY = "ollama"
-⋮----
-VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
-LLAMACPP_API_KEY = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
-⋮----
-openai_chat_model_pref_list = [
-⋮----
-openai_completion_model_pref_list = [
-⋮----
-available_models = set(map(lambda m: m.id, OpenAI().models.list()))
-⋮----
-available_models = set()
-⋮----
-default_openai_chat_model = next(
-default_openai_completion_model = next(
-⋮----
-class AccessWarning(Warning)
-⋮----
-@cache
-def gpt_3_5_warning() -> None
-⋮----
-@cache
-def parallel_strict_warning() -> None
-⋮----
-def noop() -> None
-⋮----
-"""Does nothing."""
-⋮----
-class OpenAICallParams(BaseModel)
-⋮----
-"""
-    Various params that can be sent to an OpenAI API chat-completion call.
-    When specified, any param here overrides the one with same name in the
-    OpenAIGPTConfig.
-    See OpenAI API Reference for details on the params:
-    https://platform.openai.com/docs/api-reference/chat
-    """
-⋮----
-max_tokens: int | None = None
-temperature: float | None = None
-frequency_penalty: float | None = None  # between -2 and 2
-presence_penalty: float | None = None  # between -2 and 2
-response_format: Dict[str, str] | None = None
-logit_bias: Dict[int, float] | None = None  # token_id -> bias
-logprobs: bool | None = None
-top_p: float | None = None
-reasoning_effort: str | None = None  # or "low" or "high" or "medium"
-top_logprobs: int | None = None  # if int, requires logprobs=True
-n: int | None = None  # how many completions to generate (n > 1 is NOT handled now)
-stop: str | List[str] | None = None  # (list of) stop sequence(s)
-seed: int | None = None
-user: str | None = None  # user id for tracking
-extra_body: Dict[str, Any] | None = None  # additional params for API request body
-⋮----
-def to_dict_exclude_none(self) -> Dict[str, Any]
-⋮----
-class LiteLLMProxyConfig(BaseSettings)
-⋮----
-"""Configuration for LiteLLM proxy connection."""
-⋮----
-api_key: str = ""  # read from env var LITELLM_API_KEY if set
-api_base: str = ""  # read from env var LITELLM_API_BASE if set
-⋮----
-model_config = SettingsConfigDict(env_prefix="LITELLM_")
-⋮----
-class OpenAIGPTConfig(LLMConfig)
-⋮----
-"""
-    Class for any LLM with an OpenAI-like API: besides the OpenAI models this includes:
-    (a) locally-served models behind an OpenAI-compatible API
-    (b) non-local models, using a proxy adaptor lib like litellm that provides
-        an OpenAI-compatible API.
-    (We could rename this class to OpenAILikeConfig, but we keep it as-is for now)
-
-    Important Note:
-    Due to the `env_prefix = "OPENAI_"` defined below,
-    all of the fields below can be set AND OVERRIDDEN via env vars,
-    # by upper-casing the name and prefixing with OPENAI_, e.g.
-    # OPENAI_MAX_OUTPUT_TOKENS=1000.
-    # If any of these is defined in this way in the environment
-    # (either via explicit setenv or export or via .env file + load_dotenv()),
-    # the environment variable takes precedence over the value in the config.
-    """
-⋮----
-type: str = "openai"
-api_key: str = DUMMY_API_KEY
-# Callable returning a fresh API key/bearer token, for endpoints that
-# authenticate with short-lived rotating credentials (e.g. Vertex AI
-# OAuth tokens, Azure Entra ID). Resolved per-request by the OpenAI
-# client, and excluded from the client-cache key (the cache is keyed on
-# the provider's identity), so rotating tokens neither go stale nor grow
-# the cache. Takes precedence over `api_key`. Only supported for models
-# served via an OpenAI-compatible endpoint (not Groq/Cerebras/litellm).
-# See docs/notes/rotating-api-keys.md.
-api_key_provider: Optional[Callable[[], str]] = None
-organization: str = ""
-api_base: str | None = None  # used for local or other non-OpenAI models
-litellm: bool = False  # use litellm api?
-litellm_proxy: LiteLLMProxyConfig = LiteLLMProxyConfig()
-ollama: bool = False  # use ollama's OpenAI-compatible endpoint?
-min_output_tokens: int = 1
-use_chat_for_completion: bool = True  # do not change this, for OpenAI models!
-timeout: int = 20
-temperature: float = 0.2
-seed: int | None = 42
-params: OpenAICallParams | None = None
-use_cached_client: bool = (
-⋮----
-True  # Whether to reuse cached clients (prevents resource exhaustion)
-⋮----
-# these can be any model name that is served at an OpenAI-compatible API end point
-chat_model: str = default_openai_chat_model
-chat_model_orig: Optional[str] = None
-completion_model: str = default_openai_completion_model
-run_on_first_use: Callable[[], None] = noop
-parallel_tool_calls: Optional[bool] = None
-# Supports constrained decoding which enforces that the output of the LLM
-# adheres to a JSON schema
-supports_json_schema: Optional[bool] = None
-# Supports strict decoding for the generation of tool calls with
-# the OpenAI Tools API; this ensures that the generated tools
-# adhere to the provided schema.
-supports_strict_tools: Optional[bool] = None
-# a string that roughly matches a HuggingFace chat_template,
-# e.g. "mistral-instruct-v0.2 (a fuzzy search is done to find the closest match)
-formatter: str | None = None
-hf_formatter: HFFormatter | None = None
-langdb_params: LangDBParams = LangDBParams()
-portkey_params: PortkeyParams = PortkeyParams()
-headers: Dict[str, str] = {}
-http_client_factory: Optional[Callable[[], Any]] = (
-⋮----
-None  # Factory: returns Client or (Client, AsyncClient)
-⋮----
-http_verify_ssl: bool = True  # Simple flag for SSL verification
-http_client_config: Optional[Dict[str, Any]] = None  # Config dict for httpx.Client
-_api_base_was_supplied: bool = False
-⋮----
-def __init__(self, **kwargs) -> None:  # type: ignore
-⋮----
-api_base_was_supplied = "api_base" in kwargs
-local_model = "api_base" in kwargs and kwargs["api_base"] is not None
-⋮----
-chat_model = kwargs.get("chat_model", "")
-local_prefixes = ["local/", "litellm/", "ollama/", "vllm/", "llamacpp/"]
-⋮----
-local_model = True
-⋮----
-warn_gpt_3_5 = (
-⋮----
-existing_hook = kwargs.get("run_on_first_use", noop)
-⋮----
-def with_warning() -> None
-⋮----
-env_prefix = self.model_config.get("env_prefix")
-env_api_base_name = f"{env_prefix}API_BASE"
-env_api_base = os.getenv(env_api_base_name)
-⋮----
-case_insensitive_env = {
-env_api_base = case_insensitive_env.get(env_api_base_name.lower())
-api_base_was_supplied = api_base_was_supplied or (
-⋮----
-model_config = SettingsConfigDict(env_prefix="OPENAI_")
-⋮----
-def __setattr__(self, name: str, value: Any) -> None
-⋮----
-"""Track API bases assigned after config construction."""
-⋮----
-"""
-        Copy config while preserving nested model instances and subclasses.
-
-        Important: Avoid reconstructing via `model_dump` as that coerces nested
-        models to their annotated base types (dropping subclass-only fields).
-        Instead, defer to Pydantic's native `model_copy`, which keeps nested
-        `BaseModel` instances (and their concrete subclasses) intact.
-
-        An `api_base` supplied through `update` is caller configuration, so the
-        copy must retain that provenance for provider-specific routing.
-        """
-# Delegate to BaseSettings/BaseModel implementation to preserve types
-copied = super().model_copy(update=update, deep=deep)
-⋮----
-return copied  # type: ignore[return-value]
-⋮----
-def _validate_litellm(self) -> None
-⋮----
-"""
-        When using liteLLM, validate whether all env vars required by the model
-        have been set.
-        """
-⋮----
-litellm.drop_params = True  # drop un-supported params without crashing
-⋮----
-self.seed = None  # some local mdls don't support seed
-⋮----
-keys_dict = litellm.utils.validate_environment(self.chat_model)
-missing_keys = keys_dict.get("missing_keys", [])
-⋮----
-@classmethod
-    def create(cls, prefix: str) -> Type["OpenAIGPTConfig"]
-⋮----
-"""Create a config class whose params can be set via a desired
-        prefix from the .env file or env vars.
-        E.g., using
-        ```python
-        OllamaConfig = OpenAIGPTConfig.create("ollama")
-        ollama_config = OllamaConfig()
-        ```
-        you can have a group of params prefixed by "OLLAMA_", to be used
-        with models served via `ollama`.
-        This way, you can maintain several setting-groups in your .env file,
-        one per model type.
-        """
-⋮----
-class DynamicConfig(OpenAIGPTConfig)
-⋮----
-class OpenAIResponse(BaseModel)
-⋮----
-"""OpenAI response model, either completion or chat."""
-⋮----
-choices: List[Dict]  # type: ignore
-usage: Dict  # type: ignore
-⋮----
-def litellm_logging_fn(model_call_dict: Dict[str, Any]) -> None
-⋮----
-"""Logging function for litellm"""
-⋮----
-api_input_dict = model_call_dict.get("additional_args", {}).get(
-⋮----
-text = escape(json.dumps(api_input_dict, indent=2))
-⋮----
-# Define a class for OpenAI GPT models that extends the base class
-class OpenAIGPT(LanguageModel)
-⋮----
-"""
-    Class for OpenAI LLMs
-    """
-⋮----
-client: OpenAI | Groq | Cerebras | None
-async_client: AsyncOpenAI | AsyncGroq | AsyncCerebras | None
-⋮----
-def __init__(self, config: OpenAIGPTConfig = OpenAIGPTConfig())
-⋮----
-"""
-        Args:
-            config: configuration for openai-gpt model
-        """
-# copy the config to avoid modifying the original; deep to decouple
-# nested models while preserving their concrete subclasses
-# The api_key_provider must NOT be deep-copied: the client cache is
-# keyed on its identity (so a copy would defeat cache sharing), and it
-# may hold non-copyable state (e.g. a threading.Lock). Clear it in a
-# shallow copy first, then restore the original callable afterwards.
-api_key_provider = config.api_key_provider
-⋮----
-config = config.model_copy(update={"api_key_provider": None})
-config = config.model_copy(deep=True)
-⋮----
-# save original model name such as `provider/model` before
-# we strip out the `provider` - we retain the original in
-# case some params are specific to a provider.
-⋮----
-# Run the first time the model is used
-⋮----
-# global override of chat_model,
-# to allow quick testing with other models
-⋮----
-# there is a formatter specified, e.g.
-# "litellm/ollama/mistral//hf" or
-# "local/localhost:8000/v1//mistral-instruct-v0.2"
-formatter = parts[1]
-⋮----
-# e.g. "litellm/ollama/mistral//hf" -> "litellm/ollama/mistral"
-formatter = find_hf_formatter(self.config.chat_model)
-⋮----
-# e.g. "mistral"
-⋮----
-# e.g. "local/localhost:8000/v1//mistral-instruct-v0.2"
-⋮----
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", DUMMY_API_KEY)
-⋮----
-# if model name starts with "litellm",
-# set the actual model name by stripping the "litellm/" prefix
-# and set the litellm flag to True
-⋮----
-# e.g. litellm/ollama/mistral
-⋮----
-# strip the "litellm/" prefix
-# e.g. litellm/ollama/llama2 => ollama/llama2
-⋮----
-# expect this to be of the form "local/localhost:8000/v1",
-# depending on how the model is launched locally.
-# In this case the model served locally behind an OpenAI-compatible API
-# so we can just use `openai.*` methods directly,
-# and don't need a adaptor library like litellm
-⋮----
-self.config.seed = None  # some models raise an error when seed is set
-# Extract the api_base from the model name after the "local/" prefix
-⋮----
-# use api_base from config if set, else fall back on OLLAMA_BASE_URL
-⋮----
-# If api_base is unset we use OpenAI's endpoint, which supports
-# these features (with JSON schema restricted to a limited set of models)
-⋮----
-# if we're overriding chat model globally, set completion model to same
-⋮----
-# we want to format chats -> completions using this specific formatter
-⋮----
-# use groq-specific client
-⋮----
-# Create new clients without caching
-⋮----
-# use cerebras-specific client
-⋮----
-# TODO there is not async client, so should we do anything here?
-⋮----
-# in these cases, there's no specific client: OpenAI python client suffices
-⋮----
-# Prefer caller config, then Gemini env, then the default.
-gemini_api_base = os.getenv("GEMINI_API_BASE", "")
-explicit_api_base = (
-⋮----
-# Honor caller-supplied base URL (e.g. regional endpoints,
-# proxies) instead of always forcing the default.
-openai_api_base = os.getenv("OPENAI_API_BASE")
-⋮----
-# Only overwrite with MINIMAX_API_KEY when it is actually
-# set, so users who intentionally put their MiniMax key in
-# OPENAI_API_KEY are not silently downgraded to a dummy key.
-minimax_key = os.getenv("MINIMAX_API_KEY", "")
-⋮----
-# Recompute capabilities now that the prefix has been stripped
-# and self.info() can find the model in MODEL_INFO.
-⋮----
-project_id = self.config.langdb_params.project_id
-⋮----
-params = self.config.langdb_params
-⋮----
-# Parse the model string and extract provider/model
-⋮----
-# Set Portkey base URL
-⋮----
-# Set API key - use provider's API key from env if available
-⋮----
-# Add Portkey-specific headers
-⋮----
-# Sanitize the API key: strip leading/trailing whitespace
-# (including stray newlines from .env files or CI secrets).
-⋮----
-# Create http_client if needed - Priority order:
-# 1. http_client_factory (most flexibility, not cacheable)
-# 2. http_client_config (cacheable, moderate flexibility)
-# 3. http_verify_ssl=False (cacheable, simple SSL bypass)
-http_client = None
-async_http_client = None
-http_client_config_used = None
-⋮----
-# Use the factory to create http_client (not cacheable)
-http_client = self.config.http_client_factory()
-⋮----
-# set async_http_client to None - so that it will
-# be created later
-⋮----
-# Use config dict (cacheable)
-http_client_config_used = self.config.http_client_config
-⋮----
-# Simple SSL bypass (cacheable)
-http_client_config_used = {"verify": False}
-⋮----
-# With an api_key_provider, hand the callable itself to the
-# OpenAI client, which resolves a fresh token on each request.
-openai_api_key: Union[str, Callable[[], str]] = (
-⋮----
-client_kwargs: Dict[str, Any] = dict(
-⋮----
-# Create http_client from config for non-cached scenario
-⋮----
-async_client_kwargs: Dict[str, Any] = dict(
-⋮----
-# AsyncOpenAI awaits its api_key callable
-⋮----
-# Create async http_client from config for non-cached scenario
-⋮----
-use_cache = self.config.cache_config is not None
-⋮----
-# switch to fresh redis config if needed
-⋮----
-# force use of fake redis if global cache_type is "fakeredis"
-⋮----
-def _openai_api_call_params(self, kwargs: Dict[str, Any]) -> Dict[str, Any]
-⋮----
-"""
-        Prep the params to be sent to the OpenAI API
-        (or any OpenAI-compatible API, e.g. from Ooba or LmStudio)
-        for chat-completion.
-
-        Order of priority:
-        - (1) Params (mainly max_tokens) in the chat/achat/generate/agenerate call
-                (these are passed in via kwargs)
-        - (2) Params in OpenAIGPTConfig.params (of class OpenAICallParams)
-        - (3) Specific Params in OpenAIGPTConfig (just temperature for now)
-        """
-params = dict(
-⋮----
-def is_openai_chat_model(self) -> bool
-⋮----
-openai_chat_models = [e.value for e in OpenAIChatModel]
-⋮----
-def is_openai_completion_model(self) -> bool
-⋮----
-openai_completion_models = [e.value for e in OpenAICompletionModel]
-⋮----
-def is_gemini_model(self) -> bool
-⋮----
-"""Are we using the gemini OpenAI-compatible API?"""
-⋮----
-def is_deepseek_model(self) -> bool
-⋮----
-deepseek_models = [e.value for e in DeepSeekModel]
-⋮----
-def is_minimax_model(self) -> bool
-⋮----
-"""Are we using the MiniMax OpenAI-compatible API?"""
-minimax_models = [e.value for e in MiniMaxModel]
-⋮----
-def unsupported_params(self) -> List[str]
-⋮----
-"""
-        List of params that are not supported by the current model
-        """
-unsupported = set(self.info().unsupported_params)
-⋮----
-def rename_params(self) -> Dict[str, str]
-⋮----
-"""
-        Map of param name -> new name for specific models.
-        Currently main troublemaker is o1* series.
-        """
-⋮----
-def chat_context_length(self) -> int
-⋮----
-"""
-        Context-length for chat-completion models/endpoints.
-        Get it from the config if explicitly given,
-         otherwise use model_info based on model name, and fall back to
-         generic model_info if there's no match.
-        """
-⋮----
-def completion_context_length(self) -> int
-⋮----
-"""
-        Context-length for completion models/endpoints.
-        Get it from the config if explicitly given,
-         otherwise use model_info based on model name, and fall back to
-         generic model_info if there's no match.
-        """
-⋮----
-def chat_cost(self) -> Tuple[float, float, float]
-⋮----
-"""
-        (Prompt, Cached, Generation) cost per 1000 tokens, for chat-completion
-        models/endpoints.
-        Get it from the dict, otherwise fail-over to general method
-        """
-info = self.info()
-cached_cost_per_million = info.cached_cost_per_million
-⋮----
-cached_cost_per_million = info.input_cost_per_million
-⋮----
-def set_stream(self, stream: bool) -> bool
-⋮----
-"""Enable or disable streaming output from API.
-        Args:
-            stream: enable streaming output from API
-        Returns: previous value of stream
-        """
-tmp = self.config.stream
-⋮----
-def get_stream(self) -> bool
-⋮----
-"""Get streaming status."""
-⋮----
-"""Separate inline reasoning from text tokens in a streaming chunk.
-
-        When models embed thinking inside content (e.g. <think>...</think>)
-        rather than using a separate reasoning field, this splits the chunk
-        into text-only and reasoning-only portions for proper streamer routing.
-
-        Returns (text_tokens, reasoning_tokens, in_reasoning).
-        """
-text_tokens = event_text
-reasoning_tokens = event_reasoning
-⋮----
-remaining = event_text
-⋮----
-text_tokens = ""
-⋮----
-text_tokens = before
-remaining = after
-in_reasoning = True
-⋮----
-reasoning_tokens = before
-in_reasoning = False
-⋮----
-reasoning_tokens = remaining
-⋮----
-"""Process state vars while processing a streaming API response.
-            Returns a tuple consisting of:
-        - is_break: whether to break out of the loop
-        - has_function: whether the response contains a function_call
-        - function_name: name of the function
-        - function_args: args of the function
-        - completion: completion text
-        - reasoning: reasoning text
-        - usage: usage dict
-        """
-# convert event obj (of type ChatCompletionChunk) to dict so rest of code,
-# which expects dicts, works as it did before switching to openai v1.x
-⋮----
-event = event.model_dump()
-⋮----
-usage = event.get("usage", {}) or {}
-choices = event.get("choices", [{}])
-⋮----
-choices = [{}]
-⋮----
-# we have a "usage" chunk, and empty choices, so we're done
-# ASSUMPTION: a usage chunk ONLY arrives AFTER all normal completion text!
-# If any API does not follow this, we need to change this code.
-⋮----
-event_args = ""
-event_fn_name = ""
-event_tool_deltas: Optional[List[Dict[str, Any]]] = None
-silent = settings.quiet
-# The first two events in the stream of Azure OpenAI is useless.
-# In the 1st: choices list is empty, in the 2nd: the dict delta has null content
-⋮----
-delta = choices[0].get("delta", {}) or {}
-# capture both content and reasoning_content
-event_text = delta.get("content", "")
-event_reasoning = delta.get(
-⋮----
-event_fn_name = delta["function_call"]["name"]
-⋮----
-event_args = delta["function_call"]["arguments"]
-⋮----
-# it's a list of deltas, usually just one
-event_tool_deltas = delta["tool_calls"]
-⋮----
-event_text = choices[0]["text"]
-event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
-⋮----
-finish_reason = choices[0].get("finish_reason", "")
-⋮----
-filter_names = [
-event_text = (
-⋮----
-function_name = event_fn_name
-has_function = True
-⋮----
-# print out streaming tool calls, if not async
-⋮----
-tool_fn_name = td["function"]["name"]
-⋮----
-tool_fn_args = td["function"]["arguments"]
-⋮----
-# show this delta in the stream
-is_break = finish_reason in [
-# for function_call, finish_reason does not necessarily
-# contain "function_call" as mentioned in the docs.
-# So we check for "stop" or "function_call" here.
-⋮----
-# we got usage chunk, and empty choices, so we're done
-⋮----
-silent = self.config.async_stream_quiet or settings.quiet
-⋮----
-is_break = choices[0].get("finish_reason", "") in [
-⋮----
-def _stream_response(  # type: ignore
-⋮----
-"""
-        Grab and print streaming response from API.
-        Args:
-            response: event-sequence emitted by API
-            chat: whether in chat-mode (or else completion-mode)
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                Dict version of OpenAIResponse object (with choices, usage)
-
-        """
-completion = ""
-reasoning = ""
-function_args = ""
-function_name = ""
-⋮----
-has_function = False
-tool_deltas: List[Dict[str, Any]] = []
-token_usage: Dict[str, int] = {}
-done: bool = False
-in_reasoning: bool = False  # Track if we're inside reasoning delimiters
-content_present = False
-⋮----
-event_dict = event if isinstance(event, dict) else event.model_dump()
-choices = event_dict.get("choices") or []
-⋮----
-delta = choices[0].get("delta") or {}
-content_present = content_present or (
-⋮----
-# capture the token usage when non-empty
-token_usage = usage
-⋮----
-# if not streaming, then we don't wait for last "usage" chunk
-⋮----
-# mark done, so we quit after the last "usage" chunk
-done = True
-⋮----
-# TODO- get usage info in stream mode (?)
-⋮----
-async def _stream_response_async(  # type: ignore
-⋮----
-"""
-        Grab and print streaming response from API.
-        Args:
-            response: event-sequence emitted by API
-            chat: whether in chat-mode (or else completion-mode)
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                OpenAIResponse object (with choices, usage)
-
-        """
-⋮----
-# mark done, so we quit after the next "usage" chunk
-⋮----
-"""
-        Convert accumulated tool-call deltas to OpenAIToolCall objects.
-        Adapted from this excellent code:
-         https://community.openai.com/t/help-for-function-calls-with-streaming/627170/2
-
-        Args:
-            tools: list of tool deltas received from streaming API
-
-        Returns:
-            str: plain text corresponding to tool calls that failed to parse
-            List[OpenAIToolCall]: list of OpenAIToolCall objects
-            List[Dict[str, Any]]: list of tool dicts
-                (to reconstruct OpenAI API response, so it can be cached)
-        """
-# Initialize a dictionary with default values
-⋮----
-# idx -> dict repr of tool
-# (used to simulate OpenAIResponse object later, and also to
-# accumulate function args as strings)
-idx2tool_dict: Dict[str, Dict[str, Any]] = defaultdict(
-⋮----
-# (try to) parse the fn args of each tool
-contents: List[str] = []
-good_indices = []
-id2args: Dict[str, None | Dict[str, Any]] = {}
-⋮----
-# used to build tool_calls_list below
-id2args[tool_dict["id"]] = args_dict or None  # if {}, store as None
-⋮----
-# remove the failed tool calls
-idx2tool_dict = {
-⋮----
-# create OpenAIToolCall list
-tool_calls_list = [
-⋮----
-@staticmethod
-    def _parse_function_args(args: str) -> Tuple[str, Dict[str, Any]]
-⋮----
-"""
-        Try to parse the `args` string as function args.
-
-        Args:
-            args: string containing function args
-
-        Returns:
-            Tuple of content, function name and args dict.
-            If parsing unsuccessful, returns the original string as content,
-            else returns the args dict.
-        """
-content = ""
-args_dict = {}
-⋮----
-stripped_fn_args = args.strip()
-dict_or_list = parse_imperfect_json(stripped_fn_args)
-⋮----
-args_dict = dict_or_list
-⋮----
-content = args
-⋮----
-"""
-        Create an LLMResponse object from the streaming API response.
-
-        Args:
-            chat: whether in chat-mode (or else completion-mode)
-            tool_deltas: list of tool deltas received from streaming API
-            has_function: whether the response contains a function_call
-            completion: completion text
-            reasoning: reasoning text
-            function_args: string representing function args
-            function_name: name of the function
-            usage: token usage dict
-            content_present: whether a stream delta explicitly contained content
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                Dict version of OpenAIResponse object (with choices, usage)
-                    (this is needed so we can cache the response, as if it were
-                    a non-streaming response)
-        """
-# check if function_call args are valid, if not,
-# treat this as a normal msg, not a function call
-args: Dict[str, Any] = {}
-⋮----
-completion = completion + content
-⋮----
-# mock openai response so we can cache it
-⋮----
-content_present = True
-has_valid_call = len(tool_dicts) > 0 or has_function
-response_content = (
-msg: Dict[str, Any] = dict(
-⋮----
-function_call = LLMFunctionCall(name=function_name)
-function_call_dict = function_call.model_dump()
-⋮----
-# non-chat mode has no function_call
-msg = dict(text=completion)
-response_content = completion
-# TODO: Ignoring reasoning content for non-chat models
-⋮----
-# create an OpenAIResponse object so we can cache it as if it were
-# a non-streaming response
-openai_response = OpenAIResponse(
-# Track whether we extracted inline thought tags from the text.
-# Only set message_with_reasoning when get_reasoning_final()
-# actually finds and extracts inline tags (e.g. <think>...</think>).
-# When reasoning is already provided via a separate API field
-# (e.g. reasoning_content), the message text doesn't contain
-# thought signatures, so there's nothing extra to preserve.
-message_with_reasoning = None
-message: str | None
-⋮----
-# some LLM APIs may not return a separate reasoning field,
-# and the reasoning may be included in the message content
-# within delimiters like <think> ... </think>
-⋮----
-# Inline tags were found and extracted; preserve the
-# original text so it can be restored in message history.
-message_with_reasoning = response_content
-⋮----
-message = response_content
-⋮----
-prompt_tokens = usage.get("prompt_tokens", 0)
-prompt_tokens_details: Any = usage.get("prompt_tokens_details", {})
-cached_tokens = (
-completion_tokens = usage.get("completion_tokens", 0)
-⋮----
-# don't allow empty list [] here
-⋮----
-def _cache_store(self, k: str, v: Any) -> None
-⋮----
-def _cache_lookup(self, fn_name: str, **kwargs: Dict[str, Any]) -> Tuple[str, Any]
-⋮----
-return "", None  # no cache, return empty key and None result
-# Use the kwargs as the cache key
-sorted_kwargs_str = str(sorted(kwargs.items()))
-raw_key = f"{fn_name}:{sorted_kwargs_str}"
-⋮----
-# Hash the key to a fixed length using SHA256
-hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
-⋮----
-# when caching disabled, return the hashed_key and none result
-⋮----
-# Try to get the result from the cache
-⋮----
-cached_val = self.cache.retrieve(hashed_key)
-⋮----
-def _cost_chat_model(self, prompt: int, cached: int, completion: int) -> float
-⋮----
-price = self.chat_cost()
-⋮----
-"""
-        Extracts token usage from ``response`` and computes cost, only when NOT
-        in streaming mode, since the LLM API (OpenAI currently) was not
-        populating the usage fields in streaming mode (but as of Sep 2024, streaming
-        responses include  usage info as well, so we should update the code
-        to directly use usage information from the streaming response, which is more
-        accurate, esp with "thinking" LLMs like o1 series which consume
-        thinking tokens).
-        In streaming mode, these are set to zero for
-        now, and will be updated later by the fn ``update_token_usage``.
-        """
-cost = 0.0
-prompt_tokens = 0
-cached_tokens = 0
-completion_tokens = 0
-⋮----
-usage = response.get("usage")
-⋮----
-prompt_tokens = usage.get("prompt_tokens") or 0
-prompt_tokens_details = usage.get("prompt_tokens_details", {}) or {}
-cached_tokens = prompt_tokens_details.get("cached_tokens") or 0
-completion_tokens = usage.get("completion_tokens") or 0
-cost = self._cost_chat_model(
-⋮----
-def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-# Catch HTTP-level API errors (400, 401, 403, 404, 422, 429, 5xx)
-# without traceback — these originate server-side and a local
-# stack trace adds no diagnostic value.
-# Note: APIConnectionError/APITimeoutError are intentionally NOT
-# caught here so they fall through to the generic handler below,
-# where the full traceback aids in diagnosing local network issues.
-⋮----
-# log and re-raise exception
-⋮----
-def _generate(self, prompt: str, max_tokens: int) -> LLMResponse
-⋮----
-@retry_with_exponential_backoff
-        def completions_with_backoff(**kwargs):  # type: ignore
-⋮----
-cached = False
-⋮----
-cached = True
-⋮----
-completion_call = litellm_completion
-⋮----
-completion_call = self.client.completions.create
-⋮----
-# If it's not in the cache, call the API
-result = completion_call(**kwargs)
-⋮----
-kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
-⋮----
-# TODO this is a temp fix, we should really be using a proper completion fn
-# that takes a pre-formatted prompt, rather than mocking it as a sys msg.
-⋮----
-else:  # any other OpenAI-compatible endpoint
-⋮----
-args = dict(
-⋮----
-max_tokens=max_tokens,  # for output/completion
-⋮----
-args = self._openai_api_call_params(args)
-⋮----
-# assume response is an actual response rather than a streaming event
-⋮----
-response = response.model_dump()
-⋮----
-msg = (response["choices"][0]["message"]["content"] or "").strip()
-⋮----
-msg = (response["choices"][0]["text"] or "").strip()
-⋮----
-async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-# Catch HTTP-level API errors (see comment in generate() above).
-⋮----
-async def _agenerate(self, prompt: str, max_tokens: int) -> LLMResponse
-⋮----
-# note we typically will not have self.config.stream = True
-# when issuing several api calls concurrently/asynchronously.
-# The calling fn should use the context `with Streaming(..., False)` to
-# disable streaming.
-⋮----
-# WARNING: .Completion.* endpoints are deprecated,
-# and as of Sep 2023 only legacy models will work here,
-# e.g. text-davinci-003, text-ada-001.
-⋮----
-@async_retry_with_exponential_backoff
-        async def completions_with_backoff(**kwargs):  # type: ignore
-⋮----
-# TODO this may not work: text_completion is not async,
-# and we didn't find an async version in litellm
-⋮----
-acompletion_call = (
-⋮----
-result = await acompletion_call(**kwargs)
-⋮----
-# only makes sense for non-OpenAI models
-⋮----
-messages = [
-prompt = self.config.hf_formatter.format(messages)
-⋮----
-# turn off streaming for async calls
-⋮----
-# only makes sense for local models, where we are trying to
-# convert a chat dialog msg-sequence to a simple completion prompt.
-⋮----
-formatter = HFFormatter(
-⋮----
-prompt = formatter.format(messages)
-⋮----
-result = await self._achat(
-⋮----
-def _chat_completions_with_backoff_body(self, **kwargs):  # type: ignore
-⋮----
-completion_call = self.client.chat.completions.create
-⋮----
-# If streaming, cannot cache result
-# since it is a generator. Instead,
-# we hold on to the hashed_key and
-# cache the result later
-⋮----
-# Test if this is a stream with an exception by
-# trying to get first chunk: Some providers like LiteLLM
-# produce a valid stream object `result` instead of throwing a
-# rate-limit error, and if we don't catch it here,
-# we end up returning an empty response and not
-# using the retry mechanism in the decorator.
-⋮----
-# try to get the first chunk to check for errors
-test_iter = iter(result)
-first_chunk = next(test_iter)
-# If we get here without error, recreate the stream
-result = chain([first_chunk], test_iter)
-⋮----
-# Empty stream is fine
-⋮----
-# Propagate any errors in the stream
-⋮----
-def _chat_completions_with_backoff(self, **kwargs):  # type: ignore
-⋮----
-retry_func = retry_with_exponential_backoff(
-⋮----
-async def _achat_completions_with_backoff_body(self, **kwargs):  # type: ignore
-⋮----
-acompletion_call = litellm_acompletion
-⋮----
-acompletion_call = self.async_client.chat.completions.create
-⋮----
-# Try to peek at the first chunk to immediately catch any errors
-# Store the original result (the stream)
-original_stream = result
-⋮----
-# Manually create and advance the iterator to check for errors
-stream_iter = original_stream.__aiter__()
-⋮----
-# This will raise an exception if the stream is invalid
-first_chunk = await anext(stream_iter)
-⋮----
-# If we reach here, the stream started successfully
-# Now recreate a fresh stream from the original API result
-# Otherwise, return a new stream that yields the first chunk
-# and remaining items
-async def combined_stream():  # type: ignore
-⋮----
-result = combined_stream()  # type: ignore
-⋮----
-# Empty stream is normal - nothing to do
-⋮----
-# Any exception here should be raised to trigger the retry mechanism
-⋮----
-async def _achat_completions_with_backoff(self, **kwargs):  # type: ignore
-⋮----
-retry_func = async_retry_with_exponential_backoff(
-⋮----
-"""Prepare args for LLM chat-completion API call"""
-⋮----
-llm_messages = [
-⋮----
-llm_messages = messages
-⋮----
-# TODO: we will unconditionally insert a dummy user msg
-# if the only msg is a system msg.
-# We could make this conditional on ModelInfo.needs_first_user_message
-⋮----
-# some LLMs, notable Gemini as of 12/11/24,
-# require the first message to be from the user,
-# so insert a dummy user msg if needed.
-⋮----
-chat_model = self.config.chat_model
-⋮----
-args: Dict[str, Any] = dict(
-⋮----
-# groq fails when we include stream_options in the request
-⋮----
-# get token-usage numbers in stream mode from OpenAI API,
-# and possibly other OpenAI-compatible APIs.
-⋮----
-# only include functions-related args if functions are provided
-# since the OpenAI API will throw an error if `functions` is None or []
-⋮----
-# some models e.g. o1-mini (as of sep 2024) don't support some params,
-# like temperature and stream, so we need to remove them.
-⋮----
-param_rename_map = self.rename_params()
-⋮----
-# finally, get rid of extra_body params exclusive to certain models
-# Only apply allowlist restrictions for known models.
-# Unknown/custom models are allowed to use all params by default.
-is_known_model = self.info().name != "unknown"
-extra_params = args.get("extra_body", {})
-⋮----
-# openAI response will look like this:
-"""
-        {
-            "id": "chatcmpl-123",
-            "object": "chat.completion",
-            "created": 1677652288,
-            "choices": [{
-                "index": 0,
-                "message": {
-                    "role": "assistant",
-                    "name": "",
-                    "content": "\n\nHello there, how may I help you?",
-                    "reasoning_content": "Okay, let's see here, hmmm...",
-                    "function_call": {
-                        "name": "fun_name",
-                        "arguments: {
-                            "arg1": "val1",
-                            "arg2": "val2"
-                        }
-                    },
-                },
-                "finish_reason": "stop"
-            }],
-            "usage": {
-                "prompt_tokens": 9,
-                "completion_tokens": 12,
-                "total_tokens": 21
-            }
-        }
-        """
-choices = response.get("choices")
-⋮----
-message = choices[0].get("message", {})
-⋮----
-message = {}
-⋮----
-content = message.get("content")
-reasoning = message.get("reasoning_content", "")
-⋮----
-message_with_reasoning = content
-⋮----
-msg = content
-⋮----
-fun_call = None
-⋮----
-fun_call = LLMFunctionCall.from_dict(message["function_call"])
-⋮----
-args_str = message["function_call"]["arguments"] or ""
-msg_str = message["content"] or ""
-msg = msg_str + args_str
-oai_tool_calls = None
-⋮----
-oai_tool_calls = []
-⋮----
-tool_call = OpenAIToolCall.from_dict(tool_call_dict)
-⋮----
-serialized_tool_call = json.dumps(tool_call_dict)
-msg = (msg or "") + ("\n" if msg else "") + serialized_tool_call
-⋮----
-# None (no content, e.g. a tool-call-only response) is preserved as
-# None rather than coerced to "", so the distinction survives
-# downstream (see LLMMessage.content / ChatDocument.content_is_none).
-⋮----
-oai_tool_calls=oai_tool_calls or None,  # don't allow empty list [] here
-⋮----
-"""
-        ChatCompletion API call to OpenAI.
-        Args:
-            messages: list of messages  to send to the API, typically
-                represents back and forth dialogue between user and LLM, but could
-                also include "function"-role messages. If messages is a string,
-                it is assumed to be a user message.
-            max_tokens: max output tokens to generate
-            functions: list of LLMFunction specs available to the LLM, to possibly
-                use in its response
-            function_call: controls how the LLM uses `functions`:
-                - "auto": LLM decides whether to use `functions` or not,
-                - "none": LLM blocked from using any function
-                - a dict of {"name": "function_name"} which forces the LLM to use
-                    the specified function.
-        Returns:
-            LLMResponse object
-        """
-args = self._prep_chat_completion(
-cached, hashed_key, response = self._chat_completions_with_backoff(**args)  # type: ignore
-⋮----
-return llm_response  # type: ignore
-⋮----
-response_dict = response
-⋮----
-response_dict = response.model_dump()
-⋮----
-"""
-        Async version of _chat(). See that function for details.
-        """
-⋮----
-cached, hashed_key, response = await self._achat_completions_with_backoff(  # type: ignore
-</file>
-
 <file path="tests/main/test_llm.py">
 # allow streaming globally, but can be turned off by individual models
 ⋮----
@@ -76850,6 +77112,7 @@ nav:
       - Context-Overflow Handling: notes/context-overflow.md
       - Batch Processing: notes/batch-processing.md
       - Attachment Token Preflight: notes/attachment-token-preflight.md
+      - Vector-Store Env Prefixes: notes/vecstore-env-prefix.md
 
   - Examples:
     - Guide: examples/guide.md

--- a/llms-no-tests-compressed.txt
+++ b/llms-no-tests-compressed.txt
@@ -156,6 +156,7 @@ docs/
     tool-message-handler.md
     twitter-search.md
     url_loader.md
+    vecstore-env-prefix.md
     weaviate.md
     xml-tools.md
   overrides/
@@ -5051,6 +5052,207 @@ config = OpenAIGPTConfig(
 - Implements singleton pattern with lazy initialization
 - Automatically cleans up clients on program exit via atexit hooks
 - Compatible with both sync and async OpenAI clients
+</file>
+
+<file path="docs/notes/openai-http-client.md">
+# OpenAI HTTP Client Configuration
+
+When using OpenAI models through Langroid in corporate environments or behind proxies, you may encounter SSL certificate verification errors. Langroid provides three flexible options to configure the HTTP client used for OpenAI API calls.
+
+## Configuration Options
+
+### 1. Simple SSL Verification Bypass
+
+The quickest solution for development or trusted environments:
+
+```python
+import langroid.language_models as lm
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_verify_ssl=False  # Disables SSL certificate verification
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+!!! warning "Security Notice"
+    Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks. Only use this in trusted environments.
+
+### 2. HTTP Client Configuration Dictionary
+
+For common scenarios like proxies or custom certificates, use a configuration dictionary:
+
+```python
+import langroid.language_models as lm
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_config={
+        "verify": False,  # Or path to CA bundle: "/path/to/ca-bundle.pem"
+        "proxy": "http://proxy.company.com:8080",
+        "timeout": 30.0,
+        "headers": {
+            "User-Agent": "MyApp/1.0"
+        }
+    }
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+**Benefits**: This approach enables client caching, improving performance when creating multiple agents.
+
+### 3. Custom HTTP Client Factory
+
+For advanced scenarios requiring dynamic behavior or custom authentication:
+
+```python
+import langroid.language_models as lm
+from httpx import Client
+
+def create_custom_client():
+    """Factory function to create a custom HTTP client."""
+    client = Client(
+        verify="/path/to/corporate-ca-bundle.pem",
+        proxies={
+            "http": "http://proxy.corp.com:8080",
+            "https": "http://proxy.corp.com:8080"
+        },
+        timeout=30.0
+    )
+
+    # Add custom event hooks for logging
+    def log_request(request):
+        print(f"API Request: {request.method} {request.url}")
+
+    client.event_hooks = {"request": [log_request]}
+
+    return client
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_factory=create_custom_client
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+If you are using `async` methods, return a tuple of `(Client, AsyncClient)` from your factory:
+
+```python
+from httpx import AsyncClient, Client
+
+def create_custom_client():
+    """Factory function to create a custom sync and async HTTP clients."""
+    client_args = {
+        "verify": "/path/to/corporate-ca-bundle.pem",
+        "proxy": "http://proxy.corp.com:8080",
+        "timeout": 30.0,
+    }
+    client = Client(**client_args)
+    async_client = AsyncClient(**client_args)
+
+    return client, async_client
+```
+
+**Note**: Custom factories bypass client caching. Each `OpenAIGPT` instance creates a new client.
+
+## Priority Order
+
+When multiple options are specified, they are applied in this order:
+1. `http_client_factory` (highest priority)
+2. `http_client_config`
+3. `http_verify_ssl` (lowest priority)
+
+## Common Use Cases
+
+### Corporate Proxy with Custom CA Certificate
+
+```python
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_config={
+        "verify": "/path/to/corporate-ca-bundle.pem",
+        "proxies": {
+            "http": "http://proxy.corp.com:8080",
+            "https": "https://proxy.corp.com:8443"
+        }
+    }
+)
+```
+
+### Debugging API Calls
+
+```python
+def debug_client_factory():
+    from httpx import Client
+
+    client = Client(verify=False)
+
+    def log_response(response):
+        print(f"Status: {response.status_code}")
+        print(f"Headers: {response.headers}")
+
+    client.event_hooks = {
+        "response": [log_response]
+    }
+
+    return client
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_factory=debug_client_factory
+)
+```
+
+### Local Development with Self-Signed Certificates
+
+```python
+# For local OpenAI-compatible APIs
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    api_base="https://localhost:8443/v1",
+    http_verify_ssl=False
+)
+```
+
+
+## Best Practices
+
+1. **Use the simplest option that meets your needs**:
+   - Development/testing: `http_verify_ssl=False`
+   - Corporate environments: `http_client_config` with proper CA bundle
+   - Complex requirements: `http_client_factory`
+
+2. **Prefer configuration over factories for better performance** - configured clients are cached and reused
+
+3. **Always use proper CA certificates in production** instead of disabling SSL verification
+
+4. **Test your configuration** with a simple API call before deploying:
+   ```python
+   llm = lm.OpenAIGPT(config)
+   response = llm.chat("Hello")
+   print(response.content)
+   ```
+
+## Troubleshooting
+
+### SSL Certificate Errors
+```
+ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
+```
+**Solution**: Use one of the three configuration options above.
+
+
+### Proxy Connection Issues
+- Verify proxy URL format: `http://proxy:port` or `https://proxy:port`
+- Check if proxy requires authentication
+- Ensure proxy allows connections to `api.openai.com`
+
+## See Also
+
+- [OpenAI API Reference](https://platform.openai.com/docs/api-reference) - Official OpenAI documentation
 </file>
 
 <file path="docs/notes/overview.md">
@@ -33526,116 +33728,6 @@ logged = True
 __all__ = [
 </file>
 
-<file path="langroid/utils/configuration.py">
-# Global reentrant lock to serialize any modifications to the global settings.
-_global_lock = threading.RLock()
-⋮----
-class Settings(BaseSettings)
-⋮----
-debug: bool = False  # show debug messages?
-max_turns: int = -1  # maximum number of turns in a task (to avoid inf loop)
-progress: bool = False  # show progress spinners/bars?
-stream: bool = True  # stream output?
-cache: bool = True  # use cache?
-cache_type: Literal["redis", "fakeredis", "none"] = "redis"  # cache type
-chat_model: str = ""  # language model name, e.g. litellm/ollama/llama2
-quiet: bool = False  # quiet mode (i.e. suppress all output)?
-notebook: bool = False  # running in a notebook?
-⋮----
-model_config = SettingsConfigDict(extra="forbid")
-⋮----
-# Load environment variables from .env file.
-⋮----
-# The global (default) settings instance.
-# This is updated by update_global_settings() and set_global().
-_global_settings = Settings()
-⋮----
-# Thread-local storage for temporary (per-thread) settings overrides.
-_thread_local = threading.local()
-⋮----
-class SettingsProxy
-⋮----
-"""
-    A proxy for the settings that returns a thread‐local override if set,
-    or else falls back to the global settings.
-    """
-⋮----
-def __getattr__(self, name: str) -> Any
-⋮----
-# If the calling thread has set an override, use that.
-⋮----
-def __setattr__(self, name: str, value: Any) -> None
-⋮----
-# All writes go to the global settings.
-⋮----
-def update(self, new_settings: Settings) -> None
-⋮----
-def dict(self) -> Dict[str, Any]
-⋮----
-# Return a dict view of the settings as seen by the caller.
-# Note that temporary overrides are not “merged” with global settings.
-⋮----
-settings = SettingsProxy()
-⋮----
-def update_global_settings(cfg: BaseSettings, keys: List[str]) -> None
-⋮----
-"""
-    Update global settings so that modules can later access them via, e.g.,
-
-        from langroid.utils.configuration import settings
-        if settings.debug: ...
-
-    This updates the global default.
-    """
-config_dict = cfg.model_dump()
-filtered_config = {key: config_dict[key] for key in keys if key in config_dict}
-new_settings = Settings(**filtered_config)
-⋮----
-def set_global(key_vals: Settings) -> None
-⋮----
-"""
-    Update the global settings object.
-    """
-⋮----
-@contextmanager
-def temporary_settings(temp_settings: Settings) -> Iterator[None]
-⋮----
-"""
-    Temporarily override the settings for the calling thread.
-
-    Within the context, any access to "settings" will use the provided temporary
-    settings. Once the context is exited, the thread reverts to the global settings.
-    """
-saved = getattr(_thread_local, "override", None)
-⋮----
-@contextmanager
-def quiet_mode(quiet: bool = True) -> Iterator[None]
-⋮----
-"""
-    Temporarily override settings.quiet for the current thread.
-    This implementation builds on the thread‑local temporary_settings context manager.
-    The effective quiet mode is merged:
-    if quiet is already True (from an outer context),
-    then it remains True even if a nested context passes quiet=False.
-    """
-current_effective = (
-⋮----
-)  # get the current thread's effective settings
-# Create a new settings instance from the current effective state.
-temp = Settings(**current_effective)
-# Merge the new flag: once quiet is enabled, it stays enabled.
-⋮----
-def set_env(settings_instance: BaseSettings) -> None
-⋮----
-"""
-    Set environment variables from a BaseSettings instance.
-
-    Each field in the settings is written to os.environ.
-    """
-⋮----
-env_var_name = field.alias or field_name.upper()
-</file>
-
 <file path="langroid/utils/constants.py">
 # Define the ANSI escape sequences for various colors and reset
 class Colors(BaseModel)
@@ -38641,207 +38733,6 @@ matches = agent.vecdb.similar_texts_with_scores(
     where='{"source": "milvus-docs"}',
 )
 ```
-</file>
-
-<file path="docs/notes/openai-http-client.md">
-# OpenAI HTTP Client Configuration
-
-When using OpenAI models through Langroid in corporate environments or behind proxies, you may encounter SSL certificate verification errors. Langroid provides three flexible options to configure the HTTP client used for OpenAI API calls.
-
-## Configuration Options
-
-### 1. Simple SSL Verification Bypass
-
-The quickest solution for development or trusted environments:
-
-```python
-import langroid.language_models as lm
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_verify_ssl=False  # Disables SSL certificate verification
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-!!! warning "Security Notice"
-    Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks. Only use this in trusted environments.
-
-### 2. HTTP Client Configuration Dictionary
-
-For common scenarios like proxies or custom certificates, use a configuration dictionary:
-
-```python
-import langroid.language_models as lm
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_config={
-        "verify": False,  # Or path to CA bundle: "/path/to/ca-bundle.pem"
-        "proxy": "http://proxy.company.com:8080",
-        "timeout": 30.0,
-        "headers": {
-            "User-Agent": "MyApp/1.0"
-        }
-    }
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-**Benefits**: This approach enables client caching, improving performance when creating multiple agents.
-
-### 3. Custom HTTP Client Factory
-
-For advanced scenarios requiring dynamic behavior or custom authentication:
-
-```python
-import langroid.language_models as lm
-from httpx import Client
-
-def create_custom_client():
-    """Factory function to create a custom HTTP client."""
-    client = Client(
-        verify="/path/to/corporate-ca-bundle.pem",
-        proxies={
-            "http": "http://proxy.corp.com:8080",
-            "https": "http://proxy.corp.com:8080"
-        },
-        timeout=30.0
-    )
-
-    # Add custom event hooks for logging
-    def log_request(request):
-        print(f"API Request: {request.method} {request.url}")
-
-    client.event_hooks = {"request": [log_request]}
-
-    return client
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_factory=create_custom_client
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-If you are using `async` methods, return a tuple of `(Client, AsyncClient)` from your factory:
-
-```python
-from httpx import AsyncClient, Client
-
-def create_custom_client():
-    """Factory function to create a custom sync and async HTTP clients."""
-    client_args = {
-        "verify": "/path/to/corporate-ca-bundle.pem",
-        "proxy": "http://proxy.corp.com:8080",
-        "timeout": 30.0,
-    }
-    client = Client(**client_args)
-    async_client = AsyncClient(**client_args)
-
-    return client, async_client
-```
-
-**Note**: Custom factories bypass client caching. Each `OpenAIGPT` instance creates a new client.
-
-## Priority Order
-
-When multiple options are specified, they are applied in this order:
-1. `http_client_factory` (highest priority)
-2. `http_client_config`
-3. `http_verify_ssl` (lowest priority)
-
-## Common Use Cases
-
-### Corporate Proxy with Custom CA Certificate
-
-```python
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_config={
-        "verify": "/path/to/corporate-ca-bundle.pem",
-        "proxies": {
-            "http": "http://proxy.corp.com:8080",
-            "https": "https://proxy.corp.com:8443"
-        }
-    }
-)
-```
-
-### Debugging API Calls
-
-```python
-def debug_client_factory():
-    from httpx import Client
-
-    client = Client(verify=False)
-
-    def log_response(response):
-        print(f"Status: {response.status_code}")
-        print(f"Headers: {response.headers}")
-
-    client.event_hooks = {
-        "response": [log_response]
-    }
-
-    return client
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_factory=debug_client_factory
-)
-```
-
-### Local Development with Self-Signed Certificates
-
-```python
-# For local OpenAI-compatible APIs
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    api_base="https://localhost:8443/v1",
-    http_verify_ssl=False
-)
-```
-
-
-## Best Practices
-
-1. **Use the simplest option that meets your needs**:
-   - Development/testing: `http_verify_ssl=False`
-   - Corporate environments: `http_client_config` with proper CA bundle
-   - Complex requirements: `http_client_factory`
-
-2. **Prefer configuration over factories for better performance** - configured clients are cached and reused
-
-3. **Always use proper CA certificates in production** instead of disabling SSL verification
-
-4. **Test your configuration** with a simple API call before deploying:
-   ```python
-   llm = lm.OpenAIGPT(config)
-   response = llm.chat("Hello")
-   print(response.content)
-   ```
-
-## Troubleshooting
-
-### SSL Certificate Errors
-```
-ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
-```
-**Solution**: Use one of the three configuration options above.
-
-
-### Proxy Connection Issues
-- Verify proxy URL format: `http://proxy:port` or `https://proxy:port`
-- Check if proxy requires authentication
-- Ensure proxy allows connections to `api.openai.com`
-
-## See Also
-
-- [OpenAI API Reference](https://platform.openai.com/docs/api-reference) - Official OpenAI documentation
 </file>
 
 <file path="docs/notes/rotating-api-keys.md">
@@ -44410,6 +44301,120 @@ result = WebSearchResult(
 link=None,  # skip HTTP fetch; Seltz already provides content
 </file>
 
+<file path="langroid/utils/configuration.py">
+# Global reentrant lock to serialize any modifications to the global settings.
+_global_lock = threading.RLock()
+⋮----
+class Settings(BaseSettings)
+⋮----
+debug: bool = False  # show debug messages?
+max_turns: int = -1  # maximum number of turns in a task (to avoid inf loop)
+progress: bool = False  # show progress spinners/bars?
+stream: bool = True  # stream output?
+cache: bool = True  # use cache?
+cache_type: Literal["redis", "fakeredis", "none"] = "redis"  # cache type
+chat_model: str = ""  # language model name, e.g. litellm/ollama/llama2
+quiet: bool = False  # quiet mode (i.e. suppress all output)?
+notebook: bool = False  # running in a notebook?
+⋮----
+model_config = SettingsConfigDict(extra="forbid")
+⋮----
+# Load environment variables from .env file.
+⋮----
+# The global (default) settings instance.
+# This is updated by update_global_settings() and set_global().
+_global_settings = Settings()
+⋮----
+# Thread-local storage for temporary (per-thread) settings overrides.
+_thread_local = threading.local()
+⋮----
+class SettingsProxy
+⋮----
+"""
+    A proxy for the settings that returns a thread‐local override if set,
+    or else falls back to the global settings.
+    """
+⋮----
+def __getattr__(self, name: str) -> Any
+⋮----
+# If the calling thread has set an override, use that.
+⋮----
+def __setattr__(self, name: str, value: Any) -> None
+⋮----
+# All writes go to the global settings.
+⋮----
+def update(self, new_settings: Settings) -> None
+⋮----
+def dict(self) -> Dict[str, Any]
+⋮----
+# Return a dict view of the settings as seen by the caller.
+# Note that temporary overrides are not “merged” with global settings.
+⋮----
+settings = SettingsProxy()
+⋮----
+def update_global_settings(cfg: BaseSettings, keys: List[str]) -> None
+⋮----
+"""
+    Update global settings so that modules can later access them via, e.g.,
+
+        from langroid.utils.configuration import settings
+        if settings.debug: ...
+
+    This updates the global default.
+    """
+config_dict = cfg.model_dump()
+filtered_config = {key: config_dict[key] for key in keys if key in config_dict}
+new_settings = Settings(**filtered_config)
+⋮----
+def set_global(key_vals: Settings) -> None
+⋮----
+"""
+    Update the global settings object.
+    """
+⋮----
+@contextmanager
+def temporary_settings(temp_settings: Settings) -> Iterator[None]
+⋮----
+"""
+    Temporarily override the settings for the calling thread.
+
+    Within the context, any access to "settings" will use the provided temporary
+    settings. Once the context is exited, the thread reverts to the global settings.
+    """
+saved = getattr(_thread_local, "override", None)
+⋮----
+@contextmanager
+def quiet_mode(quiet: bool = True) -> Iterator[None]
+⋮----
+"""
+    Temporarily override settings.quiet for the current thread.
+    This implementation builds on the thread‑local temporary_settings context manager.
+    The effective quiet mode is merged:
+    if quiet is already True (from an outer context),
+    then it remains True even if a nested context passes quiet=False.
+    """
+current_effective = (
+⋮----
+)  # get the current thread's effective settings
+# Create a new settings instance from the current effective state.
+temp = Settings(**current_effective)
+# Merge the new flag: once quiet is enabled, it stays enabled.
+⋮----
+def set_env(settings_instance: BaseSettings) -> None
+⋮----
+"""
+    Set environment variables from a BaseSettings instance.
+
+    Each field in the settings is written to os.environ, under the name
+    the settings class itself reads: `<env_prefix><FIELD_NAME_UPPER>`,
+    or the field's explicit alias (which, per pydantic-settings
+    semantics, is the full env name and is not prefixed).
+    """
+env_prefix = settings_instance.model_config.get("env_prefix", "")
+⋮----
+env_var_name = field.alias or f"{env_prefix}{field_name.upper()}"
+</file>
+
 <file path="langroid/utils/pandas_utils.py">
 COMMON_USE_DF_METHODS = {
 ⋮----
@@ -45137,472 +45142,6 @@ chromadb  # silence linters
 postgres  # silence linters
 </file>
 
-<file path="langroid/vector_store/chromadb.py">
-logger = logging.getLogger(__name__)
-⋮----
-class ChromaDBConfig(VectorStoreConfig)
-⋮----
-collection_name: str = "temp"
-storage_path: str = ".chroma/data"
-distance: Literal["cosine", "l2", "ip"] = "cosine"
-construction_ef: int = 100
-search_ef: int = 100
-max_neighbors: int = 16
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-host: str = "127.0.0.1"
-port: int = 6333
-⋮----
-class ChromaDB(VectorStore)
-⋮----
-def __init__(self, config: ChromaDBConfig | None = None)
-⋮----
-config = config if config is not None else ChromaDBConfig()
-⋮----
-# chroma_db_impl="duckdb+parquet",
-# is_persistent=bool(config.storage_path),
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""Clear all collections in the vector store with the given prefix."""
-⋮----
-coll = [c for c in self.client.list_collections() if c.name.startswith(prefix)]
-⋮----
-n_empty_deletes = 0
-n_non_empty_deletes = 0
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-colls = self.client.list_collections()
-n_deletes = 0
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""
-        List non-empty collections in the vector store.
-        Args:
-            empty (bool, optional): Whether to list empty collections.
-        Returns:
-            List[str]: List of non-empty collection names.
-        """
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""
-        Create a collection in the vector store, optionally replacing an existing
-            collection if `replace` is True.
-        Args:
-            collection_name (str): Name of the collection to create or replace.
-            replace (bool, optional): Whether to replace an existing collection.
-                Defaults to False.
-
-        """
-⋮----
-# we could expose other configs, see:
-# https://docs.trychroma.com/docs/collections/configure
-⋮----
-def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-contents: List[str] = [document.content for document in documents]
-# convert metadatas to dicts so chroma can handle them
-metadata_dicts: List[dict[str, Any]] = [
-⋮----
-# chroma does not handle non-atomic types in metadata
-⋮----
-ids = [str(d.id()) for d in documents]
-⋮----
-colls = self.list_collections(empty=True)
-⋮----
-# embedding_models=embedding_models,
-⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-filter = json.loads(where) if where else None
-results = self.collection.get(
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-# get them one by one since chroma mangles the order of the results
-# when fetched from a list of ids.
-results = [
-final_results = {}
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-n = self.collection.count()
-⋮----
-results = self.collection.query(
-docs = self._docs_from_results(results)
-# chroma distances are 1 - cosine.
-scores = [1 - s for s in results["distances"][0]]
-⋮----
-def _docs_from_results(self, results: Dict[str, Any]) -> List[Document]
-⋮----
-"""
-        Helper function to convert results from ChromaDB to a list of Documents
-        Args:
-            results (dict): results from ChromaDB
-
-        Returns:
-            List[Document]: list of Documents
-        """
-⋮----
-contents = results["documents"][0]
-⋮----
-metadatas = results["metadatas"][0]
-⋮----
-# restore the stringified list of window_ids into the original List[str]
-⋮----
-docs = [
-</file>
-
-<file path="langroid/vector_store/lancedb.py">
-has_lancedb = True
-⋮----
-has_lancedb = False
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-class LanceDBConfig(VectorStoreConfig)
-⋮----
-cloud: bool = False
-collection_name: str | None = "temp"
-storage_path: str = ".lancedb/data"
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-distance: str = "cosine"
-⋮----
-class LanceDB(VectorStore)
-⋮----
-def __init__(self, config: LanceDBConfig | None = None)
-⋮----
-config = config if config is not None else LanceDBConfig()
-⋮----
-self.is_from_dataframe = False  # were docs ingested from a dataframe?
-self.df_metadata_columns: List[str] = []  # metadata columns from dataframe
-⋮----
-new_storage_path = config.storage_path + ".new"
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-coll_names = self.list_collections()
-n_deletes = 0
-⋮----
-nr = self.client.open_table(name).head(1).shape[0]
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""Clear all collections with the given prefix."""
-⋮----
-coll_names = [
-⋮----
-n_empty_deletes = 0
-n_non_empty_deletes = 0
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""
-        Returns:
-            List of collection names that have at least one vector.
-
-        Args:
-            empty (bool, optional): Whether to include empty collections.
-        """
-colls = self.client.table_names(limit=None)
-⋮----
-if empty:  # include empty tbls
-return colls  # type: ignore
-counts = [self.client.open_table(coll).head(1).shape[0] for coll in colls]
-⋮----
-def _create_lance_schema(self, doc_cls: Type[Document]) -> Type[BaseModel]
-⋮----
-"""
-        NOTE: NOT USED, but leaving it here as it may be useful.
-
-        Create a subclass of LanceModel with fields:
-         - id (str)
-         - Vector field that has dims equal to
-            the embedding dimension of the embedding model, and a data field of type
-            DocClass.
-         - other fields from doc_cls
-
-        Args:
-            doc_cls (Type[Document]): A Pydantic model which should be a subclass of
-                Document, to be used as the type for the data field.
-
-        Returns:
-            Type[BaseModel]: A new Pydantic model subclassing from LanceModel.
-
-        Raises:
-            ValueError: If `n` is not a non-negative integer or if `DocClass` is not a
-                subclass of Document.
-        """
-⋮----
-n = self.embedding_dim
-⋮----
-# Prepare fields for the new model
-fields = {"id": (str, ...), "vector": (Vector(n), ...)}
-⋮----
-sorted_fields = dict(
-# Add both statically and dynamically defined fields from doc_cls
-⋮----
-field_type = field.annotation if hasattr(field, "annotation") else field
-⋮----
-# Create the new model with dynamic fields
-NewModel = create_model(
-⋮----
-)  # type: ignore
-return NewModel  # type: ignore
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-colls = self.list_collections(empty=True)
-⋮----
-embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-coll_name = self.config.collection_name
-⋮----
-# self._maybe_set_doc_class_schema(documents[0])
-table_exists = False
-⋮----
-# collection exists and  is not empty:
-# if replace_collection is True, we'll overwrite the existing collection,
-# else we'll append to it.
-⋮----
-table_exists = True
-⋮----
-ids = [str(d.id()) for d in documents]
-# don't insert all at once, batch in chunks of b,
-# else we get an API error
-b = self.config.batch_size
-⋮----
-def make_batches() -> Generator[List[Dict[str, Any]], None, None]
-⋮----
-batch = [
-⋮----
-tbl = self.client.open_table(coll_name)
-⋮----
-batch_gen = make_batches()
-batch = next(batch_gen)
-# use first batch to create table...
-tbl = self.client.create_table(
-# ... and add the rest
-⋮----
-"""
-        Add a dataframe to the collection.
-        Args:
-            df (pd.DataFrame): A dataframe
-            content (str): The name of the column in the dataframe that contains the
-                text content to be embedded using the embedding model.
-            metadata (List[str]): A list of column names in the dataframe that contain
-                metadata to be stored in the database. Defaults to [].
-        """
-⋮----
-actual_metadata = metadata.copy()
-self.df_metadata_columns = actual_metadata  # could be updated below
-# get content column
-content_values = df[content].values.tolist()
-embedding_vecs = self.embedding_fn(content_values)
-⋮----
-# add vector column
-⋮----
-# rename content column to "content", leave existing column intact
-df = df.rename(columns={content: "content"}, inplace=False)
-⋮----
-docs = dataframe_to_documents(df, content="content", metadata=metadata)
-ids = [str(d.id()) for d in docs]
-⋮----
-# collection either doesn't exist or is empty, so replace it
-# and set new schema from df
-⋮----
-doc_cls = dataframe_to_document_model(
-self.config.document_class = doc_cls  # type: ignore
-⋮----
-# collection exists and is not empty, so append to it
-tbl = self.client.open_table(self.config.collection_name)
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-df = result.to_pandas()
-⋮----
-records = result.to_arrow().to_pylist()
-⋮----
-def _records_to_docs(self, records: List[Dict[str, Any]]) -> List[Document]
-⋮----
-docs = [self.config.document_class(**rec) for rec in records]
-⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-pre_result = tbl.search(None).where(where or None).limit(None)
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-_ids = [str(id) for id in ids]
-⋮----
-docs = []
-⋮----
-results = self._lance_result_to_docs(tbl.search().where(f"id == '{_id}'"))
-⋮----
-embedding = self.embedding_fn([text])[0]
-⋮----
-result = (
-docs = self._lance_result_to_docs(result)
-# note _distance is 1 - cosine
-⋮----
-scores = [
-⋮----
-scores = [1 - rec["_distance"] for rec in result.to_arrow().to_pylist()]
-⋮----
-doc_score_pairs = list(zip(docs, scores))
-</file>
-
-<file path="langroid/vector_store/meilisearch.py">
-"""
-MeiliSearch as a pure document store, without its
-(experimental) vector-store functionality.
-We aim to use MeiliSearch for fast lexical search.
-Note that what we call "Collection" in Langroid is referred to as
-"Index" in MeiliSearch. Each data-store has its own terminology,
-but for uniformity we use the Langroid terminology here.
-"""
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-class MeiliSearchConfig(VectorStoreConfig)
-⋮----
-cloud: bool = False
-collection_name: str | None = None
-primary_key: str = "id"
-port: int = 7700
-⋮----
-class MeiliSearch(VectorStore)
-⋮----
-def __init__(self, config: MeiliSearchConfig | None = None)
-⋮----
-config = config if config is not None else MeiliSearchConfig()
-⋮----
-# Note: Only create collection if a non-null collection name is provided.
-# This is useful to delay creation of db until we have a suitable
-# collection name (e.g. we could get it from the url or folder path).
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-"""All collections are treated as non-empty in MeiliSearch, so this is a
-        no-op"""
-⋮----
-async def _async_delete_indices(self, uids: List[str]) -> List[bool]
-⋮----
-"""Delete any indicecs in `uids` that exist.
-        Returns list of bools indicating whether the index has been deleted"""
-⋮----
-result = await asyncio.gather(
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""Delete all indices whose names start with `prefix`"""
-⋮----
-coll_names = [c for c in self.list_collections() if c.startswith(prefix)]
-deletes = asyncio.run(self._async_delete_indices(coll_names))
-n_deletes = sum(deletes)
-⋮----
-def _list_all_collections(self) -> List[str]
-⋮----
-"""
-        List all collections, including empty ones.
-        Returns:
-            List of collection names.
-        """
-⋮----
-async def _async_get_indexes(self) -> List[AsyncIndex]
-⋮----
-indexes = await client.get_indexes(limit=10_000)
-return [] if indexes is None else indexes  # type: ignore
-⋮----
-async def _async_get_index(self, index_uid: str) -> "AsyncIndex"
-⋮----
-index = await client.get_index(index_uid)
-return index  # type: ignore
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""
-        Returns:
-            List of index names stored. We treat any existing index as non-empty.
-        """
-indexes = asyncio.run(self._async_get_indexes())
-⋮----
-async def _async_create_index(self, collection_name: str) -> "AsyncIndex"
-⋮----
-index = await client.create_index(
-⋮----
-async def _async_delete_index(self, collection_name: str) -> bool
-⋮----
-"""Delete index if it exists. Returns True iff index was deleted"""
-⋮----
-result = await client.delete_index_if_exists(uid=collection_name)
-return result  # type: ignore
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""
-        Create a collection with the given name, optionally replacing an existing
-            collection if `replace` is True.
-        Args:
-            collection_name (str): Name of the collection to create.
-            replace (bool): Whether to replace an existing collection
-                with the same name. Defaults to False.
-        """
-⋮----
-collections = self.list_collections()
-⋮----
-collection_info = asyncio.run(self._async_get_index(collection_name))
-⋮----
-level = logger.getEffectiveLevel()
-⋮----
-index = client.index(collection_name)
-⋮----
-def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-colls = self._list_all_collections()
-⋮----
-docs = [
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-def _to_int_or_uuid(self, id: str) -> int | str
-⋮----
-async def _async_get_documents(self, where: str = "") -> "DocumentsInfo"
-⋮----
-filter = [] if where is None else where
-⋮----
-index = client.index(self.config.collection_name)
-documents = await index.get_documents(limit=10_000, filter=filter)
-⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-docs = asyncio.run(self._async_get_documents(where))
-⋮----
-doc_results = docs.results
-⋮----
-async def _async_get_documents_by_ids(self, ids: List[str]) -> List[Dict[str, Any]]
-⋮----
-documents = await asyncio.gather(*[index.get_document(id) for id in ids])
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-docs = asyncio.run(self._async_get_documents_by_ids(ids))
-⋮----
-results = await index.search(
-return results.hits  # type: ignore
-⋮----
-neighbors: int = 0,  # ignored
-⋮----
-_docs = asyncio.run(self._async_search(text, k, filter))  # type: ignore
-⋮----
-scores = [h["_rankingScore"] for h in _docs]
-⋮----
-doc_score_pairs = list(zip(docs, scores))
-</file>
-
 <file path="langroid/vector_store/milvusdb.py">
 logger = logging.getLogger(__name__)
 ⋮----
@@ -45787,346 +45326,90 @@ comparisons = " or ".join(
     def _format_filter_value(value: Any) -> str
 </file>
 
-<file path="langroid/vector_store/pineconedb.py">
-# import dataclass
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-has_pinecone: bool = True
-⋮----
-class ServerlessSpec(BaseModel)
-⋮----
-"""
-            Fallback Serverless specification configuration to avoid import errors.
-            """
-⋮----
-cloud: str
-region: str
-⋮----
-PineconeApiException = Any  # type: ignore
-Pinecone = Any  # type: ignore
-has_pinecone = False
-⋮----
-@dataclass(frozen=True)
-class IndexMeta
-⋮----
-name: str
-total_vector_count: int
-⋮----
-class PineconeDBConfig(VectorStoreConfig)
-⋮----
-cloud: bool = True
-collection_name: str | None = "temp"
-spec: ServerlessSpec = ServerlessSpec(cloud="aws", region="us-east-1")
-deletion_protection: Literal["enabled", "disabled"] | None = None
-metric: str = "cosine"
-pagination_size: int = 100
-⋮----
-class PineconeDB(VectorStore)
-⋮----
-def __init__(self, config: PineconeDBConfig | None = None)
-⋮----
-config = config if config is not None else PineconeDBConfig()
-⋮----
-key = os.getenv("PINECONE_API_KEY")
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-indexes = self._list_index_metas(empty=True)
-n_deletes = 0
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""
-        Returns:
-            Number of Pinecone indexes that were deleted
+<file path="docs/notes/vecstore-env-prefix.md">
+# Vector-Store Config Env-Var Prefixes
 
-        Args:
-            really: Optional[bool] - whether to really delete all Pinecone collections
-            prefix: Optional[str] - string to match potential Pinecone
-                indexes for deletion
-        """
-⋮----
-indexes = [
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""
-        Returns:
-            List of Pinecone indices that have at least one vector.
+Vector-store configs are `pydantic-settings` classes, which means their
+fields can be set via environment variables. Prior to this change (see
+issue #1078), `VectorStoreConfig` and its subclasses declared **no
+`env_prefix`**, so every field name was itself a case-insensitive
+environment variable. A bare `HOST`, `PORT`, `CLOUD`, `TIMEOUT`,
+`BATCH_SIZE`, `STORAGE_PATH`, `COLLECTION_NAME`, or `FULL_EVAL` in the
+environment silently overrode the default for *every* vector-store
+config:
 
-        Args:
-            empty: Optional[bool] - whether to include empty collections
-        """
-indexes = self.client.list_indexes()
-res: List[str] = []
-⋮----
-index_meta = self.client.Index(name=index)
-⋮----
-def _list_index_metas(self, empty: bool = False) -> List[IndexMeta]
-⋮----
-"""
-        Returns:
-            List of objects describing Pinecone indices
+```bash
+HOST=evil.example.com PORT=9999 FULL_EVAL=true \
+  python -c "from langroid.vector_store.qdrantdb import QdrantDBConfig; \
+             c = QdrantDBConfig(); print(c.host, c.port, c.full_eval)"
+# old behavior: evil.example.com 9999 True
+```
 
-        Args:
-            empty: Optional[bool] - whether to include empty collections
-        """
-⋮----
-res = []
-⋮----
-index_meta = self._fetch_index_meta(index)
-⋮----
-def _fetch_index_meta(self, index_name: str) -> IndexMeta
-⋮----
-"""
-        Returns:
-            A dataclass describing the input Index by name and vector count
-            to save a bit on index description calls
+This was dangerous for two reasons:
 
-        Args:
-            index_name: str - Name of the index in Pinecone
-        """
-⋮----
-index = self.client.Index(name=index_name)
-stats = index.describe_index_stats()
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""
-        Create a collection with the given name, optionally replacing an existing
-        collection if `replace` is True.
+- `HOST` and `PORT` are routinely set by shells, containers, and CI
+  systems, so vector-store clients could silently point at the wrong
+  server.
+- `FULL_EVAL=true` disabled the code-injection guard (see
+  [code-injection-protection](code-injection-protection.md)) with no
+  explicit opt-in anywhere in the user's code.
 
-        Args:
-            collection_name: str - Configuration of the collection to create.
-            replace: Optional[Bool] - Whether to replace an existing collection
-                with the same name. Defaults to False.
-        """
-pattern = re.compile(r"^[a-z0-9-]+$")
-⋮----
-index = self.client.Index(name=collection_name)
-⋮----
-status = self.client.describe_index(name=collection_name)
-⋮----
-payload = {
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-def add_documents(self, documents: Sequence[Document], namespace: str = "") -> None
-⋮----
-document_dicts = [doc.model_dump() for doc in documents]
-document_ids = [doc.id() for doc in documents]
-embedding_vectors = self.embedding_fn([doc.content for doc in documents])
-vectors = [
-⋮----
-index = self.client.Index(name=self.config.collection_name)
-batch_size = self.config.batch_size
-⋮----
-"""
-        Returns:
-            All documents for the collection currently defined in
-            the configuration object
+## New behavior
 
-        Args:
-            prefix: str - document id prefix to search for
-            namespace: str - partition of vectors to search within the index
-        """
-⋮----
-docs = []
-⋮----
-request_filters: Dict[str, Union[str, int]] = {
-⋮----
-response = index.list_paginated(**request_filters)
-vectors = response.get("vectors", [])
-⋮----
-pagination_token = response.get("pagination", {}).get("next", None)
-⋮----
-"""
-        Returns:
-            Fetches document text embedded in Pinecone index metadata
+Each vector-store config now has its own env prefix, consistent with
+the rest of the codebase (`OPENAI_`, `AZURE_OPENAI_`, `NEO4J_`, ...):
 
-        Args:
-            ids: List[str] - vector data object ids to retrieve
-            namespace: str - partition of vectors to search within the index
-        """
-⋮----
-records = index.fetch(ids=ids, namespace=namespace)
-⋮----
-records = index.fetch(ids=ids)
-⋮----
-id_mapping = {key: value for key, value in records["vectors"].items()}
-ordered_payloads = [id_mapping[_id] for _id in ids if _id in id_mapping]
-⋮----
-vector_search_request = {
-⋮----
-response = index.query(**vector_search_request)
-doc_score_pairs = [
-⋮----
-max_score = max([pair[1] for pair in doc_score_pairs])
-⋮----
-def transform_pinecone_vector(self, metadata_dict: Dict[str, Any]) -> Document
-⋮----
-"""
-        Parses the metadata response from the Pinecone vector query and
-        formats it into a dictionary that can be parsed by the Document class
-        associated with the PineconeDBConfig class
+| Config class        | Env prefix     |
+|---------------------|----------------|
+| `VectorStoreConfig` | `VECDB_`       |
+| `QdrantDBConfig`    | `QDRANT_`      |
+| `ChromaDBConfig`    | `CHROMA_`      |
+| `LanceDBConfig`     | `LANCEDB_`     |
+| `PineconeDBConfig`  | `PINECONE_`    |
+| `PostgresDBConfig`  | `POSTGRES_`    |
+| `MeiliSearchConfig` | `MEILISEARCH_` |
+| `WeaviateDBConfig`  | `WEAVIATE_`    |
 
-        Returns:
-            Well formed dictionary object to be transformed into a Document
+Bare env vars (`HOST`, `FULL_EVAL`, ...) are now ignored by all of
+these configs. To set a field via the environment, use the prefix of
+the specific config class, e.g. `QDRANT_HOST=my.qdrant.example` or
+`QDRANT_FULL_EVAL=true` for `QdrantDBConfig`. Every provider subclass
+in langroid overrides the prefix with its own, so within langroid
+`VECDB_*` vars affect only direct `VectorStoreConfig` instances.
+However, pydantic inherits `model_config`, so a third-party subclass
+of `VectorStoreConfig` that does not set its own `env_prefix` will
+read `VECDB_*` vars.
 
-        Args:
-            metadata_dict: Dict - the metadata dictionary from the Pinecone
-                vector query match
-        """
-</file>
+A `port` value coming from the *environment* that matches the exact
+Kubernetes service-link format `tcp://<host>:<digits>` (e.g.
+`QDRANT_PORT=tcp://10.0.0.8:6333`, injected into every pod by a
+service named `qdrant` when `enableServiceLinks` is on) is ignored
+with a warning and the default port is used. This exception applies
+only to the env settings source and only to that full format:
+malformed `tcp://` junk in the environment, and any `tcp://...` value
+passed explicitly to the constructor, fail validation as usual.
 
-<file path="langroid/vector_store/weaviatedb.py">
-logger = logging.getLogger(__name__)
-⋮----
-class VectorDistances
-⋮----
-"""
-    Fallback class when weaviate is not installed, to avoid import errors.
-    """
-⋮----
-COSINE: str = "cosine"
-DOTPRODUCT: str = "dot"
-L2: str = "l2"
-⋮----
-class WeaviateDBConfig(VectorStoreConfig)
-⋮----
-collection_name: str | None = "temp"
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-distance: str = VectorDistances.COSINE
-cloud: bool = False
-docker: bool = False
-host: str = "127.0.0.1"
-port: int = 8080
-storage_path: str = ".weaviate_embedded/data"
-⋮----
-class WeaviateDB(VectorStore)
-⋮----
-def __init__(self, config: WeaviateDBConfig | None = None)
-⋮----
-config = config if config is not None else WeaviateDBConfig()
-⋮----
-key = os.getenv("WEAVIATE_API_KEY")
-url = os.getenv("WEAVIATE_API_URL")
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-colls = self.client.collections.list_all()
-n_deletes = 0
-⋮----
-val = self.client.collections.get(coll_name)
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-non_empty_colls = [
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-coll_names = [
-⋮----
-n_empty_deletes = 0
-n_non_empty_deletes = 0
-⋮----
-info = self.client.collections.get(name)
-points_count = len(info)
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-collection_name = WeaviateDB.validate_and_format_collection_name(
-⋮----
-coll = self.client.collections.get(name=collection_name)
-⋮----
-vector_index_config = Configure.VectorIndex.hnsw(
-⋮----
-vectorizer_config = Configure.Vectorizer.text2vec_openai(
-⋮----
-vectorizer_config = None
-⋮----
-collection_info = self.client.collections.create(
-collection_info = self.client.collections.get(name=collection_name)
-⋮----
-level = logger.getEffectiveLevel()
-⋮----
-def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-colls = self.list_collections(empty=True)
-⋮----
-document_dicts = [doc.model_dump() for doc in documents]
-embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-⋮----
-coll_name = self.client.collections.get(self.config.collection_name)
-⋮----
-id = doc_dict["metadata"].pop("id", None)
-⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-# cannot use filter as client does not support json type queries
-coll = self.client.collections.get(self.config.collection_name)
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-docs = []
-⋮----
-result = coll_name.query.fetch_objects(
-⋮----
-id_to_doc = {}
-⋮----
-doc = self.weaviate_obj_to_doc(item)
-⋮----
-# Reconstruct the list of documents in the original order of input ids
-docs = [id_to_doc[id] for id in ids if id in id_to_doc]
-⋮----
-embedding = self.embedding_fn([text])[0]
-⋮----
-response = coll.query.near_vector(
-maybe_distances = [item.metadata.distance for item in response.objects]
-similarities = [0 if d is None else 1 - d for d in maybe_distances]
-docs = [self.weaviate_obj_to_doc(item) for item in response.objects]
-⋮----
-def _create_valid_uuid_id(self, id: str) -> Any
-⋮----
-id = get_valid_uuid(id)
-⋮----
-def weaviate_obj_to_doc(self, input_object: Any) -> Document
-⋮----
-content = input_object.properties.get("content", "")
-metadata_dict = input_object.properties.get("metadata", {})
-⋮----
-window_ids = metadata_dict.pop("window_ids", [])
-window_ids = [str(uuid) for uuid in window_ids]
-⋮----
-# Ensure the id is a valid UUID string
-id_value = get_valid_uuid(input_object.uuid)
-⋮----
-metadata = DocMetaData(id=id_value, window_ids=window_ids, **metadata_dict)
-⋮----
-@staticmethod
-    def validate_and_format_collection_name(name: str) -> str
-⋮----
-"""
-        Formats the collection name to comply with Weaviate's naming rules:
-        - Name must start with a capital letter.
-        - Name can only contain letters, numbers, and underscores.
-        - Replaces invalid characters with underscores.
-        """
-⋮----
-formatted_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
-⋮----
-# Ensure the first letter is capitalized
-⋮----
-formatted_name = formatted_name.capitalize()
-⋮----
-# Check if the name now meets the criteria
-⋮----
-def __del__(self) -> None
-⋮----
-# Gracefully close the connection with local client
+Explicit constructor arguments always take priority over environment
+values (standard `pydantic-settings` precedence):
+
+```python
+config = QdrantDBConfig(host="10.0.0.5")  # wins over QDRANT_HOST
+```
+
+## Migration
+
+If you (deliberately) relied on bare env vars to configure a
+vector store, rename them with the appropriate prefix from the table
+above, e.g. `COLLECTION_NAME=mydocs` becomes
+`QDRANT_COLLECTION_NAME=mydocs`.
+
+Env vars read via `os.getenv` outside the config classes are
+unaffected, e.g. `QDRANT_API_KEY`, `PINECONE_API_KEY`,
+`MEILISEARCH_API_KEY`, `MEILISEARCH_API_URL`, `WEAVIATE_API_KEY`, and
+`WEAVIATE_API_URL` keep their existing meanings. Note that the
+`QDRANT_*` and `PINECONE_*` prefixes overlap with those existing
+names, but the config classes have no `api_key`/`api_url` fields, so
+extra prefixed vars are ignored.
 </file>
 
 <file path="docs/tutorials/non-openai-llms.md">
@@ -48402,574 +47685,160 @@ contents = ""
 path = file["path"]
 </file>
 
-<file path="langroid/vector_store/base.py">
+<file path="langroid/vector_store/chromadb.py">
 logger = logging.getLogger(__name__)
 ⋮----
-class VectorStoreConfig(BaseSettings)
+class ChromaDBConfig(VectorStoreConfig)
 ⋮----
-type: str = ""  # deprecated, keeping it for backward compatibility
-collection_name: str | None = "temp"
-replace_collection: bool = False  # replace collection if it already exists
-storage_path: str = ".qdrant/data"
-cloud: bool = False
-batch_size: int = 200
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig(
-embedding_model: Optional[EmbeddingModel] = None
-timeout: int = 60
+model_config = SettingsConfigDict(env_prefix="CHROMA_")
+⋮----
+collection_name: str = "temp"
+storage_path: str = ".chroma/data"
+distance: Literal["cosine", "l2", "ip"] = "cosine"
+construction_ef: int = 100
+search_ef: int = 100
+max_neighbors: int = 16
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
 host: str = "127.0.0.1"
 port: int = 6333
-# used when parsing search results back as Document objects
-document_class: Type[Document] = Document
-metadata_class: Type[DocMetaData] = DocMetaData
-# compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
-full_eval: bool = False  # runs eval without sanitization. Use only on trusted input
 ⋮----
-class VectorStore(ABC)
+class ChromaDB(VectorStore)
 ⋮----
-"""
-    Abstract base class for a vector store.
-    """
+def __init__(self, config: ChromaDBConfig | None = None)
 ⋮----
-def __init__(self, config: VectorStoreConfig)
+config = config if config is not None else ChromaDBConfig()
 ⋮----
-@staticmethod
-    def create(config: VectorStoreConfig) -> Optional["VectorStore"]
-⋮----
-@property
-    def embedding_dim(self) -> int
-⋮----
-def clone(self) -> "VectorStore"
-⋮----
-"""Return a vector-store clone suitable for agent cloning.
-
-        The default implementation deep-copies the configuration, reuses any
-        existing embedding model, and instantiates a fresh store of the same
-        type. Subclasses can override when sharing the instance is required
-        (e.g., embedded/local stores that rely on file locks).
-        """
-⋮----
-config_class = self.config.__class__
-config_data = self.config.model_dump(mode="python")
-⋮----
-config_copy = config_class.model_validate(config_data)
-⋮----
-# Preserve the calculated collection contents without forcing replaces
-⋮----
-config_copy.replace_collection = False  # type: ignore[attr-defined]
-cloned_embedding: Optional[EmbeddingModel] = None
-⋮----
-cloned_embedding = self.embedding_model.clone()  # type: ignore[attr-defined]
-⋮----
-cloned_store = type(self)(config_copy)  # type: ignore[call-arg]
-⋮----
-# Some stores might not honour replace_collection; ensure same collection
-⋮----
-@abstractmethod
-    def clear_empty_collections(self) -> int
-⋮----
-"""Clear all empty collections in the vector store.
-        Returns the number of collections deleted.
-        """
-⋮----
-@abstractmethod
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""
-        Clear all collections in the vector store.
-
-        Args:
-            really (bool, optional): Whether to really clear all collections.
-                Defaults to False.
-            prefix (str, optional): Prefix of collections to clear.
-        Returns:
-            int: Number of collections deleted.
-        """
-⋮----
-@abstractmethod
-    def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""List all collections in the vector store
-        (only non empty collections if empty=False).
-        """
-⋮----
-def set_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""
-        Set the current collection to the given collection name.
-        Args:
-            collection_name (str): Name of the collection.
-            replace (bool, optional): Whether to replace the collection if it
-                already exists. Defaults to False.
-        """
-⋮----
-@abstractmethod
-    def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""Create a collection with the given name.
-        Args:
-            collection_name (str): Name of the collection.
-            replace (bool, optional): Whether to replace the
-                collection if it already exists. Defaults to False.
-        """
-⋮----
-@abstractmethod
-    def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-def compute_from_docs(self, docs: List[Document], calc: str) -> str
-⋮----
-"""Compute a result on a set of documents,
-        using a dataframe calc string like `df.groupby('state')['income'].mean()`.
-
-        If full_eval is False (default), the input expression is sanitized to prevent
-        most common code injection attack vectors.
-        If full_eval is True, sanitization is bypassed - use only with trusted input!
-        """
-# convert each doc to a dict, using dotted paths for nested fields
-dicts = [flatten_dict(doc.model_dump(by_alias=True)) for doc in docs]
-df = pd.DataFrame(dicts)
-⋮----
-# SECURITY MITIGATION: Eval input is sanitized to prevent most common
-# code injection attack vectors when full_eval is False. The globals
-# dict also restricts ``__builtins__`` so that even with
-# ``full_eval=True`` the expression cannot reach
-# ``__import__``/``eval``/``exec`` via Python's implicit builtin
-# injection (GHSA-q9p7-wqxg-mrhc).
-vars = {"df": df}
-⋮----
-calc = sanitize_command(calc)
-code = compile(calc, "<calc>", "eval")
-result = eval(code, safe_eval_globals(vars), {})
-⋮----
-# return error message so LLM can fix the calc string if needed
-err = f"""
-⋮----
-# Pd.eval sometimes fails on a perfectly valid exprn like
-# df.loc[..., 'column'] with a KeyError.
-⋮----
-def maybe_add_ids(self, documents: Sequence[Document]) -> None
-⋮----
-"""Add ids to metadata if absent, since some
-        vecdbs don't like having blank ids."""
-⋮----
-"""
-        Find k most similar texts to the given text, in terms of vector distance metric
-        (e.g., cosine similarity).
-
-        Args:
-            text (str): The text to find similar texts for.
-            k (int, optional): Number of similar texts to retrieve. Defaults to 1.
-            where (Optional[str], optional): Where clause to filter the search.
-
-        Returns:
-            List[Tuple[Document,float]]: List of (Document, score) tuples.
-
-        """
-⋮----
-"""
-        In each doc's metadata, there may be a window_ids field indicating
-        the ids of the chunks around the current chunk.
-        These window_ids may overlap, so we
-        - coalesce each overlapping groups into a single window (maintaining ordering),
-        - create a new document for each part, preserving metadata,
-
-        We may have stored a longer set of window_ids than we need during chunking.
-        Now, we just want `neighbors` on each side of the center of the window_ids list.
-
-        Args:
-            docs_scores (List[Tuple[Document, float]]): List of pairs of documents
-                to add context windows to together with their match scores.
-            neighbors (int, optional): Number of neighbors on "each side" of match to
-                retrieve. Defaults to 0.
-                "Each side" here means before and after the match,
-                in the original text.
-
-        Returns:
-            List[Tuple[Document, float]]: List of (Document, score) tuples.
-        """
-# We return a larger context around each match, i.e.
-# a window of `neighbors` on each side of the match.
-docs = [d for d, s in docs_scores]
-scores = [s for d, s in docs_scores]
-⋮----
-doc_chunks = [d for d in docs if d.metadata.is_chunk]
-⋮----
-window_ids_list = []
-id2metadata = {}
-# id -> highest score of a doc it appears in
-id2max_score: Dict[int | str, float] = {}
-⋮----
-window_ids = d.metadata.window_ids
-⋮----
-window_ids = [d.id()]
-⋮----
-n = len(window_ids)
-chunk_idx = window_ids.index(d.id())
-neighbor_ids = window_ids[
-⋮----
-# window_ids could be from different docs,
-# and they may overlap, so we coalesce overlapping groups into
-# separate windows.
-window_ids_list = self.remove_overlaps(window_ids_list)
-final_docs = []
-final_scores = []
-⋮----
-metadata = copy.deepcopy(id2metadata[w[0]])
-⋮----
-document = Document(
-# make a fresh id since content is in general different
-⋮----
-@staticmethod
-    def remove_overlaps(windows: List[List[str]]) -> List[List[str]]
-⋮----
-"""
-        Given a collection of windows, where each window is a sequence of ids,
-        identify groups of overlapping windows, and for each overlapping group,
-        order the chunk-ids using topological sort so they appear in the original
-        order in the text.
-
-        Args:
-            windows (List[int|str]): List of windows, where each window is a
-                sequence of ids.
-
-        Returns:
-            List[int|str]: List of windows, where each window is a sequence of ids,
-                and no two windows overlap.
-        """
-ids = set(id for w in windows for id in w)
-# id -> {win -> # pos}
-id2win2pos: Dict[str, Dict[int, int]] = {id: {} for id in ids}
-⋮----
-n = len(windows)
-# relation between windows:
-order = np.zeros((n, n), dtype=np.int8)
-⋮----
-id = list(set(w).intersection(x))[0]  # any common id
-⋮----
-order[i, j] = -1  # win i is before win j
-⋮----
-order[i, j] = 1  # win i is after win j
-⋮----
-# find groups of windows that overlap, like connected components in a graph
-groups = components(np.abs(order))
-⋮----
-# order the chunk-ids in each group using topological sort
-new_windows = []
-⋮----
-# find total ordering among windows in group based on order matrix
-# (this is a topological sort)
-_g = np.array(g)
-order_matrix = order[_g][:, _g]
-ordered_window_indices = topological_sort(order_matrix)
-ordered_window_ids = [windows[i] for i in _g[ordered_window_indices]]
-flattened = [id for w in ordered_window_ids for id in w]
-flattened_deduped = list(dict.fromkeys(flattened))
-# Note we are not going to split these, and instead we'll return
-# larger windows from concatenating the connected groups.
-# This ensures context is retained for LLM q/a
-⋮----
-@abstractmethod
-    def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-"""
-        Get all documents in the current collection, possibly filtered by `where`.
-        """
-⋮----
-@abstractmethod
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-"""
-        Get documents by their ids.
-        Args:
-            ids (List[str]): List of document ids.
-
-        Returns:
-            List[Document]: List of documents
-        """
-⋮----
-@abstractmethod
-    def delete_collection(self, collection_name: str) -> None
-⋮----
-def show_if_debug(self, doc_score_pairs: List[Tuple[Document, float]]) -> None
-</file>
-
-<file path="langroid/vector_store/postgres.py">
-has_postgres: bool = True
-⋮----
-Engine = Any  # type: ignore
-Connection = Any  # type: ignore
-has_postgres = False
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-def _quote_ident(name: str) -> str
-⋮----
-"""Quote a SQL identifier (table/index name) for use in raw DDL, so a name
-    containing characters that are invalid in an unquoted identifier -- e.g.
-    the ``-`` in a pytest-xdist worker suffix like ``mycollection-gw1`` -- does
-    not produce a syntax error. Embedded double-quotes are escaped per the SQL
-    standard.
-    """
-⋮----
-class PostgresDBConfig(VectorStoreConfig)
-⋮----
-collection_name: str = "embeddings"
-cloud: bool = False
-docker: bool = True
-host: str = "127.0.0.1"
-port: int = 5432
-replace_collection: bool = False
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-pool_size: int = 10
-max_overflow: int = 20
-hnsw_m: int = 16
-hnsw_ef_construction: int = 200
-⋮----
-class PostgresDB(VectorStore)
-⋮----
-def __init__(self, config: PostgresDBConfig | None = None)
-⋮----
-config = config if config is not None else PostgresDBConfig()
-⋮----
-def _create_engine(self) -> Engine
-⋮----
-"""Creates a SQLAlchemy engine based on the configuration."""
-⋮----
-connection_string: str | None = None  # Ensure variable is always defined
-⋮----
-connection_string = os.getenv("POSTGRES_CONNECTION_STRING")
-⋮----
-connection_string = connection_string.replace(
-⋮----
-username = os.getenv("POSTGRES_USER", "postgres")
-password = os.getenv("POSTGRES_PASSWORD", "postgres")
-database = os.getenv("POSTGRES_DB", "langroid")
-⋮----
-connection_string = (
-self.config.cloud = False  # Ensures cloud is disabled if using Docker
-⋮----
-def _setup_table(self) -> None
-⋮----
-# Create HNSW index for embeddings column if it doesn't exist.
-# This index enables efficient nearest-neighbor search using cosine similarity.
-# PostgreSQL automatically builds the index after creation;
-# no manual step required.
-# Read more about pgvector hnsw index here:
-# https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw
-⋮----
-index_name = f"hnsw_index_{self.config.collection_name}_embedding"
-⋮----
-create_index_query = text(
-⋮----
-def index_exists(self, connection: Connection, index_name: str) -> bool
-⋮----
-"""Check if an index exists."""
-query = text(
-result = connection.execute(query).scalar()
-⋮----
-@staticmethod
-    def _create_vector_extension(conn: Engine) -> None
-⋮----
-# The number is a unique identifier used to lock a specific resource
-# during transaction. Any 64-bit integer can be used for advisory locks.
-# Acquire advisory lock to ensure atomic, isolated setup
-# and prevent race conditions.
-⋮----
-statement = text(
-⋮----
-def set_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-inspector = inspect(self.engine)
-table_exists = collection_name in inspector.get_table_names()
-⋮----
-def list_collections(self, empty: bool = True) -> List[str]
-⋮----
-table_names = inspector.get_table_names()
-⋮----
-collections = []
-⋮----
-table = Table(table_name, self.metadata, autoload_with=self.engine)
-⋮----
-# Efficiently check for non-emptiness
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-"""
-        Deletes a collection and its associated HNSW index, handling metadata
-        synchronization issues.
-        """
-⋮----
-index_name = f"hnsw_index_{collection_name}_embedding"
-drop_index_query = text(
-⋮----
-# 3. Now, drop the table using SQLAlchemy
-table = Table(collection_name, self.metadata)
-⋮----
-# 4. Refresh metadata again after dropping the table
+# chroma_db_impl="duckdb+parquet",
+# is_persistent=bool(config.storage_path),
 ⋮----
 def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
 ⋮----
-deleted_count = 0
+"""Clear all collections in the vector store with the given prefix."""
 ⋮----
-# Use delete_collection to handle index and table deletion
+coll = [c for c in self.client.list_collections() if c.name.startswith(prefix)]
+⋮----
+n_empty_deletes = 0
+n_non_empty_deletes = 0
 ⋮----
 def clear_empty_collections(self) -> int
 ⋮----
-# Efficiently check for emptiness without fetching all rows
+colls = self.client.list_collections()
+n_deletes = 0
 ⋮----
-session.commit()  # Commit is likely not needed here
+def list_collections(self, empty: bool = False) -> List[str]
 ⋮----
-def _parse_embedding_store_record(self, res: Any) -> Dict[str, Any]
+"""
+        List non-empty collections in the vector store.
+        Args:
+            empty (bool, optional): Whether to list empty collections.
+        Returns:
+            List[str]: List of non-empty collection names.
+        """
 ⋮----
-metadata = res.cmetadata or {}
+def create_collection(self, collection_name: str, replace: bool = False) -> None
 ⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
+"""
+        Create a collection in the vector store, optionally replacing an existing
+            collection if `replace` is True.
+        Args:
+            collection_name (str): Name of the collection to create or replace.
+            replace (bool, optional): Whether to replace an existing collection.
+                Defaults to False.
+
+        """
 ⋮----
-query = session.query(self.embeddings_table)
-⋮----
-# Apply 'where' clause if provided
-⋮----
-where_json = json.loads(where)
-query = query.filter(
-⋮----
-return []  # Return empty list or handle error as appropriate
-⋮----
-results = query.all()
-documents = [
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-# Add a CASE statement to preserve the order of IDs
-case_stmt = case(
-⋮----
-query = (
-⋮----
-.order_by(case_stmt)  # Order by the CASE statement
+# we could expose other configs, see:
+# https://docs.trychroma.com/docs/collections/configure
 ⋮----
 def add_documents(self, documents: Sequence[Document]) -> None
 ⋮----
-embeddings = self.embedding_fn([doc.content for doc in documents])
+contents: List[str] = [document.content for document in documents]
+# convert metadatas to dicts so chroma can handle them
+metadata_dicts: List[dict[str, Any]] = [
 ⋮----
-batch_size = self.config.batch_size
+# chroma does not handle non-atomic types in metadata
 ⋮----
-batch_docs = documents[i : i + batch_size]
-batch_embeddings = embeddings[i : i + batch_size]
+ids = [str(d.id()) for d in documents]
 ⋮----
-new_records = [
+colls = self.list_collections(empty=True)
 ⋮----
-stmt = insert(self.embeddings_table).values(new_records)
+# embedding_models=embedding_models,
 ⋮----
-@staticmethod
-    def _id_to_uuid(id: str, obj: object) -> str
+def get_all_documents(self, where: str = "") -> List[Document]
 ⋮----
-doc_id = str(uuid.UUID(id))
+filter = json.loads(where) if where else None
+results = self.collection.get(
 ⋮----
-obj_repr = repr(obj)
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
 ⋮----
-obj_hash = hashlib.sha256(obj_repr.encode()).hexdigest()
+# get them one by one since chroma mangles the order of the results
+# when fetched from a list of ids.
+results = [
+final_results = {}
 ⋮----
-combined = f"{id}-{obj_hash}"
+def delete_collection(self, collection_name: str) -> None
 ⋮----
-doc_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, combined))
+n = self.collection.count()
 ⋮----
-neighbors: int = 1,  # Parameter not used in this implementation
+results = self.collection.query(
+docs = self._docs_from_results(results)
+# chroma distances are 1 - cosine.
+scores = [1 - s for s in results["distances"][0]]
 ⋮----
-embedding = self.embedding_fn([query])[0]
+def _docs_from_results(self, results: Dict[str, Any]) -> List[Document]
 ⋮----
-# Calculate the score (1 - cosine_distance) and label it as "score"
-score = (
-⋮----
-json_query = json.loads(where)
-⋮----
-results = (
-⋮----
-score,  # Select the calculated score
-⋮----
-.order_by(score.desc())  # Order by score in descending order
-⋮----
-documents_with_scores = [
-⋮----
-result.score,  # Use the score from the query result
-</file>
+"""
+        Helper function to convert results from ChromaDB to a list of Documents
+        Args:
+            results (dict): results from ChromaDB
 
-<file path="langroid/vector_store/qdrantdb.py">
-logger = logging.getLogger(__name__)
-⋮----
-T = TypeVar("T")
-⋮----
-def from_optional(x: Optional[T], default: T) -> T
-⋮----
-def is_valid_uuid(uuid_to_test: str) -> bool
-⋮----
-"""
-    Check if a given string is a valid UUID.
-    """
-⋮----
-uuid_obj = uuid.UUID(uuid_to_test)
-⋮----
-# Check for valid unsigned 64-bit integer
-⋮----
-int_value = int(uuid_to_test)
-⋮----
-class QdrantDBConfig(VectorStoreConfig)
-⋮----
-cloud: bool = True
-docker: bool = False
-collection_name: str | None = "temp"
-storage_path: str = ".qdrant/data"
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-use_sparse_embeddings: bool = False
-sparse_embedding_model: str = "naver/splade-v3-distilbert"
-sparse_limit: int = 3
-distance: str = "cosine"
-⋮----
-class QdrantDB(VectorStore)
-⋮----
-def __init__(self, config: QdrantDBConfig | None = None)
-⋮----
-config = config if config is not None else QdrantDBConfig()
-⋮----
-self.sparse_tokenizer = AutoTokenizer.from_pretrained(  # type: ignore
-⋮----
-key = os.getenv("QDRANT_API_KEY")
-url = os.getenv("QDRANT_API_URL")
-⋮----
-new_storage_path = config.storage_path + ".new"
-⋮----
-# Note: Only create collection if a non-null collection name is provided.
-# This is useful to delay creation of vecdb until we have a suitable
-# collection name (e.g. we could get it from the url or folder path).
-⋮----
-def clone(self) -> "QdrantDB"
-⋮----
-"""Create an independent Qdrant client when running against Qdrant Cloud."""
-⋮----
-cloned = super().clone()
-⋮----
-def close(self) -> None
-⋮----
-"""
-        Close the QdrantDB client and release any resources (e.g., file locks).
-        This is especially important for local storage to release the .lock file.
+        Returns:
+            List[Document]: list of Documents
         """
 ⋮----
-# QdrantLocal has a close method that releases the lock
+contents = results["documents"][0]
 ⋮----
-def __enter__(self) -> "QdrantDB"
+metadatas = results["metadatas"][0]
 ⋮----
-"""Context manager entry."""
+# restore the stringified list of window_ids into the original List[str]
 ⋮----
-def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
+docs = [
+</file>
+
+<file path="langroid/vector_store/lancedb.py">
+has_lancedb = True
 ⋮----
-"""Context manager exit - ensure cleanup even if an exception occurred."""
+has_lancedb = False
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+class LanceDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="LANCEDB_")
+⋮----
+cloud: bool = False
+collection_name: str | None = "temp"
+storage_path: str = ".lancedb/data"
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+distance: str = "cosine"
+⋮----
+class LanceDB(VectorStore)
+⋮----
+def __init__(self, config: LanceDBConfig | None = None)
+⋮----
+config = config if config is not None else LanceDBConfig()
+⋮----
+self.is_from_dataframe = False  # were docs ingested from a dataframe?
+self.df_metadata_columns: List[str] = []  # metadata columns from dataframe
+⋮----
+new_storage_path = config.storage_path + ".new"
 ⋮----
 def clear_empty_collections(self) -> int
 ⋮----
 coll_names = self.list_collections()
 n_deletes = 0
 ⋮----
-info = self.client.get_collection(collection_name=name)
+nr = self.client.open_table(name).head(1).shape[0]
 ⋮----
 def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
 ⋮----
@@ -48980,8 +47849,6 @@ coll_names = [
 n_empty_deletes = 0
 n_non_empty_deletes = 0
 ⋮----
-points_count = from_optional(info.points_count, 0)
-⋮----
 def list_collections(self, empty: bool = False) -> List[str]
 ⋮----
 """
@@ -48991,10 +47858,242 @@ def list_collections(self, empty: bool = False) -> List[str]
         Args:
             empty (bool, optional): Whether to include empty collections.
         """
+colls = self.client.table_names(limit=None)
 ⋮----
-colls = list(self.client.get_collections())[0][1]
+if empty:  # include empty tbls
+return colls  # type: ignore
+counts = [self.client.open_table(coll).head(1).shape[0] for coll in colls]
 ⋮----
-counts = []
+def _create_lance_schema(self, doc_cls: Type[Document]) -> Type[BaseModel]
+⋮----
+"""
+        NOTE: NOT USED, but leaving it here as it may be useful.
+
+        Create a subclass of LanceModel with fields:
+         - id (str)
+         - Vector field that has dims equal to
+            the embedding dimension of the embedding model, and a data field of type
+            DocClass.
+         - other fields from doc_cls
+
+        Args:
+            doc_cls (Type[Document]): A Pydantic model which should be a subclass of
+                Document, to be used as the type for the data field.
+
+        Returns:
+            Type[BaseModel]: A new Pydantic model subclassing from LanceModel.
+
+        Raises:
+            ValueError: If `n` is not a non-negative integer or if `DocClass` is not a
+                subclass of Document.
+        """
+⋮----
+n = self.embedding_dim
+⋮----
+# Prepare fields for the new model
+fields = {"id": (str, ...), "vector": (Vector(n), ...)}
+⋮----
+sorted_fields = dict(
+# Add both statically and dynamically defined fields from doc_cls
+⋮----
+field_type = field.annotation if hasattr(field, "annotation") else field
+⋮----
+# Create the new model with dynamic fields
+NewModel = create_model(
+⋮----
+)  # type: ignore
+return NewModel  # type: ignore
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+colls = self.list_collections(empty=True)
+⋮----
+embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+coll_name = self.config.collection_name
+⋮----
+# self._maybe_set_doc_class_schema(documents[0])
+table_exists = False
+⋮----
+# collection exists and  is not empty:
+# if replace_collection is True, we'll overwrite the existing collection,
+# else we'll append to it.
+⋮----
+table_exists = True
+⋮----
+ids = [str(d.id()) for d in documents]
+# don't insert all at once, batch in chunks of b,
+# else we get an API error
+b = self.config.batch_size
+⋮----
+def make_batches() -> Generator[List[Dict[str, Any]], None, None]
+⋮----
+batch = [
+⋮----
+tbl = self.client.open_table(coll_name)
+⋮----
+batch_gen = make_batches()
+batch = next(batch_gen)
+# use first batch to create table...
+tbl = self.client.create_table(
+# ... and add the rest
+⋮----
+"""
+        Add a dataframe to the collection.
+        Args:
+            df (pd.DataFrame): A dataframe
+            content (str): The name of the column in the dataframe that contains the
+                text content to be embedded using the embedding model.
+            metadata (List[str]): A list of column names in the dataframe that contain
+                metadata to be stored in the database. Defaults to [].
+        """
+⋮----
+actual_metadata = metadata.copy()
+self.df_metadata_columns = actual_metadata  # could be updated below
+# get content column
+content_values = df[content].values.tolist()
+embedding_vecs = self.embedding_fn(content_values)
+⋮----
+# add vector column
+⋮----
+# rename content column to "content", leave existing column intact
+df = df.rename(columns={content: "content"}, inplace=False)
+⋮----
+docs = dataframe_to_documents(df, content="content", metadata=metadata)
+ids = [str(d.id()) for d in docs]
+⋮----
+# collection either doesn't exist or is empty, so replace it
+# and set new schema from df
+⋮----
+doc_cls = dataframe_to_document_model(
+self.config.document_class = doc_cls  # type: ignore
+⋮----
+# collection exists and is not empty, so append to it
+tbl = self.client.open_table(self.config.collection_name)
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+df = result.to_pandas()
+⋮----
+records = result.to_arrow().to_pylist()
+⋮----
+def _records_to_docs(self, records: List[Dict[str, Any]]) -> List[Document]
+⋮----
+docs = [self.config.document_class(**rec) for rec in records]
+⋮----
+def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+pre_result = tbl.search(None).where(where or None).limit(None)
+⋮----
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+_ids = [str(id) for id in ids]
+⋮----
+docs = []
+⋮----
+results = self._lance_result_to_docs(tbl.search().where(f"id == '{_id}'"))
+⋮----
+embedding = self.embedding_fn([text])[0]
+⋮----
+result = (
+docs = self._lance_result_to_docs(result)
+# note _distance is 1 - cosine
+⋮----
+scores = [
+⋮----
+scores = [1 - rec["_distance"] for rec in result.to_arrow().to_pylist()]
+⋮----
+doc_score_pairs = list(zip(docs, scores))
+</file>
+
+<file path="langroid/vector_store/meilisearch.py">
+"""
+MeiliSearch as a pure document store, without its
+(experimental) vector-store functionality.
+We aim to use MeiliSearch for fast lexical search.
+Note that what we call "Collection" in Langroid is referred to as
+"Index" in MeiliSearch. Each data-store has its own terminology,
+but for uniformity we use the Langroid terminology here.
+"""
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+class MeiliSearchConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="MEILISEARCH_")
+⋮----
+cloud: bool = False
+collection_name: str | None = None
+primary_key: str = "id"
+port: int = 7700
+⋮----
+class MeiliSearch(VectorStore)
+⋮----
+def __init__(self, config: MeiliSearchConfig | None = None)
+⋮----
+config = config if config is not None else MeiliSearchConfig()
+⋮----
+# Note: Only create collection if a non-null collection name is provided.
+# This is useful to delay creation of db until we have a suitable
+# collection name (e.g. we could get it from the url or folder path).
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+"""All collections are treated as non-empty in MeiliSearch, so this is a
+        no-op"""
+⋮----
+async def _async_delete_indices(self, uids: List[str]) -> List[bool]
+⋮----
+"""Delete any indicecs in `uids` that exist.
+        Returns list of bools indicating whether the index has been deleted"""
+⋮----
+result = await asyncio.gather(
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+"""Delete all indices whose names start with `prefix`"""
+⋮----
+coll_names = [c for c in self.list_collections() if c.startswith(prefix)]
+deletes = asyncio.run(self._async_delete_indices(coll_names))
+n_deletes = sum(deletes)
+⋮----
+def _list_all_collections(self) -> List[str]
+⋮----
+"""
+        List all collections, including empty ones.
+        Returns:
+            List of collection names.
+        """
+⋮----
+async def _async_get_indexes(self) -> List[AsyncIndex]
+⋮----
+indexes = await client.get_indexes(limit=10_000)
+return [] if indexes is None else indexes  # type: ignore
+⋮----
+async def _async_get_index(self, index_uid: str) -> "AsyncIndex"
+⋮----
+index = await client.get_index(index_uid)
+return index  # type: ignore
+⋮----
+def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+"""
+        Returns:
+            List of index names stored. We treat any existing index as non-empty.
+        """
+indexes = asyncio.run(self._async_get_indexes())
+⋮----
+async def _async_create_index(self, collection_name: str) -> "AsyncIndex"
+⋮----
+index = await client.create_index(
+⋮----
+async def _async_delete_index(self, collection_name: str) -> bool
+⋮----
+"""Delete index if it exists. Returns True iff index was deleted"""
+⋮----
+result = await client.delete_index_if_exists(uid=collection_name)
+return result  # type: ignore
 ⋮----
 def create_collection(self, collection_name: str, replace: bool = False) -> None
 ⋮----
@@ -49007,120 +48106,401 @@ def create_collection(self, collection_name: str, replace: bool = False) -> None
                 with the same name. Defaults to False.
         """
 ⋮----
-coll = self.client.get_collection(collection_name=collection_name)
+collections = self.list_collections()
 ⋮----
-vectors_config = {
-sparse_vectors_config = None
-⋮----
-sparse_vectors_config = {
-⋮----
-collection_info = self.client.get_collection(collection_name=collection_name)
+collection_info = asyncio.run(self._async_get_index(collection_name))
 ⋮----
 level = logger.getEffectiveLevel()
 ⋮----
-def get_sparse_embeddings(self, inputs: List[str]) -> List["SparseVector"]
-⋮----
-tokens = self.sparse_tokenizer(
-output = self.sparse_model(**tokens)
-vectors = torch.max(
-sparse_embeddings = []
-⋮----
-cols = vec.nonzero().squeeze().cpu().tolist()
-weights = vec[cols].cpu().tolist()
+index = client.index(collection_name)
 ⋮----
 def add_documents(self, documents: Sequence[Document]) -> None
 ⋮----
-# Add id to metadata if not already present
+colls = self._list_all_collections()
 ⋮----
-# Fix the ids due to qdrant finickiness
-⋮----
-colls = self.list_collections(empty=True)
-⋮----
-document_dicts = [doc.model_dump() for doc in documents]
-embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-sparse_embedding_vecs = self.get_sparse_embeddings(
-⋮----
-ids = [self._to_int_or_uuid(d.id()) for d in documents]
-# don't insert all at once, batch in chunks of b,
-# else we get an API error
-b = self.config.batch_size
-⋮----
-vectors: Dict[str, Embeddings | List[SparseVector]] = {
-⋮----
-coll_found: bool = False
-⋮----
-# poll until collection is ready
-⋮----
-coll_found = True
+docs = [
 ⋮----
 def delete_collection(self, collection_name: str) -> None
 ⋮----
 def _to_int_or_uuid(self, id: str) -> int | str
 ⋮----
-int_val = int(id)
+async def _async_get_documents(self, where: str = "") -> "DocumentsInfo"
 ⋮----
-# If doc_id is already a valid UUID, return it as is
+filter = [] if where is None else where
 ⋮----
-# Otherwise, generate a UUID from the doc_id
-# Convert doc_id to string if it's not already
-id_str = str(id)
-⋮----
-# Hash the document ID using SHA-1
-hash_object = hashlib.sha1(id_str.encode())
-hash_digest = hash_object.hexdigest()
-⋮----
-# Truncate or manipulate the hash to fit into a UUID (128 bits)
-uuid_str = hash_digest[:32]
-⋮----
-# Format this string into a UUID format
-formatted_uuid = uuid.UUID(uuid_str)
+index = client.index(self.config.collection_name)
+documents = await index.get_documents(limit=10_000, filter=filter)
 ⋮----
 def get_all_documents(self, where: str = "") -> List[Document]
 ⋮----
-docs = []
-offset = 0
-filter = Filter() if where == "" else Filter.model_validate(json.loads(where))
+docs = asyncio.run(self._async_get_documents(where))
 ⋮----
-limit=10_000,  # try getting all at once, if not we keep paging
+doc_results = docs.results
 ⋮----
-self.config.document_class(**record.payload)  # type: ignore
+async def _async_get_documents_by_ids(self, ids: List[str]) -> List[Dict[str, Any]]
 ⋮----
-# ignore
-⋮----
-offset = next_page_offset  # type: ignore
+documents = await asyncio.gather(*[index.get_document(id) for id in ids])
 ⋮----
 def get_documents_by_ids(self, ids: List[str]) -> List[Document]
 ⋮----
-_ids = [self._to_int_or_uuid(id) for id in ids]
-records = self.client.retrieve(
-# Note the records may NOT be in the order of the ids,
-# so we re-order them here.
-id2payload = {record.id: record.payload for record in records}
-ordered_payloads = [id2payload[id] for id in _ids if id in id2payload]
-docs = [Document(**payload) for payload in ordered_payloads]  # type: ignore
+docs = asyncio.run(self._async_get_documents_by_ids(ids))
 ⋮----
-embedding = self.embedding_fn([text])[0]
-# TODO filter may not work yet
+results = await index.search(
+return results.hits  # type: ignore
 ⋮----
-filter = Filter()
+neighbors: int = 0,  # ignored
 ⋮----
-filter = Filter.model_validate(json.loads(where))
-requests = [
+_docs = asyncio.run(self._async_search(text, k, filter))  # type: ignore
 ⋮----
-sparse_embedding = self.get_sparse_embeddings([text])[0]
-⋮----
-search_result_lists: List[List[ScoredPoint]] = self.client.search_batch(
-⋮----
-search_result = [
-⋮----
-]  # 2D list -> 1D list
-scores = [match.score for match in search_result if match is not None]
-docs = [
-⋮----
-self.config.document_class(**(match.payload))  # type: ignore
+scores = [h["_rankingScore"] for h in _docs]
 ⋮----
 doc_score_pairs = list(zip(docs, scores))
-max_score = max(ds[1] for ds in doc_score_pairs)
+</file>
+
+<file path="langroid/vector_store/pineconedb.py">
+# import dataclass
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+has_pinecone: bool = True
+⋮----
+class ServerlessSpec(BaseModel)
+⋮----
+"""
+            Fallback Serverless specification configuration to avoid import errors.
+            """
+⋮----
+cloud: str
+region: str
+⋮----
+PineconeApiException = Any  # type: ignore
+Pinecone = Any  # type: ignore
+has_pinecone = False
+⋮----
+@dataclass(frozen=True)
+class IndexMeta
+⋮----
+name: str
+total_vector_count: int
+⋮----
+class PineconeDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="PINECONE_")
+⋮----
+cloud: bool = True
+collection_name: str | None = "temp"
+spec: ServerlessSpec = ServerlessSpec(cloud="aws", region="us-east-1")
+deletion_protection: Literal["enabled", "disabled"] | None = None
+metric: str = "cosine"
+pagination_size: int = 100
+⋮----
+class PineconeDB(VectorStore)
+⋮----
+def __init__(self, config: PineconeDBConfig | None = None)
+⋮----
+config = config if config is not None else PineconeDBConfig()
+⋮----
+key = os.getenv("PINECONE_API_KEY")
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+indexes = self._list_index_metas(empty=True)
+n_deletes = 0
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+"""
+        Returns:
+            Number of Pinecone indexes that were deleted
+
+        Args:
+            really: Optional[bool] - whether to really delete all Pinecone collections
+            prefix: Optional[str] - string to match potential Pinecone
+                indexes for deletion
+        """
+⋮----
+indexes = [
+⋮----
+def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+"""
+        Returns:
+            List of Pinecone indices that have at least one vector.
+
+        Args:
+            empty: Optional[bool] - whether to include empty collections
+        """
+indexes = self.client.list_indexes()
+res: List[str] = []
+⋮----
+index_meta = self.client.Index(name=index)
+⋮----
+def _list_index_metas(self, empty: bool = False) -> List[IndexMeta]
+⋮----
+"""
+        Returns:
+            List of objects describing Pinecone indices
+
+        Args:
+            empty: Optional[bool] - whether to include empty collections
+        """
+⋮----
+res = []
+⋮----
+index_meta = self._fetch_index_meta(index)
+⋮----
+def _fetch_index_meta(self, index_name: str) -> IndexMeta
+⋮----
+"""
+        Returns:
+            A dataclass describing the input Index by name and vector count
+            to save a bit on index description calls
+
+        Args:
+            index_name: str - Name of the index in Pinecone
+        """
+⋮----
+index = self.client.Index(name=index_name)
+stats = index.describe_index_stats()
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+"""
+        Create a collection with the given name, optionally replacing an existing
+        collection if `replace` is True.
+
+        Args:
+            collection_name: str - Configuration of the collection to create.
+            replace: Optional[Bool] - Whether to replace an existing collection
+                with the same name. Defaults to False.
+        """
+pattern = re.compile(r"^[a-z0-9-]+$")
+⋮----
+index = self.client.Index(name=collection_name)
+⋮----
+status = self.client.describe_index(name=collection_name)
+⋮----
+payload = {
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+def add_documents(self, documents: Sequence[Document], namespace: str = "") -> None
+⋮----
+document_dicts = [doc.model_dump() for doc in documents]
+document_ids = [doc.id() for doc in documents]
+embedding_vectors = self.embedding_fn([doc.content for doc in documents])
+vectors = [
+⋮----
+index = self.client.Index(name=self.config.collection_name)
+batch_size = self.config.batch_size
+⋮----
+"""
+        Returns:
+            All documents for the collection currently defined in
+            the configuration object
+
+        Args:
+            prefix: str - document id prefix to search for
+            namespace: str - partition of vectors to search within the index
+        """
+⋮----
+docs = []
+⋮----
+request_filters: Dict[str, Union[str, int]] = {
+⋮----
+response = index.list_paginated(**request_filters)
+vectors = response.get("vectors", [])
+⋮----
+pagination_token = response.get("pagination", {}).get("next", None)
+⋮----
+"""
+        Returns:
+            Fetches document text embedded in Pinecone index metadata
+
+        Args:
+            ids: List[str] - vector data object ids to retrieve
+            namespace: str - partition of vectors to search within the index
+        """
+⋮----
+records = index.fetch(ids=ids, namespace=namespace)
+⋮----
+records = index.fetch(ids=ids)
+⋮----
+id_mapping = {key: value for key, value in records["vectors"].items()}
+ordered_payloads = [id_mapping[_id] for _id in ids if _id in id_mapping]
+⋮----
+vector_search_request = {
+⋮----
+response = index.query(**vector_search_request)
+doc_score_pairs = [
+⋮----
+max_score = max([pair[1] for pair in doc_score_pairs])
+⋮----
+def transform_pinecone_vector(self, metadata_dict: Dict[str, Any]) -> Document
+⋮----
+"""
+        Parses the metadata response from the Pinecone vector query and
+        formats it into a dictionary that can be parsed by the Document class
+        associated with the PineconeDBConfig class
+
+        Returns:
+            Well formed dictionary object to be transformed into a Document
+
+        Args:
+            metadata_dict: Dict - the metadata dictionary from the Pinecone
+                vector query match
+        """
+</file>
+
+<file path="langroid/vector_store/weaviatedb.py">
+logger = logging.getLogger(__name__)
+⋮----
+class VectorDistances
+⋮----
+"""
+    Fallback class when weaviate is not installed, to avoid import errors.
+    """
+⋮----
+COSINE: str = "cosine"
+DOTPRODUCT: str = "dot"
+L2: str = "l2"
+⋮----
+class WeaviateDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="WEAVIATE_")
+⋮----
+collection_name: str | None = "temp"
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+distance: str = VectorDistances.COSINE
+cloud: bool = False
+docker: bool = False
+host: str = "127.0.0.1"
+port: int = 8080
+storage_path: str = ".weaviate_embedded/data"
+⋮----
+class WeaviateDB(VectorStore)
+⋮----
+def __init__(self, config: WeaviateDBConfig | None = None)
+⋮----
+config = config if config is not None else WeaviateDBConfig()
+⋮----
+key = os.getenv("WEAVIATE_API_KEY")
+url = os.getenv("WEAVIATE_API_URL")
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+colls = self.client.collections.list_all()
+n_deletes = 0
+⋮----
+val = self.client.collections.get(coll_name)
+⋮----
+def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+non_empty_colls = [
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+coll_names = [
+⋮----
+n_empty_deletes = 0
+n_non_empty_deletes = 0
+⋮----
+info = self.client.collections.get(name)
+points_count = len(info)
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+collection_name = WeaviateDB.validate_and_format_collection_name(
+⋮----
+coll = self.client.collections.get(name=collection_name)
+⋮----
+vector_index_config = Configure.VectorIndex.hnsw(
+⋮----
+vectorizer_config = Configure.Vectorizer.text2vec_openai(
+⋮----
+vectorizer_config = None
+⋮----
+collection_info = self.client.collections.create(
+collection_info = self.client.collections.get(name=collection_name)
+⋮----
+level = logger.getEffectiveLevel()
+⋮----
+def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+colls = self.list_collections(empty=True)
+⋮----
+document_dicts = [doc.model_dump() for doc in documents]
+embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+⋮----
+coll_name = self.client.collections.get(self.config.collection_name)
+⋮----
+id = doc_dict["metadata"].pop("id", None)
+⋮----
+def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+# cannot use filter as client does not support json type queries
+coll = self.client.collections.get(self.config.collection_name)
+⋮----
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+docs = []
+⋮----
+result = coll_name.query.fetch_objects(
+⋮----
+id_to_doc = {}
+⋮----
+doc = self.weaviate_obj_to_doc(item)
+⋮----
+# Reconstruct the list of documents in the original order of input ids
+docs = [id_to_doc[id] for id in ids if id in id_to_doc]
+⋮----
+embedding = self.embedding_fn([text])[0]
+⋮----
+response = coll.query.near_vector(
+maybe_distances = [item.metadata.distance for item in response.objects]
+similarities = [0 if d is None else 1 - d for d in maybe_distances]
+docs = [self.weaviate_obj_to_doc(item) for item in response.objects]
+⋮----
+def _create_valid_uuid_id(self, id: str) -> Any
+⋮----
+id = get_valid_uuid(id)
+⋮----
+def weaviate_obj_to_doc(self, input_object: Any) -> Document
+⋮----
+content = input_object.properties.get("content", "")
+metadata_dict = input_object.properties.get("metadata", {})
+⋮----
+window_ids = metadata_dict.pop("window_ids", [])
+window_ids = [str(uuid) for uuid in window_ids]
+⋮----
+# Ensure the id is a valid UUID string
+id_value = get_valid_uuid(input_object.uuid)
+⋮----
+metadata = DocMetaData(id=id_value, window_ids=window_ids, **metadata_dict)
+⋮----
+@staticmethod
+    def validate_and_format_collection_name(name: str) -> str
+⋮----
+"""
+        Formats the collection name to comply with Weaviate's naming rules:
+        - Name must start with a capital letter.
+        - Name can only contain letters, numbers, and underscores.
+        - Replaces invalid characters with underscores.
+        """
+⋮----
+formatted_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+⋮----
+# Ensure the first letter is capitalized
+⋮----
+formatted_name = formatted_name.capitalize()
+⋮----
+# Check if the name now meets the criteria
+⋮----
+def __del__(self) -> None
+⋮----
+# Gracefully close the connection with local client
 </file>
 
 <file path="CONTRIBUTING.md">
@@ -54236,6 +53616,441 @@ page_no = 0
         """
 </file>
 
+<file path="langroid/vector_store/postgres.py">
+has_postgres: bool = True
+⋮----
+Engine = Any  # type: ignore
+Connection = Any  # type: ignore
+has_postgres = False
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+def _quote_ident(name: str) -> str
+⋮----
+"""Quote a SQL identifier (table/index name) for use in raw DDL, so a name
+    containing characters that are invalid in an unquoted identifier -- e.g.
+    the ``-`` in a pytest-xdist worker suffix like ``mycollection-gw1`` -- does
+    not produce a syntax error. Embedded double-quotes are escaped per the SQL
+    standard.
+    """
+⋮----
+class PostgresDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="POSTGRES_")
+⋮----
+collection_name: str = "embeddings"
+cloud: bool = False
+docker: bool = True
+host: str = "127.0.0.1"
+port: int = 5432
+replace_collection: bool = False
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+pool_size: int = 10
+max_overflow: int = 20
+hnsw_m: int = 16
+hnsw_ef_construction: int = 200
+⋮----
+class PostgresDB(VectorStore)
+⋮----
+def __init__(self, config: PostgresDBConfig | None = None)
+⋮----
+config = config if config is not None else PostgresDBConfig()
+⋮----
+def _create_engine(self) -> Engine
+⋮----
+"""Creates a SQLAlchemy engine based on the configuration."""
+⋮----
+connection_string: str | None = None  # Ensure variable is always defined
+⋮----
+connection_string = os.getenv("POSTGRES_CONNECTION_STRING")
+⋮----
+connection_string = connection_string.replace(
+⋮----
+username = os.getenv("POSTGRES_USER", "postgres")
+password = os.getenv("POSTGRES_PASSWORD", "postgres")
+database = os.getenv("POSTGRES_DB", "langroid")
+⋮----
+connection_string = (
+self.config.cloud = False  # Ensures cloud is disabled if using Docker
+⋮----
+def _setup_table(self) -> None
+⋮----
+# Create HNSW index for embeddings column if it doesn't exist.
+# This index enables efficient nearest-neighbor search using cosine similarity.
+# PostgreSQL automatically builds the index after creation;
+# no manual step required.
+# Read more about pgvector hnsw index here:
+# https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw
+⋮----
+index_name = f"hnsw_index_{self.config.collection_name}_embedding"
+⋮----
+create_index_query = text(
+⋮----
+def index_exists(self, connection: Connection, index_name: str) -> bool
+⋮----
+"""Check if an index exists."""
+query = text(
+result = connection.execute(query).scalar()
+⋮----
+@staticmethod
+    def _create_vector_extension(conn: Engine) -> None
+⋮----
+# The number is a unique identifier used to lock a specific resource
+# during transaction. Any 64-bit integer can be used for advisory locks.
+# Acquire advisory lock to ensure atomic, isolated setup
+# and prevent race conditions.
+⋮----
+statement = text(
+⋮----
+def set_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+inspector = inspect(self.engine)
+table_exists = collection_name in inspector.get_table_names()
+⋮----
+def list_collections(self, empty: bool = True) -> List[str]
+⋮----
+table_names = inspector.get_table_names()
+⋮----
+collections = []
+⋮----
+table = Table(table_name, self.metadata, autoload_with=self.engine)
+⋮----
+# Efficiently check for non-emptiness
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+"""
+        Deletes a collection and its associated HNSW index, handling metadata
+        synchronization issues.
+        """
+⋮----
+index_name = f"hnsw_index_{collection_name}_embedding"
+drop_index_query = text(
+⋮----
+# 3. Now, drop the table using SQLAlchemy
+table = Table(collection_name, self.metadata)
+⋮----
+# 4. Refresh metadata again after dropping the table
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+deleted_count = 0
+⋮----
+# Use delete_collection to handle index and table deletion
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+# Efficiently check for emptiness without fetching all rows
+⋮----
+session.commit()  # Commit is likely not needed here
+⋮----
+def _parse_embedding_store_record(self, res: Any) -> Dict[str, Any]
+⋮----
+metadata = res.cmetadata or {}
+⋮----
+def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+query = session.query(self.embeddings_table)
+⋮----
+# Apply 'where' clause if provided
+⋮----
+where_json = json.loads(where)
+query = query.filter(
+⋮----
+return []  # Return empty list or handle error as appropriate
+⋮----
+results = query.all()
+documents = [
+⋮----
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+# Add a CASE statement to preserve the order of IDs
+case_stmt = case(
+⋮----
+query = (
+⋮----
+.order_by(case_stmt)  # Order by the CASE statement
+⋮----
+def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+embeddings = self.embedding_fn([doc.content for doc in documents])
+⋮----
+batch_size = self.config.batch_size
+⋮----
+batch_docs = documents[i : i + batch_size]
+batch_embeddings = embeddings[i : i + batch_size]
+⋮----
+new_records = [
+⋮----
+stmt = insert(self.embeddings_table).values(new_records)
+⋮----
+@staticmethod
+    def _id_to_uuid(id: str, obj: object) -> str
+⋮----
+doc_id = str(uuid.UUID(id))
+⋮----
+obj_repr = repr(obj)
+⋮----
+obj_hash = hashlib.sha256(obj_repr.encode()).hexdigest()
+⋮----
+combined = f"{id}-{obj_hash}"
+⋮----
+doc_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, combined))
+⋮----
+neighbors: int = 1,  # Parameter not used in this implementation
+⋮----
+embedding = self.embedding_fn([query])[0]
+⋮----
+# Calculate the score (1 - cosine_distance) and label it as "score"
+score = (
+⋮----
+json_query = json.loads(where)
+⋮----
+results = (
+⋮----
+score,  # Select the calculated score
+⋮----
+.order_by(score.desc())  # Order by score in descending order
+⋮----
+documents_with_scores = [
+⋮----
+result.score,  # Use the score from the query result
+</file>
+
+<file path="langroid/vector_store/qdrantdb.py">
+logger = logging.getLogger(__name__)
+⋮----
+T = TypeVar("T")
+⋮----
+def from_optional(x: Optional[T], default: T) -> T
+⋮----
+def is_valid_uuid(uuid_to_test: str) -> bool
+⋮----
+"""
+    Check if a given string is a valid UUID.
+    """
+⋮----
+uuid_obj = uuid.UUID(uuid_to_test)
+⋮----
+# Check for valid unsigned 64-bit integer
+⋮----
+int_value = int(uuid_to_test)
+⋮----
+class QdrantDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="QDRANT_")
+⋮----
+cloud: bool = True
+docker: bool = False
+collection_name: str | None = "temp"
+storage_path: str = ".qdrant/data"
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+use_sparse_embeddings: bool = False
+sparse_embedding_model: str = "naver/splade-v3-distilbert"
+sparse_limit: int = 3
+distance: str = "cosine"
+⋮----
+class QdrantDB(VectorStore)
+⋮----
+def __init__(self, config: QdrantDBConfig | None = None)
+⋮----
+config = config if config is not None else QdrantDBConfig()
+⋮----
+self.sparse_tokenizer = AutoTokenizer.from_pretrained(  # type: ignore
+⋮----
+key = os.getenv("QDRANT_API_KEY")
+url = os.getenv("QDRANT_API_URL")
+⋮----
+new_storage_path = config.storage_path + ".new"
+⋮----
+# Note: Only create collection if a non-null collection name is provided.
+# This is useful to delay creation of vecdb until we have a suitable
+# collection name (e.g. we could get it from the url or folder path).
+⋮----
+def clone(self) -> "QdrantDB"
+⋮----
+"""Create an independent Qdrant client when running against Qdrant Cloud."""
+⋮----
+cloned = super().clone()
+⋮----
+def close(self) -> None
+⋮----
+"""
+        Close the QdrantDB client and release any resources (e.g., file locks).
+        This is especially important for local storage to release the .lock file.
+        """
+⋮----
+# QdrantLocal has a close method that releases the lock
+⋮----
+def __enter__(self) -> "QdrantDB"
+⋮----
+"""Context manager entry."""
+⋮----
+def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
+⋮----
+"""Context manager exit - ensure cleanup even if an exception occurred."""
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+coll_names = self.list_collections()
+n_deletes = 0
+⋮----
+info = self.client.get_collection(collection_name=name)
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+"""Clear all collections with the given prefix."""
+⋮----
+coll_names = [
+⋮----
+n_empty_deletes = 0
+n_non_empty_deletes = 0
+⋮----
+points_count = from_optional(info.points_count, 0)
+⋮----
+def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+"""
+        Returns:
+            List of collection names that have at least one vector.
+
+        Args:
+            empty (bool, optional): Whether to include empty collections.
+        """
+⋮----
+colls = list(self.client.get_collections())[0][1]
+⋮----
+counts = []
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+"""
+        Create a collection with the given name, optionally replacing an existing
+            collection if `replace` is True.
+        Args:
+            collection_name (str): Name of the collection to create.
+            replace (bool): Whether to replace an existing collection
+                with the same name. Defaults to False.
+        """
+⋮----
+coll = self.client.get_collection(collection_name=collection_name)
+⋮----
+vectors_config = {
+sparse_vectors_config = None
+⋮----
+sparse_vectors_config = {
+⋮----
+collection_info = self.client.get_collection(collection_name=collection_name)
+⋮----
+level = logger.getEffectiveLevel()
+⋮----
+def get_sparse_embeddings(self, inputs: List[str]) -> List["SparseVector"]
+⋮----
+tokens = self.sparse_tokenizer(
+output = self.sparse_model(**tokens)
+vectors = torch.max(
+sparse_embeddings = []
+⋮----
+cols = vec.nonzero().squeeze().cpu().tolist()
+weights = vec[cols].cpu().tolist()
+⋮----
+def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+# Add id to metadata if not already present
+⋮----
+# Fix the ids due to qdrant finickiness
+⋮----
+colls = self.list_collections(empty=True)
+⋮----
+document_dicts = [doc.model_dump() for doc in documents]
+embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+sparse_embedding_vecs = self.get_sparse_embeddings(
+⋮----
+ids = [self._to_int_or_uuid(d.id()) for d in documents]
+# don't insert all at once, batch in chunks of b,
+# else we get an API error
+b = self.config.batch_size
+⋮----
+vectors: Dict[str, Embeddings | List[SparseVector]] = {
+⋮----
+coll_found: bool = False
+⋮----
+# poll until collection is ready
+⋮----
+coll_found = True
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+def _to_int_or_uuid(self, id: str) -> int | str
+⋮----
+int_val = int(id)
+⋮----
+# If doc_id is already a valid UUID, return it as is
+⋮----
+# Otherwise, generate a UUID from the doc_id
+# Convert doc_id to string if it's not already
+id_str = str(id)
+⋮----
+# Hash the document ID using SHA-1
+hash_object = hashlib.sha1(id_str.encode())
+hash_digest = hash_object.hexdigest()
+⋮----
+# Truncate or manipulate the hash to fit into a UUID (128 bits)
+uuid_str = hash_digest[:32]
+⋮----
+# Format this string into a UUID format
+formatted_uuid = uuid.UUID(uuid_str)
+⋮----
+def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+docs = []
+offset = 0
+filter = Filter() if where == "" else Filter.model_validate(json.loads(where))
+⋮----
+limit=10_000,  # try getting all at once, if not we keep paging
+⋮----
+self.config.document_class(**record.payload)  # type: ignore
+⋮----
+# ignore
+⋮----
+offset = next_page_offset  # type: ignore
+⋮----
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+_ids = [self._to_int_or_uuid(id) for id in ids]
+records = self.client.retrieve(
+# Note the records may NOT be in the order of the ids,
+# so we re-order them here.
+id2payload = {record.id: record.payload for record in records}
+ordered_payloads = [id2payload[id] for id in _ids if id in id2payload]
+docs = [Document(**payload) for payload in ordered_payloads]  # type: ignore
+⋮----
+embedding = self.embedding_fn([text])[0]
+# TODO filter may not work yet
+⋮----
+filter = Filter()
+⋮----
+filter = Filter.model_validate(json.loads(where))
+requests = [
+⋮----
+sparse_embedding = self.get_sparse_embeddings([text])[0]
+⋮----
+search_result_lists: List[List[ScoredPoint]] = self.client.search_batch(
+⋮----
+search_result = [
+⋮----
+]  # 2D list -> 1D list
+scores = [match.score for match in search_result if match is not None]
+docs = [
+⋮----
+self.config.document_class(**(match.payload))  # type: ignore
+⋮----
+doc_score_pairs = list(zip(docs, scores))
+max_score = max(ds[1] for ds in doc_score_pairs)
+</file>
+
 <file path="SECURITY.md">
 # Security Policy
 
@@ -54364,6 +54179,1447 @@ it, and if it was a denylist gap it is out of scope.
 
 Security fixes ship in the latest release. Please upgrade to the current
 version of `langroid` rather than requesting backports.
+</file>
+
+<file path="langroid/language_models/openai_gpt.py">
+OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
+⋮----
+OLLAMA_BASE_URL = "http://localhost:11434/v1"
+⋮----
+DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+# Provider prefixes that route to the Gemini OpenAI-compatible API.
+GEMINI_MODEL_PREFIXES = ("gemini/", "google/gemini-")
+GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+OLLAMA_API_KEY = "ollama"
+⋮----
+VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
+LLAMACPP_API_KEY = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
+⋮----
+openai_chat_model_pref_list = [
+⋮----
+openai_completion_model_pref_list = [
+⋮----
+available_models = set(map(lambda m: m.id, OpenAI().models.list()))
+⋮----
+available_models = set()
+⋮----
+default_openai_chat_model = next(
+default_openai_completion_model = next(
+⋮----
+class AccessWarning(Warning)
+⋮----
+@cache
+def gpt_3_5_warning() -> None
+⋮----
+@cache
+def parallel_strict_warning() -> None
+⋮----
+def noop() -> None
+⋮----
+"""Does nothing."""
+⋮----
+class OpenAICallParams(BaseModel)
+⋮----
+"""
+    Various params that can be sent to an OpenAI API chat-completion call.
+    When specified, any param here overrides the one with same name in the
+    OpenAIGPTConfig.
+    See OpenAI API Reference for details on the params:
+    https://platform.openai.com/docs/api-reference/chat
+    """
+⋮----
+max_tokens: int | None = None
+temperature: float | None = None
+frequency_penalty: float | None = None  # between -2 and 2
+presence_penalty: float | None = None  # between -2 and 2
+response_format: Dict[str, str] | None = None
+logit_bias: Dict[int, float] | None = None  # token_id -> bias
+logprobs: bool | None = None
+top_p: float | None = None
+reasoning_effort: str | None = None  # or "low" or "high" or "medium"
+top_logprobs: int | None = None  # if int, requires logprobs=True
+n: int | None = None  # how many completions to generate (n > 1 is NOT handled now)
+stop: str | List[str] | None = None  # (list of) stop sequence(s)
+seed: int | None = None
+user: str | None = None  # user id for tracking
+extra_body: Dict[str, Any] | None = None  # additional params for API request body
+⋮----
+def to_dict_exclude_none(self) -> Dict[str, Any]
+⋮----
+class LiteLLMProxyConfig(BaseSettings)
+⋮----
+"""Configuration for LiteLLM proxy connection."""
+⋮----
+api_key: str = ""  # read from env var LITELLM_API_KEY if set
+api_base: str = ""  # read from env var LITELLM_API_BASE if set
+⋮----
+model_config = SettingsConfigDict(env_prefix="LITELLM_")
+⋮----
+class OpenAIGPTConfig(LLMConfig)
+⋮----
+"""
+    Class for any LLM with an OpenAI-like API: besides the OpenAI models this includes:
+    (a) locally-served models behind an OpenAI-compatible API
+    (b) non-local models, using a proxy adaptor lib like litellm that provides
+        an OpenAI-compatible API.
+    (We could rename this class to OpenAILikeConfig, but we keep it as-is for now)
+
+    Important Note:
+    Due to the `env_prefix = "OPENAI_"` defined below,
+    all of the fields below can be set AND OVERRIDDEN via env vars,
+    # by upper-casing the name and prefixing with OPENAI_, e.g.
+    # OPENAI_MAX_OUTPUT_TOKENS=1000.
+    # If any of these is defined in this way in the environment
+    # (either via explicit setenv or export or via .env file + load_dotenv()),
+    # the environment variable takes precedence over the value in the config.
+    """
+⋮----
+type: str = "openai"
+api_key: str = DUMMY_API_KEY
+# Callable returning a fresh API key/bearer token, for endpoints that
+# authenticate with short-lived rotating credentials (e.g. Vertex AI
+# OAuth tokens, Azure Entra ID). Resolved per-request by the OpenAI
+# client, and excluded from the client-cache key (the cache is keyed on
+# the provider's identity), so rotating tokens neither go stale nor grow
+# the cache. Takes precedence over `api_key`. Only supported for models
+# served via an OpenAI-compatible endpoint (not Groq/Cerebras/litellm).
+# See docs/notes/rotating-api-keys.md.
+api_key_provider: Optional[Callable[[], str]] = None
+organization: str = ""
+api_base: str | None = None  # used for local or other non-OpenAI models
+litellm: bool = False  # use litellm api?
+litellm_proxy: LiteLLMProxyConfig = LiteLLMProxyConfig()
+ollama: bool = False  # use ollama's OpenAI-compatible endpoint?
+min_output_tokens: int = 1
+use_chat_for_completion: bool = True  # do not change this, for OpenAI models!
+timeout: int = 20
+temperature: float = 0.2
+seed: int | None = 42
+params: OpenAICallParams | None = None
+use_cached_client: bool = (
+⋮----
+True  # Whether to reuse cached clients (prevents resource exhaustion)
+⋮----
+# these can be any model name that is served at an OpenAI-compatible API end point
+chat_model: str = default_openai_chat_model
+chat_model_orig: Optional[str] = None
+completion_model: str = default_openai_completion_model
+run_on_first_use: Callable[[], None] = noop
+parallel_tool_calls: Optional[bool] = None
+# Supports constrained decoding which enforces that the output of the LLM
+# adheres to a JSON schema
+supports_json_schema: Optional[bool] = None
+# Supports strict decoding for the generation of tool calls with
+# the OpenAI Tools API; this ensures that the generated tools
+# adhere to the provided schema.
+supports_strict_tools: Optional[bool] = None
+# a string that roughly matches a HuggingFace chat_template,
+# e.g. "mistral-instruct-v0.2 (a fuzzy search is done to find the closest match)
+formatter: str | None = None
+hf_formatter: HFFormatter | None = None
+langdb_params: LangDBParams = LangDBParams()
+portkey_params: PortkeyParams = PortkeyParams()
+headers: Dict[str, str] = {}
+http_client_factory: Optional[Callable[[], Any]] = (
+⋮----
+None  # Factory: returns Client or (Client, AsyncClient)
+⋮----
+http_verify_ssl: bool = True  # Simple flag for SSL verification
+http_client_config: Optional[Dict[str, Any]] = None  # Config dict for httpx.Client
+_api_base_was_supplied: bool = False
+⋮----
+def __init__(self, **kwargs) -> None:  # type: ignore
+⋮----
+api_base_was_supplied = "api_base" in kwargs
+local_model = "api_base" in kwargs and kwargs["api_base"] is not None
+⋮----
+chat_model = kwargs.get("chat_model", "")
+local_prefixes = ["local/", "litellm/", "ollama/", "vllm/", "llamacpp/"]
+⋮----
+local_model = True
+⋮----
+warn_gpt_3_5 = (
+⋮----
+existing_hook = kwargs.get("run_on_first_use", noop)
+⋮----
+def with_warning() -> None
+⋮----
+env_prefix = self.model_config.get("env_prefix")
+env_api_base_name = f"{env_prefix}API_BASE"
+env_api_base = os.getenv(env_api_base_name)
+⋮----
+case_insensitive_env = {
+env_api_base = case_insensitive_env.get(env_api_base_name.lower())
+api_base_was_supplied = api_base_was_supplied or (
+⋮----
+model_config = SettingsConfigDict(env_prefix="OPENAI_")
+⋮----
+def __setattr__(self, name: str, value: Any) -> None
+⋮----
+"""Track API bases assigned after config construction."""
+⋮----
+"""
+        Copy config while preserving nested model instances and subclasses.
+
+        Important: Avoid reconstructing via `model_dump` as that coerces nested
+        models to their annotated base types (dropping subclass-only fields).
+        Instead, defer to Pydantic's native `model_copy`, which keeps nested
+        `BaseModel` instances (and their concrete subclasses) intact.
+
+        An `api_base` supplied through `update` is caller configuration, so the
+        copy must retain that provenance for provider-specific routing.
+        """
+# Delegate to BaseSettings/BaseModel implementation to preserve types
+copied = super().model_copy(update=update, deep=deep)
+⋮----
+return copied  # type: ignore[return-value]
+⋮----
+def _validate_litellm(self) -> None
+⋮----
+"""
+        When using liteLLM, validate whether all env vars required by the model
+        have been set.
+        """
+⋮----
+litellm.drop_params = True  # drop un-supported params without crashing
+⋮----
+self.seed = None  # some local mdls don't support seed
+⋮----
+keys_dict = litellm.utils.validate_environment(self.chat_model)
+missing_keys = keys_dict.get("missing_keys", [])
+⋮----
+@classmethod
+    def create(cls, prefix: str) -> Type["OpenAIGPTConfig"]
+⋮----
+"""Create a config class whose params can be set via a desired
+        prefix from the .env file or env vars.
+        E.g., using
+        ```python
+        OllamaConfig = OpenAIGPTConfig.create("ollama")
+        ollama_config = OllamaConfig()
+        ```
+        you can have a group of params prefixed by "OLLAMA_", to be used
+        with models served via `ollama`.
+        This way, you can maintain several setting-groups in your .env file,
+        one per model type.
+        """
+⋮----
+class DynamicConfig(OpenAIGPTConfig)
+⋮----
+class OpenAIResponse(BaseModel)
+⋮----
+"""OpenAI response model, either completion or chat."""
+⋮----
+choices: List[Dict]  # type: ignore
+usage: Dict  # type: ignore
+⋮----
+def litellm_logging_fn(model_call_dict: Dict[str, Any]) -> None
+⋮----
+"""Logging function for litellm"""
+⋮----
+api_input_dict = model_call_dict.get("additional_args", {}).get(
+⋮----
+text = escape(json.dumps(api_input_dict, indent=2))
+⋮----
+# Define a class for OpenAI GPT models that extends the base class
+class OpenAIGPT(LanguageModel)
+⋮----
+"""
+    Class for OpenAI LLMs
+    """
+⋮----
+client: OpenAI | Groq | Cerebras | None
+async_client: AsyncOpenAI | AsyncGroq | AsyncCerebras | None
+⋮----
+def __init__(self, config: OpenAIGPTConfig = OpenAIGPTConfig())
+⋮----
+"""
+        Args:
+            config: configuration for openai-gpt model
+        """
+# copy the config to avoid modifying the original; deep to decouple
+# nested models while preserving their concrete subclasses
+# The api_key_provider must NOT be deep-copied: the client cache is
+# keyed on its identity (so a copy would defeat cache sharing), and it
+# may hold non-copyable state (e.g. a threading.Lock). Clear it in a
+# shallow copy first, then restore the original callable afterwards.
+api_key_provider = config.api_key_provider
+⋮----
+config = config.model_copy(update={"api_key_provider": None})
+config = config.model_copy(deep=True)
+⋮----
+# save original model name such as `provider/model` before
+# we strip out the `provider` - we retain the original in
+# case some params are specific to a provider.
+⋮----
+# Run the first time the model is used
+⋮----
+# global override of chat_model,
+# to allow quick testing with other models
+⋮----
+# there is a formatter specified, e.g.
+# "litellm/ollama/mistral//hf" or
+# "local/localhost:8000/v1//mistral-instruct-v0.2"
+formatter = parts[1]
+⋮----
+# e.g. "litellm/ollama/mistral//hf" -> "litellm/ollama/mistral"
+formatter = find_hf_formatter(self.config.chat_model)
+⋮----
+# e.g. "mistral"
+⋮----
+# e.g. "local/localhost:8000/v1//mistral-instruct-v0.2"
+⋮----
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", DUMMY_API_KEY)
+⋮----
+# if model name starts with "litellm",
+# set the actual model name by stripping the "litellm/" prefix
+# and set the litellm flag to True
+⋮----
+# e.g. litellm/ollama/mistral
+⋮----
+# strip the "litellm/" prefix
+# e.g. litellm/ollama/llama2 => ollama/llama2
+⋮----
+# expect this to be of the form "local/localhost:8000/v1",
+# depending on how the model is launched locally.
+# In this case the model served locally behind an OpenAI-compatible API
+# so we can just use `openai.*` methods directly,
+# and don't need a adaptor library like litellm
+⋮----
+self.config.seed = None  # some models raise an error when seed is set
+# Extract the api_base from the model name after the "local/" prefix
+⋮----
+# use api_base from config if set, else fall back on OLLAMA_BASE_URL
+⋮----
+# If api_base is unset we use OpenAI's endpoint, which supports
+# these features (with JSON schema restricted to a limited set of models)
+⋮----
+# if we're overriding chat model globally, set completion model to same
+⋮----
+# we want to format chats -> completions using this specific formatter
+⋮----
+# use groq-specific client
+⋮----
+# Create new clients without caching
+⋮----
+# use cerebras-specific client
+⋮----
+# TODO there is not async client, so should we do anything here?
+⋮----
+# in these cases, there's no specific client: OpenAI python client suffices
+⋮----
+# Prefer caller config, then Gemini env, then the default.
+gemini_api_base = os.getenv("GEMINI_API_BASE", "")
+explicit_api_base = (
+⋮----
+# Honor caller-supplied base URL (e.g. regional endpoints,
+# proxies) instead of always forcing the default.
+openai_api_base = os.getenv("OPENAI_API_BASE")
+⋮----
+# Only overwrite with MINIMAX_API_KEY when it is actually
+# set, so users who intentionally put their MiniMax key in
+# OPENAI_API_KEY are not silently downgraded to a dummy key.
+minimax_key = os.getenv("MINIMAX_API_KEY", "")
+⋮----
+# Recompute capabilities now that the prefix has been stripped
+# and self.info() can find the model in MODEL_INFO.
+⋮----
+project_id = self.config.langdb_params.project_id
+⋮----
+params = self.config.langdb_params
+⋮----
+# Parse the model string and extract provider/model
+⋮----
+# Set Portkey base URL
+⋮----
+# Set API key - use provider's API key from env if available
+⋮----
+# Add Portkey-specific headers
+⋮----
+# Sanitize the API key: strip leading/trailing whitespace
+# (including stray newlines from .env files or CI secrets).
+⋮----
+# Create http_client if needed - Priority order:
+# 1. http_client_factory (most flexibility, not cacheable)
+# 2. http_client_config (cacheable, moderate flexibility)
+# 3. http_verify_ssl=False (cacheable, simple SSL bypass)
+http_client = None
+async_http_client = None
+http_client_config_used = None
+⋮----
+# Use the factory to create http_client (not cacheable)
+http_client = self.config.http_client_factory()
+⋮----
+# set async_http_client to None - so that it will
+# be created later
+⋮----
+# Use config dict (cacheable)
+http_client_config_used = self.config.http_client_config
+⋮----
+# Simple SSL bypass (cacheable)
+http_client_config_used = {"verify": False}
+⋮----
+# With an api_key_provider, hand the callable itself to the
+# OpenAI client, which resolves a fresh token on each request.
+openai_api_key: Union[str, Callable[[], str]] = (
+⋮----
+client_kwargs: Dict[str, Any] = dict(
+⋮----
+# Create http_client from config for non-cached scenario
+⋮----
+async_client_kwargs: Dict[str, Any] = dict(
+⋮----
+# AsyncOpenAI awaits its api_key callable
+⋮----
+# Create async http_client from config for non-cached scenario
+⋮----
+use_cache = self.config.cache_config is not None
+⋮----
+# switch to fresh redis config if needed
+⋮----
+# force use of fake redis if global cache_type is "fakeredis"
+⋮----
+def _openai_api_call_params(self, kwargs: Dict[str, Any]) -> Dict[str, Any]
+⋮----
+"""
+        Prep the params to be sent to the OpenAI API
+        (or any OpenAI-compatible API, e.g. from Ooba or LmStudio)
+        for chat-completion.
+
+        Order of priority:
+        - (1) Params (mainly max_tokens) in the chat/achat/generate/agenerate call
+                (these are passed in via kwargs)
+        - (2) Params in OpenAIGPTConfig.params (of class OpenAICallParams)
+        - (3) Specific Params in OpenAIGPTConfig (just temperature for now)
+        """
+params = dict(
+⋮----
+def is_openai_chat_model(self) -> bool
+⋮----
+openai_chat_models = [e.value for e in OpenAIChatModel]
+⋮----
+def is_openai_completion_model(self) -> bool
+⋮----
+openai_completion_models = [e.value for e in OpenAICompletionModel]
+⋮----
+def is_gemini_model(self) -> bool
+⋮----
+"""Are we using the gemini OpenAI-compatible API?"""
+⋮----
+def is_deepseek_model(self) -> bool
+⋮----
+deepseek_models = [e.value for e in DeepSeekModel]
+⋮----
+def is_minimax_model(self) -> bool
+⋮----
+"""Are we using the MiniMax OpenAI-compatible API?"""
+minimax_models = [e.value for e in MiniMaxModel]
+⋮----
+def unsupported_params(self) -> List[str]
+⋮----
+"""
+        List of params that are not supported by the current model
+        """
+unsupported = set(self.info().unsupported_params)
+⋮----
+def rename_params(self) -> Dict[str, str]
+⋮----
+"""
+        Map of param name -> new name for specific models.
+        Currently main troublemaker is o1* series.
+        """
+⋮----
+def chat_context_length(self) -> int
+⋮----
+"""
+        Context-length for chat-completion models/endpoints.
+        Get it from the config if explicitly given,
+         otherwise use model_info based on model name, and fall back to
+         generic model_info if there's no match.
+        """
+⋮----
+def completion_context_length(self) -> int
+⋮----
+"""
+        Context-length for completion models/endpoints.
+        Get it from the config if explicitly given,
+         otherwise use model_info based on model name, and fall back to
+         generic model_info if there's no match.
+        """
+⋮----
+def chat_cost(self) -> Tuple[float, float, float]
+⋮----
+"""
+        (Prompt, Cached, Generation) cost per 1000 tokens, for chat-completion
+        models/endpoints.
+        Get it from the dict, otherwise fail-over to general method
+        """
+info = self.info()
+cached_cost_per_million = info.cached_cost_per_million
+⋮----
+cached_cost_per_million = info.input_cost_per_million
+⋮----
+def set_stream(self, stream: bool) -> bool
+⋮----
+"""Enable or disable streaming output from API.
+        Args:
+            stream: enable streaming output from API
+        Returns: previous value of stream
+        """
+tmp = self.config.stream
+⋮----
+def get_stream(self) -> bool
+⋮----
+"""Get streaming status."""
+⋮----
+"""Separate inline reasoning from text tokens in a streaming chunk.
+
+        When models embed thinking inside content (e.g. <think>...</think>)
+        rather than using a separate reasoning field, this splits the chunk
+        into text-only and reasoning-only portions for proper streamer routing.
+
+        Returns (text_tokens, reasoning_tokens, in_reasoning).
+        """
+text_tokens = event_text
+reasoning_tokens = event_reasoning
+⋮----
+remaining = event_text
+⋮----
+text_tokens = ""
+⋮----
+text_tokens = before
+remaining = after
+in_reasoning = True
+⋮----
+reasoning_tokens = before
+in_reasoning = False
+⋮----
+reasoning_tokens = remaining
+⋮----
+"""Process state vars while processing a streaming API response.
+            Returns a tuple consisting of:
+        - is_break: whether to break out of the loop
+        - has_function: whether the response contains a function_call
+        - function_name: name of the function
+        - function_args: args of the function
+        - completion: completion text
+        - reasoning: reasoning text
+        - usage: usage dict
+        """
+# convert event obj (of type ChatCompletionChunk) to dict so rest of code,
+# which expects dicts, works as it did before switching to openai v1.x
+⋮----
+event = event.model_dump()
+⋮----
+usage = event.get("usage", {}) or {}
+choices = event.get("choices", [{}])
+⋮----
+choices = [{}]
+⋮----
+# we have a "usage" chunk, and empty choices, so we're done
+# ASSUMPTION: a usage chunk ONLY arrives AFTER all normal completion text!
+# If any API does not follow this, we need to change this code.
+⋮----
+event_args = ""
+event_fn_name = ""
+event_tool_deltas: Optional[List[Dict[str, Any]]] = None
+silent = settings.quiet
+# The first two events in the stream of Azure OpenAI is useless.
+# In the 1st: choices list is empty, in the 2nd: the dict delta has null content
+⋮----
+delta = choices[0].get("delta", {}) or {}
+# capture both content and reasoning_content
+event_text = delta.get("content", "")
+event_reasoning = delta.get(
+⋮----
+event_fn_name = delta["function_call"]["name"]
+⋮----
+event_args = delta["function_call"]["arguments"]
+⋮----
+# it's a list of deltas, usually just one
+event_tool_deltas = delta["tool_calls"]
+⋮----
+event_text = choices[0]["text"]
+event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
+⋮----
+finish_reason = choices[0].get("finish_reason", "")
+⋮----
+filter_names = [
+event_text = (
+⋮----
+function_name = event_fn_name
+has_function = True
+⋮----
+# print out streaming tool calls, if not async
+⋮----
+tool_fn_name = td["function"]["name"]
+⋮----
+tool_fn_args = td["function"]["arguments"]
+⋮----
+# show this delta in the stream
+is_break = finish_reason in [
+# for function_call, finish_reason does not necessarily
+# contain "function_call" as mentioned in the docs.
+# So we check for "stop" or "function_call" here.
+⋮----
+# we got usage chunk, and empty choices, so we're done
+⋮----
+silent = self.config.async_stream_quiet or settings.quiet
+⋮----
+is_break = choices[0].get("finish_reason", "") in [
+⋮----
+def _stream_response(  # type: ignore
+⋮----
+"""
+        Grab and print streaming response from API.
+        Args:
+            response: event-sequence emitted by API
+            chat: whether in chat-mode (or else completion-mode)
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                Dict version of OpenAIResponse object (with choices, usage)
+
+        """
+completion = ""
+reasoning = ""
+function_args = ""
+function_name = ""
+⋮----
+has_function = False
+tool_deltas: List[Dict[str, Any]] = []
+token_usage: Dict[str, int] = {}
+done: bool = False
+in_reasoning: bool = False  # Track if we're inside reasoning delimiters
+content_present = False
+⋮----
+event_dict = event if isinstance(event, dict) else event.model_dump()
+choices = event_dict.get("choices") or []
+⋮----
+delta = choices[0].get("delta") or {}
+content_present = content_present or (
+⋮----
+# capture the token usage when non-empty
+token_usage = usage
+⋮----
+# if not streaming, then we don't wait for last "usage" chunk
+⋮----
+# mark done, so we quit after the last "usage" chunk
+done = True
+⋮----
+# TODO- get usage info in stream mode (?)
+⋮----
+async def _stream_response_async(  # type: ignore
+⋮----
+"""
+        Grab and print streaming response from API.
+        Args:
+            response: event-sequence emitted by API
+            chat: whether in chat-mode (or else completion-mode)
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                OpenAIResponse object (with choices, usage)
+
+        """
+⋮----
+# mark done, so we quit after the next "usage" chunk
+⋮----
+"""
+        Convert accumulated tool-call deltas to OpenAIToolCall objects.
+        Adapted from this excellent code:
+         https://community.openai.com/t/help-for-function-calls-with-streaming/627170/2
+
+        Args:
+            tools: list of tool deltas received from streaming API
+
+        Returns:
+            str: plain text corresponding to tool calls that failed to parse
+            List[OpenAIToolCall]: list of OpenAIToolCall objects
+            List[Dict[str, Any]]: list of tool dicts
+                (to reconstruct OpenAI API response, so it can be cached)
+        """
+# Initialize a dictionary with default values
+⋮----
+# idx -> dict repr of tool
+# (used to simulate OpenAIResponse object later, and also to
+# accumulate function args as strings)
+idx2tool_dict: Dict[str, Dict[str, Any]] = defaultdict(
+⋮----
+# (try to) parse the fn args of each tool
+contents: List[str] = []
+good_indices = []
+id2args: Dict[str, None | Dict[str, Any]] = {}
+⋮----
+# used to build tool_calls_list below
+id2args[tool_dict["id"]] = args_dict or None  # if {}, store as None
+⋮----
+# remove the failed tool calls
+idx2tool_dict = {
+⋮----
+# create OpenAIToolCall list
+tool_calls_list = [
+⋮----
+@staticmethod
+    def _parse_function_args(args: str) -> Tuple[str, Dict[str, Any]]
+⋮----
+"""
+        Try to parse the `args` string as function args.
+
+        Args:
+            args: string containing function args
+
+        Returns:
+            Tuple of content, function name and args dict.
+            If parsing unsuccessful, returns the original string as content,
+            else returns the args dict.
+        """
+content = ""
+args_dict = {}
+⋮----
+stripped_fn_args = args.strip()
+dict_or_list = parse_imperfect_json(stripped_fn_args)
+⋮----
+args_dict = dict_or_list
+⋮----
+content = args
+⋮----
+"""
+        Create an LLMResponse object from the streaming API response.
+
+        Args:
+            chat: whether in chat-mode (or else completion-mode)
+            tool_deltas: list of tool deltas received from streaming API
+            has_function: whether the response contains a function_call
+            completion: completion text
+            reasoning: reasoning text
+            function_args: string representing function args
+            function_name: name of the function
+            usage: token usage dict
+            content_present: whether a stream delta explicitly contained content
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                Dict version of OpenAIResponse object (with choices, usage)
+                    (this is needed so we can cache the response, as if it were
+                    a non-streaming response)
+        """
+# check if function_call args are valid, if not,
+# treat this as a normal msg, not a function call
+args: Dict[str, Any] = {}
+⋮----
+completion = completion + content
+⋮----
+# mock openai response so we can cache it
+⋮----
+content_present = True
+has_valid_call = len(tool_dicts) > 0 or has_function
+response_content = (
+msg: Dict[str, Any] = dict(
+⋮----
+function_call = LLMFunctionCall(name=function_name)
+function_call_dict = function_call.model_dump()
+⋮----
+# non-chat mode has no function_call
+msg = dict(text=completion)
+response_content = completion
+# TODO: Ignoring reasoning content for non-chat models
+⋮----
+# create an OpenAIResponse object so we can cache it as if it were
+# a non-streaming response
+openai_response = OpenAIResponse(
+# Track whether we extracted inline thought tags from the text.
+# Only set message_with_reasoning when get_reasoning_final()
+# actually finds and extracts inline tags (e.g. <think>...</think>).
+# When reasoning is already provided via a separate API field
+# (e.g. reasoning_content), the message text doesn't contain
+# thought signatures, so there's nothing extra to preserve.
+message_with_reasoning = None
+message: str | None
+⋮----
+# some LLM APIs may not return a separate reasoning field,
+# and the reasoning may be included in the message content
+# within delimiters like <think> ... </think>
+⋮----
+# Inline tags were found and extracted; preserve the
+# original text so it can be restored in message history.
+message_with_reasoning = response_content
+⋮----
+message = response_content
+⋮----
+prompt_tokens = usage.get("prompt_tokens", 0)
+prompt_tokens_details: Any = usage.get("prompt_tokens_details", {})
+cached_tokens = (
+completion_tokens = usage.get("completion_tokens", 0)
+⋮----
+# don't allow empty list [] here
+⋮----
+def _cache_store(self, k: str, v: Any) -> None
+⋮----
+def _cache_lookup(self, fn_name: str, **kwargs: Dict[str, Any]) -> Tuple[str, Any]
+⋮----
+return "", None  # no cache, return empty key and None result
+# Use the kwargs as the cache key
+sorted_kwargs_str = str(sorted(kwargs.items()))
+raw_key = f"{fn_name}:{sorted_kwargs_str}"
+⋮----
+# Hash the key to a fixed length using SHA256
+hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
+⋮----
+# when caching disabled, return the hashed_key and none result
+⋮----
+# Try to get the result from the cache
+⋮----
+cached_val = self.cache.retrieve(hashed_key)
+⋮----
+def _cost_chat_model(self, prompt: int, cached: int, completion: int) -> float
+⋮----
+price = self.chat_cost()
+⋮----
+"""
+        Extracts token usage from ``response`` and computes cost, only when NOT
+        in streaming mode, since the LLM API (OpenAI currently) was not
+        populating the usage fields in streaming mode (but as of Sep 2024, streaming
+        responses include  usage info as well, so we should update the code
+        to directly use usage information from the streaming response, which is more
+        accurate, esp with "thinking" LLMs like o1 series which consume
+        thinking tokens).
+        In streaming mode, these are set to zero for
+        now, and will be updated later by the fn ``update_token_usage``.
+        """
+cost = 0.0
+prompt_tokens = 0
+cached_tokens = 0
+completion_tokens = 0
+⋮----
+usage = response.get("usage")
+⋮----
+prompt_tokens = usage.get("prompt_tokens") or 0
+prompt_tokens_details = usage.get("prompt_tokens_details", {}) or {}
+cached_tokens = prompt_tokens_details.get("cached_tokens") or 0
+completion_tokens = usage.get("completion_tokens") or 0
+cost = self._cost_chat_model(
+⋮----
+def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+# Catch HTTP-level API errors (400, 401, 403, 404, 422, 429, 5xx)
+# without traceback — these originate server-side and a local
+# stack trace adds no diagnostic value.
+# Note: APIConnectionError/APITimeoutError are intentionally NOT
+# caught here so they fall through to the generic handler below,
+# where the full traceback aids in diagnosing local network issues.
+⋮----
+# log and re-raise exception
+⋮----
+def _generate(self, prompt: str, max_tokens: int) -> LLMResponse
+⋮----
+@retry_with_exponential_backoff
+        def completions_with_backoff(**kwargs):  # type: ignore
+⋮----
+cached = False
+⋮----
+cached = True
+⋮----
+completion_call = litellm_completion
+⋮----
+completion_call = self.client.completions.create
+⋮----
+# If it's not in the cache, call the API
+result = completion_call(**kwargs)
+⋮----
+kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
+⋮----
+# TODO this is a temp fix, we should really be using a proper completion fn
+# that takes a pre-formatted prompt, rather than mocking it as a sys msg.
+⋮----
+else:  # any other OpenAI-compatible endpoint
+⋮----
+args = dict(
+⋮----
+max_tokens=max_tokens,  # for output/completion
+⋮----
+args = self._openai_api_call_params(args)
+⋮----
+# assume response is an actual response rather than a streaming event
+⋮----
+response = response.model_dump()
+⋮----
+msg = (response["choices"][0]["message"]["content"] or "").strip()
+⋮----
+msg = (response["choices"][0]["text"] or "").strip()
+⋮----
+async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+# Catch HTTP-level API errors (see comment in generate() above).
+⋮----
+async def _agenerate(self, prompt: str, max_tokens: int) -> LLMResponse
+⋮----
+# note we typically will not have self.config.stream = True
+# when issuing several api calls concurrently/asynchronously.
+# The calling fn should use the context `with Streaming(..., False)` to
+# disable streaming.
+⋮----
+# WARNING: .Completion.* endpoints are deprecated,
+# and as of Sep 2023 only legacy models will work here,
+# e.g. text-davinci-003, text-ada-001.
+⋮----
+@async_retry_with_exponential_backoff
+        async def completions_with_backoff(**kwargs):  # type: ignore
+⋮----
+# TODO this may not work: text_completion is not async,
+# and we didn't find an async version in litellm
+⋮----
+acompletion_call = (
+⋮----
+result = await acompletion_call(**kwargs)
+⋮----
+# only makes sense for non-OpenAI models
+⋮----
+messages = [
+prompt = self.config.hf_formatter.format(messages)
+⋮----
+# turn off streaming for async calls
+⋮----
+# only makes sense for local models, where we are trying to
+# convert a chat dialog msg-sequence to a simple completion prompt.
+⋮----
+formatter = HFFormatter(
+⋮----
+prompt = formatter.format(messages)
+⋮----
+result = await self._achat(
+⋮----
+def _chat_completions_with_backoff_body(self, **kwargs):  # type: ignore
+⋮----
+completion_call = self.client.chat.completions.create
+⋮----
+# If streaming, cannot cache result
+# since it is a generator. Instead,
+# we hold on to the hashed_key and
+# cache the result later
+⋮----
+# Test if this is a stream with an exception by
+# trying to get first chunk: Some providers like LiteLLM
+# produce a valid stream object `result` instead of throwing a
+# rate-limit error, and if we don't catch it here,
+# we end up returning an empty response and not
+# using the retry mechanism in the decorator.
+⋮----
+# try to get the first chunk to check for errors
+test_iter = iter(result)
+first_chunk = next(test_iter)
+# If we get here without error, recreate the stream
+result = chain([first_chunk], test_iter)
+⋮----
+# Empty stream is fine
+⋮----
+# Propagate any errors in the stream
+⋮----
+def _chat_completions_with_backoff(self, **kwargs):  # type: ignore
+⋮----
+retry_func = retry_with_exponential_backoff(
+⋮----
+async def _achat_completions_with_backoff_body(self, **kwargs):  # type: ignore
+⋮----
+acompletion_call = litellm_acompletion
+⋮----
+acompletion_call = self.async_client.chat.completions.create
+⋮----
+# Try to peek at the first chunk to immediately catch any errors
+# Store the original result (the stream)
+original_stream = result
+⋮----
+# Manually create and advance the iterator to check for errors
+stream_iter = original_stream.__aiter__()
+⋮----
+# This will raise an exception if the stream is invalid
+first_chunk = await anext(stream_iter)
+⋮----
+# If we reach here, the stream started successfully
+# Now recreate a fresh stream from the original API result
+# Otherwise, return a new stream that yields the first chunk
+# and remaining items
+async def combined_stream():  # type: ignore
+⋮----
+result = combined_stream()  # type: ignore
+⋮----
+# Empty stream is normal - nothing to do
+⋮----
+# Any exception here should be raised to trigger the retry mechanism
+⋮----
+async def _achat_completions_with_backoff(self, **kwargs):  # type: ignore
+⋮----
+retry_func = async_retry_with_exponential_backoff(
+⋮----
+"""Prepare args for LLM chat-completion API call"""
+⋮----
+llm_messages = [
+⋮----
+llm_messages = messages
+⋮----
+# TODO: we will unconditionally insert a dummy user msg
+# if the only msg is a system msg.
+# We could make this conditional on ModelInfo.needs_first_user_message
+⋮----
+# some LLMs, notable Gemini as of 12/11/24,
+# require the first message to be from the user,
+# so insert a dummy user msg if needed.
+⋮----
+chat_model = self.config.chat_model
+⋮----
+args: Dict[str, Any] = dict(
+⋮----
+# groq fails when we include stream_options in the request
+⋮----
+# get token-usage numbers in stream mode from OpenAI API,
+# and possibly other OpenAI-compatible APIs.
+⋮----
+# only include functions-related args if functions are provided
+# since the OpenAI API will throw an error if `functions` is None or []
+⋮----
+# some models e.g. o1-mini (as of sep 2024) don't support some params,
+# like temperature and stream, so we need to remove them.
+⋮----
+param_rename_map = self.rename_params()
+⋮----
+# finally, get rid of extra_body params exclusive to certain models
+# Only apply allowlist restrictions for known models.
+# Unknown/custom models are allowed to use all params by default.
+is_known_model = self.info().name != "unknown"
+extra_params = args.get("extra_body", {})
+⋮----
+# openAI response will look like this:
+"""
+        {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1677652288,
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "name": "",
+                    "content": "\n\nHello there, how may I help you?",
+                    "reasoning_content": "Okay, let's see here, hmmm...",
+                    "function_call": {
+                        "name": "fun_name",
+                        "arguments: {
+                            "arg1": "val1",
+                            "arg2": "val2"
+                        }
+                    },
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 12,
+                "total_tokens": 21
+            }
+        }
+        """
+choices = response.get("choices")
+⋮----
+message = choices[0].get("message", {})
+⋮----
+message = {}
+⋮----
+content = message.get("content")
+reasoning = message.get("reasoning_content", "")
+⋮----
+message_with_reasoning = content
+⋮----
+msg = content
+⋮----
+fun_call = None
+⋮----
+fun_call = LLMFunctionCall.from_dict(message["function_call"])
+⋮----
+args_str = message["function_call"]["arguments"] or ""
+msg_str = message["content"] or ""
+msg = msg_str + args_str
+oai_tool_calls = None
+⋮----
+oai_tool_calls = []
+⋮----
+tool_call = OpenAIToolCall.from_dict(tool_call_dict)
+⋮----
+serialized_tool_call = json.dumps(tool_call_dict)
+msg = (msg or "") + ("\n" if msg else "") + serialized_tool_call
+⋮----
+# None (no content, e.g. a tool-call-only response) is preserved as
+# None rather than coerced to "", so the distinction survives
+# downstream (see LLMMessage.content / ChatDocument.content_is_none).
+⋮----
+oai_tool_calls=oai_tool_calls or None,  # don't allow empty list [] here
+⋮----
+"""
+        ChatCompletion API call to OpenAI.
+        Args:
+            messages: list of messages  to send to the API, typically
+                represents back and forth dialogue between user and LLM, but could
+                also include "function"-role messages. If messages is a string,
+                it is assumed to be a user message.
+            max_tokens: max output tokens to generate
+            functions: list of LLMFunction specs available to the LLM, to possibly
+                use in its response
+            function_call: controls how the LLM uses `functions`:
+                - "auto": LLM decides whether to use `functions` or not,
+                - "none": LLM blocked from using any function
+                - a dict of {"name": "function_name"} which forces the LLM to use
+                    the specified function.
+        Returns:
+            LLMResponse object
+        """
+args = self._prep_chat_completion(
+cached, hashed_key, response = self._chat_completions_with_backoff(**args)  # type: ignore
+⋮----
+return llm_response  # type: ignore
+⋮----
+response_dict = response
+⋮----
+response_dict = response.model_dump()
+⋮----
+"""
+        Async version of _chat(). See that function for details.
+        """
+⋮----
+cached, hashed_key, response = await self._achat_completions_with_backoff(  # type: ignore
+</file>
+
+<file path="langroid/vector_store/base.py">
+logger = logging.getLogger(__name__)
+⋮----
+# the exact shape Kubernetes service links inject, e.g. tcp://10.0.0.8:6333
+# (\Z, not $: $ would match before a trailing newline, silently
+# discarding a value that should fail validation)
+_SERVICE_LINK_PORT_RE = re.compile(r"^tcp://\S+:\d+\Z")
+⋮----
+class _ServiceLinkPortFilter(PydanticBaseSettingsSource)
+⋮----
+"""Env-source wrapper dropping k8s/docker service-link `port` values.
+
+    With `enableServiceLinks` (on by default in Kubernetes), a service
+    named e.g. `qdrant` injects `QDRANT_PORT=tcp://IP:PORT` into every
+    pod, which would otherwise fail integer validation of the `port`
+    field. If the wrapped env source yields a `port` string matching
+    exactly that format, it is dropped (with a warning) so the class
+    default applies. Any other value — including malformed `tcp://`
+    junk, or a `tcp://` value passed to the constructor (which never
+    goes through this source) — still fails validation as usual.
+    """
+⋮----
+def __init__(self, wrapped: PydanticBaseSettingsSource) -> None
+⋮----
+def __call__(self) -> Dict[str, Any]
+⋮----
+values = self._wrapped()
+port = values.get("port")
+⋮----
+default = self.settings_cls.model_fields["port"].default
+⋮----
+values = {k: v for k, v in values.items() if k != "port"}
+⋮----
+class VectorStoreConfig(BaseSettings)
+⋮----
+# Without a prefix, every field name would itself be a
+# case-insensitive env var (e.g. a bare HOST, PORT, or FULL_EVAL
+# in the environment would silently override defaults); subclasses
+# each set their own prefix (QDRANT_, LANCEDB_, ...).
+model_config = SettingsConfigDict(env_prefix="VECDB_")
+⋮----
+type: str = ""  # deprecated, keeping it for backward compatibility
+collection_name: str | None = "temp"
+replace_collection: bool = False  # replace collection if it already exists
+storage_path: str = ".qdrant/data"
+cloud: bool = False
+batch_size: int = 200
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig(
+embedding_model: Optional[EmbeddingModel] = None
+timeout: int = 60
+host: str = "127.0.0.1"
+port: int = 6333
+# used when parsing search results back as Document objects
+document_class: Type[Document] = Document
+metadata_class: Type[DocMetaData] = DocMetaData
+# compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
+full_eval: bool = False  # runs eval without sanitization. Use only on trusted input
+⋮----
+"""Wrap the env source to drop k8s service-link `port` values.
+
+        Source precedence is unchanged (init beats env, etc.); only the
+        env source is filtered — see `_ServiceLinkPortFilter`.
+        """
+⋮----
+class VectorStore(ABC)
+⋮----
+"""
+    Abstract base class for a vector store.
+    """
+⋮----
+def __init__(self, config: VectorStoreConfig)
+⋮----
+@staticmethod
+    def create(config: VectorStoreConfig) -> Optional["VectorStore"]
+⋮----
+@property
+    def embedding_dim(self) -> int
+⋮----
+def clone(self) -> "VectorStore"
+⋮----
+"""Return a vector-store clone suitable for agent cloning.
+
+        The default implementation deep-copies the configuration, reuses any
+        existing embedding model, and instantiates a fresh store of the same
+        type. Subclasses can override when sharing the instance is required
+        (e.g., embedded/local stores that rely on file locks).
+        """
+⋮----
+config_class = self.config.__class__
+config_data = self.config.model_dump(mode="python")
+⋮----
+config_copy = config_class.model_validate(config_data)
+⋮----
+# Preserve the calculated collection contents without forcing replaces
+⋮----
+config_copy.replace_collection = False  # type: ignore[attr-defined]
+cloned_embedding: Optional[EmbeddingModel] = None
+⋮----
+cloned_embedding = self.embedding_model.clone()  # type: ignore[attr-defined]
+⋮----
+cloned_store = type(self)(config_copy)  # type: ignore[call-arg]
+⋮----
+# Some stores might not honour replace_collection; ensure same collection
+⋮----
+@abstractmethod
+    def clear_empty_collections(self) -> int
+⋮----
+"""Clear all empty collections in the vector store.
+        Returns the number of collections deleted.
+        """
+⋮----
+@abstractmethod
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+"""
+        Clear all collections in the vector store.
+
+        Args:
+            really (bool, optional): Whether to really clear all collections.
+                Defaults to False.
+            prefix (str, optional): Prefix of collections to clear.
+        Returns:
+            int: Number of collections deleted.
+        """
+⋮----
+@abstractmethod
+    def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+"""List all collections in the vector store
+        (only non empty collections if empty=False).
+        """
+⋮----
+def set_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+"""
+        Set the current collection to the given collection name.
+        Args:
+            collection_name (str): Name of the collection.
+            replace (bool, optional): Whether to replace the collection if it
+                already exists. Defaults to False.
+        """
+⋮----
+@abstractmethod
+    def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+"""Create a collection with the given name.
+        Args:
+            collection_name (str): Name of the collection.
+            replace (bool, optional): Whether to replace the
+                collection if it already exists. Defaults to False.
+        """
+⋮----
+@abstractmethod
+    def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+def compute_from_docs(self, docs: List[Document], calc: str) -> str
+⋮----
+"""Compute a result on a set of documents,
+        using a dataframe calc string like `df.groupby('state')['income'].mean()`.
+
+        If full_eval is False (default), the input expression is sanitized to prevent
+        most common code injection attack vectors.
+        If full_eval is True, sanitization is bypassed - use only with trusted input!
+        """
+# convert each doc to a dict, using dotted paths for nested fields
+dicts = [flatten_dict(doc.model_dump(by_alias=True)) for doc in docs]
+df = pd.DataFrame(dicts)
+⋮----
+# SECURITY MITIGATION: Eval input is sanitized to prevent most common
+# code injection attack vectors when full_eval is False. The globals
+# dict also restricts ``__builtins__`` so that even with
+# ``full_eval=True`` the expression cannot reach
+# ``__import__``/``eval``/``exec`` via Python's implicit builtin
+# injection (GHSA-q9p7-wqxg-mrhc).
+vars = {"df": df}
+⋮----
+calc = sanitize_command(calc)
+code = compile(calc, "<calc>", "eval")
+result = eval(code, safe_eval_globals(vars), {})
+⋮----
+# return error message so LLM can fix the calc string if needed
+err = f"""
+⋮----
+# Pd.eval sometimes fails on a perfectly valid exprn like
+# df.loc[..., 'column'] with a KeyError.
+⋮----
+def maybe_add_ids(self, documents: Sequence[Document]) -> None
+⋮----
+"""Add ids to metadata if absent, since some
+        vecdbs don't like having blank ids."""
+⋮----
+"""
+        Find k most similar texts to the given text, in terms of vector distance metric
+        (e.g., cosine similarity).
+
+        Args:
+            text (str): The text to find similar texts for.
+            k (int, optional): Number of similar texts to retrieve. Defaults to 1.
+            where (Optional[str], optional): Where clause to filter the search.
+
+        Returns:
+            List[Tuple[Document,float]]: List of (Document, score) tuples.
+
+        """
+⋮----
+"""
+        In each doc's metadata, there may be a window_ids field indicating
+        the ids of the chunks around the current chunk.
+        These window_ids may overlap, so we
+        - coalesce each overlapping groups into a single window (maintaining ordering),
+        - create a new document for each part, preserving metadata,
+
+        We may have stored a longer set of window_ids than we need during chunking.
+        Now, we just want `neighbors` on each side of the center of the window_ids list.
+
+        Args:
+            docs_scores (List[Tuple[Document, float]]): List of pairs of documents
+                to add context windows to together with their match scores.
+            neighbors (int, optional): Number of neighbors on "each side" of match to
+                retrieve. Defaults to 0.
+                "Each side" here means before and after the match,
+                in the original text.
+
+        Returns:
+            List[Tuple[Document, float]]: List of (Document, score) tuples.
+        """
+# We return a larger context around each match, i.e.
+# a window of `neighbors` on each side of the match.
+docs = [d for d, s in docs_scores]
+scores = [s for d, s in docs_scores]
+⋮----
+doc_chunks = [d for d in docs if d.metadata.is_chunk]
+⋮----
+window_ids_list = []
+id2metadata = {}
+# id -> highest score of a doc it appears in
+id2max_score: Dict[int | str, float] = {}
+⋮----
+window_ids = d.metadata.window_ids
+⋮----
+window_ids = [d.id()]
+⋮----
+n = len(window_ids)
+chunk_idx = window_ids.index(d.id())
+neighbor_ids = window_ids[
+⋮----
+# window_ids could be from different docs,
+# and they may overlap, so we coalesce overlapping groups into
+# separate windows.
+window_ids_list = self.remove_overlaps(window_ids_list)
+final_docs = []
+final_scores = []
+⋮----
+metadata = copy.deepcopy(id2metadata[w[0]])
+⋮----
+document = Document(
+# make a fresh id since content is in general different
+⋮----
+@staticmethod
+    def remove_overlaps(windows: List[List[str]]) -> List[List[str]]
+⋮----
+"""
+        Given a collection of windows, where each window is a sequence of ids,
+        identify groups of overlapping windows, and for each overlapping group,
+        order the chunk-ids using topological sort so they appear in the original
+        order in the text.
+
+        Args:
+            windows (List[int|str]): List of windows, where each window is a
+                sequence of ids.
+
+        Returns:
+            List[int|str]: List of windows, where each window is a sequence of ids,
+                and no two windows overlap.
+        """
+ids = set(id for w in windows for id in w)
+# id -> {win -> # pos}
+id2win2pos: Dict[str, Dict[int, int]] = {id: {} for id in ids}
+⋮----
+n = len(windows)
+# relation between windows:
+order = np.zeros((n, n), dtype=np.int8)
+⋮----
+id = list(set(w).intersection(x))[0]  # any common id
+⋮----
+order[i, j] = -1  # win i is before win j
+⋮----
+order[i, j] = 1  # win i is after win j
+⋮----
+# find groups of windows that overlap, like connected components in a graph
+groups = components(np.abs(order))
+⋮----
+# order the chunk-ids in each group using topological sort
+new_windows = []
+⋮----
+# find total ordering among windows in group based on order matrix
+# (this is a topological sort)
+_g = np.array(g)
+order_matrix = order[_g][:, _g]
+ordered_window_indices = topological_sort(order_matrix)
+ordered_window_ids = [windows[i] for i in _g[ordered_window_indices]]
+flattened = [id for w in ordered_window_ids for id in w]
+flattened_deduped = list(dict.fromkeys(flattened))
+# Note we are not going to split these, and instead we'll return
+# larger windows from concatenating the connected groups.
+# This ensures context is retained for LLM q/a
+⋮----
+@abstractmethod
+    def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+"""
+        Get all documents in the current collection, possibly filtered by `where`.
+        """
+⋮----
+@abstractmethod
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+"""
+        Get documents by their ids.
+        Args:
+            ids (List[str]): List of document ids.
+
+        Returns:
+            List[Document]: List of documents
+        """
+⋮----
+@abstractmethod
+    def delete_collection(self, collection_name: str) -> None
+⋮----
+def show_if_debug(self, doc_score_pairs: List[Tuple[Document, float]]) -> None
 </file>
 
 <file path="langroid/agent/special/sql/sql_chat_agent.py">
@@ -57542,1115 +58798,6 @@ model_names = tuple(_model_name(model) for model in models)
 def _model_name(model: str | ModelName) -> str
 </file>
 
-<file path="langroid/language_models/openai_gpt.py">
-OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
-⋮----
-OLLAMA_BASE_URL = "http://localhost:11434/v1"
-⋮----
-DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
-# Provider prefixes that route to the Gemini OpenAI-compatible API.
-GEMINI_MODEL_PREFIXES = ("gemini/", "google/gemini-")
-GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
-MINIMAX_BASE_URL = "https://api.minimax.io/v1"
-OLLAMA_API_KEY = "ollama"
-⋮----
-VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
-LLAMACPP_API_KEY = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
-⋮----
-openai_chat_model_pref_list = [
-⋮----
-openai_completion_model_pref_list = [
-⋮----
-available_models = set(map(lambda m: m.id, OpenAI().models.list()))
-⋮----
-available_models = set()
-⋮----
-default_openai_chat_model = next(
-default_openai_completion_model = next(
-⋮----
-class AccessWarning(Warning)
-⋮----
-@cache
-def gpt_3_5_warning() -> None
-⋮----
-@cache
-def parallel_strict_warning() -> None
-⋮----
-def noop() -> None
-⋮----
-"""Does nothing."""
-⋮----
-class OpenAICallParams(BaseModel)
-⋮----
-"""
-    Various params that can be sent to an OpenAI API chat-completion call.
-    When specified, any param here overrides the one with same name in the
-    OpenAIGPTConfig.
-    See OpenAI API Reference for details on the params:
-    https://platform.openai.com/docs/api-reference/chat
-    """
-⋮----
-max_tokens: int | None = None
-temperature: float | None = None
-frequency_penalty: float | None = None  # between -2 and 2
-presence_penalty: float | None = None  # between -2 and 2
-response_format: Dict[str, str] | None = None
-logit_bias: Dict[int, float] | None = None  # token_id -> bias
-logprobs: bool | None = None
-top_p: float | None = None
-reasoning_effort: str | None = None  # or "low" or "high" or "medium"
-top_logprobs: int | None = None  # if int, requires logprobs=True
-n: int | None = None  # how many completions to generate (n > 1 is NOT handled now)
-stop: str | List[str] | None = None  # (list of) stop sequence(s)
-seed: int | None = None
-user: str | None = None  # user id for tracking
-extra_body: Dict[str, Any] | None = None  # additional params for API request body
-⋮----
-def to_dict_exclude_none(self) -> Dict[str, Any]
-⋮----
-class LiteLLMProxyConfig(BaseSettings)
-⋮----
-"""Configuration for LiteLLM proxy connection."""
-⋮----
-api_key: str = ""  # read from env var LITELLM_API_KEY if set
-api_base: str = ""  # read from env var LITELLM_API_BASE if set
-⋮----
-model_config = SettingsConfigDict(env_prefix="LITELLM_")
-⋮----
-class OpenAIGPTConfig(LLMConfig)
-⋮----
-"""
-    Class for any LLM with an OpenAI-like API: besides the OpenAI models this includes:
-    (a) locally-served models behind an OpenAI-compatible API
-    (b) non-local models, using a proxy adaptor lib like litellm that provides
-        an OpenAI-compatible API.
-    (We could rename this class to OpenAILikeConfig, but we keep it as-is for now)
-
-    Important Note:
-    Due to the `env_prefix = "OPENAI_"` defined below,
-    all of the fields below can be set AND OVERRIDDEN via env vars,
-    # by upper-casing the name and prefixing with OPENAI_, e.g.
-    # OPENAI_MAX_OUTPUT_TOKENS=1000.
-    # If any of these is defined in this way in the environment
-    # (either via explicit setenv or export or via .env file + load_dotenv()),
-    # the environment variable takes precedence over the value in the config.
-    """
-⋮----
-type: str = "openai"
-api_key: str = DUMMY_API_KEY
-# Callable returning a fresh API key/bearer token, for endpoints that
-# authenticate with short-lived rotating credentials (e.g. Vertex AI
-# OAuth tokens, Azure Entra ID). Resolved per-request by the OpenAI
-# client, and excluded from the client-cache key (the cache is keyed on
-# the provider's identity), so rotating tokens neither go stale nor grow
-# the cache. Takes precedence over `api_key`. Only supported for models
-# served via an OpenAI-compatible endpoint (not Groq/Cerebras/litellm).
-# See docs/notes/rotating-api-keys.md.
-api_key_provider: Optional[Callable[[], str]] = None
-organization: str = ""
-api_base: str | None = None  # used for local or other non-OpenAI models
-litellm: bool = False  # use litellm api?
-litellm_proxy: LiteLLMProxyConfig = LiteLLMProxyConfig()
-ollama: bool = False  # use ollama's OpenAI-compatible endpoint?
-min_output_tokens: int = 1
-use_chat_for_completion: bool = True  # do not change this, for OpenAI models!
-timeout: int = 20
-temperature: float = 0.2
-seed: int | None = 42
-params: OpenAICallParams | None = None
-use_cached_client: bool = (
-⋮----
-True  # Whether to reuse cached clients (prevents resource exhaustion)
-⋮----
-# these can be any model name that is served at an OpenAI-compatible API end point
-chat_model: str = default_openai_chat_model
-chat_model_orig: Optional[str] = None
-completion_model: str = default_openai_completion_model
-run_on_first_use: Callable[[], None] = noop
-parallel_tool_calls: Optional[bool] = None
-# Supports constrained decoding which enforces that the output of the LLM
-# adheres to a JSON schema
-supports_json_schema: Optional[bool] = None
-# Supports strict decoding for the generation of tool calls with
-# the OpenAI Tools API; this ensures that the generated tools
-# adhere to the provided schema.
-supports_strict_tools: Optional[bool] = None
-# a string that roughly matches a HuggingFace chat_template,
-# e.g. "mistral-instruct-v0.2 (a fuzzy search is done to find the closest match)
-formatter: str | None = None
-hf_formatter: HFFormatter | None = None
-langdb_params: LangDBParams = LangDBParams()
-portkey_params: PortkeyParams = PortkeyParams()
-headers: Dict[str, str] = {}
-http_client_factory: Optional[Callable[[], Any]] = (
-⋮----
-None  # Factory: returns Client or (Client, AsyncClient)
-⋮----
-http_verify_ssl: bool = True  # Simple flag for SSL verification
-http_client_config: Optional[Dict[str, Any]] = None  # Config dict for httpx.Client
-_api_base_was_supplied: bool = False
-⋮----
-def __init__(self, **kwargs) -> None:  # type: ignore
-⋮----
-api_base_was_supplied = "api_base" in kwargs
-local_model = "api_base" in kwargs and kwargs["api_base"] is not None
-⋮----
-chat_model = kwargs.get("chat_model", "")
-local_prefixes = ["local/", "litellm/", "ollama/", "vllm/", "llamacpp/"]
-⋮----
-local_model = True
-⋮----
-warn_gpt_3_5 = (
-⋮----
-existing_hook = kwargs.get("run_on_first_use", noop)
-⋮----
-def with_warning() -> None
-⋮----
-env_prefix = self.model_config.get("env_prefix")
-env_api_base_name = f"{env_prefix}API_BASE"
-env_api_base = os.getenv(env_api_base_name)
-⋮----
-case_insensitive_env = {
-env_api_base = case_insensitive_env.get(env_api_base_name.lower())
-api_base_was_supplied = api_base_was_supplied or (
-⋮----
-model_config = SettingsConfigDict(env_prefix="OPENAI_")
-⋮----
-def __setattr__(self, name: str, value: Any) -> None
-⋮----
-"""Track API bases assigned after config construction."""
-⋮----
-"""
-        Copy config while preserving nested model instances and subclasses.
-
-        Important: Avoid reconstructing via `model_dump` as that coerces nested
-        models to their annotated base types (dropping subclass-only fields).
-        Instead, defer to Pydantic's native `model_copy`, which keeps nested
-        `BaseModel` instances (and their concrete subclasses) intact.
-
-        An `api_base` supplied through `update` is caller configuration, so the
-        copy must retain that provenance for provider-specific routing.
-        """
-# Delegate to BaseSettings/BaseModel implementation to preserve types
-copied = super().model_copy(update=update, deep=deep)
-⋮----
-return copied  # type: ignore[return-value]
-⋮----
-def _validate_litellm(self) -> None
-⋮----
-"""
-        When using liteLLM, validate whether all env vars required by the model
-        have been set.
-        """
-⋮----
-litellm.drop_params = True  # drop un-supported params without crashing
-⋮----
-self.seed = None  # some local mdls don't support seed
-⋮----
-keys_dict = litellm.utils.validate_environment(self.chat_model)
-missing_keys = keys_dict.get("missing_keys", [])
-⋮----
-@classmethod
-    def create(cls, prefix: str) -> Type["OpenAIGPTConfig"]
-⋮----
-"""Create a config class whose params can be set via a desired
-        prefix from the .env file or env vars.
-        E.g., using
-        ```python
-        OllamaConfig = OpenAIGPTConfig.create("ollama")
-        ollama_config = OllamaConfig()
-        ```
-        you can have a group of params prefixed by "OLLAMA_", to be used
-        with models served via `ollama`.
-        This way, you can maintain several setting-groups in your .env file,
-        one per model type.
-        """
-⋮----
-class DynamicConfig(OpenAIGPTConfig)
-⋮----
-class OpenAIResponse(BaseModel)
-⋮----
-"""OpenAI response model, either completion or chat."""
-⋮----
-choices: List[Dict]  # type: ignore
-usage: Dict  # type: ignore
-⋮----
-def litellm_logging_fn(model_call_dict: Dict[str, Any]) -> None
-⋮----
-"""Logging function for litellm"""
-⋮----
-api_input_dict = model_call_dict.get("additional_args", {}).get(
-⋮----
-text = escape(json.dumps(api_input_dict, indent=2))
-⋮----
-# Define a class for OpenAI GPT models that extends the base class
-class OpenAIGPT(LanguageModel)
-⋮----
-"""
-    Class for OpenAI LLMs
-    """
-⋮----
-client: OpenAI | Groq | Cerebras | None
-async_client: AsyncOpenAI | AsyncGroq | AsyncCerebras | None
-⋮----
-def __init__(self, config: OpenAIGPTConfig = OpenAIGPTConfig())
-⋮----
-"""
-        Args:
-            config: configuration for openai-gpt model
-        """
-# copy the config to avoid modifying the original; deep to decouple
-# nested models while preserving their concrete subclasses
-# The api_key_provider must NOT be deep-copied: the client cache is
-# keyed on its identity (so a copy would defeat cache sharing), and it
-# may hold non-copyable state (e.g. a threading.Lock). Clear it in a
-# shallow copy first, then restore the original callable afterwards.
-api_key_provider = config.api_key_provider
-⋮----
-config = config.model_copy(update={"api_key_provider": None})
-config = config.model_copy(deep=True)
-⋮----
-# save original model name such as `provider/model` before
-# we strip out the `provider` - we retain the original in
-# case some params are specific to a provider.
-⋮----
-# Run the first time the model is used
-⋮----
-# global override of chat_model,
-# to allow quick testing with other models
-⋮----
-# there is a formatter specified, e.g.
-# "litellm/ollama/mistral//hf" or
-# "local/localhost:8000/v1//mistral-instruct-v0.2"
-formatter = parts[1]
-⋮----
-# e.g. "litellm/ollama/mistral//hf" -> "litellm/ollama/mistral"
-formatter = find_hf_formatter(self.config.chat_model)
-⋮----
-# e.g. "mistral"
-⋮----
-# e.g. "local/localhost:8000/v1//mistral-instruct-v0.2"
-⋮----
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", DUMMY_API_KEY)
-⋮----
-# if model name starts with "litellm",
-# set the actual model name by stripping the "litellm/" prefix
-# and set the litellm flag to True
-⋮----
-# e.g. litellm/ollama/mistral
-⋮----
-# strip the "litellm/" prefix
-# e.g. litellm/ollama/llama2 => ollama/llama2
-⋮----
-# expect this to be of the form "local/localhost:8000/v1",
-# depending on how the model is launched locally.
-# In this case the model served locally behind an OpenAI-compatible API
-# so we can just use `openai.*` methods directly,
-# and don't need a adaptor library like litellm
-⋮----
-self.config.seed = None  # some models raise an error when seed is set
-# Extract the api_base from the model name after the "local/" prefix
-⋮----
-# use api_base from config if set, else fall back on OLLAMA_BASE_URL
-⋮----
-# If api_base is unset we use OpenAI's endpoint, which supports
-# these features (with JSON schema restricted to a limited set of models)
-⋮----
-# if we're overriding chat model globally, set completion model to same
-⋮----
-# we want to format chats -> completions using this specific formatter
-⋮----
-# use groq-specific client
-⋮----
-# Create new clients without caching
-⋮----
-# use cerebras-specific client
-⋮----
-# TODO there is not async client, so should we do anything here?
-⋮----
-# in these cases, there's no specific client: OpenAI python client suffices
-⋮----
-# Prefer caller config, then Gemini env, then the default.
-gemini_api_base = os.getenv("GEMINI_API_BASE", "")
-explicit_api_base = (
-⋮----
-# Honor caller-supplied base URL (e.g. regional endpoints,
-# proxies) instead of always forcing the default.
-openai_api_base = os.getenv("OPENAI_API_BASE")
-⋮----
-# Only overwrite with MINIMAX_API_KEY when it is actually
-# set, so users who intentionally put their MiniMax key in
-# OPENAI_API_KEY are not silently downgraded to a dummy key.
-minimax_key = os.getenv("MINIMAX_API_KEY", "")
-⋮----
-# Recompute capabilities now that the prefix has been stripped
-# and self.info() can find the model in MODEL_INFO.
-⋮----
-project_id = self.config.langdb_params.project_id
-⋮----
-params = self.config.langdb_params
-⋮----
-# Parse the model string and extract provider/model
-⋮----
-# Set Portkey base URL
-⋮----
-# Set API key - use provider's API key from env if available
-⋮----
-# Add Portkey-specific headers
-⋮----
-# Sanitize the API key: strip leading/trailing whitespace
-# (including stray newlines from .env files or CI secrets).
-⋮----
-# Create http_client if needed - Priority order:
-# 1. http_client_factory (most flexibility, not cacheable)
-# 2. http_client_config (cacheable, moderate flexibility)
-# 3. http_verify_ssl=False (cacheable, simple SSL bypass)
-http_client = None
-async_http_client = None
-http_client_config_used = None
-⋮----
-# Use the factory to create http_client (not cacheable)
-http_client = self.config.http_client_factory()
-⋮----
-# set async_http_client to None - so that it will
-# be created later
-⋮----
-# Use config dict (cacheable)
-http_client_config_used = self.config.http_client_config
-⋮----
-# Simple SSL bypass (cacheable)
-http_client_config_used = {"verify": False}
-⋮----
-# With an api_key_provider, hand the callable itself to the
-# OpenAI client, which resolves a fresh token on each request.
-openai_api_key: Union[str, Callable[[], str]] = (
-⋮----
-client_kwargs: Dict[str, Any] = dict(
-⋮----
-# Create http_client from config for non-cached scenario
-⋮----
-async_client_kwargs: Dict[str, Any] = dict(
-⋮----
-# AsyncOpenAI awaits its api_key callable
-⋮----
-# Create async http_client from config for non-cached scenario
-⋮----
-use_cache = self.config.cache_config is not None
-⋮----
-# switch to fresh redis config if needed
-⋮----
-# force use of fake redis if global cache_type is "fakeredis"
-⋮----
-def _openai_api_call_params(self, kwargs: Dict[str, Any]) -> Dict[str, Any]
-⋮----
-"""
-        Prep the params to be sent to the OpenAI API
-        (or any OpenAI-compatible API, e.g. from Ooba or LmStudio)
-        for chat-completion.
-
-        Order of priority:
-        - (1) Params (mainly max_tokens) in the chat/achat/generate/agenerate call
-                (these are passed in via kwargs)
-        - (2) Params in OpenAIGPTConfig.params (of class OpenAICallParams)
-        - (3) Specific Params in OpenAIGPTConfig (just temperature for now)
-        """
-params = dict(
-⋮----
-def is_openai_chat_model(self) -> bool
-⋮----
-openai_chat_models = [e.value for e in OpenAIChatModel]
-⋮----
-def is_openai_completion_model(self) -> bool
-⋮----
-openai_completion_models = [e.value for e in OpenAICompletionModel]
-⋮----
-def is_gemini_model(self) -> bool
-⋮----
-"""Are we using the gemini OpenAI-compatible API?"""
-⋮----
-def is_deepseek_model(self) -> bool
-⋮----
-deepseek_models = [e.value for e in DeepSeekModel]
-⋮----
-def is_minimax_model(self) -> bool
-⋮----
-"""Are we using the MiniMax OpenAI-compatible API?"""
-minimax_models = [e.value for e in MiniMaxModel]
-⋮----
-def unsupported_params(self) -> List[str]
-⋮----
-"""
-        List of params that are not supported by the current model
-        """
-unsupported = set(self.info().unsupported_params)
-⋮----
-def rename_params(self) -> Dict[str, str]
-⋮----
-"""
-        Map of param name -> new name for specific models.
-        Currently main troublemaker is o1* series.
-        """
-⋮----
-def chat_context_length(self) -> int
-⋮----
-"""
-        Context-length for chat-completion models/endpoints.
-        Get it from the config if explicitly given,
-         otherwise use model_info based on model name, and fall back to
-         generic model_info if there's no match.
-        """
-⋮----
-def completion_context_length(self) -> int
-⋮----
-"""
-        Context-length for completion models/endpoints.
-        Get it from the config if explicitly given,
-         otherwise use model_info based on model name, and fall back to
-         generic model_info if there's no match.
-        """
-⋮----
-def chat_cost(self) -> Tuple[float, float, float]
-⋮----
-"""
-        (Prompt, Cached, Generation) cost per 1000 tokens, for chat-completion
-        models/endpoints.
-        Get it from the dict, otherwise fail-over to general method
-        """
-info = self.info()
-cached_cost_per_million = info.cached_cost_per_million
-⋮----
-cached_cost_per_million = info.input_cost_per_million
-⋮----
-def set_stream(self, stream: bool) -> bool
-⋮----
-"""Enable or disable streaming output from API.
-        Args:
-            stream: enable streaming output from API
-        Returns: previous value of stream
-        """
-tmp = self.config.stream
-⋮----
-def get_stream(self) -> bool
-⋮----
-"""Get streaming status."""
-⋮----
-"""Separate inline reasoning from text tokens in a streaming chunk.
-
-        When models embed thinking inside content (e.g. <think>...</think>)
-        rather than using a separate reasoning field, this splits the chunk
-        into text-only and reasoning-only portions for proper streamer routing.
-
-        Returns (text_tokens, reasoning_tokens, in_reasoning).
-        """
-text_tokens = event_text
-reasoning_tokens = event_reasoning
-⋮----
-remaining = event_text
-⋮----
-text_tokens = ""
-⋮----
-text_tokens = before
-remaining = after
-in_reasoning = True
-⋮----
-reasoning_tokens = before
-in_reasoning = False
-⋮----
-reasoning_tokens = remaining
-⋮----
-"""Process state vars while processing a streaming API response.
-            Returns a tuple consisting of:
-        - is_break: whether to break out of the loop
-        - has_function: whether the response contains a function_call
-        - function_name: name of the function
-        - function_args: args of the function
-        - completion: completion text
-        - reasoning: reasoning text
-        - usage: usage dict
-        """
-# convert event obj (of type ChatCompletionChunk) to dict so rest of code,
-# which expects dicts, works as it did before switching to openai v1.x
-⋮----
-event = event.model_dump()
-⋮----
-usage = event.get("usage", {}) or {}
-choices = event.get("choices", [{}])
-⋮----
-choices = [{}]
-⋮----
-# we have a "usage" chunk, and empty choices, so we're done
-# ASSUMPTION: a usage chunk ONLY arrives AFTER all normal completion text!
-# If any API does not follow this, we need to change this code.
-⋮----
-event_args = ""
-event_fn_name = ""
-event_tool_deltas: Optional[List[Dict[str, Any]]] = None
-silent = settings.quiet
-# The first two events in the stream of Azure OpenAI is useless.
-# In the 1st: choices list is empty, in the 2nd: the dict delta has null content
-⋮----
-delta = choices[0].get("delta", {}) or {}
-# capture both content and reasoning_content
-event_text = delta.get("content", "")
-event_reasoning = delta.get(
-⋮----
-event_fn_name = delta["function_call"]["name"]
-⋮----
-event_args = delta["function_call"]["arguments"]
-⋮----
-# it's a list of deltas, usually just one
-event_tool_deltas = delta["tool_calls"]
-⋮----
-event_text = choices[0]["text"]
-event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
-⋮----
-finish_reason = choices[0].get("finish_reason", "")
-⋮----
-filter_names = [
-event_text = (
-⋮----
-function_name = event_fn_name
-has_function = True
-⋮----
-# print out streaming tool calls, if not async
-⋮----
-tool_fn_name = td["function"]["name"]
-⋮----
-tool_fn_args = td["function"]["arguments"]
-⋮----
-# show this delta in the stream
-is_break = finish_reason in [
-# for function_call, finish_reason does not necessarily
-# contain "function_call" as mentioned in the docs.
-# So we check for "stop" or "function_call" here.
-⋮----
-# we got usage chunk, and empty choices, so we're done
-⋮----
-silent = self.config.async_stream_quiet or settings.quiet
-⋮----
-is_break = choices[0].get("finish_reason", "") in [
-⋮----
-def _stream_response(  # type: ignore
-⋮----
-"""
-        Grab and print streaming response from API.
-        Args:
-            response: event-sequence emitted by API
-            chat: whether in chat-mode (or else completion-mode)
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                Dict version of OpenAIResponse object (with choices, usage)
-
-        """
-completion = ""
-reasoning = ""
-function_args = ""
-function_name = ""
-⋮----
-has_function = False
-tool_deltas: List[Dict[str, Any]] = []
-token_usage: Dict[str, int] = {}
-done: bool = False
-in_reasoning: bool = False  # Track if we're inside reasoning delimiters
-content_present = False
-⋮----
-event_dict = event if isinstance(event, dict) else event.model_dump()
-choices = event_dict.get("choices") or []
-⋮----
-delta = choices[0].get("delta") or {}
-content_present = content_present or (
-⋮----
-# capture the token usage when non-empty
-token_usage = usage
-⋮----
-# if not streaming, then we don't wait for last "usage" chunk
-⋮----
-# mark done, so we quit after the last "usage" chunk
-done = True
-⋮----
-# TODO- get usage info in stream mode (?)
-⋮----
-async def _stream_response_async(  # type: ignore
-⋮----
-"""
-        Grab and print streaming response from API.
-        Args:
-            response: event-sequence emitted by API
-            chat: whether in chat-mode (or else completion-mode)
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                OpenAIResponse object (with choices, usage)
-
-        """
-⋮----
-# mark done, so we quit after the next "usage" chunk
-⋮----
-"""
-        Convert accumulated tool-call deltas to OpenAIToolCall objects.
-        Adapted from this excellent code:
-         https://community.openai.com/t/help-for-function-calls-with-streaming/627170/2
-
-        Args:
-            tools: list of tool deltas received from streaming API
-
-        Returns:
-            str: plain text corresponding to tool calls that failed to parse
-            List[OpenAIToolCall]: list of OpenAIToolCall objects
-            List[Dict[str, Any]]: list of tool dicts
-                (to reconstruct OpenAI API response, so it can be cached)
-        """
-# Initialize a dictionary with default values
-⋮----
-# idx -> dict repr of tool
-# (used to simulate OpenAIResponse object later, and also to
-# accumulate function args as strings)
-idx2tool_dict: Dict[str, Dict[str, Any]] = defaultdict(
-⋮----
-# (try to) parse the fn args of each tool
-contents: List[str] = []
-good_indices = []
-id2args: Dict[str, None | Dict[str, Any]] = {}
-⋮----
-# used to build tool_calls_list below
-id2args[tool_dict["id"]] = args_dict or None  # if {}, store as None
-⋮----
-# remove the failed tool calls
-idx2tool_dict = {
-⋮----
-# create OpenAIToolCall list
-tool_calls_list = [
-⋮----
-@staticmethod
-    def _parse_function_args(args: str) -> Tuple[str, Dict[str, Any]]
-⋮----
-"""
-        Try to parse the `args` string as function args.
-
-        Args:
-            args: string containing function args
-
-        Returns:
-            Tuple of content, function name and args dict.
-            If parsing unsuccessful, returns the original string as content,
-            else returns the args dict.
-        """
-content = ""
-args_dict = {}
-⋮----
-stripped_fn_args = args.strip()
-dict_or_list = parse_imperfect_json(stripped_fn_args)
-⋮----
-args_dict = dict_or_list
-⋮----
-content = args
-⋮----
-"""
-        Create an LLMResponse object from the streaming API response.
-
-        Args:
-            chat: whether in chat-mode (or else completion-mode)
-            tool_deltas: list of tool deltas received from streaming API
-            has_function: whether the response contains a function_call
-            completion: completion text
-            reasoning: reasoning text
-            function_args: string representing function args
-            function_name: name of the function
-            usage: token usage dict
-            content_present: whether a stream delta explicitly contained content
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                Dict version of OpenAIResponse object (with choices, usage)
-                    (this is needed so we can cache the response, as if it were
-                    a non-streaming response)
-        """
-# check if function_call args are valid, if not,
-# treat this as a normal msg, not a function call
-args: Dict[str, Any] = {}
-⋮----
-completion = completion + content
-⋮----
-# mock openai response so we can cache it
-⋮----
-content_present = True
-has_valid_call = len(tool_dicts) > 0 or has_function
-response_content = (
-msg: Dict[str, Any] = dict(
-⋮----
-function_call = LLMFunctionCall(name=function_name)
-function_call_dict = function_call.model_dump()
-⋮----
-# non-chat mode has no function_call
-msg = dict(text=completion)
-response_content = completion
-# TODO: Ignoring reasoning content for non-chat models
-⋮----
-# create an OpenAIResponse object so we can cache it as if it were
-# a non-streaming response
-openai_response = OpenAIResponse(
-# Track whether we extracted inline thought tags from the text.
-# Only set message_with_reasoning when get_reasoning_final()
-# actually finds and extracts inline tags (e.g. <think>...</think>).
-# When reasoning is already provided via a separate API field
-# (e.g. reasoning_content), the message text doesn't contain
-# thought signatures, so there's nothing extra to preserve.
-message_with_reasoning = None
-message: str | None
-⋮----
-# some LLM APIs may not return a separate reasoning field,
-# and the reasoning may be included in the message content
-# within delimiters like <think> ... </think>
-⋮----
-# Inline tags were found and extracted; preserve the
-# original text so it can be restored in message history.
-message_with_reasoning = response_content
-⋮----
-message = response_content
-⋮----
-prompt_tokens = usage.get("prompt_tokens", 0)
-prompt_tokens_details: Any = usage.get("prompt_tokens_details", {})
-cached_tokens = (
-completion_tokens = usage.get("completion_tokens", 0)
-⋮----
-# don't allow empty list [] here
-⋮----
-def _cache_store(self, k: str, v: Any) -> None
-⋮----
-def _cache_lookup(self, fn_name: str, **kwargs: Dict[str, Any]) -> Tuple[str, Any]
-⋮----
-return "", None  # no cache, return empty key and None result
-# Use the kwargs as the cache key
-sorted_kwargs_str = str(sorted(kwargs.items()))
-raw_key = f"{fn_name}:{sorted_kwargs_str}"
-⋮----
-# Hash the key to a fixed length using SHA256
-hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
-⋮----
-# when caching disabled, return the hashed_key and none result
-⋮----
-# Try to get the result from the cache
-⋮----
-cached_val = self.cache.retrieve(hashed_key)
-⋮----
-def _cost_chat_model(self, prompt: int, cached: int, completion: int) -> float
-⋮----
-price = self.chat_cost()
-⋮----
-"""
-        Extracts token usage from ``response`` and computes cost, only when NOT
-        in streaming mode, since the LLM API (OpenAI currently) was not
-        populating the usage fields in streaming mode (but as of Sep 2024, streaming
-        responses include  usage info as well, so we should update the code
-        to directly use usage information from the streaming response, which is more
-        accurate, esp with "thinking" LLMs like o1 series which consume
-        thinking tokens).
-        In streaming mode, these are set to zero for
-        now, and will be updated later by the fn ``update_token_usage``.
-        """
-cost = 0.0
-prompt_tokens = 0
-cached_tokens = 0
-completion_tokens = 0
-⋮----
-usage = response.get("usage")
-⋮----
-prompt_tokens = usage.get("prompt_tokens") or 0
-prompt_tokens_details = usage.get("prompt_tokens_details", {}) or {}
-cached_tokens = prompt_tokens_details.get("cached_tokens") or 0
-completion_tokens = usage.get("completion_tokens") or 0
-cost = self._cost_chat_model(
-⋮----
-def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-# Catch HTTP-level API errors (400, 401, 403, 404, 422, 429, 5xx)
-# without traceback — these originate server-side and a local
-# stack trace adds no diagnostic value.
-# Note: APIConnectionError/APITimeoutError are intentionally NOT
-# caught here so they fall through to the generic handler below,
-# where the full traceback aids in diagnosing local network issues.
-⋮----
-# log and re-raise exception
-⋮----
-def _generate(self, prompt: str, max_tokens: int) -> LLMResponse
-⋮----
-@retry_with_exponential_backoff
-        def completions_with_backoff(**kwargs):  # type: ignore
-⋮----
-cached = False
-⋮----
-cached = True
-⋮----
-completion_call = litellm_completion
-⋮----
-completion_call = self.client.completions.create
-⋮----
-# If it's not in the cache, call the API
-result = completion_call(**kwargs)
-⋮----
-kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
-⋮----
-# TODO this is a temp fix, we should really be using a proper completion fn
-# that takes a pre-formatted prompt, rather than mocking it as a sys msg.
-⋮----
-else:  # any other OpenAI-compatible endpoint
-⋮----
-args = dict(
-⋮----
-max_tokens=max_tokens,  # for output/completion
-⋮----
-args = self._openai_api_call_params(args)
-⋮----
-# assume response is an actual response rather than a streaming event
-⋮----
-response = response.model_dump()
-⋮----
-msg = (response["choices"][0]["message"]["content"] or "").strip()
-⋮----
-msg = (response["choices"][0]["text"] or "").strip()
-⋮----
-async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-# Catch HTTP-level API errors (see comment in generate() above).
-⋮----
-async def _agenerate(self, prompt: str, max_tokens: int) -> LLMResponse
-⋮----
-# note we typically will not have self.config.stream = True
-# when issuing several api calls concurrently/asynchronously.
-# The calling fn should use the context `with Streaming(..., False)` to
-# disable streaming.
-⋮----
-# WARNING: .Completion.* endpoints are deprecated,
-# and as of Sep 2023 only legacy models will work here,
-# e.g. text-davinci-003, text-ada-001.
-⋮----
-@async_retry_with_exponential_backoff
-        async def completions_with_backoff(**kwargs):  # type: ignore
-⋮----
-# TODO this may not work: text_completion is not async,
-# and we didn't find an async version in litellm
-⋮----
-acompletion_call = (
-⋮----
-result = await acompletion_call(**kwargs)
-⋮----
-# only makes sense for non-OpenAI models
-⋮----
-messages = [
-prompt = self.config.hf_formatter.format(messages)
-⋮----
-# turn off streaming for async calls
-⋮----
-# only makes sense for local models, where we are trying to
-# convert a chat dialog msg-sequence to a simple completion prompt.
-⋮----
-formatter = HFFormatter(
-⋮----
-prompt = formatter.format(messages)
-⋮----
-result = await self._achat(
-⋮----
-def _chat_completions_with_backoff_body(self, **kwargs):  # type: ignore
-⋮----
-completion_call = self.client.chat.completions.create
-⋮----
-# If streaming, cannot cache result
-# since it is a generator. Instead,
-# we hold on to the hashed_key and
-# cache the result later
-⋮----
-# Test if this is a stream with an exception by
-# trying to get first chunk: Some providers like LiteLLM
-# produce a valid stream object `result` instead of throwing a
-# rate-limit error, and if we don't catch it here,
-# we end up returning an empty response and not
-# using the retry mechanism in the decorator.
-⋮----
-# try to get the first chunk to check for errors
-test_iter = iter(result)
-first_chunk = next(test_iter)
-# If we get here without error, recreate the stream
-result = chain([first_chunk], test_iter)
-⋮----
-# Empty stream is fine
-⋮----
-# Propagate any errors in the stream
-⋮----
-def _chat_completions_with_backoff(self, **kwargs):  # type: ignore
-⋮----
-retry_func = retry_with_exponential_backoff(
-⋮----
-async def _achat_completions_with_backoff_body(self, **kwargs):  # type: ignore
-⋮----
-acompletion_call = litellm_acompletion
-⋮----
-acompletion_call = self.async_client.chat.completions.create
-⋮----
-# Try to peek at the first chunk to immediately catch any errors
-# Store the original result (the stream)
-original_stream = result
-⋮----
-# Manually create and advance the iterator to check for errors
-stream_iter = original_stream.__aiter__()
-⋮----
-# This will raise an exception if the stream is invalid
-first_chunk = await anext(stream_iter)
-⋮----
-# If we reach here, the stream started successfully
-# Now recreate a fresh stream from the original API result
-# Otherwise, return a new stream that yields the first chunk
-# and remaining items
-async def combined_stream():  # type: ignore
-⋮----
-result = combined_stream()  # type: ignore
-⋮----
-# Empty stream is normal - nothing to do
-⋮----
-# Any exception here should be raised to trigger the retry mechanism
-⋮----
-async def _achat_completions_with_backoff(self, **kwargs):  # type: ignore
-⋮----
-retry_func = async_retry_with_exponential_backoff(
-⋮----
-"""Prepare args for LLM chat-completion API call"""
-⋮----
-llm_messages = [
-⋮----
-llm_messages = messages
-⋮----
-# TODO: we will unconditionally insert a dummy user msg
-# if the only msg is a system msg.
-# We could make this conditional on ModelInfo.needs_first_user_message
-⋮----
-# some LLMs, notable Gemini as of 12/11/24,
-# require the first message to be from the user,
-# so insert a dummy user msg if needed.
-⋮----
-chat_model = self.config.chat_model
-⋮----
-args: Dict[str, Any] = dict(
-⋮----
-# groq fails when we include stream_options in the request
-⋮----
-# get token-usage numbers in stream mode from OpenAI API,
-# and possibly other OpenAI-compatible APIs.
-⋮----
-# only include functions-related args if functions are provided
-# since the OpenAI API will throw an error if `functions` is None or []
-⋮----
-# some models e.g. o1-mini (as of sep 2024) don't support some params,
-# like temperature and stream, so we need to remove them.
-⋮----
-param_rename_map = self.rename_params()
-⋮----
-# finally, get rid of extra_body params exclusive to certain models
-# Only apply allowlist restrictions for known models.
-# Unknown/custom models are allowed to use all params by default.
-is_known_model = self.info().name != "unknown"
-extra_params = args.get("extra_body", {})
-⋮----
-# openAI response will look like this:
-"""
-        {
-            "id": "chatcmpl-123",
-            "object": "chat.completion",
-            "created": 1677652288,
-            "choices": [{
-                "index": 0,
-                "message": {
-                    "role": "assistant",
-                    "name": "",
-                    "content": "\n\nHello there, how may I help you?",
-                    "reasoning_content": "Okay, let's see here, hmmm...",
-                    "function_call": {
-                        "name": "fun_name",
-                        "arguments: {
-                            "arg1": "val1",
-                            "arg2": "val2"
-                        }
-                    },
-                },
-                "finish_reason": "stop"
-            }],
-            "usage": {
-                "prompt_tokens": 9,
-                "completion_tokens": 12,
-                "total_tokens": 21
-            }
-        }
-        """
-choices = response.get("choices")
-⋮----
-message = choices[0].get("message", {})
-⋮----
-message = {}
-⋮----
-content = message.get("content")
-reasoning = message.get("reasoning_content", "")
-⋮----
-message_with_reasoning = content
-⋮----
-msg = content
-⋮----
-fun_call = None
-⋮----
-fun_call = LLMFunctionCall.from_dict(message["function_call"])
-⋮----
-args_str = message["function_call"]["arguments"] or ""
-msg_str = message["content"] or ""
-msg = msg_str + args_str
-oai_tool_calls = None
-⋮----
-oai_tool_calls = []
-⋮----
-tool_call = OpenAIToolCall.from_dict(tool_call_dict)
-⋮----
-serialized_tool_call = json.dumps(tool_call_dict)
-msg = (msg or "") + ("\n" if msg else "") + serialized_tool_call
-⋮----
-# None (no content, e.g. a tool-call-only response) is preserved as
-# None rather than coerced to "", so the distinction survives
-# downstream (see LLMMessage.content / ChatDocument.content_is_none).
-⋮----
-oai_tool_calls=oai_tool_calls or None,  # don't allow empty list [] here
-⋮----
-"""
-        ChatCompletion API call to OpenAI.
-        Args:
-            messages: list of messages  to send to the API, typically
-                represents back and forth dialogue between user and LLM, but could
-                also include "function"-role messages. If messages is a string,
-                it is assumed to be a user message.
-            max_tokens: max output tokens to generate
-            functions: list of LLMFunction specs available to the LLM, to possibly
-                use in its response
-            function_call: controls how the LLM uses `functions`:
-                - "auto": LLM decides whether to use `functions` or not,
-                - "none": LLM blocked from using any function
-                - a dict of {"name": "function_name"} which forces the LLM to use
-                    the specified function.
-        Returns:
-            LLMResponse object
-        """
-args = self._prep_chat_completion(
-cached, hashed_key, response = self._chat_completions_with_backoff(**args)  # type: ignore
-⋮----
-return llm_response  # type: ignore
-⋮----
-response_dict = response
-⋮----
-response_dict = response.model_dump()
-⋮----
-"""
-        Async version of _chat(). See that function for details.
-        """
-⋮----
-cached, hashed_key, response = await self._achat_completions_with_backoff(  # type: ignore
-</file>
-
 <file path=".pre-commit-config.yaml">
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -60095,6 +60242,7 @@ nav:
       - Context-Overflow Handling: notes/context-overflow.md
       - Batch Processing: notes/batch-processing.md
       - Attachment Token Preflight: notes/attachment-token-preflight.md
+      - Vector-Store Env Prefixes: notes/vecstore-env-prefix.md
 
   - Examples:
     - Guide: examples/guide.md

--- a/llms-no-tests-no-examples-compressed.txt
+++ b/llms-no-tests-no-examples-compressed.txt
@@ -156,6 +156,7 @@ docs/
     tool-message-handler.md
     twitter-search.md
     url_loader.md
+    vecstore-env-prefix.md
     weaviate.md
     xml-tools.md
   overrides/
@@ -4821,6 +4822,207 @@ config = OpenAIGPTConfig(
 - Implements singleton pattern with lazy initialization
 - Automatically cleans up clients on program exit via atexit hooks
 - Compatible with both sync and async OpenAI clients
+</file>
+
+<file path="docs/notes/openai-http-client.md">
+# OpenAI HTTP Client Configuration
+
+When using OpenAI models through Langroid in corporate environments or behind proxies, you may encounter SSL certificate verification errors. Langroid provides three flexible options to configure the HTTP client used for OpenAI API calls.
+
+## Configuration Options
+
+### 1. Simple SSL Verification Bypass
+
+The quickest solution for development or trusted environments:
+
+```python
+import langroid.language_models as lm
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_verify_ssl=False  # Disables SSL certificate verification
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+!!! warning "Security Notice"
+    Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks. Only use this in trusted environments.
+
+### 2. HTTP Client Configuration Dictionary
+
+For common scenarios like proxies or custom certificates, use a configuration dictionary:
+
+```python
+import langroid.language_models as lm
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_config={
+        "verify": False,  # Or path to CA bundle: "/path/to/ca-bundle.pem"
+        "proxy": "http://proxy.company.com:8080",
+        "timeout": 30.0,
+        "headers": {
+            "User-Agent": "MyApp/1.0"
+        }
+    }
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+**Benefits**: This approach enables client caching, improving performance when creating multiple agents.
+
+### 3. Custom HTTP Client Factory
+
+For advanced scenarios requiring dynamic behavior or custom authentication:
+
+```python
+import langroid.language_models as lm
+from httpx import Client
+
+def create_custom_client():
+    """Factory function to create a custom HTTP client."""
+    client = Client(
+        verify="/path/to/corporate-ca-bundle.pem",
+        proxies={
+            "http": "http://proxy.corp.com:8080",
+            "https": "http://proxy.corp.com:8080"
+        },
+        timeout=30.0
+    )
+
+    # Add custom event hooks for logging
+    def log_request(request):
+        print(f"API Request: {request.method} {request.url}")
+
+    client.event_hooks = {"request": [log_request]}
+
+    return client
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_factory=create_custom_client
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+If you are using `async` methods, return a tuple of `(Client, AsyncClient)` from your factory:
+
+```python
+from httpx import AsyncClient, Client
+
+def create_custom_client():
+    """Factory function to create a custom sync and async HTTP clients."""
+    client_args = {
+        "verify": "/path/to/corporate-ca-bundle.pem",
+        "proxy": "http://proxy.corp.com:8080",
+        "timeout": 30.0,
+    }
+    client = Client(**client_args)
+    async_client = AsyncClient(**client_args)
+
+    return client, async_client
+```
+
+**Note**: Custom factories bypass client caching. Each `OpenAIGPT` instance creates a new client.
+
+## Priority Order
+
+When multiple options are specified, they are applied in this order:
+1. `http_client_factory` (highest priority)
+2. `http_client_config`
+3. `http_verify_ssl` (lowest priority)
+
+## Common Use Cases
+
+### Corporate Proxy with Custom CA Certificate
+
+```python
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_config={
+        "verify": "/path/to/corporate-ca-bundle.pem",
+        "proxies": {
+            "http": "http://proxy.corp.com:8080",
+            "https": "https://proxy.corp.com:8443"
+        }
+    }
+)
+```
+
+### Debugging API Calls
+
+```python
+def debug_client_factory():
+    from httpx import Client
+
+    client = Client(verify=False)
+
+    def log_response(response):
+        print(f"Status: {response.status_code}")
+        print(f"Headers: {response.headers}")
+
+    client.event_hooks = {
+        "response": [log_response]
+    }
+
+    return client
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_factory=debug_client_factory
+)
+```
+
+### Local Development with Self-Signed Certificates
+
+```python
+# For local OpenAI-compatible APIs
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    api_base="https://localhost:8443/v1",
+    http_verify_ssl=False
+)
+```
+
+
+## Best Practices
+
+1. **Use the simplest option that meets your needs**:
+   - Development/testing: `http_verify_ssl=False`
+   - Corporate environments: `http_client_config` with proper CA bundle
+   - Complex requirements: `http_client_factory`
+
+2. **Prefer configuration over factories for better performance** - configured clients are cached and reused
+
+3. **Always use proper CA certificates in production** instead of disabling SSL verification
+
+4. **Test your configuration** with a simple API call before deploying:
+   ```python
+   llm = lm.OpenAIGPT(config)
+   response = llm.chat("Hello")
+   print(response.content)
+   ```
+
+## Troubleshooting
+
+### SSL Certificate Errors
+```
+ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
+```
+**Solution**: Use one of the three configuration options above.
+
+
+### Proxy Connection Issues
+- Verify proxy URL format: `http://proxy:port` or `https://proxy:port`
+- Check if proxy requires authentication
+- Ensure proxy allows connections to `api.openai.com`
+
+## See Also
+
+- [OpenAI API Reference](https://platform.openai.com/docs/api-reference) - Official OpenAI documentation
 </file>
 
 <file path="docs/notes/overview.md">
@@ -17009,116 +17211,6 @@ logged = True
 __all__ = [
 </file>
 
-<file path="langroid/utils/configuration.py">
-# Global reentrant lock to serialize any modifications to the global settings.
-_global_lock = threading.RLock()
-⋮----
-class Settings(BaseSettings)
-⋮----
-debug: bool = False  # show debug messages?
-max_turns: int = -1  # maximum number of turns in a task (to avoid inf loop)
-progress: bool = False  # show progress spinners/bars?
-stream: bool = True  # stream output?
-cache: bool = True  # use cache?
-cache_type: Literal["redis", "fakeredis", "none"] = "redis"  # cache type
-chat_model: str = ""  # language model name, e.g. litellm/ollama/llama2
-quiet: bool = False  # quiet mode (i.e. suppress all output)?
-notebook: bool = False  # running in a notebook?
-⋮----
-model_config = SettingsConfigDict(extra="forbid")
-⋮----
-# Load environment variables from .env file.
-⋮----
-# The global (default) settings instance.
-# This is updated by update_global_settings() and set_global().
-_global_settings = Settings()
-⋮----
-# Thread-local storage for temporary (per-thread) settings overrides.
-_thread_local = threading.local()
-⋮----
-class SettingsProxy
-⋮----
-"""
-    A proxy for the settings that returns a thread‐local override if set,
-    or else falls back to the global settings.
-    """
-⋮----
-def __getattr__(self, name: str) -> Any
-⋮----
-# If the calling thread has set an override, use that.
-⋮----
-def __setattr__(self, name: str, value: Any) -> None
-⋮----
-# All writes go to the global settings.
-⋮----
-def update(self, new_settings: Settings) -> None
-⋮----
-def dict(self) -> Dict[str, Any]
-⋮----
-# Return a dict view of the settings as seen by the caller.
-# Note that temporary overrides are not “merged” with global settings.
-⋮----
-settings = SettingsProxy()
-⋮----
-def update_global_settings(cfg: BaseSettings, keys: List[str]) -> None
-⋮----
-"""
-    Update global settings so that modules can later access them via, e.g.,
-
-        from langroid.utils.configuration import settings
-        if settings.debug: ...
-
-    This updates the global default.
-    """
-config_dict = cfg.model_dump()
-filtered_config = {key: config_dict[key] for key in keys if key in config_dict}
-new_settings = Settings(**filtered_config)
-⋮----
-def set_global(key_vals: Settings) -> None
-⋮----
-"""
-    Update the global settings object.
-    """
-⋮----
-@contextmanager
-def temporary_settings(temp_settings: Settings) -> Iterator[None]
-⋮----
-"""
-    Temporarily override the settings for the calling thread.
-
-    Within the context, any access to "settings" will use the provided temporary
-    settings. Once the context is exited, the thread reverts to the global settings.
-    """
-saved = getattr(_thread_local, "override", None)
-⋮----
-@contextmanager
-def quiet_mode(quiet: bool = True) -> Iterator[None]
-⋮----
-"""
-    Temporarily override settings.quiet for the current thread.
-    This implementation builds on the thread‑local temporary_settings context manager.
-    The effective quiet mode is merged:
-    if quiet is already True (from an outer context),
-    then it remains True even if a nested context passes quiet=False.
-    """
-current_effective = (
-⋮----
-)  # get the current thread's effective settings
-# Create a new settings instance from the current effective state.
-temp = Settings(**current_effective)
-# Merge the new flag: once quiet is enabled, it stays enabled.
-⋮----
-def set_env(settings_instance: BaseSettings) -> None
-⋮----
-"""
-    Set environment variables from a BaseSettings instance.
-
-    Each field in the settings is written to os.environ.
-    """
-⋮----
-env_var_name = field.alias or field_name.upper()
-</file>
-
 <file path="langroid/utils/constants.py">
 # Define the ANSI escape sequences for various colors and reset
 class Colors(BaseModel)
@@ -22124,207 +22216,6 @@ matches = agent.vecdb.similar_texts_with_scores(
     where='{"source": "milvus-docs"}',
 )
 ```
-</file>
-
-<file path="docs/notes/openai-http-client.md">
-# OpenAI HTTP Client Configuration
-
-When using OpenAI models through Langroid in corporate environments or behind proxies, you may encounter SSL certificate verification errors. Langroid provides three flexible options to configure the HTTP client used for OpenAI API calls.
-
-## Configuration Options
-
-### 1. Simple SSL Verification Bypass
-
-The quickest solution for development or trusted environments:
-
-```python
-import langroid.language_models as lm
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_verify_ssl=False  # Disables SSL certificate verification
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-!!! warning "Security Notice"
-    Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks. Only use this in trusted environments.
-
-### 2. HTTP Client Configuration Dictionary
-
-For common scenarios like proxies or custom certificates, use a configuration dictionary:
-
-```python
-import langroid.language_models as lm
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_config={
-        "verify": False,  # Or path to CA bundle: "/path/to/ca-bundle.pem"
-        "proxy": "http://proxy.company.com:8080",
-        "timeout": 30.0,
-        "headers": {
-            "User-Agent": "MyApp/1.0"
-        }
-    }
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-**Benefits**: This approach enables client caching, improving performance when creating multiple agents.
-
-### 3. Custom HTTP Client Factory
-
-For advanced scenarios requiring dynamic behavior or custom authentication:
-
-```python
-import langroid.language_models as lm
-from httpx import Client
-
-def create_custom_client():
-    """Factory function to create a custom HTTP client."""
-    client = Client(
-        verify="/path/to/corporate-ca-bundle.pem",
-        proxies={
-            "http": "http://proxy.corp.com:8080",
-            "https": "http://proxy.corp.com:8080"
-        },
-        timeout=30.0
-    )
-
-    # Add custom event hooks for logging
-    def log_request(request):
-        print(f"API Request: {request.method} {request.url}")
-
-    client.event_hooks = {"request": [log_request]}
-
-    return client
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_factory=create_custom_client
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-If you are using `async` methods, return a tuple of `(Client, AsyncClient)` from your factory:
-
-```python
-from httpx import AsyncClient, Client
-
-def create_custom_client():
-    """Factory function to create a custom sync and async HTTP clients."""
-    client_args = {
-        "verify": "/path/to/corporate-ca-bundle.pem",
-        "proxy": "http://proxy.corp.com:8080",
-        "timeout": 30.0,
-    }
-    client = Client(**client_args)
-    async_client = AsyncClient(**client_args)
-
-    return client, async_client
-```
-
-**Note**: Custom factories bypass client caching. Each `OpenAIGPT` instance creates a new client.
-
-## Priority Order
-
-When multiple options are specified, they are applied in this order:
-1. `http_client_factory` (highest priority)
-2. `http_client_config`
-3. `http_verify_ssl` (lowest priority)
-
-## Common Use Cases
-
-### Corporate Proxy with Custom CA Certificate
-
-```python
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_config={
-        "verify": "/path/to/corporate-ca-bundle.pem",
-        "proxies": {
-            "http": "http://proxy.corp.com:8080",
-            "https": "https://proxy.corp.com:8443"
-        }
-    }
-)
-```
-
-### Debugging API Calls
-
-```python
-def debug_client_factory():
-    from httpx import Client
-
-    client = Client(verify=False)
-
-    def log_response(response):
-        print(f"Status: {response.status_code}")
-        print(f"Headers: {response.headers}")
-
-    client.event_hooks = {
-        "response": [log_response]
-    }
-
-    return client
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_factory=debug_client_factory
-)
-```
-
-### Local Development with Self-Signed Certificates
-
-```python
-# For local OpenAI-compatible APIs
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    api_base="https://localhost:8443/v1",
-    http_verify_ssl=False
-)
-```
-
-
-## Best Practices
-
-1. **Use the simplest option that meets your needs**:
-   - Development/testing: `http_verify_ssl=False`
-   - Corporate environments: `http_client_config` with proper CA bundle
-   - Complex requirements: `http_client_factory`
-
-2. **Prefer configuration over factories for better performance** - configured clients are cached and reused
-
-3. **Always use proper CA certificates in production** instead of disabling SSL verification
-
-4. **Test your configuration** with a simple API call before deploying:
-   ```python
-   llm = lm.OpenAIGPT(config)
-   response = llm.chat("Hello")
-   print(response.content)
-   ```
-
-## Troubleshooting
-
-### SSL Certificate Errors
-```
-ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
-```
-**Solution**: Use one of the three configuration options above.
-
-
-### Proxy Connection Issues
-- Verify proxy URL format: `http://proxy:port` or `https://proxy:port`
-- Check if proxy requires authentication
-- Ensure proxy allows connections to `api.openai.com`
-
-## See Also
-
-- [OpenAI API Reference](https://platform.openai.com/docs/api-reference) - Official OpenAI documentation
 </file>
 
 <file path="docs/notes/rotating-api-keys.md">
@@ -27609,6 +27500,120 @@ result = WebSearchResult(
 link=None,  # skip HTTP fetch; Seltz already provides content
 </file>
 
+<file path="langroid/utils/configuration.py">
+# Global reentrant lock to serialize any modifications to the global settings.
+_global_lock = threading.RLock()
+⋮----
+class Settings(BaseSettings)
+⋮----
+debug: bool = False  # show debug messages?
+max_turns: int = -1  # maximum number of turns in a task (to avoid inf loop)
+progress: bool = False  # show progress spinners/bars?
+stream: bool = True  # stream output?
+cache: bool = True  # use cache?
+cache_type: Literal["redis", "fakeredis", "none"] = "redis"  # cache type
+chat_model: str = ""  # language model name, e.g. litellm/ollama/llama2
+quiet: bool = False  # quiet mode (i.e. suppress all output)?
+notebook: bool = False  # running in a notebook?
+⋮----
+model_config = SettingsConfigDict(extra="forbid")
+⋮----
+# Load environment variables from .env file.
+⋮----
+# The global (default) settings instance.
+# This is updated by update_global_settings() and set_global().
+_global_settings = Settings()
+⋮----
+# Thread-local storage for temporary (per-thread) settings overrides.
+_thread_local = threading.local()
+⋮----
+class SettingsProxy
+⋮----
+"""
+    A proxy for the settings that returns a thread‐local override if set,
+    or else falls back to the global settings.
+    """
+⋮----
+def __getattr__(self, name: str) -> Any
+⋮----
+# If the calling thread has set an override, use that.
+⋮----
+def __setattr__(self, name: str, value: Any) -> None
+⋮----
+# All writes go to the global settings.
+⋮----
+def update(self, new_settings: Settings) -> None
+⋮----
+def dict(self) -> Dict[str, Any]
+⋮----
+# Return a dict view of the settings as seen by the caller.
+# Note that temporary overrides are not “merged” with global settings.
+⋮----
+settings = SettingsProxy()
+⋮----
+def update_global_settings(cfg: BaseSettings, keys: List[str]) -> None
+⋮----
+"""
+    Update global settings so that modules can later access them via, e.g.,
+
+        from langroid.utils.configuration import settings
+        if settings.debug: ...
+
+    This updates the global default.
+    """
+config_dict = cfg.model_dump()
+filtered_config = {key: config_dict[key] for key in keys if key in config_dict}
+new_settings = Settings(**filtered_config)
+⋮----
+def set_global(key_vals: Settings) -> None
+⋮----
+"""
+    Update the global settings object.
+    """
+⋮----
+@contextmanager
+def temporary_settings(temp_settings: Settings) -> Iterator[None]
+⋮----
+"""
+    Temporarily override the settings for the calling thread.
+
+    Within the context, any access to "settings" will use the provided temporary
+    settings. Once the context is exited, the thread reverts to the global settings.
+    """
+saved = getattr(_thread_local, "override", None)
+⋮----
+@contextmanager
+def quiet_mode(quiet: bool = True) -> Iterator[None]
+⋮----
+"""
+    Temporarily override settings.quiet for the current thread.
+    This implementation builds on the thread‑local temporary_settings context manager.
+    The effective quiet mode is merged:
+    if quiet is already True (from an outer context),
+    then it remains True even if a nested context passes quiet=False.
+    """
+current_effective = (
+⋮----
+)  # get the current thread's effective settings
+# Create a new settings instance from the current effective state.
+temp = Settings(**current_effective)
+# Merge the new flag: once quiet is enabled, it stays enabled.
+⋮----
+def set_env(settings_instance: BaseSettings) -> None
+⋮----
+"""
+    Set environment variables from a BaseSettings instance.
+
+    Each field in the settings is written to os.environ, under the name
+    the settings class itself reads: `<env_prefix><FIELD_NAME_UPPER>`,
+    or the field's explicit alias (which, per pydantic-settings
+    semantics, is the full env name and is not prefixed).
+    """
+env_prefix = settings_instance.model_config.get("env_prefix", "")
+⋮----
+env_var_name = field.alias or f"{env_prefix}{field_name.upper()}"
+</file>
+
 <file path="langroid/utils/pandas_utils.py">
 COMMON_USE_DF_METHODS = {
 ⋮----
@@ -28336,472 +28341,6 @@ chromadb  # silence linters
 postgres  # silence linters
 </file>
 
-<file path="langroid/vector_store/chromadb.py">
-logger = logging.getLogger(__name__)
-⋮----
-class ChromaDBConfig(VectorStoreConfig)
-⋮----
-collection_name: str = "temp"
-storage_path: str = ".chroma/data"
-distance: Literal["cosine", "l2", "ip"] = "cosine"
-construction_ef: int = 100
-search_ef: int = 100
-max_neighbors: int = 16
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-host: str = "127.0.0.1"
-port: int = 6333
-⋮----
-class ChromaDB(VectorStore)
-⋮----
-def __init__(self, config: ChromaDBConfig | None = None)
-⋮----
-config = config if config is not None else ChromaDBConfig()
-⋮----
-# chroma_db_impl="duckdb+parquet",
-# is_persistent=bool(config.storage_path),
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""Clear all collections in the vector store with the given prefix."""
-⋮----
-coll = [c for c in self.client.list_collections() if c.name.startswith(prefix)]
-⋮----
-n_empty_deletes = 0
-n_non_empty_deletes = 0
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-colls = self.client.list_collections()
-n_deletes = 0
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""
-        List non-empty collections in the vector store.
-        Args:
-            empty (bool, optional): Whether to list empty collections.
-        Returns:
-            List[str]: List of non-empty collection names.
-        """
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""
-        Create a collection in the vector store, optionally replacing an existing
-            collection if `replace` is True.
-        Args:
-            collection_name (str): Name of the collection to create or replace.
-            replace (bool, optional): Whether to replace an existing collection.
-                Defaults to False.
-
-        """
-⋮----
-# we could expose other configs, see:
-# https://docs.trychroma.com/docs/collections/configure
-⋮----
-def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-contents: List[str] = [document.content for document in documents]
-# convert metadatas to dicts so chroma can handle them
-metadata_dicts: List[dict[str, Any]] = [
-⋮----
-# chroma does not handle non-atomic types in metadata
-⋮----
-ids = [str(d.id()) for d in documents]
-⋮----
-colls = self.list_collections(empty=True)
-⋮----
-# embedding_models=embedding_models,
-⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-filter = json.loads(where) if where else None
-results = self.collection.get(
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-# get them one by one since chroma mangles the order of the results
-# when fetched from a list of ids.
-results = [
-final_results = {}
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-n = self.collection.count()
-⋮----
-results = self.collection.query(
-docs = self._docs_from_results(results)
-# chroma distances are 1 - cosine.
-scores = [1 - s for s in results["distances"][0]]
-⋮----
-def _docs_from_results(self, results: Dict[str, Any]) -> List[Document]
-⋮----
-"""
-        Helper function to convert results from ChromaDB to a list of Documents
-        Args:
-            results (dict): results from ChromaDB
-
-        Returns:
-            List[Document]: list of Documents
-        """
-⋮----
-contents = results["documents"][0]
-⋮----
-metadatas = results["metadatas"][0]
-⋮----
-# restore the stringified list of window_ids into the original List[str]
-⋮----
-docs = [
-</file>
-
-<file path="langroid/vector_store/lancedb.py">
-has_lancedb = True
-⋮----
-has_lancedb = False
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-class LanceDBConfig(VectorStoreConfig)
-⋮----
-cloud: bool = False
-collection_name: str | None = "temp"
-storage_path: str = ".lancedb/data"
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-distance: str = "cosine"
-⋮----
-class LanceDB(VectorStore)
-⋮----
-def __init__(self, config: LanceDBConfig | None = None)
-⋮----
-config = config if config is not None else LanceDBConfig()
-⋮----
-self.is_from_dataframe = False  # were docs ingested from a dataframe?
-self.df_metadata_columns: List[str] = []  # metadata columns from dataframe
-⋮----
-new_storage_path = config.storage_path + ".new"
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-coll_names = self.list_collections()
-n_deletes = 0
-⋮----
-nr = self.client.open_table(name).head(1).shape[0]
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""Clear all collections with the given prefix."""
-⋮----
-coll_names = [
-⋮----
-n_empty_deletes = 0
-n_non_empty_deletes = 0
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""
-        Returns:
-            List of collection names that have at least one vector.
-
-        Args:
-            empty (bool, optional): Whether to include empty collections.
-        """
-colls = self.client.table_names(limit=None)
-⋮----
-if empty:  # include empty tbls
-return colls  # type: ignore
-counts = [self.client.open_table(coll).head(1).shape[0] for coll in colls]
-⋮----
-def _create_lance_schema(self, doc_cls: Type[Document]) -> Type[BaseModel]
-⋮----
-"""
-        NOTE: NOT USED, but leaving it here as it may be useful.
-
-        Create a subclass of LanceModel with fields:
-         - id (str)
-         - Vector field that has dims equal to
-            the embedding dimension of the embedding model, and a data field of type
-            DocClass.
-         - other fields from doc_cls
-
-        Args:
-            doc_cls (Type[Document]): A Pydantic model which should be a subclass of
-                Document, to be used as the type for the data field.
-
-        Returns:
-            Type[BaseModel]: A new Pydantic model subclassing from LanceModel.
-
-        Raises:
-            ValueError: If `n` is not a non-negative integer or if `DocClass` is not a
-                subclass of Document.
-        """
-⋮----
-n = self.embedding_dim
-⋮----
-# Prepare fields for the new model
-fields = {"id": (str, ...), "vector": (Vector(n), ...)}
-⋮----
-sorted_fields = dict(
-# Add both statically and dynamically defined fields from doc_cls
-⋮----
-field_type = field.annotation if hasattr(field, "annotation") else field
-⋮----
-# Create the new model with dynamic fields
-NewModel = create_model(
-⋮----
-)  # type: ignore
-return NewModel  # type: ignore
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-colls = self.list_collections(empty=True)
-⋮----
-embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-coll_name = self.config.collection_name
-⋮----
-# self._maybe_set_doc_class_schema(documents[0])
-table_exists = False
-⋮----
-# collection exists and  is not empty:
-# if replace_collection is True, we'll overwrite the existing collection,
-# else we'll append to it.
-⋮----
-table_exists = True
-⋮----
-ids = [str(d.id()) for d in documents]
-# don't insert all at once, batch in chunks of b,
-# else we get an API error
-b = self.config.batch_size
-⋮----
-def make_batches() -> Generator[List[Dict[str, Any]], None, None]
-⋮----
-batch = [
-⋮----
-tbl = self.client.open_table(coll_name)
-⋮----
-batch_gen = make_batches()
-batch = next(batch_gen)
-# use first batch to create table...
-tbl = self.client.create_table(
-# ... and add the rest
-⋮----
-"""
-        Add a dataframe to the collection.
-        Args:
-            df (pd.DataFrame): A dataframe
-            content (str): The name of the column in the dataframe that contains the
-                text content to be embedded using the embedding model.
-            metadata (List[str]): A list of column names in the dataframe that contain
-                metadata to be stored in the database. Defaults to [].
-        """
-⋮----
-actual_metadata = metadata.copy()
-self.df_metadata_columns = actual_metadata  # could be updated below
-# get content column
-content_values = df[content].values.tolist()
-embedding_vecs = self.embedding_fn(content_values)
-⋮----
-# add vector column
-⋮----
-# rename content column to "content", leave existing column intact
-df = df.rename(columns={content: "content"}, inplace=False)
-⋮----
-docs = dataframe_to_documents(df, content="content", metadata=metadata)
-ids = [str(d.id()) for d in docs]
-⋮----
-# collection either doesn't exist or is empty, so replace it
-# and set new schema from df
-⋮----
-doc_cls = dataframe_to_document_model(
-self.config.document_class = doc_cls  # type: ignore
-⋮----
-# collection exists and is not empty, so append to it
-tbl = self.client.open_table(self.config.collection_name)
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-df = result.to_pandas()
-⋮----
-records = result.to_arrow().to_pylist()
-⋮----
-def _records_to_docs(self, records: List[Dict[str, Any]]) -> List[Document]
-⋮----
-docs = [self.config.document_class(**rec) for rec in records]
-⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-pre_result = tbl.search(None).where(where or None).limit(None)
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-_ids = [str(id) for id in ids]
-⋮----
-docs = []
-⋮----
-results = self._lance_result_to_docs(tbl.search().where(f"id == '{_id}'"))
-⋮----
-embedding = self.embedding_fn([text])[0]
-⋮----
-result = (
-docs = self._lance_result_to_docs(result)
-# note _distance is 1 - cosine
-⋮----
-scores = [
-⋮----
-scores = [1 - rec["_distance"] for rec in result.to_arrow().to_pylist()]
-⋮----
-doc_score_pairs = list(zip(docs, scores))
-</file>
-
-<file path="langroid/vector_store/meilisearch.py">
-"""
-MeiliSearch as a pure document store, without its
-(experimental) vector-store functionality.
-We aim to use MeiliSearch for fast lexical search.
-Note that what we call "Collection" in Langroid is referred to as
-"Index" in MeiliSearch. Each data-store has its own terminology,
-but for uniformity we use the Langroid terminology here.
-"""
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-class MeiliSearchConfig(VectorStoreConfig)
-⋮----
-cloud: bool = False
-collection_name: str | None = None
-primary_key: str = "id"
-port: int = 7700
-⋮----
-class MeiliSearch(VectorStore)
-⋮----
-def __init__(self, config: MeiliSearchConfig | None = None)
-⋮----
-config = config if config is not None else MeiliSearchConfig()
-⋮----
-# Note: Only create collection if a non-null collection name is provided.
-# This is useful to delay creation of db until we have a suitable
-# collection name (e.g. we could get it from the url or folder path).
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-"""All collections are treated as non-empty in MeiliSearch, so this is a
-        no-op"""
-⋮----
-async def _async_delete_indices(self, uids: List[str]) -> List[bool]
-⋮----
-"""Delete any indicecs in `uids` that exist.
-        Returns list of bools indicating whether the index has been deleted"""
-⋮----
-result = await asyncio.gather(
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""Delete all indices whose names start with `prefix`"""
-⋮----
-coll_names = [c for c in self.list_collections() if c.startswith(prefix)]
-deletes = asyncio.run(self._async_delete_indices(coll_names))
-n_deletes = sum(deletes)
-⋮----
-def _list_all_collections(self) -> List[str]
-⋮----
-"""
-        List all collections, including empty ones.
-        Returns:
-            List of collection names.
-        """
-⋮----
-async def _async_get_indexes(self) -> List[AsyncIndex]
-⋮----
-indexes = await client.get_indexes(limit=10_000)
-return [] if indexes is None else indexes  # type: ignore
-⋮----
-async def _async_get_index(self, index_uid: str) -> "AsyncIndex"
-⋮----
-index = await client.get_index(index_uid)
-return index  # type: ignore
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""
-        Returns:
-            List of index names stored. We treat any existing index as non-empty.
-        """
-indexes = asyncio.run(self._async_get_indexes())
-⋮----
-async def _async_create_index(self, collection_name: str) -> "AsyncIndex"
-⋮----
-index = await client.create_index(
-⋮----
-async def _async_delete_index(self, collection_name: str) -> bool
-⋮----
-"""Delete index if it exists. Returns True iff index was deleted"""
-⋮----
-result = await client.delete_index_if_exists(uid=collection_name)
-return result  # type: ignore
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""
-        Create a collection with the given name, optionally replacing an existing
-            collection if `replace` is True.
-        Args:
-            collection_name (str): Name of the collection to create.
-            replace (bool): Whether to replace an existing collection
-                with the same name. Defaults to False.
-        """
-⋮----
-collections = self.list_collections()
-⋮----
-collection_info = asyncio.run(self._async_get_index(collection_name))
-⋮----
-level = logger.getEffectiveLevel()
-⋮----
-index = client.index(collection_name)
-⋮----
-def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-colls = self._list_all_collections()
-⋮----
-docs = [
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-def _to_int_or_uuid(self, id: str) -> int | str
-⋮----
-async def _async_get_documents(self, where: str = "") -> "DocumentsInfo"
-⋮----
-filter = [] if where is None else where
-⋮----
-index = client.index(self.config.collection_name)
-documents = await index.get_documents(limit=10_000, filter=filter)
-⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-docs = asyncio.run(self._async_get_documents(where))
-⋮----
-doc_results = docs.results
-⋮----
-async def _async_get_documents_by_ids(self, ids: List[str]) -> List[Dict[str, Any]]
-⋮----
-documents = await asyncio.gather(*[index.get_document(id) for id in ids])
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-docs = asyncio.run(self._async_get_documents_by_ids(ids))
-⋮----
-results = await index.search(
-return results.hits  # type: ignore
-⋮----
-neighbors: int = 0,  # ignored
-⋮----
-_docs = asyncio.run(self._async_search(text, k, filter))  # type: ignore
-⋮----
-scores = [h["_rankingScore"] for h in _docs]
-⋮----
-doc_score_pairs = list(zip(docs, scores))
-</file>
-
 <file path="langroid/vector_store/milvusdb.py">
 logger = logging.getLogger(__name__)
 ⋮----
@@ -28986,346 +28525,90 @@ comparisons = " or ".join(
     def _format_filter_value(value: Any) -> str
 </file>
 
-<file path="langroid/vector_store/pineconedb.py">
-# import dataclass
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-has_pinecone: bool = True
-⋮----
-class ServerlessSpec(BaseModel)
-⋮----
-"""
-            Fallback Serverless specification configuration to avoid import errors.
-            """
-⋮----
-cloud: str
-region: str
-⋮----
-PineconeApiException = Any  # type: ignore
-Pinecone = Any  # type: ignore
-has_pinecone = False
-⋮----
-@dataclass(frozen=True)
-class IndexMeta
-⋮----
-name: str
-total_vector_count: int
-⋮----
-class PineconeDBConfig(VectorStoreConfig)
-⋮----
-cloud: bool = True
-collection_name: str | None = "temp"
-spec: ServerlessSpec = ServerlessSpec(cloud="aws", region="us-east-1")
-deletion_protection: Literal["enabled", "disabled"] | None = None
-metric: str = "cosine"
-pagination_size: int = 100
-⋮----
-class PineconeDB(VectorStore)
-⋮----
-def __init__(self, config: PineconeDBConfig | None = None)
-⋮----
-config = config if config is not None else PineconeDBConfig()
-⋮----
-key = os.getenv("PINECONE_API_KEY")
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-indexes = self._list_index_metas(empty=True)
-n_deletes = 0
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""
-        Returns:
-            Number of Pinecone indexes that were deleted
+<file path="docs/notes/vecstore-env-prefix.md">
+# Vector-Store Config Env-Var Prefixes
 
-        Args:
-            really: Optional[bool] - whether to really delete all Pinecone collections
-            prefix: Optional[str] - string to match potential Pinecone
-                indexes for deletion
-        """
-⋮----
-indexes = [
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""
-        Returns:
-            List of Pinecone indices that have at least one vector.
+Vector-store configs are `pydantic-settings` classes, which means their
+fields can be set via environment variables. Prior to this change (see
+issue #1078), `VectorStoreConfig` and its subclasses declared **no
+`env_prefix`**, so every field name was itself a case-insensitive
+environment variable. A bare `HOST`, `PORT`, `CLOUD`, `TIMEOUT`,
+`BATCH_SIZE`, `STORAGE_PATH`, `COLLECTION_NAME`, or `FULL_EVAL` in the
+environment silently overrode the default for *every* vector-store
+config:
 
-        Args:
-            empty: Optional[bool] - whether to include empty collections
-        """
-indexes = self.client.list_indexes()
-res: List[str] = []
-⋮----
-index_meta = self.client.Index(name=index)
-⋮----
-def _list_index_metas(self, empty: bool = False) -> List[IndexMeta]
-⋮----
-"""
-        Returns:
-            List of objects describing Pinecone indices
+```bash
+HOST=evil.example.com PORT=9999 FULL_EVAL=true \
+  python -c "from langroid.vector_store.qdrantdb import QdrantDBConfig; \
+             c = QdrantDBConfig(); print(c.host, c.port, c.full_eval)"
+# old behavior: evil.example.com 9999 True
+```
 
-        Args:
-            empty: Optional[bool] - whether to include empty collections
-        """
-⋮----
-res = []
-⋮----
-index_meta = self._fetch_index_meta(index)
-⋮----
-def _fetch_index_meta(self, index_name: str) -> IndexMeta
-⋮----
-"""
-        Returns:
-            A dataclass describing the input Index by name and vector count
-            to save a bit on index description calls
+This was dangerous for two reasons:
 
-        Args:
-            index_name: str - Name of the index in Pinecone
-        """
-⋮----
-index = self.client.Index(name=index_name)
-stats = index.describe_index_stats()
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""
-        Create a collection with the given name, optionally replacing an existing
-        collection if `replace` is True.
+- `HOST` and `PORT` are routinely set by shells, containers, and CI
+  systems, so vector-store clients could silently point at the wrong
+  server.
+- `FULL_EVAL=true` disabled the code-injection guard (see
+  [code-injection-protection](code-injection-protection.md)) with no
+  explicit opt-in anywhere in the user's code.
 
-        Args:
-            collection_name: str - Configuration of the collection to create.
-            replace: Optional[Bool] - Whether to replace an existing collection
-                with the same name. Defaults to False.
-        """
-pattern = re.compile(r"^[a-z0-9-]+$")
-⋮----
-index = self.client.Index(name=collection_name)
-⋮----
-status = self.client.describe_index(name=collection_name)
-⋮----
-payload = {
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-def add_documents(self, documents: Sequence[Document], namespace: str = "") -> None
-⋮----
-document_dicts = [doc.model_dump() for doc in documents]
-document_ids = [doc.id() for doc in documents]
-embedding_vectors = self.embedding_fn([doc.content for doc in documents])
-vectors = [
-⋮----
-index = self.client.Index(name=self.config.collection_name)
-batch_size = self.config.batch_size
-⋮----
-"""
-        Returns:
-            All documents for the collection currently defined in
-            the configuration object
+## New behavior
 
-        Args:
-            prefix: str - document id prefix to search for
-            namespace: str - partition of vectors to search within the index
-        """
-⋮----
-docs = []
-⋮----
-request_filters: Dict[str, Union[str, int]] = {
-⋮----
-response = index.list_paginated(**request_filters)
-vectors = response.get("vectors", [])
-⋮----
-pagination_token = response.get("pagination", {}).get("next", None)
-⋮----
-"""
-        Returns:
-            Fetches document text embedded in Pinecone index metadata
+Each vector-store config now has its own env prefix, consistent with
+the rest of the codebase (`OPENAI_`, `AZURE_OPENAI_`, `NEO4J_`, ...):
 
-        Args:
-            ids: List[str] - vector data object ids to retrieve
-            namespace: str - partition of vectors to search within the index
-        """
-⋮----
-records = index.fetch(ids=ids, namespace=namespace)
-⋮----
-records = index.fetch(ids=ids)
-⋮----
-id_mapping = {key: value for key, value in records["vectors"].items()}
-ordered_payloads = [id_mapping[_id] for _id in ids if _id in id_mapping]
-⋮----
-vector_search_request = {
-⋮----
-response = index.query(**vector_search_request)
-doc_score_pairs = [
-⋮----
-max_score = max([pair[1] for pair in doc_score_pairs])
-⋮----
-def transform_pinecone_vector(self, metadata_dict: Dict[str, Any]) -> Document
-⋮----
-"""
-        Parses the metadata response from the Pinecone vector query and
-        formats it into a dictionary that can be parsed by the Document class
-        associated with the PineconeDBConfig class
+| Config class        | Env prefix     |
+|---------------------|----------------|
+| `VectorStoreConfig` | `VECDB_`       |
+| `QdrantDBConfig`    | `QDRANT_`      |
+| `ChromaDBConfig`    | `CHROMA_`      |
+| `LanceDBConfig`     | `LANCEDB_`     |
+| `PineconeDBConfig`  | `PINECONE_`    |
+| `PostgresDBConfig`  | `POSTGRES_`    |
+| `MeiliSearchConfig` | `MEILISEARCH_` |
+| `WeaviateDBConfig`  | `WEAVIATE_`    |
 
-        Returns:
-            Well formed dictionary object to be transformed into a Document
+Bare env vars (`HOST`, `FULL_EVAL`, ...) are now ignored by all of
+these configs. To set a field via the environment, use the prefix of
+the specific config class, e.g. `QDRANT_HOST=my.qdrant.example` or
+`QDRANT_FULL_EVAL=true` for `QdrantDBConfig`. Every provider subclass
+in langroid overrides the prefix with its own, so within langroid
+`VECDB_*` vars affect only direct `VectorStoreConfig` instances.
+However, pydantic inherits `model_config`, so a third-party subclass
+of `VectorStoreConfig` that does not set its own `env_prefix` will
+read `VECDB_*` vars.
 
-        Args:
-            metadata_dict: Dict - the metadata dictionary from the Pinecone
-                vector query match
-        """
-</file>
+A `port` value coming from the *environment* that matches the exact
+Kubernetes service-link format `tcp://<host>:<digits>` (e.g.
+`QDRANT_PORT=tcp://10.0.0.8:6333`, injected into every pod by a
+service named `qdrant` when `enableServiceLinks` is on) is ignored
+with a warning and the default port is used. This exception applies
+only to the env settings source and only to that full format:
+malformed `tcp://` junk in the environment, and any `tcp://...` value
+passed explicitly to the constructor, fail validation as usual.
 
-<file path="langroid/vector_store/weaviatedb.py">
-logger = logging.getLogger(__name__)
-⋮----
-class VectorDistances
-⋮----
-"""
-    Fallback class when weaviate is not installed, to avoid import errors.
-    """
-⋮----
-COSINE: str = "cosine"
-DOTPRODUCT: str = "dot"
-L2: str = "l2"
-⋮----
-class WeaviateDBConfig(VectorStoreConfig)
-⋮----
-collection_name: str | None = "temp"
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-distance: str = VectorDistances.COSINE
-cloud: bool = False
-docker: bool = False
-host: str = "127.0.0.1"
-port: int = 8080
-storage_path: str = ".weaviate_embedded/data"
-⋮----
-class WeaviateDB(VectorStore)
-⋮----
-def __init__(self, config: WeaviateDBConfig | None = None)
-⋮----
-config = config if config is not None else WeaviateDBConfig()
-⋮----
-key = os.getenv("WEAVIATE_API_KEY")
-url = os.getenv("WEAVIATE_API_URL")
-⋮----
-def clear_empty_collections(self) -> int
-⋮----
-colls = self.client.collections.list_all()
-n_deletes = 0
-⋮----
-val = self.client.collections.get(coll_name)
-⋮----
-def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-non_empty_colls = [
-⋮----
-def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-coll_names = [
-⋮----
-n_empty_deletes = 0
-n_non_empty_deletes = 0
-⋮----
-info = self.client.collections.get(name)
-points_count = len(info)
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-collection_name = WeaviateDB.validate_and_format_collection_name(
-⋮----
-coll = self.client.collections.get(name=collection_name)
-⋮----
-vector_index_config = Configure.VectorIndex.hnsw(
-⋮----
-vectorizer_config = Configure.Vectorizer.text2vec_openai(
-⋮----
-vectorizer_config = None
-⋮----
-collection_info = self.client.collections.create(
-collection_info = self.client.collections.get(name=collection_name)
-⋮----
-level = logger.getEffectiveLevel()
-⋮----
-def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-colls = self.list_collections(empty=True)
-⋮----
-document_dicts = [doc.model_dump() for doc in documents]
-embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-⋮----
-coll_name = self.client.collections.get(self.config.collection_name)
-⋮----
-id = doc_dict["metadata"].pop("id", None)
-⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-# cannot use filter as client does not support json type queries
-coll = self.client.collections.get(self.config.collection_name)
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-docs = []
-⋮----
-result = coll_name.query.fetch_objects(
-⋮----
-id_to_doc = {}
-⋮----
-doc = self.weaviate_obj_to_doc(item)
-⋮----
-# Reconstruct the list of documents in the original order of input ids
-docs = [id_to_doc[id] for id in ids if id in id_to_doc]
-⋮----
-embedding = self.embedding_fn([text])[0]
-⋮----
-response = coll.query.near_vector(
-maybe_distances = [item.metadata.distance for item in response.objects]
-similarities = [0 if d is None else 1 - d for d in maybe_distances]
-docs = [self.weaviate_obj_to_doc(item) for item in response.objects]
-⋮----
-def _create_valid_uuid_id(self, id: str) -> Any
-⋮----
-id = get_valid_uuid(id)
-⋮----
-def weaviate_obj_to_doc(self, input_object: Any) -> Document
-⋮----
-content = input_object.properties.get("content", "")
-metadata_dict = input_object.properties.get("metadata", {})
-⋮----
-window_ids = metadata_dict.pop("window_ids", [])
-window_ids = [str(uuid) for uuid in window_ids]
-⋮----
-# Ensure the id is a valid UUID string
-id_value = get_valid_uuid(input_object.uuid)
-⋮----
-metadata = DocMetaData(id=id_value, window_ids=window_ids, **metadata_dict)
-⋮----
-@staticmethod
-    def validate_and_format_collection_name(name: str) -> str
-⋮----
-"""
-        Formats the collection name to comply with Weaviate's naming rules:
-        - Name must start with a capital letter.
-        - Name can only contain letters, numbers, and underscores.
-        - Replaces invalid characters with underscores.
-        """
-⋮----
-formatted_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
-⋮----
-# Ensure the first letter is capitalized
-⋮----
-formatted_name = formatted_name.capitalize()
-⋮----
-# Check if the name now meets the criteria
-⋮----
-def __del__(self) -> None
-⋮----
-# Gracefully close the connection with local client
+Explicit constructor arguments always take priority over environment
+values (standard `pydantic-settings` precedence):
+
+```python
+config = QdrantDBConfig(host="10.0.0.5")  # wins over QDRANT_HOST
+```
+
+## Migration
+
+If you (deliberately) relied on bare env vars to configure a
+vector store, rename them with the appropriate prefix from the table
+above, e.g. `COLLECTION_NAME=mydocs` becomes
+`QDRANT_COLLECTION_NAME=mydocs`.
+
+Env vars read via `os.getenv` outside the config classes are
+unaffected, e.g. `QDRANT_API_KEY`, `PINECONE_API_KEY`,
+`MEILISEARCH_API_KEY`, `MEILISEARCH_API_URL`, `WEAVIATE_API_KEY`, and
+`WEAVIATE_API_URL` keep their existing meanings. Note that the
+`QDRANT_*` and `PINECONE_*` prefixes overlap with those existing
+names, but the config classes have no `api_key`/`api_url` fields, so
+extra prefixed vars are ignored.
 </file>
 
 <file path="docs/tutorials/non-openai-llms.md">
@@ -31560,574 +30843,160 @@ contents = ""
 path = file["path"]
 </file>
 
-<file path="langroid/vector_store/base.py">
+<file path="langroid/vector_store/chromadb.py">
 logger = logging.getLogger(__name__)
 ⋮----
-class VectorStoreConfig(BaseSettings)
+class ChromaDBConfig(VectorStoreConfig)
 ⋮----
-type: str = ""  # deprecated, keeping it for backward compatibility
-collection_name: str | None = "temp"
-replace_collection: bool = False  # replace collection if it already exists
-storage_path: str = ".qdrant/data"
-cloud: bool = False
-batch_size: int = 200
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig(
-embedding_model: Optional[EmbeddingModel] = None
-timeout: int = 60
+model_config = SettingsConfigDict(env_prefix="CHROMA_")
+⋮----
+collection_name: str = "temp"
+storage_path: str = ".chroma/data"
+distance: Literal["cosine", "l2", "ip"] = "cosine"
+construction_ef: int = 100
+search_ef: int = 100
+max_neighbors: int = 16
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
 host: str = "127.0.0.1"
 port: int = 6333
-# used when parsing search results back as Document objects
-document_class: Type[Document] = Document
-metadata_class: Type[DocMetaData] = DocMetaData
-# compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
-full_eval: bool = False  # runs eval without sanitization. Use only on trusted input
 ⋮----
-class VectorStore(ABC)
+class ChromaDB(VectorStore)
 ⋮----
-"""
-    Abstract base class for a vector store.
-    """
+def __init__(self, config: ChromaDBConfig | None = None)
 ⋮----
-def __init__(self, config: VectorStoreConfig)
+config = config if config is not None else ChromaDBConfig()
 ⋮----
-@staticmethod
-    def create(config: VectorStoreConfig) -> Optional["VectorStore"]
-⋮----
-@property
-    def embedding_dim(self) -> int
-⋮----
-def clone(self) -> "VectorStore"
-⋮----
-"""Return a vector-store clone suitable for agent cloning.
-
-        The default implementation deep-copies the configuration, reuses any
-        existing embedding model, and instantiates a fresh store of the same
-        type. Subclasses can override when sharing the instance is required
-        (e.g., embedded/local stores that rely on file locks).
-        """
-⋮----
-config_class = self.config.__class__
-config_data = self.config.model_dump(mode="python")
-⋮----
-config_copy = config_class.model_validate(config_data)
-⋮----
-# Preserve the calculated collection contents without forcing replaces
-⋮----
-config_copy.replace_collection = False  # type: ignore[attr-defined]
-cloned_embedding: Optional[EmbeddingModel] = None
-⋮----
-cloned_embedding = self.embedding_model.clone()  # type: ignore[attr-defined]
-⋮----
-cloned_store = type(self)(config_copy)  # type: ignore[call-arg]
-⋮----
-# Some stores might not honour replace_collection; ensure same collection
-⋮----
-@abstractmethod
-    def clear_empty_collections(self) -> int
-⋮----
-"""Clear all empty collections in the vector store.
-        Returns the number of collections deleted.
-        """
-⋮----
-@abstractmethod
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
-⋮----
-"""
-        Clear all collections in the vector store.
-
-        Args:
-            really (bool, optional): Whether to really clear all collections.
-                Defaults to False.
-            prefix (str, optional): Prefix of collections to clear.
-        Returns:
-            int: Number of collections deleted.
-        """
-⋮----
-@abstractmethod
-    def list_collections(self, empty: bool = False) -> List[str]
-⋮----
-"""List all collections in the vector store
-        (only non empty collections if empty=False).
-        """
-⋮----
-def set_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""
-        Set the current collection to the given collection name.
-        Args:
-            collection_name (str): Name of the collection.
-            replace (bool, optional): Whether to replace the collection if it
-                already exists. Defaults to False.
-        """
-⋮----
-@abstractmethod
-    def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-"""Create a collection with the given name.
-        Args:
-            collection_name (str): Name of the collection.
-            replace (bool, optional): Whether to replace the
-                collection if it already exists. Defaults to False.
-        """
-⋮----
-@abstractmethod
-    def add_documents(self, documents: Sequence[Document]) -> None
-⋮----
-def compute_from_docs(self, docs: List[Document], calc: str) -> str
-⋮----
-"""Compute a result on a set of documents,
-        using a dataframe calc string like `df.groupby('state')['income'].mean()`.
-
-        If full_eval is False (default), the input expression is sanitized to prevent
-        most common code injection attack vectors.
-        If full_eval is True, sanitization is bypassed - use only with trusted input!
-        """
-# convert each doc to a dict, using dotted paths for nested fields
-dicts = [flatten_dict(doc.model_dump(by_alias=True)) for doc in docs]
-df = pd.DataFrame(dicts)
-⋮----
-# SECURITY MITIGATION: Eval input is sanitized to prevent most common
-# code injection attack vectors when full_eval is False. The globals
-# dict also restricts ``__builtins__`` so that even with
-# ``full_eval=True`` the expression cannot reach
-# ``__import__``/``eval``/``exec`` via Python's implicit builtin
-# injection (GHSA-q9p7-wqxg-mrhc).
-vars = {"df": df}
-⋮----
-calc = sanitize_command(calc)
-code = compile(calc, "<calc>", "eval")
-result = eval(code, safe_eval_globals(vars), {})
-⋮----
-# return error message so LLM can fix the calc string if needed
-err = f"""
-⋮----
-# Pd.eval sometimes fails on a perfectly valid exprn like
-# df.loc[..., 'column'] with a KeyError.
-⋮----
-def maybe_add_ids(self, documents: Sequence[Document]) -> None
-⋮----
-"""Add ids to metadata if absent, since some
-        vecdbs don't like having blank ids."""
-⋮----
-"""
-        Find k most similar texts to the given text, in terms of vector distance metric
-        (e.g., cosine similarity).
-
-        Args:
-            text (str): The text to find similar texts for.
-            k (int, optional): Number of similar texts to retrieve. Defaults to 1.
-            where (Optional[str], optional): Where clause to filter the search.
-
-        Returns:
-            List[Tuple[Document,float]]: List of (Document, score) tuples.
-
-        """
-⋮----
-"""
-        In each doc's metadata, there may be a window_ids field indicating
-        the ids of the chunks around the current chunk.
-        These window_ids may overlap, so we
-        - coalesce each overlapping groups into a single window (maintaining ordering),
-        - create a new document for each part, preserving metadata,
-
-        We may have stored a longer set of window_ids than we need during chunking.
-        Now, we just want `neighbors` on each side of the center of the window_ids list.
-
-        Args:
-            docs_scores (List[Tuple[Document, float]]): List of pairs of documents
-                to add context windows to together with their match scores.
-            neighbors (int, optional): Number of neighbors on "each side" of match to
-                retrieve. Defaults to 0.
-                "Each side" here means before and after the match,
-                in the original text.
-
-        Returns:
-            List[Tuple[Document, float]]: List of (Document, score) tuples.
-        """
-# We return a larger context around each match, i.e.
-# a window of `neighbors` on each side of the match.
-docs = [d for d, s in docs_scores]
-scores = [s for d, s in docs_scores]
-⋮----
-doc_chunks = [d for d in docs if d.metadata.is_chunk]
-⋮----
-window_ids_list = []
-id2metadata = {}
-# id -> highest score of a doc it appears in
-id2max_score: Dict[int | str, float] = {}
-⋮----
-window_ids = d.metadata.window_ids
-⋮----
-window_ids = [d.id()]
-⋮----
-n = len(window_ids)
-chunk_idx = window_ids.index(d.id())
-neighbor_ids = window_ids[
-⋮----
-# window_ids could be from different docs,
-# and they may overlap, so we coalesce overlapping groups into
-# separate windows.
-window_ids_list = self.remove_overlaps(window_ids_list)
-final_docs = []
-final_scores = []
-⋮----
-metadata = copy.deepcopy(id2metadata[w[0]])
-⋮----
-document = Document(
-# make a fresh id since content is in general different
-⋮----
-@staticmethod
-    def remove_overlaps(windows: List[List[str]]) -> List[List[str]]
-⋮----
-"""
-        Given a collection of windows, where each window is a sequence of ids,
-        identify groups of overlapping windows, and for each overlapping group,
-        order the chunk-ids using topological sort so they appear in the original
-        order in the text.
-
-        Args:
-            windows (List[int|str]): List of windows, where each window is a
-                sequence of ids.
-
-        Returns:
-            List[int|str]: List of windows, where each window is a sequence of ids,
-                and no two windows overlap.
-        """
-ids = set(id for w in windows for id in w)
-# id -> {win -> # pos}
-id2win2pos: Dict[str, Dict[int, int]] = {id: {} for id in ids}
-⋮----
-n = len(windows)
-# relation between windows:
-order = np.zeros((n, n), dtype=np.int8)
-⋮----
-id = list(set(w).intersection(x))[0]  # any common id
-⋮----
-order[i, j] = -1  # win i is before win j
-⋮----
-order[i, j] = 1  # win i is after win j
-⋮----
-# find groups of windows that overlap, like connected components in a graph
-groups = components(np.abs(order))
-⋮----
-# order the chunk-ids in each group using topological sort
-new_windows = []
-⋮----
-# find total ordering among windows in group based on order matrix
-# (this is a topological sort)
-_g = np.array(g)
-order_matrix = order[_g][:, _g]
-ordered_window_indices = topological_sort(order_matrix)
-ordered_window_ids = [windows[i] for i in _g[ordered_window_indices]]
-flattened = [id for w in ordered_window_ids for id in w]
-flattened_deduped = list(dict.fromkeys(flattened))
-# Note we are not going to split these, and instead we'll return
-# larger windows from concatenating the connected groups.
-# This ensures context is retained for LLM q/a
-⋮----
-@abstractmethod
-    def get_all_documents(self, where: str = "") -> List[Document]
-⋮----
-"""
-        Get all documents in the current collection, possibly filtered by `where`.
-        """
-⋮----
-@abstractmethod
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-"""
-        Get documents by their ids.
-        Args:
-            ids (List[str]): List of document ids.
-
-        Returns:
-            List[Document]: List of documents
-        """
-⋮----
-@abstractmethod
-    def delete_collection(self, collection_name: str) -> None
-⋮----
-def show_if_debug(self, doc_score_pairs: List[Tuple[Document, float]]) -> None
-</file>
-
-<file path="langroid/vector_store/postgres.py">
-has_postgres: bool = True
-⋮----
-Engine = Any  # type: ignore
-Connection = Any  # type: ignore
-has_postgres = False
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-def _quote_ident(name: str) -> str
-⋮----
-"""Quote a SQL identifier (table/index name) for use in raw DDL, so a name
-    containing characters that are invalid in an unquoted identifier -- e.g.
-    the ``-`` in a pytest-xdist worker suffix like ``mycollection-gw1`` -- does
-    not produce a syntax error. Embedded double-quotes are escaped per the SQL
-    standard.
-    """
-⋮----
-class PostgresDBConfig(VectorStoreConfig)
-⋮----
-collection_name: str = "embeddings"
-cloud: bool = False
-docker: bool = True
-host: str = "127.0.0.1"
-port: int = 5432
-replace_collection: bool = False
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-pool_size: int = 10
-max_overflow: int = 20
-hnsw_m: int = 16
-hnsw_ef_construction: int = 200
-⋮----
-class PostgresDB(VectorStore)
-⋮----
-def __init__(self, config: PostgresDBConfig | None = None)
-⋮----
-config = config if config is not None else PostgresDBConfig()
-⋮----
-def _create_engine(self) -> Engine
-⋮----
-"""Creates a SQLAlchemy engine based on the configuration."""
-⋮----
-connection_string: str | None = None  # Ensure variable is always defined
-⋮----
-connection_string = os.getenv("POSTGRES_CONNECTION_STRING")
-⋮----
-connection_string = connection_string.replace(
-⋮----
-username = os.getenv("POSTGRES_USER", "postgres")
-password = os.getenv("POSTGRES_PASSWORD", "postgres")
-database = os.getenv("POSTGRES_DB", "langroid")
-⋮----
-connection_string = (
-self.config.cloud = False  # Ensures cloud is disabled if using Docker
-⋮----
-def _setup_table(self) -> None
-⋮----
-# Create HNSW index for embeddings column if it doesn't exist.
-# This index enables efficient nearest-neighbor search using cosine similarity.
-# PostgreSQL automatically builds the index after creation;
-# no manual step required.
-# Read more about pgvector hnsw index here:
-# https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw
-⋮----
-index_name = f"hnsw_index_{self.config.collection_name}_embedding"
-⋮----
-create_index_query = text(
-⋮----
-def index_exists(self, connection: Connection, index_name: str) -> bool
-⋮----
-"""Check if an index exists."""
-query = text(
-result = connection.execute(query).scalar()
-⋮----
-@staticmethod
-    def _create_vector_extension(conn: Engine) -> None
-⋮----
-# The number is a unique identifier used to lock a specific resource
-# during transaction. Any 64-bit integer can be used for advisory locks.
-# Acquire advisory lock to ensure atomic, isolated setup
-# and prevent race conditions.
-⋮----
-statement = text(
-⋮----
-def set_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-inspector = inspect(self.engine)
-table_exists = collection_name in inspector.get_table_names()
-⋮----
-def list_collections(self, empty: bool = True) -> List[str]
-⋮----
-table_names = inspector.get_table_names()
-⋮----
-collections = []
-⋮----
-table = Table(table_name, self.metadata, autoload_with=self.engine)
-⋮----
-# Efficiently check for non-emptiness
-⋮----
-def create_collection(self, collection_name: str, replace: bool = False) -> None
-⋮----
-def delete_collection(self, collection_name: str) -> None
-⋮----
-"""
-        Deletes a collection and its associated HNSW index, handling metadata
-        synchronization issues.
-        """
-⋮----
-index_name = f"hnsw_index_{collection_name}_embedding"
-drop_index_query = text(
-⋮----
-# 3. Now, drop the table using SQLAlchemy
-table = Table(collection_name, self.metadata)
-⋮----
-# 4. Refresh metadata again after dropping the table
+# chroma_db_impl="duckdb+parquet",
+# is_persistent=bool(config.storage_path),
 ⋮----
 def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
 ⋮----
-deleted_count = 0
+"""Clear all collections in the vector store with the given prefix."""
 ⋮----
-# Use delete_collection to handle index and table deletion
+coll = [c for c in self.client.list_collections() if c.name.startswith(prefix)]
+⋮----
+n_empty_deletes = 0
+n_non_empty_deletes = 0
 ⋮----
 def clear_empty_collections(self) -> int
 ⋮----
-# Efficiently check for emptiness without fetching all rows
+colls = self.client.list_collections()
+n_deletes = 0
 ⋮----
-session.commit()  # Commit is likely not needed here
+def list_collections(self, empty: bool = False) -> List[str]
 ⋮----
-def _parse_embedding_store_record(self, res: Any) -> Dict[str, Any]
+"""
+        List non-empty collections in the vector store.
+        Args:
+            empty (bool, optional): Whether to list empty collections.
+        Returns:
+            List[str]: List of non-empty collection names.
+        """
 ⋮----
-metadata = res.cmetadata or {}
+def create_collection(self, collection_name: str, replace: bool = False) -> None
 ⋮----
-def get_all_documents(self, where: str = "") -> List[Document]
+"""
+        Create a collection in the vector store, optionally replacing an existing
+            collection if `replace` is True.
+        Args:
+            collection_name (str): Name of the collection to create or replace.
+            replace (bool, optional): Whether to replace an existing collection.
+                Defaults to False.
+
+        """
 ⋮----
-query = session.query(self.embeddings_table)
-⋮----
-# Apply 'where' clause if provided
-⋮----
-where_json = json.loads(where)
-query = query.filter(
-⋮----
-return []  # Return empty list or handle error as appropriate
-⋮----
-results = query.all()
-documents = [
-⋮----
-def get_documents_by_ids(self, ids: List[str]) -> List[Document]
-⋮----
-# Add a CASE statement to preserve the order of IDs
-case_stmt = case(
-⋮----
-query = (
-⋮----
-.order_by(case_stmt)  # Order by the CASE statement
+# we could expose other configs, see:
+# https://docs.trychroma.com/docs/collections/configure
 ⋮----
 def add_documents(self, documents: Sequence[Document]) -> None
 ⋮----
-embeddings = self.embedding_fn([doc.content for doc in documents])
+contents: List[str] = [document.content for document in documents]
+# convert metadatas to dicts so chroma can handle them
+metadata_dicts: List[dict[str, Any]] = [
 ⋮----
-batch_size = self.config.batch_size
+# chroma does not handle non-atomic types in metadata
 ⋮----
-batch_docs = documents[i : i + batch_size]
-batch_embeddings = embeddings[i : i + batch_size]
+ids = [str(d.id()) for d in documents]
 ⋮----
-new_records = [
+colls = self.list_collections(empty=True)
 ⋮----
-stmt = insert(self.embeddings_table).values(new_records)
+# embedding_models=embedding_models,
 ⋮----
-@staticmethod
-    def _id_to_uuid(id: str, obj: object) -> str
+def get_all_documents(self, where: str = "") -> List[Document]
 ⋮----
-doc_id = str(uuid.UUID(id))
+filter = json.loads(where) if where else None
+results = self.collection.get(
 ⋮----
-obj_repr = repr(obj)
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
 ⋮----
-obj_hash = hashlib.sha256(obj_repr.encode()).hexdigest()
+# get them one by one since chroma mangles the order of the results
+# when fetched from a list of ids.
+results = [
+final_results = {}
 ⋮----
-combined = f"{id}-{obj_hash}"
+def delete_collection(self, collection_name: str) -> None
 ⋮----
-doc_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, combined))
+n = self.collection.count()
 ⋮----
-neighbors: int = 1,  # Parameter not used in this implementation
+results = self.collection.query(
+docs = self._docs_from_results(results)
+# chroma distances are 1 - cosine.
+scores = [1 - s for s in results["distances"][0]]
 ⋮----
-embedding = self.embedding_fn([query])[0]
+def _docs_from_results(self, results: Dict[str, Any]) -> List[Document]
 ⋮----
-# Calculate the score (1 - cosine_distance) and label it as "score"
-score = (
-⋮----
-json_query = json.loads(where)
-⋮----
-results = (
-⋮----
-score,  # Select the calculated score
-⋮----
-.order_by(score.desc())  # Order by score in descending order
-⋮----
-documents_with_scores = [
-⋮----
-result.score,  # Use the score from the query result
-</file>
+"""
+        Helper function to convert results from ChromaDB to a list of Documents
+        Args:
+            results (dict): results from ChromaDB
 
-<file path="langroid/vector_store/qdrantdb.py">
-logger = logging.getLogger(__name__)
-⋮----
-T = TypeVar("T")
-⋮----
-def from_optional(x: Optional[T], default: T) -> T
-⋮----
-def is_valid_uuid(uuid_to_test: str) -> bool
-⋮----
-"""
-    Check if a given string is a valid UUID.
-    """
-⋮----
-uuid_obj = uuid.UUID(uuid_to_test)
-⋮----
-# Check for valid unsigned 64-bit integer
-⋮----
-int_value = int(uuid_to_test)
-⋮----
-class QdrantDBConfig(VectorStoreConfig)
-⋮----
-cloud: bool = True
-docker: bool = False
-collection_name: str | None = "temp"
-storage_path: str = ".qdrant/data"
-embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-use_sparse_embeddings: bool = False
-sparse_embedding_model: str = "naver/splade-v3-distilbert"
-sparse_limit: int = 3
-distance: str = "cosine"
-⋮----
-class QdrantDB(VectorStore)
-⋮----
-def __init__(self, config: QdrantDBConfig | None = None)
-⋮----
-config = config if config is not None else QdrantDBConfig()
-⋮----
-self.sparse_tokenizer = AutoTokenizer.from_pretrained(  # type: ignore
-⋮----
-key = os.getenv("QDRANT_API_KEY")
-url = os.getenv("QDRANT_API_URL")
-⋮----
-new_storage_path = config.storage_path + ".new"
-⋮----
-# Note: Only create collection if a non-null collection name is provided.
-# This is useful to delay creation of vecdb until we have a suitable
-# collection name (e.g. we could get it from the url or folder path).
-⋮----
-def clone(self) -> "QdrantDB"
-⋮----
-"""Create an independent Qdrant client when running against Qdrant Cloud."""
-⋮----
-cloned = super().clone()
-⋮----
-def close(self) -> None
-⋮----
-"""
-        Close the QdrantDB client and release any resources (e.g., file locks).
-        This is especially important for local storage to release the .lock file.
+        Returns:
+            List[Document]: list of Documents
         """
 ⋮----
-# QdrantLocal has a close method that releases the lock
+contents = results["documents"][0]
 ⋮----
-def __enter__(self) -> "QdrantDB"
+metadatas = results["metadatas"][0]
 ⋮----
-"""Context manager entry."""
+# restore the stringified list of window_ids into the original List[str]
 ⋮----
-def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
+docs = [
+</file>
+
+<file path="langroid/vector_store/lancedb.py">
+has_lancedb = True
 ⋮----
-"""Context manager exit - ensure cleanup even if an exception occurred."""
+has_lancedb = False
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+class LanceDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="LANCEDB_")
+⋮----
+cloud: bool = False
+collection_name: str | None = "temp"
+storage_path: str = ".lancedb/data"
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+distance: str = "cosine"
+⋮----
+class LanceDB(VectorStore)
+⋮----
+def __init__(self, config: LanceDBConfig | None = None)
+⋮----
+config = config if config is not None else LanceDBConfig()
+⋮----
+self.is_from_dataframe = False  # were docs ingested from a dataframe?
+self.df_metadata_columns: List[str] = []  # metadata columns from dataframe
+⋮----
+new_storage_path = config.storage_path + ".new"
 ⋮----
 def clear_empty_collections(self) -> int
 ⋮----
 coll_names = self.list_collections()
 n_deletes = 0
 ⋮----
-info = self.client.get_collection(collection_name=name)
+nr = self.client.open_table(name).head(1).shape[0]
 ⋮----
 def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
 ⋮----
@@ -32138,8 +31007,6 @@ coll_names = [
 n_empty_deletes = 0
 n_non_empty_deletes = 0
 ⋮----
-points_count = from_optional(info.points_count, 0)
-⋮----
 def list_collections(self, empty: bool = False) -> List[str]
 ⋮----
 """
@@ -32149,10 +31016,242 @@ def list_collections(self, empty: bool = False) -> List[str]
         Args:
             empty (bool, optional): Whether to include empty collections.
         """
+colls = self.client.table_names(limit=None)
 ⋮----
-colls = list(self.client.get_collections())[0][1]
+if empty:  # include empty tbls
+return colls  # type: ignore
+counts = [self.client.open_table(coll).head(1).shape[0] for coll in colls]
 ⋮----
-counts = []
+def _create_lance_schema(self, doc_cls: Type[Document]) -> Type[BaseModel]
+⋮----
+"""
+        NOTE: NOT USED, but leaving it here as it may be useful.
+
+        Create a subclass of LanceModel with fields:
+         - id (str)
+         - Vector field that has dims equal to
+            the embedding dimension of the embedding model, and a data field of type
+            DocClass.
+         - other fields from doc_cls
+
+        Args:
+            doc_cls (Type[Document]): A Pydantic model which should be a subclass of
+                Document, to be used as the type for the data field.
+
+        Returns:
+            Type[BaseModel]: A new Pydantic model subclassing from LanceModel.
+
+        Raises:
+            ValueError: If `n` is not a non-negative integer or if `DocClass` is not a
+                subclass of Document.
+        """
+⋮----
+n = self.embedding_dim
+⋮----
+# Prepare fields for the new model
+fields = {"id": (str, ...), "vector": (Vector(n), ...)}
+⋮----
+sorted_fields = dict(
+# Add both statically and dynamically defined fields from doc_cls
+⋮----
+field_type = field.annotation if hasattr(field, "annotation") else field
+⋮----
+# Create the new model with dynamic fields
+NewModel = create_model(
+⋮----
+)  # type: ignore
+return NewModel  # type: ignore
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+colls = self.list_collections(empty=True)
+⋮----
+embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+coll_name = self.config.collection_name
+⋮----
+# self._maybe_set_doc_class_schema(documents[0])
+table_exists = False
+⋮----
+# collection exists and  is not empty:
+# if replace_collection is True, we'll overwrite the existing collection,
+# else we'll append to it.
+⋮----
+table_exists = True
+⋮----
+ids = [str(d.id()) for d in documents]
+# don't insert all at once, batch in chunks of b,
+# else we get an API error
+b = self.config.batch_size
+⋮----
+def make_batches() -> Generator[List[Dict[str, Any]], None, None]
+⋮----
+batch = [
+⋮----
+tbl = self.client.open_table(coll_name)
+⋮----
+batch_gen = make_batches()
+batch = next(batch_gen)
+# use first batch to create table...
+tbl = self.client.create_table(
+# ... and add the rest
+⋮----
+"""
+        Add a dataframe to the collection.
+        Args:
+            df (pd.DataFrame): A dataframe
+            content (str): The name of the column in the dataframe that contains the
+                text content to be embedded using the embedding model.
+            metadata (List[str]): A list of column names in the dataframe that contain
+                metadata to be stored in the database. Defaults to [].
+        """
+⋮----
+actual_metadata = metadata.copy()
+self.df_metadata_columns = actual_metadata  # could be updated below
+# get content column
+content_values = df[content].values.tolist()
+embedding_vecs = self.embedding_fn(content_values)
+⋮----
+# add vector column
+⋮----
+# rename content column to "content", leave existing column intact
+df = df.rename(columns={content: "content"}, inplace=False)
+⋮----
+docs = dataframe_to_documents(df, content="content", metadata=metadata)
+ids = [str(d.id()) for d in docs]
+⋮----
+# collection either doesn't exist or is empty, so replace it
+# and set new schema from df
+⋮----
+doc_cls = dataframe_to_document_model(
+self.config.document_class = doc_cls  # type: ignore
+⋮----
+# collection exists and is not empty, so append to it
+tbl = self.client.open_table(self.config.collection_name)
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+df = result.to_pandas()
+⋮----
+records = result.to_arrow().to_pylist()
+⋮----
+def _records_to_docs(self, records: List[Dict[str, Any]]) -> List[Document]
+⋮----
+docs = [self.config.document_class(**rec) for rec in records]
+⋮----
+def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+pre_result = tbl.search(None).where(where or None).limit(None)
+⋮----
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+_ids = [str(id) for id in ids]
+⋮----
+docs = []
+⋮----
+results = self._lance_result_to_docs(tbl.search().where(f"id == '{_id}'"))
+⋮----
+embedding = self.embedding_fn([text])[0]
+⋮----
+result = (
+docs = self._lance_result_to_docs(result)
+# note _distance is 1 - cosine
+⋮----
+scores = [
+⋮----
+scores = [1 - rec["_distance"] for rec in result.to_arrow().to_pylist()]
+⋮----
+doc_score_pairs = list(zip(docs, scores))
+</file>
+
+<file path="langroid/vector_store/meilisearch.py">
+"""
+MeiliSearch as a pure document store, without its
+(experimental) vector-store functionality.
+We aim to use MeiliSearch for fast lexical search.
+Note that what we call "Collection" in Langroid is referred to as
+"Index" in MeiliSearch. Each data-store has its own terminology,
+but for uniformity we use the Langroid terminology here.
+"""
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+class MeiliSearchConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="MEILISEARCH_")
+⋮----
+cloud: bool = False
+collection_name: str | None = None
+primary_key: str = "id"
+port: int = 7700
+⋮----
+class MeiliSearch(VectorStore)
+⋮----
+def __init__(self, config: MeiliSearchConfig | None = None)
+⋮----
+config = config if config is not None else MeiliSearchConfig()
+⋮----
+# Note: Only create collection if a non-null collection name is provided.
+# This is useful to delay creation of db until we have a suitable
+# collection name (e.g. we could get it from the url or folder path).
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+"""All collections are treated as non-empty in MeiliSearch, so this is a
+        no-op"""
+⋮----
+async def _async_delete_indices(self, uids: List[str]) -> List[bool]
+⋮----
+"""Delete any indicecs in `uids` that exist.
+        Returns list of bools indicating whether the index has been deleted"""
+⋮----
+result = await asyncio.gather(
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+"""Delete all indices whose names start with `prefix`"""
+⋮----
+coll_names = [c for c in self.list_collections() if c.startswith(prefix)]
+deletes = asyncio.run(self._async_delete_indices(coll_names))
+n_deletes = sum(deletes)
+⋮----
+def _list_all_collections(self) -> List[str]
+⋮----
+"""
+        List all collections, including empty ones.
+        Returns:
+            List of collection names.
+        """
+⋮----
+async def _async_get_indexes(self) -> List[AsyncIndex]
+⋮----
+indexes = await client.get_indexes(limit=10_000)
+return [] if indexes is None else indexes  # type: ignore
+⋮----
+async def _async_get_index(self, index_uid: str) -> "AsyncIndex"
+⋮----
+index = await client.get_index(index_uid)
+return index  # type: ignore
+⋮----
+def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+"""
+        Returns:
+            List of index names stored. We treat any existing index as non-empty.
+        """
+indexes = asyncio.run(self._async_get_indexes())
+⋮----
+async def _async_create_index(self, collection_name: str) -> "AsyncIndex"
+⋮----
+index = await client.create_index(
+⋮----
+async def _async_delete_index(self, collection_name: str) -> bool
+⋮----
+"""Delete index if it exists. Returns True iff index was deleted"""
+⋮----
+result = await client.delete_index_if_exists(uid=collection_name)
+return result  # type: ignore
 ⋮----
 def create_collection(self, collection_name: str, replace: bool = False) -> None
 ⋮----
@@ -32165,120 +31264,401 @@ def create_collection(self, collection_name: str, replace: bool = False) -> None
                 with the same name. Defaults to False.
         """
 ⋮----
-coll = self.client.get_collection(collection_name=collection_name)
+collections = self.list_collections()
 ⋮----
-vectors_config = {
-sparse_vectors_config = None
-⋮----
-sparse_vectors_config = {
-⋮----
-collection_info = self.client.get_collection(collection_name=collection_name)
+collection_info = asyncio.run(self._async_get_index(collection_name))
 ⋮----
 level = logger.getEffectiveLevel()
 ⋮----
-def get_sparse_embeddings(self, inputs: List[str]) -> List["SparseVector"]
-⋮----
-tokens = self.sparse_tokenizer(
-output = self.sparse_model(**tokens)
-vectors = torch.max(
-sparse_embeddings = []
-⋮----
-cols = vec.nonzero().squeeze().cpu().tolist()
-weights = vec[cols].cpu().tolist()
+index = client.index(collection_name)
 ⋮----
 def add_documents(self, documents: Sequence[Document]) -> None
 ⋮----
-# Add id to metadata if not already present
+colls = self._list_all_collections()
 ⋮----
-# Fix the ids due to qdrant finickiness
-⋮----
-colls = self.list_collections(empty=True)
-⋮----
-document_dicts = [doc.model_dump() for doc in documents]
-embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-sparse_embedding_vecs = self.get_sparse_embeddings(
-⋮----
-ids = [self._to_int_or_uuid(d.id()) for d in documents]
-# don't insert all at once, batch in chunks of b,
-# else we get an API error
-b = self.config.batch_size
-⋮----
-vectors: Dict[str, Embeddings | List[SparseVector]] = {
-⋮----
-coll_found: bool = False
-⋮----
-# poll until collection is ready
-⋮----
-coll_found = True
+docs = [
 ⋮----
 def delete_collection(self, collection_name: str) -> None
 ⋮----
 def _to_int_or_uuid(self, id: str) -> int | str
 ⋮----
-int_val = int(id)
+async def _async_get_documents(self, where: str = "") -> "DocumentsInfo"
 ⋮----
-# If doc_id is already a valid UUID, return it as is
+filter = [] if where is None else where
 ⋮----
-# Otherwise, generate a UUID from the doc_id
-# Convert doc_id to string if it's not already
-id_str = str(id)
-⋮----
-# Hash the document ID using SHA-1
-hash_object = hashlib.sha1(id_str.encode())
-hash_digest = hash_object.hexdigest()
-⋮----
-# Truncate or manipulate the hash to fit into a UUID (128 bits)
-uuid_str = hash_digest[:32]
-⋮----
-# Format this string into a UUID format
-formatted_uuid = uuid.UUID(uuid_str)
+index = client.index(self.config.collection_name)
+documents = await index.get_documents(limit=10_000, filter=filter)
 ⋮----
 def get_all_documents(self, where: str = "") -> List[Document]
 ⋮----
-docs = []
-offset = 0
-filter = Filter() if where == "" else Filter.model_validate(json.loads(where))
+docs = asyncio.run(self._async_get_documents(where))
 ⋮----
-limit=10_000,  # try getting all at once, if not we keep paging
+doc_results = docs.results
 ⋮----
-self.config.document_class(**record.payload)  # type: ignore
+async def _async_get_documents_by_ids(self, ids: List[str]) -> List[Dict[str, Any]]
 ⋮----
-# ignore
-⋮----
-offset = next_page_offset  # type: ignore
+documents = await asyncio.gather(*[index.get_document(id) for id in ids])
 ⋮----
 def get_documents_by_ids(self, ids: List[str]) -> List[Document]
 ⋮----
-_ids = [self._to_int_or_uuid(id) for id in ids]
-records = self.client.retrieve(
-# Note the records may NOT be in the order of the ids,
-# so we re-order them here.
-id2payload = {record.id: record.payload for record in records}
-ordered_payloads = [id2payload[id] for id in _ids if id in id2payload]
-docs = [Document(**payload) for payload in ordered_payloads]  # type: ignore
+docs = asyncio.run(self._async_get_documents_by_ids(ids))
 ⋮----
-embedding = self.embedding_fn([text])[0]
-# TODO filter may not work yet
+results = await index.search(
+return results.hits  # type: ignore
 ⋮----
-filter = Filter()
+neighbors: int = 0,  # ignored
 ⋮----
-filter = Filter.model_validate(json.loads(where))
-requests = [
+_docs = asyncio.run(self._async_search(text, k, filter))  # type: ignore
 ⋮----
-sparse_embedding = self.get_sparse_embeddings([text])[0]
-⋮----
-search_result_lists: List[List[ScoredPoint]] = self.client.search_batch(
-⋮----
-search_result = [
-⋮----
-]  # 2D list -> 1D list
-scores = [match.score for match in search_result if match is not None]
-docs = [
-⋮----
-self.config.document_class(**(match.payload))  # type: ignore
+scores = [h["_rankingScore"] for h in _docs]
 ⋮----
 doc_score_pairs = list(zip(docs, scores))
-max_score = max(ds[1] for ds in doc_score_pairs)
+</file>
+
+<file path="langroid/vector_store/pineconedb.py">
+# import dataclass
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+has_pinecone: bool = True
+⋮----
+class ServerlessSpec(BaseModel)
+⋮----
+"""
+            Fallback Serverless specification configuration to avoid import errors.
+            """
+⋮----
+cloud: str
+region: str
+⋮----
+PineconeApiException = Any  # type: ignore
+Pinecone = Any  # type: ignore
+has_pinecone = False
+⋮----
+@dataclass(frozen=True)
+class IndexMeta
+⋮----
+name: str
+total_vector_count: int
+⋮----
+class PineconeDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="PINECONE_")
+⋮----
+cloud: bool = True
+collection_name: str | None = "temp"
+spec: ServerlessSpec = ServerlessSpec(cloud="aws", region="us-east-1")
+deletion_protection: Literal["enabled", "disabled"] | None = None
+metric: str = "cosine"
+pagination_size: int = 100
+⋮----
+class PineconeDB(VectorStore)
+⋮----
+def __init__(self, config: PineconeDBConfig | None = None)
+⋮----
+config = config if config is not None else PineconeDBConfig()
+⋮----
+key = os.getenv("PINECONE_API_KEY")
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+indexes = self._list_index_metas(empty=True)
+n_deletes = 0
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+"""
+        Returns:
+            Number of Pinecone indexes that were deleted
+
+        Args:
+            really: Optional[bool] - whether to really delete all Pinecone collections
+            prefix: Optional[str] - string to match potential Pinecone
+                indexes for deletion
+        """
+⋮----
+indexes = [
+⋮----
+def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+"""
+        Returns:
+            List of Pinecone indices that have at least one vector.
+
+        Args:
+            empty: Optional[bool] - whether to include empty collections
+        """
+indexes = self.client.list_indexes()
+res: List[str] = []
+⋮----
+index_meta = self.client.Index(name=index)
+⋮----
+def _list_index_metas(self, empty: bool = False) -> List[IndexMeta]
+⋮----
+"""
+        Returns:
+            List of objects describing Pinecone indices
+
+        Args:
+            empty: Optional[bool] - whether to include empty collections
+        """
+⋮----
+res = []
+⋮----
+index_meta = self._fetch_index_meta(index)
+⋮----
+def _fetch_index_meta(self, index_name: str) -> IndexMeta
+⋮----
+"""
+        Returns:
+            A dataclass describing the input Index by name and vector count
+            to save a bit on index description calls
+
+        Args:
+            index_name: str - Name of the index in Pinecone
+        """
+⋮----
+index = self.client.Index(name=index_name)
+stats = index.describe_index_stats()
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+"""
+        Create a collection with the given name, optionally replacing an existing
+        collection if `replace` is True.
+
+        Args:
+            collection_name: str - Configuration of the collection to create.
+            replace: Optional[Bool] - Whether to replace an existing collection
+                with the same name. Defaults to False.
+        """
+pattern = re.compile(r"^[a-z0-9-]+$")
+⋮----
+index = self.client.Index(name=collection_name)
+⋮----
+status = self.client.describe_index(name=collection_name)
+⋮----
+payload = {
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+def add_documents(self, documents: Sequence[Document], namespace: str = "") -> None
+⋮----
+document_dicts = [doc.model_dump() for doc in documents]
+document_ids = [doc.id() for doc in documents]
+embedding_vectors = self.embedding_fn([doc.content for doc in documents])
+vectors = [
+⋮----
+index = self.client.Index(name=self.config.collection_name)
+batch_size = self.config.batch_size
+⋮----
+"""
+        Returns:
+            All documents for the collection currently defined in
+            the configuration object
+
+        Args:
+            prefix: str - document id prefix to search for
+            namespace: str - partition of vectors to search within the index
+        """
+⋮----
+docs = []
+⋮----
+request_filters: Dict[str, Union[str, int]] = {
+⋮----
+response = index.list_paginated(**request_filters)
+vectors = response.get("vectors", [])
+⋮----
+pagination_token = response.get("pagination", {}).get("next", None)
+⋮----
+"""
+        Returns:
+            Fetches document text embedded in Pinecone index metadata
+
+        Args:
+            ids: List[str] - vector data object ids to retrieve
+            namespace: str - partition of vectors to search within the index
+        """
+⋮----
+records = index.fetch(ids=ids, namespace=namespace)
+⋮----
+records = index.fetch(ids=ids)
+⋮----
+id_mapping = {key: value for key, value in records["vectors"].items()}
+ordered_payloads = [id_mapping[_id] for _id in ids if _id in id_mapping]
+⋮----
+vector_search_request = {
+⋮----
+response = index.query(**vector_search_request)
+doc_score_pairs = [
+⋮----
+max_score = max([pair[1] for pair in doc_score_pairs])
+⋮----
+def transform_pinecone_vector(self, metadata_dict: Dict[str, Any]) -> Document
+⋮----
+"""
+        Parses the metadata response from the Pinecone vector query and
+        formats it into a dictionary that can be parsed by the Document class
+        associated with the PineconeDBConfig class
+
+        Returns:
+            Well formed dictionary object to be transformed into a Document
+
+        Args:
+            metadata_dict: Dict - the metadata dictionary from the Pinecone
+                vector query match
+        """
+</file>
+
+<file path="langroid/vector_store/weaviatedb.py">
+logger = logging.getLogger(__name__)
+⋮----
+class VectorDistances
+⋮----
+"""
+    Fallback class when weaviate is not installed, to avoid import errors.
+    """
+⋮----
+COSINE: str = "cosine"
+DOTPRODUCT: str = "dot"
+L2: str = "l2"
+⋮----
+class WeaviateDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="WEAVIATE_")
+⋮----
+collection_name: str | None = "temp"
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+distance: str = VectorDistances.COSINE
+cloud: bool = False
+docker: bool = False
+host: str = "127.0.0.1"
+port: int = 8080
+storage_path: str = ".weaviate_embedded/data"
+⋮----
+class WeaviateDB(VectorStore)
+⋮----
+def __init__(self, config: WeaviateDBConfig | None = None)
+⋮----
+config = config if config is not None else WeaviateDBConfig()
+⋮----
+key = os.getenv("WEAVIATE_API_KEY")
+url = os.getenv("WEAVIATE_API_URL")
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+colls = self.client.collections.list_all()
+n_deletes = 0
+⋮----
+val = self.client.collections.get(coll_name)
+⋮----
+def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+non_empty_colls = [
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+coll_names = [
+⋮----
+n_empty_deletes = 0
+n_non_empty_deletes = 0
+⋮----
+info = self.client.collections.get(name)
+points_count = len(info)
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+collection_name = WeaviateDB.validate_and_format_collection_name(
+⋮----
+coll = self.client.collections.get(name=collection_name)
+⋮----
+vector_index_config = Configure.VectorIndex.hnsw(
+⋮----
+vectorizer_config = Configure.Vectorizer.text2vec_openai(
+⋮----
+vectorizer_config = None
+⋮----
+collection_info = self.client.collections.create(
+collection_info = self.client.collections.get(name=collection_name)
+⋮----
+level = logger.getEffectiveLevel()
+⋮----
+def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+colls = self.list_collections(empty=True)
+⋮----
+document_dicts = [doc.model_dump() for doc in documents]
+embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+⋮----
+coll_name = self.client.collections.get(self.config.collection_name)
+⋮----
+id = doc_dict["metadata"].pop("id", None)
+⋮----
+def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+# cannot use filter as client does not support json type queries
+coll = self.client.collections.get(self.config.collection_name)
+⋮----
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+docs = []
+⋮----
+result = coll_name.query.fetch_objects(
+⋮----
+id_to_doc = {}
+⋮----
+doc = self.weaviate_obj_to_doc(item)
+⋮----
+# Reconstruct the list of documents in the original order of input ids
+docs = [id_to_doc[id] for id in ids if id in id_to_doc]
+⋮----
+embedding = self.embedding_fn([text])[0]
+⋮----
+response = coll.query.near_vector(
+maybe_distances = [item.metadata.distance for item in response.objects]
+similarities = [0 if d is None else 1 - d for d in maybe_distances]
+docs = [self.weaviate_obj_to_doc(item) for item in response.objects]
+⋮----
+def _create_valid_uuid_id(self, id: str) -> Any
+⋮----
+id = get_valid_uuid(id)
+⋮----
+def weaviate_obj_to_doc(self, input_object: Any) -> Document
+⋮----
+content = input_object.properties.get("content", "")
+metadata_dict = input_object.properties.get("metadata", {})
+⋮----
+window_ids = metadata_dict.pop("window_ids", [])
+window_ids = [str(uuid) for uuid in window_ids]
+⋮----
+# Ensure the id is a valid UUID string
+id_value = get_valid_uuid(input_object.uuid)
+⋮----
+metadata = DocMetaData(id=id_value, window_ids=window_ids, **metadata_dict)
+⋮----
+@staticmethod
+    def validate_and_format_collection_name(name: str) -> str
+⋮----
+"""
+        Formats the collection name to comply with Weaviate's naming rules:
+        - Name must start with a capital letter.
+        - Name can only contain letters, numbers, and underscores.
+        - Replaces invalid characters with underscores.
+        """
+⋮----
+formatted_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+⋮----
+# Ensure the first letter is capitalized
+⋮----
+formatted_name = formatted_name.capitalize()
+⋮----
+# Check if the name now meets the criteria
+⋮----
+def __del__(self) -> None
+⋮----
+# Gracefully close the connection with local client
 </file>
 
 <file path="CONTRIBUTING.md">
@@ -37394,6 +36774,441 @@ page_no = 0
         """
 </file>
 
+<file path="langroid/vector_store/postgres.py">
+has_postgres: bool = True
+⋮----
+Engine = Any  # type: ignore
+Connection = Any  # type: ignore
+has_postgres = False
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+def _quote_ident(name: str) -> str
+⋮----
+"""Quote a SQL identifier (table/index name) for use in raw DDL, so a name
+    containing characters that are invalid in an unquoted identifier -- e.g.
+    the ``-`` in a pytest-xdist worker suffix like ``mycollection-gw1`` -- does
+    not produce a syntax error. Embedded double-quotes are escaped per the SQL
+    standard.
+    """
+⋮----
+class PostgresDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="POSTGRES_")
+⋮----
+collection_name: str = "embeddings"
+cloud: bool = False
+docker: bool = True
+host: str = "127.0.0.1"
+port: int = 5432
+replace_collection: bool = False
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+pool_size: int = 10
+max_overflow: int = 20
+hnsw_m: int = 16
+hnsw_ef_construction: int = 200
+⋮----
+class PostgresDB(VectorStore)
+⋮----
+def __init__(self, config: PostgresDBConfig | None = None)
+⋮----
+config = config if config is not None else PostgresDBConfig()
+⋮----
+def _create_engine(self) -> Engine
+⋮----
+"""Creates a SQLAlchemy engine based on the configuration."""
+⋮----
+connection_string: str | None = None  # Ensure variable is always defined
+⋮----
+connection_string = os.getenv("POSTGRES_CONNECTION_STRING")
+⋮----
+connection_string = connection_string.replace(
+⋮----
+username = os.getenv("POSTGRES_USER", "postgres")
+password = os.getenv("POSTGRES_PASSWORD", "postgres")
+database = os.getenv("POSTGRES_DB", "langroid")
+⋮----
+connection_string = (
+self.config.cloud = False  # Ensures cloud is disabled if using Docker
+⋮----
+def _setup_table(self) -> None
+⋮----
+# Create HNSW index for embeddings column if it doesn't exist.
+# This index enables efficient nearest-neighbor search using cosine similarity.
+# PostgreSQL automatically builds the index after creation;
+# no manual step required.
+# Read more about pgvector hnsw index here:
+# https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw
+⋮----
+index_name = f"hnsw_index_{self.config.collection_name}_embedding"
+⋮----
+create_index_query = text(
+⋮----
+def index_exists(self, connection: Connection, index_name: str) -> bool
+⋮----
+"""Check if an index exists."""
+query = text(
+result = connection.execute(query).scalar()
+⋮----
+@staticmethod
+    def _create_vector_extension(conn: Engine) -> None
+⋮----
+# The number is a unique identifier used to lock a specific resource
+# during transaction. Any 64-bit integer can be used for advisory locks.
+# Acquire advisory lock to ensure atomic, isolated setup
+# and prevent race conditions.
+⋮----
+statement = text(
+⋮----
+def set_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+inspector = inspect(self.engine)
+table_exists = collection_name in inspector.get_table_names()
+⋮----
+def list_collections(self, empty: bool = True) -> List[str]
+⋮----
+table_names = inspector.get_table_names()
+⋮----
+collections = []
+⋮----
+table = Table(table_name, self.metadata, autoload_with=self.engine)
+⋮----
+# Efficiently check for non-emptiness
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+"""
+        Deletes a collection and its associated HNSW index, handling metadata
+        synchronization issues.
+        """
+⋮----
+index_name = f"hnsw_index_{collection_name}_embedding"
+drop_index_query = text(
+⋮----
+# 3. Now, drop the table using SQLAlchemy
+table = Table(collection_name, self.metadata)
+⋮----
+# 4. Refresh metadata again after dropping the table
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+deleted_count = 0
+⋮----
+# Use delete_collection to handle index and table deletion
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+# Efficiently check for emptiness without fetching all rows
+⋮----
+session.commit()  # Commit is likely not needed here
+⋮----
+def _parse_embedding_store_record(self, res: Any) -> Dict[str, Any]
+⋮----
+metadata = res.cmetadata or {}
+⋮----
+def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+query = session.query(self.embeddings_table)
+⋮----
+# Apply 'where' clause if provided
+⋮----
+where_json = json.loads(where)
+query = query.filter(
+⋮----
+return []  # Return empty list or handle error as appropriate
+⋮----
+results = query.all()
+documents = [
+⋮----
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+# Add a CASE statement to preserve the order of IDs
+case_stmt = case(
+⋮----
+query = (
+⋮----
+.order_by(case_stmt)  # Order by the CASE statement
+⋮----
+def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+embeddings = self.embedding_fn([doc.content for doc in documents])
+⋮----
+batch_size = self.config.batch_size
+⋮----
+batch_docs = documents[i : i + batch_size]
+batch_embeddings = embeddings[i : i + batch_size]
+⋮----
+new_records = [
+⋮----
+stmt = insert(self.embeddings_table).values(new_records)
+⋮----
+@staticmethod
+    def _id_to_uuid(id: str, obj: object) -> str
+⋮----
+doc_id = str(uuid.UUID(id))
+⋮----
+obj_repr = repr(obj)
+⋮----
+obj_hash = hashlib.sha256(obj_repr.encode()).hexdigest()
+⋮----
+combined = f"{id}-{obj_hash}"
+⋮----
+doc_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, combined))
+⋮----
+neighbors: int = 1,  # Parameter not used in this implementation
+⋮----
+embedding = self.embedding_fn([query])[0]
+⋮----
+# Calculate the score (1 - cosine_distance) and label it as "score"
+score = (
+⋮----
+json_query = json.loads(where)
+⋮----
+results = (
+⋮----
+score,  # Select the calculated score
+⋮----
+.order_by(score.desc())  # Order by score in descending order
+⋮----
+documents_with_scores = [
+⋮----
+result.score,  # Use the score from the query result
+</file>
+
+<file path="langroid/vector_store/qdrantdb.py">
+logger = logging.getLogger(__name__)
+⋮----
+T = TypeVar("T")
+⋮----
+def from_optional(x: Optional[T], default: T) -> T
+⋮----
+def is_valid_uuid(uuid_to_test: str) -> bool
+⋮----
+"""
+    Check if a given string is a valid UUID.
+    """
+⋮----
+uuid_obj = uuid.UUID(uuid_to_test)
+⋮----
+# Check for valid unsigned 64-bit integer
+⋮----
+int_value = int(uuid_to_test)
+⋮----
+class QdrantDBConfig(VectorStoreConfig)
+⋮----
+model_config = SettingsConfigDict(env_prefix="QDRANT_")
+⋮----
+cloud: bool = True
+docker: bool = False
+collection_name: str | None = "temp"
+storage_path: str = ".qdrant/data"
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+use_sparse_embeddings: bool = False
+sparse_embedding_model: str = "naver/splade-v3-distilbert"
+sparse_limit: int = 3
+distance: str = "cosine"
+⋮----
+class QdrantDB(VectorStore)
+⋮----
+def __init__(self, config: QdrantDBConfig | None = None)
+⋮----
+config = config if config is not None else QdrantDBConfig()
+⋮----
+self.sparse_tokenizer = AutoTokenizer.from_pretrained(  # type: ignore
+⋮----
+key = os.getenv("QDRANT_API_KEY")
+url = os.getenv("QDRANT_API_URL")
+⋮----
+new_storage_path = config.storage_path + ".new"
+⋮----
+# Note: Only create collection if a non-null collection name is provided.
+# This is useful to delay creation of vecdb until we have a suitable
+# collection name (e.g. we could get it from the url or folder path).
+⋮----
+def clone(self) -> "QdrantDB"
+⋮----
+"""Create an independent Qdrant client when running against Qdrant Cloud."""
+⋮----
+cloned = super().clone()
+⋮----
+def close(self) -> None
+⋮----
+"""
+        Close the QdrantDB client and release any resources (e.g., file locks).
+        This is especially important for local storage to release the .lock file.
+        """
+⋮----
+# QdrantLocal has a close method that releases the lock
+⋮----
+def __enter__(self) -> "QdrantDB"
+⋮----
+"""Context manager entry."""
+⋮----
+def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
+⋮----
+"""Context manager exit - ensure cleanup even if an exception occurred."""
+⋮----
+def clear_empty_collections(self) -> int
+⋮----
+coll_names = self.list_collections()
+n_deletes = 0
+⋮----
+info = self.client.get_collection(collection_name=name)
+⋮----
+def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+"""Clear all collections with the given prefix."""
+⋮----
+coll_names = [
+⋮----
+n_empty_deletes = 0
+n_non_empty_deletes = 0
+⋮----
+points_count = from_optional(info.points_count, 0)
+⋮----
+def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+"""
+        Returns:
+            List of collection names that have at least one vector.
+
+        Args:
+            empty (bool, optional): Whether to include empty collections.
+        """
+⋮----
+colls = list(self.client.get_collections())[0][1]
+⋮----
+counts = []
+⋮----
+def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+"""
+        Create a collection with the given name, optionally replacing an existing
+            collection if `replace` is True.
+        Args:
+            collection_name (str): Name of the collection to create.
+            replace (bool): Whether to replace an existing collection
+                with the same name. Defaults to False.
+        """
+⋮----
+coll = self.client.get_collection(collection_name=collection_name)
+⋮----
+vectors_config = {
+sparse_vectors_config = None
+⋮----
+sparse_vectors_config = {
+⋮----
+collection_info = self.client.get_collection(collection_name=collection_name)
+⋮----
+level = logger.getEffectiveLevel()
+⋮----
+def get_sparse_embeddings(self, inputs: List[str]) -> List["SparseVector"]
+⋮----
+tokens = self.sparse_tokenizer(
+output = self.sparse_model(**tokens)
+vectors = torch.max(
+sparse_embeddings = []
+⋮----
+cols = vec.nonzero().squeeze().cpu().tolist()
+weights = vec[cols].cpu().tolist()
+⋮----
+def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+# Add id to metadata if not already present
+⋮----
+# Fix the ids due to qdrant finickiness
+⋮----
+colls = self.list_collections(empty=True)
+⋮----
+document_dicts = [doc.model_dump() for doc in documents]
+embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+sparse_embedding_vecs = self.get_sparse_embeddings(
+⋮----
+ids = [self._to_int_or_uuid(d.id()) for d in documents]
+# don't insert all at once, batch in chunks of b,
+# else we get an API error
+b = self.config.batch_size
+⋮----
+vectors: Dict[str, Embeddings | List[SparseVector]] = {
+⋮----
+coll_found: bool = False
+⋮----
+# poll until collection is ready
+⋮----
+coll_found = True
+⋮----
+def delete_collection(self, collection_name: str) -> None
+⋮----
+def _to_int_or_uuid(self, id: str) -> int | str
+⋮----
+int_val = int(id)
+⋮----
+# If doc_id is already a valid UUID, return it as is
+⋮----
+# Otherwise, generate a UUID from the doc_id
+# Convert doc_id to string if it's not already
+id_str = str(id)
+⋮----
+# Hash the document ID using SHA-1
+hash_object = hashlib.sha1(id_str.encode())
+hash_digest = hash_object.hexdigest()
+⋮----
+# Truncate or manipulate the hash to fit into a UUID (128 bits)
+uuid_str = hash_digest[:32]
+⋮----
+# Format this string into a UUID format
+formatted_uuid = uuid.UUID(uuid_str)
+⋮----
+def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+docs = []
+offset = 0
+filter = Filter() if where == "" else Filter.model_validate(json.loads(where))
+⋮----
+limit=10_000,  # try getting all at once, if not we keep paging
+⋮----
+self.config.document_class(**record.payload)  # type: ignore
+⋮----
+# ignore
+⋮----
+offset = next_page_offset  # type: ignore
+⋮----
+def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+_ids = [self._to_int_or_uuid(id) for id in ids]
+records = self.client.retrieve(
+# Note the records may NOT be in the order of the ids,
+# so we re-order them here.
+id2payload = {record.id: record.payload for record in records}
+ordered_payloads = [id2payload[id] for id in _ids if id in id2payload]
+docs = [Document(**payload) for payload in ordered_payloads]  # type: ignore
+⋮----
+embedding = self.embedding_fn([text])[0]
+# TODO filter may not work yet
+⋮----
+filter = Filter()
+⋮----
+filter = Filter.model_validate(json.loads(where))
+requests = [
+⋮----
+sparse_embedding = self.get_sparse_embeddings([text])[0]
+⋮----
+search_result_lists: List[List[ScoredPoint]] = self.client.search_batch(
+⋮----
+search_result = [
+⋮----
+]  # 2D list -> 1D list
+scores = [match.score for match in search_result if match is not None]
+docs = [
+⋮----
+self.config.document_class(**(match.payload))  # type: ignore
+⋮----
+doc_score_pairs = list(zip(docs, scores))
+max_score = max(ds[1] for ds in doc_score_pairs)
+</file>
+
 <file path="SECURITY.md">
 # Security Policy
 
@@ -37522,6 +37337,1447 @@ it, and if it was a denylist gap it is out of scope.
 
 Security fixes ship in the latest release. Please upgrade to the current
 version of `langroid` rather than requesting backports.
+</file>
+
+<file path="langroid/language_models/openai_gpt.py">
+OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
+⋮----
+OLLAMA_BASE_URL = "http://localhost:11434/v1"
+⋮----
+DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+# Provider prefixes that route to the Gemini OpenAI-compatible API.
+GEMINI_MODEL_PREFIXES = ("gemini/", "google/gemini-")
+GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+OLLAMA_API_KEY = "ollama"
+⋮----
+VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
+LLAMACPP_API_KEY = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
+⋮----
+openai_chat_model_pref_list = [
+⋮----
+openai_completion_model_pref_list = [
+⋮----
+available_models = set(map(lambda m: m.id, OpenAI().models.list()))
+⋮----
+available_models = set()
+⋮----
+default_openai_chat_model = next(
+default_openai_completion_model = next(
+⋮----
+class AccessWarning(Warning)
+⋮----
+@cache
+def gpt_3_5_warning() -> None
+⋮----
+@cache
+def parallel_strict_warning() -> None
+⋮----
+def noop() -> None
+⋮----
+"""Does nothing."""
+⋮----
+class OpenAICallParams(BaseModel)
+⋮----
+"""
+    Various params that can be sent to an OpenAI API chat-completion call.
+    When specified, any param here overrides the one with same name in the
+    OpenAIGPTConfig.
+    See OpenAI API Reference for details on the params:
+    https://platform.openai.com/docs/api-reference/chat
+    """
+⋮----
+max_tokens: int | None = None
+temperature: float | None = None
+frequency_penalty: float | None = None  # between -2 and 2
+presence_penalty: float | None = None  # between -2 and 2
+response_format: Dict[str, str] | None = None
+logit_bias: Dict[int, float] | None = None  # token_id -> bias
+logprobs: bool | None = None
+top_p: float | None = None
+reasoning_effort: str | None = None  # or "low" or "high" or "medium"
+top_logprobs: int | None = None  # if int, requires logprobs=True
+n: int | None = None  # how many completions to generate (n > 1 is NOT handled now)
+stop: str | List[str] | None = None  # (list of) stop sequence(s)
+seed: int | None = None
+user: str | None = None  # user id for tracking
+extra_body: Dict[str, Any] | None = None  # additional params for API request body
+⋮----
+def to_dict_exclude_none(self) -> Dict[str, Any]
+⋮----
+class LiteLLMProxyConfig(BaseSettings)
+⋮----
+"""Configuration for LiteLLM proxy connection."""
+⋮----
+api_key: str = ""  # read from env var LITELLM_API_KEY if set
+api_base: str = ""  # read from env var LITELLM_API_BASE if set
+⋮----
+model_config = SettingsConfigDict(env_prefix="LITELLM_")
+⋮----
+class OpenAIGPTConfig(LLMConfig)
+⋮----
+"""
+    Class for any LLM with an OpenAI-like API: besides the OpenAI models this includes:
+    (a) locally-served models behind an OpenAI-compatible API
+    (b) non-local models, using a proxy adaptor lib like litellm that provides
+        an OpenAI-compatible API.
+    (We could rename this class to OpenAILikeConfig, but we keep it as-is for now)
+
+    Important Note:
+    Due to the `env_prefix = "OPENAI_"` defined below,
+    all of the fields below can be set AND OVERRIDDEN via env vars,
+    # by upper-casing the name and prefixing with OPENAI_, e.g.
+    # OPENAI_MAX_OUTPUT_TOKENS=1000.
+    # If any of these is defined in this way in the environment
+    # (either via explicit setenv or export or via .env file + load_dotenv()),
+    # the environment variable takes precedence over the value in the config.
+    """
+⋮----
+type: str = "openai"
+api_key: str = DUMMY_API_KEY
+# Callable returning a fresh API key/bearer token, for endpoints that
+# authenticate with short-lived rotating credentials (e.g. Vertex AI
+# OAuth tokens, Azure Entra ID). Resolved per-request by the OpenAI
+# client, and excluded from the client-cache key (the cache is keyed on
+# the provider's identity), so rotating tokens neither go stale nor grow
+# the cache. Takes precedence over `api_key`. Only supported for models
+# served via an OpenAI-compatible endpoint (not Groq/Cerebras/litellm).
+# See docs/notes/rotating-api-keys.md.
+api_key_provider: Optional[Callable[[], str]] = None
+organization: str = ""
+api_base: str | None = None  # used for local or other non-OpenAI models
+litellm: bool = False  # use litellm api?
+litellm_proxy: LiteLLMProxyConfig = LiteLLMProxyConfig()
+ollama: bool = False  # use ollama's OpenAI-compatible endpoint?
+min_output_tokens: int = 1
+use_chat_for_completion: bool = True  # do not change this, for OpenAI models!
+timeout: int = 20
+temperature: float = 0.2
+seed: int | None = 42
+params: OpenAICallParams | None = None
+use_cached_client: bool = (
+⋮----
+True  # Whether to reuse cached clients (prevents resource exhaustion)
+⋮----
+# these can be any model name that is served at an OpenAI-compatible API end point
+chat_model: str = default_openai_chat_model
+chat_model_orig: Optional[str] = None
+completion_model: str = default_openai_completion_model
+run_on_first_use: Callable[[], None] = noop
+parallel_tool_calls: Optional[bool] = None
+# Supports constrained decoding which enforces that the output of the LLM
+# adheres to a JSON schema
+supports_json_schema: Optional[bool] = None
+# Supports strict decoding for the generation of tool calls with
+# the OpenAI Tools API; this ensures that the generated tools
+# adhere to the provided schema.
+supports_strict_tools: Optional[bool] = None
+# a string that roughly matches a HuggingFace chat_template,
+# e.g. "mistral-instruct-v0.2 (a fuzzy search is done to find the closest match)
+formatter: str | None = None
+hf_formatter: HFFormatter | None = None
+langdb_params: LangDBParams = LangDBParams()
+portkey_params: PortkeyParams = PortkeyParams()
+headers: Dict[str, str] = {}
+http_client_factory: Optional[Callable[[], Any]] = (
+⋮----
+None  # Factory: returns Client or (Client, AsyncClient)
+⋮----
+http_verify_ssl: bool = True  # Simple flag for SSL verification
+http_client_config: Optional[Dict[str, Any]] = None  # Config dict for httpx.Client
+_api_base_was_supplied: bool = False
+⋮----
+def __init__(self, **kwargs) -> None:  # type: ignore
+⋮----
+api_base_was_supplied = "api_base" in kwargs
+local_model = "api_base" in kwargs and kwargs["api_base"] is not None
+⋮----
+chat_model = kwargs.get("chat_model", "")
+local_prefixes = ["local/", "litellm/", "ollama/", "vllm/", "llamacpp/"]
+⋮----
+local_model = True
+⋮----
+warn_gpt_3_5 = (
+⋮----
+existing_hook = kwargs.get("run_on_first_use", noop)
+⋮----
+def with_warning() -> None
+⋮----
+env_prefix = self.model_config.get("env_prefix")
+env_api_base_name = f"{env_prefix}API_BASE"
+env_api_base = os.getenv(env_api_base_name)
+⋮----
+case_insensitive_env = {
+env_api_base = case_insensitive_env.get(env_api_base_name.lower())
+api_base_was_supplied = api_base_was_supplied or (
+⋮----
+model_config = SettingsConfigDict(env_prefix="OPENAI_")
+⋮----
+def __setattr__(self, name: str, value: Any) -> None
+⋮----
+"""Track API bases assigned after config construction."""
+⋮----
+"""
+        Copy config while preserving nested model instances and subclasses.
+
+        Important: Avoid reconstructing via `model_dump` as that coerces nested
+        models to their annotated base types (dropping subclass-only fields).
+        Instead, defer to Pydantic's native `model_copy`, which keeps nested
+        `BaseModel` instances (and their concrete subclasses) intact.
+
+        An `api_base` supplied through `update` is caller configuration, so the
+        copy must retain that provenance for provider-specific routing.
+        """
+# Delegate to BaseSettings/BaseModel implementation to preserve types
+copied = super().model_copy(update=update, deep=deep)
+⋮----
+return copied  # type: ignore[return-value]
+⋮----
+def _validate_litellm(self) -> None
+⋮----
+"""
+        When using liteLLM, validate whether all env vars required by the model
+        have been set.
+        """
+⋮----
+litellm.drop_params = True  # drop un-supported params without crashing
+⋮----
+self.seed = None  # some local mdls don't support seed
+⋮----
+keys_dict = litellm.utils.validate_environment(self.chat_model)
+missing_keys = keys_dict.get("missing_keys", [])
+⋮----
+@classmethod
+    def create(cls, prefix: str) -> Type["OpenAIGPTConfig"]
+⋮----
+"""Create a config class whose params can be set via a desired
+        prefix from the .env file or env vars.
+        E.g., using
+        ```python
+        OllamaConfig = OpenAIGPTConfig.create("ollama")
+        ollama_config = OllamaConfig()
+        ```
+        you can have a group of params prefixed by "OLLAMA_", to be used
+        with models served via `ollama`.
+        This way, you can maintain several setting-groups in your .env file,
+        one per model type.
+        """
+⋮----
+class DynamicConfig(OpenAIGPTConfig)
+⋮----
+class OpenAIResponse(BaseModel)
+⋮----
+"""OpenAI response model, either completion or chat."""
+⋮----
+choices: List[Dict]  # type: ignore
+usage: Dict  # type: ignore
+⋮----
+def litellm_logging_fn(model_call_dict: Dict[str, Any]) -> None
+⋮----
+"""Logging function for litellm"""
+⋮----
+api_input_dict = model_call_dict.get("additional_args", {}).get(
+⋮----
+text = escape(json.dumps(api_input_dict, indent=2))
+⋮----
+# Define a class for OpenAI GPT models that extends the base class
+class OpenAIGPT(LanguageModel)
+⋮----
+"""
+    Class for OpenAI LLMs
+    """
+⋮----
+client: OpenAI | Groq | Cerebras | None
+async_client: AsyncOpenAI | AsyncGroq | AsyncCerebras | None
+⋮----
+def __init__(self, config: OpenAIGPTConfig = OpenAIGPTConfig())
+⋮----
+"""
+        Args:
+            config: configuration for openai-gpt model
+        """
+# copy the config to avoid modifying the original; deep to decouple
+# nested models while preserving their concrete subclasses
+# The api_key_provider must NOT be deep-copied: the client cache is
+# keyed on its identity (so a copy would defeat cache sharing), and it
+# may hold non-copyable state (e.g. a threading.Lock). Clear it in a
+# shallow copy first, then restore the original callable afterwards.
+api_key_provider = config.api_key_provider
+⋮----
+config = config.model_copy(update={"api_key_provider": None})
+config = config.model_copy(deep=True)
+⋮----
+# save original model name such as `provider/model` before
+# we strip out the `provider` - we retain the original in
+# case some params are specific to a provider.
+⋮----
+# Run the first time the model is used
+⋮----
+# global override of chat_model,
+# to allow quick testing with other models
+⋮----
+# there is a formatter specified, e.g.
+# "litellm/ollama/mistral//hf" or
+# "local/localhost:8000/v1//mistral-instruct-v0.2"
+formatter = parts[1]
+⋮----
+# e.g. "litellm/ollama/mistral//hf" -> "litellm/ollama/mistral"
+formatter = find_hf_formatter(self.config.chat_model)
+⋮----
+# e.g. "mistral"
+⋮----
+# e.g. "local/localhost:8000/v1//mistral-instruct-v0.2"
+⋮----
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", DUMMY_API_KEY)
+⋮----
+# if model name starts with "litellm",
+# set the actual model name by stripping the "litellm/" prefix
+# and set the litellm flag to True
+⋮----
+# e.g. litellm/ollama/mistral
+⋮----
+# strip the "litellm/" prefix
+# e.g. litellm/ollama/llama2 => ollama/llama2
+⋮----
+# expect this to be of the form "local/localhost:8000/v1",
+# depending on how the model is launched locally.
+# In this case the model served locally behind an OpenAI-compatible API
+# so we can just use `openai.*` methods directly,
+# and don't need a adaptor library like litellm
+⋮----
+self.config.seed = None  # some models raise an error when seed is set
+# Extract the api_base from the model name after the "local/" prefix
+⋮----
+# use api_base from config if set, else fall back on OLLAMA_BASE_URL
+⋮----
+# If api_base is unset we use OpenAI's endpoint, which supports
+# these features (with JSON schema restricted to a limited set of models)
+⋮----
+# if we're overriding chat model globally, set completion model to same
+⋮----
+# we want to format chats -> completions using this specific formatter
+⋮----
+# use groq-specific client
+⋮----
+# Create new clients without caching
+⋮----
+# use cerebras-specific client
+⋮----
+# TODO there is not async client, so should we do anything here?
+⋮----
+# in these cases, there's no specific client: OpenAI python client suffices
+⋮----
+# Prefer caller config, then Gemini env, then the default.
+gemini_api_base = os.getenv("GEMINI_API_BASE", "")
+explicit_api_base = (
+⋮----
+# Honor caller-supplied base URL (e.g. regional endpoints,
+# proxies) instead of always forcing the default.
+openai_api_base = os.getenv("OPENAI_API_BASE")
+⋮----
+# Only overwrite with MINIMAX_API_KEY when it is actually
+# set, so users who intentionally put their MiniMax key in
+# OPENAI_API_KEY are not silently downgraded to a dummy key.
+minimax_key = os.getenv("MINIMAX_API_KEY", "")
+⋮----
+# Recompute capabilities now that the prefix has been stripped
+# and self.info() can find the model in MODEL_INFO.
+⋮----
+project_id = self.config.langdb_params.project_id
+⋮----
+params = self.config.langdb_params
+⋮----
+# Parse the model string and extract provider/model
+⋮----
+# Set Portkey base URL
+⋮----
+# Set API key - use provider's API key from env if available
+⋮----
+# Add Portkey-specific headers
+⋮----
+# Sanitize the API key: strip leading/trailing whitespace
+# (including stray newlines from .env files or CI secrets).
+⋮----
+# Create http_client if needed - Priority order:
+# 1. http_client_factory (most flexibility, not cacheable)
+# 2. http_client_config (cacheable, moderate flexibility)
+# 3. http_verify_ssl=False (cacheable, simple SSL bypass)
+http_client = None
+async_http_client = None
+http_client_config_used = None
+⋮----
+# Use the factory to create http_client (not cacheable)
+http_client = self.config.http_client_factory()
+⋮----
+# set async_http_client to None - so that it will
+# be created later
+⋮----
+# Use config dict (cacheable)
+http_client_config_used = self.config.http_client_config
+⋮----
+# Simple SSL bypass (cacheable)
+http_client_config_used = {"verify": False}
+⋮----
+# With an api_key_provider, hand the callable itself to the
+# OpenAI client, which resolves a fresh token on each request.
+openai_api_key: Union[str, Callable[[], str]] = (
+⋮----
+client_kwargs: Dict[str, Any] = dict(
+⋮----
+# Create http_client from config for non-cached scenario
+⋮----
+async_client_kwargs: Dict[str, Any] = dict(
+⋮----
+# AsyncOpenAI awaits its api_key callable
+⋮----
+# Create async http_client from config for non-cached scenario
+⋮----
+use_cache = self.config.cache_config is not None
+⋮----
+# switch to fresh redis config if needed
+⋮----
+# force use of fake redis if global cache_type is "fakeredis"
+⋮----
+def _openai_api_call_params(self, kwargs: Dict[str, Any]) -> Dict[str, Any]
+⋮----
+"""
+        Prep the params to be sent to the OpenAI API
+        (or any OpenAI-compatible API, e.g. from Ooba or LmStudio)
+        for chat-completion.
+
+        Order of priority:
+        - (1) Params (mainly max_tokens) in the chat/achat/generate/agenerate call
+                (these are passed in via kwargs)
+        - (2) Params in OpenAIGPTConfig.params (of class OpenAICallParams)
+        - (3) Specific Params in OpenAIGPTConfig (just temperature for now)
+        """
+params = dict(
+⋮----
+def is_openai_chat_model(self) -> bool
+⋮----
+openai_chat_models = [e.value for e in OpenAIChatModel]
+⋮----
+def is_openai_completion_model(self) -> bool
+⋮----
+openai_completion_models = [e.value for e in OpenAICompletionModel]
+⋮----
+def is_gemini_model(self) -> bool
+⋮----
+"""Are we using the gemini OpenAI-compatible API?"""
+⋮----
+def is_deepseek_model(self) -> bool
+⋮----
+deepseek_models = [e.value for e in DeepSeekModel]
+⋮----
+def is_minimax_model(self) -> bool
+⋮----
+"""Are we using the MiniMax OpenAI-compatible API?"""
+minimax_models = [e.value for e in MiniMaxModel]
+⋮----
+def unsupported_params(self) -> List[str]
+⋮----
+"""
+        List of params that are not supported by the current model
+        """
+unsupported = set(self.info().unsupported_params)
+⋮----
+def rename_params(self) -> Dict[str, str]
+⋮----
+"""
+        Map of param name -> new name for specific models.
+        Currently main troublemaker is o1* series.
+        """
+⋮----
+def chat_context_length(self) -> int
+⋮----
+"""
+        Context-length for chat-completion models/endpoints.
+        Get it from the config if explicitly given,
+         otherwise use model_info based on model name, and fall back to
+         generic model_info if there's no match.
+        """
+⋮----
+def completion_context_length(self) -> int
+⋮----
+"""
+        Context-length for completion models/endpoints.
+        Get it from the config if explicitly given,
+         otherwise use model_info based on model name, and fall back to
+         generic model_info if there's no match.
+        """
+⋮----
+def chat_cost(self) -> Tuple[float, float, float]
+⋮----
+"""
+        (Prompt, Cached, Generation) cost per 1000 tokens, for chat-completion
+        models/endpoints.
+        Get it from the dict, otherwise fail-over to general method
+        """
+info = self.info()
+cached_cost_per_million = info.cached_cost_per_million
+⋮----
+cached_cost_per_million = info.input_cost_per_million
+⋮----
+def set_stream(self, stream: bool) -> bool
+⋮----
+"""Enable or disable streaming output from API.
+        Args:
+            stream: enable streaming output from API
+        Returns: previous value of stream
+        """
+tmp = self.config.stream
+⋮----
+def get_stream(self) -> bool
+⋮----
+"""Get streaming status."""
+⋮----
+"""Separate inline reasoning from text tokens in a streaming chunk.
+
+        When models embed thinking inside content (e.g. <think>...</think>)
+        rather than using a separate reasoning field, this splits the chunk
+        into text-only and reasoning-only portions for proper streamer routing.
+
+        Returns (text_tokens, reasoning_tokens, in_reasoning).
+        """
+text_tokens = event_text
+reasoning_tokens = event_reasoning
+⋮----
+remaining = event_text
+⋮----
+text_tokens = ""
+⋮----
+text_tokens = before
+remaining = after
+in_reasoning = True
+⋮----
+reasoning_tokens = before
+in_reasoning = False
+⋮----
+reasoning_tokens = remaining
+⋮----
+"""Process state vars while processing a streaming API response.
+            Returns a tuple consisting of:
+        - is_break: whether to break out of the loop
+        - has_function: whether the response contains a function_call
+        - function_name: name of the function
+        - function_args: args of the function
+        - completion: completion text
+        - reasoning: reasoning text
+        - usage: usage dict
+        """
+# convert event obj (of type ChatCompletionChunk) to dict so rest of code,
+# which expects dicts, works as it did before switching to openai v1.x
+⋮----
+event = event.model_dump()
+⋮----
+usage = event.get("usage", {}) or {}
+choices = event.get("choices", [{}])
+⋮----
+choices = [{}]
+⋮----
+# we have a "usage" chunk, and empty choices, so we're done
+# ASSUMPTION: a usage chunk ONLY arrives AFTER all normal completion text!
+# If any API does not follow this, we need to change this code.
+⋮----
+event_args = ""
+event_fn_name = ""
+event_tool_deltas: Optional[List[Dict[str, Any]]] = None
+silent = settings.quiet
+# The first two events in the stream of Azure OpenAI is useless.
+# In the 1st: choices list is empty, in the 2nd: the dict delta has null content
+⋮----
+delta = choices[0].get("delta", {}) or {}
+# capture both content and reasoning_content
+event_text = delta.get("content", "")
+event_reasoning = delta.get(
+⋮----
+event_fn_name = delta["function_call"]["name"]
+⋮----
+event_args = delta["function_call"]["arguments"]
+⋮----
+# it's a list of deltas, usually just one
+event_tool_deltas = delta["tool_calls"]
+⋮----
+event_text = choices[0]["text"]
+event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
+⋮----
+finish_reason = choices[0].get("finish_reason", "")
+⋮----
+filter_names = [
+event_text = (
+⋮----
+function_name = event_fn_name
+has_function = True
+⋮----
+# print out streaming tool calls, if not async
+⋮----
+tool_fn_name = td["function"]["name"]
+⋮----
+tool_fn_args = td["function"]["arguments"]
+⋮----
+# show this delta in the stream
+is_break = finish_reason in [
+# for function_call, finish_reason does not necessarily
+# contain "function_call" as mentioned in the docs.
+# So we check for "stop" or "function_call" here.
+⋮----
+# we got usage chunk, and empty choices, so we're done
+⋮----
+silent = self.config.async_stream_quiet or settings.quiet
+⋮----
+is_break = choices[0].get("finish_reason", "") in [
+⋮----
+def _stream_response(  # type: ignore
+⋮----
+"""
+        Grab and print streaming response from API.
+        Args:
+            response: event-sequence emitted by API
+            chat: whether in chat-mode (or else completion-mode)
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                Dict version of OpenAIResponse object (with choices, usage)
+
+        """
+completion = ""
+reasoning = ""
+function_args = ""
+function_name = ""
+⋮----
+has_function = False
+tool_deltas: List[Dict[str, Any]] = []
+token_usage: Dict[str, int] = {}
+done: bool = False
+in_reasoning: bool = False  # Track if we're inside reasoning delimiters
+content_present = False
+⋮----
+event_dict = event if isinstance(event, dict) else event.model_dump()
+choices = event_dict.get("choices") or []
+⋮----
+delta = choices[0].get("delta") or {}
+content_present = content_present or (
+⋮----
+# capture the token usage when non-empty
+token_usage = usage
+⋮----
+# if not streaming, then we don't wait for last "usage" chunk
+⋮----
+# mark done, so we quit after the last "usage" chunk
+done = True
+⋮----
+# TODO- get usage info in stream mode (?)
+⋮----
+async def _stream_response_async(  # type: ignore
+⋮----
+"""
+        Grab and print streaming response from API.
+        Args:
+            response: event-sequence emitted by API
+            chat: whether in chat-mode (or else completion-mode)
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                OpenAIResponse object (with choices, usage)
+
+        """
+⋮----
+# mark done, so we quit after the next "usage" chunk
+⋮----
+"""
+        Convert accumulated tool-call deltas to OpenAIToolCall objects.
+        Adapted from this excellent code:
+         https://community.openai.com/t/help-for-function-calls-with-streaming/627170/2
+
+        Args:
+            tools: list of tool deltas received from streaming API
+
+        Returns:
+            str: plain text corresponding to tool calls that failed to parse
+            List[OpenAIToolCall]: list of OpenAIToolCall objects
+            List[Dict[str, Any]]: list of tool dicts
+                (to reconstruct OpenAI API response, so it can be cached)
+        """
+# Initialize a dictionary with default values
+⋮----
+# idx -> dict repr of tool
+# (used to simulate OpenAIResponse object later, and also to
+# accumulate function args as strings)
+idx2tool_dict: Dict[str, Dict[str, Any]] = defaultdict(
+⋮----
+# (try to) parse the fn args of each tool
+contents: List[str] = []
+good_indices = []
+id2args: Dict[str, None | Dict[str, Any]] = {}
+⋮----
+# used to build tool_calls_list below
+id2args[tool_dict["id"]] = args_dict or None  # if {}, store as None
+⋮----
+# remove the failed tool calls
+idx2tool_dict = {
+⋮----
+# create OpenAIToolCall list
+tool_calls_list = [
+⋮----
+@staticmethod
+    def _parse_function_args(args: str) -> Tuple[str, Dict[str, Any]]
+⋮----
+"""
+        Try to parse the `args` string as function args.
+
+        Args:
+            args: string containing function args
+
+        Returns:
+            Tuple of content, function name and args dict.
+            If parsing unsuccessful, returns the original string as content,
+            else returns the args dict.
+        """
+content = ""
+args_dict = {}
+⋮----
+stripped_fn_args = args.strip()
+dict_or_list = parse_imperfect_json(stripped_fn_args)
+⋮----
+args_dict = dict_or_list
+⋮----
+content = args
+⋮----
+"""
+        Create an LLMResponse object from the streaming API response.
+
+        Args:
+            chat: whether in chat-mode (or else completion-mode)
+            tool_deltas: list of tool deltas received from streaming API
+            has_function: whether the response contains a function_call
+            completion: completion text
+            reasoning: reasoning text
+            function_args: string representing function args
+            function_name: name of the function
+            usage: token usage dict
+            content_present: whether a stream delta explicitly contained content
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                Dict version of OpenAIResponse object (with choices, usage)
+                    (this is needed so we can cache the response, as if it were
+                    a non-streaming response)
+        """
+# check if function_call args are valid, if not,
+# treat this as a normal msg, not a function call
+args: Dict[str, Any] = {}
+⋮----
+completion = completion + content
+⋮----
+# mock openai response so we can cache it
+⋮----
+content_present = True
+has_valid_call = len(tool_dicts) > 0 or has_function
+response_content = (
+msg: Dict[str, Any] = dict(
+⋮----
+function_call = LLMFunctionCall(name=function_name)
+function_call_dict = function_call.model_dump()
+⋮----
+# non-chat mode has no function_call
+msg = dict(text=completion)
+response_content = completion
+# TODO: Ignoring reasoning content for non-chat models
+⋮----
+# create an OpenAIResponse object so we can cache it as if it were
+# a non-streaming response
+openai_response = OpenAIResponse(
+# Track whether we extracted inline thought tags from the text.
+# Only set message_with_reasoning when get_reasoning_final()
+# actually finds and extracts inline tags (e.g. <think>...</think>).
+# When reasoning is already provided via a separate API field
+# (e.g. reasoning_content), the message text doesn't contain
+# thought signatures, so there's nothing extra to preserve.
+message_with_reasoning = None
+message: str | None
+⋮----
+# some LLM APIs may not return a separate reasoning field,
+# and the reasoning may be included in the message content
+# within delimiters like <think> ... </think>
+⋮----
+# Inline tags were found and extracted; preserve the
+# original text so it can be restored in message history.
+message_with_reasoning = response_content
+⋮----
+message = response_content
+⋮----
+prompt_tokens = usage.get("prompt_tokens", 0)
+prompt_tokens_details: Any = usage.get("prompt_tokens_details", {})
+cached_tokens = (
+completion_tokens = usage.get("completion_tokens", 0)
+⋮----
+# don't allow empty list [] here
+⋮----
+def _cache_store(self, k: str, v: Any) -> None
+⋮----
+def _cache_lookup(self, fn_name: str, **kwargs: Dict[str, Any]) -> Tuple[str, Any]
+⋮----
+return "", None  # no cache, return empty key and None result
+# Use the kwargs as the cache key
+sorted_kwargs_str = str(sorted(kwargs.items()))
+raw_key = f"{fn_name}:{sorted_kwargs_str}"
+⋮----
+# Hash the key to a fixed length using SHA256
+hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
+⋮----
+# when caching disabled, return the hashed_key and none result
+⋮----
+# Try to get the result from the cache
+⋮----
+cached_val = self.cache.retrieve(hashed_key)
+⋮----
+def _cost_chat_model(self, prompt: int, cached: int, completion: int) -> float
+⋮----
+price = self.chat_cost()
+⋮----
+"""
+        Extracts token usage from ``response`` and computes cost, only when NOT
+        in streaming mode, since the LLM API (OpenAI currently) was not
+        populating the usage fields in streaming mode (but as of Sep 2024, streaming
+        responses include  usage info as well, so we should update the code
+        to directly use usage information from the streaming response, which is more
+        accurate, esp with "thinking" LLMs like o1 series which consume
+        thinking tokens).
+        In streaming mode, these are set to zero for
+        now, and will be updated later by the fn ``update_token_usage``.
+        """
+cost = 0.0
+prompt_tokens = 0
+cached_tokens = 0
+completion_tokens = 0
+⋮----
+usage = response.get("usage")
+⋮----
+prompt_tokens = usage.get("prompt_tokens") or 0
+prompt_tokens_details = usage.get("prompt_tokens_details", {}) or {}
+cached_tokens = prompt_tokens_details.get("cached_tokens") or 0
+completion_tokens = usage.get("completion_tokens") or 0
+cost = self._cost_chat_model(
+⋮----
+def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+# Catch HTTP-level API errors (400, 401, 403, 404, 422, 429, 5xx)
+# without traceback — these originate server-side and a local
+# stack trace adds no diagnostic value.
+# Note: APIConnectionError/APITimeoutError are intentionally NOT
+# caught here so they fall through to the generic handler below,
+# where the full traceback aids in diagnosing local network issues.
+⋮----
+# log and re-raise exception
+⋮----
+def _generate(self, prompt: str, max_tokens: int) -> LLMResponse
+⋮----
+@retry_with_exponential_backoff
+        def completions_with_backoff(**kwargs):  # type: ignore
+⋮----
+cached = False
+⋮----
+cached = True
+⋮----
+completion_call = litellm_completion
+⋮----
+completion_call = self.client.completions.create
+⋮----
+# If it's not in the cache, call the API
+result = completion_call(**kwargs)
+⋮----
+kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
+⋮----
+# TODO this is a temp fix, we should really be using a proper completion fn
+# that takes a pre-formatted prompt, rather than mocking it as a sys msg.
+⋮----
+else:  # any other OpenAI-compatible endpoint
+⋮----
+args = dict(
+⋮----
+max_tokens=max_tokens,  # for output/completion
+⋮----
+args = self._openai_api_call_params(args)
+⋮----
+# assume response is an actual response rather than a streaming event
+⋮----
+response = response.model_dump()
+⋮----
+msg = (response["choices"][0]["message"]["content"] or "").strip()
+⋮----
+msg = (response["choices"][0]["text"] or "").strip()
+⋮----
+async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+# Catch HTTP-level API errors (see comment in generate() above).
+⋮----
+async def _agenerate(self, prompt: str, max_tokens: int) -> LLMResponse
+⋮----
+# note we typically will not have self.config.stream = True
+# when issuing several api calls concurrently/asynchronously.
+# The calling fn should use the context `with Streaming(..., False)` to
+# disable streaming.
+⋮----
+# WARNING: .Completion.* endpoints are deprecated,
+# and as of Sep 2023 only legacy models will work here,
+# e.g. text-davinci-003, text-ada-001.
+⋮----
+@async_retry_with_exponential_backoff
+        async def completions_with_backoff(**kwargs):  # type: ignore
+⋮----
+# TODO this may not work: text_completion is not async,
+# and we didn't find an async version in litellm
+⋮----
+acompletion_call = (
+⋮----
+result = await acompletion_call(**kwargs)
+⋮----
+# only makes sense for non-OpenAI models
+⋮----
+messages = [
+prompt = self.config.hf_formatter.format(messages)
+⋮----
+# turn off streaming for async calls
+⋮----
+# only makes sense for local models, where we are trying to
+# convert a chat dialog msg-sequence to a simple completion prompt.
+⋮----
+formatter = HFFormatter(
+⋮----
+prompt = formatter.format(messages)
+⋮----
+result = await self._achat(
+⋮----
+def _chat_completions_with_backoff_body(self, **kwargs):  # type: ignore
+⋮----
+completion_call = self.client.chat.completions.create
+⋮----
+# If streaming, cannot cache result
+# since it is a generator. Instead,
+# we hold on to the hashed_key and
+# cache the result later
+⋮----
+# Test if this is a stream with an exception by
+# trying to get first chunk: Some providers like LiteLLM
+# produce a valid stream object `result` instead of throwing a
+# rate-limit error, and if we don't catch it here,
+# we end up returning an empty response and not
+# using the retry mechanism in the decorator.
+⋮----
+# try to get the first chunk to check for errors
+test_iter = iter(result)
+first_chunk = next(test_iter)
+# If we get here without error, recreate the stream
+result = chain([first_chunk], test_iter)
+⋮----
+# Empty stream is fine
+⋮----
+# Propagate any errors in the stream
+⋮----
+def _chat_completions_with_backoff(self, **kwargs):  # type: ignore
+⋮----
+retry_func = retry_with_exponential_backoff(
+⋮----
+async def _achat_completions_with_backoff_body(self, **kwargs):  # type: ignore
+⋮----
+acompletion_call = litellm_acompletion
+⋮----
+acompletion_call = self.async_client.chat.completions.create
+⋮----
+# Try to peek at the first chunk to immediately catch any errors
+# Store the original result (the stream)
+original_stream = result
+⋮----
+# Manually create and advance the iterator to check for errors
+stream_iter = original_stream.__aiter__()
+⋮----
+# This will raise an exception if the stream is invalid
+first_chunk = await anext(stream_iter)
+⋮----
+# If we reach here, the stream started successfully
+# Now recreate a fresh stream from the original API result
+# Otherwise, return a new stream that yields the first chunk
+# and remaining items
+async def combined_stream():  # type: ignore
+⋮----
+result = combined_stream()  # type: ignore
+⋮----
+# Empty stream is normal - nothing to do
+⋮----
+# Any exception here should be raised to trigger the retry mechanism
+⋮----
+async def _achat_completions_with_backoff(self, **kwargs):  # type: ignore
+⋮----
+retry_func = async_retry_with_exponential_backoff(
+⋮----
+"""Prepare args for LLM chat-completion API call"""
+⋮----
+llm_messages = [
+⋮----
+llm_messages = messages
+⋮----
+# TODO: we will unconditionally insert a dummy user msg
+# if the only msg is a system msg.
+# We could make this conditional on ModelInfo.needs_first_user_message
+⋮----
+# some LLMs, notable Gemini as of 12/11/24,
+# require the first message to be from the user,
+# so insert a dummy user msg if needed.
+⋮----
+chat_model = self.config.chat_model
+⋮----
+args: Dict[str, Any] = dict(
+⋮----
+# groq fails when we include stream_options in the request
+⋮----
+# get token-usage numbers in stream mode from OpenAI API,
+# and possibly other OpenAI-compatible APIs.
+⋮----
+# only include functions-related args if functions are provided
+# since the OpenAI API will throw an error if `functions` is None or []
+⋮----
+# some models e.g. o1-mini (as of sep 2024) don't support some params,
+# like temperature and stream, so we need to remove them.
+⋮----
+param_rename_map = self.rename_params()
+⋮----
+# finally, get rid of extra_body params exclusive to certain models
+# Only apply allowlist restrictions for known models.
+# Unknown/custom models are allowed to use all params by default.
+is_known_model = self.info().name != "unknown"
+extra_params = args.get("extra_body", {})
+⋮----
+# openAI response will look like this:
+"""
+        {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1677652288,
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "name": "",
+                    "content": "\n\nHello there, how may I help you?",
+                    "reasoning_content": "Okay, let's see here, hmmm...",
+                    "function_call": {
+                        "name": "fun_name",
+                        "arguments: {
+                            "arg1": "val1",
+                            "arg2": "val2"
+                        }
+                    },
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 12,
+                "total_tokens": 21
+            }
+        }
+        """
+choices = response.get("choices")
+⋮----
+message = choices[0].get("message", {})
+⋮----
+message = {}
+⋮----
+content = message.get("content")
+reasoning = message.get("reasoning_content", "")
+⋮----
+message_with_reasoning = content
+⋮----
+msg = content
+⋮----
+fun_call = None
+⋮----
+fun_call = LLMFunctionCall.from_dict(message["function_call"])
+⋮----
+args_str = message["function_call"]["arguments"] or ""
+msg_str = message["content"] or ""
+msg = msg_str + args_str
+oai_tool_calls = None
+⋮----
+oai_tool_calls = []
+⋮----
+tool_call = OpenAIToolCall.from_dict(tool_call_dict)
+⋮----
+serialized_tool_call = json.dumps(tool_call_dict)
+msg = (msg or "") + ("\n" if msg else "") + serialized_tool_call
+⋮----
+# None (no content, e.g. a tool-call-only response) is preserved as
+# None rather than coerced to "", so the distinction survives
+# downstream (see LLMMessage.content / ChatDocument.content_is_none).
+⋮----
+oai_tool_calls=oai_tool_calls or None,  # don't allow empty list [] here
+⋮----
+"""
+        ChatCompletion API call to OpenAI.
+        Args:
+            messages: list of messages  to send to the API, typically
+                represents back and forth dialogue between user and LLM, but could
+                also include "function"-role messages. If messages is a string,
+                it is assumed to be a user message.
+            max_tokens: max output tokens to generate
+            functions: list of LLMFunction specs available to the LLM, to possibly
+                use in its response
+            function_call: controls how the LLM uses `functions`:
+                - "auto": LLM decides whether to use `functions` or not,
+                - "none": LLM blocked from using any function
+                - a dict of {"name": "function_name"} which forces the LLM to use
+                    the specified function.
+        Returns:
+            LLMResponse object
+        """
+args = self._prep_chat_completion(
+cached, hashed_key, response = self._chat_completions_with_backoff(**args)  # type: ignore
+⋮----
+return llm_response  # type: ignore
+⋮----
+response_dict = response
+⋮----
+response_dict = response.model_dump()
+⋮----
+"""
+        Async version of _chat(). See that function for details.
+        """
+⋮----
+cached, hashed_key, response = await self._achat_completions_with_backoff(  # type: ignore
+</file>
+
+<file path="langroid/vector_store/base.py">
+logger = logging.getLogger(__name__)
+⋮----
+# the exact shape Kubernetes service links inject, e.g. tcp://10.0.0.8:6333
+# (\Z, not $: $ would match before a trailing newline, silently
+# discarding a value that should fail validation)
+_SERVICE_LINK_PORT_RE = re.compile(r"^tcp://\S+:\d+\Z")
+⋮----
+class _ServiceLinkPortFilter(PydanticBaseSettingsSource)
+⋮----
+"""Env-source wrapper dropping k8s/docker service-link `port` values.
+
+    With `enableServiceLinks` (on by default in Kubernetes), a service
+    named e.g. `qdrant` injects `QDRANT_PORT=tcp://IP:PORT` into every
+    pod, which would otherwise fail integer validation of the `port`
+    field. If the wrapped env source yields a `port` string matching
+    exactly that format, it is dropped (with a warning) so the class
+    default applies. Any other value — including malformed `tcp://`
+    junk, or a `tcp://` value passed to the constructor (which never
+    goes through this source) — still fails validation as usual.
+    """
+⋮----
+def __init__(self, wrapped: PydanticBaseSettingsSource) -> None
+⋮----
+def __call__(self) -> Dict[str, Any]
+⋮----
+values = self._wrapped()
+port = values.get("port")
+⋮----
+default = self.settings_cls.model_fields["port"].default
+⋮----
+values = {k: v for k, v in values.items() if k != "port"}
+⋮----
+class VectorStoreConfig(BaseSettings)
+⋮----
+# Without a prefix, every field name would itself be a
+# case-insensitive env var (e.g. a bare HOST, PORT, or FULL_EVAL
+# in the environment would silently override defaults); subclasses
+# each set their own prefix (QDRANT_, LANCEDB_, ...).
+model_config = SettingsConfigDict(env_prefix="VECDB_")
+⋮----
+type: str = ""  # deprecated, keeping it for backward compatibility
+collection_name: str | None = "temp"
+replace_collection: bool = False  # replace collection if it already exists
+storage_path: str = ".qdrant/data"
+cloud: bool = False
+batch_size: int = 200
+embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig(
+embedding_model: Optional[EmbeddingModel] = None
+timeout: int = 60
+host: str = "127.0.0.1"
+port: int = 6333
+# used when parsing search results back as Document objects
+document_class: Type[Document] = Document
+metadata_class: Type[DocMetaData] = DocMetaData
+# compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
+full_eval: bool = False  # runs eval without sanitization. Use only on trusted input
+⋮----
+"""Wrap the env source to drop k8s service-link `port` values.
+
+        Source precedence is unchanged (init beats env, etc.); only the
+        env source is filtered — see `_ServiceLinkPortFilter`.
+        """
+⋮----
+class VectorStore(ABC)
+⋮----
+"""
+    Abstract base class for a vector store.
+    """
+⋮----
+def __init__(self, config: VectorStoreConfig)
+⋮----
+@staticmethod
+    def create(config: VectorStoreConfig) -> Optional["VectorStore"]
+⋮----
+@property
+    def embedding_dim(self) -> int
+⋮----
+def clone(self) -> "VectorStore"
+⋮----
+"""Return a vector-store clone suitable for agent cloning.
+
+        The default implementation deep-copies the configuration, reuses any
+        existing embedding model, and instantiates a fresh store of the same
+        type. Subclasses can override when sharing the instance is required
+        (e.g., embedded/local stores that rely on file locks).
+        """
+⋮----
+config_class = self.config.__class__
+config_data = self.config.model_dump(mode="python")
+⋮----
+config_copy = config_class.model_validate(config_data)
+⋮----
+# Preserve the calculated collection contents without forcing replaces
+⋮----
+config_copy.replace_collection = False  # type: ignore[attr-defined]
+cloned_embedding: Optional[EmbeddingModel] = None
+⋮----
+cloned_embedding = self.embedding_model.clone()  # type: ignore[attr-defined]
+⋮----
+cloned_store = type(self)(config_copy)  # type: ignore[call-arg]
+⋮----
+# Some stores might not honour replace_collection; ensure same collection
+⋮----
+@abstractmethod
+    def clear_empty_collections(self) -> int
+⋮----
+"""Clear all empty collections in the vector store.
+        Returns the number of collections deleted.
+        """
+⋮----
+@abstractmethod
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int
+⋮----
+"""
+        Clear all collections in the vector store.
+
+        Args:
+            really (bool, optional): Whether to really clear all collections.
+                Defaults to False.
+            prefix (str, optional): Prefix of collections to clear.
+        Returns:
+            int: Number of collections deleted.
+        """
+⋮----
+@abstractmethod
+    def list_collections(self, empty: bool = False) -> List[str]
+⋮----
+"""List all collections in the vector store
+        (only non empty collections if empty=False).
+        """
+⋮----
+def set_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+"""
+        Set the current collection to the given collection name.
+        Args:
+            collection_name (str): Name of the collection.
+            replace (bool, optional): Whether to replace the collection if it
+                already exists. Defaults to False.
+        """
+⋮----
+@abstractmethod
+    def create_collection(self, collection_name: str, replace: bool = False) -> None
+⋮----
+"""Create a collection with the given name.
+        Args:
+            collection_name (str): Name of the collection.
+            replace (bool, optional): Whether to replace the
+                collection if it already exists. Defaults to False.
+        """
+⋮----
+@abstractmethod
+    def add_documents(self, documents: Sequence[Document]) -> None
+⋮----
+def compute_from_docs(self, docs: List[Document], calc: str) -> str
+⋮----
+"""Compute a result on a set of documents,
+        using a dataframe calc string like `df.groupby('state')['income'].mean()`.
+
+        If full_eval is False (default), the input expression is sanitized to prevent
+        most common code injection attack vectors.
+        If full_eval is True, sanitization is bypassed - use only with trusted input!
+        """
+# convert each doc to a dict, using dotted paths for nested fields
+dicts = [flatten_dict(doc.model_dump(by_alias=True)) for doc in docs]
+df = pd.DataFrame(dicts)
+⋮----
+# SECURITY MITIGATION: Eval input is sanitized to prevent most common
+# code injection attack vectors when full_eval is False. The globals
+# dict also restricts ``__builtins__`` so that even with
+# ``full_eval=True`` the expression cannot reach
+# ``__import__``/``eval``/``exec`` via Python's implicit builtin
+# injection (GHSA-q9p7-wqxg-mrhc).
+vars = {"df": df}
+⋮----
+calc = sanitize_command(calc)
+code = compile(calc, "<calc>", "eval")
+result = eval(code, safe_eval_globals(vars), {})
+⋮----
+# return error message so LLM can fix the calc string if needed
+err = f"""
+⋮----
+# Pd.eval sometimes fails on a perfectly valid exprn like
+# df.loc[..., 'column'] with a KeyError.
+⋮----
+def maybe_add_ids(self, documents: Sequence[Document]) -> None
+⋮----
+"""Add ids to metadata if absent, since some
+        vecdbs don't like having blank ids."""
+⋮----
+"""
+        Find k most similar texts to the given text, in terms of vector distance metric
+        (e.g., cosine similarity).
+
+        Args:
+            text (str): The text to find similar texts for.
+            k (int, optional): Number of similar texts to retrieve. Defaults to 1.
+            where (Optional[str], optional): Where clause to filter the search.
+
+        Returns:
+            List[Tuple[Document,float]]: List of (Document, score) tuples.
+
+        """
+⋮----
+"""
+        In each doc's metadata, there may be a window_ids field indicating
+        the ids of the chunks around the current chunk.
+        These window_ids may overlap, so we
+        - coalesce each overlapping groups into a single window (maintaining ordering),
+        - create a new document for each part, preserving metadata,
+
+        We may have stored a longer set of window_ids than we need during chunking.
+        Now, we just want `neighbors` on each side of the center of the window_ids list.
+
+        Args:
+            docs_scores (List[Tuple[Document, float]]): List of pairs of documents
+                to add context windows to together with their match scores.
+            neighbors (int, optional): Number of neighbors on "each side" of match to
+                retrieve. Defaults to 0.
+                "Each side" here means before and after the match,
+                in the original text.
+
+        Returns:
+            List[Tuple[Document, float]]: List of (Document, score) tuples.
+        """
+# We return a larger context around each match, i.e.
+# a window of `neighbors` on each side of the match.
+docs = [d for d, s in docs_scores]
+scores = [s for d, s in docs_scores]
+⋮----
+doc_chunks = [d for d in docs if d.metadata.is_chunk]
+⋮----
+window_ids_list = []
+id2metadata = {}
+# id -> highest score of a doc it appears in
+id2max_score: Dict[int | str, float] = {}
+⋮----
+window_ids = d.metadata.window_ids
+⋮----
+window_ids = [d.id()]
+⋮----
+n = len(window_ids)
+chunk_idx = window_ids.index(d.id())
+neighbor_ids = window_ids[
+⋮----
+# window_ids could be from different docs,
+# and they may overlap, so we coalesce overlapping groups into
+# separate windows.
+window_ids_list = self.remove_overlaps(window_ids_list)
+final_docs = []
+final_scores = []
+⋮----
+metadata = copy.deepcopy(id2metadata[w[0]])
+⋮----
+document = Document(
+# make a fresh id since content is in general different
+⋮----
+@staticmethod
+    def remove_overlaps(windows: List[List[str]]) -> List[List[str]]
+⋮----
+"""
+        Given a collection of windows, where each window is a sequence of ids,
+        identify groups of overlapping windows, and for each overlapping group,
+        order the chunk-ids using topological sort so they appear in the original
+        order in the text.
+
+        Args:
+            windows (List[int|str]): List of windows, where each window is a
+                sequence of ids.
+
+        Returns:
+            List[int|str]: List of windows, where each window is a sequence of ids,
+                and no two windows overlap.
+        """
+ids = set(id for w in windows for id in w)
+# id -> {win -> # pos}
+id2win2pos: Dict[str, Dict[int, int]] = {id: {} for id in ids}
+⋮----
+n = len(windows)
+# relation between windows:
+order = np.zeros((n, n), dtype=np.int8)
+⋮----
+id = list(set(w).intersection(x))[0]  # any common id
+⋮----
+order[i, j] = -1  # win i is before win j
+⋮----
+order[i, j] = 1  # win i is after win j
+⋮----
+# find groups of windows that overlap, like connected components in a graph
+groups = components(np.abs(order))
+⋮----
+# order the chunk-ids in each group using topological sort
+new_windows = []
+⋮----
+# find total ordering among windows in group based on order matrix
+# (this is a topological sort)
+_g = np.array(g)
+order_matrix = order[_g][:, _g]
+ordered_window_indices = topological_sort(order_matrix)
+ordered_window_ids = [windows[i] for i in _g[ordered_window_indices]]
+flattened = [id for w in ordered_window_ids for id in w]
+flattened_deduped = list(dict.fromkeys(flattened))
+# Note we are not going to split these, and instead we'll return
+# larger windows from concatenating the connected groups.
+# This ensures context is retained for LLM q/a
+⋮----
+@abstractmethod
+    def get_all_documents(self, where: str = "") -> List[Document]
+⋮----
+"""
+        Get all documents in the current collection, possibly filtered by `where`.
+        """
+⋮----
+@abstractmethod
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]
+⋮----
+"""
+        Get documents by their ids.
+        Args:
+            ids (List[str]): List of document ids.
+
+        Returns:
+            List[Document]: List of documents
+        """
+⋮----
+@abstractmethod
+    def delete_collection(self, collection_name: str) -> None
+⋮----
+def show_if_debug(self, doc_score_pairs: List[Tuple[Document, float]]) -> None
 </file>
 
 <file path="langroid/agent/special/sql/sql_chat_agent.py">
@@ -40700,1115 +41956,6 @@ model_names = tuple(_model_name(model) for model in models)
 def _model_name(model: str | ModelName) -> str
 </file>
 
-<file path="langroid/language_models/openai_gpt.py">
-OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
-⋮----
-OLLAMA_BASE_URL = "http://localhost:11434/v1"
-⋮----
-DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
-# Provider prefixes that route to the Gemini OpenAI-compatible API.
-GEMINI_MODEL_PREFIXES = ("gemini/", "google/gemini-")
-GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
-MINIMAX_BASE_URL = "https://api.minimax.io/v1"
-OLLAMA_API_KEY = "ollama"
-⋮----
-VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
-LLAMACPP_API_KEY = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
-⋮----
-openai_chat_model_pref_list = [
-⋮----
-openai_completion_model_pref_list = [
-⋮----
-available_models = set(map(lambda m: m.id, OpenAI().models.list()))
-⋮----
-available_models = set()
-⋮----
-default_openai_chat_model = next(
-default_openai_completion_model = next(
-⋮----
-class AccessWarning(Warning)
-⋮----
-@cache
-def gpt_3_5_warning() -> None
-⋮----
-@cache
-def parallel_strict_warning() -> None
-⋮----
-def noop() -> None
-⋮----
-"""Does nothing."""
-⋮----
-class OpenAICallParams(BaseModel)
-⋮----
-"""
-    Various params that can be sent to an OpenAI API chat-completion call.
-    When specified, any param here overrides the one with same name in the
-    OpenAIGPTConfig.
-    See OpenAI API Reference for details on the params:
-    https://platform.openai.com/docs/api-reference/chat
-    """
-⋮----
-max_tokens: int | None = None
-temperature: float | None = None
-frequency_penalty: float | None = None  # between -2 and 2
-presence_penalty: float | None = None  # between -2 and 2
-response_format: Dict[str, str] | None = None
-logit_bias: Dict[int, float] | None = None  # token_id -> bias
-logprobs: bool | None = None
-top_p: float | None = None
-reasoning_effort: str | None = None  # or "low" or "high" or "medium"
-top_logprobs: int | None = None  # if int, requires logprobs=True
-n: int | None = None  # how many completions to generate (n > 1 is NOT handled now)
-stop: str | List[str] | None = None  # (list of) stop sequence(s)
-seed: int | None = None
-user: str | None = None  # user id for tracking
-extra_body: Dict[str, Any] | None = None  # additional params for API request body
-⋮----
-def to_dict_exclude_none(self) -> Dict[str, Any]
-⋮----
-class LiteLLMProxyConfig(BaseSettings)
-⋮----
-"""Configuration for LiteLLM proxy connection."""
-⋮----
-api_key: str = ""  # read from env var LITELLM_API_KEY if set
-api_base: str = ""  # read from env var LITELLM_API_BASE if set
-⋮----
-model_config = SettingsConfigDict(env_prefix="LITELLM_")
-⋮----
-class OpenAIGPTConfig(LLMConfig)
-⋮----
-"""
-    Class for any LLM with an OpenAI-like API: besides the OpenAI models this includes:
-    (a) locally-served models behind an OpenAI-compatible API
-    (b) non-local models, using a proxy adaptor lib like litellm that provides
-        an OpenAI-compatible API.
-    (We could rename this class to OpenAILikeConfig, but we keep it as-is for now)
-
-    Important Note:
-    Due to the `env_prefix = "OPENAI_"` defined below,
-    all of the fields below can be set AND OVERRIDDEN via env vars,
-    # by upper-casing the name and prefixing with OPENAI_, e.g.
-    # OPENAI_MAX_OUTPUT_TOKENS=1000.
-    # If any of these is defined in this way in the environment
-    # (either via explicit setenv or export or via .env file + load_dotenv()),
-    # the environment variable takes precedence over the value in the config.
-    """
-⋮----
-type: str = "openai"
-api_key: str = DUMMY_API_KEY
-# Callable returning a fresh API key/bearer token, for endpoints that
-# authenticate with short-lived rotating credentials (e.g. Vertex AI
-# OAuth tokens, Azure Entra ID). Resolved per-request by the OpenAI
-# client, and excluded from the client-cache key (the cache is keyed on
-# the provider's identity), so rotating tokens neither go stale nor grow
-# the cache. Takes precedence over `api_key`. Only supported for models
-# served via an OpenAI-compatible endpoint (not Groq/Cerebras/litellm).
-# See docs/notes/rotating-api-keys.md.
-api_key_provider: Optional[Callable[[], str]] = None
-organization: str = ""
-api_base: str | None = None  # used for local or other non-OpenAI models
-litellm: bool = False  # use litellm api?
-litellm_proxy: LiteLLMProxyConfig = LiteLLMProxyConfig()
-ollama: bool = False  # use ollama's OpenAI-compatible endpoint?
-min_output_tokens: int = 1
-use_chat_for_completion: bool = True  # do not change this, for OpenAI models!
-timeout: int = 20
-temperature: float = 0.2
-seed: int | None = 42
-params: OpenAICallParams | None = None
-use_cached_client: bool = (
-⋮----
-True  # Whether to reuse cached clients (prevents resource exhaustion)
-⋮----
-# these can be any model name that is served at an OpenAI-compatible API end point
-chat_model: str = default_openai_chat_model
-chat_model_orig: Optional[str] = None
-completion_model: str = default_openai_completion_model
-run_on_first_use: Callable[[], None] = noop
-parallel_tool_calls: Optional[bool] = None
-# Supports constrained decoding which enforces that the output of the LLM
-# adheres to a JSON schema
-supports_json_schema: Optional[bool] = None
-# Supports strict decoding for the generation of tool calls with
-# the OpenAI Tools API; this ensures that the generated tools
-# adhere to the provided schema.
-supports_strict_tools: Optional[bool] = None
-# a string that roughly matches a HuggingFace chat_template,
-# e.g. "mistral-instruct-v0.2 (a fuzzy search is done to find the closest match)
-formatter: str | None = None
-hf_formatter: HFFormatter | None = None
-langdb_params: LangDBParams = LangDBParams()
-portkey_params: PortkeyParams = PortkeyParams()
-headers: Dict[str, str] = {}
-http_client_factory: Optional[Callable[[], Any]] = (
-⋮----
-None  # Factory: returns Client or (Client, AsyncClient)
-⋮----
-http_verify_ssl: bool = True  # Simple flag for SSL verification
-http_client_config: Optional[Dict[str, Any]] = None  # Config dict for httpx.Client
-_api_base_was_supplied: bool = False
-⋮----
-def __init__(self, **kwargs) -> None:  # type: ignore
-⋮----
-api_base_was_supplied = "api_base" in kwargs
-local_model = "api_base" in kwargs and kwargs["api_base"] is not None
-⋮----
-chat_model = kwargs.get("chat_model", "")
-local_prefixes = ["local/", "litellm/", "ollama/", "vllm/", "llamacpp/"]
-⋮----
-local_model = True
-⋮----
-warn_gpt_3_5 = (
-⋮----
-existing_hook = kwargs.get("run_on_first_use", noop)
-⋮----
-def with_warning() -> None
-⋮----
-env_prefix = self.model_config.get("env_prefix")
-env_api_base_name = f"{env_prefix}API_BASE"
-env_api_base = os.getenv(env_api_base_name)
-⋮----
-case_insensitive_env = {
-env_api_base = case_insensitive_env.get(env_api_base_name.lower())
-api_base_was_supplied = api_base_was_supplied or (
-⋮----
-model_config = SettingsConfigDict(env_prefix="OPENAI_")
-⋮----
-def __setattr__(self, name: str, value: Any) -> None
-⋮----
-"""Track API bases assigned after config construction."""
-⋮----
-"""
-        Copy config while preserving nested model instances and subclasses.
-
-        Important: Avoid reconstructing via `model_dump` as that coerces nested
-        models to their annotated base types (dropping subclass-only fields).
-        Instead, defer to Pydantic's native `model_copy`, which keeps nested
-        `BaseModel` instances (and their concrete subclasses) intact.
-
-        An `api_base` supplied through `update` is caller configuration, so the
-        copy must retain that provenance for provider-specific routing.
-        """
-# Delegate to BaseSettings/BaseModel implementation to preserve types
-copied = super().model_copy(update=update, deep=deep)
-⋮----
-return copied  # type: ignore[return-value]
-⋮----
-def _validate_litellm(self) -> None
-⋮----
-"""
-        When using liteLLM, validate whether all env vars required by the model
-        have been set.
-        """
-⋮----
-litellm.drop_params = True  # drop un-supported params without crashing
-⋮----
-self.seed = None  # some local mdls don't support seed
-⋮----
-keys_dict = litellm.utils.validate_environment(self.chat_model)
-missing_keys = keys_dict.get("missing_keys", [])
-⋮----
-@classmethod
-    def create(cls, prefix: str) -> Type["OpenAIGPTConfig"]
-⋮----
-"""Create a config class whose params can be set via a desired
-        prefix from the .env file or env vars.
-        E.g., using
-        ```python
-        OllamaConfig = OpenAIGPTConfig.create("ollama")
-        ollama_config = OllamaConfig()
-        ```
-        you can have a group of params prefixed by "OLLAMA_", to be used
-        with models served via `ollama`.
-        This way, you can maintain several setting-groups in your .env file,
-        one per model type.
-        """
-⋮----
-class DynamicConfig(OpenAIGPTConfig)
-⋮----
-class OpenAIResponse(BaseModel)
-⋮----
-"""OpenAI response model, either completion or chat."""
-⋮----
-choices: List[Dict]  # type: ignore
-usage: Dict  # type: ignore
-⋮----
-def litellm_logging_fn(model_call_dict: Dict[str, Any]) -> None
-⋮----
-"""Logging function for litellm"""
-⋮----
-api_input_dict = model_call_dict.get("additional_args", {}).get(
-⋮----
-text = escape(json.dumps(api_input_dict, indent=2))
-⋮----
-# Define a class for OpenAI GPT models that extends the base class
-class OpenAIGPT(LanguageModel)
-⋮----
-"""
-    Class for OpenAI LLMs
-    """
-⋮----
-client: OpenAI | Groq | Cerebras | None
-async_client: AsyncOpenAI | AsyncGroq | AsyncCerebras | None
-⋮----
-def __init__(self, config: OpenAIGPTConfig = OpenAIGPTConfig())
-⋮----
-"""
-        Args:
-            config: configuration for openai-gpt model
-        """
-# copy the config to avoid modifying the original; deep to decouple
-# nested models while preserving their concrete subclasses
-# The api_key_provider must NOT be deep-copied: the client cache is
-# keyed on its identity (so a copy would defeat cache sharing), and it
-# may hold non-copyable state (e.g. a threading.Lock). Clear it in a
-# shallow copy first, then restore the original callable afterwards.
-api_key_provider = config.api_key_provider
-⋮----
-config = config.model_copy(update={"api_key_provider": None})
-config = config.model_copy(deep=True)
-⋮----
-# save original model name such as `provider/model` before
-# we strip out the `provider` - we retain the original in
-# case some params are specific to a provider.
-⋮----
-# Run the first time the model is used
-⋮----
-# global override of chat_model,
-# to allow quick testing with other models
-⋮----
-# there is a formatter specified, e.g.
-# "litellm/ollama/mistral//hf" or
-# "local/localhost:8000/v1//mistral-instruct-v0.2"
-formatter = parts[1]
-⋮----
-# e.g. "litellm/ollama/mistral//hf" -> "litellm/ollama/mistral"
-formatter = find_hf_formatter(self.config.chat_model)
-⋮----
-# e.g. "mistral"
-⋮----
-# e.g. "local/localhost:8000/v1//mistral-instruct-v0.2"
-⋮----
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", DUMMY_API_KEY)
-⋮----
-# if model name starts with "litellm",
-# set the actual model name by stripping the "litellm/" prefix
-# and set the litellm flag to True
-⋮----
-# e.g. litellm/ollama/mistral
-⋮----
-# strip the "litellm/" prefix
-# e.g. litellm/ollama/llama2 => ollama/llama2
-⋮----
-# expect this to be of the form "local/localhost:8000/v1",
-# depending on how the model is launched locally.
-# In this case the model served locally behind an OpenAI-compatible API
-# so we can just use `openai.*` methods directly,
-# and don't need a adaptor library like litellm
-⋮----
-self.config.seed = None  # some models raise an error when seed is set
-# Extract the api_base from the model name after the "local/" prefix
-⋮----
-# use api_base from config if set, else fall back on OLLAMA_BASE_URL
-⋮----
-# If api_base is unset we use OpenAI's endpoint, which supports
-# these features (with JSON schema restricted to a limited set of models)
-⋮----
-# if we're overriding chat model globally, set completion model to same
-⋮----
-# we want to format chats -> completions using this specific formatter
-⋮----
-# use groq-specific client
-⋮----
-# Create new clients without caching
-⋮----
-# use cerebras-specific client
-⋮----
-# TODO there is not async client, so should we do anything here?
-⋮----
-# in these cases, there's no specific client: OpenAI python client suffices
-⋮----
-# Prefer caller config, then Gemini env, then the default.
-gemini_api_base = os.getenv("GEMINI_API_BASE", "")
-explicit_api_base = (
-⋮----
-# Honor caller-supplied base URL (e.g. regional endpoints,
-# proxies) instead of always forcing the default.
-openai_api_base = os.getenv("OPENAI_API_BASE")
-⋮----
-# Only overwrite with MINIMAX_API_KEY when it is actually
-# set, so users who intentionally put their MiniMax key in
-# OPENAI_API_KEY are not silently downgraded to a dummy key.
-minimax_key = os.getenv("MINIMAX_API_KEY", "")
-⋮----
-# Recompute capabilities now that the prefix has been stripped
-# and self.info() can find the model in MODEL_INFO.
-⋮----
-project_id = self.config.langdb_params.project_id
-⋮----
-params = self.config.langdb_params
-⋮----
-# Parse the model string and extract provider/model
-⋮----
-# Set Portkey base URL
-⋮----
-# Set API key - use provider's API key from env if available
-⋮----
-# Add Portkey-specific headers
-⋮----
-# Sanitize the API key: strip leading/trailing whitespace
-# (including stray newlines from .env files or CI secrets).
-⋮----
-# Create http_client if needed - Priority order:
-# 1. http_client_factory (most flexibility, not cacheable)
-# 2. http_client_config (cacheable, moderate flexibility)
-# 3. http_verify_ssl=False (cacheable, simple SSL bypass)
-http_client = None
-async_http_client = None
-http_client_config_used = None
-⋮----
-# Use the factory to create http_client (not cacheable)
-http_client = self.config.http_client_factory()
-⋮----
-# set async_http_client to None - so that it will
-# be created later
-⋮----
-# Use config dict (cacheable)
-http_client_config_used = self.config.http_client_config
-⋮----
-# Simple SSL bypass (cacheable)
-http_client_config_used = {"verify": False}
-⋮----
-# With an api_key_provider, hand the callable itself to the
-# OpenAI client, which resolves a fresh token on each request.
-openai_api_key: Union[str, Callable[[], str]] = (
-⋮----
-client_kwargs: Dict[str, Any] = dict(
-⋮----
-# Create http_client from config for non-cached scenario
-⋮----
-async_client_kwargs: Dict[str, Any] = dict(
-⋮----
-# AsyncOpenAI awaits its api_key callable
-⋮----
-# Create async http_client from config for non-cached scenario
-⋮----
-use_cache = self.config.cache_config is not None
-⋮----
-# switch to fresh redis config if needed
-⋮----
-# force use of fake redis if global cache_type is "fakeredis"
-⋮----
-def _openai_api_call_params(self, kwargs: Dict[str, Any]) -> Dict[str, Any]
-⋮----
-"""
-        Prep the params to be sent to the OpenAI API
-        (or any OpenAI-compatible API, e.g. from Ooba or LmStudio)
-        for chat-completion.
-
-        Order of priority:
-        - (1) Params (mainly max_tokens) in the chat/achat/generate/agenerate call
-                (these are passed in via kwargs)
-        - (2) Params in OpenAIGPTConfig.params (of class OpenAICallParams)
-        - (3) Specific Params in OpenAIGPTConfig (just temperature for now)
-        """
-params = dict(
-⋮----
-def is_openai_chat_model(self) -> bool
-⋮----
-openai_chat_models = [e.value for e in OpenAIChatModel]
-⋮----
-def is_openai_completion_model(self) -> bool
-⋮----
-openai_completion_models = [e.value for e in OpenAICompletionModel]
-⋮----
-def is_gemini_model(self) -> bool
-⋮----
-"""Are we using the gemini OpenAI-compatible API?"""
-⋮----
-def is_deepseek_model(self) -> bool
-⋮----
-deepseek_models = [e.value for e in DeepSeekModel]
-⋮----
-def is_minimax_model(self) -> bool
-⋮----
-"""Are we using the MiniMax OpenAI-compatible API?"""
-minimax_models = [e.value for e in MiniMaxModel]
-⋮----
-def unsupported_params(self) -> List[str]
-⋮----
-"""
-        List of params that are not supported by the current model
-        """
-unsupported = set(self.info().unsupported_params)
-⋮----
-def rename_params(self) -> Dict[str, str]
-⋮----
-"""
-        Map of param name -> new name for specific models.
-        Currently main troublemaker is o1* series.
-        """
-⋮----
-def chat_context_length(self) -> int
-⋮----
-"""
-        Context-length for chat-completion models/endpoints.
-        Get it from the config if explicitly given,
-         otherwise use model_info based on model name, and fall back to
-         generic model_info if there's no match.
-        """
-⋮----
-def completion_context_length(self) -> int
-⋮----
-"""
-        Context-length for completion models/endpoints.
-        Get it from the config if explicitly given,
-         otherwise use model_info based on model name, and fall back to
-         generic model_info if there's no match.
-        """
-⋮----
-def chat_cost(self) -> Tuple[float, float, float]
-⋮----
-"""
-        (Prompt, Cached, Generation) cost per 1000 tokens, for chat-completion
-        models/endpoints.
-        Get it from the dict, otherwise fail-over to general method
-        """
-info = self.info()
-cached_cost_per_million = info.cached_cost_per_million
-⋮----
-cached_cost_per_million = info.input_cost_per_million
-⋮----
-def set_stream(self, stream: bool) -> bool
-⋮----
-"""Enable or disable streaming output from API.
-        Args:
-            stream: enable streaming output from API
-        Returns: previous value of stream
-        """
-tmp = self.config.stream
-⋮----
-def get_stream(self) -> bool
-⋮----
-"""Get streaming status."""
-⋮----
-"""Separate inline reasoning from text tokens in a streaming chunk.
-
-        When models embed thinking inside content (e.g. <think>...</think>)
-        rather than using a separate reasoning field, this splits the chunk
-        into text-only and reasoning-only portions for proper streamer routing.
-
-        Returns (text_tokens, reasoning_tokens, in_reasoning).
-        """
-text_tokens = event_text
-reasoning_tokens = event_reasoning
-⋮----
-remaining = event_text
-⋮----
-text_tokens = ""
-⋮----
-text_tokens = before
-remaining = after
-in_reasoning = True
-⋮----
-reasoning_tokens = before
-in_reasoning = False
-⋮----
-reasoning_tokens = remaining
-⋮----
-"""Process state vars while processing a streaming API response.
-            Returns a tuple consisting of:
-        - is_break: whether to break out of the loop
-        - has_function: whether the response contains a function_call
-        - function_name: name of the function
-        - function_args: args of the function
-        - completion: completion text
-        - reasoning: reasoning text
-        - usage: usage dict
-        """
-# convert event obj (of type ChatCompletionChunk) to dict so rest of code,
-# which expects dicts, works as it did before switching to openai v1.x
-⋮----
-event = event.model_dump()
-⋮----
-usage = event.get("usage", {}) or {}
-choices = event.get("choices", [{}])
-⋮----
-choices = [{}]
-⋮----
-# we have a "usage" chunk, and empty choices, so we're done
-# ASSUMPTION: a usage chunk ONLY arrives AFTER all normal completion text!
-# If any API does not follow this, we need to change this code.
-⋮----
-event_args = ""
-event_fn_name = ""
-event_tool_deltas: Optional[List[Dict[str, Any]]] = None
-silent = settings.quiet
-# The first two events in the stream of Azure OpenAI is useless.
-# In the 1st: choices list is empty, in the 2nd: the dict delta has null content
-⋮----
-delta = choices[0].get("delta", {}) or {}
-# capture both content and reasoning_content
-event_text = delta.get("content", "")
-event_reasoning = delta.get(
-⋮----
-event_fn_name = delta["function_call"]["name"]
-⋮----
-event_args = delta["function_call"]["arguments"]
-⋮----
-# it's a list of deltas, usually just one
-event_tool_deltas = delta["tool_calls"]
-⋮----
-event_text = choices[0]["text"]
-event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
-⋮----
-finish_reason = choices[0].get("finish_reason", "")
-⋮----
-filter_names = [
-event_text = (
-⋮----
-function_name = event_fn_name
-has_function = True
-⋮----
-# print out streaming tool calls, if not async
-⋮----
-tool_fn_name = td["function"]["name"]
-⋮----
-tool_fn_args = td["function"]["arguments"]
-⋮----
-# show this delta in the stream
-is_break = finish_reason in [
-# for function_call, finish_reason does not necessarily
-# contain "function_call" as mentioned in the docs.
-# So we check for "stop" or "function_call" here.
-⋮----
-# we got usage chunk, and empty choices, so we're done
-⋮----
-silent = self.config.async_stream_quiet or settings.quiet
-⋮----
-is_break = choices[0].get("finish_reason", "") in [
-⋮----
-def _stream_response(  # type: ignore
-⋮----
-"""
-        Grab and print streaming response from API.
-        Args:
-            response: event-sequence emitted by API
-            chat: whether in chat-mode (or else completion-mode)
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                Dict version of OpenAIResponse object (with choices, usage)
-
-        """
-completion = ""
-reasoning = ""
-function_args = ""
-function_name = ""
-⋮----
-has_function = False
-tool_deltas: List[Dict[str, Any]] = []
-token_usage: Dict[str, int] = {}
-done: bool = False
-in_reasoning: bool = False  # Track if we're inside reasoning delimiters
-content_present = False
-⋮----
-event_dict = event if isinstance(event, dict) else event.model_dump()
-choices = event_dict.get("choices") or []
-⋮----
-delta = choices[0].get("delta") or {}
-content_present = content_present or (
-⋮----
-# capture the token usage when non-empty
-token_usage = usage
-⋮----
-# if not streaming, then we don't wait for last "usage" chunk
-⋮----
-# mark done, so we quit after the last "usage" chunk
-done = True
-⋮----
-# TODO- get usage info in stream mode (?)
-⋮----
-async def _stream_response_async(  # type: ignore
-⋮----
-"""
-        Grab and print streaming response from API.
-        Args:
-            response: event-sequence emitted by API
-            chat: whether in chat-mode (or else completion-mode)
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                OpenAIResponse object (with choices, usage)
-
-        """
-⋮----
-# mark done, so we quit after the next "usage" chunk
-⋮----
-"""
-        Convert accumulated tool-call deltas to OpenAIToolCall objects.
-        Adapted from this excellent code:
-         https://community.openai.com/t/help-for-function-calls-with-streaming/627170/2
-
-        Args:
-            tools: list of tool deltas received from streaming API
-
-        Returns:
-            str: plain text corresponding to tool calls that failed to parse
-            List[OpenAIToolCall]: list of OpenAIToolCall objects
-            List[Dict[str, Any]]: list of tool dicts
-                (to reconstruct OpenAI API response, so it can be cached)
-        """
-# Initialize a dictionary with default values
-⋮----
-# idx -> dict repr of tool
-# (used to simulate OpenAIResponse object later, and also to
-# accumulate function args as strings)
-idx2tool_dict: Dict[str, Dict[str, Any]] = defaultdict(
-⋮----
-# (try to) parse the fn args of each tool
-contents: List[str] = []
-good_indices = []
-id2args: Dict[str, None | Dict[str, Any]] = {}
-⋮----
-# used to build tool_calls_list below
-id2args[tool_dict["id"]] = args_dict or None  # if {}, store as None
-⋮----
-# remove the failed tool calls
-idx2tool_dict = {
-⋮----
-# create OpenAIToolCall list
-tool_calls_list = [
-⋮----
-@staticmethod
-    def _parse_function_args(args: str) -> Tuple[str, Dict[str, Any]]
-⋮----
-"""
-        Try to parse the `args` string as function args.
-
-        Args:
-            args: string containing function args
-
-        Returns:
-            Tuple of content, function name and args dict.
-            If parsing unsuccessful, returns the original string as content,
-            else returns the args dict.
-        """
-content = ""
-args_dict = {}
-⋮----
-stripped_fn_args = args.strip()
-dict_or_list = parse_imperfect_json(stripped_fn_args)
-⋮----
-args_dict = dict_or_list
-⋮----
-content = args
-⋮----
-"""
-        Create an LLMResponse object from the streaming API response.
-
-        Args:
-            chat: whether in chat-mode (or else completion-mode)
-            tool_deltas: list of tool deltas received from streaming API
-            has_function: whether the response contains a function_call
-            completion: completion text
-            reasoning: reasoning text
-            function_args: string representing function args
-            function_name: name of the function
-            usage: token usage dict
-            content_present: whether a stream delta explicitly contained content
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                Dict version of OpenAIResponse object (with choices, usage)
-                    (this is needed so we can cache the response, as if it were
-                    a non-streaming response)
-        """
-# check if function_call args are valid, if not,
-# treat this as a normal msg, not a function call
-args: Dict[str, Any] = {}
-⋮----
-completion = completion + content
-⋮----
-# mock openai response so we can cache it
-⋮----
-content_present = True
-has_valid_call = len(tool_dicts) > 0 or has_function
-response_content = (
-msg: Dict[str, Any] = dict(
-⋮----
-function_call = LLMFunctionCall(name=function_name)
-function_call_dict = function_call.model_dump()
-⋮----
-# non-chat mode has no function_call
-msg = dict(text=completion)
-response_content = completion
-# TODO: Ignoring reasoning content for non-chat models
-⋮----
-# create an OpenAIResponse object so we can cache it as if it were
-# a non-streaming response
-openai_response = OpenAIResponse(
-# Track whether we extracted inline thought tags from the text.
-# Only set message_with_reasoning when get_reasoning_final()
-# actually finds and extracts inline tags (e.g. <think>...</think>).
-# When reasoning is already provided via a separate API field
-# (e.g. reasoning_content), the message text doesn't contain
-# thought signatures, so there's nothing extra to preserve.
-message_with_reasoning = None
-message: str | None
-⋮----
-# some LLM APIs may not return a separate reasoning field,
-# and the reasoning may be included in the message content
-# within delimiters like <think> ... </think>
-⋮----
-# Inline tags were found and extracted; preserve the
-# original text so it can be restored in message history.
-message_with_reasoning = response_content
-⋮----
-message = response_content
-⋮----
-prompt_tokens = usage.get("prompt_tokens", 0)
-prompt_tokens_details: Any = usage.get("prompt_tokens_details", {})
-cached_tokens = (
-completion_tokens = usage.get("completion_tokens", 0)
-⋮----
-# don't allow empty list [] here
-⋮----
-def _cache_store(self, k: str, v: Any) -> None
-⋮----
-def _cache_lookup(self, fn_name: str, **kwargs: Dict[str, Any]) -> Tuple[str, Any]
-⋮----
-return "", None  # no cache, return empty key and None result
-# Use the kwargs as the cache key
-sorted_kwargs_str = str(sorted(kwargs.items()))
-raw_key = f"{fn_name}:{sorted_kwargs_str}"
-⋮----
-# Hash the key to a fixed length using SHA256
-hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
-⋮----
-# when caching disabled, return the hashed_key and none result
-⋮----
-# Try to get the result from the cache
-⋮----
-cached_val = self.cache.retrieve(hashed_key)
-⋮----
-def _cost_chat_model(self, prompt: int, cached: int, completion: int) -> float
-⋮----
-price = self.chat_cost()
-⋮----
-"""
-        Extracts token usage from ``response`` and computes cost, only when NOT
-        in streaming mode, since the LLM API (OpenAI currently) was not
-        populating the usage fields in streaming mode (but as of Sep 2024, streaming
-        responses include  usage info as well, so we should update the code
-        to directly use usage information from the streaming response, which is more
-        accurate, esp with "thinking" LLMs like o1 series which consume
-        thinking tokens).
-        In streaming mode, these are set to zero for
-        now, and will be updated later by the fn ``update_token_usage``.
-        """
-cost = 0.0
-prompt_tokens = 0
-cached_tokens = 0
-completion_tokens = 0
-⋮----
-usage = response.get("usage")
-⋮----
-prompt_tokens = usage.get("prompt_tokens") or 0
-prompt_tokens_details = usage.get("prompt_tokens_details", {}) or {}
-cached_tokens = prompt_tokens_details.get("cached_tokens") or 0
-completion_tokens = usage.get("completion_tokens") or 0
-cost = self._cost_chat_model(
-⋮----
-def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-# Catch HTTP-level API errors (400, 401, 403, 404, 422, 429, 5xx)
-# without traceback — these originate server-side and a local
-# stack trace adds no diagnostic value.
-# Note: APIConnectionError/APITimeoutError are intentionally NOT
-# caught here so they fall through to the generic handler below,
-# where the full traceback aids in diagnosing local network issues.
-⋮----
-# log and re-raise exception
-⋮----
-def _generate(self, prompt: str, max_tokens: int) -> LLMResponse
-⋮----
-@retry_with_exponential_backoff
-        def completions_with_backoff(**kwargs):  # type: ignore
-⋮----
-cached = False
-⋮----
-cached = True
-⋮----
-completion_call = litellm_completion
-⋮----
-completion_call = self.client.completions.create
-⋮----
-# If it's not in the cache, call the API
-result = completion_call(**kwargs)
-⋮----
-kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
-⋮----
-# TODO this is a temp fix, we should really be using a proper completion fn
-# that takes a pre-formatted prompt, rather than mocking it as a sys msg.
-⋮----
-else:  # any other OpenAI-compatible endpoint
-⋮----
-args = dict(
-⋮----
-max_tokens=max_tokens,  # for output/completion
-⋮----
-args = self._openai_api_call_params(args)
-⋮----
-# assume response is an actual response rather than a streaming event
-⋮----
-response = response.model_dump()
-⋮----
-msg = (response["choices"][0]["message"]["content"] or "").strip()
-⋮----
-msg = (response["choices"][0]["text"] or "").strip()
-⋮----
-async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-# Catch HTTP-level API errors (see comment in generate() above).
-⋮----
-async def _agenerate(self, prompt: str, max_tokens: int) -> LLMResponse
-⋮----
-# note we typically will not have self.config.stream = True
-# when issuing several api calls concurrently/asynchronously.
-# The calling fn should use the context `with Streaming(..., False)` to
-# disable streaming.
-⋮----
-# WARNING: .Completion.* endpoints are deprecated,
-# and as of Sep 2023 only legacy models will work here,
-# e.g. text-davinci-003, text-ada-001.
-⋮----
-@async_retry_with_exponential_backoff
-        async def completions_with_backoff(**kwargs):  # type: ignore
-⋮----
-# TODO this may not work: text_completion is not async,
-# and we didn't find an async version in litellm
-⋮----
-acompletion_call = (
-⋮----
-result = await acompletion_call(**kwargs)
-⋮----
-# only makes sense for non-OpenAI models
-⋮----
-messages = [
-prompt = self.config.hf_formatter.format(messages)
-⋮----
-# turn off streaming for async calls
-⋮----
-# only makes sense for local models, where we are trying to
-# convert a chat dialog msg-sequence to a simple completion prompt.
-⋮----
-formatter = HFFormatter(
-⋮----
-prompt = formatter.format(messages)
-⋮----
-result = await self._achat(
-⋮----
-def _chat_completions_with_backoff_body(self, **kwargs):  # type: ignore
-⋮----
-completion_call = self.client.chat.completions.create
-⋮----
-# If streaming, cannot cache result
-# since it is a generator. Instead,
-# we hold on to the hashed_key and
-# cache the result later
-⋮----
-# Test if this is a stream with an exception by
-# trying to get first chunk: Some providers like LiteLLM
-# produce a valid stream object `result` instead of throwing a
-# rate-limit error, and if we don't catch it here,
-# we end up returning an empty response and not
-# using the retry mechanism in the decorator.
-⋮----
-# try to get the first chunk to check for errors
-test_iter = iter(result)
-first_chunk = next(test_iter)
-# If we get here without error, recreate the stream
-result = chain([first_chunk], test_iter)
-⋮----
-# Empty stream is fine
-⋮----
-# Propagate any errors in the stream
-⋮----
-def _chat_completions_with_backoff(self, **kwargs):  # type: ignore
-⋮----
-retry_func = retry_with_exponential_backoff(
-⋮----
-async def _achat_completions_with_backoff_body(self, **kwargs):  # type: ignore
-⋮----
-acompletion_call = litellm_acompletion
-⋮----
-acompletion_call = self.async_client.chat.completions.create
-⋮----
-# Try to peek at the first chunk to immediately catch any errors
-# Store the original result (the stream)
-original_stream = result
-⋮----
-# Manually create and advance the iterator to check for errors
-stream_iter = original_stream.__aiter__()
-⋮----
-# This will raise an exception if the stream is invalid
-first_chunk = await anext(stream_iter)
-⋮----
-# If we reach here, the stream started successfully
-# Now recreate a fresh stream from the original API result
-# Otherwise, return a new stream that yields the first chunk
-# and remaining items
-async def combined_stream():  # type: ignore
-⋮----
-result = combined_stream()  # type: ignore
-⋮----
-# Empty stream is normal - nothing to do
-⋮----
-# Any exception here should be raised to trigger the retry mechanism
-⋮----
-async def _achat_completions_with_backoff(self, **kwargs):  # type: ignore
-⋮----
-retry_func = async_retry_with_exponential_backoff(
-⋮----
-"""Prepare args for LLM chat-completion API call"""
-⋮----
-llm_messages = [
-⋮----
-llm_messages = messages
-⋮----
-# TODO: we will unconditionally insert a dummy user msg
-# if the only msg is a system msg.
-# We could make this conditional on ModelInfo.needs_first_user_message
-⋮----
-# some LLMs, notable Gemini as of 12/11/24,
-# require the first message to be from the user,
-# so insert a dummy user msg if needed.
-⋮----
-chat_model = self.config.chat_model
-⋮----
-args: Dict[str, Any] = dict(
-⋮----
-# groq fails when we include stream_options in the request
-⋮----
-# get token-usage numbers in stream mode from OpenAI API,
-# and possibly other OpenAI-compatible APIs.
-⋮----
-# only include functions-related args if functions are provided
-# since the OpenAI API will throw an error if `functions` is None or []
-⋮----
-# some models e.g. o1-mini (as of sep 2024) don't support some params,
-# like temperature and stream, so we need to remove them.
-⋮----
-param_rename_map = self.rename_params()
-⋮----
-# finally, get rid of extra_body params exclusive to certain models
-# Only apply allowlist restrictions for known models.
-# Unknown/custom models are allowed to use all params by default.
-is_known_model = self.info().name != "unknown"
-extra_params = args.get("extra_body", {})
-⋮----
-# openAI response will look like this:
-"""
-        {
-            "id": "chatcmpl-123",
-            "object": "chat.completion",
-            "created": 1677652288,
-            "choices": [{
-                "index": 0,
-                "message": {
-                    "role": "assistant",
-                    "name": "",
-                    "content": "\n\nHello there, how may I help you?",
-                    "reasoning_content": "Okay, let's see here, hmmm...",
-                    "function_call": {
-                        "name": "fun_name",
-                        "arguments: {
-                            "arg1": "val1",
-                            "arg2": "val2"
-                        }
-                    },
-                },
-                "finish_reason": "stop"
-            }],
-            "usage": {
-                "prompt_tokens": 9,
-                "completion_tokens": 12,
-                "total_tokens": 21
-            }
-        }
-        """
-choices = response.get("choices")
-⋮----
-message = choices[0].get("message", {})
-⋮----
-message = {}
-⋮----
-content = message.get("content")
-reasoning = message.get("reasoning_content", "")
-⋮----
-message_with_reasoning = content
-⋮----
-msg = content
-⋮----
-fun_call = None
-⋮----
-fun_call = LLMFunctionCall.from_dict(message["function_call"])
-⋮----
-args_str = message["function_call"]["arguments"] or ""
-msg_str = message["content"] or ""
-msg = msg_str + args_str
-oai_tool_calls = None
-⋮----
-oai_tool_calls = []
-⋮----
-tool_call = OpenAIToolCall.from_dict(tool_call_dict)
-⋮----
-serialized_tool_call = json.dumps(tool_call_dict)
-msg = (msg or "") + ("\n" if msg else "") + serialized_tool_call
-⋮----
-# None (no content, e.g. a tool-call-only response) is preserved as
-# None rather than coerced to "", so the distinction survives
-# downstream (see LLMMessage.content / ChatDocument.content_is_none).
-⋮----
-oai_tool_calls=oai_tool_calls or None,  # don't allow empty list [] here
-⋮----
-"""
-        ChatCompletion API call to OpenAI.
-        Args:
-            messages: list of messages  to send to the API, typically
-                represents back and forth dialogue between user and LLM, but could
-                also include "function"-role messages. If messages is a string,
-                it is assumed to be a user message.
-            max_tokens: max output tokens to generate
-            functions: list of LLMFunction specs available to the LLM, to possibly
-                use in its response
-            function_call: controls how the LLM uses `functions`:
-                - "auto": LLM decides whether to use `functions` or not,
-                - "none": LLM blocked from using any function
-                - a dict of {"name": "function_name"} which forces the LLM to use
-                    the specified function.
-        Returns:
-            LLMResponse object
-        """
-args = self._prep_chat_completion(
-cached, hashed_key, response = self._chat_completions_with_backoff(**args)  # type: ignore
-⋮----
-return llm_response  # type: ignore
-⋮----
-response_dict = response
-⋮----
-response_dict = response.model_dump()
-⋮----
-"""
-        Async version of _chat(). See that function for details.
-        """
-⋮----
-cached, hashed_key, response = await self._achat_completions_with_backoff(  # type: ignore
-</file>
-
 <file path=".pre-commit-config.yaml">
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -43253,6 +43400,7 @@ nav:
       - Context-Overflow Handling: notes/context-overflow.md
       - Batch Processing: notes/batch-processing.md
       - Attachment Token Preflight: notes/attachment-token-preflight.md
+      - Vector-Store Env Prefixes: notes/vecstore-env-prefix.md
 
   - Examples:
     - Guide: examples/guide.md

--- a/llms-no-tests-no-examples.txt
+++ b/llms-no-tests-no-examples.txt
@@ -154,6 +154,7 @@ docs/
     tool-message-handler.md
     twitter-search.md
     url_loader.md
+    vecstore-env-prefix.md
     weaviate.md
     xml-tools.md
   overrides/
@@ -4834,6 +4835,207 @@ config = OpenAIGPTConfig(
 - Implements singleton pattern with lazy initialization
 - Automatically cleans up clients on program exit via atexit hooks
 - Compatible with both sync and async OpenAI clients
+</file>
+
+<file path="docs/notes/openai-http-client.md">
+# OpenAI HTTP Client Configuration
+
+When using OpenAI models through Langroid in corporate environments or behind proxies, you may encounter SSL certificate verification errors. Langroid provides three flexible options to configure the HTTP client used for OpenAI API calls.
+
+## Configuration Options
+
+### 1. Simple SSL Verification Bypass
+
+The quickest solution for development or trusted environments:
+
+```python
+import langroid.language_models as lm
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_verify_ssl=False  # Disables SSL certificate verification
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+!!! warning "Security Notice"
+    Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks. Only use this in trusted environments.
+
+### 2. HTTP Client Configuration Dictionary
+
+For common scenarios like proxies or custom certificates, use a configuration dictionary:
+
+```python
+import langroid.language_models as lm
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_config={
+        "verify": False,  # Or path to CA bundle: "/path/to/ca-bundle.pem"
+        "proxy": "http://proxy.company.com:8080",
+        "timeout": 30.0,
+        "headers": {
+            "User-Agent": "MyApp/1.0"
+        }
+    }
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+**Benefits**: This approach enables client caching, improving performance when creating multiple agents.
+
+### 3. Custom HTTP Client Factory
+
+For advanced scenarios requiring dynamic behavior or custom authentication:
+
+```python
+import langroid.language_models as lm
+from httpx import Client
+
+def create_custom_client():
+    """Factory function to create a custom HTTP client."""
+    client = Client(
+        verify="/path/to/corporate-ca-bundle.pem",
+        proxies={
+            "http": "http://proxy.corp.com:8080",
+            "https": "http://proxy.corp.com:8080"
+        },
+        timeout=30.0
+    )
+
+    # Add custom event hooks for logging
+    def log_request(request):
+        print(f"API Request: {request.method} {request.url}")
+
+    client.event_hooks = {"request": [log_request]}
+
+    return client
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_factory=create_custom_client
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+If you are using `async` methods, return a tuple of `(Client, AsyncClient)` from your factory:
+
+```python
+from httpx import AsyncClient, Client
+
+def create_custom_client():
+    """Factory function to create a custom sync and async HTTP clients."""
+    client_args = {
+        "verify": "/path/to/corporate-ca-bundle.pem",
+        "proxy": "http://proxy.corp.com:8080",
+        "timeout": 30.0,
+    }
+    client = Client(**client_args)
+    async_client = AsyncClient(**client_args)
+
+    return client, async_client
+```
+
+**Note**: Custom factories bypass client caching. Each `OpenAIGPT` instance creates a new client.
+
+## Priority Order
+
+When multiple options are specified, they are applied in this order:
+1. `http_client_factory` (highest priority)
+2. `http_client_config`
+3. `http_verify_ssl` (lowest priority)
+
+## Common Use Cases
+
+### Corporate Proxy with Custom CA Certificate
+
+```python
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_config={
+        "verify": "/path/to/corporate-ca-bundle.pem",
+        "proxies": {
+            "http": "http://proxy.corp.com:8080",
+            "https": "https://proxy.corp.com:8443"
+        }
+    }
+)
+```
+
+### Debugging API Calls
+
+```python
+def debug_client_factory():
+    from httpx import Client
+
+    client = Client(verify=False)
+
+    def log_response(response):
+        print(f"Status: {response.status_code}")
+        print(f"Headers: {response.headers}")
+
+    client.event_hooks = {
+        "response": [log_response]
+    }
+
+    return client
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_factory=debug_client_factory
+)
+```
+
+### Local Development with Self-Signed Certificates
+
+```python
+# For local OpenAI-compatible APIs
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    api_base="https://localhost:8443/v1",
+    http_verify_ssl=False
+)
+```
+
+
+## Best Practices
+
+1. **Use the simplest option that meets your needs**:
+   - Development/testing: `http_verify_ssl=False`
+   - Corporate environments: `http_client_config` with proper CA bundle
+   - Complex requirements: `http_client_factory`
+
+2. **Prefer configuration over factories for better performance** - configured clients are cached and reused
+
+3. **Always use proper CA certificates in production** instead of disabling SSL verification
+
+4. **Test your configuration** with a simple API call before deploying:
+   ```python
+   llm = lm.OpenAIGPT(config)
+   response = llm.chat("Hello")
+   print(response.content)
+   ```
+
+## Troubleshooting
+
+### SSL Certificate Errors
+```
+ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
+```
+**Solution**: Use one of the three configuration options above.
+
+
+### Proxy Connection Issues
+- Verify proxy URL format: `http://proxy:port` or `https://proxy:port`
+- Check if proxy requires authentication
+- Ensure proxy allows connections to `api.openai.com`
+
+## See Also
+
+- [OpenAI API Reference](https://platform.openai.com/docs/api-reference) - Official OpenAI documentation
 </file>
 
 <file path="docs/notes/overview.md">
@@ -21105,148 +21307,6 @@ __all__ = [
 ]
 </file>
 
-<file path="langroid/utils/configuration.py">
-import os
-import threading
-from contextlib import contextmanager
-from typing import Any, Dict, Iterator, List, Literal, cast
-
-from dotenv import find_dotenv, load_dotenv
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
-# Global reentrant lock to serialize any modifications to the global settings.
-_global_lock = threading.RLock()
-
-
-class Settings(BaseSettings):
-    debug: bool = False  # show debug messages?
-    max_turns: int = -1  # maximum number of turns in a task (to avoid inf loop)
-    progress: bool = False  # show progress spinners/bars?
-    stream: bool = True  # stream output?
-    cache: bool = True  # use cache?
-    cache_type: Literal["redis", "fakeredis", "none"] = "redis"  # cache type
-    chat_model: str = ""  # language model name, e.g. litellm/ollama/llama2
-    quiet: bool = False  # quiet mode (i.e. suppress all output)?
-    notebook: bool = False  # running in a notebook?
-
-    model_config = SettingsConfigDict(extra="forbid")
-
-
-# Load environment variables from .env file.
-load_dotenv(find_dotenv(usecwd=True))
-
-# The global (default) settings instance.
-# This is updated by update_global_settings() and set_global().
-_global_settings = Settings()
-
-# Thread-local storage for temporary (per-thread) settings overrides.
-_thread_local = threading.local()
-
-
-class SettingsProxy:
-    """
-    A proxy for the settings that returns a thread‐local override if set,
-    or else falls back to the global settings.
-    """
-
-    def __getattr__(self, name: str) -> Any:
-        # If the calling thread has set an override, use that.
-        if hasattr(_thread_local, "override"):
-            return getattr(_thread_local.override, name)
-        return getattr(_global_settings, name)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        # All writes go to the global settings.
-        setattr(_global_settings, name, value)
-
-    def update(self, new_settings: Settings) -> None:
-        _global_settings.__dict__.update(new_settings.__dict__)
-
-    def dict(self) -> Dict[str, Any]:
-        # Return a dict view of the settings as seen by the caller.
-        # Note that temporary overrides are not “merged” with global settings.
-        if hasattr(_thread_local, "override"):
-            return cast(
-                Dict[str, Any], cast(Settings, _thread_local.override.model_dump())
-            )
-        return _global_settings.model_dump()
-
-
-settings = SettingsProxy()
-
-
-def update_global_settings(cfg: BaseSettings, keys: List[str]) -> None:
-    """
-    Update global settings so that modules can later access them via, e.g.,
-
-        from langroid.utils.configuration import settings
-        if settings.debug: ...
-
-    This updates the global default.
-    """
-    config_dict = cfg.model_dump()
-    filtered_config = {key: config_dict[key] for key in keys if key in config_dict}
-    new_settings = Settings(**filtered_config)
-    _global_settings.__dict__.update(new_settings.__dict__)
-
-
-def set_global(key_vals: Settings) -> None:
-    """
-    Update the global settings object.
-    """
-    _global_settings.__dict__.update(key_vals.__dict__)
-
-
-@contextmanager
-def temporary_settings(temp_settings: Settings) -> Iterator[None]:
-    """
-    Temporarily override the settings for the calling thread.
-
-    Within the context, any access to "settings" will use the provided temporary
-    settings. Once the context is exited, the thread reverts to the global settings.
-    """
-    saved = getattr(_thread_local, "override", None)
-    _thread_local.override = temp_settings
-    try:
-        yield
-    finally:
-        if saved is not None:
-            _thread_local.override = saved
-        else:
-            del _thread_local.override
-
-
-@contextmanager
-def quiet_mode(quiet: bool = True) -> Iterator[None]:
-    """
-    Temporarily override settings.quiet for the current thread.
-    This implementation builds on the thread‑local temporary_settings context manager.
-    The effective quiet mode is merged:
-    if quiet is already True (from an outer context),
-    then it remains True even if a nested context passes quiet=False.
-    """
-    current_effective = (
-        settings.model_dump()
-    )  # get the current thread's effective settings
-    # Create a new settings instance from the current effective state.
-    temp = Settings(**current_effective)
-    # Merge the new flag: once quiet is enabled, it stays enabled.
-    temp.quiet = settings.quiet or quiet
-    with temporary_settings(temp):
-        yield
-
-
-def set_env(settings_instance: BaseSettings) -> None:
-    """
-    Set environment variables from a BaseSettings instance.
-
-    Each field in the settings is written to os.environ.
-    """
-    for field_name, field in settings_instance.__class__.model_fields.items():
-        env_var_name = field.alias or field_name.upper()
-        os.environ[env_var_name] = str(settings_instance.model_dump()[field_name])
-</file>
-
 <file path="langroid/utils/constants.py">
 from pydantic import BaseModel
 
@@ -27363,207 +27423,6 @@ matches = agent.vecdb.similar_texts_with_scores(
     where='{"source": "milvus-docs"}',
 )
 ```
-</file>
-
-<file path="docs/notes/openai-http-client.md">
-# OpenAI HTTP Client Configuration
-
-When using OpenAI models through Langroid in corporate environments or behind proxies, you may encounter SSL certificate verification errors. Langroid provides three flexible options to configure the HTTP client used for OpenAI API calls.
-
-## Configuration Options
-
-### 1. Simple SSL Verification Bypass
-
-The quickest solution for development or trusted environments:
-
-```python
-import langroid.language_models as lm
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_verify_ssl=False  # Disables SSL certificate verification
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-!!! warning "Security Notice"
-    Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks. Only use this in trusted environments.
-
-### 2. HTTP Client Configuration Dictionary
-
-For common scenarios like proxies or custom certificates, use a configuration dictionary:
-
-```python
-import langroid.language_models as lm
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_config={
-        "verify": False,  # Or path to CA bundle: "/path/to/ca-bundle.pem"
-        "proxy": "http://proxy.company.com:8080",
-        "timeout": 30.0,
-        "headers": {
-            "User-Agent": "MyApp/1.0"
-        }
-    }
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-**Benefits**: This approach enables client caching, improving performance when creating multiple agents.
-
-### 3. Custom HTTP Client Factory
-
-For advanced scenarios requiring dynamic behavior or custom authentication:
-
-```python
-import langroid.language_models as lm
-from httpx import Client
-
-def create_custom_client():
-    """Factory function to create a custom HTTP client."""
-    client = Client(
-        verify="/path/to/corporate-ca-bundle.pem",
-        proxies={
-            "http": "http://proxy.corp.com:8080",
-            "https": "http://proxy.corp.com:8080"
-        },
-        timeout=30.0
-    )
-
-    # Add custom event hooks for logging
-    def log_request(request):
-        print(f"API Request: {request.method} {request.url}")
-
-    client.event_hooks = {"request": [log_request]}
-
-    return client
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_factory=create_custom_client
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-If you are using `async` methods, return a tuple of `(Client, AsyncClient)` from your factory:
-
-```python
-from httpx import AsyncClient, Client
-
-def create_custom_client():
-    """Factory function to create a custom sync and async HTTP clients."""
-    client_args = {
-        "verify": "/path/to/corporate-ca-bundle.pem",
-        "proxy": "http://proxy.corp.com:8080",
-        "timeout": 30.0,
-    }
-    client = Client(**client_args)
-    async_client = AsyncClient(**client_args)
-
-    return client, async_client
-```
-
-**Note**: Custom factories bypass client caching. Each `OpenAIGPT` instance creates a new client.
-
-## Priority Order
-
-When multiple options are specified, they are applied in this order:
-1. `http_client_factory` (highest priority)
-2. `http_client_config`
-3. `http_verify_ssl` (lowest priority)
-
-## Common Use Cases
-
-### Corporate Proxy with Custom CA Certificate
-
-```python
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_config={
-        "verify": "/path/to/corporate-ca-bundle.pem",
-        "proxies": {
-            "http": "http://proxy.corp.com:8080",
-            "https": "https://proxy.corp.com:8443"
-        }
-    }
-)
-```
-
-### Debugging API Calls
-
-```python
-def debug_client_factory():
-    from httpx import Client
-
-    client = Client(verify=False)
-
-    def log_response(response):
-        print(f"Status: {response.status_code}")
-        print(f"Headers: {response.headers}")
-
-    client.event_hooks = {
-        "response": [log_response]
-    }
-
-    return client
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_factory=debug_client_factory
-)
-```
-
-### Local Development with Self-Signed Certificates
-
-```python
-# For local OpenAI-compatible APIs
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    api_base="https://localhost:8443/v1",
-    http_verify_ssl=False
-)
-```
-
-
-## Best Practices
-
-1. **Use the simplest option that meets your needs**:
-   - Development/testing: `http_verify_ssl=False`
-   - Corporate environments: `http_client_config` with proper CA bundle
-   - Complex requirements: `http_client_factory`
-
-2. **Prefer configuration over factories for better performance** - configured clients are cached and reused
-
-3. **Always use proper CA certificates in production** instead of disabling SSL verification
-
-4. **Test your configuration** with a simple API call before deploying:
-   ```python
-   llm = lm.OpenAIGPT(config)
-   response = llm.chat("Hello")
-   print(response.content)
-   ```
-
-## Troubleshooting
-
-### SSL Certificate Errors
-```
-ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
-```
-**Solution**: Use one of the three configuration options above.
-
-
-### Proxy Connection Issues
-- Verify proxy URL format: `http://proxy:port` or `https://proxy:port`
-- Check if proxy requires authentication
-- Ensure proxy allows connections to `api.openai.com`
-
-## See Also
-
-- [OpenAI API Reference](https://platform.openai.com/docs/api-reference) - Official OpenAI documentation
 </file>
 
 <file path="docs/notes/rotating-api-keys.md">
@@ -36096,6 +35955,152 @@ def seltz_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
     return results
 </file>
 
+<file path="langroid/utils/configuration.py">
+import os
+import threading
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Literal, cast
+
+from dotenv import find_dotenv, load_dotenv
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Global reentrant lock to serialize any modifications to the global settings.
+_global_lock = threading.RLock()
+
+
+class Settings(BaseSettings):
+    debug: bool = False  # show debug messages?
+    max_turns: int = -1  # maximum number of turns in a task (to avoid inf loop)
+    progress: bool = False  # show progress spinners/bars?
+    stream: bool = True  # stream output?
+    cache: bool = True  # use cache?
+    cache_type: Literal["redis", "fakeredis", "none"] = "redis"  # cache type
+    chat_model: str = ""  # language model name, e.g. litellm/ollama/llama2
+    quiet: bool = False  # quiet mode (i.e. suppress all output)?
+    notebook: bool = False  # running in a notebook?
+
+    model_config = SettingsConfigDict(extra="forbid")
+
+
+# Load environment variables from .env file.
+load_dotenv(find_dotenv(usecwd=True))
+
+# The global (default) settings instance.
+# This is updated by update_global_settings() and set_global().
+_global_settings = Settings()
+
+# Thread-local storage for temporary (per-thread) settings overrides.
+_thread_local = threading.local()
+
+
+class SettingsProxy:
+    """
+    A proxy for the settings that returns a thread‐local override if set,
+    or else falls back to the global settings.
+    """
+
+    def __getattr__(self, name: str) -> Any:
+        # If the calling thread has set an override, use that.
+        if hasattr(_thread_local, "override"):
+            return getattr(_thread_local.override, name)
+        return getattr(_global_settings, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        # All writes go to the global settings.
+        setattr(_global_settings, name, value)
+
+    def update(self, new_settings: Settings) -> None:
+        _global_settings.__dict__.update(new_settings.__dict__)
+
+    def dict(self) -> Dict[str, Any]:
+        # Return a dict view of the settings as seen by the caller.
+        # Note that temporary overrides are not “merged” with global settings.
+        if hasattr(_thread_local, "override"):
+            return cast(
+                Dict[str, Any], cast(Settings, _thread_local.override.model_dump())
+            )
+        return _global_settings.model_dump()
+
+
+settings = SettingsProxy()
+
+
+def update_global_settings(cfg: BaseSettings, keys: List[str]) -> None:
+    """
+    Update global settings so that modules can later access them via, e.g.,
+
+        from langroid.utils.configuration import settings
+        if settings.debug: ...
+
+    This updates the global default.
+    """
+    config_dict = cfg.model_dump()
+    filtered_config = {key: config_dict[key] for key in keys if key in config_dict}
+    new_settings = Settings(**filtered_config)
+    _global_settings.__dict__.update(new_settings.__dict__)
+
+
+def set_global(key_vals: Settings) -> None:
+    """
+    Update the global settings object.
+    """
+    _global_settings.__dict__.update(key_vals.__dict__)
+
+
+@contextmanager
+def temporary_settings(temp_settings: Settings) -> Iterator[None]:
+    """
+    Temporarily override the settings for the calling thread.
+
+    Within the context, any access to "settings" will use the provided temporary
+    settings. Once the context is exited, the thread reverts to the global settings.
+    """
+    saved = getattr(_thread_local, "override", None)
+    _thread_local.override = temp_settings
+    try:
+        yield
+    finally:
+        if saved is not None:
+            _thread_local.override = saved
+        else:
+            del _thread_local.override
+
+
+@contextmanager
+def quiet_mode(quiet: bool = True) -> Iterator[None]:
+    """
+    Temporarily override settings.quiet for the current thread.
+    This implementation builds on the thread‑local temporary_settings context manager.
+    The effective quiet mode is merged:
+    if quiet is already True (from an outer context),
+    then it remains True even if a nested context passes quiet=False.
+    """
+    current_effective = (
+        settings.model_dump()
+    )  # get the current thread's effective settings
+    # Create a new settings instance from the current effective state.
+    temp = Settings(**current_effective)
+    # Merge the new flag: once quiet is enabled, it stays enabled.
+    temp.quiet = settings.quiet or quiet
+    with temporary_settings(temp):
+        yield
+
+
+def set_env(settings_instance: BaseSettings) -> None:
+    """
+    Set environment variables from a BaseSettings instance.
+
+    Each field in the settings is written to os.environ, under the name
+    the settings class itself reads: `<env_prefix><FIELD_NAME_UPPER>`,
+    or the field's explicit alias (which, per pydantic-settings
+    semantics, is the full env name and is not prefixed).
+    """
+    env_prefix = settings_instance.model_config.get("env_prefix", "")
+    for field_name, field in settings_instance.__class__.model_fields.items():
+        env_var_name = field.alias or f"{env_prefix}{field_name.upper()}"
+        os.environ[env_var_name] = str(settings_instance.model_dump()[field_name])
+</file>
+
 <file path="langroid/utils/pandas_utils.py">
 import ast
 from typing import Any, Dict
@@ -37510,945 +37515,6 @@ except ImportError:
     pass
 </file>
 
-<file path="langroid/vector_store/chromadb.py">
-import json
-import logging
-from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
-
-from langroid.embedding_models.base import (
-    EmbeddingModelsConfig,
-)
-from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.exceptions import LangroidImportError
-from langroid.mytypes import Document
-from langroid.utils.configuration import settings
-from langroid.utils.output.printing import print_long_text
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-logger = logging.getLogger(__name__)
-
-
-class ChromaDBConfig(VectorStoreConfig):
-    collection_name: str = "temp"
-    storage_path: str = ".chroma/data"
-    distance: Literal["cosine", "l2", "ip"] = "cosine"
-    construction_ef: int = 100
-    search_ef: int = 100
-    max_neighbors: int = 16
-    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    host: str = "127.0.0.1"
-    port: int = 6333
-
-
-class ChromaDB(VectorStore):
-    def __init__(self, config: ChromaDBConfig | None = None):
-        config = config if config is not None else ChromaDBConfig()
-        super().__init__(config)
-        try:
-            import chromadb
-        except ImportError:
-            raise LangroidImportError("chromadb", "chromadb")
-        self.config = config
-        self.client = chromadb.Client(
-            chromadb.config.Settings(
-                # chroma_db_impl="duckdb+parquet",
-                # is_persistent=bool(config.storage_path),
-                persist_directory=config.storage_path,
-            )
-        )
-        if self.config.collection_name is not None:
-            self.create_collection(
-                self.config.collection_name,
-                replace=self.config.replace_collection,
-            )
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """Clear all collections in the vector store with the given prefix."""
-
-        if not really:
-            logger.warning("Not deleting all collections, set really=True to confirm")
-            return 0
-        coll = [c for c in self.client.list_collections() if c.name.startswith(prefix)]
-        if len(coll) == 0:
-            logger.warning(f"No collections found with prefix {prefix}")
-            return 0
-        n_empty_deletes = 0
-        n_non_empty_deletes = 0
-        for c in coll:
-            n_empty_deletes += c.count() == 0
-            n_non_empty_deletes += c.count() > 0
-            self.client.delete_collection(name=c.name)
-        logger.warning(
-            f"""
-            Deleted {n_empty_deletes} empty collections and
-            {n_non_empty_deletes} non-empty collections.
-            """
-        )
-        return n_empty_deletes + n_non_empty_deletes
-
-    def clear_empty_collections(self) -> int:
-        colls = self.client.list_collections()
-        n_deletes = 0
-        for coll in colls:
-            if coll.count() == 0:
-                n_deletes += 1
-                self.client.delete_collection(name=coll.name)
-        return n_deletes
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """
-        List non-empty collections in the vector store.
-        Args:
-            empty (bool, optional): Whether to list empty collections.
-        Returns:
-            List[str]: List of non-empty collection names.
-        """
-        colls = self.client.list_collections()
-        if empty:
-            return [coll.name for coll in colls]
-        return [coll.name for coll in colls if coll.count() > 0]
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        """
-        Create a collection in the vector store, optionally replacing an existing
-            collection if `replace` is True.
-        Args:
-            collection_name (str): Name of the collection to create or replace.
-            replace (bool, optional): Whether to replace an existing collection.
-                Defaults to False.
-
-        """
-        self.config.collection_name = collection_name
-        if collection_name in self.list_collections(empty=True) and replace:
-            logger.warning(f"Replacing existing collection {collection_name}")
-            self.client.delete_collection(collection_name)
-        self.collection = self.client.create_collection(
-            name=self.config.collection_name,
-            embedding_function=self.embedding_fn,
-            get_or_create=not replace,
-            metadata={
-                "hnsw:space": self.config.distance,
-                "hnsw:construction_ef": self.config.construction_ef,
-                "hnsw:search_ef": self.config.search_ef,
-                # we could expose other configs, see:
-                # https://docs.trychroma.com/docs/collections/configure
-            },
-        )
-
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        super().maybe_add_ids(documents)
-        if documents is None:
-            return
-        contents: List[str] = [document.content for document in documents]
-        # convert metadatas to dicts so chroma can handle them
-        metadata_dicts: List[dict[str, Any]] = [
-            d.metadata.dict_bool_int() for d in documents
-        ]
-        for m in metadata_dicts:
-            # chroma does not handle non-atomic types in metadata
-            m["window_ids"] = ",".join(m["window_ids"])
-
-        ids = [str(d.id()) for d in documents]
-
-        colls = self.list_collections(empty=True)
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-        if self.config.collection_name not in colls:
-            self.create_collection(self.config.collection_name, replace=True)
-
-        self.collection.add(
-            # embedding_models=embedding_models,
-            documents=contents,
-            metadatas=metadata_dicts,
-            ids=ids,
-        )
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        filter = json.loads(where) if where else None
-        results = self.collection.get(
-            include=["documents", "metadatas"],
-            where=filter,
-        )
-        results["documents"] = [results["documents"]]
-        results["metadatas"] = [results["metadatas"]]
-        return self._docs_from_results(results)
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        # get them one by one since chroma mangles the order of the results
-        # when fetched from a list of ids.
-        results = [
-            self.collection.get(ids=[id], include=["documents", "metadatas"])
-            for id in ids
-        ]
-        final_results = {}
-        final_results["documents"] = [[r["documents"][0] for r in results]]
-        final_results["metadatas"] = [[r["metadatas"][0] for r in results]]
-        return self._docs_from_results(final_results)
-
-    def delete_collection(self, collection_name: str) -> None:
-        try:
-            self.client.delete_collection(name=collection_name)
-        except Exception:
-            pass
-
-    def similar_texts_with_scores(
-        self, text: str, k: int = 1, where: Optional[str] = None
-    ) -> List[Tuple[Document, float]]:
-        n = self.collection.count()
-        filter = json.loads(where) if where else None
-        results = self.collection.query(
-            query_texts=[text],
-            n_results=min(n, k),
-            where=filter,
-            include=["documents", "distances", "metadatas"],
-        )
-        docs = self._docs_from_results(results)
-        # chroma distances are 1 - cosine.
-        scores = [1 - s for s in results["distances"][0]]
-        return list(zip(docs, scores))
-
-    def _docs_from_results(self, results: Dict[str, Any]) -> List[Document]:
-        """
-        Helper function to convert results from ChromaDB to a list of Documents
-        Args:
-            results (dict): results from ChromaDB
-
-        Returns:
-            List[Document]: list of Documents
-        """
-        if len(results["documents"][0]) == 0:
-            return []
-        contents = results["documents"][0]
-        if settings.debug:
-            for i, c in enumerate(contents):
-                print_long_text("red", "italic red", f"MATCH-{i}", c)
-        metadatas = results["metadatas"][0]
-        for m in metadatas:
-            # restore the stringified list of window_ids into the original List[str]
-            if m["window_ids"].strip() == "":
-                m["window_ids"] = []
-            else:
-                m["window_ids"] = m["window_ids"].split(",")
-        docs = [
-            self.config.document_class(
-                content=d, metadata=self.config.metadata_class(**m)
-            )
-            for d, m in zip(contents, metadatas)
-        ]
-        return docs
-</file>
-
-<file path="langroid/vector_store/lancedb.py">
-from __future__ import annotations
-
-import logging
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Generator,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-)
-
-import pandas as pd
-from dotenv import load_dotenv
-from pydantic import BaseModel, ValidationError, create_model
-
-if TYPE_CHECKING:
-    from lancedb.query import LanceVectorQueryBuilder
-
-from langroid.embedding_models.base import (
-    EmbeddingModelsConfig,
-)
-from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.exceptions import LangroidImportError
-from langroid.mytypes import Document
-from langroid.utils.configuration import settings
-from langroid.utils.pydantic_utils import (
-    dataframe_to_document_model,
-    dataframe_to_documents,
-)
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-try:
-    import lancedb
-    from lancedb.pydantic import LanceModel, Vector
-
-    has_lancedb = True
-except ImportError:
-    has_lancedb = False
-
-logger = logging.getLogger(__name__)
-
-
-class LanceDBConfig(VectorStoreConfig):
-    cloud: bool = False
-    collection_name: str | None = "temp"
-    storage_path: str = ".lancedb/data"
-    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    distance: str = "cosine"
-
-
-class LanceDB(VectorStore):
-    def __init__(self, config: LanceDBConfig | None = None):
-        config = config if config is not None else LanceDBConfig()
-        super().__init__(config)
-        if not has_lancedb:
-            raise LangroidImportError("lancedb", "lancedb")
-
-        self.config: LanceDBConfig = config
-        self.host = config.host
-        self.port = config.port
-        self.is_from_dataframe = False  # were docs ingested from a dataframe?
-        self.df_metadata_columns: List[str] = []  # metadata columns from dataframe
-
-        load_dotenv()
-        if self.config.cloud:
-            logger.warning(
-                "LanceDB Cloud is not available yet. Switching to local storage."
-            )
-            config.cloud = False
-        else:
-            try:
-                self.client = lancedb.connect(
-                    uri=config.storage_path,
-                )
-            except Exception as e:
-                new_storage_path = config.storage_path + ".new"
-                logger.warning(
-                    f"""
-                    Error connecting to local LanceDB at {config.storage_path}:
-                    {e}
-                    Switching to {new_storage_path}
-                    """
-                )
-                self.client = lancedb.connect(
-                    uri=new_storage_path,
-                )
-
-    def clear_empty_collections(self) -> int:
-        coll_names = self.list_collections()
-        n_deletes = 0
-        for name in coll_names:
-            nr = self.client.open_table(name).head(1).shape[0]
-            if nr == 0:
-                n_deletes += 1
-                self.client.drop_table(name)
-        return n_deletes
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """Clear all collections with the given prefix."""
-        if not really:
-            logger.warning("Not deleting all collections, set really=True to confirm")
-            return 0
-        coll_names = [
-            c for c in self.list_collections(empty=True) if c.startswith(prefix)
-        ]
-        if len(coll_names) == 0:
-            logger.warning(f"No collections found with prefix {prefix}")
-            return 0
-        n_empty_deletes = 0
-        n_non_empty_deletes = 0
-        for name in coll_names:
-            nr = self.client.open_table(name).head(1).shape[0]
-            n_empty_deletes += nr == 0
-            n_non_empty_deletes += nr > 0
-            self.client.drop_table(name)
-        logger.warning(
-            f"""
-            Deleted {n_empty_deletes} empty collections and
-            {n_non_empty_deletes} non-empty collections.
-            """
-        )
-        return n_empty_deletes + n_non_empty_deletes
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """
-        Returns:
-            List of collection names that have at least one vector.
-
-        Args:
-            empty (bool, optional): Whether to include empty collections.
-        """
-        colls = self.client.table_names(limit=None)
-        if len(colls) == 0:
-            return []
-        if empty:  # include empty tbls
-            return colls  # type: ignore
-        counts = [self.client.open_table(coll).head(1).shape[0] for coll in colls]
-        return [coll for coll, count in zip(colls, counts) if count > 0]
-
-    def _create_lance_schema(self, doc_cls: Type[Document]) -> Type[BaseModel]:
-        """
-        NOTE: NOT USED, but leaving it here as it may be useful.
-
-        Create a subclass of LanceModel with fields:
-         - id (str)
-         - Vector field that has dims equal to
-            the embedding dimension of the embedding model, and a data field of type
-            DocClass.
-         - other fields from doc_cls
-
-        Args:
-            doc_cls (Type[Document]): A Pydantic model which should be a subclass of
-                Document, to be used as the type for the data field.
-
-        Returns:
-            Type[BaseModel]: A new Pydantic model subclassing from LanceModel.
-
-        Raises:
-            ValueError: If `n` is not a non-negative integer or if `DocClass` is not a
-                subclass of Document.
-        """
-        if not issubclass(doc_cls, Document):
-            raise ValueError("DocClass must be a subclass of Document")
-
-        if not has_lancedb:
-            raise LangroidImportError("lancedb", "lancedb")
-
-        n = self.embedding_dim
-
-        # Prepare fields for the new model
-        fields = {"id": (str, ...), "vector": (Vector(n), ...)}
-
-        sorted_fields = dict(
-            sorted(doc_cls.model_fields.items(), key=lambda item: item[0])
-        )
-        # Add both statically and dynamically defined fields from doc_cls
-        for field_name, field in sorted_fields.items():
-            field_type = field.annotation if hasattr(field, "annotation") else field
-            fields[field_name] = (field_type, field.default)
-
-        # Create the new model with dynamic fields
-        NewModel = create_model(
-            "NewModel", __base__=LanceModel, **fields
-        )  # type: ignore
-        return NewModel  # type: ignore
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        self.config.replace_collection = replace
-        self.config.collection_name = collection_name
-        if replace:
-            self.delete_collection(collection_name)
-
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        super().maybe_add_ids(documents)
-        colls = self.list_collections(empty=True)
-        if len(documents) == 0:
-            return
-        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-        coll_name = self.config.collection_name
-        if coll_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-        # self._maybe_set_doc_class_schema(documents[0])
-        table_exists = False
-        if (
-            coll_name in colls
-            and self.client.open_table(coll_name).head(1).shape[0] > 0
-        ):
-            # collection exists and  is not empty:
-            # if replace_collection is True, we'll overwrite the existing collection,
-            # else we'll append to it.
-            if self.config.replace_collection:
-                self.client.drop_table(coll_name)
-            else:
-                table_exists = True
-
-        ids = [str(d.id()) for d in documents]
-        # don't insert all at once, batch in chunks of b,
-        # else we get an API error
-        b = self.config.batch_size
-
-        def make_batches() -> Generator[List[Dict[str, Any]], None, None]:
-            for i in range(0, len(ids), b):
-                batch = [
-                    dict(
-                        id=ids[i + j],
-                        vector=embedding_vecs[i + j],
-                        **doc.model_dump(),
-                    )
-                    for j, doc in enumerate(documents[i : i + b])
-                ]
-                yield batch
-
-        try:
-            if table_exists:
-                tbl = self.client.open_table(coll_name)
-                tbl.add(make_batches())
-            else:
-                batch_gen = make_batches()
-                batch = next(batch_gen)
-                # use first batch to create table...
-                tbl = self.client.create_table(
-                    coll_name,
-                    data=batch,
-                    mode="create",
-                )
-                # ... and add the rest
-                tbl.add(batch_gen)
-        except Exception as e:
-            logger.error(
-                f"""
-                Error adding documents to LanceDB: {e}
-                POSSIBLE REMEDY: Delete the LancdDB storage directory
-                {self.config.storage_path} and try again.
-                """
-            )
-
-    def add_dataframe(
-        self,
-        df: pd.DataFrame,
-        content: str = "content",
-        metadata: List[str] = [],
-    ) -> None:
-        """
-        Add a dataframe to the collection.
-        Args:
-            df (pd.DataFrame): A dataframe
-            content (str): The name of the column in the dataframe that contains the
-                text content to be embedded using the embedding model.
-            metadata (List[str]): A list of column names in the dataframe that contain
-                metadata to be stored in the database. Defaults to [].
-        """
-        self.is_from_dataframe = True
-        actual_metadata = metadata.copy()
-        self.df_metadata_columns = actual_metadata  # could be updated below
-        # get content column
-        content_values = df[content].values.tolist()
-        embedding_vecs = self.embedding_fn(content_values)
-
-        # add vector column
-        df["vector"] = embedding_vecs
-        if content != "content":
-            # rename content column to "content", leave existing column intact
-            df = df.rename(columns={content: "content"}, inplace=False)
-
-        if "id" not in df.columns:
-            docs = dataframe_to_documents(df, content="content", metadata=metadata)
-            ids = [str(d.id()) for d in docs]
-            df["id"] = ids
-
-        if "id" not in actual_metadata:
-            actual_metadata += ["id"]
-
-        colls = self.list_collections(empty=True)
-        coll_name = self.config.collection_name
-        if (
-            coll_name not in colls
-            or self.client.open_table(coll_name).head(1).shape[0] == 0
-        ):
-            # collection either doesn't exist or is empty, so replace it
-            # and set new schema from df
-            self.client.create_table(
-                self.config.collection_name,
-                data=df,
-                mode="overwrite",
-            )
-            doc_cls = dataframe_to_document_model(
-                df,
-                content=content,
-                metadata=actual_metadata,
-                exclude=["vector"],
-            )
-            self.config.document_class = doc_cls  # type: ignore
-        else:
-            # collection exists and is not empty, so append to it
-            tbl = self.client.open_table(self.config.collection_name)
-            tbl.add(df)
-
-    def delete_collection(self, collection_name: str) -> None:
-        self.client.drop_table(collection_name, ignore_missing=True)
-
-    def _lance_result_to_docs(
-        self, result: "LanceVectorQueryBuilder"
-    ) -> List[Document]:
-        if self.is_from_dataframe:
-            df = result.to_pandas()
-            return dataframe_to_documents(
-                df,
-                content="content",
-                metadata=self.df_metadata_columns,
-                doc_cls=self.config.document_class,
-            )
-        else:
-            records = result.to_arrow().to_pylist()
-            return self._records_to_docs(records)
-
-    def _records_to_docs(self, records: List[Dict[str, Any]]) -> List[Document]:
-        try:
-            docs = [self.config.document_class(**rec) for rec in records]
-        except ValidationError as e:
-            raise ValueError(
-                f"""
-            Error validating LanceDB result: {e}
-            HINT: This could happen when you're re-using an
-            existing LanceDB store with a different schema.
-            Try deleting your local lancedb storage at `{self.config.storage_path}`
-            re-ingesting your documents and/or replacing the collections.
-            """
-            )
-        return docs
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        if self.config.collection_name not in self.list_collections(empty=True):
-            return []
-        tbl = self.client.open_table(self.config.collection_name)
-        pre_result = tbl.search(None).where(where or None).limit(None)
-        return self._lance_result_to_docs(pre_result)
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        _ids = [str(id) for id in ids]
-        tbl = self.client.open_table(self.config.collection_name)
-        docs = []
-        for _id in _ids:
-            results = self._lance_result_to_docs(tbl.search().where(f"id == '{_id}'"))
-            if len(results) > 0:
-                docs.append(results[0])
-        return docs
-
-    def similar_texts_with_scores(
-        self,
-        text: str,
-        k: int = 1,
-        where: Optional[str] = None,
-    ) -> List[Tuple[Document, float]]:
-        embedding = self.embedding_fn([text])[0]
-        tbl = self.client.open_table(self.config.collection_name)
-        result = (
-            tbl.search(embedding)
-            .metric(self.config.distance)
-            .where(where, prefilter=True)
-            .limit(k)
-        )
-        docs = self._lance_result_to_docs(result)
-        # note _distance is 1 - cosine
-        if self.is_from_dataframe:
-            scores = [
-                1 - rec["_distance"] for rec in result.to_pandas().to_dict("records")
-            ]
-        else:
-            scores = [1 - rec["_distance"] for rec in result.to_arrow().to_pylist()]
-        if len(docs) == 0:
-            logger.warning(f"No matches found for {text}")
-            return []
-        if settings.debug:
-            logger.info(f"Found {len(docs)} matches, max score: {max(scores)}")
-        doc_score_pairs = list(zip(docs, scores))
-        self.show_if_debug(doc_score_pairs)
-        return doc_score_pairs
-</file>
-
-<file path="langroid/vector_store/meilisearch.py">
-"""
-MeiliSearch as a pure document store, without its
-(experimental) vector-store functionality.
-We aim to use MeiliSearch for fast lexical search.
-Note that what we call "Collection" in Langroid is referred to as
-"Index" in MeiliSearch. Each data-store has its own terminology,
-but for uniformity we use the Langroid terminology here.
-"""
-
-from __future__ import annotations
-
-import asyncio
-import logging
-import os
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple
-
-from dotenv import load_dotenv
-
-if TYPE_CHECKING:
-    from meilisearch_python_sdk.index import AsyncIndex
-    from meilisearch_python_sdk.models.documents import DocumentsInfo
-
-
-from langroid.exceptions import LangroidImportError
-from langroid.mytypes import DocMetaData, Document
-from langroid.utils.configuration import settings
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-logger = logging.getLogger(__name__)
-
-
-class MeiliSearchConfig(VectorStoreConfig):
-    cloud: bool = False
-    collection_name: str | None = None
-    primary_key: str = "id"
-    port: int = 7700
-
-
-class MeiliSearch(VectorStore):
-    def __init__(self, config: MeiliSearchConfig | None = None):
-        config = config if config is not None else MeiliSearchConfig()
-        super().__init__(config)
-        try:
-            import meilisearch_python_sdk as meilisearch
-        except ImportError:
-            raise LangroidImportError("meilisearch", "meilisearch")
-
-        self.config: MeiliSearchConfig = config
-        self.host = config.host
-        self.port = config.port
-        load_dotenv()
-        self.key = os.getenv("MEILISEARCH_API_KEY") or "masterKey"
-        self.url = os.getenv("MEILISEARCH_API_URL") or f"http://{self.host}:{self.port}"
-        if config.cloud and None in [self.key, self.url]:
-            logger.warning(
-                f"""MEILISEARCH_API_KEY, MEILISEARCH_API_URL env variable must be set 
-                to use MeiliSearch in cloud mode. Please set these values 
-                in your .env file. Switching to local MeiliSearch at 
-                {self.url} 
-                """
-            )
-            config.cloud = False
-
-        self.client: Callable[[], meilisearch.AsyncClient] = lambda: (
-            meilisearch.AsyncClient(url=self.url, api_key=self.key)
-        )
-
-        # Note: Only create collection if a non-null collection name is provided.
-        # This is useful to delay creation of db until we have a suitable
-        # collection name (e.g. we could get it from the url or folder path).
-        if config.collection_name is not None:
-            self.create_collection(
-                config.collection_name, replace=config.replace_collection
-            )
-
-    def clear_empty_collections(self) -> int:
-        """All collections are treated as non-empty in MeiliSearch, so this is a
-        no-op"""
-        return 0
-
-    async def _async_delete_indices(self, uids: List[str]) -> List[bool]:
-        """Delete any indicecs in `uids` that exist.
-        Returns list of bools indicating whether the index has been deleted"""
-        async with self.client() as client:
-            result = await asyncio.gather(
-                *[client.delete_index_if_exists(uid=uid) for uid in uids]
-            )
-        return result
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """Delete all indices whose names start with `prefix`"""
-        if not really:
-            logger.warning("Not deleting all collections, set really=True to confirm")
-            return 0
-        coll_names = [c for c in self.list_collections() if c.startswith(prefix)]
-        deletes = asyncio.run(self._async_delete_indices(coll_names))
-        n_deletes = sum(deletes)
-        logger.warning(f"Deleted {n_deletes} indices in MeiliSearch")
-        return n_deletes
-
-    def _list_all_collections(self) -> List[str]:
-        """
-        List all collections, including empty ones.
-        Returns:
-            List of collection names.
-        """
-        return self.list_collections()
-
-    async def _async_get_indexes(self) -> List[AsyncIndex]:
-        async with self.client() as client:
-            indexes = await client.get_indexes(limit=10_000)
-        return [] if indexes is None else indexes  # type: ignore
-
-    async def _async_get_index(self, index_uid: str) -> "AsyncIndex":
-        async with self.client() as client:
-            index = await client.get_index(index_uid)
-        return index  # type: ignore
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """
-        Returns:
-            List of index names stored. We treat any existing index as non-empty.
-        """
-        indexes = asyncio.run(self._async_get_indexes())
-        if len(indexes) == 0:
-            return []
-        else:
-            return [ind.uid for ind in indexes]
-
-    async def _async_create_index(self, collection_name: str) -> "AsyncIndex":
-        async with self.client() as client:
-            index = await client.create_index(
-                uid=collection_name,
-                primary_key=self.config.primary_key,
-            )
-        return index
-
-    async def _async_delete_index(self, collection_name: str) -> bool:
-        """Delete index if it exists. Returns True iff index was deleted"""
-        async with self.client() as client:
-            result = await client.delete_index_if_exists(uid=collection_name)
-        return result  # type: ignore
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        """
-        Create a collection with the given name, optionally replacing an existing
-            collection if `replace` is True.
-        Args:
-            collection_name (str): Name of the collection to create.
-            replace (bool): Whether to replace an existing collection
-                with the same name. Defaults to False.
-        """
-        self.config.collection_name = collection_name
-        collections = self.list_collections()
-        if collection_name in collections:
-            logger.warning(
-                f"MeiliSearch Non-empty Index {collection_name} already exists"
-            )
-            if not replace:
-                logger.warning("Not replacing collection")
-                return
-            else:
-                logger.warning("Recreating fresh collection")
-                asyncio.run(self._async_delete_index(collection_name))
-        asyncio.run(self._async_create_index(collection_name))
-        collection_info = asyncio.run(self._async_get_index(collection_name))
-        if settings.debug:
-            level = logger.getEffectiveLevel()
-            logger.setLevel(logging.INFO)
-            logger.info(collection_info)
-            logger.setLevel(level)
-
-    async def _async_add_documents(
-        self, collection_name: str, documents: Sequence[Dict[str, Any]]
-    ) -> None:
-        async with self.client() as client:
-            index = client.index(collection_name)
-            await index.add_documents_in_batches(
-                documents=documents,
-                batch_size=self.config.batch_size,
-                primary_key=self.config.primary_key,
-            )
-
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        super().maybe_add_ids(documents)
-        if len(documents) == 0:
-            return
-        colls = self._list_all_collections()
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-        if self.config.collection_name not in colls:
-            self.create_collection(self.config.collection_name, replace=True)
-        docs = [
-            dict(
-                id=d.id(),
-                content=d.content,
-                metadata=d.metadata.model_dump(),
-            )
-            for d in documents
-        ]
-        asyncio.run(self._async_add_documents(self.config.collection_name, docs))
-
-    def delete_collection(self, collection_name: str) -> None:
-        asyncio.run(self._async_delete_index(collection_name))
-
-    def _to_int_or_uuid(self, id: str) -> int | str:
-        try:
-            return int(id)
-        except ValueError:
-            return id
-
-    async def _async_get_documents(self, where: str = "") -> "DocumentsInfo":
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        filter = [] if where is None else where
-        async with self.client() as client:
-            index = client.index(self.config.collection_name)
-            documents = await index.get_documents(limit=10_000, filter=filter)
-        return documents
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        docs = asyncio.run(self._async_get_documents(where))
-        if docs is None:
-            return []
-        doc_results = docs.results
-        return [
-            Document(
-                content=d["content"],
-                metadata=DocMetaData(**d["metadata"]),
-            )
-            for d in doc_results
-        ]
-
-    async def _async_get_documents_by_ids(self, ids: List[str]) -> List[Dict[str, Any]]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        async with self.client() as client:
-            index = client.index(self.config.collection_name)
-            documents = await asyncio.gather(*[index.get_document(id) for id in ids])
-        return documents
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        docs = asyncio.run(self._async_get_documents_by_ids(ids))
-        return [
-            Document(
-                content=d["content"],
-                metadata=DocMetaData(**d["metadata"]),
-            )
-            for d in docs
-        ]
-
-    async def _async_search(
-        self,
-        query: str,
-        k: int = 20,
-        filter: str | list[str | list[str]] | None = None,
-    ) -> List[Dict[str, Any]]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot search")
-        async with self.client() as client:
-            index = client.index(self.config.collection_name)
-            results = await index.search(
-                query,
-                limit=k,
-                show_ranking_score=True,
-                filter=filter,
-            )
-        return results.hits  # type: ignore
-
-    def similar_texts_with_scores(
-        self,
-        text: str,
-        k: int = 20,
-        where: Optional[str] = None,
-        neighbors: int = 0,  # ignored
-    ) -> List[Tuple[Document, float]]:
-        filter = [] if where is None else where
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot search")
-        _docs = asyncio.run(self._async_search(text, k, filter))  # type: ignore
-        if len(_docs) == 0:
-            logger.warning(f"No matches found for {text}")
-            return []
-        scores = [h["_rankingScore"] for h in _docs]
-        if settings.debug:
-            logger.info(f"Found {len(_docs)} matches, max score: {max(scores)}")
-        docs = [
-            Document(
-                content=d["content"],
-                metadata=DocMetaData(**d["metadata"]),
-            )
-            for d in _docs
-        ]
-        doc_score_pairs = list(zip(docs, scores))
-        self.show_if_debug(doc_score_pairs)
-        return doc_score_pairs
-</file>
-
 <file path="langroid/vector_store/milvusdb.py">
 import json
 import logging
@@ -38951,750 +38017,90 @@ class MilvusDB(VectorStore):
         raise ValueError(f"Unsupported Milvus filter value: {value!r}")
 </file>
 
-<file path="langroid/vector_store/pineconedb.py">
-import json
-import logging
-import os
-import re
-from dataclasses import dataclass
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-)
-
-from dotenv import load_dotenv
-
-# import dataclass
-from pydantic import BaseModel
-
-from langroid import LangroidImportError
-from langroid.mytypes import Document
-from langroid.utils.configuration import settings
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-logger = logging.getLogger(__name__)
-
-
-has_pinecone: bool = True
-try:
-    from pinecone import Pinecone, PineconeApiException, ServerlessSpec
-except ImportError:
-
-    if not TYPE_CHECKING:
-
-        class ServerlessSpec(BaseModel):
-            """
-            Fallback Serverless specification configuration to avoid import errors.
-            """
-
-            cloud: str
-            region: str
-
-        PineconeApiException = Any  # type: ignore
-        Pinecone = Any  # type: ignore
-        has_pinecone = False
-
-
-@dataclass(frozen=True)
-class IndexMeta:
-    name: str
-    total_vector_count: int
-
-
-class PineconeDBConfig(VectorStoreConfig):
-    cloud: bool = True
-    collection_name: str | None = "temp"
-    spec: ServerlessSpec = ServerlessSpec(cloud="aws", region="us-east-1")
-    deletion_protection: Literal["enabled", "disabled"] | None = None
-    metric: str = "cosine"
-    pagination_size: int = 100
-
-
-class PineconeDB(VectorStore):
-    def __init__(self, config: PineconeDBConfig | None = None):
-        config = config if config is not None else PineconeDBConfig()
-        super().__init__(config)
-        if not has_pinecone:
-            raise LangroidImportError("pinecone", "pinecone")
-        self.config: PineconeDBConfig = config
-        load_dotenv()
-        key = os.getenv("PINECONE_API_KEY")
-
-        if not key:
-            raise ValueError("PINECONE_API_KEY not set, could not instantiate client")
-        self.client = Pinecone(api_key=key)
-
-        if config.collection_name:
-            self.create_collection(
-                collection_name=config.collection_name,
-                replace=config.replace_collection,
-            )
-
-    def clear_empty_collections(self) -> int:
-        indexes = self._list_index_metas(empty=True)
-        n_deletes = 0
-        for index in indexes:
-            if index.total_vector_count == -1:
-                logger.warning(
-                    f"Error fetching details for {index.name} when scanning indexes"
-                )
-            n_deletes += 1
-            self.delete_collection(collection_name=index.name)
-        return n_deletes
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """
-        Returns:
-            Number of Pinecone indexes that were deleted
-
-        Args:
-            really: Optional[bool] - whether to really delete all Pinecone collections
-            prefix: Optional[str] - string to match potential Pinecone
-                indexes for deletion
-        """
-        if not really:
-            logger.warning("Not deleting all collections, set really=True to confirm")
-            return 0
-        indexes = [
-            c for c in self._list_index_metas(empty=True) if c.name.startswith(prefix)
-        ]
-        if len(indexes) == 0:
-            logger.warning(f"No collections found with prefix {prefix}")
-            return 0
-        n_empty_deletes, n_non_empty_deletes = 0, 0
-        for index_desc in indexes:
-            self.delete_collection(collection_name=index_desc.name)
-            n_empty_deletes += index_desc.total_vector_count == 0
-            n_non_empty_deletes += index_desc.total_vector_count > 0
-        logger.warning(
-            f"""
-            Deleted {n_empty_deletes} empty indexes and
-            {n_non_empty_deletes} non-empty indexes
-            """
-        )
-        return n_empty_deletes + n_non_empty_deletes
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """
-        Returns:
-            List of Pinecone indices that have at least one vector.
-
-        Args:
-            empty: Optional[bool] - whether to include empty collections
-        """
-        indexes = self.client.list_indexes()
-        res: List[str] = []
-        if empty:
-            res.extend(indexes.names())
-            return res
-
-        for index in indexes.names():
-            index_meta = self.client.Index(name=index)
-            if index_meta.describe_index_stats().get("total_vector_count", 0) > 0:
-                res.append(index)
-        return res
-
-    def _list_index_metas(self, empty: bool = False) -> List[IndexMeta]:
-        """
-        Returns:
-            List of objects describing Pinecone indices
-
-        Args:
-            empty: Optional[bool] - whether to include empty collections
-        """
-        indexes = self.client.list_indexes()
-        res = []
-        for index in indexes.names():
-            index_meta = self._fetch_index_meta(index)
-            if empty:
-                res.append(index_meta)
-            elif index_meta.total_vector_count > 0:
-                res.append(index_meta)
-        return res
-
-    def _fetch_index_meta(self, index_name: str) -> IndexMeta:
-        """
-        Returns:
-            A dataclass describing the input Index by name and vector count
-            to save a bit on index description calls
-
-        Args:
-            index_name: str - Name of the index in Pinecone
-        """
-        try:
-            index = self.client.Index(name=index_name)
-            stats = index.describe_index_stats()
-            return IndexMeta(
-                name=index_name, total_vector_count=stats.get("total_vector_count", 0)
-            )
-        except PineconeApiException as e:
-            logger.warning(f"Error fetching details for index {index_name}")
-            logger.warning(e)
-            return IndexMeta(name=index_name, total_vector_count=-1)
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        """
-        Create a collection with the given name, optionally replacing an existing
-        collection if `replace` is True.
-
-        Args:
-            collection_name: str - Configuration of the collection to create.
-            replace: Optional[Bool] - Whether to replace an existing collection
-                with the same name. Defaults to False.
-        """
-        pattern = re.compile(r"^[a-z0-9-]+$")
-        if not pattern.match(collection_name):
-            raise ValueError(
-                "Pinecone index names must be lowercase alphanumeric characters or '-'"
-            )
-        self.config.collection_name = collection_name
-        if collection_name in self.list_collections(empty=True):
-            index = self.client.Index(name=collection_name)
-            stats = index.describe_index_stats()
-            status = self.client.describe_index(name=collection_name)
-            if status["status"]["ready"] and stats["total_vector_count"] > 0:
-                logger.warning(f"Non-empty collection {collection_name} already exists")
-                if not replace:
-                    logger.warning("Not replacing collection")
-                    return
-                else:
-                    logger.warning("Recreating fresh collection")
-            self.delete_collection(collection_name=collection_name)
-
-        payload = {
-            "name": collection_name,
-            "dimension": self.embedding_dim,
-            "spec": self.config.spec,
-            "metric": self.config.metric,
-            "timeout": self.config.timeout,
-        }
-
-        if self.config.deletion_protection:
-            payload["deletion_protection"] = self.config.deletion_protection
-
-        try:
-            self.client.create_index(**payload)
-        except PineconeApiException as e:
-            logger.error(e)
-
-    def delete_collection(self, collection_name: str) -> None:
-        logger.info(f"Attempting to delete {collection_name}")
-        try:
-            self.client.delete_index(name=collection_name)
-        except PineconeApiException as e:
-            logger.error(f"Failed to delete {collection_name}")
-            logger.error(e)
-
-    def add_documents(self, documents: Sequence[Document], namespace: str = "") -> None:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-
-        if len(documents) == 0:
-            logger.warning("Empty list of documents passed into add_documents")
-            return
-
-        super().maybe_add_ids(documents)
-        document_dicts = [doc.model_dump() for doc in documents]
-        document_ids = [doc.id() for doc in documents]
-        embedding_vectors = self.embedding_fn([doc.content for doc in documents])
-        vectors = [
-            {
-                "id": document_id,
-                "values": embedding_vector,
-                "metadata": {
-                    **document_dict["metadata"],
-                    **{
-                        key: value
-                        for key, value in document_dict.items()
-                        if key != "metadata"
-                    },
-                },
-            }
-            for document_dict, document_id, embedding_vector in zip(
-                document_dicts, document_ids, embedding_vectors
-            )
-        ]
-
-        if self.config.collection_name not in self.list_collections(empty=True):
-            self.create_collection(
-                collection_name=self.config.collection_name, replace=True
-            )
-
-        index = self.client.Index(name=self.config.collection_name)
-        batch_size = self.config.batch_size
-
-        for i in range(0, len(documents), batch_size):
-            try:
-                if namespace:
-                    index.upsert(
-                        vectors=vectors[i : i + batch_size], namespace=namespace
-                    )
-                else:
-                    index.upsert(vectors=vectors[i : i + batch_size])
-            except PineconeApiException as e:
-                logger.error(
-                    f"Unable to add of docs between indices {i} and {batch_size}"
-                )
-                logger.error(e)
-
-    def get_all_documents(
-        self, prefix: str = "", namespace: str = ""
-    ) -> List[Document]:
-        """
-        Returns:
-            All documents for the collection currently defined in
-            the configuration object
-
-        Args:
-            prefix: str - document id prefix to search for
-            namespace: str - partition of vectors to search within the index
-        """
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        docs = []
-
-        request_filters: Dict[str, Union[str, int]] = {
-            "limit": self.config.pagination_size
-        }
-        if prefix:
-            request_filters["prefix"] = prefix
-        if namespace:
-            request_filters["namespace"] = namespace
-
-        index = self.client.Index(name=self.config.collection_name)
-
-        while True:
-            response = index.list_paginated(**request_filters)
-            vectors = response.get("vectors", [])
-
-            if not vectors:
-                logger.warning("Received empty list while requesting for vector ids")
-                logger.warning("Halting fetch requests")
-                if settings.debug:
-                    logger.debug(f"Request for failed fetch was: {request_filters}")
-                break
-
-            docs.extend(
-                self.get_documents_by_ids(
-                    ids=[vector.get("id") for vector in vectors],
-                    namespace=namespace if namespace else "",
-                )
-            )
-
-            pagination_token = response.get("pagination", {}).get("next", None)
-
-            if not pagination_token:
-                break
-
-            request_filters["pagination_token"] = pagination_token
-
-        return docs
-
-    def get_documents_by_ids(
-        self, ids: List[str], namespace: str = ""
-    ) -> List[Document]:
-        """
-        Returns:
-            Fetches document text embedded in Pinecone index metadata
-
-        Args:
-            ids: List[str] - vector data object ids to retrieve
-            namespace: str - partition of vectors to search within the index
-        """
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        index = self.client.Index(name=self.config.collection_name)
-
-        if namespace:
-            records = index.fetch(ids=ids, namespace=namespace)
-        else:
-            records = index.fetch(ids=ids)
-
-        id_mapping = {key: value for key, value in records["vectors"].items()}
-        ordered_payloads = [id_mapping[_id] for _id in ids if _id in id_mapping]
-        return [
-            self.transform_pinecone_vector(payload.get("metadata", {}))
-            for payload in ordered_payloads
-        ]
-
-    def similar_texts_with_scores(
-        self,
-        text: str,
-        k: int = 1,
-        where: Optional[str] = None,
-        namespace: Optional[str] = None,
-    ) -> List[Tuple[Document, float]]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot search")
-
-        if k < 1 or k > 9999:
-            raise ValueError(
-                f"TopK for Pinecone vector search must be 1 < k < 10000, k was {k}"
-            )
-
-        vector_search_request = {
-            "top_k": k,
-            "include_metadata": True,
-            "vector": self.embedding_fn([text])[0],
-        }
-        if where:
-            vector_search_request["filter"] = json.loads(where) if where else None
-        if namespace:
-            vector_search_request["namespace"] = namespace
-
-        index = self.client.Index(name=self.config.collection_name)
-        response = index.query(**vector_search_request)
-        doc_score_pairs = [
-            (
-                self.transform_pinecone_vector(match.get("metadata", {})),
-                match.get("score", 0),
-            )
-            for match in response.get("matches", [])
-        ]
-        if settings.debug:
-            max_score = max([pair[1] for pair in doc_score_pairs])
-            logger.info(f"Found {len(doc_score_pairs)} matches, max score: {max_score}")
-        self.show_if_debug(doc_score_pairs)
-        return doc_score_pairs
-
-    def transform_pinecone_vector(self, metadata_dict: Dict[str, Any]) -> Document:
-        """
-        Parses the metadata response from the Pinecone vector query and
-        formats it into a dictionary that can be parsed by the Document class
-        associated with the PineconeDBConfig class
-
-        Returns:
-            Well formed dictionary object to be transformed into a Document
-
-        Args:
-            metadata_dict: Dict - the metadata dictionary from the Pinecone
-                vector query match
-        """
-        return self.config.document_class(
-            **{**metadata_dict, "metadata": {**metadata_dict}}
-        )
-</file>
-
-<file path="langroid/vector_store/weaviatedb.py">
-import logging
-import os
-import re
-from typing import Any, List, Optional, Sequence, Tuple
-
-from dotenv import load_dotenv
-
-from langroid.embedding_models.base import (
-    EmbeddingModelsConfig,
-)
-from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.exceptions import LangroidImportError
-from langroid.mytypes import DocMetaData, Document
-from langroid.utils.configuration import settings
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-logger = logging.getLogger(__name__)
-
-
-class VectorDistances:
-    """
-    Fallback class when weaviate is not installed, to avoid import errors.
-    """
-
-    COSINE: str = "cosine"
-    DOTPRODUCT: str = "dot"
-    L2: str = "l2"
-
-
-class WeaviateDBConfig(VectorStoreConfig):
-    collection_name: str | None = "temp"
-    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    distance: str = VectorDistances.COSINE
-    cloud: bool = False
-    docker: bool = False
-    host: str = "127.0.0.1"
-    port: int = 8080
-    storage_path: str = ".weaviate_embedded/data"
-
-
-class WeaviateDB(VectorStore):
-    def __init__(self, config: WeaviateDBConfig | None = None):
-        config = config if config is not None else WeaviateDBConfig()
-        super().__init__(config)
-        try:
-            import weaviate
-            from weaviate.classes.init import Auth
-        except ImportError:
-            raise LangroidImportError("weaviate", "weaviate")
-
-        self.config: WeaviateDBConfig = config
-        load_dotenv()
-        if self.config.docker:
-            self.client = weaviate.connect_to_local(
-                host=self.config.host,
-                port=self.config.port,
-            )
-            self.config.cloud = False
-        elif self.config.cloud:
-            key = os.getenv("WEAVIATE_API_KEY")
-            url = os.getenv("WEAVIATE_API_URL")
-            if url is None or key is None:
-                raise ValueError(
-                    """WEAVIATE_API_KEY, WEAVIATE_API_URL env variables must be set to 
-                    use WeaviateDB in cloud mode. Please set these values
-                    in your .env file.
-                    """
-                )
-            self.client = weaviate.connect_to_weaviate_cloud(
-                cluster_url=url,
-                auth_credentials=Auth.api_key(key),
-            )
-        else:
-            self.client = weaviate.connect_to_embedded(
-                version="latest", persistence_data_path=self.config.storage_path
-            )
-
-        if config.collection_name is not None:
-            WeaviateDB.validate_and_format_collection_name(config.collection_name)
-
-    def clear_empty_collections(self) -> int:
-        colls = self.client.collections.list_all()
-        n_deletes = 0
-        for coll_name, _ in colls.items():
-            val = self.client.collections.get(coll_name)
-            if len(val) == 0:
-                n_deletes += 1
-                self.client.collections.delete(coll_name)
-        return n_deletes
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        colls = self.client.collections.list_all()
-        if empty:
-            return list(colls.keys())
-        non_empty_colls = [
-            coll_name
-            for coll_name in colls.keys()
-            if len(self.client.collections.get(coll_name)) > 0
-        ]
-
-        return non_empty_colls
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        if not really:
-            logger.warning(
-                "Not really deleting all collections ,set really=True to confirm"
-            )
-            return 0
-        coll_names = [
-            c for c in self.list_collections(empty=True) if c.startswith(prefix)
-        ]
-        if len(coll_names) == 0:
-            logger.warning(f"No collections found with prefix {prefix}")
-            return 0
-        n_empty_deletes = 0
-        n_non_empty_deletes = 0
-        for name in coll_names:
-            info = self.client.collections.get(name)
-            points_count = len(info)
-
-            n_empty_deletes += points_count == 0
-            n_non_empty_deletes += points_count > 0
-            self.client.collections.delete(name)
-        logger.warning(
-            f"""
-            Deleted {n_empty_deletes} empty collections and
-            {n_non_empty_deletes} non-empty collections.
-            """
-        )
-        return n_empty_deletes + n_non_empty_deletes
-
-    def delete_collection(self, collection_name: str) -> None:
-        self.client.collections.delete(name=collection_name)
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        try:
-            from weaviate.classes.config import (
-                Configure,
-                VectorDistances,
-            )
-        except ImportError:
-            raise LangroidImportError("weaviate", "weaviate")
-        collection_name = WeaviateDB.validate_and_format_collection_name(
-            collection_name
-        )
-        self.config.collection_name = collection_name
-        if self.client.collections.exists(name=collection_name):
-            coll = self.client.collections.get(name=collection_name)
-            if len(coll) > 0:
-                logger.warning(f"Non-empty Collection {collection_name} already exists")
-                if not replace:
-                    logger.warning("Not replacing collection")
-                    return
-                else:
-                    logger.warning("Recreating fresh collection")
-            self.client.collections.delete(name=collection_name)
-
-        vector_index_config = Configure.VectorIndex.hnsw(
-            distance_metric=VectorDistances.COSINE,
-        )
-        if isinstance(self.config.embedding, OpenAIEmbeddingsConfig):
-            vectorizer_config = Configure.Vectorizer.text2vec_openai(
-                model=self.config.embedding.model_name,
-            )
-        else:
-            vectorizer_config = None
-
-        collection_info = self.client.collections.create(
-            name=collection_name,
-            vector_index_config=vector_index_config,
-            vectorizer_config=vectorizer_config,
-        )
-        collection_info = self.client.collections.get(name=collection_name)
-        assert len(collection_info) in [0, None]
-        if settings.debug:
-            level = logger.getEffectiveLevel()
-            logger.setLevel(logging.INFO)
-            logger.info(collection_info)
-            logger.setLevel(level)
-
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        super().maybe_add_ids(documents)
-        colls = self.list_collections(empty=True)
-        for doc in documents:
-            doc.metadata.id = str(self._create_valid_uuid_id(doc.metadata.id))
-        if len(documents) == 0:
-            return
-
-        document_dicts = [doc.model_dump() for doc in documents]
-        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-        if self.config.collection_name not in colls:
-            self.create_collection(self.config.collection_name, replace=True)
-        coll_name = self.client.collections.get(self.config.collection_name)
-        with coll_name.batch.dynamic() as batch:
-            for i, doc_dict in enumerate(document_dicts):
-                id = doc_dict["metadata"].pop("id", None)
-                batch.add_object(properties=doc_dict, uuid=id, vector=embedding_vecs[i])
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        # cannot use filter as client does not support json type queries
-        coll = self.client.collections.get(self.config.collection_name)
-        return [self.weaviate_obj_to_doc(item) for item in coll.iterator()]
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        from weaviate.classes.query import Filter
-
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-
-        docs = []
-        coll_name = self.client.collections.get(self.config.collection_name)
-
-        result = coll_name.query.fetch_objects(
-            filters=Filter.by_property("_id").contains_any(ids), limit=len(coll_name)
-        )
-
-        id_to_doc = {}
-        for item in result.objects:
-            doc = self.weaviate_obj_to_doc(item)
-            id_to_doc[doc.metadata.id] = doc
-
-        # Reconstruct the list of documents in the original order of input ids
-        docs = [id_to_doc[id] for id in ids if id in id_to_doc]
-
-        return docs
-
-    def similar_texts_with_scores(
-        self, text: str, k: int = 1, where: Optional[str] = None
-    ) -> List[Tuple[Document, float]]:
-        from weaviate.classes.query import MetadataQuery
-
-        embedding = self.embedding_fn([text])[0]
-        if self.config.collection_name is None:
-            raise ValueError("No collections name set,cannot search")
-        coll = self.client.collections.get(self.config.collection_name)
-        response = coll.query.near_vector(
-            near_vector=embedding,
-            limit=k,
-            return_properties=True,
-            return_metadata=MetadataQuery(distance=True),
-        )
-        maybe_distances = [item.metadata.distance for item in response.objects]
-        similarities = [0 if d is None else 1 - d for d in maybe_distances]
-        docs = [self.weaviate_obj_to_doc(item) for item in response.objects]
-        return list(zip(docs, similarities))
-
-    def _create_valid_uuid_id(self, id: str) -> Any:
-        from weaviate.util import generate_uuid5, get_valid_uuid
-
-        try:
-            id = get_valid_uuid(id)
-            return id
-        except Exception:
-            return generate_uuid5(id)
-
-    def weaviate_obj_to_doc(self, input_object: Any) -> Document:
-        from weaviate.util import get_valid_uuid
-
-        content = input_object.properties.get("content", "")
-        metadata_dict = input_object.properties.get("metadata", {})
-
-        window_ids = metadata_dict.pop("window_ids", [])
-        window_ids = [str(uuid) for uuid in window_ids]
-
-        # Ensure the id is a valid UUID string
-        id_value = get_valid_uuid(input_object.uuid)
-
-        metadata = DocMetaData(id=id_value, window_ids=window_ids, **metadata_dict)
-
-        return Document(content=content, metadata=metadata)
-
-    @staticmethod
-    def validate_and_format_collection_name(name: str) -> str:
-        """
-        Formats the collection name to comply with Weaviate's naming rules:
-        - Name must start with a capital letter.
-        - Name can only contain letters, numbers, and underscores.
-        - Replaces invalid characters with underscores.
-        """
-        if not name:
-            raise ValueError("Collection name cannot be empty.")
-
-        formatted_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
-
-        # Ensure the first letter is capitalized
-        if not formatted_name[0].isupper():
-            formatted_name = formatted_name.capitalize()
-
-        # Check if the name now meets the criteria
-        if not re.match(r"^[A-Z][A-Za-z0-9_]*$", formatted_name):
-            raise ValueError(
-                f"Invalid collection name '{name}'."
-                " Names must start with a capital letter "
-                "and contain only letters, numbers, and underscores."
-            )
-
-        if formatted_name != name:
-            logger.warning(
-                f"Collection name '{name}' was reformatted to '{formatted_name}' "
-                "to comply with Weaviate's rules."
-            )
-
-        return formatted_name
-
-    def __del__(self) -> None:
-        # Gracefully close the connection with local client
-        if not self.config.cloud:
-            self.client.close()
+<file path="docs/notes/vecstore-env-prefix.md">
+# Vector-Store Config Env-Var Prefixes
+
+Vector-store configs are `pydantic-settings` classes, which means their
+fields can be set via environment variables. Prior to this change (see
+issue #1078), `VectorStoreConfig` and its subclasses declared **no
+`env_prefix`**, so every field name was itself a case-insensitive
+environment variable. A bare `HOST`, `PORT`, `CLOUD`, `TIMEOUT`,
+`BATCH_SIZE`, `STORAGE_PATH`, `COLLECTION_NAME`, or `FULL_EVAL` in the
+environment silently overrode the default for *every* vector-store
+config:
+
+```bash
+HOST=evil.example.com PORT=9999 FULL_EVAL=true \
+  python -c "from langroid.vector_store.qdrantdb import QdrantDBConfig; \
+             c = QdrantDBConfig(); print(c.host, c.port, c.full_eval)"
+# old behavior: evil.example.com 9999 True
+```
+
+This was dangerous for two reasons:
+
+- `HOST` and `PORT` are routinely set by shells, containers, and CI
+  systems, so vector-store clients could silently point at the wrong
+  server.
+- `FULL_EVAL=true` disabled the code-injection guard (see
+  [code-injection-protection](code-injection-protection.md)) with no
+  explicit opt-in anywhere in the user's code.
+
+## New behavior
+
+Each vector-store config now has its own env prefix, consistent with
+the rest of the codebase (`OPENAI_`, `AZURE_OPENAI_`, `NEO4J_`, ...):
+
+| Config class        | Env prefix     |
+|---------------------|----------------|
+| `VectorStoreConfig` | `VECDB_`       |
+| `QdrantDBConfig`    | `QDRANT_`      |
+| `ChromaDBConfig`    | `CHROMA_`      |
+| `LanceDBConfig`     | `LANCEDB_`     |
+| `PineconeDBConfig`  | `PINECONE_`    |
+| `PostgresDBConfig`  | `POSTGRES_`    |
+| `MeiliSearchConfig` | `MEILISEARCH_` |
+| `WeaviateDBConfig`  | `WEAVIATE_`    |
+
+Bare env vars (`HOST`, `FULL_EVAL`, ...) are now ignored by all of
+these configs. To set a field via the environment, use the prefix of
+the specific config class, e.g. `QDRANT_HOST=my.qdrant.example` or
+`QDRANT_FULL_EVAL=true` for `QdrantDBConfig`. Every provider subclass
+in langroid overrides the prefix with its own, so within langroid
+`VECDB_*` vars affect only direct `VectorStoreConfig` instances.
+However, pydantic inherits `model_config`, so a third-party subclass
+of `VectorStoreConfig` that does not set its own `env_prefix` will
+read `VECDB_*` vars.
+
+A `port` value coming from the *environment* that matches the exact
+Kubernetes service-link format `tcp://<host>:<digits>` (e.g.
+`QDRANT_PORT=tcp://10.0.0.8:6333`, injected into every pod by a
+service named `qdrant` when `enableServiceLinks` is on) is ignored
+with a warning and the default port is used. This exception applies
+only to the env settings source and only to that full format:
+malformed `tcp://` junk in the environment, and any `tcp://...` value
+passed explicitly to the constructor, fail validation as usual.
+
+Explicit constructor arguments always take priority over environment
+values (standard `pydantic-settings` precedence):
+
+```python
+config = QdrantDBConfig(host="10.0.0.5")  # wins over QDRANT_HOST
+```
+
+## Migration
+
+If you (deliberately) relied on bare env vars to configure a
+vector store, rename them with the appropriate prefix from the table
+above, e.g. `COLLECTION_NAME=mydocs` becomes
+`QDRANT_COLLECTION_NAME=mydocs`.
+
+Env vars read via `os.getenv` outside the config classes are
+unaffected, e.g. `QDRANT_API_KEY`, `PINECONE_API_KEY`,
+`MEILISEARCH_API_KEY`, `MEILISEARCH_API_URL`, `WEAVIATE_API_KEY`, and
+`WEAVIATE_API_URL` keep their existing meanings. Note that the
+`QDRANT_*` and `PINECONE_*` prefixes overlap with those existing
+names, but the config classes have no `api_key`/`api_url` fields, so
+extra prefixed vars are ignored.
 </file>
 
 <file path="docs/tutorials/non-openai-llms.md">
@@ -43394,1072 +41800,346 @@ class RepoLoader:
         return contents
 </file>
 
-<file path="langroid/vector_store/base.py">
-import copy
-import logging
-from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Sequence, Tuple, Type
-
-import numpy as np
-import pandas as pd
-from pydantic_settings import BaseSettings
-
-from langroid.embedding_models.base import EmbeddingModel, EmbeddingModelsConfig
-from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.mytypes import DocMetaData, Document, EmbeddingFunction
-from langroid.utils.algorithms.graph import components, topological_sort
-from langroid.utils.configuration import settings
-from langroid.utils.object_registry import ObjectRegistry
-from langroid.utils.output.printing import print_long_text
-from langroid.utils.pandas_utils import safe_eval_globals, sanitize_command, stringify
-from langroid.utils.pydantic_utils import flatten_dict
-
-logger = logging.getLogger(__name__)
-
-
-class VectorStoreConfig(BaseSettings):
-    type: str = ""  # deprecated, keeping it for backward compatibility
-    collection_name: str | None = "temp"
-    replace_collection: bool = False  # replace collection if it already exists
-    storage_path: str = ".qdrant/data"
-    cloud: bool = False
-    batch_size: int = 200
-    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig(
-        model_type="openai",
-    )
-    embedding_model: Optional[EmbeddingModel] = None
-    timeout: int = 60
-    host: str = "127.0.0.1"
-    port: int = 6333
-    # used when parsing search results back as Document objects
-    document_class: Type[Document] = Document
-    metadata_class: Type[DocMetaData] = DocMetaData
-    # compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
-    full_eval: bool = False  # runs eval without sanitization. Use only on trusted input
-
-
-class VectorStore(ABC):
-    """
-    Abstract base class for a vector store.
-    """
-
-    def __init__(self, config: VectorStoreConfig):
-        self.config = config
-        if config.embedding_model is None:
-            self.embedding_model = EmbeddingModel.create(config.embedding)
-        else:
-            self.embedding_model = config.embedding_model
-        if hasattr(self.config, "embedding_model"):
-            self.config.embedding_model = None
-        self.embedding_fn: EmbeddingFunction = self.embedding_model.embedding_fn()
-
-    @staticmethod
-    def create(config: VectorStoreConfig) -> Optional["VectorStore"]:
-        from langroid.vector_store.chromadb import ChromaDB, ChromaDBConfig
-        from langroid.vector_store.lancedb import LanceDB, LanceDBConfig
-        from langroid.vector_store.meilisearch import MeiliSearch, MeiliSearchConfig
-        from langroid.vector_store.milvusdb import MilvusDB, MilvusDBConfig
-        from langroid.vector_store.pineconedb import PineconeDB, PineconeDBConfig
-        from langroid.vector_store.postgres import PostgresDB, PostgresDBConfig
-        from langroid.vector_store.qdrantdb import QdrantDB, QdrantDBConfig
-        from langroid.vector_store.weaviatedb import WeaviateDB, WeaviateDBConfig
-
-        if isinstance(config, QdrantDBConfig):
-            return QdrantDB(config)
-        elif isinstance(config, ChromaDBConfig):
-            return ChromaDB(config)
-        elif isinstance(config, LanceDBConfig):
-            return LanceDB(config)
-        elif isinstance(config, MeiliSearchConfig):
-            return MeiliSearch(config)
-        elif isinstance(config, PostgresDBConfig):
-            return PostgresDB(config)
-        elif isinstance(config, MilvusDBConfig):
-            return MilvusDB(config)
-        elif isinstance(config, WeaviateDBConfig):
-            return WeaviateDB(config)
-        elif isinstance(config, PineconeDBConfig):
-            return PineconeDB(config)
-
-        else:
-            logger.warning(
-                f"""
-                Unknown vector store config: {config.__class__.__name__},
-                so skipping vector store creation!
-                If you intended to use a vector-store, please set a specific 
-                vector-store in your script, typically in the `vecdb` field of a 
-                `ChatAgentConfig`, otherwise set it to None.
-                """
-            )
-            return None
-
-    @property
-    def embedding_dim(self) -> int:
-        return len(self.embedding_fn(["test"])[0])
-
-    def clone(self) -> "VectorStore":
-        """Return a vector-store clone suitable for agent cloning.
-
-        The default implementation deep-copies the configuration, reuses any
-        existing embedding model, and instantiates a fresh store of the same
-        type. Subclasses can override when sharing the instance is required
-        (e.g., embedded/local stores that rely on file locks).
-        """
-
-        config_class = self.config.__class__
-        config_data = self.config.model_dump(mode="python")
-        config_data["embedding_model"] = None
-        config_copy = config_class.model_validate(config_data)
-        logger.debug(
-            "Cloning VectorStore %s: original collection=%s, copied collection=%s",
-            type(self).__name__,
-            getattr(self.config, "collection_name", None),
-            getattr(config_copy, "collection_name", None),
-        )
-        # Preserve the calculated collection contents without forcing replaces
-        if hasattr(config_copy, "replace_collection"):
-            config_copy.replace_collection = False  # type: ignore[attr-defined]
-        cloned_embedding: Optional[EmbeddingModel] = None
-        if (
-            hasattr(self, "embedding_model")
-            and getattr(self, "embedding_model") is not None
-        ):
-            cloned_embedding = self.embedding_model.clone()  # type: ignore[attr-defined]
-            if hasattr(config_copy, "embedding_model"):
-                config_copy.embedding_model = cloned_embedding
-
-        cloned_store = type(self)(config_copy)  # type: ignore[call-arg]
-        if hasattr(cloned_store.config, "embedding_model"):
-            cloned_store.config.embedding_model = None
-        logger.debug(
-            "Cloned VectorStore %s: cloned collection=%s",
-            type(self).__name__,
-            getattr(cloned_store.config, "collection_name", None),
-        )
-        if hasattr(cloned_store.config, "replace_collection"):
-            cloned_store.config.replace_collection = False
-        # Some stores might not honour replace_collection; ensure same collection
-        if getattr(self.config, "collection_name", None) is not None:
-            setattr(
-                cloned_store.config,
-                "collection_name",
-                getattr(self.config, "collection_name", None),
-            )
-        return cloned_store
-
-    @abstractmethod
-    def clear_empty_collections(self) -> int:
-        """Clear all empty collections in the vector store.
-        Returns the number of collections deleted.
-        """
-        pass
-
-    @abstractmethod
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """
-        Clear all collections in the vector store.
-
-        Args:
-            really (bool, optional): Whether to really clear all collections.
-                Defaults to False.
-            prefix (str, optional): Prefix of collections to clear.
-        Returns:
-            int: Number of collections deleted.
-        """
-        pass
-
-    @abstractmethod
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """List all collections in the vector store
-        (only non empty collections if empty=False).
-        """
-        pass
-
-    def set_collection(self, collection_name: str, replace: bool = False) -> None:
-        """
-        Set the current collection to the given collection name.
-        Args:
-            collection_name (str): Name of the collection.
-            replace (bool, optional): Whether to replace the collection if it
-                already exists. Defaults to False.
-        """
-
-        self.config.collection_name = collection_name
-        self.config.replace_collection = replace
-        if replace:
-            self.create_collection(collection_name, replace=True)
-
-    @abstractmethod
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        """Create a collection with the given name.
-        Args:
-            collection_name (str): Name of the collection.
-            replace (bool, optional): Whether to replace the
-                collection if it already exists. Defaults to False.
-        """
-        pass
-
-    @abstractmethod
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        pass
-
-    def compute_from_docs(self, docs: List[Document], calc: str) -> str:
-        """Compute a result on a set of documents,
-        using a dataframe calc string like `df.groupby('state')['income'].mean()`.
-
-        If full_eval is False (default), the input expression is sanitized to prevent
-        most common code injection attack vectors.
-        If full_eval is True, sanitization is bypassed - use only with trusted input!
-        """
-        # convert each doc to a dict, using dotted paths for nested fields
-        dicts = [flatten_dict(doc.model_dump(by_alias=True)) for doc in docs]
-        df = pd.DataFrame(dicts)
-
-        try:
-            # SECURITY MITIGATION: Eval input is sanitized to prevent most common
-            # code injection attack vectors when full_eval is False. The globals
-            # dict also restricts ``__builtins__`` so that even with
-            # ``full_eval=True`` the expression cannot reach
-            # ``__import__``/``eval``/``exec`` via Python's implicit builtin
-            # injection (GHSA-q9p7-wqxg-mrhc).
-            vars = {"df": df}
-            if not self.config.full_eval:
-                calc = sanitize_command(calc)
-            code = compile(calc, "<calc>", "eval")
-            result = eval(code, safe_eval_globals(vars), {})
-        except Exception as e:
-            # return error message so LLM can fix the calc string if needed
-            err = f"""
-            Error encountered in pandas eval: {str(e)}
-            """
-            if isinstance(e, KeyError) and "not in index" in str(e):
-                # Pd.eval sometimes fails on a perfectly valid exprn like
-                # df.loc[..., 'column'] with a KeyError.
-                err += """
-                Maybe try a different way, e.g. 
-                instead of df.loc[..., 'column'], try df.loc[...]['column']
-                """
-            return err
-        return stringify(result)
-
-    def maybe_add_ids(self, documents: Sequence[Document]) -> None:
-        """Add ids to metadata if absent, since some
-        vecdbs don't like having blank ids."""
-        for d in documents:
-            if d.metadata.id in [None, ""]:
-                d.metadata.id = ObjectRegistry.new_id()
-
-    @abstractmethod
-    def similar_texts_with_scores(
-        self,
-        text: str,
-        k: int = 1,
-        where: Optional[str] = None,
-    ) -> List[Tuple[Document, float]]:
-        """
-        Find k most similar texts to the given text, in terms of vector distance metric
-        (e.g., cosine similarity).
-
-        Args:
-            text (str): The text to find similar texts for.
-            k (int, optional): Number of similar texts to retrieve. Defaults to 1.
-            where (Optional[str], optional): Where clause to filter the search.
-
-        Returns:
-            List[Tuple[Document,float]]: List of (Document, score) tuples.
-
-        """
-        pass
-
-    def add_context_window(
-        self, docs_scores: List[Tuple[Document, float]], neighbors: int = 0
-    ) -> List[Tuple[Document, float]]:
-        """
-        In each doc's metadata, there may be a window_ids field indicating
-        the ids of the chunks around the current chunk.
-        These window_ids may overlap, so we
-        - coalesce each overlapping groups into a single window (maintaining ordering),
-        - create a new document for each part, preserving metadata,
-
-        We may have stored a longer set of window_ids than we need during chunking.
-        Now, we just want `neighbors` on each side of the center of the window_ids list.
-
-        Args:
-            docs_scores (List[Tuple[Document, float]]): List of pairs of documents
-                to add context windows to together with their match scores.
-            neighbors (int, optional): Number of neighbors on "each side" of match to
-                retrieve. Defaults to 0.
-                "Each side" here means before and after the match,
-                in the original text.
-
-        Returns:
-            List[Tuple[Document, float]]: List of (Document, score) tuples.
-        """
-        # We return a larger context around each match, i.e.
-        # a window of `neighbors` on each side of the match.
-        docs = [d for d, s in docs_scores]
-        scores = [s for d, s in docs_scores]
-        if neighbors == 0:
-            return docs_scores
-        doc_chunks = [d for d in docs if d.metadata.is_chunk]
-        if len(doc_chunks) == 0:
-            return docs_scores
-        window_ids_list = []
-        id2metadata = {}
-        # id -> highest score of a doc it appears in
-        id2max_score: Dict[int | str, float] = {}
-        for i, d in enumerate(docs):
-            window_ids = d.metadata.window_ids
-            if len(window_ids) == 0:
-                window_ids = [d.id()]
-            id2metadata.update({id: d.metadata for id in window_ids})
-
-            id2max_score.update(
-                {id: max(id2max_score.get(id, 0), scores[i]) for id in window_ids}
-            )
-            n = len(window_ids)
-            chunk_idx = window_ids.index(d.id())
-            neighbor_ids = window_ids[
-                max(0, chunk_idx - neighbors) : min(n, chunk_idx + neighbors + 1)
-            ]
-            window_ids_list += [neighbor_ids]
-
-        # window_ids could be from different docs,
-        # and they may overlap, so we coalesce overlapping groups into
-        # separate windows.
-        window_ids_list = self.remove_overlaps(window_ids_list)
-        final_docs = []
-        final_scores = []
-        for w in window_ids_list:
-            metadata = copy.deepcopy(id2metadata[w[0]])
-            metadata.window_ids = w
-            document = Document(
-                content="".join([d.content for d in self.get_documents_by_ids(w)]),
-                metadata=metadata,
-            )
-            # make a fresh id since content is in general different
-            document.metadata.id = ObjectRegistry.new_id()
-            final_docs += [document]
-            final_scores += [max(id2max_score[id] for id in w)]
-        return list(zip(final_docs, final_scores))
-
-    @staticmethod
-    def remove_overlaps(windows: List[List[str]]) -> List[List[str]]:
-        """
-        Given a collection of windows, where each window is a sequence of ids,
-        identify groups of overlapping windows, and for each overlapping group,
-        order the chunk-ids using topological sort so they appear in the original
-        order in the text.
-
-        Args:
-            windows (List[int|str]): List of windows, where each window is a
-                sequence of ids.
-
-        Returns:
-            List[int|str]: List of windows, where each window is a sequence of ids,
-                and no two windows overlap.
-        """
-        ids = set(id for w in windows for id in w)
-        # id -> {win -> # pos}
-        id2win2pos: Dict[str, Dict[int, int]] = {id: {} for id in ids}
-
-        for i, w in enumerate(windows):
-            for j, id in enumerate(w):
-                id2win2pos[id][i] = j
-
-        n = len(windows)
-        # relation between windows:
-        order = np.zeros((n, n), dtype=np.int8)
-        for i, w in enumerate(windows):
-            for j, x in enumerate(windows):
-                if i == j:
-                    continue
-                if len(set(w).intersection(x)) == 0:
-                    continue
-                id = list(set(w).intersection(x))[0]  # any common id
-                if id2win2pos[id][i] > id2win2pos[id][j]:
-                    order[i, j] = -1  # win i is before win j
-                else:
-                    order[i, j] = 1  # win i is after win j
-
-        # find groups of windows that overlap, like connected components in a graph
-        groups = components(np.abs(order))
-
-        # order the chunk-ids in each group using topological sort
-        new_windows = []
-        for g in groups:
-            # find total ordering among windows in group based on order matrix
-            # (this is a topological sort)
-            _g = np.array(g)
-            order_matrix = order[_g][:, _g]
-            ordered_window_indices = topological_sort(order_matrix)
-            ordered_window_ids = [windows[i] for i in _g[ordered_window_indices]]
-            flattened = [id for w in ordered_window_ids for id in w]
-            flattened_deduped = list(dict.fromkeys(flattened))
-            # Note we are not going to split these, and instead we'll return
-            # larger windows from concatenating the connected groups.
-            # This ensures context is retained for LLM q/a
-            new_windows += [flattened_deduped]
-
-        return new_windows
-
-    @abstractmethod
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        """
-        Get all documents in the current collection, possibly filtered by `where`.
-        """
-        pass
-
-    @abstractmethod
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        """
-        Get documents by their ids.
-        Args:
-            ids (List[str]): List of document ids.
-
-        Returns:
-            List[Document]: List of documents
-        """
-        pass
-
-    @abstractmethod
-    def delete_collection(self, collection_name: str) -> None:
-        pass
-
-    def show_if_debug(self, doc_score_pairs: List[Tuple[Document, float]]) -> None:
-        if settings.debug:
-            for i, (d, s) in enumerate(doc_score_pairs):
-                print_long_text("red", "italic red", f"\nMATCH-{i}\n", d.content)
-</file>
-
-<file path="langroid/vector_store/postgres.py">
-import hashlib
+<file path="langroid/vector_store/chromadb.py">
 import json
 import logging
-import os
-import uuid
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
+
+from pydantic_settings import SettingsConfigDict
 
 from langroid.embedding_models.base import (
     EmbeddingModelsConfig,
 )
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
 from langroid.exceptions import LangroidImportError
-from langroid.mytypes import DocMetaData, Document
+from langroid.mytypes import Document
+from langroid.utils.configuration import settings
+from langroid.utils.output.printing import print_long_text
 from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-has_postgres: bool = True
-try:
-    from sqlalchemy import (
-        Column,
-        MetaData,
-        String,
-        Table,
-        case,
-        create_engine,
-        inspect,
-        text,
-    )
-    from sqlalchemy.dialects.postgresql import JSONB
-    from sqlalchemy.engine import Connection, Engine
-    from sqlalchemy.sql.expression import insert
-except ImportError:
-    Engine = Any  # type: ignore
-    Connection = Any  # type: ignore
-    has_postgres = False
 
 logger = logging.getLogger(__name__)
 
 
-def _quote_ident(name: str) -> str:
-    """Quote a SQL identifier (table/index name) for use in raw DDL, so a name
-    containing characters that are invalid in an unquoted identifier -- e.g.
-    the ``-`` in a pytest-xdist worker suffix like ``mycollection-gw1`` -- does
-    not produce a syntax error. Embedded double-quotes are escaped per the SQL
-    standard.
-    """
-    return '"' + name.replace('"', '""') + '"'
+class ChromaDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="CHROMA_")
 
-
-class PostgresDBConfig(VectorStoreConfig):
-    collection_name: str = "embeddings"
-    cloud: bool = False
-    docker: bool = True
-    host: str = "127.0.0.1"
-    port: int = 5432
-    replace_collection: bool = False
+    collection_name: str = "temp"
+    storage_path: str = ".chroma/data"
+    distance: Literal["cosine", "l2", "ip"] = "cosine"
+    construction_ef: int = 100
+    search_ef: int = 100
+    max_neighbors: int = 16
     embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    pool_size: int = 10
-    max_overflow: int = 20
-    hnsw_m: int = 16
-    hnsw_ef_construction: int = 200
+    host: str = "127.0.0.1"
+    port: int = 6333
 
 
-class PostgresDB(VectorStore):
-    def __init__(self, config: PostgresDBConfig | None = None):
-        config = config if config is not None else PostgresDBConfig()
+class ChromaDB(VectorStore):
+    def __init__(self, config: ChromaDBConfig | None = None):
+        config = config if config is not None else ChromaDBConfig()
         super().__init__(config)
-        if not has_postgres:
-            raise LangroidImportError("pgvector", "postgres")
         try:
-            from sqlalchemy.orm import sessionmaker
+            import chromadb
         except ImportError:
-            raise LangroidImportError("sqlalchemy", "postgres")
-
-        self.config: PostgresDBConfig = config
-        self.engine = self._create_engine()
-        PostgresDB._create_vector_extension(self.engine)
-        self.SessionLocal = sessionmaker(
-            autocommit=False, autoflush=False, bind=self.engine
-        )
-        self.metadata = MetaData()
-        self._setup_table()
-
-    def _create_engine(self) -> Engine:
-        """Creates a SQLAlchemy engine based on the configuration."""
-
-        connection_string: str | None = None  # Ensure variable is always defined
-
-        if self.config.cloud:
-            connection_string = os.getenv("POSTGRES_CONNECTION_STRING")
-
-            if connection_string and connection_string.startswith("postgres://"):
-                connection_string = connection_string.replace(
-                    "postgres://", "postgresql+psycopg2://", 1
-                )
-            elif not connection_string:
-                raise ValueError("Provide the POSTGRES_CONNECTION_STRING.")
-
-        elif self.config.docker:
-            username = os.getenv("POSTGRES_USER", "postgres")
-            password = os.getenv("POSTGRES_PASSWORD", "postgres")
-            database = os.getenv("POSTGRES_DB", "langroid")
-
-            if not (username and password and database):
-                raise ValueError(
-                    "Provide POSTGRES_USER, POSTGRES_PASSWORD, " "POSTGRES_DB. "
-                )
-
-            connection_string = (
-                f"postgresql+psycopg2://{username}:{password}@"
-                f"{self.config.host}:{self.config.port}/{database}"
+            raise LangroidImportError("chromadb", "chromadb")
+        self.config = config
+        self.client = chromadb.Client(
+            chromadb.config.Settings(
+                # chroma_db_impl="duckdb+parquet",
+                # is_persistent=bool(config.storage_path),
+                persist_directory=config.storage_path,
             )
-            self.config.cloud = False  # Ensures cloud is disabled if using Docker
-
-        else:
-            raise ValueError(
-                "Provide either Docker or Cloud config to connect to the database."
-            )
-
-        return create_engine(
-            connection_string,
-            pool_size=self.config.pool_size,
-            max_overflow=self.config.max_overflow,
         )
-
-    def _setup_table(self) -> None:
-        try:
-            from pgvector.sqlalchemy import Vector
-        except ImportError as e:
-            raise LangroidImportError(extra="postgres", error=str(e))
-
-        if self.config.replace_collection:
-            self.delete_collection(self.config.collection_name)
-
-        self.embeddings_table = Table(
-            self.config.collection_name,
-            self.metadata,
-            Column("id", String, primary_key=True, nullable=False, unique=True),
-            Column("embedding", Vector(self.embedding_dim)),
-            Column("document", String),
-            Column("cmetadata", JSONB),
-            extend_existing=True,
-        )
-
-        self.metadata.create_all(self.engine)
-        self.metadata.reflect(bind=self.engine, only=[self.config.collection_name])
-
-        # Create HNSW index for embeddings column if it doesn't exist.
-        # This index enables efficient nearest-neighbor search using cosine similarity.
-        # PostgreSQL automatically builds the index after creation;
-        # no manual step required.
-        # Read more about pgvector hnsw index here:
-        # https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw
-
-        index_name = f"hnsw_index_{self.config.collection_name}_embedding"
-        with self.engine.connect() as connection:
-            if not self.index_exists(connection, index_name):
-                connection.execute(text("COMMIT"))
-                create_index_query = text(
-                    f"""
-                    CREATE INDEX CONCURRENTLY IF NOT EXISTS {_quote_ident(index_name)}
-                    ON {_quote_ident(self.config.collection_name)}
-                    USING hnsw (embedding vector_cosine_ops)
-                    WITH (
-                        m = {self.config.hnsw_m},
-                        ef_construction = {self.config.hnsw_ef_construction}
-                    );
-                    """
-                )
-                connection.execute(create_index_query)
-
-    def index_exists(self, connection: Connection, index_name: str) -> bool:
-        """Check if an index exists."""
-        query = text(
-            "SELECT 1 FROM pg_indexes WHERE indexname = :index_name"
-        ).bindparams(index_name=index_name)
-        result = connection.execute(query).scalar()
-        return bool(result)
-
-    @staticmethod
-    def _create_vector_extension(conn: Engine) -> None:
-
-        with conn.connect() as connection:
-            with connection.begin():
-                # The number is a unique identifier used to lock a specific resource
-                # during transaction. Any 64-bit integer can be used for advisory locks.
-                # Acquire advisory lock to ensure atomic, isolated setup
-                # and prevent race conditions.
-
-                statement = text(
-                    "SELECT pg_advisory_xact_lock(1573678846307946496);"
-                    "CREATE EXTENSION IF NOT EXISTS vector;"
-                )
-                connection.execute(statement)
-
-    def set_collection(self, collection_name: str, replace: bool = False) -> None:
-        inspector = inspect(self.engine)
-        table_exists = collection_name in inspector.get_table_names()
-
-        if (
-            collection_name == self.config.collection_name
-            and table_exists
-            and not replace
-        ):
-            return
-        else:
-            self.config.collection_name = collection_name
-            self.config.replace_collection = replace
-            self._setup_table()
-
-    def list_collections(self, empty: bool = True) -> List[str]:
-        inspector = inspect(self.engine)
-        table_names = inspector.get_table_names()
-
-        with self.SessionLocal() as session:
-            collections = []
-            for table_name in table_names:
-                table = Table(table_name, self.metadata, autoload_with=self.engine)
-                if empty:
-                    collections.append(table_name)
-                else:
-                    # Efficiently check for non-emptiness
-                    if session.query(table.select().limit(1).exists()).scalar():
-                        collections.append(table_name)
-            return collections
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        self.set_collection(collection_name, replace=replace)
-
-    def delete_collection(self, collection_name: str) -> None:
-        """
-        Deletes a collection and its associated HNSW index, handling metadata
-        synchronization issues.
-        """
-        with self.engine.connect() as connection:
-            connection.execute(text("COMMIT"))
-            index_name = f"hnsw_index_{collection_name}_embedding"
-            drop_index_query = text(
-                f"DROP INDEX CONCURRENTLY IF EXISTS {_quote_ident(index_name)}"
+        if self.config.collection_name is not None:
+            self.create_collection(
+                self.config.collection_name,
+                replace=self.config.replace_collection,
             )
-            connection.execute(drop_index_query)
-
-            # 3. Now, drop the table using SQLAlchemy
-            table = Table(collection_name, self.metadata)
-            table.drop(self.engine, checkfirst=True)
-
-            # 4. Refresh metadata again after dropping the table
-            self.metadata.clear()
-            self.metadata.reflect(bind=self.engine)
 
     def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """Clear all collections in the vector store with the given prefix."""
+
         if not really:
-            logger.warning("Not deleting all tables, set really=True to confirm")
+            logger.warning("Not deleting all collections, set really=True to confirm")
             return 0
-
-        inspector = inspect(self.engine)
-        table_names = inspector.get_table_names()
-
-        with self.SessionLocal() as session:
-            deleted_count = 0
-            for table_name in table_names:
-                if table_name.startswith(prefix):
-                    # Use delete_collection to handle index and table deletion
-                    self.delete_collection(table_name)
-                    deleted_count += 1
-            session.commit()
-            logger.warning(f"Deleted {deleted_count} tables with prefix '{prefix}'.")
-            return deleted_count
+        coll = [c for c in self.client.list_collections() if c.name.startswith(prefix)]
+        if len(coll) == 0:
+            logger.warning(f"No collections found with prefix {prefix}")
+            return 0
+        n_empty_deletes = 0
+        n_non_empty_deletes = 0
+        for c in coll:
+            n_empty_deletes += c.count() == 0
+            n_non_empty_deletes += c.count() > 0
+            self.client.delete_collection(name=c.name)
+        logger.warning(
+            f"""
+            Deleted {n_empty_deletes} empty collections and
+            {n_non_empty_deletes} non-empty collections.
+            """
+        )
+        return n_empty_deletes + n_non_empty_deletes
 
     def clear_empty_collections(self) -> int:
-        inspector = inspect(self.engine)
-        table_names = inspector.get_table_names()
+        colls = self.client.list_collections()
+        n_deletes = 0
+        for coll in colls:
+            if coll.count() == 0:
+                n_deletes += 1
+                self.client.delete_collection(name=coll.name)
+        return n_deletes
 
-        with self.SessionLocal() as session:
-            deleted_count = 0
-            for table_name in table_names:
-                table = Table(table_name, self.metadata, autoload_with=self.engine)
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """
+        List non-empty collections in the vector store.
+        Args:
+            empty (bool, optional): Whether to list empty collections.
+        Returns:
+            List[str]: List of non-empty collection names.
+        """
+        colls = self.client.list_collections()
+        if empty:
+            return [coll.name for coll in colls]
+        return [coll.name for coll in colls if coll.count() > 0]
 
-                # Efficiently check for emptiness without fetching all rows
-                if session.query(table.select().limit(1).exists()).scalar():
-                    continue
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        """
+        Create a collection in the vector store, optionally replacing an existing
+            collection if `replace` is True.
+        Args:
+            collection_name (str): Name of the collection to create or replace.
+            replace (bool, optional): Whether to replace an existing collection.
+                Defaults to False.
 
-                # Use delete_collection to handle index and table deletion
-                self.delete_collection(table_name)
-                deleted_count += 1
-
-            session.commit()  # Commit is likely not needed here
-            logger.warning(f"Deleted {deleted_count} empty tables.")
-            return deleted_count
-
-    def _parse_embedding_store_record(self, res: Any) -> Dict[str, Any]:
-        metadata = res.cmetadata or {}
-        metadata["id"] = res.id
-        return {
-            "content": res.document,
-            "metadata": DocMetaData(**metadata),
-        }
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        with self.SessionLocal() as session:
-            query = session.query(self.embeddings_table)
-
-            # Apply 'where' clause if provided
-            if where:
-                try:
-                    where_json = json.loads(where)
-                    query = query.filter(
-                        self.embeddings_table.c.cmetadata.contains(where_json)
-                    )
-                except json.JSONDecodeError:
-                    logger.error(f"Invalid JSON in 'where' clause: {where}")
-                    return []  # Return empty list or handle error as appropriate
-
-            results = query.all()
-            documents = [
-                Document(**self._parse_embedding_store_record(res)) for res in results
-            ]
-            return documents
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        with self.SessionLocal() as session:
-            # Add a CASE statement to preserve the order of IDs
-            case_stmt = case(
-                {id_: index for index, id_ in enumerate(ids)},
-                value=self.embeddings_table.c.id,
-            )
-
-            query = (
-                session.query(self.embeddings_table)
-                .filter(self.embeddings_table.c.id.in_(ids))
-                .order_by(case_stmt)  # Order by the CASE statement
-            )
-            results = query.all()
-
-            documents = [
-                Document(**self._parse_embedding_store_record(row)) for row in results
-            ]
-            return documents
+        """
+        self.config.collection_name = collection_name
+        if collection_name in self.list_collections(empty=True) and replace:
+            logger.warning(f"Replacing existing collection {collection_name}")
+            self.client.delete_collection(collection_name)
+        self.collection = self.client.create_collection(
+            name=self.config.collection_name,
+            embedding_function=self.embedding_fn,
+            get_or_create=not replace,
+            metadata={
+                "hnsw:space": self.config.distance,
+                "hnsw:construction_ef": self.config.construction_ef,
+                "hnsw:search_ef": self.config.search_ef,
+                # we could expose other configs, see:
+                # https://docs.trychroma.com/docs/collections/configure
+            },
+        )
 
     def add_documents(self, documents: Sequence[Document]) -> None:
         super().maybe_add_ids(documents)
-        for doc in documents:
-            doc.metadata.id = str(PostgresDB._id_to_uuid(doc.metadata.id, doc.metadata))
+        if documents is None:
+            return
+        contents: List[str] = [document.content for document in documents]
+        # convert metadatas to dicts so chroma can handle them
+        metadata_dicts: List[dict[str, Any]] = [
+            d.metadata.dict_bool_int() for d in documents
+        ]
+        for m in metadata_dicts:
+            # chroma does not handle non-atomic types in metadata
+            m["window_ids"] = ",".join(m["window_ids"])
 
-        embeddings = self.embedding_fn([doc.content for doc in documents])
+        ids = [str(d.id()) for d in documents]
 
-        batch_size = self.config.batch_size
-        with self.SessionLocal() as session:
-            for i in range(0, len(documents), batch_size):
-                batch_docs = documents[i : i + batch_size]
-                batch_embeddings = embeddings[i : i + batch_size]
+        colls = self.list_collections(empty=True)
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        if self.config.collection_name not in colls:
+            self.create_collection(self.config.collection_name, replace=True)
 
-                new_records = [
-                    {
-                        "id": doc.metadata.id,
-                        "embedding": embedding,
-                        "document": doc.content,
-                        "cmetadata": doc.metadata.model_dump(),
-                    }
-                    for doc, embedding in zip(batch_docs, batch_embeddings)
-                ]
+        self.collection.add(
+            # embedding_models=embedding_models,
+            documents=contents,
+            metadatas=metadata_dicts,
+            ids=ids,
+        )
 
-                if new_records:
-                    stmt = insert(self.embeddings_table).values(new_records)
-                    session.execute(stmt)
-                session.commit()
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        filter = json.loads(where) if where else None
+        results = self.collection.get(
+            include=["documents", "metadatas"],
+            where=filter,
+        )
+        results["documents"] = [results["documents"]]
+        results["metadatas"] = [results["metadatas"]]
+        return self._docs_from_results(results)
 
-    @staticmethod
-    def _id_to_uuid(id: str, obj: object) -> str:
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        # get them one by one since chroma mangles the order of the results
+        # when fetched from a list of ids.
+        results = [
+            self.collection.get(ids=[id], include=["documents", "metadatas"])
+            for id in ids
+        ]
+        final_results = {}
+        final_results["documents"] = [[r["documents"][0] for r in results]]
+        final_results["metadatas"] = [[r["metadatas"][0] for r in results]]
+        return self._docs_from_results(final_results)
+
+    def delete_collection(self, collection_name: str) -> None:
         try:
-            doc_id = str(uuid.UUID(id))
-        except ValueError:
-            obj_repr = repr(obj)
-
-            obj_hash = hashlib.sha256(obj_repr.encode()).hexdigest()
-
-            combined = f"{id}-{obj_hash}"
-
-            doc_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, combined))
-
-        return doc_id
+            self.client.delete_collection(name=collection_name)
+        except Exception:
+            pass
 
     def similar_texts_with_scores(
-        self,
-        query: str,
-        k: int = 1,
-        where: Optional[str] = None,
-        neighbors: int = 1,  # Parameter not used in this implementation
+        self, text: str, k: int = 1, where: Optional[str] = None
     ) -> List[Tuple[Document, float]]:
-        embedding = self.embedding_fn([query])[0]
+        n = self.collection.count()
+        filter = json.loads(where) if where else None
+        results = self.collection.query(
+            query_texts=[text],
+            n_results=min(n, k),
+            where=filter,
+            include=["documents", "distances", "metadatas"],
+        )
+        docs = self._docs_from_results(results)
+        # chroma distances are 1 - cosine.
+        scores = [1 - s for s in results["distances"][0]]
+        return list(zip(docs, scores))
 
-        with self.SessionLocal() as session:
-            # Calculate the score (1 - cosine_distance) and label it as "score"
-            score = (
-                1 - (self.embeddings_table.c.embedding.cosine_distance(embedding))
-            ).label("score")
+    def _docs_from_results(self, results: Dict[str, Any]) -> List[Document]:
+        """
+        Helper function to convert results from ChromaDB to a list of Documents
+        Args:
+            results (dict): results from ChromaDB
 
-            if where is not None:
-                try:
-                    json_query = json.loads(where)
-                except json.JSONDecodeError:
-                    raise ValueError(f"Invalid JSON in 'where' clause: {where}")
-
-                results = (
-                    session.query(
-                        self.embeddings_table.c.id,
-                        self.embeddings_table.c.document,
-                        self.embeddings_table.c.cmetadata,
-                        score,  # Select the calculated score
-                    )
-                    .filter(self.embeddings_table.c.cmetadata.contains(json_query))
-                    .order_by(score.desc())  # Order by score in descending order
-                    .limit(k)
-                    .all()
-                )
+        Returns:
+            List[Document]: list of Documents
+        """
+        if len(results["documents"][0]) == 0:
+            return []
+        contents = results["documents"][0]
+        if settings.debug:
+            for i, c in enumerate(contents):
+                print_long_text("red", "italic red", f"MATCH-{i}", c)
+        metadatas = results["metadatas"][0]
+        for m in metadatas:
+            # restore the stringified list of window_ids into the original List[str]
+            if m["window_ids"].strip() == "":
+                m["window_ids"] = []
             else:
-                results = (
-                    session.query(
-                        self.embeddings_table.c.id,
-                        self.embeddings_table.c.document,
-                        self.embeddings_table.c.cmetadata,
-                        score,  # Select the calculated score
-                    )
-                    .order_by(score.desc())  # Order by score in descending order
-                    .limit(k)
-                    .all()
-                )
-
-            documents_with_scores = [
-                (
-                    Document(
-                        content=result.document,
-                        metadata=DocMetaData(**(result.cmetadata or {})),
-                    ),
-                    result.score,  # Use the score from the query result
-                )
-                for result in results
-            ]
-
-            return documents_with_scores
+                m["window_ids"] = m["window_ids"].split(",")
+        docs = [
+            self.config.document_class(
+                content=d, metadata=self.config.metadata_class(**m)
+            )
+            for d, m in zip(contents, metadatas)
+        ]
+        return docs
 </file>
 
-<file path="langroid/vector_store/qdrantdb.py">
-import hashlib
-import json
-import logging
-import os
-import time
-import uuid
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, TypeVar
+<file path="langroid/vector_store/lancedb.py">
+from __future__ import annotations
 
+import logging
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+)
+
+import pandas as pd
 from dotenv import load_dotenv
+from pydantic import BaseModel, ValidationError, create_model
+
+if TYPE_CHECKING:
+    from lancedb.query import LanceVectorQueryBuilder
+
+from pydantic_settings import SettingsConfigDict
 
 from langroid.embedding_models.base import (
     EmbeddingModelsConfig,
 )
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.mytypes import Document, Embeddings
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import Document
 from langroid.utils.configuration import settings
+from langroid.utils.pydantic_utils import (
+    dataframe_to_document_model,
+    dataframe_to_documents,
+)
 from langroid.vector_store.base import VectorStore, VectorStoreConfig
 
+try:
+    import lancedb
+    from lancedb.pydantic import LanceModel, Vector
+
+    has_lancedb = True
+except ImportError:
+    has_lancedb = False
+
 logger = logging.getLogger(__name__)
-if TYPE_CHECKING:
-    from qdrant_client.http.models import SparseVector
 
 
-T = TypeVar("T")
+class LanceDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="LANCEDB_")
 
-
-def from_optional(x: Optional[T], default: T) -> T:
-    if x is None:
-        return default
-
-    return x
-
-
-def is_valid_uuid(uuid_to_test: str) -> bool:
-    """
-    Check if a given string is a valid UUID.
-    """
-    try:
-        uuid_obj = uuid.UUID(uuid_to_test)
-        return str(uuid_obj) == uuid_to_test
-    except Exception:
-        pass
-    # Check for valid unsigned 64-bit integer
-    try:
-        int_value = int(uuid_to_test)
-        return 0 <= int_value <= 18446744073709551615
-    except ValueError:
-        return False
-
-
-class QdrantDBConfig(VectorStoreConfig):
-    cloud: bool = True
-    docker: bool = False
+    cloud: bool = False
     collection_name: str | None = "temp"
-    storage_path: str = ".qdrant/data"
+    storage_path: str = ".lancedb/data"
     embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    use_sparse_embeddings: bool = False
-    sparse_embedding_model: str = "naver/splade-v3-distilbert"
-    sparse_limit: int = 3
     distance: str = "cosine"
 
 
-class QdrantDB(VectorStore):
-    def __init__(self, config: QdrantDBConfig | None = None):
-        config = config if config is not None else QdrantDBConfig()
+class LanceDB(VectorStore):
+    def __init__(self, config: LanceDBConfig | None = None):
+        config = config if config is not None else LanceDBConfig()
         super().__init__(config)
-        self.config: QdrantDBConfig = config
-        from qdrant_client import QdrantClient
+        if not has_lancedb:
+            raise LangroidImportError("lancedb", "lancedb")
 
-        if self.config.use_sparse_embeddings:
-            try:
-                from transformers import AutoModelForMaskedLM, AutoTokenizer
-            except ImportError:
-                raise ImportError(
-                    """
-                    To use sparse embeddings,
-                    you must install langroid with the [transformers] extra, e.g.:
-                    pip install "langroid[transformers]"
-                    """
-                )
-
-            self.sparse_tokenizer = AutoTokenizer.from_pretrained(  # type: ignore
-                self.config.sparse_embedding_model
-            )
-            self.sparse_model = AutoModelForMaskedLM.from_pretrained(
-                self.config.sparse_embedding_model
-            )
+        self.config: LanceDBConfig = config
         self.host = config.host
         self.port = config.port
+        self.is_from_dataframe = False  # were docs ingested from a dataframe?
+        self.df_metadata_columns: List[str] = []  # metadata columns from dataframe
+
         load_dotenv()
-        key = os.getenv("QDRANT_API_KEY")
-        url = os.getenv("QDRANT_API_URL")
-        if config.docker:
-            if url is None:
-                logger.warning(
-                    f"""The QDRANT_API_URL env variable must be set to use
-                    QdrantDB in local docker mode. Please set this
-                    value in your .env file.
-                    Switching to local storage at {config.storage_path}
-                    """
-                )
-                config.cloud = False
-            else:
-                config.cloud = True
-        elif config.cloud and None in [key, url]:
+        if self.config.cloud:
             logger.warning(
-                f"""QDRANT_API_KEY, QDRANT_API_URL env variable must be set to use
-                QdrantDB in cloud mode. Please set these values
-                in your .env file.
-                Switching to local storage at {config.storage_path}
-                """
+                "LanceDB Cloud is not available yet. Switching to local storage."
             )
             config.cloud = False
-
-        if config.cloud:
-            self.client = QdrantClient(
-                url=url,
-                api_key=key,
-                timeout=config.timeout,
-            )
         else:
             try:
-                self.client = QdrantClient(
-                    path=config.storage_path,
+                self.client = lancedb.connect(
+                    uri=config.storage_path,
                 )
             except Exception as e:
                 new_storage_path = config.storage_path + ".new"
                 logger.warning(
                     f"""
-                    Error connecting to local QdrantDB at {config.storage_path}:
+                    Error connecting to local LanceDB at {config.storage_path}:
                     {e}
                     Switching to {new_storage_path}
                     """
                 )
-                self.client = QdrantClient(
-                    path=new_storage_path,
+                self.client = lancedb.connect(
+                    uri=new_storage_path,
                 )
-
-        # Note: Only create collection if a non-null collection name is provided.
-        # This is useful to delay creation of vecdb until we have a suitable
-        # collection name (e.g. we could get it from the url or folder path).
-        if config.collection_name is not None:
-            self.create_collection(
-                config.collection_name, replace=config.replace_collection
-            )
-
-    def clone(self) -> "QdrantDB":
-        """Create an independent Qdrant client when running against Qdrant Cloud."""
-        if not self.config.cloud:
-            return self
-        cloned = super().clone()
-        assert isinstance(cloned, QdrantDB)
-        return cloned
-
-    def close(self) -> None:
-        """
-        Close the QdrantDB client and release any resources (e.g., file locks).
-        This is especially important for local storage to release the .lock file.
-        """
-        if hasattr(self.client, "close"):
-            # QdrantLocal has a close method that releases the lock
-            self.client.close()
-            logger.info(f"Closed QdrantDB connection for {self.config.storage_path}")
-
-    def __enter__(self) -> "QdrantDB":
-        """Context manager entry."""
-        return self
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        """Context manager exit - ensure cleanup even if an exception occurred."""
-        self.close()
 
     def clear_empty_collections(self) -> int:
         coll_names = self.list_collections()
         n_deletes = 0
         for name in coll_names:
-            info = self.client.get_collection(collection_name=name)
-            if info.points_count == 0:
+            nr = self.client.open_table(name).head(1).shape[0]
+            if nr == 0:
                 n_deletes += 1
-                self.client.delete_collection(collection_name=name)
+                self.client.drop_table(name)
         return n_deletes
 
     def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
         """Clear all collections with the given prefix."""
-
         if not really:
             logger.warning("Not deleting all collections, set really=True to confirm")
             return 0
@@ -44472,12 +42152,10 @@ class QdrantDB(VectorStore):
         n_empty_deletes = 0
         n_non_empty_deletes = 0
         for name in coll_names:
-            info = self.client.get_collection(collection_name=name)
-            points_count = from_optional(info.points_count, 0)
-
-            n_empty_deletes += points_count == 0
-            n_non_empty_deletes += points_count > 0
-            self.client.delete_collection(collection_name=name)
+            nr = self.client.open_table(name).head(1).shape[0]
+            n_empty_deletes += nr == 0
+            n_non_empty_deletes += nr > 0
+            self.client.drop_table(name)
         logger.warning(
             f"""
             Deleted {n_empty_deletes} empty collections and
@@ -44494,25 +42172,425 @@ class QdrantDB(VectorStore):
         Args:
             empty (bool, optional): Whether to include empty collections.
         """
+        colls = self.client.table_names(limit=None)
+        if len(colls) == 0:
+            return []
+        if empty:  # include empty tbls
+            return colls  # type: ignore
+        counts = [self.client.open_table(coll).head(1).shape[0] for coll in colls]
+        return [coll for coll, count in zip(colls, counts) if count > 0]
 
-        colls = list(self.client.get_collections())[0][1]
-        if empty:
-            return [coll.name for coll in colls]
-        counts = []
-        for coll in colls:
-            try:
-                counts.append(
-                    from_optional(
-                        self.client.get_collection(
-                            collection_name=coll.name
-                        ).points_count,
-                        0,
+    def _create_lance_schema(self, doc_cls: Type[Document]) -> Type[BaseModel]:
+        """
+        NOTE: NOT USED, but leaving it here as it may be useful.
+
+        Create a subclass of LanceModel with fields:
+         - id (str)
+         - Vector field that has dims equal to
+            the embedding dimension of the embedding model, and a data field of type
+            DocClass.
+         - other fields from doc_cls
+
+        Args:
+            doc_cls (Type[Document]): A Pydantic model which should be a subclass of
+                Document, to be used as the type for the data field.
+
+        Returns:
+            Type[BaseModel]: A new Pydantic model subclassing from LanceModel.
+
+        Raises:
+            ValueError: If `n` is not a non-negative integer or if `DocClass` is not a
+                subclass of Document.
+        """
+        if not issubclass(doc_cls, Document):
+            raise ValueError("DocClass must be a subclass of Document")
+
+        if not has_lancedb:
+            raise LangroidImportError("lancedb", "lancedb")
+
+        n = self.embedding_dim
+
+        # Prepare fields for the new model
+        fields = {"id": (str, ...), "vector": (Vector(n), ...)}
+
+        sorted_fields = dict(
+            sorted(doc_cls.model_fields.items(), key=lambda item: item[0])
+        )
+        # Add both statically and dynamically defined fields from doc_cls
+        for field_name, field in sorted_fields.items():
+            field_type = field.annotation if hasattr(field, "annotation") else field
+            fields[field_name] = (field_type, field.default)
+
+        # Create the new model with dynamic fields
+        NewModel = create_model(
+            "NewModel", __base__=LanceModel, **fields
+        )  # type: ignore
+        return NewModel  # type: ignore
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        self.config.replace_collection = replace
+        self.config.collection_name = collection_name
+        if replace:
+            self.delete_collection(collection_name)
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        super().maybe_add_ids(documents)
+        colls = self.list_collections(empty=True)
+        if len(documents) == 0:
+            return
+        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+        coll_name = self.config.collection_name
+        if coll_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        # self._maybe_set_doc_class_schema(documents[0])
+        table_exists = False
+        if (
+            coll_name in colls
+            and self.client.open_table(coll_name).head(1).shape[0] > 0
+        ):
+            # collection exists and  is not empty:
+            # if replace_collection is True, we'll overwrite the existing collection,
+            # else we'll append to it.
+            if self.config.replace_collection:
+                self.client.drop_table(coll_name)
+            else:
+                table_exists = True
+
+        ids = [str(d.id()) for d in documents]
+        # don't insert all at once, batch in chunks of b,
+        # else we get an API error
+        b = self.config.batch_size
+
+        def make_batches() -> Generator[List[Dict[str, Any]], None, None]:
+            for i in range(0, len(ids), b):
+                batch = [
+                    dict(
+                        id=ids[i + j],
+                        vector=embedding_vecs[i + j],
+                        **doc.model_dump(),
                     )
+                    for j, doc in enumerate(documents[i : i + b])
+                ]
+                yield batch
+
+        try:
+            if table_exists:
+                tbl = self.client.open_table(coll_name)
+                tbl.add(make_batches())
+            else:
+                batch_gen = make_batches()
+                batch = next(batch_gen)
+                # use first batch to create table...
+                tbl = self.client.create_table(
+                    coll_name,
+                    data=batch,
+                    mode="create",
                 )
-            except Exception:
-                logger.warning(f"Error getting collection {coll.name}")
-                counts.append(0)
-        return [coll.name for coll, count in zip(colls, counts) if (count or 0) > 0]
+                # ... and add the rest
+                tbl.add(batch_gen)
+        except Exception as e:
+            logger.error(
+                f"""
+                Error adding documents to LanceDB: {e}
+                POSSIBLE REMEDY: Delete the LancdDB storage directory
+                {self.config.storage_path} and try again.
+                """
+            )
+
+    def add_dataframe(
+        self,
+        df: pd.DataFrame,
+        content: str = "content",
+        metadata: List[str] = [],
+    ) -> None:
+        """
+        Add a dataframe to the collection.
+        Args:
+            df (pd.DataFrame): A dataframe
+            content (str): The name of the column in the dataframe that contains the
+                text content to be embedded using the embedding model.
+            metadata (List[str]): A list of column names in the dataframe that contain
+                metadata to be stored in the database. Defaults to [].
+        """
+        self.is_from_dataframe = True
+        actual_metadata = metadata.copy()
+        self.df_metadata_columns = actual_metadata  # could be updated below
+        # get content column
+        content_values = df[content].values.tolist()
+        embedding_vecs = self.embedding_fn(content_values)
+
+        # add vector column
+        df["vector"] = embedding_vecs
+        if content != "content":
+            # rename content column to "content", leave existing column intact
+            df = df.rename(columns={content: "content"}, inplace=False)
+
+        if "id" not in df.columns:
+            docs = dataframe_to_documents(df, content="content", metadata=metadata)
+            ids = [str(d.id()) for d in docs]
+            df["id"] = ids
+
+        if "id" not in actual_metadata:
+            actual_metadata += ["id"]
+
+        colls = self.list_collections(empty=True)
+        coll_name = self.config.collection_name
+        if (
+            coll_name not in colls
+            or self.client.open_table(coll_name).head(1).shape[0] == 0
+        ):
+            # collection either doesn't exist or is empty, so replace it
+            # and set new schema from df
+            self.client.create_table(
+                self.config.collection_name,
+                data=df,
+                mode="overwrite",
+            )
+            doc_cls = dataframe_to_document_model(
+                df,
+                content=content,
+                metadata=actual_metadata,
+                exclude=["vector"],
+            )
+            self.config.document_class = doc_cls  # type: ignore
+        else:
+            # collection exists and is not empty, so append to it
+            tbl = self.client.open_table(self.config.collection_name)
+            tbl.add(df)
+
+    def delete_collection(self, collection_name: str) -> None:
+        self.client.drop_table(collection_name, ignore_missing=True)
+
+    def _lance_result_to_docs(
+        self, result: "LanceVectorQueryBuilder"
+    ) -> List[Document]:
+        if self.is_from_dataframe:
+            df = result.to_pandas()
+            return dataframe_to_documents(
+                df,
+                content="content",
+                metadata=self.df_metadata_columns,
+                doc_cls=self.config.document_class,
+            )
+        else:
+            records = result.to_arrow().to_pylist()
+            return self._records_to_docs(records)
+
+    def _records_to_docs(self, records: List[Dict[str, Any]]) -> List[Document]:
+        try:
+            docs = [self.config.document_class(**rec) for rec in records]
+        except ValidationError as e:
+            raise ValueError(
+                f"""
+            Error validating LanceDB result: {e}
+            HINT: This could happen when you're re-using an
+            existing LanceDB store with a different schema.
+            Try deleting your local lancedb storage at `{self.config.storage_path}`
+            re-ingesting your documents and/or replacing the collections.
+            """
+            )
+        return docs
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        if self.config.collection_name not in self.list_collections(empty=True):
+            return []
+        tbl = self.client.open_table(self.config.collection_name)
+        pre_result = tbl.search(None).where(where or None).limit(None)
+        return self._lance_result_to_docs(pre_result)
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        _ids = [str(id) for id in ids]
+        tbl = self.client.open_table(self.config.collection_name)
+        docs = []
+        for _id in _ids:
+            results = self._lance_result_to_docs(tbl.search().where(f"id == '{_id}'"))
+            if len(results) > 0:
+                docs.append(results[0])
+        return docs
+
+    def similar_texts_with_scores(
+        self,
+        text: str,
+        k: int = 1,
+        where: Optional[str] = None,
+    ) -> List[Tuple[Document, float]]:
+        embedding = self.embedding_fn([text])[0]
+        tbl = self.client.open_table(self.config.collection_name)
+        result = (
+            tbl.search(embedding)
+            .metric(self.config.distance)
+            .where(where, prefilter=True)
+            .limit(k)
+        )
+        docs = self._lance_result_to_docs(result)
+        # note _distance is 1 - cosine
+        if self.is_from_dataframe:
+            scores = [
+                1 - rec["_distance"] for rec in result.to_pandas().to_dict("records")
+            ]
+        else:
+            scores = [1 - rec["_distance"] for rec in result.to_arrow().to_pylist()]
+        if len(docs) == 0:
+            logger.warning(f"No matches found for {text}")
+            return []
+        if settings.debug:
+            logger.info(f"Found {len(docs)} matches, max score: {max(scores)}")
+        doc_score_pairs = list(zip(docs, scores))
+        self.show_if_debug(doc_score_pairs)
+        return doc_score_pairs
+</file>
+
+<file path="langroid/vector_store/meilisearch.py">
+"""
+MeiliSearch as a pure document store, without its
+(experimental) vector-store functionality.
+We aim to use MeiliSearch for fast lexical search.
+Note that what we call "Collection" in Langroid is referred to as
+"Index" in MeiliSearch. Each data-store has its own terminology,
+but for uniformity we use the Langroid terminology here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+from dotenv import load_dotenv
+
+if TYPE_CHECKING:
+    from meilisearch_python_sdk.index import AsyncIndex
+    from meilisearch_python_sdk.models.documents import DocumentsInfo
+
+
+from pydantic_settings import SettingsConfigDict
+
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import DocMetaData, Document
+from langroid.utils.configuration import settings
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+
+
+class MeiliSearchConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="MEILISEARCH_")
+
+    cloud: bool = False
+    collection_name: str | None = None
+    primary_key: str = "id"
+    port: int = 7700
+
+
+class MeiliSearch(VectorStore):
+    def __init__(self, config: MeiliSearchConfig | None = None):
+        config = config if config is not None else MeiliSearchConfig()
+        super().__init__(config)
+        try:
+            import meilisearch_python_sdk as meilisearch
+        except ImportError:
+            raise LangroidImportError("meilisearch", "meilisearch")
+
+        self.config: MeiliSearchConfig = config
+        self.host = config.host
+        self.port = config.port
+        load_dotenv()
+        self.key = os.getenv("MEILISEARCH_API_KEY") or "masterKey"
+        self.url = os.getenv("MEILISEARCH_API_URL") or f"http://{self.host}:{self.port}"
+        if config.cloud and None in [self.key, self.url]:
+            logger.warning(
+                f"""MEILISEARCH_API_KEY, MEILISEARCH_API_URL env variable must be set 
+                to use MeiliSearch in cloud mode. Please set these values 
+                in your .env file. Switching to local MeiliSearch at 
+                {self.url} 
+                """
+            )
+            config.cloud = False
+
+        self.client: Callable[[], meilisearch.AsyncClient] = lambda: (
+            meilisearch.AsyncClient(url=self.url, api_key=self.key)
+        )
+
+        # Note: Only create collection if a non-null collection name is provided.
+        # This is useful to delay creation of db until we have a suitable
+        # collection name (e.g. we could get it from the url or folder path).
+        if config.collection_name is not None:
+            self.create_collection(
+                config.collection_name, replace=config.replace_collection
+            )
+
+    def clear_empty_collections(self) -> int:
+        """All collections are treated as non-empty in MeiliSearch, so this is a
+        no-op"""
+        return 0
+
+    async def _async_delete_indices(self, uids: List[str]) -> List[bool]:
+        """Delete any indicecs in `uids` that exist.
+        Returns list of bools indicating whether the index has been deleted"""
+        async with self.client() as client:
+            result = await asyncio.gather(
+                *[client.delete_index_if_exists(uid=uid) for uid in uids]
+            )
+        return result
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """Delete all indices whose names start with `prefix`"""
+        if not really:
+            logger.warning("Not deleting all collections, set really=True to confirm")
+            return 0
+        coll_names = [c for c in self.list_collections() if c.startswith(prefix)]
+        deletes = asyncio.run(self._async_delete_indices(coll_names))
+        n_deletes = sum(deletes)
+        logger.warning(f"Deleted {n_deletes} indices in MeiliSearch")
+        return n_deletes
+
+    def _list_all_collections(self) -> List[str]:
+        """
+        List all collections, including empty ones.
+        Returns:
+            List of collection names.
+        """
+        return self.list_collections()
+
+    async def _async_get_indexes(self) -> List[AsyncIndex]:
+        async with self.client() as client:
+            indexes = await client.get_indexes(limit=10_000)
+        return [] if indexes is None else indexes  # type: ignore
+
+    async def _async_get_index(self, index_uid: str) -> "AsyncIndex":
+        async with self.client() as client:
+            index = await client.get_index(index_uid)
+        return index  # type: ignore
+
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """
+        Returns:
+            List of index names stored. We treat any existing index as non-empty.
+        """
+        indexes = asyncio.run(self._async_get_indexes())
+        if len(indexes) == 0:
+            return []
+        else:
+            return [ind.uid for ind in indexes]
+
+    async def _async_create_index(self, collection_name: str) -> "AsyncIndex":
+        async with self.client() as client:
+            index = await client.create_index(
+                uid=collection_name,
+                primary_key=self.config.primary_key,
+            )
+        return index
+
+    async def _async_delete_index(self, collection_name: str) -> bool:
+        """Delete index if it exists. Returns True iff index was deleted"""
+        async with self.client() as client:
+            result = await client.delete_index_if_exists(uid=collection_name)
+        return result  # type: ignore
 
     def create_collection(self, collection_name: str, replace: bool = False) -> None:
         """
@@ -44523,291 +42601,906 @@ class QdrantDB(VectorStore):
             replace (bool): Whether to replace an existing collection
                 with the same name. Defaults to False.
         """
-        from qdrant_client.http.models import (
-            CollectionStatus,
-            Distance,
-            SparseIndexParams,
-            SparseVectorParams,
-            VectorParams,
-        )
-
         self.config.collection_name = collection_name
-        if self.client.collection_exists(collection_name=collection_name):
-            coll = self.client.get_collection(collection_name=collection_name)
-            if (
-                coll.status == CollectionStatus.GREEN
-                and from_optional(coll.points_count, 0) > 0
-            ):
-                logger.warning(f"Non-empty Collection {collection_name} already exists")
-                if not replace:
-                    logger.warning("Not replacing collection")
-                    return
-                else:
-                    logger.warning("Recreating fresh collection")
-            self.client.delete_collection(collection_name=collection_name)
-
-        vectors_config = {
-            "": VectorParams(
-                size=self.embedding_dim,
-                distance=Distance.COSINE,
+        collections = self.list_collections()
+        if collection_name in collections:
+            logger.warning(
+                f"MeiliSearch Non-empty Index {collection_name} already exists"
             )
-        }
-        sparse_vectors_config = None
-        if self.config.use_sparse_embeddings:
-            sparse_vectors_config = {
-                "text-sparse": SparseVectorParams(index=SparseIndexParams())
-            }
-        self.client.create_collection(
-            collection_name=collection_name,
-            vectors_config=vectors_config,
-            sparse_vectors_config=sparse_vectors_config,
-        )
-        collection_info = self.client.get_collection(collection_name=collection_name)
-        assert collection_info.status == CollectionStatus.GREEN
-        assert collection_info.vectors_count in [0, None]
+            if not replace:
+                logger.warning("Not replacing collection")
+                return
+            else:
+                logger.warning("Recreating fresh collection")
+                asyncio.run(self._async_delete_index(collection_name))
+        asyncio.run(self._async_create_index(collection_name))
+        collection_info = asyncio.run(self._async_get_index(collection_name))
         if settings.debug:
             level = logger.getEffectiveLevel()
             logger.setLevel(logging.INFO)
             logger.info(collection_info)
             logger.setLevel(level)
 
-    def get_sparse_embeddings(self, inputs: List[str]) -> List["SparseVector"]:
-        from qdrant_client.http.models import SparseVector
-
-        if not self.config.use_sparse_embeddings:
-            return []
-        import torch
-
-        tokens = self.sparse_tokenizer(
-            inputs, return_tensors="pt", truncation=True, padding=True
-        )
-        output = self.sparse_model(**tokens)
-        vectors = torch.max(
-            torch.log(torch.relu(output.logits) + torch.tensor(1.0))
-            * tokens.attention_mask.unsqueeze(-1),
-            dim=1,
-        )[0].squeeze(dim=1)
-        sparse_embeddings = []
-        for vec in vectors:
-            cols = vec.nonzero().squeeze().cpu().tolist()
-            weights = vec[cols].cpu().tolist()
-            sparse_embeddings.append(
-                SparseVector(
-                    indices=cols,
-                    values=weights,
-                )
+    async def _async_add_documents(
+        self, collection_name: str, documents: Sequence[Dict[str, Any]]
+    ) -> None:
+        async with self.client() as client:
+            index = client.index(collection_name)
+            await index.add_documents_in_batches(
+                documents=documents,
+                batch_size=self.config.batch_size,
+                primary_key=self.config.primary_key,
             )
-        return sparse_embeddings
 
     def add_documents(self, documents: Sequence[Document]) -> None:
-        from qdrant_client.http.models import (
-            Batch,
-            CollectionStatus,
-            SparseVector,
-        )
-
-        # Add id to metadata if not already present
         super().maybe_add_ids(documents)
-        # Fix the ids due to qdrant finickiness
-        for doc in documents:
-            doc.metadata.id = str(self._to_int_or_uuid(doc.metadata.id))
-        colls = self.list_collections(empty=True)
         if len(documents) == 0:
             return
-        document_dicts = [doc.model_dump() for doc in documents]
-        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-        sparse_embedding_vecs = self.get_sparse_embeddings(
-            [doc.content for doc in documents]
-        )
+        colls = self._list_all_collections()
         if self.config.collection_name is None:
             raise ValueError("No collection name set, cannot ingest docs")
         if self.config.collection_name not in colls:
             self.create_collection(self.config.collection_name, replace=True)
-        ids = [self._to_int_or_uuid(d.id()) for d in documents]
-        # don't insert all at once, batch in chunks of b,
-        # else we get an API error
-        b = self.config.batch_size
-        for i in range(0, len(ids), b):
-            vectors: Dict[str, Embeddings | List[SparseVector]] = {
-                "": embedding_vecs[i : i + b]
-            }
-            if self.config.use_sparse_embeddings:
-                vectors["text-sparse"] = sparse_embedding_vecs[i : i + b]
-            coll_found: bool = False
-            for _ in range(3):
-                # poll until collection is ready
-                if (
-                    self.client.collection_exists(self.config.collection_name)
-                    and self.client.get_collection(self.config.collection_name).status
-                    == CollectionStatus.GREEN
-                ):
-                    coll_found = True
-                    break
-                time.sleep(1)
-
-            if not coll_found:
-                raise ValueError(
-                    f"""
-                    QdrantDB Collection {self.config.collection_name} 
-                    not found or not ready
-                    """
-                )
-
-            self.client.upsert(
-                collection_name=self.config.collection_name,
-                points=Batch(
-                    ids=ids[i : i + b],
-                    vectors=vectors,
-                    payloads=document_dicts[i : i + b],
-                ),
+        docs = [
+            dict(
+                id=d.id(),
+                content=d.content,
+                metadata=d.metadata.model_dump(),
             )
+            for d in documents
+        ]
+        asyncio.run(self._async_add_documents(self.config.collection_name, docs))
 
     def delete_collection(self, collection_name: str) -> None:
-        self.client.delete_collection(collection_name=collection_name)
+        asyncio.run(self._async_delete_index(collection_name))
 
     def _to_int_or_uuid(self, id: str) -> int | str:
         try:
-            int_val = int(id)
-            if is_valid_uuid(id):
-                return int_val
+            return int(id)
         except ValueError:
-            pass
-
-        # If doc_id is already a valid UUID, return it as is
-        if isinstance(id, str) and is_valid_uuid(id):
             return id
 
-        # Otherwise, generate a UUID from the doc_id
-        # Convert doc_id to string if it's not already
-        id_str = str(id)
-
-        # Hash the document ID using SHA-1
-        hash_object = hashlib.sha1(id_str.encode())
-        hash_digest = hash_object.hexdigest()
-
-        # Truncate or manipulate the hash to fit into a UUID (128 bits)
-        uuid_str = hash_digest[:32]
-
-        # Format this string into a UUID format
-        formatted_uuid = uuid.UUID(uuid_str)
-
-        return str(formatted_uuid)
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        from qdrant_client.http.models import (
-            Filter,
-        )
-
+    async def _async_get_documents(self, where: str = "") -> "DocumentsInfo":
         if self.config.collection_name is None:
             raise ValueError("No collection name set, cannot retrieve docs")
-        docs = []
-        offset = 0
-        filter = Filter() if where == "" else Filter.model_validate(json.loads(where))
-        while True:
-            results, next_page_offset = self.client.scroll(
-                collection_name=self.config.collection_name,
-                scroll_filter=filter,
-                offset=offset,
-                limit=10_000,  # try getting all at once, if not we keep paging
-                with_payload=True,
-                with_vectors=False,
+        filter = [] if where is None else where
+        async with self.client() as client:
+            index = client.index(self.config.collection_name)
+            documents = await index.get_documents(limit=10_000, filter=filter)
+        return documents
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        docs = asyncio.run(self._async_get_documents(where))
+        if docs is None:
+            return []
+        doc_results = docs.results
+        return [
+            Document(
+                content=d["content"],
+                metadata=DocMetaData(**d["metadata"]),
             )
-            docs += [
-                self.config.document_class(**record.payload)  # type: ignore
-                for record in results
-            ]
-            # ignore
-            if next_page_offset is None:
-                break
-            offset = next_page_offset  # type: ignore
-        return docs
+            for d in doc_results
+        ]
+
+    async def _async_get_documents_by_ids(self, ids: List[str]) -> List[Dict[str, Any]]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        async with self.client() as client:
+            index = client.index(self.config.collection_name)
+            documents = await asyncio.gather(*[index.get_document(id) for id in ids])
+        return documents
 
     def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
         if self.config.collection_name is None:
             raise ValueError("No collection name set, cannot retrieve docs")
-        _ids = [self._to_int_or_uuid(id) for id in ids]
-        records = self.client.retrieve(
-            collection_name=self.config.collection_name,
-            ids=_ids,
-            with_vectors=False,
-            with_payload=True,
+        docs = asyncio.run(self._async_get_documents_by_ids(ids))
+        return [
+            Document(
+                content=d["content"],
+                metadata=DocMetaData(**d["metadata"]),
+            )
+            for d in docs
+        ]
+
+    async def _async_search(
+        self,
+        query: str,
+        k: int = 20,
+        filter: str | list[str | list[str]] | None = None,
+    ) -> List[Dict[str, Any]]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot search")
+        async with self.client() as client:
+            index = client.index(self.config.collection_name)
+            results = await index.search(
+                query,
+                limit=k,
+                show_ranking_score=True,
+                filter=filter,
+            )
+        return results.hits  # type: ignore
+
+    def similar_texts_with_scores(
+        self,
+        text: str,
+        k: int = 20,
+        where: Optional[str] = None,
+        neighbors: int = 0,  # ignored
+    ) -> List[Tuple[Document, float]]:
+        filter = [] if where is None else where
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot search")
+        _docs = asyncio.run(self._async_search(text, k, filter))  # type: ignore
+        if len(_docs) == 0:
+            logger.warning(f"No matches found for {text}")
+            return []
+        scores = [h["_rankingScore"] for h in _docs]
+        if settings.debug:
+            logger.info(f"Found {len(_docs)} matches, max score: {max(scores)}")
+        docs = [
+            Document(
+                content=d["content"],
+                metadata=DocMetaData(**d["metadata"]),
+            )
+            for d in _docs
+        ]
+        doc_score_pairs = list(zip(docs, scores))
+        self.show_if_debug(doc_score_pairs)
+        return doc_score_pairs
+</file>
+
+<file path="langroid/vector_store/pineconedb.py">
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+from dotenv import load_dotenv
+
+# import dataclass
+from pydantic import BaseModel
+from pydantic_settings import SettingsConfigDict
+
+from langroid import LangroidImportError
+from langroid.mytypes import Document
+from langroid.utils.configuration import settings
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+
+
+has_pinecone: bool = True
+try:
+    from pinecone import Pinecone, PineconeApiException, ServerlessSpec
+except ImportError:
+
+    if not TYPE_CHECKING:
+
+        class ServerlessSpec(BaseModel):
+            """
+            Fallback Serverless specification configuration to avoid import errors.
+            """
+
+            cloud: str
+            region: str
+
+        PineconeApiException = Any  # type: ignore
+        Pinecone = Any  # type: ignore
+        has_pinecone = False
+
+
+@dataclass(frozen=True)
+class IndexMeta:
+    name: str
+    total_vector_count: int
+
+
+class PineconeDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="PINECONE_")
+
+    cloud: bool = True
+    collection_name: str | None = "temp"
+    spec: ServerlessSpec = ServerlessSpec(cloud="aws", region="us-east-1")
+    deletion_protection: Literal["enabled", "disabled"] | None = None
+    metric: str = "cosine"
+    pagination_size: int = 100
+
+
+class PineconeDB(VectorStore):
+    def __init__(self, config: PineconeDBConfig | None = None):
+        config = config if config is not None else PineconeDBConfig()
+        super().__init__(config)
+        if not has_pinecone:
+            raise LangroidImportError("pinecone", "pinecone")
+        self.config: PineconeDBConfig = config
+        load_dotenv()
+        key = os.getenv("PINECONE_API_KEY")
+
+        if not key:
+            raise ValueError("PINECONE_API_KEY not set, could not instantiate client")
+        self.client = Pinecone(api_key=key)
+
+        if config.collection_name:
+            self.create_collection(
+                collection_name=config.collection_name,
+                replace=config.replace_collection,
+            )
+
+    def clear_empty_collections(self) -> int:
+        indexes = self._list_index_metas(empty=True)
+        n_deletes = 0
+        for index in indexes:
+            if index.total_vector_count == -1:
+                logger.warning(
+                    f"Error fetching details for {index.name} when scanning indexes"
+                )
+            n_deletes += 1
+            self.delete_collection(collection_name=index.name)
+        return n_deletes
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """
+        Returns:
+            Number of Pinecone indexes that were deleted
+
+        Args:
+            really: Optional[bool] - whether to really delete all Pinecone collections
+            prefix: Optional[str] - string to match potential Pinecone
+                indexes for deletion
+        """
+        if not really:
+            logger.warning("Not deleting all collections, set really=True to confirm")
+            return 0
+        indexes = [
+            c for c in self._list_index_metas(empty=True) if c.name.startswith(prefix)
+        ]
+        if len(indexes) == 0:
+            logger.warning(f"No collections found with prefix {prefix}")
+            return 0
+        n_empty_deletes, n_non_empty_deletes = 0, 0
+        for index_desc in indexes:
+            self.delete_collection(collection_name=index_desc.name)
+            n_empty_deletes += index_desc.total_vector_count == 0
+            n_non_empty_deletes += index_desc.total_vector_count > 0
+        logger.warning(
+            f"""
+            Deleted {n_empty_deletes} empty indexes and
+            {n_non_empty_deletes} non-empty indexes
+            """
         )
-        # Note the records may NOT be in the order of the ids,
-        # so we re-order them here.
-        id2payload = {record.id: record.payload for record in records}
-        ordered_payloads = [id2payload[id] for id in _ids if id in id2payload]
-        docs = [Document(**payload) for payload in ordered_payloads]  # type: ignore
+        return n_empty_deletes + n_non_empty_deletes
+
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """
+        Returns:
+            List of Pinecone indices that have at least one vector.
+
+        Args:
+            empty: Optional[bool] - whether to include empty collections
+        """
+        indexes = self.client.list_indexes()
+        res: List[str] = []
+        if empty:
+            res.extend(indexes.names())
+            return res
+
+        for index in indexes.names():
+            index_meta = self.client.Index(name=index)
+            if index_meta.describe_index_stats().get("total_vector_count", 0) > 0:
+                res.append(index)
+        return res
+
+    def _list_index_metas(self, empty: bool = False) -> List[IndexMeta]:
+        """
+        Returns:
+            List of objects describing Pinecone indices
+
+        Args:
+            empty: Optional[bool] - whether to include empty collections
+        """
+        indexes = self.client.list_indexes()
+        res = []
+        for index in indexes.names():
+            index_meta = self._fetch_index_meta(index)
+            if empty:
+                res.append(index_meta)
+            elif index_meta.total_vector_count > 0:
+                res.append(index_meta)
+        return res
+
+    def _fetch_index_meta(self, index_name: str) -> IndexMeta:
+        """
+        Returns:
+            A dataclass describing the input Index by name and vector count
+            to save a bit on index description calls
+
+        Args:
+            index_name: str - Name of the index in Pinecone
+        """
+        try:
+            index = self.client.Index(name=index_name)
+            stats = index.describe_index_stats()
+            return IndexMeta(
+                name=index_name, total_vector_count=stats.get("total_vector_count", 0)
+            )
+        except PineconeApiException as e:
+            logger.warning(f"Error fetching details for index {index_name}")
+            logger.warning(e)
+            return IndexMeta(name=index_name, total_vector_count=-1)
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        """
+        Create a collection with the given name, optionally replacing an existing
+        collection if `replace` is True.
+
+        Args:
+            collection_name: str - Configuration of the collection to create.
+            replace: Optional[Bool] - Whether to replace an existing collection
+                with the same name. Defaults to False.
+        """
+        pattern = re.compile(r"^[a-z0-9-]+$")
+        if not pattern.match(collection_name):
+            raise ValueError(
+                "Pinecone index names must be lowercase alphanumeric characters or '-'"
+            )
+        self.config.collection_name = collection_name
+        if collection_name in self.list_collections(empty=True):
+            index = self.client.Index(name=collection_name)
+            stats = index.describe_index_stats()
+            status = self.client.describe_index(name=collection_name)
+            if status["status"]["ready"] and stats["total_vector_count"] > 0:
+                logger.warning(f"Non-empty collection {collection_name} already exists")
+                if not replace:
+                    logger.warning("Not replacing collection")
+                    return
+                else:
+                    logger.warning("Recreating fresh collection")
+            self.delete_collection(collection_name=collection_name)
+
+        payload = {
+            "name": collection_name,
+            "dimension": self.embedding_dim,
+            "spec": self.config.spec,
+            "metric": self.config.metric,
+            "timeout": self.config.timeout,
+        }
+
+        if self.config.deletion_protection:
+            payload["deletion_protection"] = self.config.deletion_protection
+
+        try:
+            self.client.create_index(**payload)
+        except PineconeApiException as e:
+            logger.error(e)
+
+    def delete_collection(self, collection_name: str) -> None:
+        logger.info(f"Attempting to delete {collection_name}")
+        try:
+            self.client.delete_index(name=collection_name)
+        except PineconeApiException as e:
+            logger.error(f"Failed to delete {collection_name}")
+            logger.error(e)
+
+    def add_documents(self, documents: Sequence[Document], namespace: str = "") -> None:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+
+        if len(documents) == 0:
+            logger.warning("Empty list of documents passed into add_documents")
+            return
+
+        super().maybe_add_ids(documents)
+        document_dicts = [doc.model_dump() for doc in documents]
+        document_ids = [doc.id() for doc in documents]
+        embedding_vectors = self.embedding_fn([doc.content for doc in documents])
+        vectors = [
+            {
+                "id": document_id,
+                "values": embedding_vector,
+                "metadata": {
+                    **document_dict["metadata"],
+                    **{
+                        key: value
+                        for key, value in document_dict.items()
+                        if key != "metadata"
+                    },
+                },
+            }
+            for document_dict, document_id, embedding_vector in zip(
+                document_dicts, document_ids, embedding_vectors
+            )
+        ]
+
+        if self.config.collection_name not in self.list_collections(empty=True):
+            self.create_collection(
+                collection_name=self.config.collection_name, replace=True
+            )
+
+        index = self.client.Index(name=self.config.collection_name)
+        batch_size = self.config.batch_size
+
+        for i in range(0, len(documents), batch_size):
+            try:
+                if namespace:
+                    index.upsert(
+                        vectors=vectors[i : i + batch_size], namespace=namespace
+                    )
+                else:
+                    index.upsert(vectors=vectors[i : i + batch_size])
+            except PineconeApiException as e:
+                logger.error(
+                    f"Unable to add of docs between indices {i} and {batch_size}"
+                )
+                logger.error(e)
+
+    def get_all_documents(
+        self, prefix: str = "", namespace: str = ""
+    ) -> List[Document]:
+        """
+        Returns:
+            All documents for the collection currently defined in
+            the configuration object
+
+        Args:
+            prefix: str - document id prefix to search for
+            namespace: str - partition of vectors to search within the index
+        """
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        docs = []
+
+        request_filters: Dict[str, Union[str, int]] = {
+            "limit": self.config.pagination_size
+        }
+        if prefix:
+            request_filters["prefix"] = prefix
+        if namespace:
+            request_filters["namespace"] = namespace
+
+        index = self.client.Index(name=self.config.collection_name)
+
+        while True:
+            response = index.list_paginated(**request_filters)
+            vectors = response.get("vectors", [])
+
+            if not vectors:
+                logger.warning("Received empty list while requesting for vector ids")
+                logger.warning("Halting fetch requests")
+                if settings.debug:
+                    logger.debug(f"Request for failed fetch was: {request_filters}")
+                break
+
+            docs.extend(
+                self.get_documents_by_ids(
+                    ids=[vector.get("id") for vector in vectors],
+                    namespace=namespace if namespace else "",
+                )
+            )
+
+            pagination_token = response.get("pagination", {}).get("next", None)
+
+            if not pagination_token:
+                break
+
+            request_filters["pagination_token"] = pagination_token
+
         return docs
+
+    def get_documents_by_ids(
+        self, ids: List[str], namespace: str = ""
+    ) -> List[Document]:
+        """
+        Returns:
+            Fetches document text embedded in Pinecone index metadata
+
+        Args:
+            ids: List[str] - vector data object ids to retrieve
+            namespace: str - partition of vectors to search within the index
+        """
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        index = self.client.Index(name=self.config.collection_name)
+
+        if namespace:
+            records = index.fetch(ids=ids, namespace=namespace)
+        else:
+            records = index.fetch(ids=ids)
+
+        id_mapping = {key: value for key, value in records["vectors"].items()}
+        ordered_payloads = [id_mapping[_id] for _id in ids if _id in id_mapping]
+        return [
+            self.transform_pinecone_vector(payload.get("metadata", {}))
+            for payload in ordered_payloads
+        ]
 
     def similar_texts_with_scores(
         self,
         text: str,
         k: int = 1,
         where: Optional[str] = None,
-        neighbors: int = 0,
+        namespace: Optional[str] = None,
     ) -> List[Tuple[Document, float]]:
-        from qdrant_client.conversions.common_types import ScoredPoint
-        from qdrant_client.http.models import (
-            Filter,
-            NamedSparseVector,
-            NamedVector,
-            SearchRequest,
-        )
-
-        embedding = self.embedding_fn([text])[0]
-        # TODO filter may not work yet
-        if where is None or where == "":
-            filter = Filter()
-        else:
-            filter = Filter.model_validate(json.loads(where))
-        requests = [
-            SearchRequest(
-                vector=NamedVector(
-                    name="",
-                    vector=embedding,
-                ),
-                limit=k,
-                with_payload=True,
-                filter=filter,
-            )
-        ]
-        if self.config.use_sparse_embeddings:
-            sparse_embedding = self.get_sparse_embeddings([text])[0]
-            requests.append(
-                SearchRequest(
-                    vector=NamedSparseVector(
-                        name="text-sparse",
-                        vector=sparse_embedding,
-                    ),
-                    limit=self.config.sparse_limit,
-                    with_payload=True,
-                    filter=filter,
-                )
-            )
         if self.config.collection_name is None:
             raise ValueError("No collection name set, cannot search")
-        search_result_lists: List[List[ScoredPoint]] = self.client.search_batch(
-            collection_name=self.config.collection_name, requests=requests
-        )
 
-        search_result = [
-            match for result in search_result_lists for match in result
-        ]  # 2D list -> 1D list
-        scores = [match.score for match in search_result if match is not None]
-        docs = [
-            self.config.document_class(**(match.payload))  # type: ignore
-            for match in search_result
-            if match is not None
+        if k < 1 or k > 9999:
+            raise ValueError(
+                f"TopK for Pinecone vector search must be 1 < k < 10000, k was {k}"
+            )
+
+        vector_search_request = {
+            "top_k": k,
+            "include_metadata": True,
+            "vector": self.embedding_fn([text])[0],
+        }
+        if where:
+            vector_search_request["filter"] = json.loads(where) if where else None
+        if namespace:
+            vector_search_request["namespace"] = namespace
+
+        index = self.client.Index(name=self.config.collection_name)
+        response = index.query(**vector_search_request)
+        doc_score_pairs = [
+            (
+                self.transform_pinecone_vector(match.get("metadata", {})),
+                match.get("score", 0),
+            )
+            for match in response.get("matches", [])
         ]
-        if len(docs) == 0:
-            logger.warning(f"No matches found for {text}")
-            return []
-        doc_score_pairs = list(zip(docs, scores))
-        max_score = max(ds[1] for ds in doc_score_pairs)
         if settings.debug:
+            max_score = max([pair[1] for pair in doc_score_pairs])
             logger.info(f"Found {len(doc_score_pairs)} matches, max score: {max_score}")
         self.show_if_debug(doc_score_pairs)
         return doc_score_pairs
+
+    def transform_pinecone_vector(self, metadata_dict: Dict[str, Any]) -> Document:
+        """
+        Parses the metadata response from the Pinecone vector query and
+        formats it into a dictionary that can be parsed by the Document class
+        associated with the PineconeDBConfig class
+
+        Returns:
+            Well formed dictionary object to be transformed into a Document
+
+        Args:
+            metadata_dict: Dict - the metadata dictionary from the Pinecone
+                vector query match
+        """
+        return self.config.document_class(
+            **{**metadata_dict, "metadata": {**metadata_dict}}
+        )
+</file>
+
+<file path="langroid/vector_store/weaviatedb.py">
+import logging
+import os
+import re
+from typing import Any, List, Optional, Sequence, Tuple
+
+from dotenv import load_dotenv
+from pydantic_settings import SettingsConfigDict
+
+from langroid.embedding_models.base import (
+    EmbeddingModelsConfig,
+)
+from langroid.embedding_models.models import OpenAIEmbeddingsConfig
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import DocMetaData, Document
+from langroid.utils.configuration import settings
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+
+
+class VectorDistances:
+    """
+    Fallback class when weaviate is not installed, to avoid import errors.
+    """
+
+    COSINE: str = "cosine"
+    DOTPRODUCT: str = "dot"
+    L2: str = "l2"
+
+
+class WeaviateDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="WEAVIATE_")
+
+    collection_name: str | None = "temp"
+    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+    distance: str = VectorDistances.COSINE
+    cloud: bool = False
+    docker: bool = False
+    host: str = "127.0.0.1"
+    port: int = 8080
+    storage_path: str = ".weaviate_embedded/data"
+
+
+class WeaviateDB(VectorStore):
+    def __init__(self, config: WeaviateDBConfig | None = None):
+        config = config if config is not None else WeaviateDBConfig()
+        super().__init__(config)
+        try:
+            import weaviate
+            from weaviate.classes.init import Auth
+        except ImportError:
+            raise LangroidImportError("weaviate", "weaviate")
+
+        self.config: WeaviateDBConfig = config
+        load_dotenv()
+        if self.config.docker:
+            self.client = weaviate.connect_to_local(
+                host=self.config.host,
+                port=self.config.port,
+            )
+            self.config.cloud = False
+        elif self.config.cloud:
+            key = os.getenv("WEAVIATE_API_KEY")
+            url = os.getenv("WEAVIATE_API_URL")
+            if url is None or key is None:
+                raise ValueError(
+                    """WEAVIATE_API_KEY, WEAVIATE_API_URL env variables must be set to 
+                    use WeaviateDB in cloud mode. Please set these values
+                    in your .env file.
+                    """
+                )
+            self.client = weaviate.connect_to_weaviate_cloud(
+                cluster_url=url,
+                auth_credentials=Auth.api_key(key),
+            )
+        else:
+            self.client = weaviate.connect_to_embedded(
+                version="latest", persistence_data_path=self.config.storage_path
+            )
+
+        if config.collection_name is not None:
+            WeaviateDB.validate_and_format_collection_name(config.collection_name)
+
+    def clear_empty_collections(self) -> int:
+        colls = self.client.collections.list_all()
+        n_deletes = 0
+        for coll_name, _ in colls.items():
+            val = self.client.collections.get(coll_name)
+            if len(val) == 0:
+                n_deletes += 1
+                self.client.collections.delete(coll_name)
+        return n_deletes
+
+    def list_collections(self, empty: bool = False) -> List[str]:
+        colls = self.client.collections.list_all()
+        if empty:
+            return list(colls.keys())
+        non_empty_colls = [
+            coll_name
+            for coll_name in colls.keys()
+            if len(self.client.collections.get(coll_name)) > 0
+        ]
+
+        return non_empty_colls
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        if not really:
+            logger.warning(
+                "Not really deleting all collections ,set really=True to confirm"
+            )
+            return 0
+        coll_names = [
+            c for c in self.list_collections(empty=True) if c.startswith(prefix)
+        ]
+        if len(coll_names) == 0:
+            logger.warning(f"No collections found with prefix {prefix}")
+            return 0
+        n_empty_deletes = 0
+        n_non_empty_deletes = 0
+        for name in coll_names:
+            info = self.client.collections.get(name)
+            points_count = len(info)
+
+            n_empty_deletes += points_count == 0
+            n_non_empty_deletes += points_count > 0
+            self.client.collections.delete(name)
+        logger.warning(
+            f"""
+            Deleted {n_empty_deletes} empty collections and
+            {n_non_empty_deletes} non-empty collections.
+            """
+        )
+        return n_empty_deletes + n_non_empty_deletes
+
+    def delete_collection(self, collection_name: str) -> None:
+        self.client.collections.delete(name=collection_name)
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        try:
+            from weaviate.classes.config import (
+                Configure,
+                VectorDistances,
+            )
+        except ImportError:
+            raise LangroidImportError("weaviate", "weaviate")
+        collection_name = WeaviateDB.validate_and_format_collection_name(
+            collection_name
+        )
+        self.config.collection_name = collection_name
+        if self.client.collections.exists(name=collection_name):
+            coll = self.client.collections.get(name=collection_name)
+            if len(coll) > 0:
+                logger.warning(f"Non-empty Collection {collection_name} already exists")
+                if not replace:
+                    logger.warning("Not replacing collection")
+                    return
+                else:
+                    logger.warning("Recreating fresh collection")
+            self.client.collections.delete(name=collection_name)
+
+        vector_index_config = Configure.VectorIndex.hnsw(
+            distance_metric=VectorDistances.COSINE,
+        )
+        if isinstance(self.config.embedding, OpenAIEmbeddingsConfig):
+            vectorizer_config = Configure.Vectorizer.text2vec_openai(
+                model=self.config.embedding.model_name,
+            )
+        else:
+            vectorizer_config = None
+
+        collection_info = self.client.collections.create(
+            name=collection_name,
+            vector_index_config=vector_index_config,
+            vectorizer_config=vectorizer_config,
+        )
+        collection_info = self.client.collections.get(name=collection_name)
+        assert len(collection_info) in [0, None]
+        if settings.debug:
+            level = logger.getEffectiveLevel()
+            logger.setLevel(logging.INFO)
+            logger.info(collection_info)
+            logger.setLevel(level)
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        super().maybe_add_ids(documents)
+        colls = self.list_collections(empty=True)
+        for doc in documents:
+            doc.metadata.id = str(self._create_valid_uuid_id(doc.metadata.id))
+        if len(documents) == 0:
+            return
+
+        document_dicts = [doc.model_dump() for doc in documents]
+        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        if self.config.collection_name not in colls:
+            self.create_collection(self.config.collection_name, replace=True)
+        coll_name = self.client.collections.get(self.config.collection_name)
+        with coll_name.batch.dynamic() as batch:
+            for i, doc_dict in enumerate(document_dicts):
+                id = doc_dict["metadata"].pop("id", None)
+                batch.add_object(properties=doc_dict, uuid=id, vector=embedding_vecs[i])
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        # cannot use filter as client does not support json type queries
+        coll = self.client.collections.get(self.config.collection_name)
+        return [self.weaviate_obj_to_doc(item) for item in coll.iterator()]
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        from weaviate.classes.query import Filter
+
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+
+        docs = []
+        coll_name = self.client.collections.get(self.config.collection_name)
+
+        result = coll_name.query.fetch_objects(
+            filters=Filter.by_property("_id").contains_any(ids), limit=len(coll_name)
+        )
+
+        id_to_doc = {}
+        for item in result.objects:
+            doc = self.weaviate_obj_to_doc(item)
+            id_to_doc[doc.metadata.id] = doc
+
+        # Reconstruct the list of documents in the original order of input ids
+        docs = [id_to_doc[id] for id in ids if id in id_to_doc]
+
+        return docs
+
+    def similar_texts_with_scores(
+        self, text: str, k: int = 1, where: Optional[str] = None
+    ) -> List[Tuple[Document, float]]:
+        from weaviate.classes.query import MetadataQuery
+
+        embedding = self.embedding_fn([text])[0]
+        if self.config.collection_name is None:
+            raise ValueError("No collections name set,cannot search")
+        coll = self.client.collections.get(self.config.collection_name)
+        response = coll.query.near_vector(
+            near_vector=embedding,
+            limit=k,
+            return_properties=True,
+            return_metadata=MetadataQuery(distance=True),
+        )
+        maybe_distances = [item.metadata.distance for item in response.objects]
+        similarities = [0 if d is None else 1 - d for d in maybe_distances]
+        docs = [self.weaviate_obj_to_doc(item) for item in response.objects]
+        return list(zip(docs, similarities))
+
+    def _create_valid_uuid_id(self, id: str) -> Any:
+        from weaviate.util import generate_uuid5, get_valid_uuid
+
+        try:
+            id = get_valid_uuid(id)
+            return id
+        except Exception:
+            return generate_uuid5(id)
+
+    def weaviate_obj_to_doc(self, input_object: Any) -> Document:
+        from weaviate.util import get_valid_uuid
+
+        content = input_object.properties.get("content", "")
+        metadata_dict = input_object.properties.get("metadata", {})
+
+        window_ids = metadata_dict.pop("window_ids", [])
+        window_ids = [str(uuid) for uuid in window_ids]
+
+        # Ensure the id is a valid UUID string
+        id_value = get_valid_uuid(input_object.uuid)
+
+        metadata = DocMetaData(id=id_value, window_ids=window_ids, **metadata_dict)
+
+        return Document(content=content, metadata=metadata)
+
+    @staticmethod
+    def validate_and_format_collection_name(name: str) -> str:
+        """
+        Formats the collection name to comply with Weaviate's naming rules:
+        - Name must start with a capital letter.
+        - Name can only contain letters, numbers, and underscores.
+        - Replaces invalid characters with underscores.
+        """
+        if not name:
+            raise ValueError("Collection name cannot be empty.")
+
+        formatted_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+
+        # Ensure the first letter is capitalized
+        if not formatted_name[0].isupper():
+            formatted_name = formatted_name.capitalize()
+
+        # Check if the name now meets the criteria
+        if not re.match(r"^[A-Z][A-Za-z0-9_]*$", formatted_name):
+            raise ValueError(
+                f"Invalid collection name '{name}'."
+                " Names must start with a capital letter "
+                "and contain only letters, numbers, and underscores."
+            )
+
+        if formatted_name != name:
+            logger.warning(
+                f"Collection name '{name}' was reformatted to '{formatted_name}' "
+                "to comply with Weaviate's rules."
+            )
+
+        return formatted_name
+
+    def __del__(self) -> None:
+        # Gracefully close the connection with local client
+        if not self.config.cloud:
+            self.client.close()
 </file>
 
 <file path="CONTRIBUTING.md">
@@ -52527,6 +51220,991 @@ class MarkerPdfParser(DocumentParser):
         )
 </file>
 
+<file path="langroid/vector_store/postgres.py">
+import hashlib
+import json
+import logging
+import os
+import uuid
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from pydantic_settings import SettingsConfigDict
+
+from langroid.embedding_models.base import (
+    EmbeddingModelsConfig,
+)
+from langroid.embedding_models.models import OpenAIEmbeddingsConfig
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import DocMetaData, Document
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+has_postgres: bool = True
+try:
+    from sqlalchemy import (
+        Column,
+        MetaData,
+        String,
+        Table,
+        case,
+        create_engine,
+        inspect,
+        text,
+    )
+    from sqlalchemy.dialects.postgresql import JSONB
+    from sqlalchemy.engine import Connection, Engine
+    from sqlalchemy.sql.expression import insert
+except ImportError:
+    Engine = Any  # type: ignore
+    Connection = Any  # type: ignore
+    has_postgres = False
+
+logger = logging.getLogger(__name__)
+
+
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier (table/index name) for use in raw DDL, so a name
+    containing characters that are invalid in an unquoted identifier -- e.g.
+    the ``-`` in a pytest-xdist worker suffix like ``mycollection-gw1`` -- does
+    not produce a syntax error. Embedded double-quotes are escaped per the SQL
+    standard.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
+class PostgresDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="POSTGRES_")
+
+    collection_name: str = "embeddings"
+    cloud: bool = False
+    docker: bool = True
+    host: str = "127.0.0.1"
+    port: int = 5432
+    replace_collection: bool = False
+    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+    pool_size: int = 10
+    max_overflow: int = 20
+    hnsw_m: int = 16
+    hnsw_ef_construction: int = 200
+
+
+class PostgresDB(VectorStore):
+    def __init__(self, config: PostgresDBConfig | None = None):
+        config = config if config is not None else PostgresDBConfig()
+        super().__init__(config)
+        if not has_postgres:
+            raise LangroidImportError("pgvector", "postgres")
+        try:
+            from sqlalchemy.orm import sessionmaker
+        except ImportError:
+            raise LangroidImportError("sqlalchemy", "postgres")
+
+        self.config: PostgresDBConfig = config
+        self.engine = self._create_engine()
+        PostgresDB._create_vector_extension(self.engine)
+        self.SessionLocal = sessionmaker(
+            autocommit=False, autoflush=False, bind=self.engine
+        )
+        self.metadata = MetaData()
+        self._setup_table()
+
+    def _create_engine(self) -> Engine:
+        """Creates a SQLAlchemy engine based on the configuration."""
+
+        connection_string: str | None = None  # Ensure variable is always defined
+
+        if self.config.cloud:
+            connection_string = os.getenv("POSTGRES_CONNECTION_STRING")
+
+            if connection_string and connection_string.startswith("postgres://"):
+                connection_string = connection_string.replace(
+                    "postgres://", "postgresql+psycopg2://", 1
+                )
+            elif not connection_string:
+                raise ValueError("Provide the POSTGRES_CONNECTION_STRING.")
+
+        elif self.config.docker:
+            username = os.getenv("POSTGRES_USER", "postgres")
+            password = os.getenv("POSTGRES_PASSWORD", "postgres")
+            database = os.getenv("POSTGRES_DB", "langroid")
+
+            if not (username and password and database):
+                raise ValueError(
+                    "Provide POSTGRES_USER, POSTGRES_PASSWORD, " "POSTGRES_DB. "
+                )
+
+            connection_string = (
+                f"postgresql+psycopg2://{username}:{password}@"
+                f"{self.config.host}:{self.config.port}/{database}"
+            )
+            self.config.cloud = False  # Ensures cloud is disabled if using Docker
+
+        else:
+            raise ValueError(
+                "Provide either Docker or Cloud config to connect to the database."
+            )
+
+        return create_engine(
+            connection_string,
+            pool_size=self.config.pool_size,
+            max_overflow=self.config.max_overflow,
+        )
+
+    def _setup_table(self) -> None:
+        try:
+            from pgvector.sqlalchemy import Vector
+        except ImportError as e:
+            raise LangroidImportError(extra="postgres", error=str(e))
+
+        if self.config.replace_collection:
+            self.delete_collection(self.config.collection_name)
+
+        self.embeddings_table = Table(
+            self.config.collection_name,
+            self.metadata,
+            Column("id", String, primary_key=True, nullable=False, unique=True),
+            Column("embedding", Vector(self.embedding_dim)),
+            Column("document", String),
+            Column("cmetadata", JSONB),
+            extend_existing=True,
+        )
+
+        self.metadata.create_all(self.engine)
+        self.metadata.reflect(bind=self.engine, only=[self.config.collection_name])
+
+        # Create HNSW index for embeddings column if it doesn't exist.
+        # This index enables efficient nearest-neighbor search using cosine similarity.
+        # PostgreSQL automatically builds the index after creation;
+        # no manual step required.
+        # Read more about pgvector hnsw index here:
+        # https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw
+
+        index_name = f"hnsw_index_{self.config.collection_name}_embedding"
+        with self.engine.connect() as connection:
+            if not self.index_exists(connection, index_name):
+                connection.execute(text("COMMIT"))
+                create_index_query = text(
+                    f"""
+                    CREATE INDEX CONCURRENTLY IF NOT EXISTS {_quote_ident(index_name)}
+                    ON {_quote_ident(self.config.collection_name)}
+                    USING hnsw (embedding vector_cosine_ops)
+                    WITH (
+                        m = {self.config.hnsw_m},
+                        ef_construction = {self.config.hnsw_ef_construction}
+                    );
+                    """
+                )
+                connection.execute(create_index_query)
+
+    def index_exists(self, connection: Connection, index_name: str) -> bool:
+        """Check if an index exists."""
+        query = text(
+            "SELECT 1 FROM pg_indexes WHERE indexname = :index_name"
+        ).bindparams(index_name=index_name)
+        result = connection.execute(query).scalar()
+        return bool(result)
+
+    @staticmethod
+    def _create_vector_extension(conn: Engine) -> None:
+
+        with conn.connect() as connection:
+            with connection.begin():
+                # The number is a unique identifier used to lock a specific resource
+                # during transaction. Any 64-bit integer can be used for advisory locks.
+                # Acquire advisory lock to ensure atomic, isolated setup
+                # and prevent race conditions.
+
+                statement = text(
+                    "SELECT pg_advisory_xact_lock(1573678846307946496);"
+                    "CREATE EXTENSION IF NOT EXISTS vector;"
+                )
+                connection.execute(statement)
+
+    def set_collection(self, collection_name: str, replace: bool = False) -> None:
+        inspector = inspect(self.engine)
+        table_exists = collection_name in inspector.get_table_names()
+
+        if (
+            collection_name == self.config.collection_name
+            and table_exists
+            and not replace
+        ):
+            return
+        else:
+            self.config.collection_name = collection_name
+            self.config.replace_collection = replace
+            self._setup_table()
+
+    def list_collections(self, empty: bool = True) -> List[str]:
+        inspector = inspect(self.engine)
+        table_names = inspector.get_table_names()
+
+        with self.SessionLocal() as session:
+            collections = []
+            for table_name in table_names:
+                table = Table(table_name, self.metadata, autoload_with=self.engine)
+                if empty:
+                    collections.append(table_name)
+                else:
+                    # Efficiently check for non-emptiness
+                    if session.query(table.select().limit(1).exists()).scalar():
+                        collections.append(table_name)
+            return collections
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        self.set_collection(collection_name, replace=replace)
+
+    def delete_collection(self, collection_name: str) -> None:
+        """
+        Deletes a collection and its associated HNSW index, handling metadata
+        synchronization issues.
+        """
+        with self.engine.connect() as connection:
+            connection.execute(text("COMMIT"))
+            index_name = f"hnsw_index_{collection_name}_embedding"
+            drop_index_query = text(
+                f"DROP INDEX CONCURRENTLY IF EXISTS {_quote_ident(index_name)}"
+            )
+            connection.execute(drop_index_query)
+
+            # 3. Now, drop the table using SQLAlchemy
+            table = Table(collection_name, self.metadata)
+            table.drop(self.engine, checkfirst=True)
+
+            # 4. Refresh metadata again after dropping the table
+            self.metadata.clear()
+            self.metadata.reflect(bind=self.engine)
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        if not really:
+            logger.warning("Not deleting all tables, set really=True to confirm")
+            return 0
+
+        inspector = inspect(self.engine)
+        table_names = inspector.get_table_names()
+
+        with self.SessionLocal() as session:
+            deleted_count = 0
+            for table_name in table_names:
+                if table_name.startswith(prefix):
+                    # Use delete_collection to handle index and table deletion
+                    self.delete_collection(table_name)
+                    deleted_count += 1
+            session.commit()
+            logger.warning(f"Deleted {deleted_count} tables with prefix '{prefix}'.")
+            return deleted_count
+
+    def clear_empty_collections(self) -> int:
+        inspector = inspect(self.engine)
+        table_names = inspector.get_table_names()
+
+        with self.SessionLocal() as session:
+            deleted_count = 0
+            for table_name in table_names:
+                table = Table(table_name, self.metadata, autoload_with=self.engine)
+
+                # Efficiently check for emptiness without fetching all rows
+                if session.query(table.select().limit(1).exists()).scalar():
+                    continue
+
+                # Use delete_collection to handle index and table deletion
+                self.delete_collection(table_name)
+                deleted_count += 1
+
+            session.commit()  # Commit is likely not needed here
+            logger.warning(f"Deleted {deleted_count} empty tables.")
+            return deleted_count
+
+    def _parse_embedding_store_record(self, res: Any) -> Dict[str, Any]:
+        metadata = res.cmetadata or {}
+        metadata["id"] = res.id
+        return {
+            "content": res.document,
+            "metadata": DocMetaData(**metadata),
+        }
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        with self.SessionLocal() as session:
+            query = session.query(self.embeddings_table)
+
+            # Apply 'where' clause if provided
+            if where:
+                try:
+                    where_json = json.loads(where)
+                    query = query.filter(
+                        self.embeddings_table.c.cmetadata.contains(where_json)
+                    )
+                except json.JSONDecodeError:
+                    logger.error(f"Invalid JSON in 'where' clause: {where}")
+                    return []  # Return empty list or handle error as appropriate
+
+            results = query.all()
+            documents = [
+                Document(**self._parse_embedding_store_record(res)) for res in results
+            ]
+            return documents
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        with self.SessionLocal() as session:
+            # Add a CASE statement to preserve the order of IDs
+            case_stmt = case(
+                {id_: index for index, id_ in enumerate(ids)},
+                value=self.embeddings_table.c.id,
+            )
+
+            query = (
+                session.query(self.embeddings_table)
+                .filter(self.embeddings_table.c.id.in_(ids))
+                .order_by(case_stmt)  # Order by the CASE statement
+            )
+            results = query.all()
+
+            documents = [
+                Document(**self._parse_embedding_store_record(row)) for row in results
+            ]
+            return documents
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        super().maybe_add_ids(documents)
+        for doc in documents:
+            doc.metadata.id = str(PostgresDB._id_to_uuid(doc.metadata.id, doc.metadata))
+
+        embeddings = self.embedding_fn([doc.content for doc in documents])
+
+        batch_size = self.config.batch_size
+        with self.SessionLocal() as session:
+            for i in range(0, len(documents), batch_size):
+                batch_docs = documents[i : i + batch_size]
+                batch_embeddings = embeddings[i : i + batch_size]
+
+                new_records = [
+                    {
+                        "id": doc.metadata.id,
+                        "embedding": embedding,
+                        "document": doc.content,
+                        "cmetadata": doc.metadata.model_dump(),
+                    }
+                    for doc, embedding in zip(batch_docs, batch_embeddings)
+                ]
+
+                if new_records:
+                    stmt = insert(self.embeddings_table).values(new_records)
+                    session.execute(stmt)
+                session.commit()
+
+    @staticmethod
+    def _id_to_uuid(id: str, obj: object) -> str:
+        try:
+            doc_id = str(uuid.UUID(id))
+        except ValueError:
+            obj_repr = repr(obj)
+
+            obj_hash = hashlib.sha256(obj_repr.encode()).hexdigest()
+
+            combined = f"{id}-{obj_hash}"
+
+            doc_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, combined))
+
+        return doc_id
+
+    def similar_texts_with_scores(
+        self,
+        query: str,
+        k: int = 1,
+        where: Optional[str] = None,
+        neighbors: int = 1,  # Parameter not used in this implementation
+    ) -> List[Tuple[Document, float]]:
+        embedding = self.embedding_fn([query])[0]
+
+        with self.SessionLocal() as session:
+            # Calculate the score (1 - cosine_distance) and label it as "score"
+            score = (
+                1 - (self.embeddings_table.c.embedding.cosine_distance(embedding))
+            ).label("score")
+
+            if where is not None:
+                try:
+                    json_query = json.loads(where)
+                except json.JSONDecodeError:
+                    raise ValueError(f"Invalid JSON in 'where' clause: {where}")
+
+                results = (
+                    session.query(
+                        self.embeddings_table.c.id,
+                        self.embeddings_table.c.document,
+                        self.embeddings_table.c.cmetadata,
+                        score,  # Select the calculated score
+                    )
+                    .filter(self.embeddings_table.c.cmetadata.contains(json_query))
+                    .order_by(score.desc())  # Order by score in descending order
+                    .limit(k)
+                    .all()
+                )
+            else:
+                results = (
+                    session.query(
+                        self.embeddings_table.c.id,
+                        self.embeddings_table.c.document,
+                        self.embeddings_table.c.cmetadata,
+                        score,  # Select the calculated score
+                    )
+                    .order_by(score.desc())  # Order by score in descending order
+                    .limit(k)
+                    .all()
+                )
+
+            documents_with_scores = [
+                (
+                    Document(
+                        content=result.document,
+                        metadata=DocMetaData(**(result.cmetadata or {})),
+                    ),
+                    result.score,  # Use the score from the query result
+                )
+                for result in results
+            ]
+
+            return documents_with_scores
+</file>
+
+<file path="langroid/vector_store/qdrantdb.py">
+import hashlib
+import json
+import logging
+import os
+import time
+import uuid
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, TypeVar
+
+from dotenv import load_dotenv
+from pydantic_settings import SettingsConfigDict
+
+from langroid.embedding_models.base import (
+    EmbeddingModelsConfig,
+)
+from langroid.embedding_models.models import OpenAIEmbeddingsConfig
+from langroid.mytypes import Document, Embeddings
+from langroid.utils.configuration import settings
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from qdrant_client.http.models import SparseVector
+
+
+T = TypeVar("T")
+
+
+def from_optional(x: Optional[T], default: T) -> T:
+    if x is None:
+        return default
+
+    return x
+
+
+def is_valid_uuid(uuid_to_test: str) -> bool:
+    """
+    Check if a given string is a valid UUID.
+    """
+    try:
+        uuid_obj = uuid.UUID(uuid_to_test)
+        return str(uuid_obj) == uuid_to_test
+    except Exception:
+        pass
+    # Check for valid unsigned 64-bit integer
+    try:
+        int_value = int(uuid_to_test)
+        return 0 <= int_value <= 18446744073709551615
+    except ValueError:
+        return False
+
+
+class QdrantDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="QDRANT_")
+
+    cloud: bool = True
+    docker: bool = False
+    collection_name: str | None = "temp"
+    storage_path: str = ".qdrant/data"
+    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+    use_sparse_embeddings: bool = False
+    sparse_embedding_model: str = "naver/splade-v3-distilbert"
+    sparse_limit: int = 3
+    distance: str = "cosine"
+
+
+class QdrantDB(VectorStore):
+    def __init__(self, config: QdrantDBConfig | None = None):
+        config = config if config is not None else QdrantDBConfig()
+        super().__init__(config)
+        self.config: QdrantDBConfig = config
+        from qdrant_client import QdrantClient
+
+        if self.config.use_sparse_embeddings:
+            try:
+                from transformers import AutoModelForMaskedLM, AutoTokenizer
+            except ImportError:
+                raise ImportError(
+                    """
+                    To use sparse embeddings,
+                    you must install langroid with the [transformers] extra, e.g.:
+                    pip install "langroid[transformers]"
+                    """
+                )
+
+            self.sparse_tokenizer = AutoTokenizer.from_pretrained(  # type: ignore
+                self.config.sparse_embedding_model
+            )
+            self.sparse_model = AutoModelForMaskedLM.from_pretrained(
+                self.config.sparse_embedding_model
+            )
+        self.host = config.host
+        self.port = config.port
+        load_dotenv()
+        key = os.getenv("QDRANT_API_KEY")
+        url = os.getenv("QDRANT_API_URL")
+        if config.docker:
+            if url is None:
+                logger.warning(
+                    f"""The QDRANT_API_URL env variable must be set to use
+                    QdrantDB in local docker mode. Please set this
+                    value in your .env file.
+                    Switching to local storage at {config.storage_path}
+                    """
+                )
+                config.cloud = False
+            else:
+                config.cloud = True
+        elif config.cloud and None in [key, url]:
+            logger.warning(
+                f"""QDRANT_API_KEY, QDRANT_API_URL env variable must be set to use
+                QdrantDB in cloud mode. Please set these values
+                in your .env file.
+                Switching to local storage at {config.storage_path}
+                """
+            )
+            config.cloud = False
+
+        if config.cloud:
+            self.client = QdrantClient(
+                url=url,
+                api_key=key,
+                timeout=config.timeout,
+            )
+        else:
+            try:
+                self.client = QdrantClient(
+                    path=config.storage_path,
+                )
+            except Exception as e:
+                new_storage_path = config.storage_path + ".new"
+                logger.warning(
+                    f"""
+                    Error connecting to local QdrantDB at {config.storage_path}:
+                    {e}
+                    Switching to {new_storage_path}
+                    """
+                )
+                self.client = QdrantClient(
+                    path=new_storage_path,
+                )
+
+        # Note: Only create collection if a non-null collection name is provided.
+        # This is useful to delay creation of vecdb until we have a suitable
+        # collection name (e.g. we could get it from the url or folder path).
+        if config.collection_name is not None:
+            self.create_collection(
+                config.collection_name, replace=config.replace_collection
+            )
+
+    def clone(self) -> "QdrantDB":
+        """Create an independent Qdrant client when running against Qdrant Cloud."""
+        if not self.config.cloud:
+            return self
+        cloned = super().clone()
+        assert isinstance(cloned, QdrantDB)
+        return cloned
+
+    def close(self) -> None:
+        """
+        Close the QdrantDB client and release any resources (e.g., file locks).
+        This is especially important for local storage to release the .lock file.
+        """
+        if hasattr(self.client, "close"):
+            # QdrantLocal has a close method that releases the lock
+            self.client.close()
+            logger.info(f"Closed QdrantDB connection for {self.config.storage_path}")
+
+    def __enter__(self) -> "QdrantDB":
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Context manager exit - ensure cleanup even if an exception occurred."""
+        self.close()
+
+    def clear_empty_collections(self) -> int:
+        coll_names = self.list_collections()
+        n_deletes = 0
+        for name in coll_names:
+            info = self.client.get_collection(collection_name=name)
+            if info.points_count == 0:
+                n_deletes += 1
+                self.client.delete_collection(collection_name=name)
+        return n_deletes
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """Clear all collections with the given prefix."""
+
+        if not really:
+            logger.warning("Not deleting all collections, set really=True to confirm")
+            return 0
+        coll_names = [
+            c for c in self.list_collections(empty=True) if c.startswith(prefix)
+        ]
+        if len(coll_names) == 0:
+            logger.warning(f"No collections found with prefix {prefix}")
+            return 0
+        n_empty_deletes = 0
+        n_non_empty_deletes = 0
+        for name in coll_names:
+            info = self.client.get_collection(collection_name=name)
+            points_count = from_optional(info.points_count, 0)
+
+            n_empty_deletes += points_count == 0
+            n_non_empty_deletes += points_count > 0
+            self.client.delete_collection(collection_name=name)
+        logger.warning(
+            f"""
+            Deleted {n_empty_deletes} empty collections and
+            {n_non_empty_deletes} non-empty collections.
+            """
+        )
+        return n_empty_deletes + n_non_empty_deletes
+
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """
+        Returns:
+            List of collection names that have at least one vector.
+
+        Args:
+            empty (bool, optional): Whether to include empty collections.
+        """
+
+        colls = list(self.client.get_collections())[0][1]
+        if empty:
+            return [coll.name for coll in colls]
+        counts = []
+        for coll in colls:
+            try:
+                counts.append(
+                    from_optional(
+                        self.client.get_collection(
+                            collection_name=coll.name
+                        ).points_count,
+                        0,
+                    )
+                )
+            except Exception:
+                logger.warning(f"Error getting collection {coll.name}")
+                counts.append(0)
+        return [coll.name for coll, count in zip(colls, counts) if (count or 0) > 0]
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        """
+        Create a collection with the given name, optionally replacing an existing
+            collection if `replace` is True.
+        Args:
+            collection_name (str): Name of the collection to create.
+            replace (bool): Whether to replace an existing collection
+                with the same name. Defaults to False.
+        """
+        from qdrant_client.http.models import (
+            CollectionStatus,
+            Distance,
+            SparseIndexParams,
+            SparseVectorParams,
+            VectorParams,
+        )
+
+        self.config.collection_name = collection_name
+        if self.client.collection_exists(collection_name=collection_name):
+            coll = self.client.get_collection(collection_name=collection_name)
+            if (
+                coll.status == CollectionStatus.GREEN
+                and from_optional(coll.points_count, 0) > 0
+            ):
+                logger.warning(f"Non-empty Collection {collection_name} already exists")
+                if not replace:
+                    logger.warning("Not replacing collection")
+                    return
+                else:
+                    logger.warning("Recreating fresh collection")
+            self.client.delete_collection(collection_name=collection_name)
+
+        vectors_config = {
+            "": VectorParams(
+                size=self.embedding_dim,
+                distance=Distance.COSINE,
+            )
+        }
+        sparse_vectors_config = None
+        if self.config.use_sparse_embeddings:
+            sparse_vectors_config = {
+                "text-sparse": SparseVectorParams(index=SparseIndexParams())
+            }
+        self.client.create_collection(
+            collection_name=collection_name,
+            vectors_config=vectors_config,
+            sparse_vectors_config=sparse_vectors_config,
+        )
+        collection_info = self.client.get_collection(collection_name=collection_name)
+        assert collection_info.status == CollectionStatus.GREEN
+        assert collection_info.vectors_count in [0, None]
+        if settings.debug:
+            level = logger.getEffectiveLevel()
+            logger.setLevel(logging.INFO)
+            logger.info(collection_info)
+            logger.setLevel(level)
+
+    def get_sparse_embeddings(self, inputs: List[str]) -> List["SparseVector"]:
+        from qdrant_client.http.models import SparseVector
+
+        if not self.config.use_sparse_embeddings:
+            return []
+        import torch
+
+        tokens = self.sparse_tokenizer(
+            inputs, return_tensors="pt", truncation=True, padding=True
+        )
+        output = self.sparse_model(**tokens)
+        vectors = torch.max(
+            torch.log(torch.relu(output.logits) + torch.tensor(1.0))
+            * tokens.attention_mask.unsqueeze(-1),
+            dim=1,
+        )[0].squeeze(dim=1)
+        sparse_embeddings = []
+        for vec in vectors:
+            cols = vec.nonzero().squeeze().cpu().tolist()
+            weights = vec[cols].cpu().tolist()
+            sparse_embeddings.append(
+                SparseVector(
+                    indices=cols,
+                    values=weights,
+                )
+            )
+        return sparse_embeddings
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        from qdrant_client.http.models import (
+            Batch,
+            CollectionStatus,
+            SparseVector,
+        )
+
+        # Add id to metadata if not already present
+        super().maybe_add_ids(documents)
+        # Fix the ids due to qdrant finickiness
+        for doc in documents:
+            doc.metadata.id = str(self._to_int_or_uuid(doc.metadata.id))
+        colls = self.list_collections(empty=True)
+        if len(documents) == 0:
+            return
+        document_dicts = [doc.model_dump() for doc in documents]
+        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+        sparse_embedding_vecs = self.get_sparse_embeddings(
+            [doc.content for doc in documents]
+        )
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        if self.config.collection_name not in colls:
+            self.create_collection(self.config.collection_name, replace=True)
+        ids = [self._to_int_or_uuid(d.id()) for d in documents]
+        # don't insert all at once, batch in chunks of b,
+        # else we get an API error
+        b = self.config.batch_size
+        for i in range(0, len(ids), b):
+            vectors: Dict[str, Embeddings | List[SparseVector]] = {
+                "": embedding_vecs[i : i + b]
+            }
+            if self.config.use_sparse_embeddings:
+                vectors["text-sparse"] = sparse_embedding_vecs[i : i + b]
+            coll_found: bool = False
+            for _ in range(3):
+                # poll until collection is ready
+                if (
+                    self.client.collection_exists(self.config.collection_name)
+                    and self.client.get_collection(self.config.collection_name).status
+                    == CollectionStatus.GREEN
+                ):
+                    coll_found = True
+                    break
+                time.sleep(1)
+
+            if not coll_found:
+                raise ValueError(
+                    f"""
+                    QdrantDB Collection {self.config.collection_name} 
+                    not found or not ready
+                    """
+                )
+
+            self.client.upsert(
+                collection_name=self.config.collection_name,
+                points=Batch(
+                    ids=ids[i : i + b],
+                    vectors=vectors,
+                    payloads=document_dicts[i : i + b],
+                ),
+            )
+
+    def delete_collection(self, collection_name: str) -> None:
+        self.client.delete_collection(collection_name=collection_name)
+
+    def _to_int_or_uuid(self, id: str) -> int | str:
+        try:
+            int_val = int(id)
+            if is_valid_uuid(id):
+                return int_val
+        except ValueError:
+            pass
+
+        # If doc_id is already a valid UUID, return it as is
+        if isinstance(id, str) and is_valid_uuid(id):
+            return id
+
+        # Otherwise, generate a UUID from the doc_id
+        # Convert doc_id to string if it's not already
+        id_str = str(id)
+
+        # Hash the document ID using SHA-1
+        hash_object = hashlib.sha1(id_str.encode())
+        hash_digest = hash_object.hexdigest()
+
+        # Truncate or manipulate the hash to fit into a UUID (128 bits)
+        uuid_str = hash_digest[:32]
+
+        # Format this string into a UUID format
+        formatted_uuid = uuid.UUID(uuid_str)
+
+        return str(formatted_uuid)
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        from qdrant_client.http.models import (
+            Filter,
+        )
+
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        docs = []
+        offset = 0
+        filter = Filter() if where == "" else Filter.model_validate(json.loads(where))
+        while True:
+            results, next_page_offset = self.client.scroll(
+                collection_name=self.config.collection_name,
+                scroll_filter=filter,
+                offset=offset,
+                limit=10_000,  # try getting all at once, if not we keep paging
+                with_payload=True,
+                with_vectors=False,
+            )
+            docs += [
+                self.config.document_class(**record.payload)  # type: ignore
+                for record in results
+            ]
+            # ignore
+            if next_page_offset is None:
+                break
+            offset = next_page_offset  # type: ignore
+        return docs
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        _ids = [self._to_int_or_uuid(id) for id in ids]
+        records = self.client.retrieve(
+            collection_name=self.config.collection_name,
+            ids=_ids,
+            with_vectors=False,
+            with_payload=True,
+        )
+        # Note the records may NOT be in the order of the ids,
+        # so we re-order them here.
+        id2payload = {record.id: record.payload for record in records}
+        ordered_payloads = [id2payload[id] for id in _ids if id in id2payload]
+        docs = [Document(**payload) for payload in ordered_payloads]  # type: ignore
+        return docs
+
+    def similar_texts_with_scores(
+        self,
+        text: str,
+        k: int = 1,
+        where: Optional[str] = None,
+        neighbors: int = 0,
+    ) -> List[Tuple[Document, float]]:
+        from qdrant_client.conversions.common_types import ScoredPoint
+        from qdrant_client.http.models import (
+            Filter,
+            NamedSparseVector,
+            NamedVector,
+            SearchRequest,
+        )
+
+        embedding = self.embedding_fn([text])[0]
+        # TODO filter may not work yet
+        if where is None or where == "":
+            filter = Filter()
+        else:
+            filter = Filter.model_validate(json.loads(where))
+        requests = [
+            SearchRequest(
+                vector=NamedVector(
+                    name="",
+                    vector=embedding,
+                ),
+                limit=k,
+                with_payload=True,
+                filter=filter,
+            )
+        ]
+        if self.config.use_sparse_embeddings:
+            sparse_embedding = self.get_sparse_embeddings([text])[0]
+            requests.append(
+                SearchRequest(
+                    vector=NamedSparseVector(
+                        name="text-sparse",
+                        vector=sparse_embedding,
+                    ),
+                    limit=self.config.sparse_limit,
+                    with_payload=True,
+                    filter=filter,
+                )
+            )
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot search")
+        search_result_lists: List[List[ScoredPoint]] = self.client.search_batch(
+            collection_name=self.config.collection_name, requests=requests
+        )
+
+        search_result = [
+            match for result in search_result_lists for match in result
+        ]  # 2D list -> 1D list
+        scores = [match.score for match in search_result if match is not None]
+        docs = [
+            self.config.document_class(**(match.payload))  # type: ignore
+            for match in search_result
+            if match is not None
+        ]
+        if len(docs) == 0:
+            logger.warning(f"No matches found for {text}")
+            return []
+        doc_score_pairs = list(zip(docs, scores))
+        max_score = max(ds[1] for ds in doc_score_pairs)
+        if settings.debug:
+            logger.info(f"Found {len(doc_score_pairs)} matches, max score: {max_score}")
+        self.show_if_debug(doc_score_pairs)
+        return doc_score_pairs
+</file>
+
 <file path="SECURITY.md">
 # Security Policy
 
@@ -52655,6 +52333,3117 @@ it, and if it was a denylist gap it is out of scope.
 
 Security fixes ship in the latest release. Please upgrade to the current
 version of `langroid` rather than requesting backports.
+</file>
+
+<file path="langroid/language_models/openai_gpt.py">
+import hashlib
+import json
+import logging
+import os
+import sys
+import warnings
+from collections import defaultdict
+from functools import cache
+from itertools import chain
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    no_type_check,
+)
+
+import openai
+from cerebras.cloud.sdk import AsyncCerebras, Cerebras
+from groq import AsyncGroq, Groq
+from httpx import Timeout
+from openai import AsyncOpenAI, OpenAI
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from rich import print
+from rich.markup import escape
+
+from langroid.cachedb.base import CacheDB
+from langroid.cachedb.redis_cachedb import RedisCache, RedisCacheConfig
+from langroid.exceptions import LangroidImportError
+from langroid.language_models.base import (
+    LanguageModel,
+    LLMConfig,
+    LLMFunctionCall,
+    LLMFunctionSpec,
+    LLMMessage,
+    LLMResponse,
+    LLMTokenUsage,
+    OpenAIJsonSchemaSpec,
+    OpenAIToolCall,
+    OpenAIToolSpec,
+    Role,
+    StreamEventType,
+    ToolChoiceTypes,
+)
+from langroid.language_models.client_cache import (
+    get_async_cerebras_client,
+    get_async_groq_client,
+    get_async_openai_client,
+    get_cerebras_client,
+    get_groq_client,
+    get_openai_client,
+    wrap_api_key_provider_async,
+)
+from langroid.language_models.config import HFPromptFormatterConfig
+from langroid.language_models.model_info import (
+    DeepSeekModel,
+    MiniMaxModel,
+    OpenAI_API_ParamInfo,
+)
+from langroid.language_models.model_info import (
+    OpenAIChatModel as OpenAIChatModel,
+)
+from langroid.language_models.model_info import (
+    OpenAICompletionModel as OpenAICompletionModel,
+)
+from langroid.language_models.prompt_formatter.hf_formatter import (
+    HFFormatter,
+    find_hf_formatter,
+)
+from langroid.language_models.provider_params import (
+    DUMMY_API_KEY,
+    LangDBParams,
+    PortkeyParams,
+)
+from langroid.language_models.utils import (
+    async_retry_with_exponential_backoff,
+    retry_with_exponential_backoff,
+)
+from langroid.parsing.parse_json import parse_imperfect_json
+from langroid.utils.configuration import settings
+from langroid.utils.constants import Colors
+from langroid.utils.system import friendly_error
+
+logging.getLogger("openai").setLevel(logging.ERROR)
+
+if "OLLAMA_HOST" in os.environ:
+    OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
+else:
+    OLLAMA_BASE_URL = "http://localhost:11434/v1"
+
+DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+# Provider prefixes that route to the Gemini OpenAI-compatible API.
+GEMINI_MODEL_PREFIXES = ("gemini/", "google/gemini-")
+GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+OLLAMA_API_KEY = "ollama"
+
+VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
+LLAMACPP_API_KEY = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
+
+
+openai_chat_model_pref_list = [
+    OpenAIChatModel.GPT4o,
+    OpenAIChatModel.GPT4_1_NANO,
+    OpenAIChatModel.GPT4_1_MINI,
+    OpenAIChatModel.GPT4_1,
+    OpenAIChatModel.GPT4o_MINI,
+    OpenAIChatModel.O1_MINI,
+    OpenAIChatModel.O3_MINI,
+    OpenAIChatModel.O1,
+]
+
+openai_completion_model_pref_list = [
+    OpenAICompletionModel.DAVINCI,
+    OpenAICompletionModel.BABBAGE,
+]
+
+
+if "OPENAI_API_KEY" in os.environ:
+    try:
+        available_models = set(map(lambda m: m.id, OpenAI().models.list()))
+    except openai.AuthenticationError as e:
+        if settings.debug:
+            logging.warning(
+                f"""
+            OpenAI Authentication Error: {e}.
+            ---
+            If you intended to use an OpenAI Model, you should fix this,
+            otherwise you can ignore this warning.
+            """
+            )
+        available_models = set()
+    except Exception as e:
+        if settings.debug:
+            logging.warning(
+                f"""
+            Error while fetching available OpenAI models: {e}.
+            Proceeding with an empty set of available models.
+            """
+            )
+        available_models = set()
+else:
+    available_models = set()
+
+default_openai_chat_model = next(
+    chain(
+        filter(
+            lambda m: m.value in available_models,
+            openai_chat_model_pref_list,
+        ),
+        [OpenAIChatModel.GPT4o],
+    )
+)
+default_openai_completion_model = next(
+    chain(
+        filter(
+            lambda m: m.value in available_models,
+            openai_completion_model_pref_list,
+        ),
+        [OpenAICompletionModel.DAVINCI],
+    )
+)
+
+
+class AccessWarning(Warning):
+    pass
+
+
+@cache
+def gpt_3_5_warning() -> None:
+    warnings.warn(
+        f"""
+        {OpenAIChatModel.GPT4o} is not available,
+        falling back to {OpenAIChatModel.GPT3_5_TURBO}.
+        Examples may not work properly and unexpected behavior may occur.
+        Adjustments to prompts may be necessary.
+        """,
+        AccessWarning,
+    )
+
+
+@cache
+def parallel_strict_warning() -> None:
+    logging.warning(
+        "OpenAI tool calling in strict mode is not supported when "
+        "parallel tool calls are made. Disable parallel tool calling "
+        "to ensure correct behavior."
+    )
+
+
+def noop() -> None:
+    """Does nothing."""
+    return None
+
+
+class OpenAICallParams(BaseModel):
+    """
+    Various params that can be sent to an OpenAI API chat-completion call.
+    When specified, any param here overrides the one with same name in the
+    OpenAIGPTConfig.
+    See OpenAI API Reference for details on the params:
+    https://platform.openai.com/docs/api-reference/chat
+    """
+
+    max_tokens: int | None = None
+    temperature: float | None = None
+    frequency_penalty: float | None = None  # between -2 and 2
+    presence_penalty: float | None = None  # between -2 and 2
+    response_format: Dict[str, str] | None = None
+    logit_bias: Dict[int, float] | None = None  # token_id -> bias
+    logprobs: bool | None = None
+    top_p: float | None = None
+    reasoning_effort: str | None = None  # or "low" or "high" or "medium"
+    top_logprobs: int | None = None  # if int, requires logprobs=True
+    n: int | None = None  # how many completions to generate (n > 1 is NOT handled now)
+    stop: str | List[str] | None = None  # (list of) stop sequence(s)
+    seed: int | None = None
+    user: str | None = None  # user id for tracking
+    extra_body: Dict[str, Any] | None = None  # additional params for API request body
+
+    def to_dict_exclude_none(self) -> Dict[str, Any]:
+        return {k: v for k, v in self.model_dump().items() if v is not None}
+
+
+class LiteLLMProxyConfig(BaseSettings):
+    """Configuration for LiteLLM proxy connection."""
+
+    api_key: str = ""  # read from env var LITELLM_API_KEY if set
+    api_base: str = ""  # read from env var LITELLM_API_BASE if set
+
+    model_config = SettingsConfigDict(env_prefix="LITELLM_")
+
+
+class OpenAIGPTConfig(LLMConfig):
+    """
+    Class for any LLM with an OpenAI-like API: besides the OpenAI models this includes:
+    (a) locally-served models behind an OpenAI-compatible API
+    (b) non-local models, using a proxy adaptor lib like litellm that provides
+        an OpenAI-compatible API.
+    (We could rename this class to OpenAILikeConfig, but we keep it as-is for now)
+
+    Important Note:
+    Due to the `env_prefix = "OPENAI_"` defined below,
+    all of the fields below can be set AND OVERRIDDEN via env vars,
+    # by upper-casing the name and prefixing with OPENAI_, e.g.
+    # OPENAI_MAX_OUTPUT_TOKENS=1000.
+    # If any of these is defined in this way in the environment
+    # (either via explicit setenv or export or via .env file + load_dotenv()),
+    # the environment variable takes precedence over the value in the config.
+    """
+
+    type: str = "openai"
+    api_key: str = DUMMY_API_KEY
+    # Callable returning a fresh API key/bearer token, for endpoints that
+    # authenticate with short-lived rotating credentials (e.g. Vertex AI
+    # OAuth tokens, Azure Entra ID). Resolved per-request by the OpenAI
+    # client, and excluded from the client-cache key (the cache is keyed on
+    # the provider's identity), so rotating tokens neither go stale nor grow
+    # the cache. Takes precedence over `api_key`. Only supported for models
+    # served via an OpenAI-compatible endpoint (not Groq/Cerebras/litellm).
+    # See docs/notes/rotating-api-keys.md.
+    api_key_provider: Optional[Callable[[], str]] = None
+    organization: str = ""
+    api_base: str | None = None  # used for local or other non-OpenAI models
+    litellm: bool = False  # use litellm api?
+    litellm_proxy: LiteLLMProxyConfig = LiteLLMProxyConfig()
+    ollama: bool = False  # use ollama's OpenAI-compatible endpoint?
+    min_output_tokens: int = 1
+    use_chat_for_completion: bool = True  # do not change this, for OpenAI models!
+    timeout: int = 20
+    temperature: float = 0.2
+    seed: int | None = 42
+    params: OpenAICallParams | None = None
+    use_cached_client: bool = (
+        True  # Whether to reuse cached clients (prevents resource exhaustion)
+    )
+    # these can be any model name that is served at an OpenAI-compatible API end point
+    chat_model: str = default_openai_chat_model
+    chat_model_orig: Optional[str] = None
+    completion_model: str = default_openai_completion_model
+    run_on_first_use: Callable[[], None] = noop
+    parallel_tool_calls: Optional[bool] = None
+    # Supports constrained decoding which enforces that the output of the LLM
+    # adheres to a JSON schema
+    supports_json_schema: Optional[bool] = None
+    # Supports strict decoding for the generation of tool calls with
+    # the OpenAI Tools API; this ensures that the generated tools
+    # adhere to the provided schema.
+    supports_strict_tools: Optional[bool] = None
+    # a string that roughly matches a HuggingFace chat_template,
+    # e.g. "mistral-instruct-v0.2 (a fuzzy search is done to find the closest match)
+    formatter: str | None = None
+    hf_formatter: HFFormatter | None = None
+    langdb_params: LangDBParams = LangDBParams()
+    portkey_params: PortkeyParams = PortkeyParams()
+    headers: Dict[str, str] = {}
+    http_client_factory: Optional[Callable[[], Any]] = (
+        None  # Factory: returns Client or (Client, AsyncClient)
+    )
+    http_verify_ssl: bool = True  # Simple flag for SSL verification
+    http_client_config: Optional[Dict[str, Any]] = None  # Config dict for httpx.Client
+    _api_base_was_supplied: bool = False
+
+    def __init__(self, **kwargs) -> None:  # type: ignore
+        api_base_was_supplied = "api_base" in kwargs
+        local_model = "api_base" in kwargs and kwargs["api_base"] is not None
+
+        chat_model = kwargs.get("chat_model", "")
+        local_prefixes = ["local/", "litellm/", "ollama/", "vllm/", "llamacpp/"]
+        if any(chat_model.startswith(prefix) for prefix in local_prefixes):
+            local_model = True
+
+        warn_gpt_3_5 = (
+            "chat_model" not in kwargs.keys()
+            and not local_model
+            and default_openai_chat_model == OpenAIChatModel.GPT3_5_TURBO
+        )
+
+        if warn_gpt_3_5:
+            existing_hook = kwargs.get("run_on_first_use", noop)
+
+            def with_warning() -> None:
+                existing_hook()
+                gpt_3_5_warning()
+
+            kwargs["run_on_first_use"] = with_warning
+
+        super().__init__(**kwargs)
+        env_prefix = self.model_config.get("env_prefix")
+        env_api_base_name = f"{env_prefix}API_BASE"
+        env_api_base = os.getenv(env_api_base_name)
+        if not self.model_config.get("case_sensitive"):
+            case_insensitive_env = {
+                name.lower(): value for name, value in os.environ.items()
+            }
+            env_api_base = case_insensitive_env.get(env_api_base_name.lower())
+        api_base_was_supplied = api_base_was_supplied or (
+            self.api_base is not None
+            and (env_prefix != "OPENAI_" or self.api_base != env_api_base)
+        )
+        self._api_base_was_supplied = api_base_was_supplied
+
+    model_config = SettingsConfigDict(env_prefix="OPENAI_")
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Track API bases assigned after config construction."""
+        super().__setattr__(name, value)
+        if name == "api_base":
+            self._api_base_was_supplied = True
+
+    def model_copy(
+        self, *, update: Mapping[str, Any] | None = None, deep: bool = False
+    ) -> "OpenAIGPTConfig":
+        """
+        Copy config while preserving nested model instances and subclasses.
+
+        Important: Avoid reconstructing via `model_dump` as that coerces nested
+        models to their annotated base types (dropping subclass-only fields).
+        Instead, defer to Pydantic's native `model_copy`, which keeps nested
+        `BaseModel` instances (and their concrete subclasses) intact.
+
+        An `api_base` supplied through `update` is caller configuration, so the
+        copy must retain that provenance for provider-specific routing.
+        """
+        # Delegate to BaseSettings/BaseModel implementation to preserve types
+        copied = super().model_copy(update=update, deep=deep)
+        if update is not None and "api_base" in update:
+            copied._api_base_was_supplied = True
+        return copied  # type: ignore[return-value]
+
+    def _validate_litellm(self) -> None:
+        """
+        When using liteLLM, validate whether all env vars required by the model
+        have been set.
+        """
+        if not self.litellm:
+            return
+        try:
+            import litellm
+        except ImportError:
+            raise LangroidImportError("litellm", "litellm")
+
+        litellm.telemetry = False
+        litellm.drop_params = True  # drop un-supported params without crashing
+        litellm.modify_params = True
+        self.seed = None  # some local mdls don't support seed
+
+        if self.api_key == DUMMY_API_KEY:
+            keys_dict = litellm.utils.validate_environment(self.chat_model)
+            missing_keys = keys_dict.get("missing_keys", [])
+            if len(missing_keys) > 0:
+                raise ValueError(
+                    f"""
+                    Missing environment variables for litellm-proxied model:
+                    {missing_keys}
+                    """
+                )
+
+    @classmethod
+    def create(cls, prefix: str) -> Type["OpenAIGPTConfig"]:
+        """Create a config class whose params can be set via a desired
+        prefix from the .env file or env vars.
+        E.g., using
+        ```python
+        OllamaConfig = OpenAIGPTConfig.create("ollama")
+        ollama_config = OllamaConfig()
+        ```
+        you can have a group of params prefixed by "OLLAMA_", to be used
+        with models served via `ollama`.
+        This way, you can maintain several setting-groups in your .env file,
+        one per model type.
+        """
+
+        class DynamicConfig(OpenAIGPTConfig):
+            pass
+
+        DynamicConfig.model_config = SettingsConfigDict(env_prefix=prefix.upper() + "_")
+        return DynamicConfig
+
+
+class OpenAIResponse(BaseModel):
+    """OpenAI response model, either completion or chat."""
+
+    choices: List[Dict]  # type: ignore
+    usage: Dict  # type: ignore
+
+
+def litellm_logging_fn(model_call_dict: Dict[str, Any]) -> None:
+    """Logging function for litellm"""
+    try:
+        api_input_dict = model_call_dict.get("additional_args", {}).get(
+            "complete_input_dict"
+        )
+        if api_input_dict is not None:
+            text = escape(json.dumps(api_input_dict, indent=2))
+            print(
+                f"[grey37]LITELLM: {text}[/grey37]",
+            )
+    except Exception:
+        pass
+
+
+# Define a class for OpenAI GPT models that extends the base class
+class OpenAIGPT(LanguageModel):
+    """
+    Class for OpenAI LLMs
+    """
+
+    client: OpenAI | Groq | Cerebras | None
+    async_client: AsyncOpenAI | AsyncGroq | AsyncCerebras | None
+
+    def __init__(self, config: OpenAIGPTConfig = OpenAIGPTConfig()):
+        """
+        Args:
+            config: configuration for openai-gpt model
+        """
+        # copy the config to avoid modifying the original; deep to decouple
+        # nested models while preserving their concrete subclasses
+        # The api_key_provider must NOT be deep-copied: the client cache is
+        # keyed on its identity (so a copy would defeat cache sharing), and it
+        # may hold non-copyable state (e.g. a threading.Lock). Clear it in a
+        # shallow copy first, then restore the original callable afterwards.
+        api_key_provider = config.api_key_provider
+        if api_key_provider is not None:
+            config = config.model_copy(update={"api_key_provider": None})
+        config = config.model_copy(deep=True)
+        if api_key_provider is not None:
+            config.api_key_provider = api_key_provider
+        super().__init__(config)
+        self.config: OpenAIGPTConfig = config
+        # save original model name such as `provider/model` before
+        # we strip out the `provider` - we retain the original in
+        # case some params are specific to a provider.
+        self.chat_model_orig = self.config.chat_model_orig or self.config.chat_model
+
+        # Run the first time the model is used
+        self.run_on_first_use = cache(self.config.run_on_first_use)
+
+        # global override of chat_model,
+        # to allow quick testing with other models
+        if settings.chat_model != "":
+            self.config.chat_model = settings.chat_model
+            self.chat_model_orig = settings.chat_model
+            self.config.completion_model = settings.chat_model
+
+        if len(parts := self.config.chat_model.split("//")) > 1:
+            # there is a formatter specified, e.g.
+            # "litellm/ollama/mistral//hf" or
+            # "local/localhost:8000/v1//mistral-instruct-v0.2"
+            formatter = parts[1]
+            self.config.chat_model = parts[0]
+            if formatter == "hf":
+                # e.g. "litellm/ollama/mistral//hf" -> "litellm/ollama/mistral"
+                formatter = find_hf_formatter(self.config.chat_model)
+                if formatter != "":
+                    # e.g. "mistral"
+                    self.config.formatter = formatter
+                    logging.warning(
+                        f"""
+                        Using completions (not chat) endpoint with HuggingFace
+                        chat_template for {formatter} for
+                        model {self.config.chat_model}
+                        """
+                    )
+            else:
+                # e.g. "local/localhost:8000/v1//mistral-instruct-v0.2"
+                self.config.formatter = formatter
+
+        if self.config.formatter is not None:
+            self.config.hf_formatter = HFFormatter(
+                HFPromptFormatterConfig(model_name=self.config.formatter)
+            )
+
+        self.supports_json_schema: bool = self.config.supports_json_schema or False
+        self.supports_strict_tools: bool = self.config.supports_strict_tools or False
+
+        OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", DUMMY_API_KEY)
+        self.api_key = config.api_key
+
+        # if model name starts with "litellm",
+        # set the actual model name by stripping the "litellm/" prefix
+        # and set the litellm flag to True
+        if self.config.chat_model.startswith("litellm/") or self.config.litellm:
+            # e.g. litellm/ollama/mistral
+            self.config.litellm = True
+            self.api_base = self.config.api_base
+            if self.config.chat_model.startswith("litellm/"):
+                # strip the "litellm/" prefix
+                # e.g. litellm/ollama/llama2 => ollama/llama2
+                self.config.chat_model = self.config.chat_model.split("/", 1)[1]
+        elif self.config.chat_model.startswith("local/"):
+            # expect this to be of the form "local/localhost:8000/v1",
+            # depending on how the model is launched locally.
+            # In this case the model served locally behind an OpenAI-compatible API
+            # so we can just use `openai.*` methods directly,
+            # and don't need a adaptor library like litellm
+            self.config.litellm = False
+            self.config.seed = None  # some models raise an error when seed is set
+            # Extract the api_base from the model name after the "local/" prefix
+            self.api_base = self.config.chat_model.split("/", 1)[1]
+            if not self.api_base.startswith("http"):
+                self.api_base = "http://" + self.api_base
+        elif self.config.chat_model.startswith("ollama/"):
+            self.config.ollama = True
+
+            # use api_base from config if set, else fall back on OLLAMA_BASE_URL
+            self.api_base = self.config.api_base or OLLAMA_BASE_URL
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = OLLAMA_API_KEY
+            self.config.chat_model = self.config.chat_model.replace("ollama/", "")
+        elif self.config.chat_model.startswith("vllm/"):
+            self.supports_json_schema = True
+            self.config.chat_model = self.config.chat_model.replace("vllm/", "")
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
+            self.api_base = self.config.api_base or "http://localhost:8000/v1"
+            if not self.api_base.startswith("http"):
+                self.api_base = "http://" + self.api_base
+            if not self.api_base.endswith("/v1"):
+                self.api_base = self.api_base + "/v1"
+        elif self.config.chat_model.startswith("llamacpp/"):
+            self.supports_json_schema = True
+            self.api_base = self.config.chat_model.split("/", 1)[1]
+            if not self.api_base.startswith("http"):
+                self.api_base = "http://" + self.api_base
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
+        else:
+            self.api_base = self.config.api_base
+            # If api_base is unset we use OpenAI's endpoint, which supports
+            # these features (with JSON schema restricted to a limited set of models)
+            self.supports_strict_tools = self.api_base is None
+            self.supports_json_schema = (
+                self.api_base is None and self.info().has_structured_output
+            )
+
+        if settings.chat_model != "":
+            # if we're overriding chat model globally, set completion model to same
+            self.config.completion_model = self.config.chat_model
+
+        if self.config.formatter is not None:
+            # we want to format chats -> completions using this specific formatter
+            self.config.use_completion_for_chat = True
+            self.config.completion_model = self.config.chat_model
+
+        if self.config.use_completion_for_chat:
+            self.config.use_chat_for_completion = False
+
+        self.is_groq = self.config.chat_model.startswith("groq/")
+        self.is_cerebras = self.config.chat_model.startswith("cerebras/")
+        self.is_gemini = self.is_gemini_model()
+        self.is_deepseek = self.is_deepseek_model()
+        self.is_minimax = self.is_minimax_model()
+        self.is_glhf = self.config.chat_model.startswith("glhf/")
+        self.is_openrouter = self.config.chat_model.startswith("openrouter/")
+        self.is_langdb = self.config.chat_model.startswith("langdb/")
+        self.is_portkey = self.config.chat_model.startswith("portkey/")
+        self.is_litellm_proxy = self.config.chat_model.startswith("litellm-proxy/")
+
+        if self.config.api_key_provider is not None and (
+            self.is_groq or self.is_cerebras or self.config.litellm
+        ):
+            raise ValueError(
+                "api_key_provider is only supported for models served via an "
+                "OpenAI-compatible endpoint (using the OpenAI client); it "
+                "cannot be used with Groq, Cerebras, or the litellm adapter."
+            )
+
+        if self.is_groq:
+            # use groq-specific client
+            self.config.chat_model = self.config.chat_model.replace("groq/", "")
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = os.getenv("GROQ_API_KEY", DUMMY_API_KEY)
+            if self.config.use_cached_client:
+                self.client = get_groq_client(api_key=self.api_key)
+                self.async_client = get_async_groq_client(api_key=self.api_key)
+            else:
+                # Create new clients without caching
+                self.client = Groq(api_key=self.api_key)
+                self.async_client = AsyncGroq(api_key=self.api_key)
+        elif self.is_cerebras:
+            # use cerebras-specific client
+            self.config.chat_model = self.config.chat_model.replace("cerebras/", "")
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = os.getenv("CEREBRAS_API_KEY", DUMMY_API_KEY)
+            if self.config.use_cached_client:
+                self.client = get_cerebras_client(api_key=self.api_key)
+                # TODO there is not async client, so should we do anything here?
+                self.async_client = get_async_cerebras_client(api_key=self.api_key)
+            else:
+                # Create new clients without caching
+                self.client = Cerebras(api_key=self.api_key)
+                self.async_client = AsyncCerebras(api_key=self.api_key)
+        else:
+            # in these cases, there's no specific client: OpenAI python client suffices
+            if self.is_litellm_proxy:
+                self.config.chat_model = self.config.chat_model.replace(
+                    "litellm-proxy/", ""
+                )
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = self.config.litellm_proxy.api_key or self.api_key
+                self.api_base = self.config.litellm_proxy.api_base or self.api_base
+            elif self.is_gemini:
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("GEMINI_API_KEY", DUMMY_API_KEY)
+                # Prefer caller config, then Gemini env, then the default.
+                gemini_api_base = os.getenv("GEMINI_API_BASE", "")
+                explicit_api_base = (
+                    self.config.api_base if self.config._api_base_was_supplied else None
+                )
+                self.api_base = explicit_api_base or gemini_api_base or GEMINI_BASE_URL
+                if (
+                    self.config.chat_model.startswith("gemini/")
+                    or self.api_base == GEMINI_BASE_URL
+                ):
+                    self.config.chat_model = self.config.chat_model.split("/", 1)[1]
+            elif self.is_glhf:
+                self.config.chat_model = self.config.chat_model.replace("glhf/", "")
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("GLHF_API_KEY", DUMMY_API_KEY)
+                self.api_base = GLHF_BASE_URL
+            elif self.is_openrouter:
+                self.config.chat_model = self.config.chat_model.replace(
+                    "openrouter/", ""
+                )
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("OPENROUTER_API_KEY", DUMMY_API_KEY)
+                self.api_base = OPENROUTER_BASE_URL
+            elif self.is_deepseek:
+                self.config.chat_model = self.config.chat_model.replace("deepseek/", "")
+                self.api_base = DEEPSEEK_BASE_URL
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("DEEPSEEK_API_KEY", DUMMY_API_KEY)
+            elif self.is_minimax:
+                self.config.chat_model = self.config.chat_model.replace("minimax/", "")
+                # Honor caller-supplied base URL (e.g. regional endpoints,
+                # proxies) instead of always forcing the default.
+                openai_api_base = os.getenv("OPENAI_API_BASE")
+                explicit_api_base = (
+                    self.config.api_base
+                    if self.config.api_base and self.config.api_base != openai_api_base
+                    else None
+                )
+                self.api_base = explicit_api_base or MINIMAX_BASE_URL
+                if self.api_key == OPENAI_API_KEY:
+                    # Only overwrite with MINIMAX_API_KEY when it is actually
+                    # set, so users who intentionally put their MiniMax key in
+                    # OPENAI_API_KEY are not silently downgraded to a dummy key.
+                    minimax_key = os.getenv("MINIMAX_API_KEY", "")
+                    if minimax_key:
+                        self.api_key = minimax_key
+                # Recompute capabilities now that the prefix has been stripped
+                # and self.info() can find the model in MODEL_INFO.
+                self.supports_strict_tools = True
+                self.supports_json_schema = self.info().has_structured_output
+            elif self.is_langdb:
+                self.config.chat_model = self.config.chat_model.replace("langdb/", "")
+                self.api_base = self.config.langdb_params.base_url
+                project_id = self.config.langdb_params.project_id
+                if project_id:
+                    self.api_base += "/" + project_id + "/v1"
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = self.config.langdb_params.api_key or DUMMY_API_KEY
+
+                if self.config.langdb_params:
+                    params = self.config.langdb_params
+                    if params.project_id:
+                        self.config.headers["x-project-id"] = params.project_id
+                    if params.label:
+                        self.config.headers["x-label"] = params.label
+                    if params.run_id:
+                        self.config.headers["x-run-id"] = params.run_id
+                    if params.thread_id:
+                        self.config.headers["x-thread-id"] = params.thread_id
+            elif self.is_portkey:
+                # Parse the model string and extract provider/model
+                provider, model = self.config.portkey_params.parse_model_string(
+                    self.config.chat_model
+                )
+                self.config.chat_model = model
+                if provider:
+                    self.config.portkey_params.provider = provider
+
+                # Set Portkey base URL
+                self.api_base = self.config.portkey_params.base_url + "/v1"
+
+                # Set API key - use provider's API key from env if available
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = self.config.portkey_params.get_provider_api_key(
+                        self.config.portkey_params.provider, DUMMY_API_KEY
+                    )
+
+                # Add Portkey-specific headers
+                self.config.headers.update(self.config.portkey_params.get_headers())
+
+            # Sanitize the API key: strip leading/trailing whitespace
+            # (including stray newlines from .env files or CI secrets).
+            self.api_key = self.api_key.strip()
+
+            # Create http_client if needed - Priority order:
+            # 1. http_client_factory (most flexibility, not cacheable)
+            # 2. http_client_config (cacheable, moderate flexibility)
+            # 3. http_verify_ssl=False (cacheable, simple SSL bypass)
+            http_client = None
+            async_http_client = None
+            http_client_config_used = None
+
+            if self.config.http_client_factory is not None:
+                # Use the factory to create http_client (not cacheable)
+                http_client = self.config.http_client_factory()
+                if isinstance(http_client, (list, tuple)):
+                    if len(http_client) != 2:
+                        raise ValueError(
+                            "http_client_factory must return either a single "
+                            "httpx.Client or a tuple of "
+                            "(httpx.Client, httpx.AsyncClient)"
+                        )
+                    http_client, async_http_client = http_client
+                else:
+                    # set async_http_client to None - so that it will
+                    # be created later
+                    async_http_client = None
+            elif self.config.http_client_config is not None:
+                # Use config dict (cacheable)
+                http_client_config_used = self.config.http_client_config
+            elif not self.config.http_verify_ssl:
+                # Simple SSL bypass (cacheable)
+                http_client_config_used = {"verify": False}
+                logging.warning(
+                    "SSL verification has been disabled. This is insecure and "
+                    "should only be used in trusted environments (e.g., "
+                    "corporate networks with self-signed certificates)."
+                )
+
+            # With an api_key_provider, hand the callable itself to the
+            # OpenAI client, which resolves a fresh token on each request.
+            openai_api_key: Union[str, Callable[[], str]] = (
+                self.config.api_key_provider
+                if self.config.api_key_provider is not None
+                else self.api_key
+            )
+
+            if self.config.use_cached_client:
+                self.client = get_openai_client(
+                    api_key=openai_api_key,
+                    base_url=self.api_base,
+                    organization=self.config.organization,
+                    timeout=Timeout(self.config.timeout),
+                    default_headers=self.config.headers,
+                    http_client=http_client,
+                    http_client_config=http_client_config_used,
+                )
+                self.async_client = get_async_openai_client(
+                    api_key=openai_api_key,
+                    base_url=self.api_base,
+                    organization=self.config.organization,
+                    timeout=Timeout(self.config.timeout),
+                    default_headers=self.config.headers,
+                    http_client=async_http_client,
+                    http_client_config=http_client_config_used,
+                )
+            else:
+                # Create new clients without caching
+                client_kwargs: Dict[str, Any] = dict(
+                    api_key=openai_api_key,
+                    base_url=self.api_base,
+                    organization=self.config.organization,
+                    timeout=Timeout(self.config.timeout),
+                    default_headers=self.config.headers,
+                )
+                if http_client is not None:
+                    client_kwargs["http_client"] = http_client
+                elif http_client_config_used is not None:
+                    # Create http_client from config for non-cached scenario
+                    try:
+                        from httpx import Client
+
+                        client_kwargs["http_client"] = Client(**http_client_config_used)
+                    except ImportError:
+                        raise ValueError(
+                            "httpx is required to use http_client_config. "
+                            "Install it with: pip install httpx"
+                        )
+                self.client = OpenAI(**client_kwargs)
+
+                async_client_kwargs: Dict[str, Any] = dict(
+                    api_key=(
+                        # AsyncOpenAI awaits its api_key callable
+                        wrap_api_key_provider_async(openai_api_key)
+                        if callable(openai_api_key)
+                        else openai_api_key
+                    ),
+                    base_url=self.api_base,
+                    organization=self.config.organization,
+                    timeout=Timeout(self.config.timeout),
+                    default_headers=self.config.headers,
+                )
+                if async_http_client is not None:
+                    async_client_kwargs["http_client"] = async_http_client
+                elif http_client_config_used is not None:
+                    # Create async http_client from config for non-cached scenario
+                    try:
+                        from httpx import AsyncClient
+
+                        async_client_kwargs["http_client"] = AsyncClient(
+                            **http_client_config_used
+                        )
+                    except ImportError:
+                        raise ValueError(
+                            "httpx is required to use http_client_config. "
+                            "Install it with: pip install httpx"
+                        )
+                self.async_client = AsyncOpenAI(**async_client_kwargs)
+
+        self.cache: CacheDB | None = None
+        use_cache = self.config.cache_config is not None
+        if "redis" in settings.cache_type and use_cache:
+            if config.cache_config is None or not isinstance(
+                config.cache_config,
+                RedisCacheConfig,
+            ):
+                # switch to fresh redis config if needed
+                config.cache_config = RedisCacheConfig(
+                    fake="fake" in settings.cache_type
+                )
+            if "fake" in settings.cache_type:
+                # force use of fake redis if global cache_type is "fakeredis"
+                config.cache_config.fake = True
+            self.cache = RedisCache(config.cache_config)
+        elif settings.cache_type != "none" and use_cache:
+            raise ValueError(
+                f"Invalid cache type {settings.cache_type}. "
+                "Valid types are redis, fakeredis, none"
+            )
+
+        self.config._validate_litellm()
+
+    def _openai_api_call_params(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Prep the params to be sent to the OpenAI API
+        (or any OpenAI-compatible API, e.g. from Ooba or LmStudio)
+        for chat-completion.
+
+        Order of priority:
+        - (1) Params (mainly max_tokens) in the chat/achat/generate/agenerate call
+                (these are passed in via kwargs)
+        - (2) Params in OpenAIGPTConfig.params (of class OpenAICallParams)
+        - (3) Specific Params in OpenAIGPTConfig (just temperature for now)
+        """
+        params = dict(
+            temperature=self.config.temperature,
+        )
+        if self.config.params is not None:
+            params.update(self.config.params.to_dict_exclude_none())
+        params.update(kwargs)
+        return params
+
+    def is_openai_chat_model(self) -> bool:
+        openai_chat_models = [e.value for e in OpenAIChatModel]
+        return self.config.chat_model in openai_chat_models
+
+    def is_openai_completion_model(self) -> bool:
+        openai_completion_models = [e.value for e in OpenAICompletionModel]
+        return self.config.completion_model in openai_completion_models
+
+    def is_gemini_model(self) -> bool:
+        """Are we using the gemini OpenAI-compatible API?"""
+        return self.chat_model_orig.startswith(GEMINI_MODEL_PREFIXES)
+
+    def is_deepseek_model(self) -> bool:
+        deepseek_models = [e.value for e in DeepSeekModel]
+        return (
+            self.chat_model_orig in deepseek_models
+            or self.chat_model_orig.startswith("deepseek/")
+        )
+
+    def is_minimax_model(self) -> bool:
+        """Are we using the MiniMax OpenAI-compatible API?"""
+        minimax_models = [e.value for e in MiniMaxModel]
+        return (
+            self.chat_model_orig in minimax_models
+            or self.chat_model_orig.startswith("minimax/")
+        )
+
+    def unsupported_params(self) -> List[str]:
+        """
+        List of params that are not supported by the current model
+        """
+        unsupported = set(self.info().unsupported_params)
+        return list(unsupported)
+
+    def rename_params(self) -> Dict[str, str]:
+        """
+        Map of param name -> new name for specific models.
+        Currently main troublemaker is o1* series.
+        """
+        return self.info().rename_params
+
+    def chat_context_length(self) -> int:
+        """
+        Context-length for chat-completion models/endpoints.
+        Get it from the config if explicitly given,
+         otherwise use model_info based on model name, and fall back to
+         generic model_info if there's no match.
+        """
+        return self.config.chat_context_length or self.info().context_length
+
+    def completion_context_length(self) -> int:
+        """
+        Context-length for completion models/endpoints.
+        Get it from the config if explicitly given,
+         otherwise use model_info based on model name, and fall back to
+         generic model_info if there's no match.
+        """
+        return (
+            self.config.completion_context_length
+            or self.completion_info().context_length
+        )
+
+    def chat_cost(self) -> Tuple[float, float, float]:
+        """
+        (Prompt, Cached, Generation) cost per 1000 tokens, for chat-completion
+        models/endpoints.
+        Get it from the dict, otherwise fail-over to general method
+        """
+        info = self.info()
+        cached_cost_per_million = info.cached_cost_per_million
+        if not cached_cost_per_million:
+            cached_cost_per_million = info.input_cost_per_million
+        return (
+            info.input_cost_per_million / 1000,
+            cached_cost_per_million / 1000,
+            info.output_cost_per_million / 1000,
+        )
+
+    def set_stream(self, stream: bool) -> bool:
+        """Enable or disable streaming output from API.
+        Args:
+            stream: enable streaming output from API
+        Returns: previous value of stream
+        """
+        tmp = self.config.stream
+        self.config.stream = stream
+        return tmp
+
+    def get_stream(self) -> bool:
+        """Get streaming status."""
+        return self.config.stream and settings.stream and self.info().allows_streaming
+
+    @staticmethod
+    def _split_inline_reasoning(
+        event_text: str,
+        event_reasoning: str,
+        in_reasoning: bool,
+        thought_delimiters: Tuple[str, str],
+    ) -> Tuple[str, str, bool]:
+        """Separate inline reasoning from text tokens in a streaming chunk.
+
+        When models embed thinking inside content (e.g. <think>...</think>)
+        rather than using a separate reasoning field, this splits the chunk
+        into text-only and reasoning-only portions for proper streamer routing.
+
+        Returns (text_tokens, reasoning_tokens, in_reasoning).
+        """
+        text_tokens = event_text
+        reasoning_tokens = event_reasoning
+
+        if not event_text or event_reasoning:
+            return text_tokens, reasoning_tokens, in_reasoning
+
+        start, end = thought_delimiters
+        remaining = event_text
+
+        if in_reasoning:
+            text_tokens = ""
+        elif start in event_text:
+            before, _, after = event_text.partition(start)
+            text_tokens = before
+            remaining = after
+            in_reasoning = True
+
+        if in_reasoning:
+            if end in remaining:
+                before, _, after = remaining.partition(end)
+                text_tokens += after
+                reasoning_tokens = before
+                in_reasoning = False
+            else:
+                reasoning_tokens = remaining
+
+        return text_tokens, reasoning_tokens, in_reasoning
+
+    @no_type_check
+    def _process_stream_event(
+        self,
+        event,
+        chat: bool = False,
+        tool_deltas: List[Dict[str, Any]] = [],
+        has_function: bool = False,
+        completion: str = "",
+        reasoning: str = "",
+        function_args: str = "",
+        function_name: str = "",
+        in_reasoning: bool = False,
+    ) -> Tuple[bool, bool, str, str, bool, Dict[str, int]]:
+        """Process state vars while processing a streaming API response.
+            Returns a tuple consisting of:
+        - is_break: whether to break out of the loop
+        - has_function: whether the response contains a function_call
+        - function_name: name of the function
+        - function_args: args of the function
+        - completion: completion text
+        - reasoning: reasoning text
+        - usage: usage dict
+        """
+        # convert event obj (of type ChatCompletionChunk) to dict so rest of code,
+        # which expects dicts, works as it did before switching to openai v1.x
+        if not isinstance(event, dict):
+            event = event.model_dump()
+
+        usage = event.get("usage", {}) or {}
+        choices = event.get("choices", [{}])
+        if choices is None or len(choices) == 0:
+            choices = [{}]
+        if len(usage) > 0 and len(choices[0]) == 0:
+            # we have a "usage" chunk, and empty choices, so we're done
+            # ASSUMPTION: a usage chunk ONLY arrives AFTER all normal completion text!
+            # If any API does not follow this, we need to change this code.
+            return (
+                True,
+                has_function,
+                function_name,
+                function_args,
+                completion,
+                reasoning,
+                in_reasoning,
+                usage,
+            )
+        event_args = ""
+        event_fn_name = ""
+        event_tool_deltas: Optional[List[Dict[str, Any]]] = None
+        silent = settings.quiet
+        # The first two events in the stream of Azure OpenAI is useless.
+        # In the 1st: choices list is empty, in the 2nd: the dict delta has null content
+        if chat:
+            delta = choices[0].get("delta", {}) or {}
+            # capture both content and reasoning_content
+            event_text = delta.get("content", "")
+            event_reasoning = delta.get(
+                "reasoning_content",
+                delta.get("reasoning", ""),
+            )
+            if "function_call" in delta and delta["function_call"] is not None:
+                if "name" in delta["function_call"]:
+                    event_fn_name = delta["function_call"]["name"]
+                if "arguments" in delta["function_call"]:
+                    event_args = delta["function_call"]["arguments"]
+            if "tool_calls" in delta and delta["tool_calls"] is not None:
+                # it's a list of deltas, usually just one
+                event_tool_deltas = delta["tool_calls"]
+                tool_deltas += event_tool_deltas
+        else:
+            event_text = choices[0]["text"]
+            event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
+
+        finish_reason = choices[0].get("finish_reason", "")
+        if not event_text and finish_reason == "content_filter":
+            filter_names = [
+                n
+                for n, r in choices[0].get("content_filter_results", {}).items()
+                if r.get("filtered")
+            ]
+            event_text = (
+                "Cannot respond due to content filters ["
+                + ", ".join(filter_names)
+                + "]"
+            )
+            logging.warning("LLM API returned content filter error: " + event_text)
+
+        event_text_tokens, event_reasoning_tokens, in_reasoning = (
+            self._split_inline_reasoning(
+                event_text,
+                event_reasoning,
+                in_reasoning,
+                self.config.thought_delimiters,
+            )
+        )
+
+        if event_text:
+            completion += event_text
+        if event_text_tokens:
+            if not silent:
+                sys.stdout.write(Colors().GREEN + event_text_tokens)
+                sys.stdout.flush()
+            self.config.streamer(event_text_tokens, StreamEventType.TEXT)
+
+        if event_reasoning:
+            reasoning += event_reasoning
+        if event_reasoning_tokens:
+            if not silent:
+                sys.stdout.write(Colors().GREEN_DIM + event_reasoning_tokens)
+                sys.stdout.flush()
+            self.config.streamer(event_reasoning_tokens, StreamEventType.REASONING)
+
+        if event_fn_name:
+            function_name = event_fn_name
+            has_function = True
+            if not silent:
+                sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
+                sys.stdout.flush()
+            self.config.streamer(event_fn_name, StreamEventType.FUNC_NAME)
+
+        if event_args:
+            function_args += event_args
+            if not silent:
+                sys.stdout.write(Colors().GREEN + event_args)
+                sys.stdout.flush()
+            self.config.streamer(event_args, StreamEventType.FUNC_ARGS)
+
+        if event_tool_deltas is not None:
+            # print out streaming tool calls, if not async
+            for td in event_tool_deltas:
+                if td["function"]["name"] is not None:
+                    tool_fn_name = td["function"]["name"]
+                    if not silent:
+                        sys.stdout.write(
+                            Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
+                        )
+                        sys.stdout.flush()
+                    self.config.streamer(tool_fn_name, StreamEventType.TOOL_NAME)
+                if td["function"]["arguments"] != "":
+                    tool_fn_args = td["function"]["arguments"]
+                    if not silent:
+                        sys.stdout.write(Colors().GREEN + tool_fn_args)
+                        sys.stdout.flush()
+                    self.config.streamer(tool_fn_args, StreamEventType.TOOL_ARGS)
+
+        # show this delta in the stream
+        is_break = finish_reason in [
+            "stop",
+            "function_call",
+            "tool_calls",
+        ]
+        # for function_call, finish_reason does not necessarily
+        # contain "function_call" as mentioned in the docs.
+        # So we check for "stop" or "function_call" here.
+        return (
+            is_break,
+            has_function,
+            function_name,
+            function_args,
+            completion,
+            reasoning,
+            in_reasoning,
+            usage,
+        )
+
+    @no_type_check
+    async def _process_stream_event_async(
+        self,
+        event,
+        chat: bool = False,
+        tool_deltas: List[Dict[str, Any]] = [],
+        has_function: bool = False,
+        completion: str = "",
+        reasoning: str = "",
+        function_args: str = "",
+        function_name: str = "",
+        in_reasoning: bool = False,
+    ) -> Tuple[bool, bool, str, str, bool, Dict[str, int]]:
+        """Process state vars while processing a streaming API response.
+            Returns a tuple consisting of:
+        - is_break: whether to break out of the loop
+        - has_function: whether the response contains a function_call
+        - function_name: name of the function
+        - function_args: args of the function
+        - completion: completion text
+        - reasoning: reasoning text
+        - usage: usage dict
+        """
+        # convert event obj (of type ChatCompletionChunk) to dict so rest of code,
+        # which expects dicts, works as it did before switching to openai v1.x
+        if not isinstance(event, dict):
+            event = event.model_dump()
+
+        usage = event.get("usage", {}) or {}
+        choices = event.get("choices", [{}])
+        if len(choices) == 0:
+            choices = [{}]
+        if len(usage) > 0 and len(choices[0]) == 0:
+            # we got usage chunk, and empty choices, so we're done
+            return (
+                True,
+                has_function,
+                function_name,
+                function_args,
+                completion,
+                reasoning,
+                in_reasoning,
+                usage,
+            )
+        event_args = ""
+        event_fn_name = ""
+        event_tool_deltas: Optional[List[Dict[str, Any]]] = None
+        silent = self.config.async_stream_quiet or settings.quiet
+        # The first two events in the stream of Azure OpenAI is useless.
+        # In the 1st: choices list is empty, in the 2nd: the dict delta has null content
+        if chat:
+            delta = choices[0].get("delta", {}) or {}
+            event_text = delta.get("content", "")
+            event_reasoning = delta.get(
+                "reasoning_content",
+                delta.get("reasoning", ""),
+            )
+            if "function_call" in delta and delta["function_call"] is not None:
+                if "name" in delta["function_call"]:
+                    event_fn_name = delta["function_call"]["name"]
+                if "arguments" in delta["function_call"]:
+                    event_args = delta["function_call"]["arguments"]
+            if "tool_calls" in delta and delta["tool_calls"] is not None:
+                # it's a list of deltas, usually just one
+                event_tool_deltas = delta["tool_calls"]
+                tool_deltas += event_tool_deltas
+        else:
+            event_text = choices[0]["text"]
+            event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
+
+        event_text_tokens, event_reasoning_tokens, in_reasoning = (
+            self._split_inline_reasoning(
+                event_text,
+                event_reasoning,
+                in_reasoning,
+                self.config.thought_delimiters,
+            )
+        )
+
+        if event_text:
+            completion += event_text
+        if event_text_tokens:
+            if not silent:
+                sys.stdout.write(Colors().GREEN + event_text_tokens)
+                sys.stdout.flush()
+            await self.config.streamer_async(event_text_tokens, StreamEventType.TEXT)
+
+        if event_reasoning:
+            reasoning += event_reasoning
+        if event_reasoning_tokens:
+            if not silent:
+                sys.stdout.write(Colors().GREEN_DIM + event_reasoning_tokens)
+                sys.stdout.flush()
+            await self.config.streamer_async(
+                event_reasoning_tokens, StreamEventType.REASONING
+            )
+
+        if event_fn_name:
+            function_name = event_fn_name
+            has_function = True
+            if not silent:
+                sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
+                sys.stdout.flush()
+            await self.config.streamer_async(event_fn_name, StreamEventType.FUNC_NAME)
+
+        if event_args:
+            function_args += event_args
+            if not silent:
+                sys.stdout.write(Colors().GREEN + event_args)
+                sys.stdout.flush()
+            await self.config.streamer_async(event_args, StreamEventType.FUNC_ARGS)
+
+        if event_tool_deltas is not None:
+            # print out streaming tool calls, if not async
+            for td in event_tool_deltas:
+                if td["function"]["name"] is not None:
+                    tool_fn_name = td["function"]["name"]
+                    if not silent:
+                        sys.stdout.write(
+                            Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
+                        )
+                        sys.stdout.flush()
+                    await self.config.streamer_async(
+                        tool_fn_name, StreamEventType.TOOL_NAME
+                    )
+                if td["function"]["arguments"] != "":
+                    tool_fn_args = td["function"]["arguments"]
+                    if not silent:
+                        sys.stdout.write(Colors().GREEN + tool_fn_args)
+                        sys.stdout.flush()
+                    await self.config.streamer_async(
+                        tool_fn_args, StreamEventType.TOOL_ARGS
+                    )
+
+        # show this delta in the stream
+        is_break = choices[0].get("finish_reason", "") in [
+            "stop",
+            "function_call",
+            "tool_calls",
+        ]
+        # for function_call, finish_reason does not necessarily
+        # contain "function_call" as mentioned in the docs.
+        # So we check for "stop" or "function_call" here.
+        return (
+            is_break,
+            has_function,
+            function_name,
+            function_args,
+            completion,
+            reasoning,
+            in_reasoning,
+            usage,
+        )
+
+    @retry_with_exponential_backoff
+    def _stream_response(  # type: ignore
+        self, response, chat: bool = False
+    ) -> Tuple[LLMResponse, Dict[str, Any]]:
+        """
+        Grab and print streaming response from API.
+        Args:
+            response: event-sequence emitted by API
+            chat: whether in chat-mode (or else completion-mode)
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                Dict version of OpenAIResponse object (with choices, usage)
+
+        """
+        completion = ""
+        reasoning = ""
+        function_args = ""
+        function_name = ""
+
+        sys.stdout.write(Colors().GREEN)
+        sys.stdout.flush()
+        has_function = False
+        tool_deltas: List[Dict[str, Any]] = []
+        token_usage: Dict[str, int] = {}
+        done: bool = False
+        in_reasoning: bool = False  # Track if we're inside reasoning delimiters
+        content_present = False
+        try:
+            for event in response:
+                event_dict = event if isinstance(event, dict) else event.model_dump()
+                choices = event_dict.get("choices") or []
+                if chat and choices:
+                    delta = choices[0].get("delta") or {}
+                    content_present = content_present or (
+                        "content" in delta and delta["content"] is not None
+                    )
+                (
+                    is_break,
+                    has_function,
+                    function_name,
+                    function_args,
+                    completion,
+                    reasoning,
+                    in_reasoning,
+                    usage,
+                ) = self._process_stream_event(
+                    event,
+                    chat=chat,
+                    tool_deltas=tool_deltas,
+                    has_function=has_function,
+                    completion=completion,
+                    reasoning=reasoning,
+                    function_args=function_args,
+                    function_name=function_name,
+                    in_reasoning=in_reasoning,
+                )
+                if len(usage) > 0:
+                    # capture the token usage when non-empty
+                    token_usage = usage
+                if is_break:
+                    if not self.get_stream() or done:
+                        # if not streaming, then we don't wait for last "usage" chunk
+                        break
+                    else:
+                        # mark done, so we quit after the last "usage" chunk
+                        done = True
+
+        except Exception as e:
+            logging.warning("Error while processing stream response: %s", str(e))
+
+        if not settings.quiet:
+            print("")
+        # TODO- get usage info in stream mode (?)
+
+        return self._create_stream_response(
+            chat=chat,
+            tool_deltas=tool_deltas,
+            has_function=has_function,
+            completion=completion,
+            reasoning=reasoning,
+            function_args=function_args,
+            function_name=function_name,
+            usage=token_usage,
+            content_present=content_present,
+        )
+
+    @async_retry_with_exponential_backoff
+    async def _stream_response_async(  # type: ignore
+        self, response, chat: bool = False
+    ) -> Tuple[LLMResponse, Dict[str, Any]]:
+        """
+        Grab and print streaming response from API.
+        Args:
+            response: event-sequence emitted by API
+            chat: whether in chat-mode (or else completion-mode)
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                OpenAIResponse object (with choices, usage)
+
+        """
+
+        completion = ""
+        reasoning = ""
+        function_args = ""
+        function_name = ""
+
+        sys.stdout.write(Colors().GREEN)
+        sys.stdout.flush()
+        has_function = False
+        tool_deltas: List[Dict[str, Any]] = []
+        token_usage: Dict[str, int] = {}
+        done: bool = False
+        in_reasoning: bool = False  # Track if we're inside reasoning delimiters
+        content_present = False
+        try:
+            async for event in response:
+                event_dict = event if isinstance(event, dict) else event.model_dump()
+                choices = event_dict.get("choices") or []
+                if chat and choices:
+                    delta = choices[0].get("delta") or {}
+                    content_present = content_present or (
+                        "content" in delta and delta["content"] is not None
+                    )
+                (
+                    is_break,
+                    has_function,
+                    function_name,
+                    function_args,
+                    completion,
+                    reasoning,
+                    in_reasoning,
+                    usage,
+                ) = await self._process_stream_event_async(
+                    event,
+                    chat=chat,
+                    tool_deltas=tool_deltas,
+                    has_function=has_function,
+                    completion=completion,
+                    reasoning=reasoning,
+                    function_args=function_args,
+                    function_name=function_name,
+                    in_reasoning=in_reasoning,
+                )
+                if len(usage) > 0:
+                    # capture the token usage when non-empty
+                    token_usage = usage
+                if is_break:
+                    if not self.get_stream() or done:
+                        # if not streaming, then we don't wait for last "usage" chunk
+                        break
+                    else:
+                        # mark done, so we quit after the next "usage" chunk
+                        done = True
+
+        except Exception as e:
+            logging.warning("Error while processing stream response: %s", str(e))
+
+        if not settings.quiet:
+            print("")
+        # TODO- get usage info in stream mode (?)
+
+        return self._create_stream_response(
+            chat=chat,
+            tool_deltas=tool_deltas,
+            has_function=has_function,
+            completion=completion,
+            reasoning=reasoning,
+            function_args=function_args,
+            function_name=function_name,
+            usage=token_usage,
+            content_present=content_present,
+        )
+
+    @staticmethod
+    def tool_deltas_to_tools(
+        tools: List[Dict[str, Any]],
+    ) -> Tuple[
+        str,
+        List[OpenAIToolCall],
+        List[Dict[str, Any]],
+    ]:
+        """
+        Convert accumulated tool-call deltas to OpenAIToolCall objects.
+        Adapted from this excellent code:
+         https://community.openai.com/t/help-for-function-calls-with-streaming/627170/2
+
+        Args:
+            tools: list of tool deltas received from streaming API
+
+        Returns:
+            str: plain text corresponding to tool calls that failed to parse
+            List[OpenAIToolCall]: list of OpenAIToolCall objects
+            List[Dict[str, Any]]: list of tool dicts
+                (to reconstruct OpenAI API response, so it can be cached)
+        """
+        # Initialize a dictionary with default values
+
+        # idx -> dict repr of tool
+        # (used to simulate OpenAIResponse object later, and also to
+        # accumulate function args as strings)
+        idx2tool_dict: Dict[str, Dict[str, Any]] = defaultdict(
+            lambda: {
+                "id": None,
+                "function": {"arguments": "", "name": None},
+                "type": None,
+                "extra_content": None,
+            }
+        )
+
+        for tool_delta in tools:
+            if tool_delta["id"] is not None:
+                idx2tool_dict[tool_delta["index"]]["id"] = tool_delta["id"]
+
+            if tool_delta["function"]["name"] is not None:
+                idx2tool_dict[tool_delta["index"]]["function"]["name"] = tool_delta[
+                    "function"
+                ]["name"]
+
+            idx2tool_dict[tool_delta["index"]]["function"]["arguments"] += tool_delta[
+                "function"
+            ]["arguments"]
+
+            if tool_delta["type"] is not None:
+                idx2tool_dict[tool_delta["index"]]["type"] = tool_delta["type"]
+
+            if tool_delta.get("extra_content") is not None:
+                idx2tool_dict[tool_delta["index"]]["extra_content"] = tool_delta[
+                    "extra_content"
+                ]
+
+        # (try to) parse the fn args of each tool
+        contents: List[str] = []
+        good_indices = []
+        id2args: Dict[str, None | Dict[str, Any]] = {}
+        for idx, tool_dict in idx2tool_dict.items():
+            failed_content, args_dict = OpenAIGPT._parse_function_args(
+                tool_dict["function"]["arguments"]
+            )
+            # used to build tool_calls_list below
+            id2args[tool_dict["id"]] = args_dict or None  # if {}, store as None
+            if failed_content != "":
+                contents.append(failed_content)
+            else:
+                good_indices.append(idx)
+
+        # remove the failed tool calls
+        idx2tool_dict = {
+            idx: tool_dict
+            for idx, tool_dict in idx2tool_dict.items()
+            if idx in good_indices
+        }
+
+        # create OpenAIToolCall list
+        tool_calls_list = [
+            OpenAIToolCall(
+                id=tool_dict["id"],
+                function=LLMFunctionCall(
+                    name=tool_dict["function"]["name"],
+                    arguments=id2args.get(tool_dict["id"]),
+                ),
+                type=tool_dict["type"],
+                extra_content=tool_dict.get("extra_content"),
+            )
+            for tool_dict in idx2tool_dict.values()
+        ]
+        return "\n".join(contents), tool_calls_list, list(idx2tool_dict.values())
+
+    @staticmethod
+    def _parse_function_args(args: str) -> Tuple[str, Dict[str, Any]]:
+        """
+        Try to parse the `args` string as function args.
+
+        Args:
+            args: string containing function args
+
+        Returns:
+            Tuple of content, function name and args dict.
+            If parsing unsuccessful, returns the original string as content,
+            else returns the args dict.
+        """
+        content = ""
+        args_dict = {}
+        try:
+            stripped_fn_args = args.strip()
+            dict_or_list = parse_imperfect_json(stripped_fn_args)
+            if not isinstance(dict_or_list, dict):
+                raise ValueError(
+                    f"""
+                        Invalid function args: {stripped_fn_args}
+                        parsed as {dict_or_list},
+                        which is not a valid dict.
+                        """
+                )
+            args_dict = dict_or_list
+        except (SyntaxError, ValueError) as e:
+            logging.warning(
+                f"""
+                    Parsing OpenAI function args failed: {args};
+                    treating args as normal message. Error detail:
+                    {e}
+                    """
+            )
+            content = args
+
+        return content, args_dict
+
+    def _create_stream_response(
+        self,
+        chat: bool = False,
+        tool_deltas: List[Dict[str, Any]] = [],
+        has_function: bool = False,
+        completion: str = "",
+        reasoning: str = "",
+        function_args: str = "",
+        function_name: str = "",
+        usage: Dict[str, int] = {},
+        content_present: bool = False,
+    ) -> Tuple[LLMResponse, Dict[str, Any]]:
+        """
+        Create an LLMResponse object from the streaming API response.
+
+        Args:
+            chat: whether in chat-mode (or else completion-mode)
+            tool_deltas: list of tool deltas received from streaming API
+            has_function: whether the response contains a function_call
+            completion: completion text
+            reasoning: reasoning text
+            function_args: string representing function args
+            function_name: name of the function
+            usage: token usage dict
+            content_present: whether a stream delta explicitly contained content
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                Dict version of OpenAIResponse object (with choices, usage)
+                    (this is needed so we can cache the response, as if it were
+                    a non-streaming response)
+        """
+        # check if function_call args are valid, if not,
+        # treat this as a normal msg, not a function call
+        args: Dict[str, Any] = {}
+        if has_function and function_args != "":
+            content, args = self._parse_function_args(function_args)
+            completion = completion + content
+            if content != "":
+                has_function = False
+
+        # mock openai response so we can cache it
+        if chat:
+            failed_content, tool_calls, tool_dicts = OpenAIGPT.tool_deltas_to_tools(
+                tool_deltas,
+            )
+            if failed_content:
+                completion += ("\n" if completion else "") + failed_content
+                content_present = True
+            has_valid_call = len(tool_dicts) > 0 or has_function
+            response_content = (
+                None
+                if has_valid_call and not content_present and completion == ""
+                else completion
+            )
+            msg: Dict[str, Any] = dict(
+                message=dict(
+                    content=response_content,
+                    reasoning_content=reasoning,
+                ),
+            )
+            if len(tool_dicts) > 0:
+                msg["message"]["tool_calls"] = tool_dicts
+
+            if has_function:
+                function_call = LLMFunctionCall(name=function_name)
+                function_call_dict = function_call.model_dump()
+                if function_args == "":
+                    function_call.arguments = None
+                else:
+                    function_call.arguments = args
+                    function_call_dict.update({"arguments": function_args.strip()})
+                msg["message"]["function_call"] = function_call_dict
+        else:
+            # non-chat mode has no function_call
+            msg = dict(text=completion)
+            response_content = completion
+            # TODO: Ignoring reasoning content for non-chat models
+
+        # create an OpenAIResponse object so we can cache it as if it were
+        # a non-streaming response
+        openai_response = OpenAIResponse(
+            choices=[msg],
+            usage=dict(total_tokens=0),
+        )
+        # Track whether we extracted inline thought tags from the text.
+        # Only set message_with_reasoning when get_reasoning_final()
+        # actually finds and extracts inline tags (e.g. <think>...</think>).
+        # When reasoning is already provided via a separate API field
+        # (e.g. reasoning_content), the message text doesn't contain
+        # thought signatures, so there's nothing extra to preserve.
+        message_with_reasoning = None
+        message: str | None
+        if reasoning == "" and response_content is not None:
+            # some LLM APIs may not return a separate reasoning field,
+            # and the reasoning may be included in the message content
+            # within delimiters like <think> ... </think>
+            reasoning, message = self.get_reasoning_final(response_content)
+            if reasoning:
+                # Inline tags were found and extracted; preserve the
+                # original text so it can be restored in message history.
+                message_with_reasoning = response_content
+        else:
+            message = response_content
+
+        prompt_tokens = usage.get("prompt_tokens", 0)
+        prompt_tokens_details: Any = usage.get("prompt_tokens_details", {})
+        cached_tokens = (
+            prompt_tokens_details.get("cached_tokens", 0)
+            if isinstance(prompt_tokens_details, dict)
+            else 0
+        )
+        completion_tokens = usage.get("completion_tokens", 0)
+
+        return (
+            LLMResponse(
+                message=message,
+                reasoning=reasoning,
+                message_with_reasoning=message_with_reasoning,
+                cached=False,
+                # don't allow empty list [] here
+                oai_tool_calls=tool_calls or None if len(tool_deltas) > 0 else None,
+                function_call=function_call if has_function else None,
+                usage=LLMTokenUsage(
+                    prompt_tokens=prompt_tokens or 0,
+                    cached_tokens=cached_tokens or 0,
+                    completion_tokens=completion_tokens or 0,
+                    cost=self._cost_chat_model(
+                        prompt_tokens or 0,
+                        cached_tokens or 0,
+                        completion_tokens or 0,
+                    ),
+                ),
+            ),
+            openai_response.model_dump(),
+        )
+
+    def _cache_store(self, k: str, v: Any) -> None:
+        if self.cache is None:
+            return
+        try:
+            self.cache.store(k, v)
+        except Exception as e:
+            logging.error(f"Error in OpenAIGPT._cache_store: {e}")
+            pass
+
+    def _cache_lookup(self, fn_name: str, **kwargs: Dict[str, Any]) -> Tuple[str, Any]:
+        if self.cache is None:
+            return "", None  # no cache, return empty key and None result
+        # Use the kwargs as the cache key
+        sorted_kwargs_str = str(sorted(kwargs.items()))
+        raw_key = f"{fn_name}:{sorted_kwargs_str}"
+
+        # Hash the key to a fixed length using SHA256
+        hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
+
+        if not settings.cache:
+            # when caching disabled, return the hashed_key and none result
+            return hashed_key, None
+        # Try to get the result from the cache
+        try:
+            cached_val = self.cache.retrieve(hashed_key)
+        except Exception as e:
+            logging.error(f"Error in OpenAIGPT._cache_lookup: {e}")
+            return hashed_key, None
+        return hashed_key, cached_val
+
+    def _cost_chat_model(self, prompt: int, cached: int, completion: int) -> float:
+        price = self.chat_cost()
+        return (
+            price[0] * (prompt - cached) + price[1] * cached + price[2] * completion
+        ) / 1000
+
+    def _get_non_stream_token_usage(
+        self, cached: bool, response: Dict[str, Any]
+    ) -> LLMTokenUsage:
+        """
+        Extracts token usage from ``response`` and computes cost, only when NOT
+        in streaming mode, since the LLM API (OpenAI currently) was not
+        populating the usage fields in streaming mode (but as of Sep 2024, streaming
+        responses include  usage info as well, so we should update the code
+        to directly use usage information from the streaming response, which is more
+        accurate, esp with "thinking" LLMs like o1 series which consume
+        thinking tokens).
+        In streaming mode, these are set to zero for
+        now, and will be updated later by the fn ``update_token_usage``.
+        """
+        cost = 0.0
+        prompt_tokens = 0
+        cached_tokens = 0
+        completion_tokens = 0
+
+        usage = response.get("usage")
+        if not cached and not self.get_stream() and usage is not None:
+            prompt_tokens = usage.get("prompt_tokens") or 0
+            prompt_tokens_details = usage.get("prompt_tokens_details", {}) or {}
+            cached_tokens = prompt_tokens_details.get("cached_tokens") or 0
+            completion_tokens = usage.get("completion_tokens") or 0
+            cost = self._cost_chat_model(
+                prompt_tokens or 0,
+                cached_tokens or 0,
+                completion_tokens or 0,
+            )
+
+        return LLMTokenUsage(
+            prompt_tokens=prompt_tokens,
+            cached_tokens=cached_tokens,
+            completion_tokens=completion_tokens,
+            cost=cost,
+        )
+
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        self.run_on_first_use()
+
+        try:
+            return self._generate(prompt, max_tokens)
+        except openai.APIStatusError as e:
+            # Catch HTTP-level API errors (400, 401, 403, 404, 422, 429, 5xx)
+            # without traceback — these originate server-side and a local
+            # stack trace adds no diagnostic value.
+            # Note: APIConnectionError/APITimeoutError are intentionally NOT
+            # caught here so they fall through to the generic handler below,
+            # where the full traceback aids in diagnosing local network issues.
+            logging.error(f"API error in OpenAIGPT.generate: {e}")
+            raise
+        except Exception as e:
+            # log and re-raise exception
+            logging.error(friendly_error(e, "Error in OpenAIGPT.generate: "))
+            raise
+
+    def _generate(self, prompt: str, max_tokens: int) -> LLMResponse:
+        if self.config.use_chat_for_completion:
+            return self.chat(messages=prompt, max_tokens=max_tokens)
+
+        if self.is_groq or self.is_cerebras:
+            raise ValueError("Groq, Cerebras do not support pure completions")
+
+        if settings.debug:
+            print(f"[grey37]PROMPT: {escape(prompt)}[/grey37]")
+
+        @retry_with_exponential_backoff
+        def completions_with_backoff(**kwargs):  # type: ignore
+            cached = False
+            hashed_key, result = self._cache_lookup("Completion", **kwargs)
+            if result is not None:
+                cached = True
+                if settings.debug:
+                    print("[grey37]CACHED[/grey37]")
+            else:
+                if self.config.litellm:
+                    from litellm import completion as litellm_completion
+
+                    completion_call = litellm_completion
+
+                    if self.api_key != DUMMY_API_KEY:
+                        kwargs["api_key"] = self.api_key
+                else:
+                    if self.client is None:
+                        raise ValueError(
+                            "OpenAI/equivalent chat-completion client not set"
+                        )
+                    assert isinstance(self.client, OpenAI)
+                    completion_call = self.client.completions.create
+                if self.config.litellm and settings.debug:
+                    kwargs["logger_fn"] = litellm_logging_fn
+                # If it's not in the cache, call the API
+                result = completion_call(**kwargs)
+                if self.get_stream():
+                    llm_response, openai_response = self._stream_response(
+                        result,
+                        chat=self.config.litellm,
+                    )
+                    self._cache_store(hashed_key, openai_response)
+                    return cached, hashed_key, openai_response
+                else:
+                    self._cache_store(hashed_key, result.model_dump())
+            return cached, hashed_key, result
+
+        kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
+        if self.config.litellm:
+            # TODO this is a temp fix, we should really be using a proper completion fn
+            # that takes a pre-formatted prompt, rather than mocking it as a sys msg.
+            kwargs["messages"] = [dict(content=prompt, role=Role.SYSTEM)]
+        else:  # any other OpenAI-compatible endpoint
+            kwargs["prompt"] = prompt
+        args = dict(
+            **kwargs,
+            max_tokens=max_tokens,  # for output/completion
+            stream=self.get_stream(),
+        )
+        args = self._openai_api_call_params(args)
+        cached, hashed_key, response = completions_with_backoff(**args)
+        # assume response is an actual response rather than a streaming event
+        if not isinstance(response, dict):
+            response = response.model_dump()
+        if "message" in response["choices"][0]:
+            msg = (response["choices"][0]["message"]["content"] or "").strip()
+        else:
+            msg = (response["choices"][0]["text"] or "").strip()
+        return LLMResponse(message=msg, cached=cached)
+
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        self.run_on_first_use()
+
+        try:
+            return await self._agenerate(prompt, max_tokens)
+        except openai.APIStatusError as e:
+            # Catch HTTP-level API errors (see comment in generate() above).
+            logging.error(f"API error in OpenAIGPT.agenerate: {e}")
+            raise
+        except Exception as e:
+            # log and re-raise exception
+            logging.error(friendly_error(e, "Error in OpenAIGPT.agenerate: "))
+            raise
+
+    async def _agenerate(self, prompt: str, max_tokens: int) -> LLMResponse:
+        # note we typically will not have self.config.stream = True
+        # when issuing several api calls concurrently/asynchronously.
+        # The calling fn should use the context `with Streaming(..., False)` to
+        # disable streaming.
+        if self.config.use_chat_for_completion:
+            return await self.achat(messages=prompt, max_tokens=max_tokens)
+
+        if self.is_groq or self.is_cerebras:
+            raise ValueError("Groq, Cerebras do not support pure completions")
+
+        if settings.debug:
+            print(f"[grey37]PROMPT: {escape(prompt)}[/grey37]")
+
+        # WARNING: .Completion.* endpoints are deprecated,
+        # and as of Sep 2023 only legacy models will work here,
+        # e.g. text-davinci-003, text-ada-001.
+        @async_retry_with_exponential_backoff
+        async def completions_with_backoff(**kwargs):  # type: ignore
+            cached = False
+            hashed_key, result = self._cache_lookup("AsyncCompletion", **kwargs)
+            if result is not None:
+                cached = True
+                if settings.debug:
+                    print("[grey37]CACHED[/grey37]")
+            else:
+                if self.config.litellm:
+                    from litellm import acompletion as litellm_acompletion
+
+                    if self.api_key != DUMMY_API_KEY:
+                        kwargs["api_key"] = self.api_key
+
+                # TODO this may not work: text_completion is not async,
+                # and we didn't find an async version in litellm
+                assert isinstance(self.async_client, AsyncOpenAI)
+                acompletion_call = (
+                    litellm_acompletion
+                    if self.config.litellm
+                    else self.async_client.completions.create
+                )
+                if self.config.litellm and settings.debug:
+                    kwargs["logger_fn"] = litellm_logging_fn
+                # If it's not in the cache, call the API
+                result = await acompletion_call(**kwargs)
+                self._cache_store(hashed_key, result.model_dump())
+            return cached, hashed_key, result
+
+        kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
+        if self.config.litellm:
+            # TODO this is a temp fix, we should really be using a proper completion fn
+            # that takes a pre-formatted prompt, rather than mocking it as a sys msg.
+            kwargs["messages"] = [dict(content=prompt, role=Role.SYSTEM)]
+        else:  # any other OpenAI-compatible endpoint
+            kwargs["prompt"] = prompt
+        cached, hashed_key, response = await completions_with_backoff(
+            **kwargs,
+            max_tokens=max_tokens,
+            stream=False,
+        )
+        # assume response is an actual response rather than a streaming event
+        if not isinstance(response, dict):
+            response = response.model_dump()
+        if "message" in response["choices"][0]:
+            msg = (response["choices"][0]["message"]["content"] or "").strip()
+        else:
+            msg = (response["choices"][0]["text"] or "").strip()
+        return LLMResponse(message=msg, cached=cached)
+
+    def chat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        self.run_on_first_use()
+
+        if self.config.use_completion_for_chat and not self.is_openai_chat_model():
+            # only makes sense for non-OpenAI models
+            if self.config.formatter is None or self.config.hf_formatter is None:
+                raise ValueError(
+                    """
+                    `formatter` must be specified in config to use completion for chat.
+                    """
+                )
+            if isinstance(messages, str):
+                messages = [
+                    LLMMessage(
+                        role=Role.SYSTEM, content="You are a helpful assistant."
+                    ),
+                    LLMMessage(role=Role.USER, content=messages),
+                ]
+            prompt = self.config.hf_formatter.format(messages)
+            return self.generate(prompt=prompt, max_tokens=max_tokens)
+        try:
+            return self._chat(
+                messages,
+                max_tokens,
+                tools,
+                tool_choice,
+                functions,
+                function_call,
+                response_format,
+            )
+        except openai.APIStatusError as e:
+            # Catch HTTP-level API errors (see comment in generate() above).
+            logging.error(f"API error in OpenAIGPT.chat: {e}")
+            raise
+        except Exception as e:
+            # log and re-raise exception
+            logging.error(friendly_error(e, "Error in OpenAIGPT.chat: "))
+            raise
+
+    async def achat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        self.run_on_first_use()
+
+        # turn off streaming for async calls
+        if (
+            self.config.use_completion_for_chat
+            and not self.is_openai_chat_model()
+            and not self.is_openai_completion_model()
+        ):
+            # only makes sense for local models, where we are trying to
+            # convert a chat dialog msg-sequence to a simple completion prompt.
+            if self.config.formatter is None:
+                raise ValueError(
+                    """
+                    `formatter` must be specified in config to use completion for chat.
+                    """
+                )
+            formatter = HFFormatter(
+                HFPromptFormatterConfig(model_name=self.config.formatter)
+            )
+            if isinstance(messages, str):
+                messages = [
+                    LLMMessage(
+                        role=Role.SYSTEM, content="You are a helpful assistant."
+                    ),
+                    LLMMessage(role=Role.USER, content=messages),
+                ]
+            prompt = formatter.format(messages)
+            return await self.agenerate(prompt=prompt, max_tokens=max_tokens)
+        try:
+            result = await self._achat(
+                messages,
+                max_tokens,
+                tools,
+                tool_choice,
+                functions,
+                function_call,
+                response_format,
+            )
+            return result
+        except openai.APIStatusError as e:
+            # Catch HTTP-level API errors (see comment in generate() above).
+            logging.error(f"API error in OpenAIGPT.achat: {e}")
+            raise
+        except Exception as e:
+            # log and re-raise exception
+            logging.error(friendly_error(e, "Error in OpenAIGPT.achat: "))
+            raise
+
+    def _chat_completions_with_backoff_body(self, **kwargs):  # type: ignore
+        cached = False
+        hashed_key, result = self._cache_lookup("Completion", **kwargs)
+        if result is not None:
+            cached = True
+            if settings.debug:
+                print("[grey37]CACHED[/grey37]")
+        else:
+            # If it's not in the cache, call the API
+            if self.config.litellm:
+                from litellm import completion as litellm_completion
+
+                completion_call = litellm_completion
+
+                if self.api_key != DUMMY_API_KEY:
+                    kwargs["api_key"] = self.api_key
+            else:
+                if self.client is None:
+                    raise ValueError("OpenAI/equivalent chat-completion client not set")
+                completion_call = self.client.chat.completions.create
+            if self.config.litellm and settings.debug:
+                kwargs["logger_fn"] = litellm_logging_fn
+            result = completion_call(**kwargs)
+
+            if self.get_stream():
+                # If streaming, cannot cache result
+                # since it is a generator. Instead,
+                # we hold on to the hashed_key and
+                # cache the result later
+
+                # Test if this is a stream with an exception by
+                # trying to get first chunk: Some providers like LiteLLM
+                # produce a valid stream object `result` instead of throwing a
+                # rate-limit error, and if we don't catch it here,
+                # we end up returning an empty response and not
+                # using the retry mechanism in the decorator.
+                try:
+                    # try to get the first chunk to check for errors
+                    test_iter = iter(result)
+                    first_chunk = next(test_iter)
+                    # If we get here without error, recreate the stream
+                    result = chain([first_chunk], test_iter)
+                except StopIteration:
+                    # Empty stream is fine
+                    pass
+                except Exception as e:
+                    # Propagate any errors in the stream
+                    raise e
+            else:
+                self._cache_store(hashed_key, result.model_dump())
+        return cached, hashed_key, result
+
+    def _chat_completions_with_backoff(self, **kwargs):  # type: ignore
+        retry_func = retry_with_exponential_backoff(
+            self._chat_completions_with_backoff_body,
+            initial_delay=self.config.retry_params.initial_delay,
+            max_retries=self.config.retry_params.max_retries,
+            exponential_base=self.config.retry_params.exponential_base,
+            jitter=self.config.retry_params.jitter,
+        )
+        return retry_func(**kwargs)
+
+    async def _achat_completions_with_backoff_body(self, **kwargs):  # type: ignore
+        cached = False
+        hashed_key, result = self._cache_lookup("Completion", **kwargs)
+        if result is not None:
+            cached = True
+            if settings.debug:
+                print("[grey37]CACHED[/grey37]")
+        else:
+            if self.config.litellm:
+                from litellm import acompletion as litellm_acompletion
+
+                acompletion_call = litellm_acompletion
+
+                if self.api_key != DUMMY_API_KEY:
+                    kwargs["api_key"] = self.api_key
+            else:
+                if self.async_client is None:
+                    raise ValueError(
+                        "OpenAI/equivalent async chat-completion client not set"
+                    )
+                acompletion_call = self.async_client.chat.completions.create
+            if self.config.litellm and settings.debug:
+                kwargs["logger_fn"] = litellm_logging_fn
+            # If it's not in the cache, call the API
+            result = await acompletion_call(**kwargs)
+            if self.get_stream():
+                try:
+                    # Try to peek at the first chunk to immediately catch any errors
+                    # Store the original result (the stream)
+                    original_stream = result
+
+                    # Manually create and advance the iterator to check for errors
+                    stream_iter = original_stream.__aiter__()
+                    try:
+                        # This will raise an exception if the stream is invalid
+                        first_chunk = await anext(stream_iter)
+
+                        # If we reach here, the stream started successfully
+                        # Now recreate a fresh stream from the original API result
+                        # Otherwise, return a new stream that yields the first chunk
+                        # and remaining items
+                        async def combined_stream():  # type: ignore
+                            yield first_chunk
+                            async for chunk in stream_iter:
+                                yield chunk
+
+                        result = combined_stream()  # type: ignore
+                    except StopAsyncIteration:
+                        # Empty stream is normal - nothing to do
+                        pass
+                except Exception as e:
+                    # Any exception here should be raised to trigger the retry mechanism
+                    raise e
+            else:
+                self._cache_store(hashed_key, result.model_dump())
+        return cached, hashed_key, result
+
+    async def _achat_completions_with_backoff(self, **kwargs):  # type: ignore
+        retry_func = async_retry_with_exponential_backoff(
+            self._achat_completions_with_backoff_body,
+            initial_delay=self.config.retry_params.initial_delay,
+            max_retries=self.config.retry_params.max_retries,
+            exponential_base=self.config.retry_params.exponential_base,
+            jitter=self.config.retry_params.jitter,
+        )
+        return await retry_func(**kwargs)
+
+    def _prep_chat_completion(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> Dict[str, Any]:
+        """Prepare args for LLM chat-completion API call"""
+        if isinstance(messages, str):
+            llm_messages = [
+                LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
+                LLMMessage(role=Role.USER, content=messages),
+            ]
+        else:
+            llm_messages = messages
+            if (
+                len(llm_messages) == 1
+                and llm_messages[0].role == Role.SYSTEM
+                # TODO: we will unconditionally insert a dummy user msg
+                # if the only msg is a system msg.
+                # We could make this conditional on ModelInfo.needs_first_user_message
+            ):
+                # some LLMs, notable Gemini as of 12/11/24,
+                # require the first message to be from the user,
+                # so insert a dummy user msg if needed.
+                llm_messages.insert(
+                    1,
+                    LLMMessage(
+                        role=Role.USER, content="Follow the above instructions."
+                    ),
+                )
+
+        chat_model = self.config.chat_model
+
+        args: Dict[str, Any] = dict(
+            model=chat_model,
+            messages=[
+                m.api_dict(
+                    self.config.chat_model,
+                    has_system_role=self.info().allows_system_message,
+                )
+                for m in (llm_messages)
+            ],
+            max_completion_tokens=max_tokens,
+            stream=self.get_stream(),
+        )
+        if self.get_stream() and "groq" not in self.chat_model_orig:
+            # groq fails when we include stream_options in the request
+            args.update(
+                dict(
+                    # get token-usage numbers in stream mode from OpenAI API,
+                    # and possibly other OpenAI-compatible APIs.
+                    stream_options=dict(include_usage=True),
+                )
+            )
+        args.update(self._openai_api_call_params(args))
+        # only include functions-related args if functions are provided
+        # since the OpenAI API will throw an error if `functions` is None or []
+        if functions is not None:
+            args.update(
+                dict(
+                    functions=[f.model_dump() for f in functions],
+                    function_call=function_call,
+                )
+            )
+        if tools is not None:
+            if self.config.parallel_tool_calls is not None:
+                args["parallel_tool_calls"] = self.config.parallel_tool_calls
+
+            if any(t.strict for t in tools) and (
+                self.config.parallel_tool_calls is None
+                or self.config.parallel_tool_calls
+            ):
+                parallel_strict_warning()
+            args.update(
+                dict(
+                    tools=[
+                        dict(
+                            type="function",
+                            function=t.function.model_dump()
+                            | ({"strict": t.strict} if t.strict is not None else {}),
+                        )
+                        for t in tools
+                    ],
+                    tool_choice=tool_choice,
+                )
+            )
+        if response_format is not None:
+            args["response_format"] = response_format.to_dict()
+
+        for p in self.unsupported_params():
+            # some models e.g. o1-mini (as of sep 2024) don't support some params,
+            # like temperature and stream, so we need to remove them.
+            args.pop(p, None)
+
+        param_rename_map = self.rename_params()
+        for old_param, new_param in param_rename_map.items():
+            if old_param in args:
+                args[new_param] = args.pop(old_param)
+
+        # finally, get rid of extra_body params exclusive to certain models
+        # Only apply allowlist restrictions for known models.
+        # Unknown/custom models are allowed to use all params by default.
+        is_known_model = self.info().name != "unknown"
+        extra_params = args.get("extra_body", {})
+        if extra_params and is_known_model:
+            for param, model_list in OpenAI_API_ParamInfo().extra_parameters.items():
+                if (
+                    self.config.chat_model not in model_list
+                    and self.chat_model_orig not in model_list
+                ):
+                    extra_params.pop(param, None)
+            if extra_params:
+                args["extra_body"] = extra_params
+        return args
+
+    def _process_chat_completion_response(
+        self,
+        cached: bool,
+        response: Dict[str, Any],
+    ) -> LLMResponse:
+        # openAI response will look like this:
+        """
+        {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1677652288,
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "name": "",
+                    "content": "\n\nHello there, how may I help you?",
+                    "reasoning_content": "Okay, let's see here, hmmm...",
+                    "function_call": {
+                        "name": "fun_name",
+                        "arguments: {
+                            "arg1": "val1",
+                            "arg2": "val2"
+                        }
+                    },
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 12,
+                "total_tokens": 21
+            }
+        }
+        """
+        choices = response.get("choices")
+        if isinstance(choices, list) and len(choices) > 0:
+            message = choices[0].get("message", {})
+        else:
+            message = {}
+        if message is None:
+            message = {}
+        content = message.get("content")
+        reasoning = message.get("reasoning_content", "")
+        # Track whether we extracted inline thought tags from the text.
+        # Only set message_with_reasoning when get_reasoning_final()
+        # actually finds and extracts inline tags (e.g. <think>...</think>).
+        # When reasoning is already provided via a separate API field
+        # (e.g. reasoning_content), the message text doesn't contain
+        # thought signatures, so there's nothing extra to preserve.
+        message_with_reasoning = None
+        if reasoning == "" and content is not None:
+            # some LLM APIs may not return a separate reasoning field,
+            # and the reasoning may be included in the message content
+            # within delimiters like <think> ... </think>
+            reasoning, msg = self.get_reasoning_final(content)
+            if reasoning:
+                # Inline tags were found and extracted; preserve the
+                # original text so it can be restored in message history.
+                message_with_reasoning = content
+        else:
+            msg = content
+
+        if message.get("function_call") is None:
+            fun_call = None
+        else:
+            try:
+                fun_call = LLMFunctionCall.from_dict(message["function_call"])
+            except (ValueError, SyntaxError):
+                logging.warning(
+                    "Could not parse function arguments: "
+                    f"{message['function_call']['arguments']} "
+                    f"for function {message['function_call']['name']} "
+                    "treating as normal non-function message"
+                )
+                fun_call = None
+                args_str = message["function_call"]["arguments"] or ""
+                msg_str = message["content"] or ""
+                msg = msg_str + args_str
+        oai_tool_calls = None
+        if message.get("tool_calls") is not None:
+            oai_tool_calls = []
+            for tool_call_dict in message["tool_calls"]:
+                try:
+                    tool_call = OpenAIToolCall.from_dict(tool_call_dict)
+                    oai_tool_calls.append(tool_call)
+                except (ValueError, SyntaxError):
+                    logging.warning(
+                        "Could not parse tool call: "
+                        f"{json.dumps(tool_call_dict)} "
+                        "treating as normal non-tool message"
+                    )
+                    serialized_tool_call = json.dumps(tool_call_dict)
+                    msg = (msg or "") + ("\n" if msg else "") + serialized_tool_call
+        return LLMResponse(
+            # None (no content, e.g. a tool-call-only response) is preserved as
+            # None rather than coerced to "", so the distinction survives
+            # downstream (see LLMMessage.content / ChatDocument.content_is_none).
+            message=msg.strip() if msg is not None else None,
+            reasoning=reasoning.strip() if reasoning is not None else "",
+            message_with_reasoning=message_with_reasoning,
+            function_call=fun_call,
+            oai_tool_calls=oai_tool_calls or None,  # don't allow empty list [] here
+            cached=cached,
+            usage=self._get_non_stream_token_usage(cached, response),
+        )
+
+    def _chat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """
+        ChatCompletion API call to OpenAI.
+        Args:
+            messages: list of messages  to send to the API, typically
+                represents back and forth dialogue between user and LLM, but could
+                also include "function"-role messages. If messages is a string,
+                it is assumed to be a user message.
+            max_tokens: max output tokens to generate
+            functions: list of LLMFunction specs available to the LLM, to possibly
+                use in its response
+            function_call: controls how the LLM uses `functions`:
+                - "auto": LLM decides whether to use `functions` or not,
+                - "none": LLM blocked from using any function
+                - a dict of {"name": "function_name"} which forces the LLM to use
+                    the specified function.
+        Returns:
+            LLMResponse object
+        """
+        args = self._prep_chat_completion(
+            messages,
+            max_tokens,
+            tools,
+            tool_choice,
+            functions,
+            function_call,
+            response_format,
+        )
+        cached, hashed_key, response = self._chat_completions_with_backoff(**args)  # type: ignore
+        if self.get_stream() and not cached:
+            llm_response, openai_response = self._stream_response(response, chat=True)
+            self._cache_store(hashed_key, openai_response)
+            return llm_response  # type: ignore
+        if isinstance(response, dict):
+            response_dict = response
+        else:
+            response_dict = response.model_dump()
+        return self._process_chat_completion_response(cached, response_dict)
+
+    async def _achat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """
+        Async version of _chat(). See that function for details.
+        """
+        args = self._prep_chat_completion(
+            messages,
+            max_tokens,
+            tools,
+            tool_choice,
+            functions,
+            function_call,
+            response_format,
+        )
+        cached, hashed_key, response = await self._achat_completions_with_backoff(  # type: ignore
+            **args
+        )
+        if self.get_stream() and not cached:
+            llm_response, openai_response = await self._stream_response_async(
+                response, chat=True
+            )
+            self._cache_store(hashed_key, openai_response)
+            return llm_response  # type: ignore
+        if isinstance(response, dict):
+            response_dict = response
+        else:
+            response_dict = response.model_dump()
+        return self._process_chat_completion_response(cached, response_dict)
+</file>
+
+<file path="langroid/vector_store/base.py">
+import copy
+import logging
+import re
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
+
+import numpy as np
+import pandas as pd
+from pydantic.fields import FieldInfo
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
+
+from langroid.embedding_models.base import EmbeddingModel, EmbeddingModelsConfig
+from langroid.embedding_models.models import OpenAIEmbeddingsConfig
+from langroid.mytypes import DocMetaData, Document, EmbeddingFunction
+from langroid.utils.algorithms.graph import components, topological_sort
+from langroid.utils.configuration import settings
+from langroid.utils.object_registry import ObjectRegistry
+from langroid.utils.output.printing import print_long_text
+from langroid.utils.pandas_utils import safe_eval_globals, sanitize_command, stringify
+from langroid.utils.pydantic_utils import flatten_dict
+
+logger = logging.getLogger(__name__)
+
+# the exact shape Kubernetes service links inject, e.g. tcp://10.0.0.8:6333
+# (\Z, not $: $ would match before a trailing newline, silently
+# discarding a value that should fail validation)
+_SERVICE_LINK_PORT_RE = re.compile(r"^tcp://\S+:\d+\Z")
+
+
+class _ServiceLinkPortFilter(PydanticBaseSettingsSource):
+    """Env-source wrapper dropping k8s/docker service-link `port` values.
+
+    With `enableServiceLinks` (on by default in Kubernetes), a service
+    named e.g. `qdrant` injects `QDRANT_PORT=tcp://IP:PORT` into every
+    pod, which would otherwise fail integer validation of the `port`
+    field. If the wrapped env source yields a `port` string matching
+    exactly that format, it is dropped (with a warning) so the class
+    default applies. Any other value — including malformed `tcp://`
+    junk, or a `tcp://` value passed to the constructor (which never
+    goes through this source) — still fails validation as usual.
+    """
+
+    def __init__(self, wrapped: PydanticBaseSettingsSource) -> None:
+        super().__init__(wrapped.settings_cls)
+        self._wrapped = wrapped
+
+    def get_field_value(
+        self, field: FieldInfo, field_name: str
+    ) -> Tuple[Any, str, bool]:
+        return self._wrapped.get_field_value(field, field_name)
+
+    def __call__(self) -> Dict[str, Any]:
+        values = self._wrapped()
+        port = values.get("port")
+        if isinstance(port, str) and _SERVICE_LINK_PORT_RE.match(port):
+            default = self.settings_cls.model_fields["port"].default
+            logger.warning(
+                f"Ignoring port value {port!r} from the environment: it "
+                f"looks like a Kubernetes/Docker service-link artifact "
+                f"(an injected <SERVICE>_PORT env var); using default "
+                f"port {default} instead."
+            )
+            values = {k: v for k, v in values.items() if k != "port"}
+        return values
+
+
+class VectorStoreConfig(BaseSettings):
+    # Without a prefix, every field name would itself be a
+    # case-insensitive env var (e.g. a bare HOST, PORT, or FULL_EVAL
+    # in the environment would silently override defaults); subclasses
+    # each set their own prefix (QDRANT_, LANCEDB_, ...).
+    model_config = SettingsConfigDict(env_prefix="VECDB_")
+
+    type: str = ""  # deprecated, keeping it for backward compatibility
+    collection_name: str | None = "temp"
+    replace_collection: bool = False  # replace collection if it already exists
+    storage_path: str = ".qdrant/data"
+    cloud: bool = False
+    batch_size: int = 200
+    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig(
+        model_type="openai",
+    )
+    embedding_model: Optional[EmbeddingModel] = None
+    timeout: int = 60
+    host: str = "127.0.0.1"
+    port: int = 6333
+    # used when parsing search results back as Document objects
+    document_class: Type[Document] = Document
+    metadata_class: Type[DocMetaData] = DocMetaData
+    # compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
+    full_eval: bool = False  # runs eval without sanitization. Use only on trusted input
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: Type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> Tuple[PydanticBaseSettingsSource, ...]:
+        """Wrap the env source to drop k8s service-link `port` values.
+
+        Source precedence is unchanged (init beats env, etc.); only the
+        env source is filtered — see `_ServiceLinkPortFilter`.
+        """
+        return (
+            init_settings,
+            _ServiceLinkPortFilter(env_settings),
+            dotenv_settings,
+            file_secret_settings,
+        )
+
+
+class VectorStore(ABC):
+    """
+    Abstract base class for a vector store.
+    """
+
+    def __init__(self, config: VectorStoreConfig):
+        self.config = config
+        if config.embedding_model is None:
+            self.embedding_model = EmbeddingModel.create(config.embedding)
+        else:
+            self.embedding_model = config.embedding_model
+        if hasattr(self.config, "embedding_model"):
+            self.config.embedding_model = None
+        self.embedding_fn: EmbeddingFunction = self.embedding_model.embedding_fn()
+
+    @staticmethod
+    def create(config: VectorStoreConfig) -> Optional["VectorStore"]:
+        from langroid.vector_store.chromadb import ChromaDB, ChromaDBConfig
+        from langroid.vector_store.lancedb import LanceDB, LanceDBConfig
+        from langroid.vector_store.meilisearch import MeiliSearch, MeiliSearchConfig
+        from langroid.vector_store.milvusdb import MilvusDB, MilvusDBConfig
+        from langroid.vector_store.pineconedb import PineconeDB, PineconeDBConfig
+        from langroid.vector_store.postgres import PostgresDB, PostgresDBConfig
+        from langroid.vector_store.qdrantdb import QdrantDB, QdrantDBConfig
+        from langroid.vector_store.weaviatedb import WeaviateDB, WeaviateDBConfig
+
+        if isinstance(config, QdrantDBConfig):
+            return QdrantDB(config)
+        elif isinstance(config, ChromaDBConfig):
+            return ChromaDB(config)
+        elif isinstance(config, LanceDBConfig):
+            return LanceDB(config)
+        elif isinstance(config, MeiliSearchConfig):
+            return MeiliSearch(config)
+        elif isinstance(config, PostgresDBConfig):
+            return PostgresDB(config)
+        elif isinstance(config, MilvusDBConfig):
+            return MilvusDB(config)
+        elif isinstance(config, WeaviateDBConfig):
+            return WeaviateDB(config)
+        elif isinstance(config, PineconeDBConfig):
+            return PineconeDB(config)
+
+        else:
+            logger.warning(
+                f"""
+                Unknown vector store config: {config.__class__.__name__},
+                so skipping vector store creation!
+                If you intended to use a vector-store, please set a specific 
+                vector-store in your script, typically in the `vecdb` field of a 
+                `ChatAgentConfig`, otherwise set it to None.
+                """
+            )
+            return None
+
+    @property
+    def embedding_dim(self) -> int:
+        return len(self.embedding_fn(["test"])[0])
+
+    def clone(self) -> "VectorStore":
+        """Return a vector-store clone suitable for agent cloning.
+
+        The default implementation deep-copies the configuration, reuses any
+        existing embedding model, and instantiates a fresh store of the same
+        type. Subclasses can override when sharing the instance is required
+        (e.g., embedded/local stores that rely on file locks).
+        """
+
+        config_class = self.config.__class__
+        config_data = self.config.model_dump(mode="python")
+        config_data["embedding_model"] = None
+        config_copy = config_class.model_validate(config_data)
+        logger.debug(
+            "Cloning VectorStore %s: original collection=%s, copied collection=%s",
+            type(self).__name__,
+            getattr(self.config, "collection_name", None),
+            getattr(config_copy, "collection_name", None),
+        )
+        # Preserve the calculated collection contents without forcing replaces
+        if hasattr(config_copy, "replace_collection"):
+            config_copy.replace_collection = False  # type: ignore[attr-defined]
+        cloned_embedding: Optional[EmbeddingModel] = None
+        if (
+            hasattr(self, "embedding_model")
+            and getattr(self, "embedding_model") is not None
+        ):
+            cloned_embedding = self.embedding_model.clone()  # type: ignore[attr-defined]
+            if hasattr(config_copy, "embedding_model"):
+                config_copy.embedding_model = cloned_embedding
+
+        cloned_store = type(self)(config_copy)  # type: ignore[call-arg]
+        if hasattr(cloned_store.config, "embedding_model"):
+            cloned_store.config.embedding_model = None
+        logger.debug(
+            "Cloned VectorStore %s: cloned collection=%s",
+            type(self).__name__,
+            getattr(cloned_store.config, "collection_name", None),
+        )
+        if hasattr(cloned_store.config, "replace_collection"):
+            cloned_store.config.replace_collection = False
+        # Some stores might not honour replace_collection; ensure same collection
+        if getattr(self.config, "collection_name", None) is not None:
+            setattr(
+                cloned_store.config,
+                "collection_name",
+                getattr(self.config, "collection_name", None),
+            )
+        return cloned_store
+
+    @abstractmethod
+    def clear_empty_collections(self) -> int:
+        """Clear all empty collections in the vector store.
+        Returns the number of collections deleted.
+        """
+        pass
+
+    @abstractmethod
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """
+        Clear all collections in the vector store.
+
+        Args:
+            really (bool, optional): Whether to really clear all collections.
+                Defaults to False.
+            prefix (str, optional): Prefix of collections to clear.
+        Returns:
+            int: Number of collections deleted.
+        """
+        pass
+
+    @abstractmethod
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """List all collections in the vector store
+        (only non empty collections if empty=False).
+        """
+        pass
+
+    def set_collection(self, collection_name: str, replace: bool = False) -> None:
+        """
+        Set the current collection to the given collection name.
+        Args:
+            collection_name (str): Name of the collection.
+            replace (bool, optional): Whether to replace the collection if it
+                already exists. Defaults to False.
+        """
+
+        self.config.collection_name = collection_name
+        self.config.replace_collection = replace
+        if replace:
+            self.create_collection(collection_name, replace=True)
+
+    @abstractmethod
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        """Create a collection with the given name.
+        Args:
+            collection_name (str): Name of the collection.
+            replace (bool, optional): Whether to replace the
+                collection if it already exists. Defaults to False.
+        """
+        pass
+
+    @abstractmethod
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        pass
+
+    def compute_from_docs(self, docs: List[Document], calc: str) -> str:
+        """Compute a result on a set of documents,
+        using a dataframe calc string like `df.groupby('state')['income'].mean()`.
+
+        If full_eval is False (default), the input expression is sanitized to prevent
+        most common code injection attack vectors.
+        If full_eval is True, sanitization is bypassed - use only with trusted input!
+        """
+        # convert each doc to a dict, using dotted paths for nested fields
+        dicts = [flatten_dict(doc.model_dump(by_alias=True)) for doc in docs]
+        df = pd.DataFrame(dicts)
+
+        try:
+            # SECURITY MITIGATION: Eval input is sanitized to prevent most common
+            # code injection attack vectors when full_eval is False. The globals
+            # dict also restricts ``__builtins__`` so that even with
+            # ``full_eval=True`` the expression cannot reach
+            # ``__import__``/``eval``/``exec`` via Python's implicit builtin
+            # injection (GHSA-q9p7-wqxg-mrhc).
+            vars = {"df": df}
+            if not self.config.full_eval:
+                calc = sanitize_command(calc)
+            code = compile(calc, "<calc>", "eval")
+            result = eval(code, safe_eval_globals(vars), {})
+        except Exception as e:
+            # return error message so LLM can fix the calc string if needed
+            err = f"""
+            Error encountered in pandas eval: {str(e)}
+            """
+            if isinstance(e, KeyError) and "not in index" in str(e):
+                # Pd.eval sometimes fails on a perfectly valid exprn like
+                # df.loc[..., 'column'] with a KeyError.
+                err += """
+                Maybe try a different way, e.g. 
+                instead of df.loc[..., 'column'], try df.loc[...]['column']
+                """
+            return err
+        return stringify(result)
+
+    def maybe_add_ids(self, documents: Sequence[Document]) -> None:
+        """Add ids to metadata if absent, since some
+        vecdbs don't like having blank ids."""
+        for d in documents:
+            if d.metadata.id in [None, ""]:
+                d.metadata.id = ObjectRegistry.new_id()
+
+    @abstractmethod
+    def similar_texts_with_scores(
+        self,
+        text: str,
+        k: int = 1,
+        where: Optional[str] = None,
+    ) -> List[Tuple[Document, float]]:
+        """
+        Find k most similar texts to the given text, in terms of vector distance metric
+        (e.g., cosine similarity).
+
+        Args:
+            text (str): The text to find similar texts for.
+            k (int, optional): Number of similar texts to retrieve. Defaults to 1.
+            where (Optional[str], optional): Where clause to filter the search.
+
+        Returns:
+            List[Tuple[Document,float]]: List of (Document, score) tuples.
+
+        """
+        pass
+
+    def add_context_window(
+        self, docs_scores: List[Tuple[Document, float]], neighbors: int = 0
+    ) -> List[Tuple[Document, float]]:
+        """
+        In each doc's metadata, there may be a window_ids field indicating
+        the ids of the chunks around the current chunk.
+        These window_ids may overlap, so we
+        - coalesce each overlapping groups into a single window (maintaining ordering),
+        - create a new document for each part, preserving metadata,
+
+        We may have stored a longer set of window_ids than we need during chunking.
+        Now, we just want `neighbors` on each side of the center of the window_ids list.
+
+        Args:
+            docs_scores (List[Tuple[Document, float]]): List of pairs of documents
+                to add context windows to together with their match scores.
+            neighbors (int, optional): Number of neighbors on "each side" of match to
+                retrieve. Defaults to 0.
+                "Each side" here means before and after the match,
+                in the original text.
+
+        Returns:
+            List[Tuple[Document, float]]: List of (Document, score) tuples.
+        """
+        # We return a larger context around each match, i.e.
+        # a window of `neighbors` on each side of the match.
+        docs = [d for d, s in docs_scores]
+        scores = [s for d, s in docs_scores]
+        if neighbors == 0:
+            return docs_scores
+        doc_chunks = [d for d in docs if d.metadata.is_chunk]
+        if len(doc_chunks) == 0:
+            return docs_scores
+        window_ids_list = []
+        id2metadata = {}
+        # id -> highest score of a doc it appears in
+        id2max_score: Dict[int | str, float] = {}
+        for i, d in enumerate(docs):
+            window_ids = d.metadata.window_ids
+            if len(window_ids) == 0:
+                window_ids = [d.id()]
+            id2metadata.update({id: d.metadata for id in window_ids})
+
+            id2max_score.update(
+                {id: max(id2max_score.get(id, 0), scores[i]) for id in window_ids}
+            )
+            n = len(window_ids)
+            chunk_idx = window_ids.index(d.id())
+            neighbor_ids = window_ids[
+                max(0, chunk_idx - neighbors) : min(n, chunk_idx + neighbors + 1)
+            ]
+            window_ids_list += [neighbor_ids]
+
+        # window_ids could be from different docs,
+        # and they may overlap, so we coalesce overlapping groups into
+        # separate windows.
+        window_ids_list = self.remove_overlaps(window_ids_list)
+        final_docs = []
+        final_scores = []
+        for w in window_ids_list:
+            metadata = copy.deepcopy(id2metadata[w[0]])
+            metadata.window_ids = w
+            document = Document(
+                content="".join([d.content for d in self.get_documents_by_ids(w)]),
+                metadata=metadata,
+            )
+            # make a fresh id since content is in general different
+            document.metadata.id = ObjectRegistry.new_id()
+            final_docs += [document]
+            final_scores += [max(id2max_score[id] for id in w)]
+        return list(zip(final_docs, final_scores))
+
+    @staticmethod
+    def remove_overlaps(windows: List[List[str]]) -> List[List[str]]:
+        """
+        Given a collection of windows, where each window is a sequence of ids,
+        identify groups of overlapping windows, and for each overlapping group,
+        order the chunk-ids using topological sort so they appear in the original
+        order in the text.
+
+        Args:
+            windows (List[int|str]): List of windows, where each window is a
+                sequence of ids.
+
+        Returns:
+            List[int|str]: List of windows, where each window is a sequence of ids,
+                and no two windows overlap.
+        """
+        ids = set(id for w in windows for id in w)
+        # id -> {win -> # pos}
+        id2win2pos: Dict[str, Dict[int, int]] = {id: {} for id in ids}
+
+        for i, w in enumerate(windows):
+            for j, id in enumerate(w):
+                id2win2pos[id][i] = j
+
+        n = len(windows)
+        # relation between windows:
+        order = np.zeros((n, n), dtype=np.int8)
+        for i, w in enumerate(windows):
+            for j, x in enumerate(windows):
+                if i == j:
+                    continue
+                if len(set(w).intersection(x)) == 0:
+                    continue
+                id = list(set(w).intersection(x))[0]  # any common id
+                if id2win2pos[id][i] > id2win2pos[id][j]:
+                    order[i, j] = -1  # win i is before win j
+                else:
+                    order[i, j] = 1  # win i is after win j
+
+        # find groups of windows that overlap, like connected components in a graph
+        groups = components(np.abs(order))
+
+        # order the chunk-ids in each group using topological sort
+        new_windows = []
+        for g in groups:
+            # find total ordering among windows in group based on order matrix
+            # (this is a topological sort)
+            _g = np.array(g)
+            order_matrix = order[_g][:, _g]
+            ordered_window_indices = topological_sort(order_matrix)
+            ordered_window_ids = [windows[i] for i in _g[ordered_window_indices]]
+            flattened = [id for w in ordered_window_ids for id in w]
+            flattened_deduped = list(dict.fromkeys(flattened))
+            # Note we are not going to split these, and instead we'll return
+            # larger windows from concatenating the connected groups.
+            # This ensures context is retained for LLM q/a
+            new_windows += [flattened_deduped]
+
+        return new_windows
+
+    @abstractmethod
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        """
+        Get all documents in the current collection, possibly filtered by `where`.
+        """
+        pass
+
+    @abstractmethod
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        """
+        Get documents by their ids.
+        Args:
+            ids (List[str]): List of document ids.
+
+        Returns:
+            List[Document]: List of documents
+        """
+        pass
+
+    @abstractmethod
+    def delete_collection(self, collection_name: str) -> None:
+        pass
+
+    def show_if_debug(self, doc_score_pairs: List[Tuple[Document, float]]) -> None:
+        if settings.debug:
+            for i, (d, s) in enumerate(doc_score_pairs):
+                print_long_text("red", "italic red", f"\nMATCH-{i}\n", d.content)
 </file>
 
 <file path="langroid/agent/special/sql/sql_chat_agent.py">
@@ -59540,2604 +62329,6 @@ def _model_name(model: str | ModelName) -> str:
     return model.value
 </file>
 
-<file path="langroid/language_models/openai_gpt.py">
-import hashlib
-import json
-import logging
-import os
-import sys
-import warnings
-from collections import defaultdict
-from functools import cache
-from itertools import chain
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Mapping,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    no_type_check,
-)
-
-import openai
-from cerebras.cloud.sdk import AsyncCerebras, Cerebras
-from groq import AsyncGroq, Groq
-from httpx import Timeout
-from openai import AsyncOpenAI, OpenAI
-from pydantic import BaseModel
-from pydantic_settings import BaseSettings, SettingsConfigDict
-from rich import print
-from rich.markup import escape
-
-from langroid.cachedb.base import CacheDB
-from langroid.cachedb.redis_cachedb import RedisCache, RedisCacheConfig
-from langroid.exceptions import LangroidImportError
-from langroid.language_models.base import (
-    LanguageModel,
-    LLMConfig,
-    LLMFunctionCall,
-    LLMFunctionSpec,
-    LLMMessage,
-    LLMResponse,
-    LLMTokenUsage,
-    OpenAIJsonSchemaSpec,
-    OpenAIToolCall,
-    OpenAIToolSpec,
-    Role,
-    StreamEventType,
-    ToolChoiceTypes,
-)
-from langroid.language_models.client_cache import (
-    get_async_cerebras_client,
-    get_async_groq_client,
-    get_async_openai_client,
-    get_cerebras_client,
-    get_groq_client,
-    get_openai_client,
-    wrap_api_key_provider_async,
-)
-from langroid.language_models.config import HFPromptFormatterConfig
-from langroid.language_models.model_info import (
-    DeepSeekModel,
-    MiniMaxModel,
-    OpenAI_API_ParamInfo,
-)
-from langroid.language_models.model_info import (
-    OpenAIChatModel as OpenAIChatModel,
-)
-from langroid.language_models.model_info import (
-    OpenAICompletionModel as OpenAICompletionModel,
-)
-from langroid.language_models.prompt_formatter.hf_formatter import (
-    HFFormatter,
-    find_hf_formatter,
-)
-from langroid.language_models.provider_params import (
-    DUMMY_API_KEY,
-    LangDBParams,
-    PortkeyParams,
-)
-from langroid.language_models.utils import (
-    async_retry_with_exponential_backoff,
-    retry_with_exponential_backoff,
-)
-from langroid.parsing.parse_json import parse_imperfect_json
-from langroid.utils.configuration import settings
-from langroid.utils.constants import Colors
-from langroid.utils.system import friendly_error
-
-logging.getLogger("openai").setLevel(logging.ERROR)
-
-if "OLLAMA_HOST" in os.environ:
-    OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
-else:
-    OLLAMA_BASE_URL = "http://localhost:11434/v1"
-
-DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
-# Provider prefixes that route to the Gemini OpenAI-compatible API.
-GEMINI_MODEL_PREFIXES = ("gemini/", "google/gemini-")
-GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
-MINIMAX_BASE_URL = "https://api.minimax.io/v1"
-OLLAMA_API_KEY = "ollama"
-
-VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
-LLAMACPP_API_KEY = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
-
-
-openai_chat_model_pref_list = [
-    OpenAIChatModel.GPT4o,
-    OpenAIChatModel.GPT4_1_NANO,
-    OpenAIChatModel.GPT4_1_MINI,
-    OpenAIChatModel.GPT4_1,
-    OpenAIChatModel.GPT4o_MINI,
-    OpenAIChatModel.O1_MINI,
-    OpenAIChatModel.O3_MINI,
-    OpenAIChatModel.O1,
-]
-
-openai_completion_model_pref_list = [
-    OpenAICompletionModel.DAVINCI,
-    OpenAICompletionModel.BABBAGE,
-]
-
-
-if "OPENAI_API_KEY" in os.environ:
-    try:
-        available_models = set(map(lambda m: m.id, OpenAI().models.list()))
-    except openai.AuthenticationError as e:
-        if settings.debug:
-            logging.warning(
-                f"""
-            OpenAI Authentication Error: {e}.
-            ---
-            If you intended to use an OpenAI Model, you should fix this,
-            otherwise you can ignore this warning.
-            """
-            )
-        available_models = set()
-    except Exception as e:
-        if settings.debug:
-            logging.warning(
-                f"""
-            Error while fetching available OpenAI models: {e}.
-            Proceeding with an empty set of available models.
-            """
-            )
-        available_models = set()
-else:
-    available_models = set()
-
-default_openai_chat_model = next(
-    chain(
-        filter(
-            lambda m: m.value in available_models,
-            openai_chat_model_pref_list,
-        ),
-        [OpenAIChatModel.GPT4o],
-    )
-)
-default_openai_completion_model = next(
-    chain(
-        filter(
-            lambda m: m.value in available_models,
-            openai_completion_model_pref_list,
-        ),
-        [OpenAICompletionModel.DAVINCI],
-    )
-)
-
-
-class AccessWarning(Warning):
-    pass
-
-
-@cache
-def gpt_3_5_warning() -> None:
-    warnings.warn(
-        f"""
-        {OpenAIChatModel.GPT4o} is not available,
-        falling back to {OpenAIChatModel.GPT3_5_TURBO}.
-        Examples may not work properly and unexpected behavior may occur.
-        Adjustments to prompts may be necessary.
-        """,
-        AccessWarning,
-    )
-
-
-@cache
-def parallel_strict_warning() -> None:
-    logging.warning(
-        "OpenAI tool calling in strict mode is not supported when "
-        "parallel tool calls are made. Disable parallel tool calling "
-        "to ensure correct behavior."
-    )
-
-
-def noop() -> None:
-    """Does nothing."""
-    return None
-
-
-class OpenAICallParams(BaseModel):
-    """
-    Various params that can be sent to an OpenAI API chat-completion call.
-    When specified, any param here overrides the one with same name in the
-    OpenAIGPTConfig.
-    See OpenAI API Reference for details on the params:
-    https://platform.openai.com/docs/api-reference/chat
-    """
-
-    max_tokens: int | None = None
-    temperature: float | None = None
-    frequency_penalty: float | None = None  # between -2 and 2
-    presence_penalty: float | None = None  # between -2 and 2
-    response_format: Dict[str, str] | None = None
-    logit_bias: Dict[int, float] | None = None  # token_id -> bias
-    logprobs: bool | None = None
-    top_p: float | None = None
-    reasoning_effort: str | None = None  # or "low" or "high" or "medium"
-    top_logprobs: int | None = None  # if int, requires logprobs=True
-    n: int | None = None  # how many completions to generate (n > 1 is NOT handled now)
-    stop: str | List[str] | None = None  # (list of) stop sequence(s)
-    seed: int | None = None
-    user: str | None = None  # user id for tracking
-    extra_body: Dict[str, Any] | None = None  # additional params for API request body
-
-    def to_dict_exclude_none(self) -> Dict[str, Any]:
-        return {k: v for k, v in self.model_dump().items() if v is not None}
-
-
-class LiteLLMProxyConfig(BaseSettings):
-    """Configuration for LiteLLM proxy connection."""
-
-    api_key: str = ""  # read from env var LITELLM_API_KEY if set
-    api_base: str = ""  # read from env var LITELLM_API_BASE if set
-
-    model_config = SettingsConfigDict(env_prefix="LITELLM_")
-
-
-class OpenAIGPTConfig(LLMConfig):
-    """
-    Class for any LLM with an OpenAI-like API: besides the OpenAI models this includes:
-    (a) locally-served models behind an OpenAI-compatible API
-    (b) non-local models, using a proxy adaptor lib like litellm that provides
-        an OpenAI-compatible API.
-    (We could rename this class to OpenAILikeConfig, but we keep it as-is for now)
-
-    Important Note:
-    Due to the `env_prefix = "OPENAI_"` defined below,
-    all of the fields below can be set AND OVERRIDDEN via env vars,
-    # by upper-casing the name and prefixing with OPENAI_, e.g.
-    # OPENAI_MAX_OUTPUT_TOKENS=1000.
-    # If any of these is defined in this way in the environment
-    # (either via explicit setenv or export or via .env file + load_dotenv()),
-    # the environment variable takes precedence over the value in the config.
-    """
-
-    type: str = "openai"
-    api_key: str = DUMMY_API_KEY
-    # Callable returning a fresh API key/bearer token, for endpoints that
-    # authenticate with short-lived rotating credentials (e.g. Vertex AI
-    # OAuth tokens, Azure Entra ID). Resolved per-request by the OpenAI
-    # client, and excluded from the client-cache key (the cache is keyed on
-    # the provider's identity), so rotating tokens neither go stale nor grow
-    # the cache. Takes precedence over `api_key`. Only supported for models
-    # served via an OpenAI-compatible endpoint (not Groq/Cerebras/litellm).
-    # See docs/notes/rotating-api-keys.md.
-    api_key_provider: Optional[Callable[[], str]] = None
-    organization: str = ""
-    api_base: str | None = None  # used for local or other non-OpenAI models
-    litellm: bool = False  # use litellm api?
-    litellm_proxy: LiteLLMProxyConfig = LiteLLMProxyConfig()
-    ollama: bool = False  # use ollama's OpenAI-compatible endpoint?
-    min_output_tokens: int = 1
-    use_chat_for_completion: bool = True  # do not change this, for OpenAI models!
-    timeout: int = 20
-    temperature: float = 0.2
-    seed: int | None = 42
-    params: OpenAICallParams | None = None
-    use_cached_client: bool = (
-        True  # Whether to reuse cached clients (prevents resource exhaustion)
-    )
-    # these can be any model name that is served at an OpenAI-compatible API end point
-    chat_model: str = default_openai_chat_model
-    chat_model_orig: Optional[str] = None
-    completion_model: str = default_openai_completion_model
-    run_on_first_use: Callable[[], None] = noop
-    parallel_tool_calls: Optional[bool] = None
-    # Supports constrained decoding which enforces that the output of the LLM
-    # adheres to a JSON schema
-    supports_json_schema: Optional[bool] = None
-    # Supports strict decoding for the generation of tool calls with
-    # the OpenAI Tools API; this ensures that the generated tools
-    # adhere to the provided schema.
-    supports_strict_tools: Optional[bool] = None
-    # a string that roughly matches a HuggingFace chat_template,
-    # e.g. "mistral-instruct-v0.2 (a fuzzy search is done to find the closest match)
-    formatter: str | None = None
-    hf_formatter: HFFormatter | None = None
-    langdb_params: LangDBParams = LangDBParams()
-    portkey_params: PortkeyParams = PortkeyParams()
-    headers: Dict[str, str] = {}
-    http_client_factory: Optional[Callable[[], Any]] = (
-        None  # Factory: returns Client or (Client, AsyncClient)
-    )
-    http_verify_ssl: bool = True  # Simple flag for SSL verification
-    http_client_config: Optional[Dict[str, Any]] = None  # Config dict for httpx.Client
-    _api_base_was_supplied: bool = False
-
-    def __init__(self, **kwargs) -> None:  # type: ignore
-        api_base_was_supplied = "api_base" in kwargs
-        local_model = "api_base" in kwargs and kwargs["api_base"] is not None
-
-        chat_model = kwargs.get("chat_model", "")
-        local_prefixes = ["local/", "litellm/", "ollama/", "vllm/", "llamacpp/"]
-        if any(chat_model.startswith(prefix) for prefix in local_prefixes):
-            local_model = True
-
-        warn_gpt_3_5 = (
-            "chat_model" not in kwargs.keys()
-            and not local_model
-            and default_openai_chat_model == OpenAIChatModel.GPT3_5_TURBO
-        )
-
-        if warn_gpt_3_5:
-            existing_hook = kwargs.get("run_on_first_use", noop)
-
-            def with_warning() -> None:
-                existing_hook()
-                gpt_3_5_warning()
-
-            kwargs["run_on_first_use"] = with_warning
-
-        super().__init__(**kwargs)
-        env_prefix = self.model_config.get("env_prefix")
-        env_api_base_name = f"{env_prefix}API_BASE"
-        env_api_base = os.getenv(env_api_base_name)
-        if not self.model_config.get("case_sensitive"):
-            case_insensitive_env = {
-                name.lower(): value for name, value in os.environ.items()
-            }
-            env_api_base = case_insensitive_env.get(env_api_base_name.lower())
-        api_base_was_supplied = api_base_was_supplied or (
-            self.api_base is not None
-            and (env_prefix != "OPENAI_" or self.api_base != env_api_base)
-        )
-        self._api_base_was_supplied = api_base_was_supplied
-
-    model_config = SettingsConfigDict(env_prefix="OPENAI_")
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        """Track API bases assigned after config construction."""
-        super().__setattr__(name, value)
-        if name == "api_base":
-            self._api_base_was_supplied = True
-
-    def model_copy(
-        self, *, update: Mapping[str, Any] | None = None, deep: bool = False
-    ) -> "OpenAIGPTConfig":
-        """
-        Copy config while preserving nested model instances and subclasses.
-
-        Important: Avoid reconstructing via `model_dump` as that coerces nested
-        models to their annotated base types (dropping subclass-only fields).
-        Instead, defer to Pydantic's native `model_copy`, which keeps nested
-        `BaseModel` instances (and their concrete subclasses) intact.
-
-        An `api_base` supplied through `update` is caller configuration, so the
-        copy must retain that provenance for provider-specific routing.
-        """
-        # Delegate to BaseSettings/BaseModel implementation to preserve types
-        copied = super().model_copy(update=update, deep=deep)
-        if update is not None and "api_base" in update:
-            copied._api_base_was_supplied = True
-        return copied  # type: ignore[return-value]
-
-    def _validate_litellm(self) -> None:
-        """
-        When using liteLLM, validate whether all env vars required by the model
-        have been set.
-        """
-        if not self.litellm:
-            return
-        try:
-            import litellm
-        except ImportError:
-            raise LangroidImportError("litellm", "litellm")
-
-        litellm.telemetry = False
-        litellm.drop_params = True  # drop un-supported params without crashing
-        litellm.modify_params = True
-        self.seed = None  # some local mdls don't support seed
-
-        if self.api_key == DUMMY_API_KEY:
-            keys_dict = litellm.utils.validate_environment(self.chat_model)
-            missing_keys = keys_dict.get("missing_keys", [])
-            if len(missing_keys) > 0:
-                raise ValueError(
-                    f"""
-                    Missing environment variables for litellm-proxied model:
-                    {missing_keys}
-                    """
-                )
-
-    @classmethod
-    def create(cls, prefix: str) -> Type["OpenAIGPTConfig"]:
-        """Create a config class whose params can be set via a desired
-        prefix from the .env file or env vars.
-        E.g., using
-        ```python
-        OllamaConfig = OpenAIGPTConfig.create("ollama")
-        ollama_config = OllamaConfig()
-        ```
-        you can have a group of params prefixed by "OLLAMA_", to be used
-        with models served via `ollama`.
-        This way, you can maintain several setting-groups in your .env file,
-        one per model type.
-        """
-
-        class DynamicConfig(OpenAIGPTConfig):
-            pass
-
-        DynamicConfig.model_config = SettingsConfigDict(env_prefix=prefix.upper() + "_")
-        return DynamicConfig
-
-
-class OpenAIResponse(BaseModel):
-    """OpenAI response model, either completion or chat."""
-
-    choices: List[Dict]  # type: ignore
-    usage: Dict  # type: ignore
-
-
-def litellm_logging_fn(model_call_dict: Dict[str, Any]) -> None:
-    """Logging function for litellm"""
-    try:
-        api_input_dict = model_call_dict.get("additional_args", {}).get(
-            "complete_input_dict"
-        )
-        if api_input_dict is not None:
-            text = escape(json.dumps(api_input_dict, indent=2))
-            print(
-                f"[grey37]LITELLM: {text}[/grey37]",
-            )
-    except Exception:
-        pass
-
-
-# Define a class for OpenAI GPT models that extends the base class
-class OpenAIGPT(LanguageModel):
-    """
-    Class for OpenAI LLMs
-    """
-
-    client: OpenAI | Groq | Cerebras | None
-    async_client: AsyncOpenAI | AsyncGroq | AsyncCerebras | None
-
-    def __init__(self, config: OpenAIGPTConfig = OpenAIGPTConfig()):
-        """
-        Args:
-            config: configuration for openai-gpt model
-        """
-        # copy the config to avoid modifying the original; deep to decouple
-        # nested models while preserving their concrete subclasses
-        # The api_key_provider must NOT be deep-copied: the client cache is
-        # keyed on its identity (so a copy would defeat cache sharing), and it
-        # may hold non-copyable state (e.g. a threading.Lock). Clear it in a
-        # shallow copy first, then restore the original callable afterwards.
-        api_key_provider = config.api_key_provider
-        if api_key_provider is not None:
-            config = config.model_copy(update={"api_key_provider": None})
-        config = config.model_copy(deep=True)
-        if api_key_provider is not None:
-            config.api_key_provider = api_key_provider
-        super().__init__(config)
-        self.config: OpenAIGPTConfig = config
-        # save original model name such as `provider/model` before
-        # we strip out the `provider` - we retain the original in
-        # case some params are specific to a provider.
-        self.chat_model_orig = self.config.chat_model_orig or self.config.chat_model
-
-        # Run the first time the model is used
-        self.run_on_first_use = cache(self.config.run_on_first_use)
-
-        # global override of chat_model,
-        # to allow quick testing with other models
-        if settings.chat_model != "":
-            self.config.chat_model = settings.chat_model
-            self.chat_model_orig = settings.chat_model
-            self.config.completion_model = settings.chat_model
-
-        if len(parts := self.config.chat_model.split("//")) > 1:
-            # there is a formatter specified, e.g.
-            # "litellm/ollama/mistral//hf" or
-            # "local/localhost:8000/v1//mistral-instruct-v0.2"
-            formatter = parts[1]
-            self.config.chat_model = parts[0]
-            if formatter == "hf":
-                # e.g. "litellm/ollama/mistral//hf" -> "litellm/ollama/mistral"
-                formatter = find_hf_formatter(self.config.chat_model)
-                if formatter != "":
-                    # e.g. "mistral"
-                    self.config.formatter = formatter
-                    logging.warning(
-                        f"""
-                        Using completions (not chat) endpoint with HuggingFace
-                        chat_template for {formatter} for
-                        model {self.config.chat_model}
-                        """
-                    )
-            else:
-                # e.g. "local/localhost:8000/v1//mistral-instruct-v0.2"
-                self.config.formatter = formatter
-
-        if self.config.formatter is not None:
-            self.config.hf_formatter = HFFormatter(
-                HFPromptFormatterConfig(model_name=self.config.formatter)
-            )
-
-        self.supports_json_schema: bool = self.config.supports_json_schema or False
-        self.supports_strict_tools: bool = self.config.supports_strict_tools or False
-
-        OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", DUMMY_API_KEY)
-        self.api_key = config.api_key
-
-        # if model name starts with "litellm",
-        # set the actual model name by stripping the "litellm/" prefix
-        # and set the litellm flag to True
-        if self.config.chat_model.startswith("litellm/") or self.config.litellm:
-            # e.g. litellm/ollama/mistral
-            self.config.litellm = True
-            self.api_base = self.config.api_base
-            if self.config.chat_model.startswith("litellm/"):
-                # strip the "litellm/" prefix
-                # e.g. litellm/ollama/llama2 => ollama/llama2
-                self.config.chat_model = self.config.chat_model.split("/", 1)[1]
-        elif self.config.chat_model.startswith("local/"):
-            # expect this to be of the form "local/localhost:8000/v1",
-            # depending on how the model is launched locally.
-            # In this case the model served locally behind an OpenAI-compatible API
-            # so we can just use `openai.*` methods directly,
-            # and don't need a adaptor library like litellm
-            self.config.litellm = False
-            self.config.seed = None  # some models raise an error when seed is set
-            # Extract the api_base from the model name after the "local/" prefix
-            self.api_base = self.config.chat_model.split("/", 1)[1]
-            if not self.api_base.startswith("http"):
-                self.api_base = "http://" + self.api_base
-        elif self.config.chat_model.startswith("ollama/"):
-            self.config.ollama = True
-
-            # use api_base from config if set, else fall back on OLLAMA_BASE_URL
-            self.api_base = self.config.api_base or OLLAMA_BASE_URL
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = OLLAMA_API_KEY
-            self.config.chat_model = self.config.chat_model.replace("ollama/", "")
-        elif self.config.chat_model.startswith("vllm/"):
-            self.supports_json_schema = True
-            self.config.chat_model = self.config.chat_model.replace("vllm/", "")
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
-            self.api_base = self.config.api_base or "http://localhost:8000/v1"
-            if not self.api_base.startswith("http"):
-                self.api_base = "http://" + self.api_base
-            if not self.api_base.endswith("/v1"):
-                self.api_base = self.api_base + "/v1"
-        elif self.config.chat_model.startswith("llamacpp/"):
-            self.supports_json_schema = True
-            self.api_base = self.config.chat_model.split("/", 1)[1]
-            if not self.api_base.startswith("http"):
-                self.api_base = "http://" + self.api_base
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
-        else:
-            self.api_base = self.config.api_base
-            # If api_base is unset we use OpenAI's endpoint, which supports
-            # these features (with JSON schema restricted to a limited set of models)
-            self.supports_strict_tools = self.api_base is None
-            self.supports_json_schema = (
-                self.api_base is None and self.info().has_structured_output
-            )
-
-        if settings.chat_model != "":
-            # if we're overriding chat model globally, set completion model to same
-            self.config.completion_model = self.config.chat_model
-
-        if self.config.formatter is not None:
-            # we want to format chats -> completions using this specific formatter
-            self.config.use_completion_for_chat = True
-            self.config.completion_model = self.config.chat_model
-
-        if self.config.use_completion_for_chat:
-            self.config.use_chat_for_completion = False
-
-        self.is_groq = self.config.chat_model.startswith("groq/")
-        self.is_cerebras = self.config.chat_model.startswith("cerebras/")
-        self.is_gemini = self.is_gemini_model()
-        self.is_deepseek = self.is_deepseek_model()
-        self.is_minimax = self.is_minimax_model()
-        self.is_glhf = self.config.chat_model.startswith("glhf/")
-        self.is_openrouter = self.config.chat_model.startswith("openrouter/")
-        self.is_langdb = self.config.chat_model.startswith("langdb/")
-        self.is_portkey = self.config.chat_model.startswith("portkey/")
-        self.is_litellm_proxy = self.config.chat_model.startswith("litellm-proxy/")
-
-        if self.config.api_key_provider is not None and (
-            self.is_groq or self.is_cerebras or self.config.litellm
-        ):
-            raise ValueError(
-                "api_key_provider is only supported for models served via an "
-                "OpenAI-compatible endpoint (using the OpenAI client); it "
-                "cannot be used with Groq, Cerebras, or the litellm adapter."
-            )
-
-        if self.is_groq:
-            # use groq-specific client
-            self.config.chat_model = self.config.chat_model.replace("groq/", "")
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = os.getenv("GROQ_API_KEY", DUMMY_API_KEY)
-            if self.config.use_cached_client:
-                self.client = get_groq_client(api_key=self.api_key)
-                self.async_client = get_async_groq_client(api_key=self.api_key)
-            else:
-                # Create new clients without caching
-                self.client = Groq(api_key=self.api_key)
-                self.async_client = AsyncGroq(api_key=self.api_key)
-        elif self.is_cerebras:
-            # use cerebras-specific client
-            self.config.chat_model = self.config.chat_model.replace("cerebras/", "")
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = os.getenv("CEREBRAS_API_KEY", DUMMY_API_KEY)
-            if self.config.use_cached_client:
-                self.client = get_cerebras_client(api_key=self.api_key)
-                # TODO there is not async client, so should we do anything here?
-                self.async_client = get_async_cerebras_client(api_key=self.api_key)
-            else:
-                # Create new clients without caching
-                self.client = Cerebras(api_key=self.api_key)
-                self.async_client = AsyncCerebras(api_key=self.api_key)
-        else:
-            # in these cases, there's no specific client: OpenAI python client suffices
-            if self.is_litellm_proxy:
-                self.config.chat_model = self.config.chat_model.replace(
-                    "litellm-proxy/", ""
-                )
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = self.config.litellm_proxy.api_key or self.api_key
-                self.api_base = self.config.litellm_proxy.api_base or self.api_base
-            elif self.is_gemini:
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = os.getenv("GEMINI_API_KEY", DUMMY_API_KEY)
-                # Prefer caller config, then Gemini env, then the default.
-                gemini_api_base = os.getenv("GEMINI_API_BASE", "")
-                explicit_api_base = (
-                    self.config.api_base if self.config._api_base_was_supplied else None
-                )
-                self.api_base = explicit_api_base or gemini_api_base or GEMINI_BASE_URL
-                if (
-                    self.config.chat_model.startswith("gemini/")
-                    or self.api_base == GEMINI_BASE_URL
-                ):
-                    self.config.chat_model = self.config.chat_model.split("/", 1)[1]
-            elif self.is_glhf:
-                self.config.chat_model = self.config.chat_model.replace("glhf/", "")
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = os.getenv("GLHF_API_KEY", DUMMY_API_KEY)
-                self.api_base = GLHF_BASE_URL
-            elif self.is_openrouter:
-                self.config.chat_model = self.config.chat_model.replace(
-                    "openrouter/", ""
-                )
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = os.getenv("OPENROUTER_API_KEY", DUMMY_API_KEY)
-                self.api_base = OPENROUTER_BASE_URL
-            elif self.is_deepseek:
-                self.config.chat_model = self.config.chat_model.replace("deepseek/", "")
-                self.api_base = DEEPSEEK_BASE_URL
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = os.getenv("DEEPSEEK_API_KEY", DUMMY_API_KEY)
-            elif self.is_minimax:
-                self.config.chat_model = self.config.chat_model.replace("minimax/", "")
-                # Honor caller-supplied base URL (e.g. regional endpoints,
-                # proxies) instead of always forcing the default.
-                openai_api_base = os.getenv("OPENAI_API_BASE")
-                explicit_api_base = (
-                    self.config.api_base
-                    if self.config.api_base and self.config.api_base != openai_api_base
-                    else None
-                )
-                self.api_base = explicit_api_base or MINIMAX_BASE_URL
-                if self.api_key == OPENAI_API_KEY:
-                    # Only overwrite with MINIMAX_API_KEY when it is actually
-                    # set, so users who intentionally put their MiniMax key in
-                    # OPENAI_API_KEY are not silently downgraded to a dummy key.
-                    minimax_key = os.getenv("MINIMAX_API_KEY", "")
-                    if minimax_key:
-                        self.api_key = minimax_key
-                # Recompute capabilities now that the prefix has been stripped
-                # and self.info() can find the model in MODEL_INFO.
-                self.supports_strict_tools = True
-                self.supports_json_schema = self.info().has_structured_output
-            elif self.is_langdb:
-                self.config.chat_model = self.config.chat_model.replace("langdb/", "")
-                self.api_base = self.config.langdb_params.base_url
-                project_id = self.config.langdb_params.project_id
-                if project_id:
-                    self.api_base += "/" + project_id + "/v1"
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = self.config.langdb_params.api_key or DUMMY_API_KEY
-
-                if self.config.langdb_params:
-                    params = self.config.langdb_params
-                    if params.project_id:
-                        self.config.headers["x-project-id"] = params.project_id
-                    if params.label:
-                        self.config.headers["x-label"] = params.label
-                    if params.run_id:
-                        self.config.headers["x-run-id"] = params.run_id
-                    if params.thread_id:
-                        self.config.headers["x-thread-id"] = params.thread_id
-            elif self.is_portkey:
-                # Parse the model string and extract provider/model
-                provider, model = self.config.portkey_params.parse_model_string(
-                    self.config.chat_model
-                )
-                self.config.chat_model = model
-                if provider:
-                    self.config.portkey_params.provider = provider
-
-                # Set Portkey base URL
-                self.api_base = self.config.portkey_params.base_url + "/v1"
-
-                # Set API key - use provider's API key from env if available
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = self.config.portkey_params.get_provider_api_key(
-                        self.config.portkey_params.provider, DUMMY_API_KEY
-                    )
-
-                # Add Portkey-specific headers
-                self.config.headers.update(self.config.portkey_params.get_headers())
-
-            # Sanitize the API key: strip leading/trailing whitespace
-            # (including stray newlines from .env files or CI secrets).
-            self.api_key = self.api_key.strip()
-
-            # Create http_client if needed - Priority order:
-            # 1. http_client_factory (most flexibility, not cacheable)
-            # 2. http_client_config (cacheable, moderate flexibility)
-            # 3. http_verify_ssl=False (cacheable, simple SSL bypass)
-            http_client = None
-            async_http_client = None
-            http_client_config_used = None
-
-            if self.config.http_client_factory is not None:
-                # Use the factory to create http_client (not cacheable)
-                http_client = self.config.http_client_factory()
-                if isinstance(http_client, (list, tuple)):
-                    if len(http_client) != 2:
-                        raise ValueError(
-                            "http_client_factory must return either a single "
-                            "httpx.Client or a tuple of "
-                            "(httpx.Client, httpx.AsyncClient)"
-                        )
-                    http_client, async_http_client = http_client
-                else:
-                    # set async_http_client to None - so that it will
-                    # be created later
-                    async_http_client = None
-            elif self.config.http_client_config is not None:
-                # Use config dict (cacheable)
-                http_client_config_used = self.config.http_client_config
-            elif not self.config.http_verify_ssl:
-                # Simple SSL bypass (cacheable)
-                http_client_config_used = {"verify": False}
-                logging.warning(
-                    "SSL verification has been disabled. This is insecure and "
-                    "should only be used in trusted environments (e.g., "
-                    "corporate networks with self-signed certificates)."
-                )
-
-            # With an api_key_provider, hand the callable itself to the
-            # OpenAI client, which resolves a fresh token on each request.
-            openai_api_key: Union[str, Callable[[], str]] = (
-                self.config.api_key_provider
-                if self.config.api_key_provider is not None
-                else self.api_key
-            )
-
-            if self.config.use_cached_client:
-                self.client = get_openai_client(
-                    api_key=openai_api_key,
-                    base_url=self.api_base,
-                    organization=self.config.organization,
-                    timeout=Timeout(self.config.timeout),
-                    default_headers=self.config.headers,
-                    http_client=http_client,
-                    http_client_config=http_client_config_used,
-                )
-                self.async_client = get_async_openai_client(
-                    api_key=openai_api_key,
-                    base_url=self.api_base,
-                    organization=self.config.organization,
-                    timeout=Timeout(self.config.timeout),
-                    default_headers=self.config.headers,
-                    http_client=async_http_client,
-                    http_client_config=http_client_config_used,
-                )
-            else:
-                # Create new clients without caching
-                client_kwargs: Dict[str, Any] = dict(
-                    api_key=openai_api_key,
-                    base_url=self.api_base,
-                    organization=self.config.organization,
-                    timeout=Timeout(self.config.timeout),
-                    default_headers=self.config.headers,
-                )
-                if http_client is not None:
-                    client_kwargs["http_client"] = http_client
-                elif http_client_config_used is not None:
-                    # Create http_client from config for non-cached scenario
-                    try:
-                        from httpx import Client
-
-                        client_kwargs["http_client"] = Client(**http_client_config_used)
-                    except ImportError:
-                        raise ValueError(
-                            "httpx is required to use http_client_config. "
-                            "Install it with: pip install httpx"
-                        )
-                self.client = OpenAI(**client_kwargs)
-
-                async_client_kwargs: Dict[str, Any] = dict(
-                    api_key=(
-                        # AsyncOpenAI awaits its api_key callable
-                        wrap_api_key_provider_async(openai_api_key)
-                        if callable(openai_api_key)
-                        else openai_api_key
-                    ),
-                    base_url=self.api_base,
-                    organization=self.config.organization,
-                    timeout=Timeout(self.config.timeout),
-                    default_headers=self.config.headers,
-                )
-                if async_http_client is not None:
-                    async_client_kwargs["http_client"] = async_http_client
-                elif http_client_config_used is not None:
-                    # Create async http_client from config for non-cached scenario
-                    try:
-                        from httpx import AsyncClient
-
-                        async_client_kwargs["http_client"] = AsyncClient(
-                            **http_client_config_used
-                        )
-                    except ImportError:
-                        raise ValueError(
-                            "httpx is required to use http_client_config. "
-                            "Install it with: pip install httpx"
-                        )
-                self.async_client = AsyncOpenAI(**async_client_kwargs)
-
-        self.cache: CacheDB | None = None
-        use_cache = self.config.cache_config is not None
-        if "redis" in settings.cache_type and use_cache:
-            if config.cache_config is None or not isinstance(
-                config.cache_config,
-                RedisCacheConfig,
-            ):
-                # switch to fresh redis config if needed
-                config.cache_config = RedisCacheConfig(
-                    fake="fake" in settings.cache_type
-                )
-            if "fake" in settings.cache_type:
-                # force use of fake redis if global cache_type is "fakeredis"
-                config.cache_config.fake = True
-            self.cache = RedisCache(config.cache_config)
-        elif settings.cache_type != "none" and use_cache:
-            raise ValueError(
-                f"Invalid cache type {settings.cache_type}. "
-                "Valid types are redis, fakeredis, none"
-            )
-
-        self.config._validate_litellm()
-
-    def _openai_api_call_params(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Prep the params to be sent to the OpenAI API
-        (or any OpenAI-compatible API, e.g. from Ooba or LmStudio)
-        for chat-completion.
-
-        Order of priority:
-        - (1) Params (mainly max_tokens) in the chat/achat/generate/agenerate call
-                (these are passed in via kwargs)
-        - (2) Params in OpenAIGPTConfig.params (of class OpenAICallParams)
-        - (3) Specific Params in OpenAIGPTConfig (just temperature for now)
-        """
-        params = dict(
-            temperature=self.config.temperature,
-        )
-        if self.config.params is not None:
-            params.update(self.config.params.to_dict_exclude_none())
-        params.update(kwargs)
-        return params
-
-    def is_openai_chat_model(self) -> bool:
-        openai_chat_models = [e.value for e in OpenAIChatModel]
-        return self.config.chat_model in openai_chat_models
-
-    def is_openai_completion_model(self) -> bool:
-        openai_completion_models = [e.value for e in OpenAICompletionModel]
-        return self.config.completion_model in openai_completion_models
-
-    def is_gemini_model(self) -> bool:
-        """Are we using the gemini OpenAI-compatible API?"""
-        return self.chat_model_orig.startswith(GEMINI_MODEL_PREFIXES)
-
-    def is_deepseek_model(self) -> bool:
-        deepseek_models = [e.value for e in DeepSeekModel]
-        return (
-            self.chat_model_orig in deepseek_models
-            or self.chat_model_orig.startswith("deepseek/")
-        )
-
-    def is_minimax_model(self) -> bool:
-        """Are we using the MiniMax OpenAI-compatible API?"""
-        minimax_models = [e.value for e in MiniMaxModel]
-        return (
-            self.chat_model_orig in minimax_models
-            or self.chat_model_orig.startswith("minimax/")
-        )
-
-    def unsupported_params(self) -> List[str]:
-        """
-        List of params that are not supported by the current model
-        """
-        unsupported = set(self.info().unsupported_params)
-        return list(unsupported)
-
-    def rename_params(self) -> Dict[str, str]:
-        """
-        Map of param name -> new name for specific models.
-        Currently main troublemaker is o1* series.
-        """
-        return self.info().rename_params
-
-    def chat_context_length(self) -> int:
-        """
-        Context-length for chat-completion models/endpoints.
-        Get it from the config if explicitly given,
-         otherwise use model_info based on model name, and fall back to
-         generic model_info if there's no match.
-        """
-        return self.config.chat_context_length or self.info().context_length
-
-    def completion_context_length(self) -> int:
-        """
-        Context-length for completion models/endpoints.
-        Get it from the config if explicitly given,
-         otherwise use model_info based on model name, and fall back to
-         generic model_info if there's no match.
-        """
-        return (
-            self.config.completion_context_length
-            or self.completion_info().context_length
-        )
-
-    def chat_cost(self) -> Tuple[float, float, float]:
-        """
-        (Prompt, Cached, Generation) cost per 1000 tokens, for chat-completion
-        models/endpoints.
-        Get it from the dict, otherwise fail-over to general method
-        """
-        info = self.info()
-        cached_cost_per_million = info.cached_cost_per_million
-        if not cached_cost_per_million:
-            cached_cost_per_million = info.input_cost_per_million
-        return (
-            info.input_cost_per_million / 1000,
-            cached_cost_per_million / 1000,
-            info.output_cost_per_million / 1000,
-        )
-
-    def set_stream(self, stream: bool) -> bool:
-        """Enable or disable streaming output from API.
-        Args:
-            stream: enable streaming output from API
-        Returns: previous value of stream
-        """
-        tmp = self.config.stream
-        self.config.stream = stream
-        return tmp
-
-    def get_stream(self) -> bool:
-        """Get streaming status."""
-        return self.config.stream and settings.stream and self.info().allows_streaming
-
-    @staticmethod
-    def _split_inline_reasoning(
-        event_text: str,
-        event_reasoning: str,
-        in_reasoning: bool,
-        thought_delimiters: Tuple[str, str],
-    ) -> Tuple[str, str, bool]:
-        """Separate inline reasoning from text tokens in a streaming chunk.
-
-        When models embed thinking inside content (e.g. <think>...</think>)
-        rather than using a separate reasoning field, this splits the chunk
-        into text-only and reasoning-only portions for proper streamer routing.
-
-        Returns (text_tokens, reasoning_tokens, in_reasoning).
-        """
-        text_tokens = event_text
-        reasoning_tokens = event_reasoning
-
-        if not event_text or event_reasoning:
-            return text_tokens, reasoning_tokens, in_reasoning
-
-        start, end = thought_delimiters
-        remaining = event_text
-
-        if in_reasoning:
-            text_tokens = ""
-        elif start in event_text:
-            before, _, after = event_text.partition(start)
-            text_tokens = before
-            remaining = after
-            in_reasoning = True
-
-        if in_reasoning:
-            if end in remaining:
-                before, _, after = remaining.partition(end)
-                text_tokens += after
-                reasoning_tokens = before
-                in_reasoning = False
-            else:
-                reasoning_tokens = remaining
-
-        return text_tokens, reasoning_tokens, in_reasoning
-
-    @no_type_check
-    def _process_stream_event(
-        self,
-        event,
-        chat: bool = False,
-        tool_deltas: List[Dict[str, Any]] = [],
-        has_function: bool = False,
-        completion: str = "",
-        reasoning: str = "",
-        function_args: str = "",
-        function_name: str = "",
-        in_reasoning: bool = False,
-    ) -> Tuple[bool, bool, str, str, bool, Dict[str, int]]:
-        """Process state vars while processing a streaming API response.
-            Returns a tuple consisting of:
-        - is_break: whether to break out of the loop
-        - has_function: whether the response contains a function_call
-        - function_name: name of the function
-        - function_args: args of the function
-        - completion: completion text
-        - reasoning: reasoning text
-        - usage: usage dict
-        """
-        # convert event obj (of type ChatCompletionChunk) to dict so rest of code,
-        # which expects dicts, works as it did before switching to openai v1.x
-        if not isinstance(event, dict):
-            event = event.model_dump()
-
-        usage = event.get("usage", {}) or {}
-        choices = event.get("choices", [{}])
-        if choices is None or len(choices) == 0:
-            choices = [{}]
-        if len(usage) > 0 and len(choices[0]) == 0:
-            # we have a "usage" chunk, and empty choices, so we're done
-            # ASSUMPTION: a usage chunk ONLY arrives AFTER all normal completion text!
-            # If any API does not follow this, we need to change this code.
-            return (
-                True,
-                has_function,
-                function_name,
-                function_args,
-                completion,
-                reasoning,
-                in_reasoning,
-                usage,
-            )
-        event_args = ""
-        event_fn_name = ""
-        event_tool_deltas: Optional[List[Dict[str, Any]]] = None
-        silent = settings.quiet
-        # The first two events in the stream of Azure OpenAI is useless.
-        # In the 1st: choices list is empty, in the 2nd: the dict delta has null content
-        if chat:
-            delta = choices[0].get("delta", {}) or {}
-            # capture both content and reasoning_content
-            event_text = delta.get("content", "")
-            event_reasoning = delta.get(
-                "reasoning_content",
-                delta.get("reasoning", ""),
-            )
-            if "function_call" in delta and delta["function_call"] is not None:
-                if "name" in delta["function_call"]:
-                    event_fn_name = delta["function_call"]["name"]
-                if "arguments" in delta["function_call"]:
-                    event_args = delta["function_call"]["arguments"]
-            if "tool_calls" in delta and delta["tool_calls"] is not None:
-                # it's a list of deltas, usually just one
-                event_tool_deltas = delta["tool_calls"]
-                tool_deltas += event_tool_deltas
-        else:
-            event_text = choices[0]["text"]
-            event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
-
-        finish_reason = choices[0].get("finish_reason", "")
-        if not event_text and finish_reason == "content_filter":
-            filter_names = [
-                n
-                for n, r in choices[0].get("content_filter_results", {}).items()
-                if r.get("filtered")
-            ]
-            event_text = (
-                "Cannot respond due to content filters ["
-                + ", ".join(filter_names)
-                + "]"
-            )
-            logging.warning("LLM API returned content filter error: " + event_text)
-
-        event_text_tokens, event_reasoning_tokens, in_reasoning = (
-            self._split_inline_reasoning(
-                event_text,
-                event_reasoning,
-                in_reasoning,
-                self.config.thought_delimiters,
-            )
-        )
-
-        if event_text:
-            completion += event_text
-        if event_text_tokens:
-            if not silent:
-                sys.stdout.write(Colors().GREEN + event_text_tokens)
-                sys.stdout.flush()
-            self.config.streamer(event_text_tokens, StreamEventType.TEXT)
-
-        if event_reasoning:
-            reasoning += event_reasoning
-        if event_reasoning_tokens:
-            if not silent:
-                sys.stdout.write(Colors().GREEN_DIM + event_reasoning_tokens)
-                sys.stdout.flush()
-            self.config.streamer(event_reasoning_tokens, StreamEventType.REASONING)
-
-        if event_fn_name:
-            function_name = event_fn_name
-            has_function = True
-            if not silent:
-                sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
-                sys.stdout.flush()
-            self.config.streamer(event_fn_name, StreamEventType.FUNC_NAME)
-
-        if event_args:
-            function_args += event_args
-            if not silent:
-                sys.stdout.write(Colors().GREEN + event_args)
-                sys.stdout.flush()
-            self.config.streamer(event_args, StreamEventType.FUNC_ARGS)
-
-        if event_tool_deltas is not None:
-            # print out streaming tool calls, if not async
-            for td in event_tool_deltas:
-                if td["function"]["name"] is not None:
-                    tool_fn_name = td["function"]["name"]
-                    if not silent:
-                        sys.stdout.write(
-                            Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
-                        )
-                        sys.stdout.flush()
-                    self.config.streamer(tool_fn_name, StreamEventType.TOOL_NAME)
-                if td["function"]["arguments"] != "":
-                    tool_fn_args = td["function"]["arguments"]
-                    if not silent:
-                        sys.stdout.write(Colors().GREEN + tool_fn_args)
-                        sys.stdout.flush()
-                    self.config.streamer(tool_fn_args, StreamEventType.TOOL_ARGS)
-
-        # show this delta in the stream
-        is_break = finish_reason in [
-            "stop",
-            "function_call",
-            "tool_calls",
-        ]
-        # for function_call, finish_reason does not necessarily
-        # contain "function_call" as mentioned in the docs.
-        # So we check for "stop" or "function_call" here.
-        return (
-            is_break,
-            has_function,
-            function_name,
-            function_args,
-            completion,
-            reasoning,
-            in_reasoning,
-            usage,
-        )
-
-    @no_type_check
-    async def _process_stream_event_async(
-        self,
-        event,
-        chat: bool = False,
-        tool_deltas: List[Dict[str, Any]] = [],
-        has_function: bool = False,
-        completion: str = "",
-        reasoning: str = "",
-        function_args: str = "",
-        function_name: str = "",
-        in_reasoning: bool = False,
-    ) -> Tuple[bool, bool, str, str, bool, Dict[str, int]]:
-        """Process state vars while processing a streaming API response.
-            Returns a tuple consisting of:
-        - is_break: whether to break out of the loop
-        - has_function: whether the response contains a function_call
-        - function_name: name of the function
-        - function_args: args of the function
-        - completion: completion text
-        - reasoning: reasoning text
-        - usage: usage dict
-        """
-        # convert event obj (of type ChatCompletionChunk) to dict so rest of code,
-        # which expects dicts, works as it did before switching to openai v1.x
-        if not isinstance(event, dict):
-            event = event.model_dump()
-
-        usage = event.get("usage", {}) or {}
-        choices = event.get("choices", [{}])
-        if len(choices) == 0:
-            choices = [{}]
-        if len(usage) > 0 and len(choices[0]) == 0:
-            # we got usage chunk, and empty choices, so we're done
-            return (
-                True,
-                has_function,
-                function_name,
-                function_args,
-                completion,
-                reasoning,
-                in_reasoning,
-                usage,
-            )
-        event_args = ""
-        event_fn_name = ""
-        event_tool_deltas: Optional[List[Dict[str, Any]]] = None
-        silent = self.config.async_stream_quiet or settings.quiet
-        # The first two events in the stream of Azure OpenAI is useless.
-        # In the 1st: choices list is empty, in the 2nd: the dict delta has null content
-        if chat:
-            delta = choices[0].get("delta", {}) or {}
-            event_text = delta.get("content", "")
-            event_reasoning = delta.get(
-                "reasoning_content",
-                delta.get("reasoning", ""),
-            )
-            if "function_call" in delta and delta["function_call"] is not None:
-                if "name" in delta["function_call"]:
-                    event_fn_name = delta["function_call"]["name"]
-                if "arguments" in delta["function_call"]:
-                    event_args = delta["function_call"]["arguments"]
-            if "tool_calls" in delta and delta["tool_calls"] is not None:
-                # it's a list of deltas, usually just one
-                event_tool_deltas = delta["tool_calls"]
-                tool_deltas += event_tool_deltas
-        else:
-            event_text = choices[0]["text"]
-            event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
-
-        event_text_tokens, event_reasoning_tokens, in_reasoning = (
-            self._split_inline_reasoning(
-                event_text,
-                event_reasoning,
-                in_reasoning,
-                self.config.thought_delimiters,
-            )
-        )
-
-        if event_text:
-            completion += event_text
-        if event_text_tokens:
-            if not silent:
-                sys.stdout.write(Colors().GREEN + event_text_tokens)
-                sys.stdout.flush()
-            await self.config.streamer_async(event_text_tokens, StreamEventType.TEXT)
-
-        if event_reasoning:
-            reasoning += event_reasoning
-        if event_reasoning_tokens:
-            if not silent:
-                sys.stdout.write(Colors().GREEN_DIM + event_reasoning_tokens)
-                sys.stdout.flush()
-            await self.config.streamer_async(
-                event_reasoning_tokens, StreamEventType.REASONING
-            )
-
-        if event_fn_name:
-            function_name = event_fn_name
-            has_function = True
-            if not silent:
-                sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
-                sys.stdout.flush()
-            await self.config.streamer_async(event_fn_name, StreamEventType.FUNC_NAME)
-
-        if event_args:
-            function_args += event_args
-            if not silent:
-                sys.stdout.write(Colors().GREEN + event_args)
-                sys.stdout.flush()
-            await self.config.streamer_async(event_args, StreamEventType.FUNC_ARGS)
-
-        if event_tool_deltas is not None:
-            # print out streaming tool calls, if not async
-            for td in event_tool_deltas:
-                if td["function"]["name"] is not None:
-                    tool_fn_name = td["function"]["name"]
-                    if not silent:
-                        sys.stdout.write(
-                            Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
-                        )
-                        sys.stdout.flush()
-                    await self.config.streamer_async(
-                        tool_fn_name, StreamEventType.TOOL_NAME
-                    )
-                if td["function"]["arguments"] != "":
-                    tool_fn_args = td["function"]["arguments"]
-                    if not silent:
-                        sys.stdout.write(Colors().GREEN + tool_fn_args)
-                        sys.stdout.flush()
-                    await self.config.streamer_async(
-                        tool_fn_args, StreamEventType.TOOL_ARGS
-                    )
-
-        # show this delta in the stream
-        is_break = choices[0].get("finish_reason", "") in [
-            "stop",
-            "function_call",
-            "tool_calls",
-        ]
-        # for function_call, finish_reason does not necessarily
-        # contain "function_call" as mentioned in the docs.
-        # So we check for "stop" or "function_call" here.
-        return (
-            is_break,
-            has_function,
-            function_name,
-            function_args,
-            completion,
-            reasoning,
-            in_reasoning,
-            usage,
-        )
-
-    @retry_with_exponential_backoff
-    def _stream_response(  # type: ignore
-        self, response, chat: bool = False
-    ) -> Tuple[LLMResponse, Dict[str, Any]]:
-        """
-        Grab and print streaming response from API.
-        Args:
-            response: event-sequence emitted by API
-            chat: whether in chat-mode (or else completion-mode)
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                Dict version of OpenAIResponse object (with choices, usage)
-
-        """
-        completion = ""
-        reasoning = ""
-        function_args = ""
-        function_name = ""
-
-        sys.stdout.write(Colors().GREEN)
-        sys.stdout.flush()
-        has_function = False
-        tool_deltas: List[Dict[str, Any]] = []
-        token_usage: Dict[str, int] = {}
-        done: bool = False
-        in_reasoning: bool = False  # Track if we're inside reasoning delimiters
-        content_present = False
-        try:
-            for event in response:
-                event_dict = event if isinstance(event, dict) else event.model_dump()
-                choices = event_dict.get("choices") or []
-                if chat and choices:
-                    delta = choices[0].get("delta") or {}
-                    content_present = content_present or (
-                        "content" in delta and delta["content"] is not None
-                    )
-                (
-                    is_break,
-                    has_function,
-                    function_name,
-                    function_args,
-                    completion,
-                    reasoning,
-                    in_reasoning,
-                    usage,
-                ) = self._process_stream_event(
-                    event,
-                    chat=chat,
-                    tool_deltas=tool_deltas,
-                    has_function=has_function,
-                    completion=completion,
-                    reasoning=reasoning,
-                    function_args=function_args,
-                    function_name=function_name,
-                    in_reasoning=in_reasoning,
-                )
-                if len(usage) > 0:
-                    # capture the token usage when non-empty
-                    token_usage = usage
-                if is_break:
-                    if not self.get_stream() or done:
-                        # if not streaming, then we don't wait for last "usage" chunk
-                        break
-                    else:
-                        # mark done, so we quit after the last "usage" chunk
-                        done = True
-
-        except Exception as e:
-            logging.warning("Error while processing stream response: %s", str(e))
-
-        if not settings.quiet:
-            print("")
-        # TODO- get usage info in stream mode (?)
-
-        return self._create_stream_response(
-            chat=chat,
-            tool_deltas=tool_deltas,
-            has_function=has_function,
-            completion=completion,
-            reasoning=reasoning,
-            function_args=function_args,
-            function_name=function_name,
-            usage=token_usage,
-            content_present=content_present,
-        )
-
-    @async_retry_with_exponential_backoff
-    async def _stream_response_async(  # type: ignore
-        self, response, chat: bool = False
-    ) -> Tuple[LLMResponse, Dict[str, Any]]:
-        """
-        Grab and print streaming response from API.
-        Args:
-            response: event-sequence emitted by API
-            chat: whether in chat-mode (or else completion-mode)
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                OpenAIResponse object (with choices, usage)
-
-        """
-
-        completion = ""
-        reasoning = ""
-        function_args = ""
-        function_name = ""
-
-        sys.stdout.write(Colors().GREEN)
-        sys.stdout.flush()
-        has_function = False
-        tool_deltas: List[Dict[str, Any]] = []
-        token_usage: Dict[str, int] = {}
-        done: bool = False
-        in_reasoning: bool = False  # Track if we're inside reasoning delimiters
-        content_present = False
-        try:
-            async for event in response:
-                event_dict = event if isinstance(event, dict) else event.model_dump()
-                choices = event_dict.get("choices") or []
-                if chat and choices:
-                    delta = choices[0].get("delta") or {}
-                    content_present = content_present or (
-                        "content" in delta and delta["content"] is not None
-                    )
-                (
-                    is_break,
-                    has_function,
-                    function_name,
-                    function_args,
-                    completion,
-                    reasoning,
-                    in_reasoning,
-                    usage,
-                ) = await self._process_stream_event_async(
-                    event,
-                    chat=chat,
-                    tool_deltas=tool_deltas,
-                    has_function=has_function,
-                    completion=completion,
-                    reasoning=reasoning,
-                    function_args=function_args,
-                    function_name=function_name,
-                    in_reasoning=in_reasoning,
-                )
-                if len(usage) > 0:
-                    # capture the token usage when non-empty
-                    token_usage = usage
-                if is_break:
-                    if not self.get_stream() or done:
-                        # if not streaming, then we don't wait for last "usage" chunk
-                        break
-                    else:
-                        # mark done, so we quit after the next "usage" chunk
-                        done = True
-
-        except Exception as e:
-            logging.warning("Error while processing stream response: %s", str(e))
-
-        if not settings.quiet:
-            print("")
-        # TODO- get usage info in stream mode (?)
-
-        return self._create_stream_response(
-            chat=chat,
-            tool_deltas=tool_deltas,
-            has_function=has_function,
-            completion=completion,
-            reasoning=reasoning,
-            function_args=function_args,
-            function_name=function_name,
-            usage=token_usage,
-            content_present=content_present,
-        )
-
-    @staticmethod
-    def tool_deltas_to_tools(
-        tools: List[Dict[str, Any]],
-    ) -> Tuple[
-        str,
-        List[OpenAIToolCall],
-        List[Dict[str, Any]],
-    ]:
-        """
-        Convert accumulated tool-call deltas to OpenAIToolCall objects.
-        Adapted from this excellent code:
-         https://community.openai.com/t/help-for-function-calls-with-streaming/627170/2
-
-        Args:
-            tools: list of tool deltas received from streaming API
-
-        Returns:
-            str: plain text corresponding to tool calls that failed to parse
-            List[OpenAIToolCall]: list of OpenAIToolCall objects
-            List[Dict[str, Any]]: list of tool dicts
-                (to reconstruct OpenAI API response, so it can be cached)
-        """
-        # Initialize a dictionary with default values
-
-        # idx -> dict repr of tool
-        # (used to simulate OpenAIResponse object later, and also to
-        # accumulate function args as strings)
-        idx2tool_dict: Dict[str, Dict[str, Any]] = defaultdict(
-            lambda: {
-                "id": None,
-                "function": {"arguments": "", "name": None},
-                "type": None,
-                "extra_content": None,
-            }
-        )
-
-        for tool_delta in tools:
-            if tool_delta["id"] is not None:
-                idx2tool_dict[tool_delta["index"]]["id"] = tool_delta["id"]
-
-            if tool_delta["function"]["name"] is not None:
-                idx2tool_dict[tool_delta["index"]]["function"]["name"] = tool_delta[
-                    "function"
-                ]["name"]
-
-            idx2tool_dict[tool_delta["index"]]["function"]["arguments"] += tool_delta[
-                "function"
-            ]["arguments"]
-
-            if tool_delta["type"] is not None:
-                idx2tool_dict[tool_delta["index"]]["type"] = tool_delta["type"]
-
-            if tool_delta.get("extra_content") is not None:
-                idx2tool_dict[tool_delta["index"]]["extra_content"] = tool_delta[
-                    "extra_content"
-                ]
-
-        # (try to) parse the fn args of each tool
-        contents: List[str] = []
-        good_indices = []
-        id2args: Dict[str, None | Dict[str, Any]] = {}
-        for idx, tool_dict in idx2tool_dict.items():
-            failed_content, args_dict = OpenAIGPT._parse_function_args(
-                tool_dict["function"]["arguments"]
-            )
-            # used to build tool_calls_list below
-            id2args[tool_dict["id"]] = args_dict or None  # if {}, store as None
-            if failed_content != "":
-                contents.append(failed_content)
-            else:
-                good_indices.append(idx)
-
-        # remove the failed tool calls
-        idx2tool_dict = {
-            idx: tool_dict
-            for idx, tool_dict in idx2tool_dict.items()
-            if idx in good_indices
-        }
-
-        # create OpenAIToolCall list
-        tool_calls_list = [
-            OpenAIToolCall(
-                id=tool_dict["id"],
-                function=LLMFunctionCall(
-                    name=tool_dict["function"]["name"],
-                    arguments=id2args.get(tool_dict["id"]),
-                ),
-                type=tool_dict["type"],
-                extra_content=tool_dict.get("extra_content"),
-            )
-            for tool_dict in idx2tool_dict.values()
-        ]
-        return "\n".join(contents), tool_calls_list, list(idx2tool_dict.values())
-
-    @staticmethod
-    def _parse_function_args(args: str) -> Tuple[str, Dict[str, Any]]:
-        """
-        Try to parse the `args` string as function args.
-
-        Args:
-            args: string containing function args
-
-        Returns:
-            Tuple of content, function name and args dict.
-            If parsing unsuccessful, returns the original string as content,
-            else returns the args dict.
-        """
-        content = ""
-        args_dict = {}
-        try:
-            stripped_fn_args = args.strip()
-            dict_or_list = parse_imperfect_json(stripped_fn_args)
-            if not isinstance(dict_or_list, dict):
-                raise ValueError(
-                    f"""
-                        Invalid function args: {stripped_fn_args}
-                        parsed as {dict_or_list},
-                        which is not a valid dict.
-                        """
-                )
-            args_dict = dict_or_list
-        except (SyntaxError, ValueError) as e:
-            logging.warning(
-                f"""
-                    Parsing OpenAI function args failed: {args};
-                    treating args as normal message. Error detail:
-                    {e}
-                    """
-            )
-            content = args
-
-        return content, args_dict
-
-    def _create_stream_response(
-        self,
-        chat: bool = False,
-        tool_deltas: List[Dict[str, Any]] = [],
-        has_function: bool = False,
-        completion: str = "",
-        reasoning: str = "",
-        function_args: str = "",
-        function_name: str = "",
-        usage: Dict[str, int] = {},
-        content_present: bool = False,
-    ) -> Tuple[LLMResponse, Dict[str, Any]]:
-        """
-        Create an LLMResponse object from the streaming API response.
-
-        Args:
-            chat: whether in chat-mode (or else completion-mode)
-            tool_deltas: list of tool deltas received from streaming API
-            has_function: whether the response contains a function_call
-            completion: completion text
-            reasoning: reasoning text
-            function_args: string representing function args
-            function_name: name of the function
-            usage: token usage dict
-            content_present: whether a stream delta explicitly contained content
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                Dict version of OpenAIResponse object (with choices, usage)
-                    (this is needed so we can cache the response, as if it were
-                    a non-streaming response)
-        """
-        # check if function_call args are valid, if not,
-        # treat this as a normal msg, not a function call
-        args: Dict[str, Any] = {}
-        if has_function and function_args != "":
-            content, args = self._parse_function_args(function_args)
-            completion = completion + content
-            if content != "":
-                has_function = False
-
-        # mock openai response so we can cache it
-        if chat:
-            failed_content, tool_calls, tool_dicts = OpenAIGPT.tool_deltas_to_tools(
-                tool_deltas,
-            )
-            if failed_content:
-                completion += ("\n" if completion else "") + failed_content
-                content_present = True
-            has_valid_call = len(tool_dicts) > 0 or has_function
-            response_content = (
-                None
-                if has_valid_call and not content_present and completion == ""
-                else completion
-            )
-            msg: Dict[str, Any] = dict(
-                message=dict(
-                    content=response_content,
-                    reasoning_content=reasoning,
-                ),
-            )
-            if len(tool_dicts) > 0:
-                msg["message"]["tool_calls"] = tool_dicts
-
-            if has_function:
-                function_call = LLMFunctionCall(name=function_name)
-                function_call_dict = function_call.model_dump()
-                if function_args == "":
-                    function_call.arguments = None
-                else:
-                    function_call.arguments = args
-                    function_call_dict.update({"arguments": function_args.strip()})
-                msg["message"]["function_call"] = function_call_dict
-        else:
-            # non-chat mode has no function_call
-            msg = dict(text=completion)
-            response_content = completion
-            # TODO: Ignoring reasoning content for non-chat models
-
-        # create an OpenAIResponse object so we can cache it as if it were
-        # a non-streaming response
-        openai_response = OpenAIResponse(
-            choices=[msg],
-            usage=dict(total_tokens=0),
-        )
-        # Track whether we extracted inline thought tags from the text.
-        # Only set message_with_reasoning when get_reasoning_final()
-        # actually finds and extracts inline tags (e.g. <think>...</think>).
-        # When reasoning is already provided via a separate API field
-        # (e.g. reasoning_content), the message text doesn't contain
-        # thought signatures, so there's nothing extra to preserve.
-        message_with_reasoning = None
-        message: str | None
-        if reasoning == "" and response_content is not None:
-            # some LLM APIs may not return a separate reasoning field,
-            # and the reasoning may be included in the message content
-            # within delimiters like <think> ... </think>
-            reasoning, message = self.get_reasoning_final(response_content)
-            if reasoning:
-                # Inline tags were found and extracted; preserve the
-                # original text so it can be restored in message history.
-                message_with_reasoning = response_content
-        else:
-            message = response_content
-
-        prompt_tokens = usage.get("prompt_tokens", 0)
-        prompt_tokens_details: Any = usage.get("prompt_tokens_details", {})
-        cached_tokens = (
-            prompt_tokens_details.get("cached_tokens", 0)
-            if isinstance(prompt_tokens_details, dict)
-            else 0
-        )
-        completion_tokens = usage.get("completion_tokens", 0)
-
-        return (
-            LLMResponse(
-                message=message,
-                reasoning=reasoning,
-                message_with_reasoning=message_with_reasoning,
-                cached=False,
-                # don't allow empty list [] here
-                oai_tool_calls=tool_calls or None if len(tool_deltas) > 0 else None,
-                function_call=function_call if has_function else None,
-                usage=LLMTokenUsage(
-                    prompt_tokens=prompt_tokens or 0,
-                    cached_tokens=cached_tokens or 0,
-                    completion_tokens=completion_tokens or 0,
-                    cost=self._cost_chat_model(
-                        prompt_tokens or 0,
-                        cached_tokens or 0,
-                        completion_tokens or 0,
-                    ),
-                ),
-            ),
-            openai_response.model_dump(),
-        )
-
-    def _cache_store(self, k: str, v: Any) -> None:
-        if self.cache is None:
-            return
-        try:
-            self.cache.store(k, v)
-        except Exception as e:
-            logging.error(f"Error in OpenAIGPT._cache_store: {e}")
-            pass
-
-    def _cache_lookup(self, fn_name: str, **kwargs: Dict[str, Any]) -> Tuple[str, Any]:
-        if self.cache is None:
-            return "", None  # no cache, return empty key and None result
-        # Use the kwargs as the cache key
-        sorted_kwargs_str = str(sorted(kwargs.items()))
-        raw_key = f"{fn_name}:{sorted_kwargs_str}"
-
-        # Hash the key to a fixed length using SHA256
-        hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
-
-        if not settings.cache:
-            # when caching disabled, return the hashed_key and none result
-            return hashed_key, None
-        # Try to get the result from the cache
-        try:
-            cached_val = self.cache.retrieve(hashed_key)
-        except Exception as e:
-            logging.error(f"Error in OpenAIGPT._cache_lookup: {e}")
-            return hashed_key, None
-        return hashed_key, cached_val
-
-    def _cost_chat_model(self, prompt: int, cached: int, completion: int) -> float:
-        price = self.chat_cost()
-        return (
-            price[0] * (prompt - cached) + price[1] * cached + price[2] * completion
-        ) / 1000
-
-    def _get_non_stream_token_usage(
-        self, cached: bool, response: Dict[str, Any]
-    ) -> LLMTokenUsage:
-        """
-        Extracts token usage from ``response`` and computes cost, only when NOT
-        in streaming mode, since the LLM API (OpenAI currently) was not
-        populating the usage fields in streaming mode (but as of Sep 2024, streaming
-        responses include  usage info as well, so we should update the code
-        to directly use usage information from the streaming response, which is more
-        accurate, esp with "thinking" LLMs like o1 series which consume
-        thinking tokens).
-        In streaming mode, these are set to zero for
-        now, and will be updated later by the fn ``update_token_usage``.
-        """
-        cost = 0.0
-        prompt_tokens = 0
-        cached_tokens = 0
-        completion_tokens = 0
-
-        usage = response.get("usage")
-        if not cached and not self.get_stream() and usage is not None:
-            prompt_tokens = usage.get("prompt_tokens") or 0
-            prompt_tokens_details = usage.get("prompt_tokens_details", {}) or {}
-            cached_tokens = prompt_tokens_details.get("cached_tokens") or 0
-            completion_tokens = usage.get("completion_tokens") or 0
-            cost = self._cost_chat_model(
-                prompt_tokens or 0,
-                cached_tokens or 0,
-                completion_tokens or 0,
-            )
-
-        return LLMTokenUsage(
-            prompt_tokens=prompt_tokens,
-            cached_tokens=cached_tokens,
-            completion_tokens=completion_tokens,
-            cost=cost,
-        )
-
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        self.run_on_first_use()
-
-        try:
-            return self._generate(prompt, max_tokens)
-        except openai.APIStatusError as e:
-            # Catch HTTP-level API errors (400, 401, 403, 404, 422, 429, 5xx)
-            # without traceback — these originate server-side and a local
-            # stack trace adds no diagnostic value.
-            # Note: APIConnectionError/APITimeoutError are intentionally NOT
-            # caught here so they fall through to the generic handler below,
-            # where the full traceback aids in diagnosing local network issues.
-            logging.error(f"API error in OpenAIGPT.generate: {e}")
-            raise
-        except Exception as e:
-            # log and re-raise exception
-            logging.error(friendly_error(e, "Error in OpenAIGPT.generate: "))
-            raise
-
-    def _generate(self, prompt: str, max_tokens: int) -> LLMResponse:
-        if self.config.use_chat_for_completion:
-            return self.chat(messages=prompt, max_tokens=max_tokens)
-
-        if self.is_groq or self.is_cerebras:
-            raise ValueError("Groq, Cerebras do not support pure completions")
-
-        if settings.debug:
-            print(f"[grey37]PROMPT: {escape(prompt)}[/grey37]")
-
-        @retry_with_exponential_backoff
-        def completions_with_backoff(**kwargs):  # type: ignore
-            cached = False
-            hashed_key, result = self._cache_lookup("Completion", **kwargs)
-            if result is not None:
-                cached = True
-                if settings.debug:
-                    print("[grey37]CACHED[/grey37]")
-            else:
-                if self.config.litellm:
-                    from litellm import completion as litellm_completion
-
-                    completion_call = litellm_completion
-
-                    if self.api_key != DUMMY_API_KEY:
-                        kwargs["api_key"] = self.api_key
-                else:
-                    if self.client is None:
-                        raise ValueError(
-                            "OpenAI/equivalent chat-completion client not set"
-                        )
-                    assert isinstance(self.client, OpenAI)
-                    completion_call = self.client.completions.create
-                if self.config.litellm and settings.debug:
-                    kwargs["logger_fn"] = litellm_logging_fn
-                # If it's not in the cache, call the API
-                result = completion_call(**kwargs)
-                if self.get_stream():
-                    llm_response, openai_response = self._stream_response(
-                        result,
-                        chat=self.config.litellm,
-                    )
-                    self._cache_store(hashed_key, openai_response)
-                    return cached, hashed_key, openai_response
-                else:
-                    self._cache_store(hashed_key, result.model_dump())
-            return cached, hashed_key, result
-
-        kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
-        if self.config.litellm:
-            # TODO this is a temp fix, we should really be using a proper completion fn
-            # that takes a pre-formatted prompt, rather than mocking it as a sys msg.
-            kwargs["messages"] = [dict(content=prompt, role=Role.SYSTEM)]
-        else:  # any other OpenAI-compatible endpoint
-            kwargs["prompt"] = prompt
-        args = dict(
-            **kwargs,
-            max_tokens=max_tokens,  # for output/completion
-            stream=self.get_stream(),
-        )
-        args = self._openai_api_call_params(args)
-        cached, hashed_key, response = completions_with_backoff(**args)
-        # assume response is an actual response rather than a streaming event
-        if not isinstance(response, dict):
-            response = response.model_dump()
-        if "message" in response["choices"][0]:
-            msg = (response["choices"][0]["message"]["content"] or "").strip()
-        else:
-            msg = (response["choices"][0]["text"] or "").strip()
-        return LLMResponse(message=msg, cached=cached)
-
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        self.run_on_first_use()
-
-        try:
-            return await self._agenerate(prompt, max_tokens)
-        except openai.APIStatusError as e:
-            # Catch HTTP-level API errors (see comment in generate() above).
-            logging.error(f"API error in OpenAIGPT.agenerate: {e}")
-            raise
-        except Exception as e:
-            # log and re-raise exception
-            logging.error(friendly_error(e, "Error in OpenAIGPT.agenerate: "))
-            raise
-
-    async def _agenerate(self, prompt: str, max_tokens: int) -> LLMResponse:
-        # note we typically will not have self.config.stream = True
-        # when issuing several api calls concurrently/asynchronously.
-        # The calling fn should use the context `with Streaming(..., False)` to
-        # disable streaming.
-        if self.config.use_chat_for_completion:
-            return await self.achat(messages=prompt, max_tokens=max_tokens)
-
-        if self.is_groq or self.is_cerebras:
-            raise ValueError("Groq, Cerebras do not support pure completions")
-
-        if settings.debug:
-            print(f"[grey37]PROMPT: {escape(prompt)}[/grey37]")
-
-        # WARNING: .Completion.* endpoints are deprecated,
-        # and as of Sep 2023 only legacy models will work here,
-        # e.g. text-davinci-003, text-ada-001.
-        @async_retry_with_exponential_backoff
-        async def completions_with_backoff(**kwargs):  # type: ignore
-            cached = False
-            hashed_key, result = self._cache_lookup("AsyncCompletion", **kwargs)
-            if result is not None:
-                cached = True
-                if settings.debug:
-                    print("[grey37]CACHED[/grey37]")
-            else:
-                if self.config.litellm:
-                    from litellm import acompletion as litellm_acompletion
-
-                    if self.api_key != DUMMY_API_KEY:
-                        kwargs["api_key"] = self.api_key
-
-                # TODO this may not work: text_completion is not async,
-                # and we didn't find an async version in litellm
-                assert isinstance(self.async_client, AsyncOpenAI)
-                acompletion_call = (
-                    litellm_acompletion
-                    if self.config.litellm
-                    else self.async_client.completions.create
-                )
-                if self.config.litellm and settings.debug:
-                    kwargs["logger_fn"] = litellm_logging_fn
-                # If it's not in the cache, call the API
-                result = await acompletion_call(**kwargs)
-                self._cache_store(hashed_key, result.model_dump())
-            return cached, hashed_key, result
-
-        kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
-        if self.config.litellm:
-            # TODO this is a temp fix, we should really be using a proper completion fn
-            # that takes a pre-formatted prompt, rather than mocking it as a sys msg.
-            kwargs["messages"] = [dict(content=prompt, role=Role.SYSTEM)]
-        else:  # any other OpenAI-compatible endpoint
-            kwargs["prompt"] = prompt
-        cached, hashed_key, response = await completions_with_backoff(
-            **kwargs,
-            max_tokens=max_tokens,
-            stream=False,
-        )
-        # assume response is an actual response rather than a streaming event
-        if not isinstance(response, dict):
-            response = response.model_dump()
-        if "message" in response["choices"][0]:
-            msg = (response["choices"][0]["message"]["content"] or "").strip()
-        else:
-            msg = (response["choices"][0]["text"] or "").strip()
-        return LLMResponse(message=msg, cached=cached)
-
-    def chat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        self.run_on_first_use()
-
-        if self.config.use_completion_for_chat and not self.is_openai_chat_model():
-            # only makes sense for non-OpenAI models
-            if self.config.formatter is None or self.config.hf_formatter is None:
-                raise ValueError(
-                    """
-                    `formatter` must be specified in config to use completion for chat.
-                    """
-                )
-            if isinstance(messages, str):
-                messages = [
-                    LLMMessage(
-                        role=Role.SYSTEM, content="You are a helpful assistant."
-                    ),
-                    LLMMessage(role=Role.USER, content=messages),
-                ]
-            prompt = self.config.hf_formatter.format(messages)
-            return self.generate(prompt=prompt, max_tokens=max_tokens)
-        try:
-            return self._chat(
-                messages,
-                max_tokens,
-                tools,
-                tool_choice,
-                functions,
-                function_call,
-                response_format,
-            )
-        except openai.APIStatusError as e:
-            # Catch HTTP-level API errors (see comment in generate() above).
-            logging.error(f"API error in OpenAIGPT.chat: {e}")
-            raise
-        except Exception as e:
-            # log and re-raise exception
-            logging.error(friendly_error(e, "Error in OpenAIGPT.chat: "))
-            raise
-
-    async def achat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        self.run_on_first_use()
-
-        # turn off streaming for async calls
-        if (
-            self.config.use_completion_for_chat
-            and not self.is_openai_chat_model()
-            and not self.is_openai_completion_model()
-        ):
-            # only makes sense for local models, where we are trying to
-            # convert a chat dialog msg-sequence to a simple completion prompt.
-            if self.config.formatter is None:
-                raise ValueError(
-                    """
-                    `formatter` must be specified in config to use completion for chat.
-                    """
-                )
-            formatter = HFFormatter(
-                HFPromptFormatterConfig(model_name=self.config.formatter)
-            )
-            if isinstance(messages, str):
-                messages = [
-                    LLMMessage(
-                        role=Role.SYSTEM, content="You are a helpful assistant."
-                    ),
-                    LLMMessage(role=Role.USER, content=messages),
-                ]
-            prompt = formatter.format(messages)
-            return await self.agenerate(prompt=prompt, max_tokens=max_tokens)
-        try:
-            result = await self._achat(
-                messages,
-                max_tokens,
-                tools,
-                tool_choice,
-                functions,
-                function_call,
-                response_format,
-            )
-            return result
-        except openai.APIStatusError as e:
-            # Catch HTTP-level API errors (see comment in generate() above).
-            logging.error(f"API error in OpenAIGPT.achat: {e}")
-            raise
-        except Exception as e:
-            # log and re-raise exception
-            logging.error(friendly_error(e, "Error in OpenAIGPT.achat: "))
-            raise
-
-    def _chat_completions_with_backoff_body(self, **kwargs):  # type: ignore
-        cached = False
-        hashed_key, result = self._cache_lookup("Completion", **kwargs)
-        if result is not None:
-            cached = True
-            if settings.debug:
-                print("[grey37]CACHED[/grey37]")
-        else:
-            # If it's not in the cache, call the API
-            if self.config.litellm:
-                from litellm import completion as litellm_completion
-
-                completion_call = litellm_completion
-
-                if self.api_key != DUMMY_API_KEY:
-                    kwargs["api_key"] = self.api_key
-            else:
-                if self.client is None:
-                    raise ValueError("OpenAI/equivalent chat-completion client not set")
-                completion_call = self.client.chat.completions.create
-            if self.config.litellm and settings.debug:
-                kwargs["logger_fn"] = litellm_logging_fn
-            result = completion_call(**kwargs)
-
-            if self.get_stream():
-                # If streaming, cannot cache result
-                # since it is a generator. Instead,
-                # we hold on to the hashed_key and
-                # cache the result later
-
-                # Test if this is a stream with an exception by
-                # trying to get first chunk: Some providers like LiteLLM
-                # produce a valid stream object `result` instead of throwing a
-                # rate-limit error, and if we don't catch it here,
-                # we end up returning an empty response and not
-                # using the retry mechanism in the decorator.
-                try:
-                    # try to get the first chunk to check for errors
-                    test_iter = iter(result)
-                    first_chunk = next(test_iter)
-                    # If we get here without error, recreate the stream
-                    result = chain([first_chunk], test_iter)
-                except StopIteration:
-                    # Empty stream is fine
-                    pass
-                except Exception as e:
-                    # Propagate any errors in the stream
-                    raise e
-            else:
-                self._cache_store(hashed_key, result.model_dump())
-        return cached, hashed_key, result
-
-    def _chat_completions_with_backoff(self, **kwargs):  # type: ignore
-        retry_func = retry_with_exponential_backoff(
-            self._chat_completions_with_backoff_body,
-            initial_delay=self.config.retry_params.initial_delay,
-            max_retries=self.config.retry_params.max_retries,
-            exponential_base=self.config.retry_params.exponential_base,
-            jitter=self.config.retry_params.jitter,
-        )
-        return retry_func(**kwargs)
-
-    async def _achat_completions_with_backoff_body(self, **kwargs):  # type: ignore
-        cached = False
-        hashed_key, result = self._cache_lookup("Completion", **kwargs)
-        if result is not None:
-            cached = True
-            if settings.debug:
-                print("[grey37]CACHED[/grey37]")
-        else:
-            if self.config.litellm:
-                from litellm import acompletion as litellm_acompletion
-
-                acompletion_call = litellm_acompletion
-
-                if self.api_key != DUMMY_API_KEY:
-                    kwargs["api_key"] = self.api_key
-            else:
-                if self.async_client is None:
-                    raise ValueError(
-                        "OpenAI/equivalent async chat-completion client not set"
-                    )
-                acompletion_call = self.async_client.chat.completions.create
-            if self.config.litellm and settings.debug:
-                kwargs["logger_fn"] = litellm_logging_fn
-            # If it's not in the cache, call the API
-            result = await acompletion_call(**kwargs)
-            if self.get_stream():
-                try:
-                    # Try to peek at the first chunk to immediately catch any errors
-                    # Store the original result (the stream)
-                    original_stream = result
-
-                    # Manually create and advance the iterator to check for errors
-                    stream_iter = original_stream.__aiter__()
-                    try:
-                        # This will raise an exception if the stream is invalid
-                        first_chunk = await anext(stream_iter)
-
-                        # If we reach here, the stream started successfully
-                        # Now recreate a fresh stream from the original API result
-                        # Otherwise, return a new stream that yields the first chunk
-                        # and remaining items
-                        async def combined_stream():  # type: ignore
-                            yield first_chunk
-                            async for chunk in stream_iter:
-                                yield chunk
-
-                        result = combined_stream()  # type: ignore
-                    except StopAsyncIteration:
-                        # Empty stream is normal - nothing to do
-                        pass
-                except Exception as e:
-                    # Any exception here should be raised to trigger the retry mechanism
-                    raise e
-            else:
-                self._cache_store(hashed_key, result.model_dump())
-        return cached, hashed_key, result
-
-    async def _achat_completions_with_backoff(self, **kwargs):  # type: ignore
-        retry_func = async_retry_with_exponential_backoff(
-            self._achat_completions_with_backoff_body,
-            initial_delay=self.config.retry_params.initial_delay,
-            max_retries=self.config.retry_params.max_retries,
-            exponential_base=self.config.retry_params.exponential_base,
-            jitter=self.config.retry_params.jitter,
-        )
-        return await retry_func(**kwargs)
-
-    def _prep_chat_completion(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> Dict[str, Any]:
-        """Prepare args for LLM chat-completion API call"""
-        if isinstance(messages, str):
-            llm_messages = [
-                LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
-                LLMMessage(role=Role.USER, content=messages),
-            ]
-        else:
-            llm_messages = messages
-            if (
-                len(llm_messages) == 1
-                and llm_messages[0].role == Role.SYSTEM
-                # TODO: we will unconditionally insert a dummy user msg
-                # if the only msg is a system msg.
-                # We could make this conditional on ModelInfo.needs_first_user_message
-            ):
-                # some LLMs, notable Gemini as of 12/11/24,
-                # require the first message to be from the user,
-                # so insert a dummy user msg if needed.
-                llm_messages.insert(
-                    1,
-                    LLMMessage(
-                        role=Role.USER, content="Follow the above instructions."
-                    ),
-                )
-
-        chat_model = self.config.chat_model
-
-        args: Dict[str, Any] = dict(
-            model=chat_model,
-            messages=[
-                m.api_dict(
-                    self.config.chat_model,
-                    has_system_role=self.info().allows_system_message,
-                )
-                for m in (llm_messages)
-            ],
-            max_completion_tokens=max_tokens,
-            stream=self.get_stream(),
-        )
-        if self.get_stream() and "groq" not in self.chat_model_orig:
-            # groq fails when we include stream_options in the request
-            args.update(
-                dict(
-                    # get token-usage numbers in stream mode from OpenAI API,
-                    # and possibly other OpenAI-compatible APIs.
-                    stream_options=dict(include_usage=True),
-                )
-            )
-        args.update(self._openai_api_call_params(args))
-        # only include functions-related args if functions are provided
-        # since the OpenAI API will throw an error if `functions` is None or []
-        if functions is not None:
-            args.update(
-                dict(
-                    functions=[f.model_dump() for f in functions],
-                    function_call=function_call,
-                )
-            )
-        if tools is not None:
-            if self.config.parallel_tool_calls is not None:
-                args["parallel_tool_calls"] = self.config.parallel_tool_calls
-
-            if any(t.strict for t in tools) and (
-                self.config.parallel_tool_calls is None
-                or self.config.parallel_tool_calls
-            ):
-                parallel_strict_warning()
-            args.update(
-                dict(
-                    tools=[
-                        dict(
-                            type="function",
-                            function=t.function.model_dump()
-                            | ({"strict": t.strict} if t.strict is not None else {}),
-                        )
-                        for t in tools
-                    ],
-                    tool_choice=tool_choice,
-                )
-            )
-        if response_format is not None:
-            args["response_format"] = response_format.to_dict()
-
-        for p in self.unsupported_params():
-            # some models e.g. o1-mini (as of sep 2024) don't support some params,
-            # like temperature and stream, so we need to remove them.
-            args.pop(p, None)
-
-        param_rename_map = self.rename_params()
-        for old_param, new_param in param_rename_map.items():
-            if old_param in args:
-                args[new_param] = args.pop(old_param)
-
-        # finally, get rid of extra_body params exclusive to certain models
-        # Only apply allowlist restrictions for known models.
-        # Unknown/custom models are allowed to use all params by default.
-        is_known_model = self.info().name != "unknown"
-        extra_params = args.get("extra_body", {})
-        if extra_params and is_known_model:
-            for param, model_list in OpenAI_API_ParamInfo().extra_parameters.items():
-                if (
-                    self.config.chat_model not in model_list
-                    and self.chat_model_orig not in model_list
-                ):
-                    extra_params.pop(param, None)
-            if extra_params:
-                args["extra_body"] = extra_params
-        return args
-
-    def _process_chat_completion_response(
-        self,
-        cached: bool,
-        response: Dict[str, Any],
-    ) -> LLMResponse:
-        # openAI response will look like this:
-        """
-        {
-            "id": "chatcmpl-123",
-            "object": "chat.completion",
-            "created": 1677652288,
-            "choices": [{
-                "index": 0,
-                "message": {
-                    "role": "assistant",
-                    "name": "",
-                    "content": "\n\nHello there, how may I help you?",
-                    "reasoning_content": "Okay, let's see here, hmmm...",
-                    "function_call": {
-                        "name": "fun_name",
-                        "arguments: {
-                            "arg1": "val1",
-                            "arg2": "val2"
-                        }
-                    },
-                },
-                "finish_reason": "stop"
-            }],
-            "usage": {
-                "prompt_tokens": 9,
-                "completion_tokens": 12,
-                "total_tokens": 21
-            }
-        }
-        """
-        choices = response.get("choices")
-        if isinstance(choices, list) and len(choices) > 0:
-            message = choices[0].get("message", {})
-        else:
-            message = {}
-        if message is None:
-            message = {}
-        content = message.get("content")
-        reasoning = message.get("reasoning_content", "")
-        # Track whether we extracted inline thought tags from the text.
-        # Only set message_with_reasoning when get_reasoning_final()
-        # actually finds and extracts inline tags (e.g. <think>...</think>).
-        # When reasoning is already provided via a separate API field
-        # (e.g. reasoning_content), the message text doesn't contain
-        # thought signatures, so there's nothing extra to preserve.
-        message_with_reasoning = None
-        if reasoning == "" and content is not None:
-            # some LLM APIs may not return a separate reasoning field,
-            # and the reasoning may be included in the message content
-            # within delimiters like <think> ... </think>
-            reasoning, msg = self.get_reasoning_final(content)
-            if reasoning:
-                # Inline tags were found and extracted; preserve the
-                # original text so it can be restored in message history.
-                message_with_reasoning = content
-        else:
-            msg = content
-
-        if message.get("function_call") is None:
-            fun_call = None
-        else:
-            try:
-                fun_call = LLMFunctionCall.from_dict(message["function_call"])
-            except (ValueError, SyntaxError):
-                logging.warning(
-                    "Could not parse function arguments: "
-                    f"{message['function_call']['arguments']} "
-                    f"for function {message['function_call']['name']} "
-                    "treating as normal non-function message"
-                )
-                fun_call = None
-                args_str = message["function_call"]["arguments"] or ""
-                msg_str = message["content"] or ""
-                msg = msg_str + args_str
-        oai_tool_calls = None
-        if message.get("tool_calls") is not None:
-            oai_tool_calls = []
-            for tool_call_dict in message["tool_calls"]:
-                try:
-                    tool_call = OpenAIToolCall.from_dict(tool_call_dict)
-                    oai_tool_calls.append(tool_call)
-                except (ValueError, SyntaxError):
-                    logging.warning(
-                        "Could not parse tool call: "
-                        f"{json.dumps(tool_call_dict)} "
-                        "treating as normal non-tool message"
-                    )
-                    serialized_tool_call = json.dumps(tool_call_dict)
-                    msg = (msg or "") + ("\n" if msg else "") + serialized_tool_call
-        return LLMResponse(
-            # None (no content, e.g. a tool-call-only response) is preserved as
-            # None rather than coerced to "", so the distinction survives
-            # downstream (see LLMMessage.content / ChatDocument.content_is_none).
-            message=msg.strip() if msg is not None else None,
-            reasoning=reasoning.strip() if reasoning is not None else "",
-            message_with_reasoning=message_with_reasoning,
-            function_call=fun_call,
-            oai_tool_calls=oai_tool_calls or None,  # don't allow empty list [] here
-            cached=cached,
-            usage=self._get_non_stream_token_usage(cached, response),
-        )
-
-    def _chat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """
-        ChatCompletion API call to OpenAI.
-        Args:
-            messages: list of messages  to send to the API, typically
-                represents back and forth dialogue between user and LLM, but could
-                also include "function"-role messages. If messages is a string,
-                it is assumed to be a user message.
-            max_tokens: max output tokens to generate
-            functions: list of LLMFunction specs available to the LLM, to possibly
-                use in its response
-            function_call: controls how the LLM uses `functions`:
-                - "auto": LLM decides whether to use `functions` or not,
-                - "none": LLM blocked from using any function
-                - a dict of {"name": "function_name"} which forces the LLM to use
-                    the specified function.
-        Returns:
-            LLMResponse object
-        """
-        args = self._prep_chat_completion(
-            messages,
-            max_tokens,
-            tools,
-            tool_choice,
-            functions,
-            function_call,
-            response_format,
-        )
-        cached, hashed_key, response = self._chat_completions_with_backoff(**args)  # type: ignore
-        if self.get_stream() and not cached:
-            llm_response, openai_response = self._stream_response(response, chat=True)
-            self._cache_store(hashed_key, openai_response)
-            return llm_response  # type: ignore
-        if isinstance(response, dict):
-            response_dict = response
-        else:
-            response_dict = response.model_dump()
-        return self._process_chat_completion_response(cached, response_dict)
-
-    async def _achat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """
-        Async version of _chat(). See that function for details.
-        """
-        args = self._prep_chat_completion(
-            messages,
-            max_tokens,
-            tools,
-            tool_choice,
-            functions,
-            function_call,
-            response_format,
-        )
-        cached, hashed_key, response = await self._achat_completions_with_backoff(  # type: ignore
-            **args
-        )
-        if self.get_stream() and not cached:
-            llm_response, openai_response = await self._stream_response_async(
-                response, chat=True
-            )
-            self._cache_store(hashed_key, openai_response)
-            return llm_response  # type: ignore
-        if isinstance(response, dict):
-            response_dict = response
-        else:
-            response_dict = response.model_dump()
-        return self._process_chat_completion_response(cached, response_dict)
-</file>
-
 <file path=".pre-commit-config.yaml">
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -65051,6 +65242,7 @@ nav:
       - Context-Overflow Handling: notes/context-overflow.md
       - Batch Processing: notes/batch-processing.md
       - Attachment Token Preflight: notes/attachment-token-preflight.md
+      - Vector-Store Env Prefixes: notes/vecstore-env-prefix.md
 
   - Examples:
     - Guide: examples/guide.md

--- a/llms-no-tests.txt
+++ b/llms-no-tests.txt
@@ -154,6 +154,7 @@ docs/
     tool-message-handler.md
     twitter-search.md
     url_loader.md
+    vecstore-env-prefix.md
     weaviate.md
     xml-tools.md
   overrides/
@@ -5064,6 +5065,207 @@ config = OpenAIGPTConfig(
 - Implements singleton pattern with lazy initialization
 - Automatically cleans up clients on program exit via atexit hooks
 - Compatible with both sync and async OpenAI clients
+</file>
+
+<file path="docs/notes/openai-http-client.md">
+# OpenAI HTTP Client Configuration
+
+When using OpenAI models through Langroid in corporate environments or behind proxies, you may encounter SSL certificate verification errors. Langroid provides three flexible options to configure the HTTP client used for OpenAI API calls.
+
+## Configuration Options
+
+### 1. Simple SSL Verification Bypass
+
+The quickest solution for development or trusted environments:
+
+```python
+import langroid.language_models as lm
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_verify_ssl=False  # Disables SSL certificate verification
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+!!! warning "Security Notice"
+    Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks. Only use this in trusted environments.
+
+### 2. HTTP Client Configuration Dictionary
+
+For common scenarios like proxies or custom certificates, use a configuration dictionary:
+
+```python
+import langroid.language_models as lm
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_config={
+        "verify": False,  # Or path to CA bundle: "/path/to/ca-bundle.pem"
+        "proxy": "http://proxy.company.com:8080",
+        "timeout": 30.0,
+        "headers": {
+            "User-Agent": "MyApp/1.0"
+        }
+    }
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+**Benefits**: This approach enables client caching, improving performance when creating multiple agents.
+
+### 3. Custom HTTP Client Factory
+
+For advanced scenarios requiring dynamic behavior or custom authentication:
+
+```python
+import langroid.language_models as lm
+from httpx import Client
+
+def create_custom_client():
+    """Factory function to create a custom HTTP client."""
+    client = Client(
+        verify="/path/to/corporate-ca-bundle.pem",
+        proxies={
+            "http": "http://proxy.corp.com:8080",
+            "https": "http://proxy.corp.com:8080"
+        },
+        timeout=30.0
+    )
+
+    # Add custom event hooks for logging
+    def log_request(request):
+        print(f"API Request: {request.method} {request.url}")
+
+    client.event_hooks = {"request": [log_request]}
+
+    return client
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_factory=create_custom_client
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+If you are using `async` methods, return a tuple of `(Client, AsyncClient)` from your factory:
+
+```python
+from httpx import AsyncClient, Client
+
+def create_custom_client():
+    """Factory function to create a custom sync and async HTTP clients."""
+    client_args = {
+        "verify": "/path/to/corporate-ca-bundle.pem",
+        "proxy": "http://proxy.corp.com:8080",
+        "timeout": 30.0,
+    }
+    client = Client(**client_args)
+    async_client = AsyncClient(**client_args)
+
+    return client, async_client
+```
+
+**Note**: Custom factories bypass client caching. Each `OpenAIGPT` instance creates a new client.
+
+## Priority Order
+
+When multiple options are specified, they are applied in this order:
+1. `http_client_factory` (highest priority)
+2. `http_client_config`
+3. `http_verify_ssl` (lowest priority)
+
+## Common Use Cases
+
+### Corporate Proxy with Custom CA Certificate
+
+```python
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_config={
+        "verify": "/path/to/corporate-ca-bundle.pem",
+        "proxies": {
+            "http": "http://proxy.corp.com:8080",
+            "https": "https://proxy.corp.com:8443"
+        }
+    }
+)
+```
+
+### Debugging API Calls
+
+```python
+def debug_client_factory():
+    from httpx import Client
+
+    client = Client(verify=False)
+
+    def log_response(response):
+        print(f"Status: {response.status_code}")
+        print(f"Headers: {response.headers}")
+
+    client.event_hooks = {
+        "response": [log_response]
+    }
+
+    return client
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_factory=debug_client_factory
+)
+```
+
+### Local Development with Self-Signed Certificates
+
+```python
+# For local OpenAI-compatible APIs
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    api_base="https://localhost:8443/v1",
+    http_verify_ssl=False
+)
+```
+
+
+## Best Practices
+
+1. **Use the simplest option that meets your needs**:
+   - Development/testing: `http_verify_ssl=False`
+   - Corporate environments: `http_client_config` with proper CA bundle
+   - Complex requirements: `http_client_factory`
+
+2. **Prefer configuration over factories for better performance** - configured clients are cached and reused
+
+3. **Always use proper CA certificates in production** instead of disabling SSL verification
+
+4. **Test your configuration** with a simple API call before deploying:
+   ```python
+   llm = lm.OpenAIGPT(config)
+   response = llm.chat("Hello")
+   print(response.content)
+   ```
+
+## Troubleshooting
+
+### SSL Certificate Errors
+```
+ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
+```
+**Solution**: Use one of the three configuration options above.
+
+
+### Proxy Connection Issues
+- Verify proxy URL format: `http://proxy:port` or `https://proxy:port`
+- Check if proxy requires authentication
+- Ensure proxy allows connections to `api.openai.com`
+
+## See Also
+
+- [OpenAI API Reference](https://platform.openai.com/docs/api-reference) - Official OpenAI documentation
 </file>
 
 <file path="docs/notes/overview.md">
@@ -51216,148 +51418,6 @@ __all__ = [
 ]
 </file>
 
-<file path="langroid/utils/configuration.py">
-import os
-import threading
-from contextlib import contextmanager
-from typing import Any, Dict, Iterator, List, Literal, cast
-
-from dotenv import find_dotenv, load_dotenv
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
-# Global reentrant lock to serialize any modifications to the global settings.
-_global_lock = threading.RLock()
-
-
-class Settings(BaseSettings):
-    debug: bool = False  # show debug messages?
-    max_turns: int = -1  # maximum number of turns in a task (to avoid inf loop)
-    progress: bool = False  # show progress spinners/bars?
-    stream: bool = True  # stream output?
-    cache: bool = True  # use cache?
-    cache_type: Literal["redis", "fakeredis", "none"] = "redis"  # cache type
-    chat_model: str = ""  # language model name, e.g. litellm/ollama/llama2
-    quiet: bool = False  # quiet mode (i.e. suppress all output)?
-    notebook: bool = False  # running in a notebook?
-
-    model_config = SettingsConfigDict(extra="forbid")
-
-
-# Load environment variables from .env file.
-load_dotenv(find_dotenv(usecwd=True))
-
-# The global (default) settings instance.
-# This is updated by update_global_settings() and set_global().
-_global_settings = Settings()
-
-# Thread-local storage for temporary (per-thread) settings overrides.
-_thread_local = threading.local()
-
-
-class SettingsProxy:
-    """
-    A proxy for the settings that returns a thread‐local override if set,
-    or else falls back to the global settings.
-    """
-
-    def __getattr__(self, name: str) -> Any:
-        # If the calling thread has set an override, use that.
-        if hasattr(_thread_local, "override"):
-            return getattr(_thread_local.override, name)
-        return getattr(_global_settings, name)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        # All writes go to the global settings.
-        setattr(_global_settings, name, value)
-
-    def update(self, new_settings: Settings) -> None:
-        _global_settings.__dict__.update(new_settings.__dict__)
-
-    def dict(self) -> Dict[str, Any]:
-        # Return a dict view of the settings as seen by the caller.
-        # Note that temporary overrides are not “merged” with global settings.
-        if hasattr(_thread_local, "override"):
-            return cast(
-                Dict[str, Any], cast(Settings, _thread_local.override.model_dump())
-            )
-        return _global_settings.model_dump()
-
-
-settings = SettingsProxy()
-
-
-def update_global_settings(cfg: BaseSettings, keys: List[str]) -> None:
-    """
-    Update global settings so that modules can later access them via, e.g.,
-
-        from langroid.utils.configuration import settings
-        if settings.debug: ...
-
-    This updates the global default.
-    """
-    config_dict = cfg.model_dump()
-    filtered_config = {key: config_dict[key] for key in keys if key in config_dict}
-    new_settings = Settings(**filtered_config)
-    _global_settings.__dict__.update(new_settings.__dict__)
-
-
-def set_global(key_vals: Settings) -> None:
-    """
-    Update the global settings object.
-    """
-    _global_settings.__dict__.update(key_vals.__dict__)
-
-
-@contextmanager
-def temporary_settings(temp_settings: Settings) -> Iterator[None]:
-    """
-    Temporarily override the settings for the calling thread.
-
-    Within the context, any access to "settings" will use the provided temporary
-    settings. Once the context is exited, the thread reverts to the global settings.
-    """
-    saved = getattr(_thread_local, "override", None)
-    _thread_local.override = temp_settings
-    try:
-        yield
-    finally:
-        if saved is not None:
-            _thread_local.override = saved
-        else:
-            del _thread_local.override
-
-
-@contextmanager
-def quiet_mode(quiet: bool = True) -> Iterator[None]:
-    """
-    Temporarily override settings.quiet for the current thread.
-    This implementation builds on the thread‑local temporary_settings context manager.
-    The effective quiet mode is merged:
-    if quiet is already True (from an outer context),
-    then it remains True even if a nested context passes quiet=False.
-    """
-    current_effective = (
-        settings.model_dump()
-    )  # get the current thread's effective settings
-    # Create a new settings instance from the current effective state.
-    temp = Settings(**current_effective)
-    # Merge the new flag: once quiet is enabled, it stays enabled.
-    temp.quiet = settings.quiet or quiet
-    with temporary_settings(temp):
-        yield
-
-
-def set_env(settings_instance: BaseSettings) -> None:
-    """
-    Set environment variables from a BaseSettings instance.
-
-    Each field in the settings is written to os.environ.
-    """
-    for field_name, field in settings_instance.__class__.model_fields.items():
-        env_var_name = field.alias or field_name.upper()
-        os.environ[env_var_name] = str(settings_instance.model_dump()[field_name])
-</file>
-
 <file path="langroid/utils/constants.py">
 from pydantic import BaseModel
 
@@ -57474,207 +57534,6 @@ matches = agent.vecdb.similar_texts_with_scores(
     where='{"source": "milvus-docs"}',
 )
 ```
-</file>
-
-<file path="docs/notes/openai-http-client.md">
-# OpenAI HTTP Client Configuration
-
-When using OpenAI models through Langroid in corporate environments or behind proxies, you may encounter SSL certificate verification errors. Langroid provides three flexible options to configure the HTTP client used for OpenAI API calls.
-
-## Configuration Options
-
-### 1. Simple SSL Verification Bypass
-
-The quickest solution for development or trusted environments:
-
-```python
-import langroid.language_models as lm
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_verify_ssl=False  # Disables SSL certificate verification
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-!!! warning "Security Notice"
-    Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks. Only use this in trusted environments.
-
-### 2. HTTP Client Configuration Dictionary
-
-For common scenarios like proxies or custom certificates, use a configuration dictionary:
-
-```python
-import langroid.language_models as lm
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_config={
-        "verify": False,  # Or path to CA bundle: "/path/to/ca-bundle.pem"
-        "proxy": "http://proxy.company.com:8080",
-        "timeout": 30.0,
-        "headers": {
-            "User-Agent": "MyApp/1.0"
-        }
-    }
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-**Benefits**: This approach enables client caching, improving performance when creating multiple agents.
-
-### 3. Custom HTTP Client Factory
-
-For advanced scenarios requiring dynamic behavior or custom authentication:
-
-```python
-import langroid.language_models as lm
-from httpx import Client
-
-def create_custom_client():
-    """Factory function to create a custom HTTP client."""
-    client = Client(
-        verify="/path/to/corporate-ca-bundle.pem",
-        proxies={
-            "http": "http://proxy.corp.com:8080",
-            "https": "http://proxy.corp.com:8080"
-        },
-        timeout=30.0
-    )
-
-    # Add custom event hooks for logging
-    def log_request(request):
-        print(f"API Request: {request.method} {request.url}")
-
-    client.event_hooks = {"request": [log_request]}
-
-    return client
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_factory=create_custom_client
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-If you are using `async` methods, return a tuple of `(Client, AsyncClient)` from your factory:
-
-```python
-from httpx import AsyncClient, Client
-
-def create_custom_client():
-    """Factory function to create a custom sync and async HTTP clients."""
-    client_args = {
-        "verify": "/path/to/corporate-ca-bundle.pem",
-        "proxy": "http://proxy.corp.com:8080",
-        "timeout": 30.0,
-    }
-    client = Client(**client_args)
-    async_client = AsyncClient(**client_args)
-
-    return client, async_client
-```
-
-**Note**: Custom factories bypass client caching. Each `OpenAIGPT` instance creates a new client.
-
-## Priority Order
-
-When multiple options are specified, they are applied in this order:
-1. `http_client_factory` (highest priority)
-2. `http_client_config`
-3. `http_verify_ssl` (lowest priority)
-
-## Common Use Cases
-
-### Corporate Proxy with Custom CA Certificate
-
-```python
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_config={
-        "verify": "/path/to/corporate-ca-bundle.pem",
-        "proxies": {
-            "http": "http://proxy.corp.com:8080",
-            "https": "https://proxy.corp.com:8443"
-        }
-    }
-)
-```
-
-### Debugging API Calls
-
-```python
-def debug_client_factory():
-    from httpx import Client
-
-    client = Client(verify=False)
-
-    def log_response(response):
-        print(f"Status: {response.status_code}")
-        print(f"Headers: {response.headers}")
-
-    client.event_hooks = {
-        "response": [log_response]
-    }
-
-    return client
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_factory=debug_client_factory
-)
-```
-
-### Local Development with Self-Signed Certificates
-
-```python
-# For local OpenAI-compatible APIs
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    api_base="https://localhost:8443/v1",
-    http_verify_ssl=False
-)
-```
-
-
-## Best Practices
-
-1. **Use the simplest option that meets your needs**:
-   - Development/testing: `http_verify_ssl=False`
-   - Corporate environments: `http_client_config` with proper CA bundle
-   - Complex requirements: `http_client_factory`
-
-2. **Prefer configuration over factories for better performance** - configured clients are cached and reused
-
-3. **Always use proper CA certificates in production** instead of disabling SSL verification
-
-4. **Test your configuration** with a simple API call before deploying:
-   ```python
-   llm = lm.OpenAIGPT(config)
-   response = llm.chat("Hello")
-   print(response.content)
-   ```
-
-## Troubleshooting
-
-### SSL Certificate Errors
-```
-ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
-```
-**Solution**: Use one of the three configuration options above.
-
-
-### Proxy Connection Issues
-- Verify proxy URL format: `http://proxy:port` or `https://proxy:port`
-- Check if proxy requires authentication
-- Ensure proxy allows connections to `api.openai.com`
-
-## See Also
-
-- [OpenAI API Reference](https://platform.openai.com/docs/api-reference) - Official OpenAI documentation
 </file>
 
 <file path="docs/notes/rotating-api-keys.md">
@@ -66918,6 +66777,152 @@ def seltz_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
     return results
 </file>
 
+<file path="langroid/utils/configuration.py">
+import os
+import threading
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Literal, cast
+
+from dotenv import find_dotenv, load_dotenv
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Global reentrant lock to serialize any modifications to the global settings.
+_global_lock = threading.RLock()
+
+
+class Settings(BaseSettings):
+    debug: bool = False  # show debug messages?
+    max_turns: int = -1  # maximum number of turns in a task (to avoid inf loop)
+    progress: bool = False  # show progress spinners/bars?
+    stream: bool = True  # stream output?
+    cache: bool = True  # use cache?
+    cache_type: Literal["redis", "fakeredis", "none"] = "redis"  # cache type
+    chat_model: str = ""  # language model name, e.g. litellm/ollama/llama2
+    quiet: bool = False  # quiet mode (i.e. suppress all output)?
+    notebook: bool = False  # running in a notebook?
+
+    model_config = SettingsConfigDict(extra="forbid")
+
+
+# Load environment variables from .env file.
+load_dotenv(find_dotenv(usecwd=True))
+
+# The global (default) settings instance.
+# This is updated by update_global_settings() and set_global().
+_global_settings = Settings()
+
+# Thread-local storage for temporary (per-thread) settings overrides.
+_thread_local = threading.local()
+
+
+class SettingsProxy:
+    """
+    A proxy for the settings that returns a thread‐local override if set,
+    or else falls back to the global settings.
+    """
+
+    def __getattr__(self, name: str) -> Any:
+        # If the calling thread has set an override, use that.
+        if hasattr(_thread_local, "override"):
+            return getattr(_thread_local.override, name)
+        return getattr(_global_settings, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        # All writes go to the global settings.
+        setattr(_global_settings, name, value)
+
+    def update(self, new_settings: Settings) -> None:
+        _global_settings.__dict__.update(new_settings.__dict__)
+
+    def dict(self) -> Dict[str, Any]:
+        # Return a dict view of the settings as seen by the caller.
+        # Note that temporary overrides are not “merged” with global settings.
+        if hasattr(_thread_local, "override"):
+            return cast(
+                Dict[str, Any], cast(Settings, _thread_local.override.model_dump())
+            )
+        return _global_settings.model_dump()
+
+
+settings = SettingsProxy()
+
+
+def update_global_settings(cfg: BaseSettings, keys: List[str]) -> None:
+    """
+    Update global settings so that modules can later access them via, e.g.,
+
+        from langroid.utils.configuration import settings
+        if settings.debug: ...
+
+    This updates the global default.
+    """
+    config_dict = cfg.model_dump()
+    filtered_config = {key: config_dict[key] for key in keys if key in config_dict}
+    new_settings = Settings(**filtered_config)
+    _global_settings.__dict__.update(new_settings.__dict__)
+
+
+def set_global(key_vals: Settings) -> None:
+    """
+    Update the global settings object.
+    """
+    _global_settings.__dict__.update(key_vals.__dict__)
+
+
+@contextmanager
+def temporary_settings(temp_settings: Settings) -> Iterator[None]:
+    """
+    Temporarily override the settings for the calling thread.
+
+    Within the context, any access to "settings" will use the provided temporary
+    settings. Once the context is exited, the thread reverts to the global settings.
+    """
+    saved = getattr(_thread_local, "override", None)
+    _thread_local.override = temp_settings
+    try:
+        yield
+    finally:
+        if saved is not None:
+            _thread_local.override = saved
+        else:
+            del _thread_local.override
+
+
+@contextmanager
+def quiet_mode(quiet: bool = True) -> Iterator[None]:
+    """
+    Temporarily override settings.quiet for the current thread.
+    This implementation builds on the thread‑local temporary_settings context manager.
+    The effective quiet mode is merged:
+    if quiet is already True (from an outer context),
+    then it remains True even if a nested context passes quiet=False.
+    """
+    current_effective = (
+        settings.model_dump()
+    )  # get the current thread's effective settings
+    # Create a new settings instance from the current effective state.
+    temp = Settings(**current_effective)
+    # Merge the new flag: once quiet is enabled, it stays enabled.
+    temp.quiet = settings.quiet or quiet
+    with temporary_settings(temp):
+        yield
+
+
+def set_env(settings_instance: BaseSettings) -> None:
+    """
+    Set environment variables from a BaseSettings instance.
+
+    Each field in the settings is written to os.environ, under the name
+    the settings class itself reads: `<env_prefix><FIELD_NAME_UPPER>`,
+    or the field's explicit alias (which, per pydantic-settings
+    semantics, is the full env name and is not prefixed).
+    """
+    env_prefix = settings_instance.model_config.get("env_prefix", "")
+    for field_name, field in settings_instance.__class__.model_fields.items():
+        env_var_name = field.alias or f"{env_prefix}{field_name.upper()}"
+        os.environ[env_var_name] = str(settings_instance.model_dump()[field_name])
+</file>
+
 <file path="langroid/utils/pandas_utils.py">
 import ast
 from typing import Any, Dict
@@ -68332,945 +68337,6 @@ except ImportError:
     pass
 </file>
 
-<file path="langroid/vector_store/chromadb.py">
-import json
-import logging
-from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
-
-from langroid.embedding_models.base import (
-    EmbeddingModelsConfig,
-)
-from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.exceptions import LangroidImportError
-from langroid.mytypes import Document
-from langroid.utils.configuration import settings
-from langroid.utils.output.printing import print_long_text
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-logger = logging.getLogger(__name__)
-
-
-class ChromaDBConfig(VectorStoreConfig):
-    collection_name: str = "temp"
-    storage_path: str = ".chroma/data"
-    distance: Literal["cosine", "l2", "ip"] = "cosine"
-    construction_ef: int = 100
-    search_ef: int = 100
-    max_neighbors: int = 16
-    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    host: str = "127.0.0.1"
-    port: int = 6333
-
-
-class ChromaDB(VectorStore):
-    def __init__(self, config: ChromaDBConfig | None = None):
-        config = config if config is not None else ChromaDBConfig()
-        super().__init__(config)
-        try:
-            import chromadb
-        except ImportError:
-            raise LangroidImportError("chromadb", "chromadb")
-        self.config = config
-        self.client = chromadb.Client(
-            chromadb.config.Settings(
-                # chroma_db_impl="duckdb+parquet",
-                # is_persistent=bool(config.storage_path),
-                persist_directory=config.storage_path,
-            )
-        )
-        if self.config.collection_name is not None:
-            self.create_collection(
-                self.config.collection_name,
-                replace=self.config.replace_collection,
-            )
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """Clear all collections in the vector store with the given prefix."""
-
-        if not really:
-            logger.warning("Not deleting all collections, set really=True to confirm")
-            return 0
-        coll = [c for c in self.client.list_collections() if c.name.startswith(prefix)]
-        if len(coll) == 0:
-            logger.warning(f"No collections found with prefix {prefix}")
-            return 0
-        n_empty_deletes = 0
-        n_non_empty_deletes = 0
-        for c in coll:
-            n_empty_deletes += c.count() == 0
-            n_non_empty_deletes += c.count() > 0
-            self.client.delete_collection(name=c.name)
-        logger.warning(
-            f"""
-            Deleted {n_empty_deletes} empty collections and
-            {n_non_empty_deletes} non-empty collections.
-            """
-        )
-        return n_empty_deletes + n_non_empty_deletes
-
-    def clear_empty_collections(self) -> int:
-        colls = self.client.list_collections()
-        n_deletes = 0
-        for coll in colls:
-            if coll.count() == 0:
-                n_deletes += 1
-                self.client.delete_collection(name=coll.name)
-        return n_deletes
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """
-        List non-empty collections in the vector store.
-        Args:
-            empty (bool, optional): Whether to list empty collections.
-        Returns:
-            List[str]: List of non-empty collection names.
-        """
-        colls = self.client.list_collections()
-        if empty:
-            return [coll.name for coll in colls]
-        return [coll.name for coll in colls if coll.count() > 0]
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        """
-        Create a collection in the vector store, optionally replacing an existing
-            collection if `replace` is True.
-        Args:
-            collection_name (str): Name of the collection to create or replace.
-            replace (bool, optional): Whether to replace an existing collection.
-                Defaults to False.
-
-        """
-        self.config.collection_name = collection_name
-        if collection_name in self.list_collections(empty=True) and replace:
-            logger.warning(f"Replacing existing collection {collection_name}")
-            self.client.delete_collection(collection_name)
-        self.collection = self.client.create_collection(
-            name=self.config.collection_name,
-            embedding_function=self.embedding_fn,
-            get_or_create=not replace,
-            metadata={
-                "hnsw:space": self.config.distance,
-                "hnsw:construction_ef": self.config.construction_ef,
-                "hnsw:search_ef": self.config.search_ef,
-                # we could expose other configs, see:
-                # https://docs.trychroma.com/docs/collections/configure
-            },
-        )
-
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        super().maybe_add_ids(documents)
-        if documents is None:
-            return
-        contents: List[str] = [document.content for document in documents]
-        # convert metadatas to dicts so chroma can handle them
-        metadata_dicts: List[dict[str, Any]] = [
-            d.metadata.dict_bool_int() for d in documents
-        ]
-        for m in metadata_dicts:
-            # chroma does not handle non-atomic types in metadata
-            m["window_ids"] = ",".join(m["window_ids"])
-
-        ids = [str(d.id()) for d in documents]
-
-        colls = self.list_collections(empty=True)
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-        if self.config.collection_name not in colls:
-            self.create_collection(self.config.collection_name, replace=True)
-
-        self.collection.add(
-            # embedding_models=embedding_models,
-            documents=contents,
-            metadatas=metadata_dicts,
-            ids=ids,
-        )
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        filter = json.loads(where) if where else None
-        results = self.collection.get(
-            include=["documents", "metadatas"],
-            where=filter,
-        )
-        results["documents"] = [results["documents"]]
-        results["metadatas"] = [results["metadatas"]]
-        return self._docs_from_results(results)
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        # get them one by one since chroma mangles the order of the results
-        # when fetched from a list of ids.
-        results = [
-            self.collection.get(ids=[id], include=["documents", "metadatas"])
-            for id in ids
-        ]
-        final_results = {}
-        final_results["documents"] = [[r["documents"][0] for r in results]]
-        final_results["metadatas"] = [[r["metadatas"][0] for r in results]]
-        return self._docs_from_results(final_results)
-
-    def delete_collection(self, collection_name: str) -> None:
-        try:
-            self.client.delete_collection(name=collection_name)
-        except Exception:
-            pass
-
-    def similar_texts_with_scores(
-        self, text: str, k: int = 1, where: Optional[str] = None
-    ) -> List[Tuple[Document, float]]:
-        n = self.collection.count()
-        filter = json.loads(where) if where else None
-        results = self.collection.query(
-            query_texts=[text],
-            n_results=min(n, k),
-            where=filter,
-            include=["documents", "distances", "metadatas"],
-        )
-        docs = self._docs_from_results(results)
-        # chroma distances are 1 - cosine.
-        scores = [1 - s for s in results["distances"][0]]
-        return list(zip(docs, scores))
-
-    def _docs_from_results(self, results: Dict[str, Any]) -> List[Document]:
-        """
-        Helper function to convert results from ChromaDB to a list of Documents
-        Args:
-            results (dict): results from ChromaDB
-
-        Returns:
-            List[Document]: list of Documents
-        """
-        if len(results["documents"][0]) == 0:
-            return []
-        contents = results["documents"][0]
-        if settings.debug:
-            for i, c in enumerate(contents):
-                print_long_text("red", "italic red", f"MATCH-{i}", c)
-        metadatas = results["metadatas"][0]
-        for m in metadatas:
-            # restore the stringified list of window_ids into the original List[str]
-            if m["window_ids"].strip() == "":
-                m["window_ids"] = []
-            else:
-                m["window_ids"] = m["window_ids"].split(",")
-        docs = [
-            self.config.document_class(
-                content=d, metadata=self.config.metadata_class(**m)
-            )
-            for d, m in zip(contents, metadatas)
-        ]
-        return docs
-</file>
-
-<file path="langroid/vector_store/lancedb.py">
-from __future__ import annotations
-
-import logging
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Generator,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-)
-
-import pandas as pd
-from dotenv import load_dotenv
-from pydantic import BaseModel, ValidationError, create_model
-
-if TYPE_CHECKING:
-    from lancedb.query import LanceVectorQueryBuilder
-
-from langroid.embedding_models.base import (
-    EmbeddingModelsConfig,
-)
-from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.exceptions import LangroidImportError
-from langroid.mytypes import Document
-from langroid.utils.configuration import settings
-from langroid.utils.pydantic_utils import (
-    dataframe_to_document_model,
-    dataframe_to_documents,
-)
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-try:
-    import lancedb
-    from lancedb.pydantic import LanceModel, Vector
-
-    has_lancedb = True
-except ImportError:
-    has_lancedb = False
-
-logger = logging.getLogger(__name__)
-
-
-class LanceDBConfig(VectorStoreConfig):
-    cloud: bool = False
-    collection_name: str | None = "temp"
-    storage_path: str = ".lancedb/data"
-    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    distance: str = "cosine"
-
-
-class LanceDB(VectorStore):
-    def __init__(self, config: LanceDBConfig | None = None):
-        config = config if config is not None else LanceDBConfig()
-        super().__init__(config)
-        if not has_lancedb:
-            raise LangroidImportError("lancedb", "lancedb")
-
-        self.config: LanceDBConfig = config
-        self.host = config.host
-        self.port = config.port
-        self.is_from_dataframe = False  # were docs ingested from a dataframe?
-        self.df_metadata_columns: List[str] = []  # metadata columns from dataframe
-
-        load_dotenv()
-        if self.config.cloud:
-            logger.warning(
-                "LanceDB Cloud is not available yet. Switching to local storage."
-            )
-            config.cloud = False
-        else:
-            try:
-                self.client = lancedb.connect(
-                    uri=config.storage_path,
-                )
-            except Exception as e:
-                new_storage_path = config.storage_path + ".new"
-                logger.warning(
-                    f"""
-                    Error connecting to local LanceDB at {config.storage_path}:
-                    {e}
-                    Switching to {new_storage_path}
-                    """
-                )
-                self.client = lancedb.connect(
-                    uri=new_storage_path,
-                )
-
-    def clear_empty_collections(self) -> int:
-        coll_names = self.list_collections()
-        n_deletes = 0
-        for name in coll_names:
-            nr = self.client.open_table(name).head(1).shape[0]
-            if nr == 0:
-                n_deletes += 1
-                self.client.drop_table(name)
-        return n_deletes
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """Clear all collections with the given prefix."""
-        if not really:
-            logger.warning("Not deleting all collections, set really=True to confirm")
-            return 0
-        coll_names = [
-            c for c in self.list_collections(empty=True) if c.startswith(prefix)
-        ]
-        if len(coll_names) == 0:
-            logger.warning(f"No collections found with prefix {prefix}")
-            return 0
-        n_empty_deletes = 0
-        n_non_empty_deletes = 0
-        for name in coll_names:
-            nr = self.client.open_table(name).head(1).shape[0]
-            n_empty_deletes += nr == 0
-            n_non_empty_deletes += nr > 0
-            self.client.drop_table(name)
-        logger.warning(
-            f"""
-            Deleted {n_empty_deletes} empty collections and
-            {n_non_empty_deletes} non-empty collections.
-            """
-        )
-        return n_empty_deletes + n_non_empty_deletes
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """
-        Returns:
-            List of collection names that have at least one vector.
-
-        Args:
-            empty (bool, optional): Whether to include empty collections.
-        """
-        colls = self.client.table_names(limit=None)
-        if len(colls) == 0:
-            return []
-        if empty:  # include empty tbls
-            return colls  # type: ignore
-        counts = [self.client.open_table(coll).head(1).shape[0] for coll in colls]
-        return [coll for coll, count in zip(colls, counts) if count > 0]
-
-    def _create_lance_schema(self, doc_cls: Type[Document]) -> Type[BaseModel]:
-        """
-        NOTE: NOT USED, but leaving it here as it may be useful.
-
-        Create a subclass of LanceModel with fields:
-         - id (str)
-         - Vector field that has dims equal to
-            the embedding dimension of the embedding model, and a data field of type
-            DocClass.
-         - other fields from doc_cls
-
-        Args:
-            doc_cls (Type[Document]): A Pydantic model which should be a subclass of
-                Document, to be used as the type for the data field.
-
-        Returns:
-            Type[BaseModel]: A new Pydantic model subclassing from LanceModel.
-
-        Raises:
-            ValueError: If `n` is not a non-negative integer or if `DocClass` is not a
-                subclass of Document.
-        """
-        if not issubclass(doc_cls, Document):
-            raise ValueError("DocClass must be a subclass of Document")
-
-        if not has_lancedb:
-            raise LangroidImportError("lancedb", "lancedb")
-
-        n = self.embedding_dim
-
-        # Prepare fields for the new model
-        fields = {"id": (str, ...), "vector": (Vector(n), ...)}
-
-        sorted_fields = dict(
-            sorted(doc_cls.model_fields.items(), key=lambda item: item[0])
-        )
-        # Add both statically and dynamically defined fields from doc_cls
-        for field_name, field in sorted_fields.items():
-            field_type = field.annotation if hasattr(field, "annotation") else field
-            fields[field_name] = (field_type, field.default)
-
-        # Create the new model with dynamic fields
-        NewModel = create_model(
-            "NewModel", __base__=LanceModel, **fields
-        )  # type: ignore
-        return NewModel  # type: ignore
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        self.config.replace_collection = replace
-        self.config.collection_name = collection_name
-        if replace:
-            self.delete_collection(collection_name)
-
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        super().maybe_add_ids(documents)
-        colls = self.list_collections(empty=True)
-        if len(documents) == 0:
-            return
-        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-        coll_name = self.config.collection_name
-        if coll_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-        # self._maybe_set_doc_class_schema(documents[0])
-        table_exists = False
-        if (
-            coll_name in colls
-            and self.client.open_table(coll_name).head(1).shape[0] > 0
-        ):
-            # collection exists and  is not empty:
-            # if replace_collection is True, we'll overwrite the existing collection,
-            # else we'll append to it.
-            if self.config.replace_collection:
-                self.client.drop_table(coll_name)
-            else:
-                table_exists = True
-
-        ids = [str(d.id()) for d in documents]
-        # don't insert all at once, batch in chunks of b,
-        # else we get an API error
-        b = self.config.batch_size
-
-        def make_batches() -> Generator[List[Dict[str, Any]], None, None]:
-            for i in range(0, len(ids), b):
-                batch = [
-                    dict(
-                        id=ids[i + j],
-                        vector=embedding_vecs[i + j],
-                        **doc.model_dump(),
-                    )
-                    for j, doc in enumerate(documents[i : i + b])
-                ]
-                yield batch
-
-        try:
-            if table_exists:
-                tbl = self.client.open_table(coll_name)
-                tbl.add(make_batches())
-            else:
-                batch_gen = make_batches()
-                batch = next(batch_gen)
-                # use first batch to create table...
-                tbl = self.client.create_table(
-                    coll_name,
-                    data=batch,
-                    mode="create",
-                )
-                # ... and add the rest
-                tbl.add(batch_gen)
-        except Exception as e:
-            logger.error(
-                f"""
-                Error adding documents to LanceDB: {e}
-                POSSIBLE REMEDY: Delete the LancdDB storage directory
-                {self.config.storage_path} and try again.
-                """
-            )
-
-    def add_dataframe(
-        self,
-        df: pd.DataFrame,
-        content: str = "content",
-        metadata: List[str] = [],
-    ) -> None:
-        """
-        Add a dataframe to the collection.
-        Args:
-            df (pd.DataFrame): A dataframe
-            content (str): The name of the column in the dataframe that contains the
-                text content to be embedded using the embedding model.
-            metadata (List[str]): A list of column names in the dataframe that contain
-                metadata to be stored in the database. Defaults to [].
-        """
-        self.is_from_dataframe = True
-        actual_metadata = metadata.copy()
-        self.df_metadata_columns = actual_metadata  # could be updated below
-        # get content column
-        content_values = df[content].values.tolist()
-        embedding_vecs = self.embedding_fn(content_values)
-
-        # add vector column
-        df["vector"] = embedding_vecs
-        if content != "content":
-            # rename content column to "content", leave existing column intact
-            df = df.rename(columns={content: "content"}, inplace=False)
-
-        if "id" not in df.columns:
-            docs = dataframe_to_documents(df, content="content", metadata=metadata)
-            ids = [str(d.id()) for d in docs]
-            df["id"] = ids
-
-        if "id" not in actual_metadata:
-            actual_metadata += ["id"]
-
-        colls = self.list_collections(empty=True)
-        coll_name = self.config.collection_name
-        if (
-            coll_name not in colls
-            or self.client.open_table(coll_name).head(1).shape[0] == 0
-        ):
-            # collection either doesn't exist or is empty, so replace it
-            # and set new schema from df
-            self.client.create_table(
-                self.config.collection_name,
-                data=df,
-                mode="overwrite",
-            )
-            doc_cls = dataframe_to_document_model(
-                df,
-                content=content,
-                metadata=actual_metadata,
-                exclude=["vector"],
-            )
-            self.config.document_class = doc_cls  # type: ignore
-        else:
-            # collection exists and is not empty, so append to it
-            tbl = self.client.open_table(self.config.collection_name)
-            tbl.add(df)
-
-    def delete_collection(self, collection_name: str) -> None:
-        self.client.drop_table(collection_name, ignore_missing=True)
-
-    def _lance_result_to_docs(
-        self, result: "LanceVectorQueryBuilder"
-    ) -> List[Document]:
-        if self.is_from_dataframe:
-            df = result.to_pandas()
-            return dataframe_to_documents(
-                df,
-                content="content",
-                metadata=self.df_metadata_columns,
-                doc_cls=self.config.document_class,
-            )
-        else:
-            records = result.to_arrow().to_pylist()
-            return self._records_to_docs(records)
-
-    def _records_to_docs(self, records: List[Dict[str, Any]]) -> List[Document]:
-        try:
-            docs = [self.config.document_class(**rec) for rec in records]
-        except ValidationError as e:
-            raise ValueError(
-                f"""
-            Error validating LanceDB result: {e}
-            HINT: This could happen when you're re-using an
-            existing LanceDB store with a different schema.
-            Try deleting your local lancedb storage at `{self.config.storage_path}`
-            re-ingesting your documents and/or replacing the collections.
-            """
-            )
-        return docs
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        if self.config.collection_name not in self.list_collections(empty=True):
-            return []
-        tbl = self.client.open_table(self.config.collection_name)
-        pre_result = tbl.search(None).where(where or None).limit(None)
-        return self._lance_result_to_docs(pre_result)
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        _ids = [str(id) for id in ids]
-        tbl = self.client.open_table(self.config.collection_name)
-        docs = []
-        for _id in _ids:
-            results = self._lance_result_to_docs(tbl.search().where(f"id == '{_id}'"))
-            if len(results) > 0:
-                docs.append(results[0])
-        return docs
-
-    def similar_texts_with_scores(
-        self,
-        text: str,
-        k: int = 1,
-        where: Optional[str] = None,
-    ) -> List[Tuple[Document, float]]:
-        embedding = self.embedding_fn([text])[0]
-        tbl = self.client.open_table(self.config.collection_name)
-        result = (
-            tbl.search(embedding)
-            .metric(self.config.distance)
-            .where(where, prefilter=True)
-            .limit(k)
-        )
-        docs = self._lance_result_to_docs(result)
-        # note _distance is 1 - cosine
-        if self.is_from_dataframe:
-            scores = [
-                1 - rec["_distance"] for rec in result.to_pandas().to_dict("records")
-            ]
-        else:
-            scores = [1 - rec["_distance"] for rec in result.to_arrow().to_pylist()]
-        if len(docs) == 0:
-            logger.warning(f"No matches found for {text}")
-            return []
-        if settings.debug:
-            logger.info(f"Found {len(docs)} matches, max score: {max(scores)}")
-        doc_score_pairs = list(zip(docs, scores))
-        self.show_if_debug(doc_score_pairs)
-        return doc_score_pairs
-</file>
-
-<file path="langroid/vector_store/meilisearch.py">
-"""
-MeiliSearch as a pure document store, without its
-(experimental) vector-store functionality.
-We aim to use MeiliSearch for fast lexical search.
-Note that what we call "Collection" in Langroid is referred to as
-"Index" in MeiliSearch. Each data-store has its own terminology,
-but for uniformity we use the Langroid terminology here.
-"""
-
-from __future__ import annotations
-
-import asyncio
-import logging
-import os
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple
-
-from dotenv import load_dotenv
-
-if TYPE_CHECKING:
-    from meilisearch_python_sdk.index import AsyncIndex
-    from meilisearch_python_sdk.models.documents import DocumentsInfo
-
-
-from langroid.exceptions import LangroidImportError
-from langroid.mytypes import DocMetaData, Document
-from langroid.utils.configuration import settings
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-logger = logging.getLogger(__name__)
-
-
-class MeiliSearchConfig(VectorStoreConfig):
-    cloud: bool = False
-    collection_name: str | None = None
-    primary_key: str = "id"
-    port: int = 7700
-
-
-class MeiliSearch(VectorStore):
-    def __init__(self, config: MeiliSearchConfig | None = None):
-        config = config if config is not None else MeiliSearchConfig()
-        super().__init__(config)
-        try:
-            import meilisearch_python_sdk as meilisearch
-        except ImportError:
-            raise LangroidImportError("meilisearch", "meilisearch")
-
-        self.config: MeiliSearchConfig = config
-        self.host = config.host
-        self.port = config.port
-        load_dotenv()
-        self.key = os.getenv("MEILISEARCH_API_KEY") or "masterKey"
-        self.url = os.getenv("MEILISEARCH_API_URL") or f"http://{self.host}:{self.port}"
-        if config.cloud and None in [self.key, self.url]:
-            logger.warning(
-                f"""MEILISEARCH_API_KEY, MEILISEARCH_API_URL env variable must be set 
-                to use MeiliSearch in cloud mode. Please set these values 
-                in your .env file. Switching to local MeiliSearch at 
-                {self.url} 
-                """
-            )
-            config.cloud = False
-
-        self.client: Callable[[], meilisearch.AsyncClient] = lambda: (
-            meilisearch.AsyncClient(url=self.url, api_key=self.key)
-        )
-
-        # Note: Only create collection if a non-null collection name is provided.
-        # This is useful to delay creation of db until we have a suitable
-        # collection name (e.g. we could get it from the url or folder path).
-        if config.collection_name is not None:
-            self.create_collection(
-                config.collection_name, replace=config.replace_collection
-            )
-
-    def clear_empty_collections(self) -> int:
-        """All collections are treated as non-empty in MeiliSearch, so this is a
-        no-op"""
-        return 0
-
-    async def _async_delete_indices(self, uids: List[str]) -> List[bool]:
-        """Delete any indicecs in `uids` that exist.
-        Returns list of bools indicating whether the index has been deleted"""
-        async with self.client() as client:
-            result = await asyncio.gather(
-                *[client.delete_index_if_exists(uid=uid) for uid in uids]
-            )
-        return result
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """Delete all indices whose names start with `prefix`"""
-        if not really:
-            logger.warning("Not deleting all collections, set really=True to confirm")
-            return 0
-        coll_names = [c for c in self.list_collections() if c.startswith(prefix)]
-        deletes = asyncio.run(self._async_delete_indices(coll_names))
-        n_deletes = sum(deletes)
-        logger.warning(f"Deleted {n_deletes} indices in MeiliSearch")
-        return n_deletes
-
-    def _list_all_collections(self) -> List[str]:
-        """
-        List all collections, including empty ones.
-        Returns:
-            List of collection names.
-        """
-        return self.list_collections()
-
-    async def _async_get_indexes(self) -> List[AsyncIndex]:
-        async with self.client() as client:
-            indexes = await client.get_indexes(limit=10_000)
-        return [] if indexes is None else indexes  # type: ignore
-
-    async def _async_get_index(self, index_uid: str) -> "AsyncIndex":
-        async with self.client() as client:
-            index = await client.get_index(index_uid)
-        return index  # type: ignore
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """
-        Returns:
-            List of index names stored. We treat any existing index as non-empty.
-        """
-        indexes = asyncio.run(self._async_get_indexes())
-        if len(indexes) == 0:
-            return []
-        else:
-            return [ind.uid for ind in indexes]
-
-    async def _async_create_index(self, collection_name: str) -> "AsyncIndex":
-        async with self.client() as client:
-            index = await client.create_index(
-                uid=collection_name,
-                primary_key=self.config.primary_key,
-            )
-        return index
-
-    async def _async_delete_index(self, collection_name: str) -> bool:
-        """Delete index if it exists. Returns True iff index was deleted"""
-        async with self.client() as client:
-            result = await client.delete_index_if_exists(uid=collection_name)
-        return result  # type: ignore
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        """
-        Create a collection with the given name, optionally replacing an existing
-            collection if `replace` is True.
-        Args:
-            collection_name (str): Name of the collection to create.
-            replace (bool): Whether to replace an existing collection
-                with the same name. Defaults to False.
-        """
-        self.config.collection_name = collection_name
-        collections = self.list_collections()
-        if collection_name in collections:
-            logger.warning(
-                f"MeiliSearch Non-empty Index {collection_name} already exists"
-            )
-            if not replace:
-                logger.warning("Not replacing collection")
-                return
-            else:
-                logger.warning("Recreating fresh collection")
-                asyncio.run(self._async_delete_index(collection_name))
-        asyncio.run(self._async_create_index(collection_name))
-        collection_info = asyncio.run(self._async_get_index(collection_name))
-        if settings.debug:
-            level = logger.getEffectiveLevel()
-            logger.setLevel(logging.INFO)
-            logger.info(collection_info)
-            logger.setLevel(level)
-
-    async def _async_add_documents(
-        self, collection_name: str, documents: Sequence[Dict[str, Any]]
-    ) -> None:
-        async with self.client() as client:
-            index = client.index(collection_name)
-            await index.add_documents_in_batches(
-                documents=documents,
-                batch_size=self.config.batch_size,
-                primary_key=self.config.primary_key,
-            )
-
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        super().maybe_add_ids(documents)
-        if len(documents) == 0:
-            return
-        colls = self._list_all_collections()
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-        if self.config.collection_name not in colls:
-            self.create_collection(self.config.collection_name, replace=True)
-        docs = [
-            dict(
-                id=d.id(),
-                content=d.content,
-                metadata=d.metadata.model_dump(),
-            )
-            for d in documents
-        ]
-        asyncio.run(self._async_add_documents(self.config.collection_name, docs))
-
-    def delete_collection(self, collection_name: str) -> None:
-        asyncio.run(self._async_delete_index(collection_name))
-
-    def _to_int_or_uuid(self, id: str) -> int | str:
-        try:
-            return int(id)
-        except ValueError:
-            return id
-
-    async def _async_get_documents(self, where: str = "") -> "DocumentsInfo":
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        filter = [] if where is None else where
-        async with self.client() as client:
-            index = client.index(self.config.collection_name)
-            documents = await index.get_documents(limit=10_000, filter=filter)
-        return documents
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        docs = asyncio.run(self._async_get_documents(where))
-        if docs is None:
-            return []
-        doc_results = docs.results
-        return [
-            Document(
-                content=d["content"],
-                metadata=DocMetaData(**d["metadata"]),
-            )
-            for d in doc_results
-        ]
-
-    async def _async_get_documents_by_ids(self, ids: List[str]) -> List[Dict[str, Any]]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        async with self.client() as client:
-            index = client.index(self.config.collection_name)
-            documents = await asyncio.gather(*[index.get_document(id) for id in ids])
-        return documents
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        docs = asyncio.run(self._async_get_documents_by_ids(ids))
-        return [
-            Document(
-                content=d["content"],
-                metadata=DocMetaData(**d["metadata"]),
-            )
-            for d in docs
-        ]
-
-    async def _async_search(
-        self,
-        query: str,
-        k: int = 20,
-        filter: str | list[str | list[str]] | None = None,
-    ) -> List[Dict[str, Any]]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot search")
-        async with self.client() as client:
-            index = client.index(self.config.collection_name)
-            results = await index.search(
-                query,
-                limit=k,
-                show_ranking_score=True,
-                filter=filter,
-            )
-        return results.hits  # type: ignore
-
-    def similar_texts_with_scores(
-        self,
-        text: str,
-        k: int = 20,
-        where: Optional[str] = None,
-        neighbors: int = 0,  # ignored
-    ) -> List[Tuple[Document, float]]:
-        filter = [] if where is None else where
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot search")
-        _docs = asyncio.run(self._async_search(text, k, filter))  # type: ignore
-        if len(_docs) == 0:
-            logger.warning(f"No matches found for {text}")
-            return []
-        scores = [h["_rankingScore"] for h in _docs]
-        if settings.debug:
-            logger.info(f"Found {len(_docs)} matches, max score: {max(scores)}")
-        docs = [
-            Document(
-                content=d["content"],
-                metadata=DocMetaData(**d["metadata"]),
-            )
-            for d in _docs
-        ]
-        doc_score_pairs = list(zip(docs, scores))
-        self.show_if_debug(doc_score_pairs)
-        return doc_score_pairs
-</file>
-
 <file path="langroid/vector_store/milvusdb.py">
 import json
 import logging
@@ -69773,750 +68839,90 @@ class MilvusDB(VectorStore):
         raise ValueError(f"Unsupported Milvus filter value: {value!r}")
 </file>
 
-<file path="langroid/vector_store/pineconedb.py">
-import json
-import logging
-import os
-import re
-from dataclasses import dataclass
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-)
-
-from dotenv import load_dotenv
-
-# import dataclass
-from pydantic import BaseModel
-
-from langroid import LangroidImportError
-from langroid.mytypes import Document
-from langroid.utils.configuration import settings
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-logger = logging.getLogger(__name__)
-
-
-has_pinecone: bool = True
-try:
-    from pinecone import Pinecone, PineconeApiException, ServerlessSpec
-except ImportError:
-
-    if not TYPE_CHECKING:
-
-        class ServerlessSpec(BaseModel):
-            """
-            Fallback Serverless specification configuration to avoid import errors.
-            """
-
-            cloud: str
-            region: str
-
-        PineconeApiException = Any  # type: ignore
-        Pinecone = Any  # type: ignore
-        has_pinecone = False
-
-
-@dataclass(frozen=True)
-class IndexMeta:
-    name: str
-    total_vector_count: int
-
-
-class PineconeDBConfig(VectorStoreConfig):
-    cloud: bool = True
-    collection_name: str | None = "temp"
-    spec: ServerlessSpec = ServerlessSpec(cloud="aws", region="us-east-1")
-    deletion_protection: Literal["enabled", "disabled"] | None = None
-    metric: str = "cosine"
-    pagination_size: int = 100
-
-
-class PineconeDB(VectorStore):
-    def __init__(self, config: PineconeDBConfig | None = None):
-        config = config if config is not None else PineconeDBConfig()
-        super().__init__(config)
-        if not has_pinecone:
-            raise LangroidImportError("pinecone", "pinecone")
-        self.config: PineconeDBConfig = config
-        load_dotenv()
-        key = os.getenv("PINECONE_API_KEY")
-
-        if not key:
-            raise ValueError("PINECONE_API_KEY not set, could not instantiate client")
-        self.client = Pinecone(api_key=key)
-
-        if config.collection_name:
-            self.create_collection(
-                collection_name=config.collection_name,
-                replace=config.replace_collection,
-            )
-
-    def clear_empty_collections(self) -> int:
-        indexes = self._list_index_metas(empty=True)
-        n_deletes = 0
-        for index in indexes:
-            if index.total_vector_count == -1:
-                logger.warning(
-                    f"Error fetching details for {index.name} when scanning indexes"
-                )
-            n_deletes += 1
-            self.delete_collection(collection_name=index.name)
-        return n_deletes
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """
-        Returns:
-            Number of Pinecone indexes that were deleted
-
-        Args:
-            really: Optional[bool] - whether to really delete all Pinecone collections
-            prefix: Optional[str] - string to match potential Pinecone
-                indexes for deletion
-        """
-        if not really:
-            logger.warning("Not deleting all collections, set really=True to confirm")
-            return 0
-        indexes = [
-            c for c in self._list_index_metas(empty=True) if c.name.startswith(prefix)
-        ]
-        if len(indexes) == 0:
-            logger.warning(f"No collections found with prefix {prefix}")
-            return 0
-        n_empty_deletes, n_non_empty_deletes = 0, 0
-        for index_desc in indexes:
-            self.delete_collection(collection_name=index_desc.name)
-            n_empty_deletes += index_desc.total_vector_count == 0
-            n_non_empty_deletes += index_desc.total_vector_count > 0
-        logger.warning(
-            f"""
-            Deleted {n_empty_deletes} empty indexes and
-            {n_non_empty_deletes} non-empty indexes
-            """
-        )
-        return n_empty_deletes + n_non_empty_deletes
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """
-        Returns:
-            List of Pinecone indices that have at least one vector.
-
-        Args:
-            empty: Optional[bool] - whether to include empty collections
-        """
-        indexes = self.client.list_indexes()
-        res: List[str] = []
-        if empty:
-            res.extend(indexes.names())
-            return res
-
-        for index in indexes.names():
-            index_meta = self.client.Index(name=index)
-            if index_meta.describe_index_stats().get("total_vector_count", 0) > 0:
-                res.append(index)
-        return res
-
-    def _list_index_metas(self, empty: bool = False) -> List[IndexMeta]:
-        """
-        Returns:
-            List of objects describing Pinecone indices
-
-        Args:
-            empty: Optional[bool] - whether to include empty collections
-        """
-        indexes = self.client.list_indexes()
-        res = []
-        for index in indexes.names():
-            index_meta = self._fetch_index_meta(index)
-            if empty:
-                res.append(index_meta)
-            elif index_meta.total_vector_count > 0:
-                res.append(index_meta)
-        return res
-
-    def _fetch_index_meta(self, index_name: str) -> IndexMeta:
-        """
-        Returns:
-            A dataclass describing the input Index by name and vector count
-            to save a bit on index description calls
-
-        Args:
-            index_name: str - Name of the index in Pinecone
-        """
-        try:
-            index = self.client.Index(name=index_name)
-            stats = index.describe_index_stats()
-            return IndexMeta(
-                name=index_name, total_vector_count=stats.get("total_vector_count", 0)
-            )
-        except PineconeApiException as e:
-            logger.warning(f"Error fetching details for index {index_name}")
-            logger.warning(e)
-            return IndexMeta(name=index_name, total_vector_count=-1)
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        """
-        Create a collection with the given name, optionally replacing an existing
-        collection if `replace` is True.
-
-        Args:
-            collection_name: str - Configuration of the collection to create.
-            replace: Optional[Bool] - Whether to replace an existing collection
-                with the same name. Defaults to False.
-        """
-        pattern = re.compile(r"^[a-z0-9-]+$")
-        if not pattern.match(collection_name):
-            raise ValueError(
-                "Pinecone index names must be lowercase alphanumeric characters or '-'"
-            )
-        self.config.collection_name = collection_name
-        if collection_name in self.list_collections(empty=True):
-            index = self.client.Index(name=collection_name)
-            stats = index.describe_index_stats()
-            status = self.client.describe_index(name=collection_name)
-            if status["status"]["ready"] and stats["total_vector_count"] > 0:
-                logger.warning(f"Non-empty collection {collection_name} already exists")
-                if not replace:
-                    logger.warning("Not replacing collection")
-                    return
-                else:
-                    logger.warning("Recreating fresh collection")
-            self.delete_collection(collection_name=collection_name)
-
-        payload = {
-            "name": collection_name,
-            "dimension": self.embedding_dim,
-            "spec": self.config.spec,
-            "metric": self.config.metric,
-            "timeout": self.config.timeout,
-        }
-
-        if self.config.deletion_protection:
-            payload["deletion_protection"] = self.config.deletion_protection
-
-        try:
-            self.client.create_index(**payload)
-        except PineconeApiException as e:
-            logger.error(e)
-
-    def delete_collection(self, collection_name: str) -> None:
-        logger.info(f"Attempting to delete {collection_name}")
-        try:
-            self.client.delete_index(name=collection_name)
-        except PineconeApiException as e:
-            logger.error(f"Failed to delete {collection_name}")
-            logger.error(e)
-
-    def add_documents(self, documents: Sequence[Document], namespace: str = "") -> None:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-
-        if len(documents) == 0:
-            logger.warning("Empty list of documents passed into add_documents")
-            return
-
-        super().maybe_add_ids(documents)
-        document_dicts = [doc.model_dump() for doc in documents]
-        document_ids = [doc.id() for doc in documents]
-        embedding_vectors = self.embedding_fn([doc.content for doc in documents])
-        vectors = [
-            {
-                "id": document_id,
-                "values": embedding_vector,
-                "metadata": {
-                    **document_dict["metadata"],
-                    **{
-                        key: value
-                        for key, value in document_dict.items()
-                        if key != "metadata"
-                    },
-                },
-            }
-            for document_dict, document_id, embedding_vector in zip(
-                document_dicts, document_ids, embedding_vectors
-            )
-        ]
-
-        if self.config.collection_name not in self.list_collections(empty=True):
-            self.create_collection(
-                collection_name=self.config.collection_name, replace=True
-            )
-
-        index = self.client.Index(name=self.config.collection_name)
-        batch_size = self.config.batch_size
-
-        for i in range(0, len(documents), batch_size):
-            try:
-                if namespace:
-                    index.upsert(
-                        vectors=vectors[i : i + batch_size], namespace=namespace
-                    )
-                else:
-                    index.upsert(vectors=vectors[i : i + batch_size])
-            except PineconeApiException as e:
-                logger.error(
-                    f"Unable to add of docs between indices {i} and {batch_size}"
-                )
-                logger.error(e)
-
-    def get_all_documents(
-        self, prefix: str = "", namespace: str = ""
-    ) -> List[Document]:
-        """
-        Returns:
-            All documents for the collection currently defined in
-            the configuration object
-
-        Args:
-            prefix: str - document id prefix to search for
-            namespace: str - partition of vectors to search within the index
-        """
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        docs = []
-
-        request_filters: Dict[str, Union[str, int]] = {
-            "limit": self.config.pagination_size
-        }
-        if prefix:
-            request_filters["prefix"] = prefix
-        if namespace:
-            request_filters["namespace"] = namespace
-
-        index = self.client.Index(name=self.config.collection_name)
-
-        while True:
-            response = index.list_paginated(**request_filters)
-            vectors = response.get("vectors", [])
-
-            if not vectors:
-                logger.warning("Received empty list while requesting for vector ids")
-                logger.warning("Halting fetch requests")
-                if settings.debug:
-                    logger.debug(f"Request for failed fetch was: {request_filters}")
-                break
-
-            docs.extend(
-                self.get_documents_by_ids(
-                    ids=[vector.get("id") for vector in vectors],
-                    namespace=namespace if namespace else "",
-                )
-            )
-
-            pagination_token = response.get("pagination", {}).get("next", None)
-
-            if not pagination_token:
-                break
-
-            request_filters["pagination_token"] = pagination_token
-
-        return docs
-
-    def get_documents_by_ids(
-        self, ids: List[str], namespace: str = ""
-    ) -> List[Document]:
-        """
-        Returns:
-            Fetches document text embedded in Pinecone index metadata
-
-        Args:
-            ids: List[str] - vector data object ids to retrieve
-            namespace: str - partition of vectors to search within the index
-        """
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        index = self.client.Index(name=self.config.collection_name)
-
-        if namespace:
-            records = index.fetch(ids=ids, namespace=namespace)
-        else:
-            records = index.fetch(ids=ids)
-
-        id_mapping = {key: value for key, value in records["vectors"].items()}
-        ordered_payloads = [id_mapping[_id] for _id in ids if _id in id_mapping]
-        return [
-            self.transform_pinecone_vector(payload.get("metadata", {}))
-            for payload in ordered_payloads
-        ]
-
-    def similar_texts_with_scores(
-        self,
-        text: str,
-        k: int = 1,
-        where: Optional[str] = None,
-        namespace: Optional[str] = None,
-    ) -> List[Tuple[Document, float]]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot search")
-
-        if k < 1 or k > 9999:
-            raise ValueError(
-                f"TopK for Pinecone vector search must be 1 < k < 10000, k was {k}"
-            )
-
-        vector_search_request = {
-            "top_k": k,
-            "include_metadata": True,
-            "vector": self.embedding_fn([text])[0],
-        }
-        if where:
-            vector_search_request["filter"] = json.loads(where) if where else None
-        if namespace:
-            vector_search_request["namespace"] = namespace
-
-        index = self.client.Index(name=self.config.collection_name)
-        response = index.query(**vector_search_request)
-        doc_score_pairs = [
-            (
-                self.transform_pinecone_vector(match.get("metadata", {})),
-                match.get("score", 0),
-            )
-            for match in response.get("matches", [])
-        ]
-        if settings.debug:
-            max_score = max([pair[1] for pair in doc_score_pairs])
-            logger.info(f"Found {len(doc_score_pairs)} matches, max score: {max_score}")
-        self.show_if_debug(doc_score_pairs)
-        return doc_score_pairs
-
-    def transform_pinecone_vector(self, metadata_dict: Dict[str, Any]) -> Document:
-        """
-        Parses the metadata response from the Pinecone vector query and
-        formats it into a dictionary that can be parsed by the Document class
-        associated with the PineconeDBConfig class
-
-        Returns:
-            Well formed dictionary object to be transformed into a Document
-
-        Args:
-            metadata_dict: Dict - the metadata dictionary from the Pinecone
-                vector query match
-        """
-        return self.config.document_class(
-            **{**metadata_dict, "metadata": {**metadata_dict}}
-        )
-</file>
-
-<file path="langroid/vector_store/weaviatedb.py">
-import logging
-import os
-import re
-from typing import Any, List, Optional, Sequence, Tuple
-
-from dotenv import load_dotenv
-
-from langroid.embedding_models.base import (
-    EmbeddingModelsConfig,
-)
-from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.exceptions import LangroidImportError
-from langroid.mytypes import DocMetaData, Document
-from langroid.utils.configuration import settings
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-logger = logging.getLogger(__name__)
-
-
-class VectorDistances:
-    """
-    Fallback class when weaviate is not installed, to avoid import errors.
-    """
-
-    COSINE: str = "cosine"
-    DOTPRODUCT: str = "dot"
-    L2: str = "l2"
-
-
-class WeaviateDBConfig(VectorStoreConfig):
-    collection_name: str | None = "temp"
-    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    distance: str = VectorDistances.COSINE
-    cloud: bool = False
-    docker: bool = False
-    host: str = "127.0.0.1"
-    port: int = 8080
-    storage_path: str = ".weaviate_embedded/data"
-
-
-class WeaviateDB(VectorStore):
-    def __init__(self, config: WeaviateDBConfig | None = None):
-        config = config if config is not None else WeaviateDBConfig()
-        super().__init__(config)
-        try:
-            import weaviate
-            from weaviate.classes.init import Auth
-        except ImportError:
-            raise LangroidImportError("weaviate", "weaviate")
-
-        self.config: WeaviateDBConfig = config
-        load_dotenv()
-        if self.config.docker:
-            self.client = weaviate.connect_to_local(
-                host=self.config.host,
-                port=self.config.port,
-            )
-            self.config.cloud = False
-        elif self.config.cloud:
-            key = os.getenv("WEAVIATE_API_KEY")
-            url = os.getenv("WEAVIATE_API_URL")
-            if url is None or key is None:
-                raise ValueError(
-                    """WEAVIATE_API_KEY, WEAVIATE_API_URL env variables must be set to 
-                    use WeaviateDB in cloud mode. Please set these values
-                    in your .env file.
-                    """
-                )
-            self.client = weaviate.connect_to_weaviate_cloud(
-                cluster_url=url,
-                auth_credentials=Auth.api_key(key),
-            )
-        else:
-            self.client = weaviate.connect_to_embedded(
-                version="latest", persistence_data_path=self.config.storage_path
-            )
-
-        if config.collection_name is not None:
-            WeaviateDB.validate_and_format_collection_name(config.collection_name)
-
-    def clear_empty_collections(self) -> int:
-        colls = self.client.collections.list_all()
-        n_deletes = 0
-        for coll_name, _ in colls.items():
-            val = self.client.collections.get(coll_name)
-            if len(val) == 0:
-                n_deletes += 1
-                self.client.collections.delete(coll_name)
-        return n_deletes
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        colls = self.client.collections.list_all()
-        if empty:
-            return list(colls.keys())
-        non_empty_colls = [
-            coll_name
-            for coll_name in colls.keys()
-            if len(self.client.collections.get(coll_name)) > 0
-        ]
-
-        return non_empty_colls
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        if not really:
-            logger.warning(
-                "Not really deleting all collections ,set really=True to confirm"
-            )
-            return 0
-        coll_names = [
-            c for c in self.list_collections(empty=True) if c.startswith(prefix)
-        ]
-        if len(coll_names) == 0:
-            logger.warning(f"No collections found with prefix {prefix}")
-            return 0
-        n_empty_deletes = 0
-        n_non_empty_deletes = 0
-        for name in coll_names:
-            info = self.client.collections.get(name)
-            points_count = len(info)
-
-            n_empty_deletes += points_count == 0
-            n_non_empty_deletes += points_count > 0
-            self.client.collections.delete(name)
-        logger.warning(
-            f"""
-            Deleted {n_empty_deletes} empty collections and
-            {n_non_empty_deletes} non-empty collections.
-            """
-        )
-        return n_empty_deletes + n_non_empty_deletes
-
-    def delete_collection(self, collection_name: str) -> None:
-        self.client.collections.delete(name=collection_name)
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        try:
-            from weaviate.classes.config import (
-                Configure,
-                VectorDistances,
-            )
-        except ImportError:
-            raise LangroidImportError("weaviate", "weaviate")
-        collection_name = WeaviateDB.validate_and_format_collection_name(
-            collection_name
-        )
-        self.config.collection_name = collection_name
-        if self.client.collections.exists(name=collection_name):
-            coll = self.client.collections.get(name=collection_name)
-            if len(coll) > 0:
-                logger.warning(f"Non-empty Collection {collection_name} already exists")
-                if not replace:
-                    logger.warning("Not replacing collection")
-                    return
-                else:
-                    logger.warning("Recreating fresh collection")
-            self.client.collections.delete(name=collection_name)
-
-        vector_index_config = Configure.VectorIndex.hnsw(
-            distance_metric=VectorDistances.COSINE,
-        )
-        if isinstance(self.config.embedding, OpenAIEmbeddingsConfig):
-            vectorizer_config = Configure.Vectorizer.text2vec_openai(
-                model=self.config.embedding.model_name,
-            )
-        else:
-            vectorizer_config = None
-
-        collection_info = self.client.collections.create(
-            name=collection_name,
-            vector_index_config=vector_index_config,
-            vectorizer_config=vectorizer_config,
-        )
-        collection_info = self.client.collections.get(name=collection_name)
-        assert len(collection_info) in [0, None]
-        if settings.debug:
-            level = logger.getEffectiveLevel()
-            logger.setLevel(logging.INFO)
-            logger.info(collection_info)
-            logger.setLevel(level)
-
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        super().maybe_add_ids(documents)
-        colls = self.list_collections(empty=True)
-        for doc in documents:
-            doc.metadata.id = str(self._create_valid_uuid_id(doc.metadata.id))
-        if len(documents) == 0:
-            return
-
-        document_dicts = [doc.model_dump() for doc in documents]
-        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-        if self.config.collection_name not in colls:
-            self.create_collection(self.config.collection_name, replace=True)
-        coll_name = self.client.collections.get(self.config.collection_name)
-        with coll_name.batch.dynamic() as batch:
-            for i, doc_dict in enumerate(document_dicts):
-                id = doc_dict["metadata"].pop("id", None)
-                batch.add_object(properties=doc_dict, uuid=id, vector=embedding_vecs[i])
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        # cannot use filter as client does not support json type queries
-        coll = self.client.collections.get(self.config.collection_name)
-        return [self.weaviate_obj_to_doc(item) for item in coll.iterator()]
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        from weaviate.classes.query import Filter
-
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-
-        docs = []
-        coll_name = self.client.collections.get(self.config.collection_name)
-
-        result = coll_name.query.fetch_objects(
-            filters=Filter.by_property("_id").contains_any(ids), limit=len(coll_name)
-        )
-
-        id_to_doc = {}
-        for item in result.objects:
-            doc = self.weaviate_obj_to_doc(item)
-            id_to_doc[doc.metadata.id] = doc
-
-        # Reconstruct the list of documents in the original order of input ids
-        docs = [id_to_doc[id] for id in ids if id in id_to_doc]
-
-        return docs
-
-    def similar_texts_with_scores(
-        self, text: str, k: int = 1, where: Optional[str] = None
-    ) -> List[Tuple[Document, float]]:
-        from weaviate.classes.query import MetadataQuery
-
-        embedding = self.embedding_fn([text])[0]
-        if self.config.collection_name is None:
-            raise ValueError("No collections name set,cannot search")
-        coll = self.client.collections.get(self.config.collection_name)
-        response = coll.query.near_vector(
-            near_vector=embedding,
-            limit=k,
-            return_properties=True,
-            return_metadata=MetadataQuery(distance=True),
-        )
-        maybe_distances = [item.metadata.distance for item in response.objects]
-        similarities = [0 if d is None else 1 - d for d in maybe_distances]
-        docs = [self.weaviate_obj_to_doc(item) for item in response.objects]
-        return list(zip(docs, similarities))
-
-    def _create_valid_uuid_id(self, id: str) -> Any:
-        from weaviate.util import generate_uuid5, get_valid_uuid
-
-        try:
-            id = get_valid_uuid(id)
-            return id
-        except Exception:
-            return generate_uuid5(id)
-
-    def weaviate_obj_to_doc(self, input_object: Any) -> Document:
-        from weaviate.util import get_valid_uuid
-
-        content = input_object.properties.get("content", "")
-        metadata_dict = input_object.properties.get("metadata", {})
-
-        window_ids = metadata_dict.pop("window_ids", [])
-        window_ids = [str(uuid) for uuid in window_ids]
-
-        # Ensure the id is a valid UUID string
-        id_value = get_valid_uuid(input_object.uuid)
-
-        metadata = DocMetaData(id=id_value, window_ids=window_ids, **metadata_dict)
-
-        return Document(content=content, metadata=metadata)
-
-    @staticmethod
-    def validate_and_format_collection_name(name: str) -> str:
-        """
-        Formats the collection name to comply with Weaviate's naming rules:
-        - Name must start with a capital letter.
-        - Name can only contain letters, numbers, and underscores.
-        - Replaces invalid characters with underscores.
-        """
-        if not name:
-            raise ValueError("Collection name cannot be empty.")
-
-        formatted_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
-
-        # Ensure the first letter is capitalized
-        if not formatted_name[0].isupper():
-            formatted_name = formatted_name.capitalize()
-
-        # Check if the name now meets the criteria
-        if not re.match(r"^[A-Z][A-Za-z0-9_]*$", formatted_name):
-            raise ValueError(
-                f"Invalid collection name '{name}'."
-                " Names must start with a capital letter "
-                "and contain only letters, numbers, and underscores."
-            )
-
-        if formatted_name != name:
-            logger.warning(
-                f"Collection name '{name}' was reformatted to '{formatted_name}' "
-                "to comply with Weaviate's rules."
-            )
-
-        return formatted_name
-
-    def __del__(self) -> None:
-        # Gracefully close the connection with local client
-        if not self.config.cloud:
-            self.client.close()
+<file path="docs/notes/vecstore-env-prefix.md">
+# Vector-Store Config Env-Var Prefixes
+
+Vector-store configs are `pydantic-settings` classes, which means their
+fields can be set via environment variables. Prior to this change (see
+issue #1078), `VectorStoreConfig` and its subclasses declared **no
+`env_prefix`**, so every field name was itself a case-insensitive
+environment variable. A bare `HOST`, `PORT`, `CLOUD`, `TIMEOUT`,
+`BATCH_SIZE`, `STORAGE_PATH`, `COLLECTION_NAME`, or `FULL_EVAL` in the
+environment silently overrode the default for *every* vector-store
+config:
+
+```bash
+HOST=evil.example.com PORT=9999 FULL_EVAL=true \
+  python -c "from langroid.vector_store.qdrantdb import QdrantDBConfig; \
+             c = QdrantDBConfig(); print(c.host, c.port, c.full_eval)"
+# old behavior: evil.example.com 9999 True
+```
+
+This was dangerous for two reasons:
+
+- `HOST` and `PORT` are routinely set by shells, containers, and CI
+  systems, so vector-store clients could silently point at the wrong
+  server.
+- `FULL_EVAL=true` disabled the code-injection guard (see
+  [code-injection-protection](code-injection-protection.md)) with no
+  explicit opt-in anywhere in the user's code.
+
+## New behavior
+
+Each vector-store config now has its own env prefix, consistent with
+the rest of the codebase (`OPENAI_`, `AZURE_OPENAI_`, `NEO4J_`, ...):
+
+| Config class        | Env prefix     |
+|---------------------|----------------|
+| `VectorStoreConfig` | `VECDB_`       |
+| `QdrantDBConfig`    | `QDRANT_`      |
+| `ChromaDBConfig`    | `CHROMA_`      |
+| `LanceDBConfig`     | `LANCEDB_`     |
+| `PineconeDBConfig`  | `PINECONE_`    |
+| `PostgresDBConfig`  | `POSTGRES_`    |
+| `MeiliSearchConfig` | `MEILISEARCH_` |
+| `WeaviateDBConfig`  | `WEAVIATE_`    |
+
+Bare env vars (`HOST`, `FULL_EVAL`, ...) are now ignored by all of
+these configs. To set a field via the environment, use the prefix of
+the specific config class, e.g. `QDRANT_HOST=my.qdrant.example` or
+`QDRANT_FULL_EVAL=true` for `QdrantDBConfig`. Every provider subclass
+in langroid overrides the prefix with its own, so within langroid
+`VECDB_*` vars affect only direct `VectorStoreConfig` instances.
+However, pydantic inherits `model_config`, so a third-party subclass
+of `VectorStoreConfig` that does not set its own `env_prefix` will
+read `VECDB_*` vars.
+
+A `port` value coming from the *environment* that matches the exact
+Kubernetes service-link format `tcp://<host>:<digits>` (e.g.
+`QDRANT_PORT=tcp://10.0.0.8:6333`, injected into every pod by a
+service named `qdrant` when `enableServiceLinks` is on) is ignored
+with a warning and the default port is used. This exception applies
+only to the env settings source and only to that full format:
+malformed `tcp://` junk in the environment, and any `tcp://...` value
+passed explicitly to the constructor, fail validation as usual.
+
+Explicit constructor arguments always take priority over environment
+values (standard `pydantic-settings` precedence):
+
+```python
+config = QdrantDBConfig(host="10.0.0.5")  # wins over QDRANT_HOST
+```
+
+## Migration
+
+If you (deliberately) relied on bare env vars to configure a
+vector store, rename them with the appropriate prefix from the table
+above, e.g. `COLLECTION_NAME=mydocs` becomes
+`QDRANT_COLLECTION_NAME=mydocs`.
+
+Env vars read via `os.getenv` outside the config classes are
+unaffected, e.g. `QDRANT_API_KEY`, `PINECONE_API_KEY`,
+`MEILISEARCH_API_KEY`, `MEILISEARCH_API_URL`, `WEAVIATE_API_KEY`, and
+`WEAVIATE_API_URL` keep their existing meanings. Note that the
+`QDRANT_*` and `PINECONE_*` prefixes overlap with those existing
+names, but the config classes have no `api_key`/`api_url` fields, so
+extra prefixed vars are ignored.
 </file>
 
 <file path="docs/tutorials/non-openai-llms.md">
@@ -74306,1072 +72712,346 @@ class RepoLoader:
         return contents
 </file>
 
-<file path="langroid/vector_store/base.py">
-import copy
-import logging
-from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Sequence, Tuple, Type
-
-import numpy as np
-import pandas as pd
-from pydantic_settings import BaseSettings
-
-from langroid.embedding_models.base import EmbeddingModel, EmbeddingModelsConfig
-from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.mytypes import DocMetaData, Document, EmbeddingFunction
-from langroid.utils.algorithms.graph import components, topological_sort
-from langroid.utils.configuration import settings
-from langroid.utils.object_registry import ObjectRegistry
-from langroid.utils.output.printing import print_long_text
-from langroid.utils.pandas_utils import safe_eval_globals, sanitize_command, stringify
-from langroid.utils.pydantic_utils import flatten_dict
-
-logger = logging.getLogger(__name__)
-
-
-class VectorStoreConfig(BaseSettings):
-    type: str = ""  # deprecated, keeping it for backward compatibility
-    collection_name: str | None = "temp"
-    replace_collection: bool = False  # replace collection if it already exists
-    storage_path: str = ".qdrant/data"
-    cloud: bool = False
-    batch_size: int = 200
-    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig(
-        model_type="openai",
-    )
-    embedding_model: Optional[EmbeddingModel] = None
-    timeout: int = 60
-    host: str = "127.0.0.1"
-    port: int = 6333
-    # used when parsing search results back as Document objects
-    document_class: Type[Document] = Document
-    metadata_class: Type[DocMetaData] = DocMetaData
-    # compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
-    full_eval: bool = False  # runs eval without sanitization. Use only on trusted input
-
-
-class VectorStore(ABC):
-    """
-    Abstract base class for a vector store.
-    """
-
-    def __init__(self, config: VectorStoreConfig):
-        self.config = config
-        if config.embedding_model is None:
-            self.embedding_model = EmbeddingModel.create(config.embedding)
-        else:
-            self.embedding_model = config.embedding_model
-        if hasattr(self.config, "embedding_model"):
-            self.config.embedding_model = None
-        self.embedding_fn: EmbeddingFunction = self.embedding_model.embedding_fn()
-
-    @staticmethod
-    def create(config: VectorStoreConfig) -> Optional["VectorStore"]:
-        from langroid.vector_store.chromadb import ChromaDB, ChromaDBConfig
-        from langroid.vector_store.lancedb import LanceDB, LanceDBConfig
-        from langroid.vector_store.meilisearch import MeiliSearch, MeiliSearchConfig
-        from langroid.vector_store.milvusdb import MilvusDB, MilvusDBConfig
-        from langroid.vector_store.pineconedb import PineconeDB, PineconeDBConfig
-        from langroid.vector_store.postgres import PostgresDB, PostgresDBConfig
-        from langroid.vector_store.qdrantdb import QdrantDB, QdrantDBConfig
-        from langroid.vector_store.weaviatedb import WeaviateDB, WeaviateDBConfig
-
-        if isinstance(config, QdrantDBConfig):
-            return QdrantDB(config)
-        elif isinstance(config, ChromaDBConfig):
-            return ChromaDB(config)
-        elif isinstance(config, LanceDBConfig):
-            return LanceDB(config)
-        elif isinstance(config, MeiliSearchConfig):
-            return MeiliSearch(config)
-        elif isinstance(config, PostgresDBConfig):
-            return PostgresDB(config)
-        elif isinstance(config, MilvusDBConfig):
-            return MilvusDB(config)
-        elif isinstance(config, WeaviateDBConfig):
-            return WeaviateDB(config)
-        elif isinstance(config, PineconeDBConfig):
-            return PineconeDB(config)
-
-        else:
-            logger.warning(
-                f"""
-                Unknown vector store config: {config.__class__.__name__},
-                so skipping vector store creation!
-                If you intended to use a vector-store, please set a specific 
-                vector-store in your script, typically in the `vecdb` field of a 
-                `ChatAgentConfig`, otherwise set it to None.
-                """
-            )
-            return None
-
-    @property
-    def embedding_dim(self) -> int:
-        return len(self.embedding_fn(["test"])[0])
-
-    def clone(self) -> "VectorStore":
-        """Return a vector-store clone suitable for agent cloning.
-
-        The default implementation deep-copies the configuration, reuses any
-        existing embedding model, and instantiates a fresh store of the same
-        type. Subclasses can override when sharing the instance is required
-        (e.g., embedded/local stores that rely on file locks).
-        """
-
-        config_class = self.config.__class__
-        config_data = self.config.model_dump(mode="python")
-        config_data["embedding_model"] = None
-        config_copy = config_class.model_validate(config_data)
-        logger.debug(
-            "Cloning VectorStore %s: original collection=%s, copied collection=%s",
-            type(self).__name__,
-            getattr(self.config, "collection_name", None),
-            getattr(config_copy, "collection_name", None),
-        )
-        # Preserve the calculated collection contents without forcing replaces
-        if hasattr(config_copy, "replace_collection"):
-            config_copy.replace_collection = False  # type: ignore[attr-defined]
-        cloned_embedding: Optional[EmbeddingModel] = None
-        if (
-            hasattr(self, "embedding_model")
-            and getattr(self, "embedding_model") is not None
-        ):
-            cloned_embedding = self.embedding_model.clone()  # type: ignore[attr-defined]
-            if hasattr(config_copy, "embedding_model"):
-                config_copy.embedding_model = cloned_embedding
-
-        cloned_store = type(self)(config_copy)  # type: ignore[call-arg]
-        if hasattr(cloned_store.config, "embedding_model"):
-            cloned_store.config.embedding_model = None
-        logger.debug(
-            "Cloned VectorStore %s: cloned collection=%s",
-            type(self).__name__,
-            getattr(cloned_store.config, "collection_name", None),
-        )
-        if hasattr(cloned_store.config, "replace_collection"):
-            cloned_store.config.replace_collection = False
-        # Some stores might not honour replace_collection; ensure same collection
-        if getattr(self.config, "collection_name", None) is not None:
-            setattr(
-                cloned_store.config,
-                "collection_name",
-                getattr(self.config, "collection_name", None),
-            )
-        return cloned_store
-
-    @abstractmethod
-    def clear_empty_collections(self) -> int:
-        """Clear all empty collections in the vector store.
-        Returns the number of collections deleted.
-        """
-        pass
-
-    @abstractmethod
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """
-        Clear all collections in the vector store.
-
-        Args:
-            really (bool, optional): Whether to really clear all collections.
-                Defaults to False.
-            prefix (str, optional): Prefix of collections to clear.
-        Returns:
-            int: Number of collections deleted.
-        """
-        pass
-
-    @abstractmethod
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """List all collections in the vector store
-        (only non empty collections if empty=False).
-        """
-        pass
-
-    def set_collection(self, collection_name: str, replace: bool = False) -> None:
-        """
-        Set the current collection to the given collection name.
-        Args:
-            collection_name (str): Name of the collection.
-            replace (bool, optional): Whether to replace the collection if it
-                already exists. Defaults to False.
-        """
-
-        self.config.collection_name = collection_name
-        self.config.replace_collection = replace
-        if replace:
-            self.create_collection(collection_name, replace=True)
-
-    @abstractmethod
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        """Create a collection with the given name.
-        Args:
-            collection_name (str): Name of the collection.
-            replace (bool, optional): Whether to replace the
-                collection if it already exists. Defaults to False.
-        """
-        pass
-
-    @abstractmethod
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        pass
-
-    def compute_from_docs(self, docs: List[Document], calc: str) -> str:
-        """Compute a result on a set of documents,
-        using a dataframe calc string like `df.groupby('state')['income'].mean()`.
-
-        If full_eval is False (default), the input expression is sanitized to prevent
-        most common code injection attack vectors.
-        If full_eval is True, sanitization is bypassed - use only with trusted input!
-        """
-        # convert each doc to a dict, using dotted paths for nested fields
-        dicts = [flatten_dict(doc.model_dump(by_alias=True)) for doc in docs]
-        df = pd.DataFrame(dicts)
-
-        try:
-            # SECURITY MITIGATION: Eval input is sanitized to prevent most common
-            # code injection attack vectors when full_eval is False. The globals
-            # dict also restricts ``__builtins__`` so that even with
-            # ``full_eval=True`` the expression cannot reach
-            # ``__import__``/``eval``/``exec`` via Python's implicit builtin
-            # injection (GHSA-q9p7-wqxg-mrhc).
-            vars = {"df": df}
-            if not self.config.full_eval:
-                calc = sanitize_command(calc)
-            code = compile(calc, "<calc>", "eval")
-            result = eval(code, safe_eval_globals(vars), {})
-        except Exception as e:
-            # return error message so LLM can fix the calc string if needed
-            err = f"""
-            Error encountered in pandas eval: {str(e)}
-            """
-            if isinstance(e, KeyError) and "not in index" in str(e):
-                # Pd.eval sometimes fails on a perfectly valid exprn like
-                # df.loc[..., 'column'] with a KeyError.
-                err += """
-                Maybe try a different way, e.g. 
-                instead of df.loc[..., 'column'], try df.loc[...]['column']
-                """
-            return err
-        return stringify(result)
-
-    def maybe_add_ids(self, documents: Sequence[Document]) -> None:
-        """Add ids to metadata if absent, since some
-        vecdbs don't like having blank ids."""
-        for d in documents:
-            if d.metadata.id in [None, ""]:
-                d.metadata.id = ObjectRegistry.new_id()
-
-    @abstractmethod
-    def similar_texts_with_scores(
-        self,
-        text: str,
-        k: int = 1,
-        where: Optional[str] = None,
-    ) -> List[Tuple[Document, float]]:
-        """
-        Find k most similar texts to the given text, in terms of vector distance metric
-        (e.g., cosine similarity).
-
-        Args:
-            text (str): The text to find similar texts for.
-            k (int, optional): Number of similar texts to retrieve. Defaults to 1.
-            where (Optional[str], optional): Where clause to filter the search.
-
-        Returns:
-            List[Tuple[Document,float]]: List of (Document, score) tuples.
-
-        """
-        pass
-
-    def add_context_window(
-        self, docs_scores: List[Tuple[Document, float]], neighbors: int = 0
-    ) -> List[Tuple[Document, float]]:
-        """
-        In each doc's metadata, there may be a window_ids field indicating
-        the ids of the chunks around the current chunk.
-        These window_ids may overlap, so we
-        - coalesce each overlapping groups into a single window (maintaining ordering),
-        - create a new document for each part, preserving metadata,
-
-        We may have stored a longer set of window_ids than we need during chunking.
-        Now, we just want `neighbors` on each side of the center of the window_ids list.
-
-        Args:
-            docs_scores (List[Tuple[Document, float]]): List of pairs of documents
-                to add context windows to together with their match scores.
-            neighbors (int, optional): Number of neighbors on "each side" of match to
-                retrieve. Defaults to 0.
-                "Each side" here means before and after the match,
-                in the original text.
-
-        Returns:
-            List[Tuple[Document, float]]: List of (Document, score) tuples.
-        """
-        # We return a larger context around each match, i.e.
-        # a window of `neighbors` on each side of the match.
-        docs = [d for d, s in docs_scores]
-        scores = [s for d, s in docs_scores]
-        if neighbors == 0:
-            return docs_scores
-        doc_chunks = [d for d in docs if d.metadata.is_chunk]
-        if len(doc_chunks) == 0:
-            return docs_scores
-        window_ids_list = []
-        id2metadata = {}
-        # id -> highest score of a doc it appears in
-        id2max_score: Dict[int | str, float] = {}
-        for i, d in enumerate(docs):
-            window_ids = d.metadata.window_ids
-            if len(window_ids) == 0:
-                window_ids = [d.id()]
-            id2metadata.update({id: d.metadata for id in window_ids})
-
-            id2max_score.update(
-                {id: max(id2max_score.get(id, 0), scores[i]) for id in window_ids}
-            )
-            n = len(window_ids)
-            chunk_idx = window_ids.index(d.id())
-            neighbor_ids = window_ids[
-                max(0, chunk_idx - neighbors) : min(n, chunk_idx + neighbors + 1)
-            ]
-            window_ids_list += [neighbor_ids]
-
-        # window_ids could be from different docs,
-        # and they may overlap, so we coalesce overlapping groups into
-        # separate windows.
-        window_ids_list = self.remove_overlaps(window_ids_list)
-        final_docs = []
-        final_scores = []
-        for w in window_ids_list:
-            metadata = copy.deepcopy(id2metadata[w[0]])
-            metadata.window_ids = w
-            document = Document(
-                content="".join([d.content for d in self.get_documents_by_ids(w)]),
-                metadata=metadata,
-            )
-            # make a fresh id since content is in general different
-            document.metadata.id = ObjectRegistry.new_id()
-            final_docs += [document]
-            final_scores += [max(id2max_score[id] for id in w)]
-        return list(zip(final_docs, final_scores))
-
-    @staticmethod
-    def remove_overlaps(windows: List[List[str]]) -> List[List[str]]:
-        """
-        Given a collection of windows, where each window is a sequence of ids,
-        identify groups of overlapping windows, and for each overlapping group,
-        order the chunk-ids using topological sort so they appear in the original
-        order in the text.
-
-        Args:
-            windows (List[int|str]): List of windows, where each window is a
-                sequence of ids.
-
-        Returns:
-            List[int|str]: List of windows, where each window is a sequence of ids,
-                and no two windows overlap.
-        """
-        ids = set(id for w in windows for id in w)
-        # id -> {win -> # pos}
-        id2win2pos: Dict[str, Dict[int, int]] = {id: {} for id in ids}
-
-        for i, w in enumerate(windows):
-            for j, id in enumerate(w):
-                id2win2pos[id][i] = j
-
-        n = len(windows)
-        # relation between windows:
-        order = np.zeros((n, n), dtype=np.int8)
-        for i, w in enumerate(windows):
-            for j, x in enumerate(windows):
-                if i == j:
-                    continue
-                if len(set(w).intersection(x)) == 0:
-                    continue
-                id = list(set(w).intersection(x))[0]  # any common id
-                if id2win2pos[id][i] > id2win2pos[id][j]:
-                    order[i, j] = -1  # win i is before win j
-                else:
-                    order[i, j] = 1  # win i is after win j
-
-        # find groups of windows that overlap, like connected components in a graph
-        groups = components(np.abs(order))
-
-        # order the chunk-ids in each group using topological sort
-        new_windows = []
-        for g in groups:
-            # find total ordering among windows in group based on order matrix
-            # (this is a topological sort)
-            _g = np.array(g)
-            order_matrix = order[_g][:, _g]
-            ordered_window_indices = topological_sort(order_matrix)
-            ordered_window_ids = [windows[i] for i in _g[ordered_window_indices]]
-            flattened = [id for w in ordered_window_ids for id in w]
-            flattened_deduped = list(dict.fromkeys(flattened))
-            # Note we are not going to split these, and instead we'll return
-            # larger windows from concatenating the connected groups.
-            # This ensures context is retained for LLM q/a
-            new_windows += [flattened_deduped]
-
-        return new_windows
-
-    @abstractmethod
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        """
-        Get all documents in the current collection, possibly filtered by `where`.
-        """
-        pass
-
-    @abstractmethod
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        """
-        Get documents by their ids.
-        Args:
-            ids (List[str]): List of document ids.
-
-        Returns:
-            List[Document]: List of documents
-        """
-        pass
-
-    @abstractmethod
-    def delete_collection(self, collection_name: str) -> None:
-        pass
-
-    def show_if_debug(self, doc_score_pairs: List[Tuple[Document, float]]) -> None:
-        if settings.debug:
-            for i, (d, s) in enumerate(doc_score_pairs):
-                print_long_text("red", "italic red", f"\nMATCH-{i}\n", d.content)
-</file>
-
-<file path="langroid/vector_store/postgres.py">
-import hashlib
+<file path="langroid/vector_store/chromadb.py">
 import json
 import logging
-import os
-import uuid
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
+
+from pydantic_settings import SettingsConfigDict
 
 from langroid.embedding_models.base import (
     EmbeddingModelsConfig,
 )
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
 from langroid.exceptions import LangroidImportError
-from langroid.mytypes import DocMetaData, Document
+from langroid.mytypes import Document
+from langroid.utils.configuration import settings
+from langroid.utils.output.printing import print_long_text
 from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-has_postgres: bool = True
-try:
-    from sqlalchemy import (
-        Column,
-        MetaData,
-        String,
-        Table,
-        case,
-        create_engine,
-        inspect,
-        text,
-    )
-    from sqlalchemy.dialects.postgresql import JSONB
-    from sqlalchemy.engine import Connection, Engine
-    from sqlalchemy.sql.expression import insert
-except ImportError:
-    Engine = Any  # type: ignore
-    Connection = Any  # type: ignore
-    has_postgres = False
 
 logger = logging.getLogger(__name__)
 
 
-def _quote_ident(name: str) -> str:
-    """Quote a SQL identifier (table/index name) for use in raw DDL, so a name
-    containing characters that are invalid in an unquoted identifier -- e.g.
-    the ``-`` in a pytest-xdist worker suffix like ``mycollection-gw1`` -- does
-    not produce a syntax error. Embedded double-quotes are escaped per the SQL
-    standard.
-    """
-    return '"' + name.replace('"', '""') + '"'
+class ChromaDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="CHROMA_")
 
-
-class PostgresDBConfig(VectorStoreConfig):
-    collection_name: str = "embeddings"
-    cloud: bool = False
-    docker: bool = True
-    host: str = "127.0.0.1"
-    port: int = 5432
-    replace_collection: bool = False
+    collection_name: str = "temp"
+    storage_path: str = ".chroma/data"
+    distance: Literal["cosine", "l2", "ip"] = "cosine"
+    construction_ef: int = 100
+    search_ef: int = 100
+    max_neighbors: int = 16
     embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    pool_size: int = 10
-    max_overflow: int = 20
-    hnsw_m: int = 16
-    hnsw_ef_construction: int = 200
+    host: str = "127.0.0.1"
+    port: int = 6333
 
 
-class PostgresDB(VectorStore):
-    def __init__(self, config: PostgresDBConfig | None = None):
-        config = config if config is not None else PostgresDBConfig()
+class ChromaDB(VectorStore):
+    def __init__(self, config: ChromaDBConfig | None = None):
+        config = config if config is not None else ChromaDBConfig()
         super().__init__(config)
-        if not has_postgres:
-            raise LangroidImportError("pgvector", "postgres")
         try:
-            from sqlalchemy.orm import sessionmaker
+            import chromadb
         except ImportError:
-            raise LangroidImportError("sqlalchemy", "postgres")
-
-        self.config: PostgresDBConfig = config
-        self.engine = self._create_engine()
-        PostgresDB._create_vector_extension(self.engine)
-        self.SessionLocal = sessionmaker(
-            autocommit=False, autoflush=False, bind=self.engine
-        )
-        self.metadata = MetaData()
-        self._setup_table()
-
-    def _create_engine(self) -> Engine:
-        """Creates a SQLAlchemy engine based on the configuration."""
-
-        connection_string: str | None = None  # Ensure variable is always defined
-
-        if self.config.cloud:
-            connection_string = os.getenv("POSTGRES_CONNECTION_STRING")
-
-            if connection_string and connection_string.startswith("postgres://"):
-                connection_string = connection_string.replace(
-                    "postgres://", "postgresql+psycopg2://", 1
-                )
-            elif not connection_string:
-                raise ValueError("Provide the POSTGRES_CONNECTION_STRING.")
-
-        elif self.config.docker:
-            username = os.getenv("POSTGRES_USER", "postgres")
-            password = os.getenv("POSTGRES_PASSWORD", "postgres")
-            database = os.getenv("POSTGRES_DB", "langroid")
-
-            if not (username and password and database):
-                raise ValueError(
-                    "Provide POSTGRES_USER, POSTGRES_PASSWORD, " "POSTGRES_DB. "
-                )
-
-            connection_string = (
-                f"postgresql+psycopg2://{username}:{password}@"
-                f"{self.config.host}:{self.config.port}/{database}"
+            raise LangroidImportError("chromadb", "chromadb")
+        self.config = config
+        self.client = chromadb.Client(
+            chromadb.config.Settings(
+                # chroma_db_impl="duckdb+parquet",
+                # is_persistent=bool(config.storage_path),
+                persist_directory=config.storage_path,
             )
-            self.config.cloud = False  # Ensures cloud is disabled if using Docker
-
-        else:
-            raise ValueError(
-                "Provide either Docker or Cloud config to connect to the database."
-            )
-
-        return create_engine(
-            connection_string,
-            pool_size=self.config.pool_size,
-            max_overflow=self.config.max_overflow,
         )
-
-    def _setup_table(self) -> None:
-        try:
-            from pgvector.sqlalchemy import Vector
-        except ImportError as e:
-            raise LangroidImportError(extra="postgres", error=str(e))
-
-        if self.config.replace_collection:
-            self.delete_collection(self.config.collection_name)
-
-        self.embeddings_table = Table(
-            self.config.collection_name,
-            self.metadata,
-            Column("id", String, primary_key=True, nullable=False, unique=True),
-            Column("embedding", Vector(self.embedding_dim)),
-            Column("document", String),
-            Column("cmetadata", JSONB),
-            extend_existing=True,
-        )
-
-        self.metadata.create_all(self.engine)
-        self.metadata.reflect(bind=self.engine, only=[self.config.collection_name])
-
-        # Create HNSW index for embeddings column if it doesn't exist.
-        # This index enables efficient nearest-neighbor search using cosine similarity.
-        # PostgreSQL automatically builds the index after creation;
-        # no manual step required.
-        # Read more about pgvector hnsw index here:
-        # https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw
-
-        index_name = f"hnsw_index_{self.config.collection_name}_embedding"
-        with self.engine.connect() as connection:
-            if not self.index_exists(connection, index_name):
-                connection.execute(text("COMMIT"))
-                create_index_query = text(
-                    f"""
-                    CREATE INDEX CONCURRENTLY IF NOT EXISTS {_quote_ident(index_name)}
-                    ON {_quote_ident(self.config.collection_name)}
-                    USING hnsw (embedding vector_cosine_ops)
-                    WITH (
-                        m = {self.config.hnsw_m},
-                        ef_construction = {self.config.hnsw_ef_construction}
-                    );
-                    """
-                )
-                connection.execute(create_index_query)
-
-    def index_exists(self, connection: Connection, index_name: str) -> bool:
-        """Check if an index exists."""
-        query = text(
-            "SELECT 1 FROM pg_indexes WHERE indexname = :index_name"
-        ).bindparams(index_name=index_name)
-        result = connection.execute(query).scalar()
-        return bool(result)
-
-    @staticmethod
-    def _create_vector_extension(conn: Engine) -> None:
-
-        with conn.connect() as connection:
-            with connection.begin():
-                # The number is a unique identifier used to lock a specific resource
-                # during transaction. Any 64-bit integer can be used for advisory locks.
-                # Acquire advisory lock to ensure atomic, isolated setup
-                # and prevent race conditions.
-
-                statement = text(
-                    "SELECT pg_advisory_xact_lock(1573678846307946496);"
-                    "CREATE EXTENSION IF NOT EXISTS vector;"
-                )
-                connection.execute(statement)
-
-    def set_collection(self, collection_name: str, replace: bool = False) -> None:
-        inspector = inspect(self.engine)
-        table_exists = collection_name in inspector.get_table_names()
-
-        if (
-            collection_name == self.config.collection_name
-            and table_exists
-            and not replace
-        ):
-            return
-        else:
-            self.config.collection_name = collection_name
-            self.config.replace_collection = replace
-            self._setup_table()
-
-    def list_collections(self, empty: bool = True) -> List[str]:
-        inspector = inspect(self.engine)
-        table_names = inspector.get_table_names()
-
-        with self.SessionLocal() as session:
-            collections = []
-            for table_name in table_names:
-                table = Table(table_name, self.metadata, autoload_with=self.engine)
-                if empty:
-                    collections.append(table_name)
-                else:
-                    # Efficiently check for non-emptiness
-                    if session.query(table.select().limit(1).exists()).scalar():
-                        collections.append(table_name)
-            return collections
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        self.set_collection(collection_name, replace=replace)
-
-    def delete_collection(self, collection_name: str) -> None:
-        """
-        Deletes a collection and its associated HNSW index, handling metadata
-        synchronization issues.
-        """
-        with self.engine.connect() as connection:
-            connection.execute(text("COMMIT"))
-            index_name = f"hnsw_index_{collection_name}_embedding"
-            drop_index_query = text(
-                f"DROP INDEX CONCURRENTLY IF EXISTS {_quote_ident(index_name)}"
+        if self.config.collection_name is not None:
+            self.create_collection(
+                self.config.collection_name,
+                replace=self.config.replace_collection,
             )
-            connection.execute(drop_index_query)
-
-            # 3. Now, drop the table using SQLAlchemy
-            table = Table(collection_name, self.metadata)
-            table.drop(self.engine, checkfirst=True)
-
-            # 4. Refresh metadata again after dropping the table
-            self.metadata.clear()
-            self.metadata.reflect(bind=self.engine)
 
     def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """Clear all collections in the vector store with the given prefix."""
+
         if not really:
-            logger.warning("Not deleting all tables, set really=True to confirm")
+            logger.warning("Not deleting all collections, set really=True to confirm")
             return 0
-
-        inspector = inspect(self.engine)
-        table_names = inspector.get_table_names()
-
-        with self.SessionLocal() as session:
-            deleted_count = 0
-            for table_name in table_names:
-                if table_name.startswith(prefix):
-                    # Use delete_collection to handle index and table deletion
-                    self.delete_collection(table_name)
-                    deleted_count += 1
-            session.commit()
-            logger.warning(f"Deleted {deleted_count} tables with prefix '{prefix}'.")
-            return deleted_count
+        coll = [c for c in self.client.list_collections() if c.name.startswith(prefix)]
+        if len(coll) == 0:
+            logger.warning(f"No collections found with prefix {prefix}")
+            return 0
+        n_empty_deletes = 0
+        n_non_empty_deletes = 0
+        for c in coll:
+            n_empty_deletes += c.count() == 0
+            n_non_empty_deletes += c.count() > 0
+            self.client.delete_collection(name=c.name)
+        logger.warning(
+            f"""
+            Deleted {n_empty_deletes} empty collections and
+            {n_non_empty_deletes} non-empty collections.
+            """
+        )
+        return n_empty_deletes + n_non_empty_deletes
 
     def clear_empty_collections(self) -> int:
-        inspector = inspect(self.engine)
-        table_names = inspector.get_table_names()
+        colls = self.client.list_collections()
+        n_deletes = 0
+        for coll in colls:
+            if coll.count() == 0:
+                n_deletes += 1
+                self.client.delete_collection(name=coll.name)
+        return n_deletes
 
-        with self.SessionLocal() as session:
-            deleted_count = 0
-            for table_name in table_names:
-                table = Table(table_name, self.metadata, autoload_with=self.engine)
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """
+        List non-empty collections in the vector store.
+        Args:
+            empty (bool, optional): Whether to list empty collections.
+        Returns:
+            List[str]: List of non-empty collection names.
+        """
+        colls = self.client.list_collections()
+        if empty:
+            return [coll.name for coll in colls]
+        return [coll.name for coll in colls if coll.count() > 0]
 
-                # Efficiently check for emptiness without fetching all rows
-                if session.query(table.select().limit(1).exists()).scalar():
-                    continue
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        """
+        Create a collection in the vector store, optionally replacing an existing
+            collection if `replace` is True.
+        Args:
+            collection_name (str): Name of the collection to create or replace.
+            replace (bool, optional): Whether to replace an existing collection.
+                Defaults to False.
 
-                # Use delete_collection to handle index and table deletion
-                self.delete_collection(table_name)
-                deleted_count += 1
-
-            session.commit()  # Commit is likely not needed here
-            logger.warning(f"Deleted {deleted_count} empty tables.")
-            return deleted_count
-
-    def _parse_embedding_store_record(self, res: Any) -> Dict[str, Any]:
-        metadata = res.cmetadata or {}
-        metadata["id"] = res.id
-        return {
-            "content": res.document,
-            "metadata": DocMetaData(**metadata),
-        }
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        with self.SessionLocal() as session:
-            query = session.query(self.embeddings_table)
-
-            # Apply 'where' clause if provided
-            if where:
-                try:
-                    where_json = json.loads(where)
-                    query = query.filter(
-                        self.embeddings_table.c.cmetadata.contains(where_json)
-                    )
-                except json.JSONDecodeError:
-                    logger.error(f"Invalid JSON in 'where' clause: {where}")
-                    return []  # Return empty list or handle error as appropriate
-
-            results = query.all()
-            documents = [
-                Document(**self._parse_embedding_store_record(res)) for res in results
-            ]
-            return documents
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        with self.SessionLocal() as session:
-            # Add a CASE statement to preserve the order of IDs
-            case_stmt = case(
-                {id_: index for index, id_ in enumerate(ids)},
-                value=self.embeddings_table.c.id,
-            )
-
-            query = (
-                session.query(self.embeddings_table)
-                .filter(self.embeddings_table.c.id.in_(ids))
-                .order_by(case_stmt)  # Order by the CASE statement
-            )
-            results = query.all()
-
-            documents = [
-                Document(**self._parse_embedding_store_record(row)) for row in results
-            ]
-            return documents
+        """
+        self.config.collection_name = collection_name
+        if collection_name in self.list_collections(empty=True) and replace:
+            logger.warning(f"Replacing existing collection {collection_name}")
+            self.client.delete_collection(collection_name)
+        self.collection = self.client.create_collection(
+            name=self.config.collection_name,
+            embedding_function=self.embedding_fn,
+            get_or_create=not replace,
+            metadata={
+                "hnsw:space": self.config.distance,
+                "hnsw:construction_ef": self.config.construction_ef,
+                "hnsw:search_ef": self.config.search_ef,
+                # we could expose other configs, see:
+                # https://docs.trychroma.com/docs/collections/configure
+            },
+        )
 
     def add_documents(self, documents: Sequence[Document]) -> None:
         super().maybe_add_ids(documents)
-        for doc in documents:
-            doc.metadata.id = str(PostgresDB._id_to_uuid(doc.metadata.id, doc.metadata))
+        if documents is None:
+            return
+        contents: List[str] = [document.content for document in documents]
+        # convert metadatas to dicts so chroma can handle them
+        metadata_dicts: List[dict[str, Any]] = [
+            d.metadata.dict_bool_int() for d in documents
+        ]
+        for m in metadata_dicts:
+            # chroma does not handle non-atomic types in metadata
+            m["window_ids"] = ",".join(m["window_ids"])
 
-        embeddings = self.embedding_fn([doc.content for doc in documents])
+        ids = [str(d.id()) for d in documents]
 
-        batch_size = self.config.batch_size
-        with self.SessionLocal() as session:
-            for i in range(0, len(documents), batch_size):
-                batch_docs = documents[i : i + batch_size]
-                batch_embeddings = embeddings[i : i + batch_size]
+        colls = self.list_collections(empty=True)
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        if self.config.collection_name not in colls:
+            self.create_collection(self.config.collection_name, replace=True)
 
-                new_records = [
-                    {
-                        "id": doc.metadata.id,
-                        "embedding": embedding,
-                        "document": doc.content,
-                        "cmetadata": doc.metadata.model_dump(),
-                    }
-                    for doc, embedding in zip(batch_docs, batch_embeddings)
-                ]
+        self.collection.add(
+            # embedding_models=embedding_models,
+            documents=contents,
+            metadatas=metadata_dicts,
+            ids=ids,
+        )
 
-                if new_records:
-                    stmt = insert(self.embeddings_table).values(new_records)
-                    session.execute(stmt)
-                session.commit()
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        filter = json.loads(where) if where else None
+        results = self.collection.get(
+            include=["documents", "metadatas"],
+            where=filter,
+        )
+        results["documents"] = [results["documents"]]
+        results["metadatas"] = [results["metadatas"]]
+        return self._docs_from_results(results)
 
-    @staticmethod
-    def _id_to_uuid(id: str, obj: object) -> str:
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        # get them one by one since chroma mangles the order of the results
+        # when fetched from a list of ids.
+        results = [
+            self.collection.get(ids=[id], include=["documents", "metadatas"])
+            for id in ids
+        ]
+        final_results = {}
+        final_results["documents"] = [[r["documents"][0] for r in results]]
+        final_results["metadatas"] = [[r["metadatas"][0] for r in results]]
+        return self._docs_from_results(final_results)
+
+    def delete_collection(self, collection_name: str) -> None:
         try:
-            doc_id = str(uuid.UUID(id))
-        except ValueError:
-            obj_repr = repr(obj)
-
-            obj_hash = hashlib.sha256(obj_repr.encode()).hexdigest()
-
-            combined = f"{id}-{obj_hash}"
-
-            doc_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, combined))
-
-        return doc_id
+            self.client.delete_collection(name=collection_name)
+        except Exception:
+            pass
 
     def similar_texts_with_scores(
-        self,
-        query: str,
-        k: int = 1,
-        where: Optional[str] = None,
-        neighbors: int = 1,  # Parameter not used in this implementation
+        self, text: str, k: int = 1, where: Optional[str] = None
     ) -> List[Tuple[Document, float]]:
-        embedding = self.embedding_fn([query])[0]
+        n = self.collection.count()
+        filter = json.loads(where) if where else None
+        results = self.collection.query(
+            query_texts=[text],
+            n_results=min(n, k),
+            where=filter,
+            include=["documents", "distances", "metadatas"],
+        )
+        docs = self._docs_from_results(results)
+        # chroma distances are 1 - cosine.
+        scores = [1 - s for s in results["distances"][0]]
+        return list(zip(docs, scores))
 
-        with self.SessionLocal() as session:
-            # Calculate the score (1 - cosine_distance) and label it as "score"
-            score = (
-                1 - (self.embeddings_table.c.embedding.cosine_distance(embedding))
-            ).label("score")
+    def _docs_from_results(self, results: Dict[str, Any]) -> List[Document]:
+        """
+        Helper function to convert results from ChromaDB to a list of Documents
+        Args:
+            results (dict): results from ChromaDB
 
-            if where is not None:
-                try:
-                    json_query = json.loads(where)
-                except json.JSONDecodeError:
-                    raise ValueError(f"Invalid JSON in 'where' clause: {where}")
-
-                results = (
-                    session.query(
-                        self.embeddings_table.c.id,
-                        self.embeddings_table.c.document,
-                        self.embeddings_table.c.cmetadata,
-                        score,  # Select the calculated score
-                    )
-                    .filter(self.embeddings_table.c.cmetadata.contains(json_query))
-                    .order_by(score.desc())  # Order by score in descending order
-                    .limit(k)
-                    .all()
-                )
+        Returns:
+            List[Document]: list of Documents
+        """
+        if len(results["documents"][0]) == 0:
+            return []
+        contents = results["documents"][0]
+        if settings.debug:
+            for i, c in enumerate(contents):
+                print_long_text("red", "italic red", f"MATCH-{i}", c)
+        metadatas = results["metadatas"][0]
+        for m in metadatas:
+            # restore the stringified list of window_ids into the original List[str]
+            if m["window_ids"].strip() == "":
+                m["window_ids"] = []
             else:
-                results = (
-                    session.query(
-                        self.embeddings_table.c.id,
-                        self.embeddings_table.c.document,
-                        self.embeddings_table.c.cmetadata,
-                        score,  # Select the calculated score
-                    )
-                    .order_by(score.desc())  # Order by score in descending order
-                    .limit(k)
-                    .all()
-                )
-
-            documents_with_scores = [
-                (
-                    Document(
-                        content=result.document,
-                        metadata=DocMetaData(**(result.cmetadata or {})),
-                    ),
-                    result.score,  # Use the score from the query result
-                )
-                for result in results
-            ]
-
-            return documents_with_scores
+                m["window_ids"] = m["window_ids"].split(",")
+        docs = [
+            self.config.document_class(
+                content=d, metadata=self.config.metadata_class(**m)
+            )
+            for d, m in zip(contents, metadatas)
+        ]
+        return docs
 </file>
 
-<file path="langroid/vector_store/qdrantdb.py">
-import hashlib
-import json
-import logging
-import os
-import time
-import uuid
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, TypeVar
+<file path="langroid/vector_store/lancedb.py">
+from __future__ import annotations
 
+import logging
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+)
+
+import pandas as pd
 from dotenv import load_dotenv
+from pydantic import BaseModel, ValidationError, create_model
+
+if TYPE_CHECKING:
+    from lancedb.query import LanceVectorQueryBuilder
+
+from pydantic_settings import SettingsConfigDict
 
 from langroid.embedding_models.base import (
     EmbeddingModelsConfig,
 )
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.mytypes import Document, Embeddings
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import Document
 from langroid.utils.configuration import settings
+from langroid.utils.pydantic_utils import (
+    dataframe_to_document_model,
+    dataframe_to_documents,
+)
 from langroid.vector_store.base import VectorStore, VectorStoreConfig
 
+try:
+    import lancedb
+    from lancedb.pydantic import LanceModel, Vector
+
+    has_lancedb = True
+except ImportError:
+    has_lancedb = False
+
 logger = logging.getLogger(__name__)
-if TYPE_CHECKING:
-    from qdrant_client.http.models import SparseVector
 
 
-T = TypeVar("T")
+class LanceDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="LANCEDB_")
 
-
-def from_optional(x: Optional[T], default: T) -> T:
-    if x is None:
-        return default
-
-    return x
-
-
-def is_valid_uuid(uuid_to_test: str) -> bool:
-    """
-    Check if a given string is a valid UUID.
-    """
-    try:
-        uuid_obj = uuid.UUID(uuid_to_test)
-        return str(uuid_obj) == uuid_to_test
-    except Exception:
-        pass
-    # Check for valid unsigned 64-bit integer
-    try:
-        int_value = int(uuid_to_test)
-        return 0 <= int_value <= 18446744073709551615
-    except ValueError:
-        return False
-
-
-class QdrantDBConfig(VectorStoreConfig):
-    cloud: bool = True
-    docker: bool = False
+    cloud: bool = False
     collection_name: str | None = "temp"
-    storage_path: str = ".qdrant/data"
+    storage_path: str = ".lancedb/data"
     embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    use_sparse_embeddings: bool = False
-    sparse_embedding_model: str = "naver/splade-v3-distilbert"
-    sparse_limit: int = 3
     distance: str = "cosine"
 
 
-class QdrantDB(VectorStore):
-    def __init__(self, config: QdrantDBConfig | None = None):
-        config = config if config is not None else QdrantDBConfig()
+class LanceDB(VectorStore):
+    def __init__(self, config: LanceDBConfig | None = None):
+        config = config if config is not None else LanceDBConfig()
         super().__init__(config)
-        self.config: QdrantDBConfig = config
-        from qdrant_client import QdrantClient
+        if not has_lancedb:
+            raise LangroidImportError("lancedb", "lancedb")
 
-        if self.config.use_sparse_embeddings:
-            try:
-                from transformers import AutoModelForMaskedLM, AutoTokenizer
-            except ImportError:
-                raise ImportError(
-                    """
-                    To use sparse embeddings,
-                    you must install langroid with the [transformers] extra, e.g.:
-                    pip install "langroid[transformers]"
-                    """
-                )
-
-            self.sparse_tokenizer = AutoTokenizer.from_pretrained(  # type: ignore
-                self.config.sparse_embedding_model
-            )
-            self.sparse_model = AutoModelForMaskedLM.from_pretrained(
-                self.config.sparse_embedding_model
-            )
+        self.config: LanceDBConfig = config
         self.host = config.host
         self.port = config.port
+        self.is_from_dataframe = False  # were docs ingested from a dataframe?
+        self.df_metadata_columns: List[str] = []  # metadata columns from dataframe
+
         load_dotenv()
-        key = os.getenv("QDRANT_API_KEY")
-        url = os.getenv("QDRANT_API_URL")
-        if config.docker:
-            if url is None:
-                logger.warning(
-                    f"""The QDRANT_API_URL env variable must be set to use
-                    QdrantDB in local docker mode. Please set this
-                    value in your .env file.
-                    Switching to local storage at {config.storage_path}
-                    """
-                )
-                config.cloud = False
-            else:
-                config.cloud = True
-        elif config.cloud and None in [key, url]:
+        if self.config.cloud:
             logger.warning(
-                f"""QDRANT_API_KEY, QDRANT_API_URL env variable must be set to use
-                QdrantDB in cloud mode. Please set these values
-                in your .env file.
-                Switching to local storage at {config.storage_path}
-                """
+                "LanceDB Cloud is not available yet. Switching to local storage."
             )
             config.cloud = False
-
-        if config.cloud:
-            self.client = QdrantClient(
-                url=url,
-                api_key=key,
-                timeout=config.timeout,
-            )
         else:
             try:
-                self.client = QdrantClient(
-                    path=config.storage_path,
+                self.client = lancedb.connect(
+                    uri=config.storage_path,
                 )
             except Exception as e:
                 new_storage_path = config.storage_path + ".new"
                 logger.warning(
                     f"""
-                    Error connecting to local QdrantDB at {config.storage_path}:
+                    Error connecting to local LanceDB at {config.storage_path}:
                     {e}
                     Switching to {new_storage_path}
                     """
                 )
-                self.client = QdrantClient(
-                    path=new_storage_path,
+                self.client = lancedb.connect(
+                    uri=new_storage_path,
                 )
-
-        # Note: Only create collection if a non-null collection name is provided.
-        # This is useful to delay creation of vecdb until we have a suitable
-        # collection name (e.g. we could get it from the url or folder path).
-        if config.collection_name is not None:
-            self.create_collection(
-                config.collection_name, replace=config.replace_collection
-            )
-
-    def clone(self) -> "QdrantDB":
-        """Create an independent Qdrant client when running against Qdrant Cloud."""
-        if not self.config.cloud:
-            return self
-        cloned = super().clone()
-        assert isinstance(cloned, QdrantDB)
-        return cloned
-
-    def close(self) -> None:
-        """
-        Close the QdrantDB client and release any resources (e.g., file locks).
-        This is especially important for local storage to release the .lock file.
-        """
-        if hasattr(self.client, "close"):
-            # QdrantLocal has a close method that releases the lock
-            self.client.close()
-            logger.info(f"Closed QdrantDB connection for {self.config.storage_path}")
-
-    def __enter__(self) -> "QdrantDB":
-        """Context manager entry."""
-        return self
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        """Context manager exit - ensure cleanup even if an exception occurred."""
-        self.close()
 
     def clear_empty_collections(self) -> int:
         coll_names = self.list_collections()
         n_deletes = 0
         for name in coll_names:
-            info = self.client.get_collection(collection_name=name)
-            if info.points_count == 0:
+            nr = self.client.open_table(name).head(1).shape[0]
+            if nr == 0:
                 n_deletes += 1
-                self.client.delete_collection(collection_name=name)
+                self.client.drop_table(name)
         return n_deletes
 
     def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
         """Clear all collections with the given prefix."""
-
         if not really:
             logger.warning("Not deleting all collections, set really=True to confirm")
             return 0
@@ -75384,12 +73064,10 @@ class QdrantDB(VectorStore):
         n_empty_deletes = 0
         n_non_empty_deletes = 0
         for name in coll_names:
-            info = self.client.get_collection(collection_name=name)
-            points_count = from_optional(info.points_count, 0)
-
-            n_empty_deletes += points_count == 0
-            n_non_empty_deletes += points_count > 0
-            self.client.delete_collection(collection_name=name)
+            nr = self.client.open_table(name).head(1).shape[0]
+            n_empty_deletes += nr == 0
+            n_non_empty_deletes += nr > 0
+            self.client.drop_table(name)
         logger.warning(
             f"""
             Deleted {n_empty_deletes} empty collections and
@@ -75406,25 +73084,425 @@ class QdrantDB(VectorStore):
         Args:
             empty (bool, optional): Whether to include empty collections.
         """
+        colls = self.client.table_names(limit=None)
+        if len(colls) == 0:
+            return []
+        if empty:  # include empty tbls
+            return colls  # type: ignore
+        counts = [self.client.open_table(coll).head(1).shape[0] for coll in colls]
+        return [coll for coll, count in zip(colls, counts) if count > 0]
 
-        colls = list(self.client.get_collections())[0][1]
-        if empty:
-            return [coll.name for coll in colls]
-        counts = []
-        for coll in colls:
-            try:
-                counts.append(
-                    from_optional(
-                        self.client.get_collection(
-                            collection_name=coll.name
-                        ).points_count,
-                        0,
+    def _create_lance_schema(self, doc_cls: Type[Document]) -> Type[BaseModel]:
+        """
+        NOTE: NOT USED, but leaving it here as it may be useful.
+
+        Create a subclass of LanceModel with fields:
+         - id (str)
+         - Vector field that has dims equal to
+            the embedding dimension of the embedding model, and a data field of type
+            DocClass.
+         - other fields from doc_cls
+
+        Args:
+            doc_cls (Type[Document]): A Pydantic model which should be a subclass of
+                Document, to be used as the type for the data field.
+
+        Returns:
+            Type[BaseModel]: A new Pydantic model subclassing from LanceModel.
+
+        Raises:
+            ValueError: If `n` is not a non-negative integer or if `DocClass` is not a
+                subclass of Document.
+        """
+        if not issubclass(doc_cls, Document):
+            raise ValueError("DocClass must be a subclass of Document")
+
+        if not has_lancedb:
+            raise LangroidImportError("lancedb", "lancedb")
+
+        n = self.embedding_dim
+
+        # Prepare fields for the new model
+        fields = {"id": (str, ...), "vector": (Vector(n), ...)}
+
+        sorted_fields = dict(
+            sorted(doc_cls.model_fields.items(), key=lambda item: item[0])
+        )
+        # Add both statically and dynamically defined fields from doc_cls
+        for field_name, field in sorted_fields.items():
+            field_type = field.annotation if hasattr(field, "annotation") else field
+            fields[field_name] = (field_type, field.default)
+
+        # Create the new model with dynamic fields
+        NewModel = create_model(
+            "NewModel", __base__=LanceModel, **fields
+        )  # type: ignore
+        return NewModel  # type: ignore
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        self.config.replace_collection = replace
+        self.config.collection_name = collection_name
+        if replace:
+            self.delete_collection(collection_name)
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        super().maybe_add_ids(documents)
+        colls = self.list_collections(empty=True)
+        if len(documents) == 0:
+            return
+        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+        coll_name = self.config.collection_name
+        if coll_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        # self._maybe_set_doc_class_schema(documents[0])
+        table_exists = False
+        if (
+            coll_name in colls
+            and self.client.open_table(coll_name).head(1).shape[0] > 0
+        ):
+            # collection exists and  is not empty:
+            # if replace_collection is True, we'll overwrite the existing collection,
+            # else we'll append to it.
+            if self.config.replace_collection:
+                self.client.drop_table(coll_name)
+            else:
+                table_exists = True
+
+        ids = [str(d.id()) for d in documents]
+        # don't insert all at once, batch in chunks of b,
+        # else we get an API error
+        b = self.config.batch_size
+
+        def make_batches() -> Generator[List[Dict[str, Any]], None, None]:
+            for i in range(0, len(ids), b):
+                batch = [
+                    dict(
+                        id=ids[i + j],
+                        vector=embedding_vecs[i + j],
+                        **doc.model_dump(),
                     )
+                    for j, doc in enumerate(documents[i : i + b])
+                ]
+                yield batch
+
+        try:
+            if table_exists:
+                tbl = self.client.open_table(coll_name)
+                tbl.add(make_batches())
+            else:
+                batch_gen = make_batches()
+                batch = next(batch_gen)
+                # use first batch to create table...
+                tbl = self.client.create_table(
+                    coll_name,
+                    data=batch,
+                    mode="create",
                 )
-            except Exception:
-                logger.warning(f"Error getting collection {coll.name}")
-                counts.append(0)
-        return [coll.name for coll, count in zip(colls, counts) if (count or 0) > 0]
+                # ... and add the rest
+                tbl.add(batch_gen)
+        except Exception as e:
+            logger.error(
+                f"""
+                Error adding documents to LanceDB: {e}
+                POSSIBLE REMEDY: Delete the LancdDB storage directory
+                {self.config.storage_path} and try again.
+                """
+            )
+
+    def add_dataframe(
+        self,
+        df: pd.DataFrame,
+        content: str = "content",
+        metadata: List[str] = [],
+    ) -> None:
+        """
+        Add a dataframe to the collection.
+        Args:
+            df (pd.DataFrame): A dataframe
+            content (str): The name of the column in the dataframe that contains the
+                text content to be embedded using the embedding model.
+            metadata (List[str]): A list of column names in the dataframe that contain
+                metadata to be stored in the database. Defaults to [].
+        """
+        self.is_from_dataframe = True
+        actual_metadata = metadata.copy()
+        self.df_metadata_columns = actual_metadata  # could be updated below
+        # get content column
+        content_values = df[content].values.tolist()
+        embedding_vecs = self.embedding_fn(content_values)
+
+        # add vector column
+        df["vector"] = embedding_vecs
+        if content != "content":
+            # rename content column to "content", leave existing column intact
+            df = df.rename(columns={content: "content"}, inplace=False)
+
+        if "id" not in df.columns:
+            docs = dataframe_to_documents(df, content="content", metadata=metadata)
+            ids = [str(d.id()) for d in docs]
+            df["id"] = ids
+
+        if "id" not in actual_metadata:
+            actual_metadata += ["id"]
+
+        colls = self.list_collections(empty=True)
+        coll_name = self.config.collection_name
+        if (
+            coll_name not in colls
+            or self.client.open_table(coll_name).head(1).shape[0] == 0
+        ):
+            # collection either doesn't exist or is empty, so replace it
+            # and set new schema from df
+            self.client.create_table(
+                self.config.collection_name,
+                data=df,
+                mode="overwrite",
+            )
+            doc_cls = dataframe_to_document_model(
+                df,
+                content=content,
+                metadata=actual_metadata,
+                exclude=["vector"],
+            )
+            self.config.document_class = doc_cls  # type: ignore
+        else:
+            # collection exists and is not empty, so append to it
+            tbl = self.client.open_table(self.config.collection_name)
+            tbl.add(df)
+
+    def delete_collection(self, collection_name: str) -> None:
+        self.client.drop_table(collection_name, ignore_missing=True)
+
+    def _lance_result_to_docs(
+        self, result: "LanceVectorQueryBuilder"
+    ) -> List[Document]:
+        if self.is_from_dataframe:
+            df = result.to_pandas()
+            return dataframe_to_documents(
+                df,
+                content="content",
+                metadata=self.df_metadata_columns,
+                doc_cls=self.config.document_class,
+            )
+        else:
+            records = result.to_arrow().to_pylist()
+            return self._records_to_docs(records)
+
+    def _records_to_docs(self, records: List[Dict[str, Any]]) -> List[Document]:
+        try:
+            docs = [self.config.document_class(**rec) for rec in records]
+        except ValidationError as e:
+            raise ValueError(
+                f"""
+            Error validating LanceDB result: {e}
+            HINT: This could happen when you're re-using an
+            existing LanceDB store with a different schema.
+            Try deleting your local lancedb storage at `{self.config.storage_path}`
+            re-ingesting your documents and/or replacing the collections.
+            """
+            )
+        return docs
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        if self.config.collection_name not in self.list_collections(empty=True):
+            return []
+        tbl = self.client.open_table(self.config.collection_name)
+        pre_result = tbl.search(None).where(where or None).limit(None)
+        return self._lance_result_to_docs(pre_result)
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        _ids = [str(id) for id in ids]
+        tbl = self.client.open_table(self.config.collection_name)
+        docs = []
+        for _id in _ids:
+            results = self._lance_result_to_docs(tbl.search().where(f"id == '{_id}'"))
+            if len(results) > 0:
+                docs.append(results[0])
+        return docs
+
+    def similar_texts_with_scores(
+        self,
+        text: str,
+        k: int = 1,
+        where: Optional[str] = None,
+    ) -> List[Tuple[Document, float]]:
+        embedding = self.embedding_fn([text])[0]
+        tbl = self.client.open_table(self.config.collection_name)
+        result = (
+            tbl.search(embedding)
+            .metric(self.config.distance)
+            .where(where, prefilter=True)
+            .limit(k)
+        )
+        docs = self._lance_result_to_docs(result)
+        # note _distance is 1 - cosine
+        if self.is_from_dataframe:
+            scores = [
+                1 - rec["_distance"] for rec in result.to_pandas().to_dict("records")
+            ]
+        else:
+            scores = [1 - rec["_distance"] for rec in result.to_arrow().to_pylist()]
+        if len(docs) == 0:
+            logger.warning(f"No matches found for {text}")
+            return []
+        if settings.debug:
+            logger.info(f"Found {len(docs)} matches, max score: {max(scores)}")
+        doc_score_pairs = list(zip(docs, scores))
+        self.show_if_debug(doc_score_pairs)
+        return doc_score_pairs
+</file>
+
+<file path="langroid/vector_store/meilisearch.py">
+"""
+MeiliSearch as a pure document store, without its
+(experimental) vector-store functionality.
+We aim to use MeiliSearch for fast lexical search.
+Note that what we call "Collection" in Langroid is referred to as
+"Index" in MeiliSearch. Each data-store has its own terminology,
+but for uniformity we use the Langroid terminology here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+from dotenv import load_dotenv
+
+if TYPE_CHECKING:
+    from meilisearch_python_sdk.index import AsyncIndex
+    from meilisearch_python_sdk.models.documents import DocumentsInfo
+
+
+from pydantic_settings import SettingsConfigDict
+
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import DocMetaData, Document
+from langroid.utils.configuration import settings
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+
+
+class MeiliSearchConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="MEILISEARCH_")
+
+    cloud: bool = False
+    collection_name: str | None = None
+    primary_key: str = "id"
+    port: int = 7700
+
+
+class MeiliSearch(VectorStore):
+    def __init__(self, config: MeiliSearchConfig | None = None):
+        config = config if config is not None else MeiliSearchConfig()
+        super().__init__(config)
+        try:
+            import meilisearch_python_sdk as meilisearch
+        except ImportError:
+            raise LangroidImportError("meilisearch", "meilisearch")
+
+        self.config: MeiliSearchConfig = config
+        self.host = config.host
+        self.port = config.port
+        load_dotenv()
+        self.key = os.getenv("MEILISEARCH_API_KEY") or "masterKey"
+        self.url = os.getenv("MEILISEARCH_API_URL") or f"http://{self.host}:{self.port}"
+        if config.cloud and None in [self.key, self.url]:
+            logger.warning(
+                f"""MEILISEARCH_API_KEY, MEILISEARCH_API_URL env variable must be set 
+                to use MeiliSearch in cloud mode. Please set these values 
+                in your .env file. Switching to local MeiliSearch at 
+                {self.url} 
+                """
+            )
+            config.cloud = False
+
+        self.client: Callable[[], meilisearch.AsyncClient] = lambda: (
+            meilisearch.AsyncClient(url=self.url, api_key=self.key)
+        )
+
+        # Note: Only create collection if a non-null collection name is provided.
+        # This is useful to delay creation of db until we have a suitable
+        # collection name (e.g. we could get it from the url or folder path).
+        if config.collection_name is not None:
+            self.create_collection(
+                config.collection_name, replace=config.replace_collection
+            )
+
+    def clear_empty_collections(self) -> int:
+        """All collections are treated as non-empty in MeiliSearch, so this is a
+        no-op"""
+        return 0
+
+    async def _async_delete_indices(self, uids: List[str]) -> List[bool]:
+        """Delete any indicecs in `uids` that exist.
+        Returns list of bools indicating whether the index has been deleted"""
+        async with self.client() as client:
+            result = await asyncio.gather(
+                *[client.delete_index_if_exists(uid=uid) for uid in uids]
+            )
+        return result
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """Delete all indices whose names start with `prefix`"""
+        if not really:
+            logger.warning("Not deleting all collections, set really=True to confirm")
+            return 0
+        coll_names = [c for c in self.list_collections() if c.startswith(prefix)]
+        deletes = asyncio.run(self._async_delete_indices(coll_names))
+        n_deletes = sum(deletes)
+        logger.warning(f"Deleted {n_deletes} indices in MeiliSearch")
+        return n_deletes
+
+    def _list_all_collections(self) -> List[str]:
+        """
+        List all collections, including empty ones.
+        Returns:
+            List of collection names.
+        """
+        return self.list_collections()
+
+    async def _async_get_indexes(self) -> List[AsyncIndex]:
+        async with self.client() as client:
+            indexes = await client.get_indexes(limit=10_000)
+        return [] if indexes is None else indexes  # type: ignore
+
+    async def _async_get_index(self, index_uid: str) -> "AsyncIndex":
+        async with self.client() as client:
+            index = await client.get_index(index_uid)
+        return index  # type: ignore
+
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """
+        Returns:
+            List of index names stored. We treat any existing index as non-empty.
+        """
+        indexes = asyncio.run(self._async_get_indexes())
+        if len(indexes) == 0:
+            return []
+        else:
+            return [ind.uid for ind in indexes]
+
+    async def _async_create_index(self, collection_name: str) -> "AsyncIndex":
+        async with self.client() as client:
+            index = await client.create_index(
+                uid=collection_name,
+                primary_key=self.config.primary_key,
+            )
+        return index
+
+    async def _async_delete_index(self, collection_name: str) -> bool:
+        """Delete index if it exists. Returns True iff index was deleted"""
+        async with self.client() as client:
+            result = await client.delete_index_if_exists(uid=collection_name)
+        return result  # type: ignore
 
     def create_collection(self, collection_name: str, replace: bool = False) -> None:
         """
@@ -75435,291 +73513,906 @@ class QdrantDB(VectorStore):
             replace (bool): Whether to replace an existing collection
                 with the same name. Defaults to False.
         """
-        from qdrant_client.http.models import (
-            CollectionStatus,
-            Distance,
-            SparseIndexParams,
-            SparseVectorParams,
-            VectorParams,
-        )
-
         self.config.collection_name = collection_name
-        if self.client.collection_exists(collection_name=collection_name):
-            coll = self.client.get_collection(collection_name=collection_name)
-            if (
-                coll.status == CollectionStatus.GREEN
-                and from_optional(coll.points_count, 0) > 0
-            ):
-                logger.warning(f"Non-empty Collection {collection_name} already exists")
-                if not replace:
-                    logger.warning("Not replacing collection")
-                    return
-                else:
-                    logger.warning("Recreating fresh collection")
-            self.client.delete_collection(collection_name=collection_name)
-
-        vectors_config = {
-            "": VectorParams(
-                size=self.embedding_dim,
-                distance=Distance.COSINE,
+        collections = self.list_collections()
+        if collection_name in collections:
+            logger.warning(
+                f"MeiliSearch Non-empty Index {collection_name} already exists"
             )
-        }
-        sparse_vectors_config = None
-        if self.config.use_sparse_embeddings:
-            sparse_vectors_config = {
-                "text-sparse": SparseVectorParams(index=SparseIndexParams())
-            }
-        self.client.create_collection(
-            collection_name=collection_name,
-            vectors_config=vectors_config,
-            sparse_vectors_config=sparse_vectors_config,
-        )
-        collection_info = self.client.get_collection(collection_name=collection_name)
-        assert collection_info.status == CollectionStatus.GREEN
-        assert collection_info.vectors_count in [0, None]
+            if not replace:
+                logger.warning("Not replacing collection")
+                return
+            else:
+                logger.warning("Recreating fresh collection")
+                asyncio.run(self._async_delete_index(collection_name))
+        asyncio.run(self._async_create_index(collection_name))
+        collection_info = asyncio.run(self._async_get_index(collection_name))
         if settings.debug:
             level = logger.getEffectiveLevel()
             logger.setLevel(logging.INFO)
             logger.info(collection_info)
             logger.setLevel(level)
 
-    def get_sparse_embeddings(self, inputs: List[str]) -> List["SparseVector"]:
-        from qdrant_client.http.models import SparseVector
-
-        if not self.config.use_sparse_embeddings:
-            return []
-        import torch
-
-        tokens = self.sparse_tokenizer(
-            inputs, return_tensors="pt", truncation=True, padding=True
-        )
-        output = self.sparse_model(**tokens)
-        vectors = torch.max(
-            torch.log(torch.relu(output.logits) + torch.tensor(1.0))
-            * tokens.attention_mask.unsqueeze(-1),
-            dim=1,
-        )[0].squeeze(dim=1)
-        sparse_embeddings = []
-        for vec in vectors:
-            cols = vec.nonzero().squeeze().cpu().tolist()
-            weights = vec[cols].cpu().tolist()
-            sparse_embeddings.append(
-                SparseVector(
-                    indices=cols,
-                    values=weights,
-                )
+    async def _async_add_documents(
+        self, collection_name: str, documents: Sequence[Dict[str, Any]]
+    ) -> None:
+        async with self.client() as client:
+            index = client.index(collection_name)
+            await index.add_documents_in_batches(
+                documents=documents,
+                batch_size=self.config.batch_size,
+                primary_key=self.config.primary_key,
             )
-        return sparse_embeddings
 
     def add_documents(self, documents: Sequence[Document]) -> None:
-        from qdrant_client.http.models import (
-            Batch,
-            CollectionStatus,
-            SparseVector,
-        )
-
-        # Add id to metadata if not already present
         super().maybe_add_ids(documents)
-        # Fix the ids due to qdrant finickiness
-        for doc in documents:
-            doc.metadata.id = str(self._to_int_or_uuid(doc.metadata.id))
-        colls = self.list_collections(empty=True)
         if len(documents) == 0:
             return
-        document_dicts = [doc.model_dump() for doc in documents]
-        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-        sparse_embedding_vecs = self.get_sparse_embeddings(
-            [doc.content for doc in documents]
-        )
+        colls = self._list_all_collections()
         if self.config.collection_name is None:
             raise ValueError("No collection name set, cannot ingest docs")
         if self.config.collection_name not in colls:
             self.create_collection(self.config.collection_name, replace=True)
-        ids = [self._to_int_or_uuid(d.id()) for d in documents]
-        # don't insert all at once, batch in chunks of b,
-        # else we get an API error
-        b = self.config.batch_size
-        for i in range(0, len(ids), b):
-            vectors: Dict[str, Embeddings | List[SparseVector]] = {
-                "": embedding_vecs[i : i + b]
-            }
-            if self.config.use_sparse_embeddings:
-                vectors["text-sparse"] = sparse_embedding_vecs[i : i + b]
-            coll_found: bool = False
-            for _ in range(3):
-                # poll until collection is ready
-                if (
-                    self.client.collection_exists(self.config.collection_name)
-                    and self.client.get_collection(self.config.collection_name).status
-                    == CollectionStatus.GREEN
-                ):
-                    coll_found = True
-                    break
-                time.sleep(1)
-
-            if not coll_found:
-                raise ValueError(
-                    f"""
-                    QdrantDB Collection {self.config.collection_name} 
-                    not found or not ready
-                    """
-                )
-
-            self.client.upsert(
-                collection_name=self.config.collection_name,
-                points=Batch(
-                    ids=ids[i : i + b],
-                    vectors=vectors,
-                    payloads=document_dicts[i : i + b],
-                ),
+        docs = [
+            dict(
+                id=d.id(),
+                content=d.content,
+                metadata=d.metadata.model_dump(),
             )
+            for d in documents
+        ]
+        asyncio.run(self._async_add_documents(self.config.collection_name, docs))
 
     def delete_collection(self, collection_name: str) -> None:
-        self.client.delete_collection(collection_name=collection_name)
+        asyncio.run(self._async_delete_index(collection_name))
 
     def _to_int_or_uuid(self, id: str) -> int | str:
         try:
-            int_val = int(id)
-            if is_valid_uuid(id):
-                return int_val
+            return int(id)
         except ValueError:
-            pass
-
-        # If doc_id is already a valid UUID, return it as is
-        if isinstance(id, str) and is_valid_uuid(id):
             return id
 
-        # Otherwise, generate a UUID from the doc_id
-        # Convert doc_id to string if it's not already
-        id_str = str(id)
-
-        # Hash the document ID using SHA-1
-        hash_object = hashlib.sha1(id_str.encode())
-        hash_digest = hash_object.hexdigest()
-
-        # Truncate or manipulate the hash to fit into a UUID (128 bits)
-        uuid_str = hash_digest[:32]
-
-        # Format this string into a UUID format
-        formatted_uuid = uuid.UUID(uuid_str)
-
-        return str(formatted_uuid)
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        from qdrant_client.http.models import (
-            Filter,
-        )
-
+    async def _async_get_documents(self, where: str = "") -> "DocumentsInfo":
         if self.config.collection_name is None:
             raise ValueError("No collection name set, cannot retrieve docs")
-        docs = []
-        offset = 0
-        filter = Filter() if where == "" else Filter.model_validate(json.loads(where))
-        while True:
-            results, next_page_offset = self.client.scroll(
-                collection_name=self.config.collection_name,
-                scroll_filter=filter,
-                offset=offset,
-                limit=10_000,  # try getting all at once, if not we keep paging
-                with_payload=True,
-                with_vectors=False,
+        filter = [] if where is None else where
+        async with self.client() as client:
+            index = client.index(self.config.collection_name)
+            documents = await index.get_documents(limit=10_000, filter=filter)
+        return documents
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        docs = asyncio.run(self._async_get_documents(where))
+        if docs is None:
+            return []
+        doc_results = docs.results
+        return [
+            Document(
+                content=d["content"],
+                metadata=DocMetaData(**d["metadata"]),
             )
-            docs += [
-                self.config.document_class(**record.payload)  # type: ignore
-                for record in results
-            ]
-            # ignore
-            if next_page_offset is None:
-                break
-            offset = next_page_offset  # type: ignore
-        return docs
+            for d in doc_results
+        ]
+
+    async def _async_get_documents_by_ids(self, ids: List[str]) -> List[Dict[str, Any]]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        async with self.client() as client:
+            index = client.index(self.config.collection_name)
+            documents = await asyncio.gather(*[index.get_document(id) for id in ids])
+        return documents
 
     def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
         if self.config.collection_name is None:
             raise ValueError("No collection name set, cannot retrieve docs")
-        _ids = [self._to_int_or_uuid(id) for id in ids]
-        records = self.client.retrieve(
-            collection_name=self.config.collection_name,
-            ids=_ids,
-            with_vectors=False,
-            with_payload=True,
+        docs = asyncio.run(self._async_get_documents_by_ids(ids))
+        return [
+            Document(
+                content=d["content"],
+                metadata=DocMetaData(**d["metadata"]),
+            )
+            for d in docs
+        ]
+
+    async def _async_search(
+        self,
+        query: str,
+        k: int = 20,
+        filter: str | list[str | list[str]] | None = None,
+    ) -> List[Dict[str, Any]]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot search")
+        async with self.client() as client:
+            index = client.index(self.config.collection_name)
+            results = await index.search(
+                query,
+                limit=k,
+                show_ranking_score=True,
+                filter=filter,
+            )
+        return results.hits  # type: ignore
+
+    def similar_texts_with_scores(
+        self,
+        text: str,
+        k: int = 20,
+        where: Optional[str] = None,
+        neighbors: int = 0,  # ignored
+    ) -> List[Tuple[Document, float]]:
+        filter = [] if where is None else where
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot search")
+        _docs = asyncio.run(self._async_search(text, k, filter))  # type: ignore
+        if len(_docs) == 0:
+            logger.warning(f"No matches found for {text}")
+            return []
+        scores = [h["_rankingScore"] for h in _docs]
+        if settings.debug:
+            logger.info(f"Found {len(_docs)} matches, max score: {max(scores)}")
+        docs = [
+            Document(
+                content=d["content"],
+                metadata=DocMetaData(**d["metadata"]),
+            )
+            for d in _docs
+        ]
+        doc_score_pairs = list(zip(docs, scores))
+        self.show_if_debug(doc_score_pairs)
+        return doc_score_pairs
+</file>
+
+<file path="langroid/vector_store/pineconedb.py">
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+from dotenv import load_dotenv
+
+# import dataclass
+from pydantic import BaseModel
+from pydantic_settings import SettingsConfigDict
+
+from langroid import LangroidImportError
+from langroid.mytypes import Document
+from langroid.utils.configuration import settings
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+
+
+has_pinecone: bool = True
+try:
+    from pinecone import Pinecone, PineconeApiException, ServerlessSpec
+except ImportError:
+
+    if not TYPE_CHECKING:
+
+        class ServerlessSpec(BaseModel):
+            """
+            Fallback Serverless specification configuration to avoid import errors.
+            """
+
+            cloud: str
+            region: str
+
+        PineconeApiException = Any  # type: ignore
+        Pinecone = Any  # type: ignore
+        has_pinecone = False
+
+
+@dataclass(frozen=True)
+class IndexMeta:
+    name: str
+    total_vector_count: int
+
+
+class PineconeDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="PINECONE_")
+
+    cloud: bool = True
+    collection_name: str | None = "temp"
+    spec: ServerlessSpec = ServerlessSpec(cloud="aws", region="us-east-1")
+    deletion_protection: Literal["enabled", "disabled"] | None = None
+    metric: str = "cosine"
+    pagination_size: int = 100
+
+
+class PineconeDB(VectorStore):
+    def __init__(self, config: PineconeDBConfig | None = None):
+        config = config if config is not None else PineconeDBConfig()
+        super().__init__(config)
+        if not has_pinecone:
+            raise LangroidImportError("pinecone", "pinecone")
+        self.config: PineconeDBConfig = config
+        load_dotenv()
+        key = os.getenv("PINECONE_API_KEY")
+
+        if not key:
+            raise ValueError("PINECONE_API_KEY not set, could not instantiate client")
+        self.client = Pinecone(api_key=key)
+
+        if config.collection_name:
+            self.create_collection(
+                collection_name=config.collection_name,
+                replace=config.replace_collection,
+            )
+
+    def clear_empty_collections(self) -> int:
+        indexes = self._list_index_metas(empty=True)
+        n_deletes = 0
+        for index in indexes:
+            if index.total_vector_count == -1:
+                logger.warning(
+                    f"Error fetching details for {index.name} when scanning indexes"
+                )
+            n_deletes += 1
+            self.delete_collection(collection_name=index.name)
+        return n_deletes
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """
+        Returns:
+            Number of Pinecone indexes that were deleted
+
+        Args:
+            really: Optional[bool] - whether to really delete all Pinecone collections
+            prefix: Optional[str] - string to match potential Pinecone
+                indexes for deletion
+        """
+        if not really:
+            logger.warning("Not deleting all collections, set really=True to confirm")
+            return 0
+        indexes = [
+            c for c in self._list_index_metas(empty=True) if c.name.startswith(prefix)
+        ]
+        if len(indexes) == 0:
+            logger.warning(f"No collections found with prefix {prefix}")
+            return 0
+        n_empty_deletes, n_non_empty_deletes = 0, 0
+        for index_desc in indexes:
+            self.delete_collection(collection_name=index_desc.name)
+            n_empty_deletes += index_desc.total_vector_count == 0
+            n_non_empty_deletes += index_desc.total_vector_count > 0
+        logger.warning(
+            f"""
+            Deleted {n_empty_deletes} empty indexes and
+            {n_non_empty_deletes} non-empty indexes
+            """
         )
-        # Note the records may NOT be in the order of the ids,
-        # so we re-order them here.
-        id2payload = {record.id: record.payload for record in records}
-        ordered_payloads = [id2payload[id] for id in _ids if id in id2payload]
-        docs = [Document(**payload) for payload in ordered_payloads]  # type: ignore
+        return n_empty_deletes + n_non_empty_deletes
+
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """
+        Returns:
+            List of Pinecone indices that have at least one vector.
+
+        Args:
+            empty: Optional[bool] - whether to include empty collections
+        """
+        indexes = self.client.list_indexes()
+        res: List[str] = []
+        if empty:
+            res.extend(indexes.names())
+            return res
+
+        for index in indexes.names():
+            index_meta = self.client.Index(name=index)
+            if index_meta.describe_index_stats().get("total_vector_count", 0) > 0:
+                res.append(index)
+        return res
+
+    def _list_index_metas(self, empty: bool = False) -> List[IndexMeta]:
+        """
+        Returns:
+            List of objects describing Pinecone indices
+
+        Args:
+            empty: Optional[bool] - whether to include empty collections
+        """
+        indexes = self.client.list_indexes()
+        res = []
+        for index in indexes.names():
+            index_meta = self._fetch_index_meta(index)
+            if empty:
+                res.append(index_meta)
+            elif index_meta.total_vector_count > 0:
+                res.append(index_meta)
+        return res
+
+    def _fetch_index_meta(self, index_name: str) -> IndexMeta:
+        """
+        Returns:
+            A dataclass describing the input Index by name and vector count
+            to save a bit on index description calls
+
+        Args:
+            index_name: str - Name of the index in Pinecone
+        """
+        try:
+            index = self.client.Index(name=index_name)
+            stats = index.describe_index_stats()
+            return IndexMeta(
+                name=index_name, total_vector_count=stats.get("total_vector_count", 0)
+            )
+        except PineconeApiException as e:
+            logger.warning(f"Error fetching details for index {index_name}")
+            logger.warning(e)
+            return IndexMeta(name=index_name, total_vector_count=-1)
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        """
+        Create a collection with the given name, optionally replacing an existing
+        collection if `replace` is True.
+
+        Args:
+            collection_name: str - Configuration of the collection to create.
+            replace: Optional[Bool] - Whether to replace an existing collection
+                with the same name. Defaults to False.
+        """
+        pattern = re.compile(r"^[a-z0-9-]+$")
+        if not pattern.match(collection_name):
+            raise ValueError(
+                "Pinecone index names must be lowercase alphanumeric characters or '-'"
+            )
+        self.config.collection_name = collection_name
+        if collection_name in self.list_collections(empty=True):
+            index = self.client.Index(name=collection_name)
+            stats = index.describe_index_stats()
+            status = self.client.describe_index(name=collection_name)
+            if status["status"]["ready"] and stats["total_vector_count"] > 0:
+                logger.warning(f"Non-empty collection {collection_name} already exists")
+                if not replace:
+                    logger.warning("Not replacing collection")
+                    return
+                else:
+                    logger.warning("Recreating fresh collection")
+            self.delete_collection(collection_name=collection_name)
+
+        payload = {
+            "name": collection_name,
+            "dimension": self.embedding_dim,
+            "spec": self.config.spec,
+            "metric": self.config.metric,
+            "timeout": self.config.timeout,
+        }
+
+        if self.config.deletion_protection:
+            payload["deletion_protection"] = self.config.deletion_protection
+
+        try:
+            self.client.create_index(**payload)
+        except PineconeApiException as e:
+            logger.error(e)
+
+    def delete_collection(self, collection_name: str) -> None:
+        logger.info(f"Attempting to delete {collection_name}")
+        try:
+            self.client.delete_index(name=collection_name)
+        except PineconeApiException as e:
+            logger.error(f"Failed to delete {collection_name}")
+            logger.error(e)
+
+    def add_documents(self, documents: Sequence[Document], namespace: str = "") -> None:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+
+        if len(documents) == 0:
+            logger.warning("Empty list of documents passed into add_documents")
+            return
+
+        super().maybe_add_ids(documents)
+        document_dicts = [doc.model_dump() for doc in documents]
+        document_ids = [doc.id() for doc in documents]
+        embedding_vectors = self.embedding_fn([doc.content for doc in documents])
+        vectors = [
+            {
+                "id": document_id,
+                "values": embedding_vector,
+                "metadata": {
+                    **document_dict["metadata"],
+                    **{
+                        key: value
+                        for key, value in document_dict.items()
+                        if key != "metadata"
+                    },
+                },
+            }
+            for document_dict, document_id, embedding_vector in zip(
+                document_dicts, document_ids, embedding_vectors
+            )
+        ]
+
+        if self.config.collection_name not in self.list_collections(empty=True):
+            self.create_collection(
+                collection_name=self.config.collection_name, replace=True
+            )
+
+        index = self.client.Index(name=self.config.collection_name)
+        batch_size = self.config.batch_size
+
+        for i in range(0, len(documents), batch_size):
+            try:
+                if namespace:
+                    index.upsert(
+                        vectors=vectors[i : i + batch_size], namespace=namespace
+                    )
+                else:
+                    index.upsert(vectors=vectors[i : i + batch_size])
+            except PineconeApiException as e:
+                logger.error(
+                    f"Unable to add of docs between indices {i} and {batch_size}"
+                )
+                logger.error(e)
+
+    def get_all_documents(
+        self, prefix: str = "", namespace: str = ""
+    ) -> List[Document]:
+        """
+        Returns:
+            All documents for the collection currently defined in
+            the configuration object
+
+        Args:
+            prefix: str - document id prefix to search for
+            namespace: str - partition of vectors to search within the index
+        """
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        docs = []
+
+        request_filters: Dict[str, Union[str, int]] = {
+            "limit": self.config.pagination_size
+        }
+        if prefix:
+            request_filters["prefix"] = prefix
+        if namespace:
+            request_filters["namespace"] = namespace
+
+        index = self.client.Index(name=self.config.collection_name)
+
+        while True:
+            response = index.list_paginated(**request_filters)
+            vectors = response.get("vectors", [])
+
+            if not vectors:
+                logger.warning("Received empty list while requesting for vector ids")
+                logger.warning("Halting fetch requests")
+                if settings.debug:
+                    logger.debug(f"Request for failed fetch was: {request_filters}")
+                break
+
+            docs.extend(
+                self.get_documents_by_ids(
+                    ids=[vector.get("id") for vector in vectors],
+                    namespace=namespace if namespace else "",
+                )
+            )
+
+            pagination_token = response.get("pagination", {}).get("next", None)
+
+            if not pagination_token:
+                break
+
+            request_filters["pagination_token"] = pagination_token
+
         return docs
+
+    def get_documents_by_ids(
+        self, ids: List[str], namespace: str = ""
+    ) -> List[Document]:
+        """
+        Returns:
+            Fetches document text embedded in Pinecone index metadata
+
+        Args:
+            ids: List[str] - vector data object ids to retrieve
+            namespace: str - partition of vectors to search within the index
+        """
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        index = self.client.Index(name=self.config.collection_name)
+
+        if namespace:
+            records = index.fetch(ids=ids, namespace=namespace)
+        else:
+            records = index.fetch(ids=ids)
+
+        id_mapping = {key: value for key, value in records["vectors"].items()}
+        ordered_payloads = [id_mapping[_id] for _id in ids if _id in id_mapping]
+        return [
+            self.transform_pinecone_vector(payload.get("metadata", {}))
+            for payload in ordered_payloads
+        ]
 
     def similar_texts_with_scores(
         self,
         text: str,
         k: int = 1,
         where: Optional[str] = None,
-        neighbors: int = 0,
+        namespace: Optional[str] = None,
     ) -> List[Tuple[Document, float]]:
-        from qdrant_client.conversions.common_types import ScoredPoint
-        from qdrant_client.http.models import (
-            Filter,
-            NamedSparseVector,
-            NamedVector,
-            SearchRequest,
-        )
-
-        embedding = self.embedding_fn([text])[0]
-        # TODO filter may not work yet
-        if where is None or where == "":
-            filter = Filter()
-        else:
-            filter = Filter.model_validate(json.loads(where))
-        requests = [
-            SearchRequest(
-                vector=NamedVector(
-                    name="",
-                    vector=embedding,
-                ),
-                limit=k,
-                with_payload=True,
-                filter=filter,
-            )
-        ]
-        if self.config.use_sparse_embeddings:
-            sparse_embedding = self.get_sparse_embeddings([text])[0]
-            requests.append(
-                SearchRequest(
-                    vector=NamedSparseVector(
-                        name="text-sparse",
-                        vector=sparse_embedding,
-                    ),
-                    limit=self.config.sparse_limit,
-                    with_payload=True,
-                    filter=filter,
-                )
-            )
         if self.config.collection_name is None:
             raise ValueError("No collection name set, cannot search")
-        search_result_lists: List[List[ScoredPoint]] = self.client.search_batch(
-            collection_name=self.config.collection_name, requests=requests
-        )
 
-        search_result = [
-            match for result in search_result_lists for match in result
-        ]  # 2D list -> 1D list
-        scores = [match.score for match in search_result if match is not None]
-        docs = [
-            self.config.document_class(**(match.payload))  # type: ignore
-            for match in search_result
-            if match is not None
+        if k < 1 or k > 9999:
+            raise ValueError(
+                f"TopK for Pinecone vector search must be 1 < k < 10000, k was {k}"
+            )
+
+        vector_search_request = {
+            "top_k": k,
+            "include_metadata": True,
+            "vector": self.embedding_fn([text])[0],
+        }
+        if where:
+            vector_search_request["filter"] = json.loads(where) if where else None
+        if namespace:
+            vector_search_request["namespace"] = namespace
+
+        index = self.client.Index(name=self.config.collection_name)
+        response = index.query(**vector_search_request)
+        doc_score_pairs = [
+            (
+                self.transform_pinecone_vector(match.get("metadata", {})),
+                match.get("score", 0),
+            )
+            for match in response.get("matches", [])
         ]
-        if len(docs) == 0:
-            logger.warning(f"No matches found for {text}")
-            return []
-        doc_score_pairs = list(zip(docs, scores))
-        max_score = max(ds[1] for ds in doc_score_pairs)
         if settings.debug:
+            max_score = max([pair[1] for pair in doc_score_pairs])
             logger.info(f"Found {len(doc_score_pairs)} matches, max score: {max_score}")
         self.show_if_debug(doc_score_pairs)
         return doc_score_pairs
+
+    def transform_pinecone_vector(self, metadata_dict: Dict[str, Any]) -> Document:
+        """
+        Parses the metadata response from the Pinecone vector query and
+        formats it into a dictionary that can be parsed by the Document class
+        associated with the PineconeDBConfig class
+
+        Returns:
+            Well formed dictionary object to be transformed into a Document
+
+        Args:
+            metadata_dict: Dict - the metadata dictionary from the Pinecone
+                vector query match
+        """
+        return self.config.document_class(
+            **{**metadata_dict, "metadata": {**metadata_dict}}
+        )
+</file>
+
+<file path="langroid/vector_store/weaviatedb.py">
+import logging
+import os
+import re
+from typing import Any, List, Optional, Sequence, Tuple
+
+from dotenv import load_dotenv
+from pydantic_settings import SettingsConfigDict
+
+from langroid.embedding_models.base import (
+    EmbeddingModelsConfig,
+)
+from langroid.embedding_models.models import OpenAIEmbeddingsConfig
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import DocMetaData, Document
+from langroid.utils.configuration import settings
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+
+
+class VectorDistances:
+    """
+    Fallback class when weaviate is not installed, to avoid import errors.
+    """
+
+    COSINE: str = "cosine"
+    DOTPRODUCT: str = "dot"
+    L2: str = "l2"
+
+
+class WeaviateDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="WEAVIATE_")
+
+    collection_name: str | None = "temp"
+    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+    distance: str = VectorDistances.COSINE
+    cloud: bool = False
+    docker: bool = False
+    host: str = "127.0.0.1"
+    port: int = 8080
+    storage_path: str = ".weaviate_embedded/data"
+
+
+class WeaviateDB(VectorStore):
+    def __init__(self, config: WeaviateDBConfig | None = None):
+        config = config if config is not None else WeaviateDBConfig()
+        super().__init__(config)
+        try:
+            import weaviate
+            from weaviate.classes.init import Auth
+        except ImportError:
+            raise LangroidImportError("weaviate", "weaviate")
+
+        self.config: WeaviateDBConfig = config
+        load_dotenv()
+        if self.config.docker:
+            self.client = weaviate.connect_to_local(
+                host=self.config.host,
+                port=self.config.port,
+            )
+            self.config.cloud = False
+        elif self.config.cloud:
+            key = os.getenv("WEAVIATE_API_KEY")
+            url = os.getenv("WEAVIATE_API_URL")
+            if url is None or key is None:
+                raise ValueError(
+                    """WEAVIATE_API_KEY, WEAVIATE_API_URL env variables must be set to 
+                    use WeaviateDB in cloud mode. Please set these values
+                    in your .env file.
+                    """
+                )
+            self.client = weaviate.connect_to_weaviate_cloud(
+                cluster_url=url,
+                auth_credentials=Auth.api_key(key),
+            )
+        else:
+            self.client = weaviate.connect_to_embedded(
+                version="latest", persistence_data_path=self.config.storage_path
+            )
+
+        if config.collection_name is not None:
+            WeaviateDB.validate_and_format_collection_name(config.collection_name)
+
+    def clear_empty_collections(self) -> int:
+        colls = self.client.collections.list_all()
+        n_deletes = 0
+        for coll_name, _ in colls.items():
+            val = self.client.collections.get(coll_name)
+            if len(val) == 0:
+                n_deletes += 1
+                self.client.collections.delete(coll_name)
+        return n_deletes
+
+    def list_collections(self, empty: bool = False) -> List[str]:
+        colls = self.client.collections.list_all()
+        if empty:
+            return list(colls.keys())
+        non_empty_colls = [
+            coll_name
+            for coll_name in colls.keys()
+            if len(self.client.collections.get(coll_name)) > 0
+        ]
+
+        return non_empty_colls
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        if not really:
+            logger.warning(
+                "Not really deleting all collections ,set really=True to confirm"
+            )
+            return 0
+        coll_names = [
+            c for c in self.list_collections(empty=True) if c.startswith(prefix)
+        ]
+        if len(coll_names) == 0:
+            logger.warning(f"No collections found with prefix {prefix}")
+            return 0
+        n_empty_deletes = 0
+        n_non_empty_deletes = 0
+        for name in coll_names:
+            info = self.client.collections.get(name)
+            points_count = len(info)
+
+            n_empty_deletes += points_count == 0
+            n_non_empty_deletes += points_count > 0
+            self.client.collections.delete(name)
+        logger.warning(
+            f"""
+            Deleted {n_empty_deletes} empty collections and
+            {n_non_empty_deletes} non-empty collections.
+            """
+        )
+        return n_empty_deletes + n_non_empty_deletes
+
+    def delete_collection(self, collection_name: str) -> None:
+        self.client.collections.delete(name=collection_name)
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        try:
+            from weaviate.classes.config import (
+                Configure,
+                VectorDistances,
+            )
+        except ImportError:
+            raise LangroidImportError("weaviate", "weaviate")
+        collection_name = WeaviateDB.validate_and_format_collection_name(
+            collection_name
+        )
+        self.config.collection_name = collection_name
+        if self.client.collections.exists(name=collection_name):
+            coll = self.client.collections.get(name=collection_name)
+            if len(coll) > 0:
+                logger.warning(f"Non-empty Collection {collection_name} already exists")
+                if not replace:
+                    logger.warning("Not replacing collection")
+                    return
+                else:
+                    logger.warning("Recreating fresh collection")
+            self.client.collections.delete(name=collection_name)
+
+        vector_index_config = Configure.VectorIndex.hnsw(
+            distance_metric=VectorDistances.COSINE,
+        )
+        if isinstance(self.config.embedding, OpenAIEmbeddingsConfig):
+            vectorizer_config = Configure.Vectorizer.text2vec_openai(
+                model=self.config.embedding.model_name,
+            )
+        else:
+            vectorizer_config = None
+
+        collection_info = self.client.collections.create(
+            name=collection_name,
+            vector_index_config=vector_index_config,
+            vectorizer_config=vectorizer_config,
+        )
+        collection_info = self.client.collections.get(name=collection_name)
+        assert len(collection_info) in [0, None]
+        if settings.debug:
+            level = logger.getEffectiveLevel()
+            logger.setLevel(logging.INFO)
+            logger.info(collection_info)
+            logger.setLevel(level)
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        super().maybe_add_ids(documents)
+        colls = self.list_collections(empty=True)
+        for doc in documents:
+            doc.metadata.id = str(self._create_valid_uuid_id(doc.metadata.id))
+        if len(documents) == 0:
+            return
+
+        document_dicts = [doc.model_dump() for doc in documents]
+        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        if self.config.collection_name not in colls:
+            self.create_collection(self.config.collection_name, replace=True)
+        coll_name = self.client.collections.get(self.config.collection_name)
+        with coll_name.batch.dynamic() as batch:
+            for i, doc_dict in enumerate(document_dicts):
+                id = doc_dict["metadata"].pop("id", None)
+                batch.add_object(properties=doc_dict, uuid=id, vector=embedding_vecs[i])
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        # cannot use filter as client does not support json type queries
+        coll = self.client.collections.get(self.config.collection_name)
+        return [self.weaviate_obj_to_doc(item) for item in coll.iterator()]
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        from weaviate.classes.query import Filter
+
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+
+        docs = []
+        coll_name = self.client.collections.get(self.config.collection_name)
+
+        result = coll_name.query.fetch_objects(
+            filters=Filter.by_property("_id").contains_any(ids), limit=len(coll_name)
+        )
+
+        id_to_doc = {}
+        for item in result.objects:
+            doc = self.weaviate_obj_to_doc(item)
+            id_to_doc[doc.metadata.id] = doc
+
+        # Reconstruct the list of documents in the original order of input ids
+        docs = [id_to_doc[id] for id in ids if id in id_to_doc]
+
+        return docs
+
+    def similar_texts_with_scores(
+        self, text: str, k: int = 1, where: Optional[str] = None
+    ) -> List[Tuple[Document, float]]:
+        from weaviate.classes.query import MetadataQuery
+
+        embedding = self.embedding_fn([text])[0]
+        if self.config.collection_name is None:
+            raise ValueError("No collections name set,cannot search")
+        coll = self.client.collections.get(self.config.collection_name)
+        response = coll.query.near_vector(
+            near_vector=embedding,
+            limit=k,
+            return_properties=True,
+            return_metadata=MetadataQuery(distance=True),
+        )
+        maybe_distances = [item.metadata.distance for item in response.objects]
+        similarities = [0 if d is None else 1 - d for d in maybe_distances]
+        docs = [self.weaviate_obj_to_doc(item) for item in response.objects]
+        return list(zip(docs, similarities))
+
+    def _create_valid_uuid_id(self, id: str) -> Any:
+        from weaviate.util import generate_uuid5, get_valid_uuid
+
+        try:
+            id = get_valid_uuid(id)
+            return id
+        except Exception:
+            return generate_uuid5(id)
+
+    def weaviate_obj_to_doc(self, input_object: Any) -> Document:
+        from weaviate.util import get_valid_uuid
+
+        content = input_object.properties.get("content", "")
+        metadata_dict = input_object.properties.get("metadata", {})
+
+        window_ids = metadata_dict.pop("window_ids", [])
+        window_ids = [str(uuid) for uuid in window_ids]
+
+        # Ensure the id is a valid UUID string
+        id_value = get_valid_uuid(input_object.uuid)
+
+        metadata = DocMetaData(id=id_value, window_ids=window_ids, **metadata_dict)
+
+        return Document(content=content, metadata=metadata)
+
+    @staticmethod
+    def validate_and_format_collection_name(name: str) -> str:
+        """
+        Formats the collection name to comply with Weaviate's naming rules:
+        - Name must start with a capital letter.
+        - Name can only contain letters, numbers, and underscores.
+        - Replaces invalid characters with underscores.
+        """
+        if not name:
+            raise ValueError("Collection name cannot be empty.")
+
+        formatted_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+
+        # Ensure the first letter is capitalized
+        if not formatted_name[0].isupper():
+            formatted_name = formatted_name.capitalize()
+
+        # Check if the name now meets the criteria
+        if not re.match(r"^[A-Z][A-Za-z0-9_]*$", formatted_name):
+            raise ValueError(
+                f"Invalid collection name '{name}'."
+                " Names must start with a capital letter "
+                "and contain only letters, numbers, and underscores."
+            )
+
+        if formatted_name != name:
+            logger.warning(
+                f"Collection name '{name}' was reformatted to '{formatted_name}' "
+                "to comply with Weaviate's rules."
+            )
+
+        return formatted_name
+
+    def __del__(self) -> None:
+        # Gracefully close the connection with local client
+        if not self.config.cloud:
+            self.client.close()
 </file>
 
 <file path="CONTRIBUTING.md">
@@ -83439,6 +82132,991 @@ class MarkerPdfParser(DocumentParser):
         )
 </file>
 
+<file path="langroid/vector_store/postgres.py">
+import hashlib
+import json
+import logging
+import os
+import uuid
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from pydantic_settings import SettingsConfigDict
+
+from langroid.embedding_models.base import (
+    EmbeddingModelsConfig,
+)
+from langroid.embedding_models.models import OpenAIEmbeddingsConfig
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import DocMetaData, Document
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+has_postgres: bool = True
+try:
+    from sqlalchemy import (
+        Column,
+        MetaData,
+        String,
+        Table,
+        case,
+        create_engine,
+        inspect,
+        text,
+    )
+    from sqlalchemy.dialects.postgresql import JSONB
+    from sqlalchemy.engine import Connection, Engine
+    from sqlalchemy.sql.expression import insert
+except ImportError:
+    Engine = Any  # type: ignore
+    Connection = Any  # type: ignore
+    has_postgres = False
+
+logger = logging.getLogger(__name__)
+
+
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier (table/index name) for use in raw DDL, so a name
+    containing characters that are invalid in an unquoted identifier -- e.g.
+    the ``-`` in a pytest-xdist worker suffix like ``mycollection-gw1`` -- does
+    not produce a syntax error. Embedded double-quotes are escaped per the SQL
+    standard.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
+class PostgresDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="POSTGRES_")
+
+    collection_name: str = "embeddings"
+    cloud: bool = False
+    docker: bool = True
+    host: str = "127.0.0.1"
+    port: int = 5432
+    replace_collection: bool = False
+    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+    pool_size: int = 10
+    max_overflow: int = 20
+    hnsw_m: int = 16
+    hnsw_ef_construction: int = 200
+
+
+class PostgresDB(VectorStore):
+    def __init__(self, config: PostgresDBConfig | None = None):
+        config = config if config is not None else PostgresDBConfig()
+        super().__init__(config)
+        if not has_postgres:
+            raise LangroidImportError("pgvector", "postgres")
+        try:
+            from sqlalchemy.orm import sessionmaker
+        except ImportError:
+            raise LangroidImportError("sqlalchemy", "postgres")
+
+        self.config: PostgresDBConfig = config
+        self.engine = self._create_engine()
+        PostgresDB._create_vector_extension(self.engine)
+        self.SessionLocal = sessionmaker(
+            autocommit=False, autoflush=False, bind=self.engine
+        )
+        self.metadata = MetaData()
+        self._setup_table()
+
+    def _create_engine(self) -> Engine:
+        """Creates a SQLAlchemy engine based on the configuration."""
+
+        connection_string: str | None = None  # Ensure variable is always defined
+
+        if self.config.cloud:
+            connection_string = os.getenv("POSTGRES_CONNECTION_STRING")
+
+            if connection_string and connection_string.startswith("postgres://"):
+                connection_string = connection_string.replace(
+                    "postgres://", "postgresql+psycopg2://", 1
+                )
+            elif not connection_string:
+                raise ValueError("Provide the POSTGRES_CONNECTION_STRING.")
+
+        elif self.config.docker:
+            username = os.getenv("POSTGRES_USER", "postgres")
+            password = os.getenv("POSTGRES_PASSWORD", "postgres")
+            database = os.getenv("POSTGRES_DB", "langroid")
+
+            if not (username and password and database):
+                raise ValueError(
+                    "Provide POSTGRES_USER, POSTGRES_PASSWORD, " "POSTGRES_DB. "
+                )
+
+            connection_string = (
+                f"postgresql+psycopg2://{username}:{password}@"
+                f"{self.config.host}:{self.config.port}/{database}"
+            )
+            self.config.cloud = False  # Ensures cloud is disabled if using Docker
+
+        else:
+            raise ValueError(
+                "Provide either Docker or Cloud config to connect to the database."
+            )
+
+        return create_engine(
+            connection_string,
+            pool_size=self.config.pool_size,
+            max_overflow=self.config.max_overflow,
+        )
+
+    def _setup_table(self) -> None:
+        try:
+            from pgvector.sqlalchemy import Vector
+        except ImportError as e:
+            raise LangroidImportError(extra="postgres", error=str(e))
+
+        if self.config.replace_collection:
+            self.delete_collection(self.config.collection_name)
+
+        self.embeddings_table = Table(
+            self.config.collection_name,
+            self.metadata,
+            Column("id", String, primary_key=True, nullable=False, unique=True),
+            Column("embedding", Vector(self.embedding_dim)),
+            Column("document", String),
+            Column("cmetadata", JSONB),
+            extend_existing=True,
+        )
+
+        self.metadata.create_all(self.engine)
+        self.metadata.reflect(bind=self.engine, only=[self.config.collection_name])
+
+        # Create HNSW index for embeddings column if it doesn't exist.
+        # This index enables efficient nearest-neighbor search using cosine similarity.
+        # PostgreSQL automatically builds the index after creation;
+        # no manual step required.
+        # Read more about pgvector hnsw index here:
+        # https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw
+
+        index_name = f"hnsw_index_{self.config.collection_name}_embedding"
+        with self.engine.connect() as connection:
+            if not self.index_exists(connection, index_name):
+                connection.execute(text("COMMIT"))
+                create_index_query = text(
+                    f"""
+                    CREATE INDEX CONCURRENTLY IF NOT EXISTS {_quote_ident(index_name)}
+                    ON {_quote_ident(self.config.collection_name)}
+                    USING hnsw (embedding vector_cosine_ops)
+                    WITH (
+                        m = {self.config.hnsw_m},
+                        ef_construction = {self.config.hnsw_ef_construction}
+                    );
+                    """
+                )
+                connection.execute(create_index_query)
+
+    def index_exists(self, connection: Connection, index_name: str) -> bool:
+        """Check if an index exists."""
+        query = text(
+            "SELECT 1 FROM pg_indexes WHERE indexname = :index_name"
+        ).bindparams(index_name=index_name)
+        result = connection.execute(query).scalar()
+        return bool(result)
+
+    @staticmethod
+    def _create_vector_extension(conn: Engine) -> None:
+
+        with conn.connect() as connection:
+            with connection.begin():
+                # The number is a unique identifier used to lock a specific resource
+                # during transaction. Any 64-bit integer can be used for advisory locks.
+                # Acquire advisory lock to ensure atomic, isolated setup
+                # and prevent race conditions.
+
+                statement = text(
+                    "SELECT pg_advisory_xact_lock(1573678846307946496);"
+                    "CREATE EXTENSION IF NOT EXISTS vector;"
+                )
+                connection.execute(statement)
+
+    def set_collection(self, collection_name: str, replace: bool = False) -> None:
+        inspector = inspect(self.engine)
+        table_exists = collection_name in inspector.get_table_names()
+
+        if (
+            collection_name == self.config.collection_name
+            and table_exists
+            and not replace
+        ):
+            return
+        else:
+            self.config.collection_name = collection_name
+            self.config.replace_collection = replace
+            self._setup_table()
+
+    def list_collections(self, empty: bool = True) -> List[str]:
+        inspector = inspect(self.engine)
+        table_names = inspector.get_table_names()
+
+        with self.SessionLocal() as session:
+            collections = []
+            for table_name in table_names:
+                table = Table(table_name, self.metadata, autoload_with=self.engine)
+                if empty:
+                    collections.append(table_name)
+                else:
+                    # Efficiently check for non-emptiness
+                    if session.query(table.select().limit(1).exists()).scalar():
+                        collections.append(table_name)
+            return collections
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        self.set_collection(collection_name, replace=replace)
+
+    def delete_collection(self, collection_name: str) -> None:
+        """
+        Deletes a collection and its associated HNSW index, handling metadata
+        synchronization issues.
+        """
+        with self.engine.connect() as connection:
+            connection.execute(text("COMMIT"))
+            index_name = f"hnsw_index_{collection_name}_embedding"
+            drop_index_query = text(
+                f"DROP INDEX CONCURRENTLY IF EXISTS {_quote_ident(index_name)}"
+            )
+            connection.execute(drop_index_query)
+
+            # 3. Now, drop the table using SQLAlchemy
+            table = Table(collection_name, self.metadata)
+            table.drop(self.engine, checkfirst=True)
+
+            # 4. Refresh metadata again after dropping the table
+            self.metadata.clear()
+            self.metadata.reflect(bind=self.engine)
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        if not really:
+            logger.warning("Not deleting all tables, set really=True to confirm")
+            return 0
+
+        inspector = inspect(self.engine)
+        table_names = inspector.get_table_names()
+
+        with self.SessionLocal() as session:
+            deleted_count = 0
+            for table_name in table_names:
+                if table_name.startswith(prefix):
+                    # Use delete_collection to handle index and table deletion
+                    self.delete_collection(table_name)
+                    deleted_count += 1
+            session.commit()
+            logger.warning(f"Deleted {deleted_count} tables with prefix '{prefix}'.")
+            return deleted_count
+
+    def clear_empty_collections(self) -> int:
+        inspector = inspect(self.engine)
+        table_names = inspector.get_table_names()
+
+        with self.SessionLocal() as session:
+            deleted_count = 0
+            for table_name in table_names:
+                table = Table(table_name, self.metadata, autoload_with=self.engine)
+
+                # Efficiently check for emptiness without fetching all rows
+                if session.query(table.select().limit(1).exists()).scalar():
+                    continue
+
+                # Use delete_collection to handle index and table deletion
+                self.delete_collection(table_name)
+                deleted_count += 1
+
+            session.commit()  # Commit is likely not needed here
+            logger.warning(f"Deleted {deleted_count} empty tables.")
+            return deleted_count
+
+    def _parse_embedding_store_record(self, res: Any) -> Dict[str, Any]:
+        metadata = res.cmetadata or {}
+        metadata["id"] = res.id
+        return {
+            "content": res.document,
+            "metadata": DocMetaData(**metadata),
+        }
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        with self.SessionLocal() as session:
+            query = session.query(self.embeddings_table)
+
+            # Apply 'where' clause if provided
+            if where:
+                try:
+                    where_json = json.loads(where)
+                    query = query.filter(
+                        self.embeddings_table.c.cmetadata.contains(where_json)
+                    )
+                except json.JSONDecodeError:
+                    logger.error(f"Invalid JSON in 'where' clause: {where}")
+                    return []  # Return empty list or handle error as appropriate
+
+            results = query.all()
+            documents = [
+                Document(**self._parse_embedding_store_record(res)) for res in results
+            ]
+            return documents
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        with self.SessionLocal() as session:
+            # Add a CASE statement to preserve the order of IDs
+            case_stmt = case(
+                {id_: index for index, id_ in enumerate(ids)},
+                value=self.embeddings_table.c.id,
+            )
+
+            query = (
+                session.query(self.embeddings_table)
+                .filter(self.embeddings_table.c.id.in_(ids))
+                .order_by(case_stmt)  # Order by the CASE statement
+            )
+            results = query.all()
+
+            documents = [
+                Document(**self._parse_embedding_store_record(row)) for row in results
+            ]
+            return documents
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        super().maybe_add_ids(documents)
+        for doc in documents:
+            doc.metadata.id = str(PostgresDB._id_to_uuid(doc.metadata.id, doc.metadata))
+
+        embeddings = self.embedding_fn([doc.content for doc in documents])
+
+        batch_size = self.config.batch_size
+        with self.SessionLocal() as session:
+            for i in range(0, len(documents), batch_size):
+                batch_docs = documents[i : i + batch_size]
+                batch_embeddings = embeddings[i : i + batch_size]
+
+                new_records = [
+                    {
+                        "id": doc.metadata.id,
+                        "embedding": embedding,
+                        "document": doc.content,
+                        "cmetadata": doc.metadata.model_dump(),
+                    }
+                    for doc, embedding in zip(batch_docs, batch_embeddings)
+                ]
+
+                if new_records:
+                    stmt = insert(self.embeddings_table).values(new_records)
+                    session.execute(stmt)
+                session.commit()
+
+    @staticmethod
+    def _id_to_uuid(id: str, obj: object) -> str:
+        try:
+            doc_id = str(uuid.UUID(id))
+        except ValueError:
+            obj_repr = repr(obj)
+
+            obj_hash = hashlib.sha256(obj_repr.encode()).hexdigest()
+
+            combined = f"{id}-{obj_hash}"
+
+            doc_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, combined))
+
+        return doc_id
+
+    def similar_texts_with_scores(
+        self,
+        query: str,
+        k: int = 1,
+        where: Optional[str] = None,
+        neighbors: int = 1,  # Parameter not used in this implementation
+    ) -> List[Tuple[Document, float]]:
+        embedding = self.embedding_fn([query])[0]
+
+        with self.SessionLocal() as session:
+            # Calculate the score (1 - cosine_distance) and label it as "score"
+            score = (
+                1 - (self.embeddings_table.c.embedding.cosine_distance(embedding))
+            ).label("score")
+
+            if where is not None:
+                try:
+                    json_query = json.loads(where)
+                except json.JSONDecodeError:
+                    raise ValueError(f"Invalid JSON in 'where' clause: {where}")
+
+                results = (
+                    session.query(
+                        self.embeddings_table.c.id,
+                        self.embeddings_table.c.document,
+                        self.embeddings_table.c.cmetadata,
+                        score,  # Select the calculated score
+                    )
+                    .filter(self.embeddings_table.c.cmetadata.contains(json_query))
+                    .order_by(score.desc())  # Order by score in descending order
+                    .limit(k)
+                    .all()
+                )
+            else:
+                results = (
+                    session.query(
+                        self.embeddings_table.c.id,
+                        self.embeddings_table.c.document,
+                        self.embeddings_table.c.cmetadata,
+                        score,  # Select the calculated score
+                    )
+                    .order_by(score.desc())  # Order by score in descending order
+                    .limit(k)
+                    .all()
+                )
+
+            documents_with_scores = [
+                (
+                    Document(
+                        content=result.document,
+                        metadata=DocMetaData(**(result.cmetadata or {})),
+                    ),
+                    result.score,  # Use the score from the query result
+                )
+                for result in results
+            ]
+
+            return documents_with_scores
+</file>
+
+<file path="langroid/vector_store/qdrantdb.py">
+import hashlib
+import json
+import logging
+import os
+import time
+import uuid
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, TypeVar
+
+from dotenv import load_dotenv
+from pydantic_settings import SettingsConfigDict
+
+from langroid.embedding_models.base import (
+    EmbeddingModelsConfig,
+)
+from langroid.embedding_models.models import OpenAIEmbeddingsConfig
+from langroid.mytypes import Document, Embeddings
+from langroid.utils.configuration import settings
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from qdrant_client.http.models import SparseVector
+
+
+T = TypeVar("T")
+
+
+def from_optional(x: Optional[T], default: T) -> T:
+    if x is None:
+        return default
+
+    return x
+
+
+def is_valid_uuid(uuid_to_test: str) -> bool:
+    """
+    Check if a given string is a valid UUID.
+    """
+    try:
+        uuid_obj = uuid.UUID(uuid_to_test)
+        return str(uuid_obj) == uuid_to_test
+    except Exception:
+        pass
+    # Check for valid unsigned 64-bit integer
+    try:
+        int_value = int(uuid_to_test)
+        return 0 <= int_value <= 18446744073709551615
+    except ValueError:
+        return False
+
+
+class QdrantDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="QDRANT_")
+
+    cloud: bool = True
+    docker: bool = False
+    collection_name: str | None = "temp"
+    storage_path: str = ".qdrant/data"
+    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+    use_sparse_embeddings: bool = False
+    sparse_embedding_model: str = "naver/splade-v3-distilbert"
+    sparse_limit: int = 3
+    distance: str = "cosine"
+
+
+class QdrantDB(VectorStore):
+    def __init__(self, config: QdrantDBConfig | None = None):
+        config = config if config is not None else QdrantDBConfig()
+        super().__init__(config)
+        self.config: QdrantDBConfig = config
+        from qdrant_client import QdrantClient
+
+        if self.config.use_sparse_embeddings:
+            try:
+                from transformers import AutoModelForMaskedLM, AutoTokenizer
+            except ImportError:
+                raise ImportError(
+                    """
+                    To use sparse embeddings,
+                    you must install langroid with the [transformers] extra, e.g.:
+                    pip install "langroid[transformers]"
+                    """
+                )
+
+            self.sparse_tokenizer = AutoTokenizer.from_pretrained(  # type: ignore
+                self.config.sparse_embedding_model
+            )
+            self.sparse_model = AutoModelForMaskedLM.from_pretrained(
+                self.config.sparse_embedding_model
+            )
+        self.host = config.host
+        self.port = config.port
+        load_dotenv()
+        key = os.getenv("QDRANT_API_KEY")
+        url = os.getenv("QDRANT_API_URL")
+        if config.docker:
+            if url is None:
+                logger.warning(
+                    f"""The QDRANT_API_URL env variable must be set to use
+                    QdrantDB in local docker mode. Please set this
+                    value in your .env file.
+                    Switching to local storage at {config.storage_path}
+                    """
+                )
+                config.cloud = False
+            else:
+                config.cloud = True
+        elif config.cloud and None in [key, url]:
+            logger.warning(
+                f"""QDRANT_API_KEY, QDRANT_API_URL env variable must be set to use
+                QdrantDB in cloud mode. Please set these values
+                in your .env file.
+                Switching to local storage at {config.storage_path}
+                """
+            )
+            config.cloud = False
+
+        if config.cloud:
+            self.client = QdrantClient(
+                url=url,
+                api_key=key,
+                timeout=config.timeout,
+            )
+        else:
+            try:
+                self.client = QdrantClient(
+                    path=config.storage_path,
+                )
+            except Exception as e:
+                new_storage_path = config.storage_path + ".new"
+                logger.warning(
+                    f"""
+                    Error connecting to local QdrantDB at {config.storage_path}:
+                    {e}
+                    Switching to {new_storage_path}
+                    """
+                )
+                self.client = QdrantClient(
+                    path=new_storage_path,
+                )
+
+        # Note: Only create collection if a non-null collection name is provided.
+        # This is useful to delay creation of vecdb until we have a suitable
+        # collection name (e.g. we could get it from the url or folder path).
+        if config.collection_name is not None:
+            self.create_collection(
+                config.collection_name, replace=config.replace_collection
+            )
+
+    def clone(self) -> "QdrantDB":
+        """Create an independent Qdrant client when running against Qdrant Cloud."""
+        if not self.config.cloud:
+            return self
+        cloned = super().clone()
+        assert isinstance(cloned, QdrantDB)
+        return cloned
+
+    def close(self) -> None:
+        """
+        Close the QdrantDB client and release any resources (e.g., file locks).
+        This is especially important for local storage to release the .lock file.
+        """
+        if hasattr(self.client, "close"):
+            # QdrantLocal has a close method that releases the lock
+            self.client.close()
+            logger.info(f"Closed QdrantDB connection for {self.config.storage_path}")
+
+    def __enter__(self) -> "QdrantDB":
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Context manager exit - ensure cleanup even if an exception occurred."""
+        self.close()
+
+    def clear_empty_collections(self) -> int:
+        coll_names = self.list_collections()
+        n_deletes = 0
+        for name in coll_names:
+            info = self.client.get_collection(collection_name=name)
+            if info.points_count == 0:
+                n_deletes += 1
+                self.client.delete_collection(collection_name=name)
+        return n_deletes
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """Clear all collections with the given prefix."""
+
+        if not really:
+            logger.warning("Not deleting all collections, set really=True to confirm")
+            return 0
+        coll_names = [
+            c for c in self.list_collections(empty=True) if c.startswith(prefix)
+        ]
+        if len(coll_names) == 0:
+            logger.warning(f"No collections found with prefix {prefix}")
+            return 0
+        n_empty_deletes = 0
+        n_non_empty_deletes = 0
+        for name in coll_names:
+            info = self.client.get_collection(collection_name=name)
+            points_count = from_optional(info.points_count, 0)
+
+            n_empty_deletes += points_count == 0
+            n_non_empty_deletes += points_count > 0
+            self.client.delete_collection(collection_name=name)
+        logger.warning(
+            f"""
+            Deleted {n_empty_deletes} empty collections and
+            {n_non_empty_deletes} non-empty collections.
+            """
+        )
+        return n_empty_deletes + n_non_empty_deletes
+
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """
+        Returns:
+            List of collection names that have at least one vector.
+
+        Args:
+            empty (bool, optional): Whether to include empty collections.
+        """
+
+        colls = list(self.client.get_collections())[0][1]
+        if empty:
+            return [coll.name for coll in colls]
+        counts = []
+        for coll in colls:
+            try:
+                counts.append(
+                    from_optional(
+                        self.client.get_collection(
+                            collection_name=coll.name
+                        ).points_count,
+                        0,
+                    )
+                )
+            except Exception:
+                logger.warning(f"Error getting collection {coll.name}")
+                counts.append(0)
+        return [coll.name for coll, count in zip(colls, counts) if (count or 0) > 0]
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        """
+        Create a collection with the given name, optionally replacing an existing
+            collection if `replace` is True.
+        Args:
+            collection_name (str): Name of the collection to create.
+            replace (bool): Whether to replace an existing collection
+                with the same name. Defaults to False.
+        """
+        from qdrant_client.http.models import (
+            CollectionStatus,
+            Distance,
+            SparseIndexParams,
+            SparseVectorParams,
+            VectorParams,
+        )
+
+        self.config.collection_name = collection_name
+        if self.client.collection_exists(collection_name=collection_name):
+            coll = self.client.get_collection(collection_name=collection_name)
+            if (
+                coll.status == CollectionStatus.GREEN
+                and from_optional(coll.points_count, 0) > 0
+            ):
+                logger.warning(f"Non-empty Collection {collection_name} already exists")
+                if not replace:
+                    logger.warning("Not replacing collection")
+                    return
+                else:
+                    logger.warning("Recreating fresh collection")
+            self.client.delete_collection(collection_name=collection_name)
+
+        vectors_config = {
+            "": VectorParams(
+                size=self.embedding_dim,
+                distance=Distance.COSINE,
+            )
+        }
+        sparse_vectors_config = None
+        if self.config.use_sparse_embeddings:
+            sparse_vectors_config = {
+                "text-sparse": SparseVectorParams(index=SparseIndexParams())
+            }
+        self.client.create_collection(
+            collection_name=collection_name,
+            vectors_config=vectors_config,
+            sparse_vectors_config=sparse_vectors_config,
+        )
+        collection_info = self.client.get_collection(collection_name=collection_name)
+        assert collection_info.status == CollectionStatus.GREEN
+        assert collection_info.vectors_count in [0, None]
+        if settings.debug:
+            level = logger.getEffectiveLevel()
+            logger.setLevel(logging.INFO)
+            logger.info(collection_info)
+            logger.setLevel(level)
+
+    def get_sparse_embeddings(self, inputs: List[str]) -> List["SparseVector"]:
+        from qdrant_client.http.models import SparseVector
+
+        if not self.config.use_sparse_embeddings:
+            return []
+        import torch
+
+        tokens = self.sparse_tokenizer(
+            inputs, return_tensors="pt", truncation=True, padding=True
+        )
+        output = self.sparse_model(**tokens)
+        vectors = torch.max(
+            torch.log(torch.relu(output.logits) + torch.tensor(1.0))
+            * tokens.attention_mask.unsqueeze(-1),
+            dim=1,
+        )[0].squeeze(dim=1)
+        sparse_embeddings = []
+        for vec in vectors:
+            cols = vec.nonzero().squeeze().cpu().tolist()
+            weights = vec[cols].cpu().tolist()
+            sparse_embeddings.append(
+                SparseVector(
+                    indices=cols,
+                    values=weights,
+                )
+            )
+        return sparse_embeddings
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        from qdrant_client.http.models import (
+            Batch,
+            CollectionStatus,
+            SparseVector,
+        )
+
+        # Add id to metadata if not already present
+        super().maybe_add_ids(documents)
+        # Fix the ids due to qdrant finickiness
+        for doc in documents:
+            doc.metadata.id = str(self._to_int_or_uuid(doc.metadata.id))
+        colls = self.list_collections(empty=True)
+        if len(documents) == 0:
+            return
+        document_dicts = [doc.model_dump() for doc in documents]
+        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+        sparse_embedding_vecs = self.get_sparse_embeddings(
+            [doc.content for doc in documents]
+        )
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        if self.config.collection_name not in colls:
+            self.create_collection(self.config.collection_name, replace=True)
+        ids = [self._to_int_or_uuid(d.id()) for d in documents]
+        # don't insert all at once, batch in chunks of b,
+        # else we get an API error
+        b = self.config.batch_size
+        for i in range(0, len(ids), b):
+            vectors: Dict[str, Embeddings | List[SparseVector]] = {
+                "": embedding_vecs[i : i + b]
+            }
+            if self.config.use_sparse_embeddings:
+                vectors["text-sparse"] = sparse_embedding_vecs[i : i + b]
+            coll_found: bool = False
+            for _ in range(3):
+                # poll until collection is ready
+                if (
+                    self.client.collection_exists(self.config.collection_name)
+                    and self.client.get_collection(self.config.collection_name).status
+                    == CollectionStatus.GREEN
+                ):
+                    coll_found = True
+                    break
+                time.sleep(1)
+
+            if not coll_found:
+                raise ValueError(
+                    f"""
+                    QdrantDB Collection {self.config.collection_name} 
+                    not found or not ready
+                    """
+                )
+
+            self.client.upsert(
+                collection_name=self.config.collection_name,
+                points=Batch(
+                    ids=ids[i : i + b],
+                    vectors=vectors,
+                    payloads=document_dicts[i : i + b],
+                ),
+            )
+
+    def delete_collection(self, collection_name: str) -> None:
+        self.client.delete_collection(collection_name=collection_name)
+
+    def _to_int_or_uuid(self, id: str) -> int | str:
+        try:
+            int_val = int(id)
+            if is_valid_uuid(id):
+                return int_val
+        except ValueError:
+            pass
+
+        # If doc_id is already a valid UUID, return it as is
+        if isinstance(id, str) and is_valid_uuid(id):
+            return id
+
+        # Otherwise, generate a UUID from the doc_id
+        # Convert doc_id to string if it's not already
+        id_str = str(id)
+
+        # Hash the document ID using SHA-1
+        hash_object = hashlib.sha1(id_str.encode())
+        hash_digest = hash_object.hexdigest()
+
+        # Truncate or manipulate the hash to fit into a UUID (128 bits)
+        uuid_str = hash_digest[:32]
+
+        # Format this string into a UUID format
+        formatted_uuid = uuid.UUID(uuid_str)
+
+        return str(formatted_uuid)
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        from qdrant_client.http.models import (
+            Filter,
+        )
+
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        docs = []
+        offset = 0
+        filter = Filter() if where == "" else Filter.model_validate(json.loads(where))
+        while True:
+            results, next_page_offset = self.client.scroll(
+                collection_name=self.config.collection_name,
+                scroll_filter=filter,
+                offset=offset,
+                limit=10_000,  # try getting all at once, if not we keep paging
+                with_payload=True,
+                with_vectors=False,
+            )
+            docs += [
+                self.config.document_class(**record.payload)  # type: ignore
+                for record in results
+            ]
+            # ignore
+            if next_page_offset is None:
+                break
+            offset = next_page_offset  # type: ignore
+        return docs
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        _ids = [self._to_int_or_uuid(id) for id in ids]
+        records = self.client.retrieve(
+            collection_name=self.config.collection_name,
+            ids=_ids,
+            with_vectors=False,
+            with_payload=True,
+        )
+        # Note the records may NOT be in the order of the ids,
+        # so we re-order them here.
+        id2payload = {record.id: record.payload for record in records}
+        ordered_payloads = [id2payload[id] for id in _ids if id in id2payload]
+        docs = [Document(**payload) for payload in ordered_payloads]  # type: ignore
+        return docs
+
+    def similar_texts_with_scores(
+        self,
+        text: str,
+        k: int = 1,
+        where: Optional[str] = None,
+        neighbors: int = 0,
+    ) -> List[Tuple[Document, float]]:
+        from qdrant_client.conversions.common_types import ScoredPoint
+        from qdrant_client.http.models import (
+            Filter,
+            NamedSparseVector,
+            NamedVector,
+            SearchRequest,
+        )
+
+        embedding = self.embedding_fn([text])[0]
+        # TODO filter may not work yet
+        if where is None or where == "":
+            filter = Filter()
+        else:
+            filter = Filter.model_validate(json.loads(where))
+        requests = [
+            SearchRequest(
+                vector=NamedVector(
+                    name="",
+                    vector=embedding,
+                ),
+                limit=k,
+                with_payload=True,
+                filter=filter,
+            )
+        ]
+        if self.config.use_sparse_embeddings:
+            sparse_embedding = self.get_sparse_embeddings([text])[0]
+            requests.append(
+                SearchRequest(
+                    vector=NamedSparseVector(
+                        name="text-sparse",
+                        vector=sparse_embedding,
+                    ),
+                    limit=self.config.sparse_limit,
+                    with_payload=True,
+                    filter=filter,
+                )
+            )
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot search")
+        search_result_lists: List[List[ScoredPoint]] = self.client.search_batch(
+            collection_name=self.config.collection_name, requests=requests
+        )
+
+        search_result = [
+            match for result in search_result_lists for match in result
+        ]  # 2D list -> 1D list
+        scores = [match.score for match in search_result if match is not None]
+        docs = [
+            self.config.document_class(**(match.payload))  # type: ignore
+            for match in search_result
+            if match is not None
+        ]
+        if len(docs) == 0:
+            logger.warning(f"No matches found for {text}")
+            return []
+        doc_score_pairs = list(zip(docs, scores))
+        max_score = max(ds[1] for ds in doc_score_pairs)
+        if settings.debug:
+            logger.info(f"Found {len(doc_score_pairs)} matches, max score: {max_score}")
+        self.show_if_debug(doc_score_pairs)
+        return doc_score_pairs
+</file>
+
 <file path="SECURITY.md">
 # Security Policy
 
@@ -83567,6 +83245,3117 @@ it, and if it was a denylist gap it is out of scope.
 
 Security fixes ship in the latest release. Please upgrade to the current
 version of `langroid` rather than requesting backports.
+</file>
+
+<file path="langroid/language_models/openai_gpt.py">
+import hashlib
+import json
+import logging
+import os
+import sys
+import warnings
+from collections import defaultdict
+from functools import cache
+from itertools import chain
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    no_type_check,
+)
+
+import openai
+from cerebras.cloud.sdk import AsyncCerebras, Cerebras
+from groq import AsyncGroq, Groq
+from httpx import Timeout
+from openai import AsyncOpenAI, OpenAI
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from rich import print
+from rich.markup import escape
+
+from langroid.cachedb.base import CacheDB
+from langroid.cachedb.redis_cachedb import RedisCache, RedisCacheConfig
+from langroid.exceptions import LangroidImportError
+from langroid.language_models.base import (
+    LanguageModel,
+    LLMConfig,
+    LLMFunctionCall,
+    LLMFunctionSpec,
+    LLMMessage,
+    LLMResponse,
+    LLMTokenUsage,
+    OpenAIJsonSchemaSpec,
+    OpenAIToolCall,
+    OpenAIToolSpec,
+    Role,
+    StreamEventType,
+    ToolChoiceTypes,
+)
+from langroid.language_models.client_cache import (
+    get_async_cerebras_client,
+    get_async_groq_client,
+    get_async_openai_client,
+    get_cerebras_client,
+    get_groq_client,
+    get_openai_client,
+    wrap_api_key_provider_async,
+)
+from langroid.language_models.config import HFPromptFormatterConfig
+from langroid.language_models.model_info import (
+    DeepSeekModel,
+    MiniMaxModel,
+    OpenAI_API_ParamInfo,
+)
+from langroid.language_models.model_info import (
+    OpenAIChatModel as OpenAIChatModel,
+)
+from langroid.language_models.model_info import (
+    OpenAICompletionModel as OpenAICompletionModel,
+)
+from langroid.language_models.prompt_formatter.hf_formatter import (
+    HFFormatter,
+    find_hf_formatter,
+)
+from langroid.language_models.provider_params import (
+    DUMMY_API_KEY,
+    LangDBParams,
+    PortkeyParams,
+)
+from langroid.language_models.utils import (
+    async_retry_with_exponential_backoff,
+    retry_with_exponential_backoff,
+)
+from langroid.parsing.parse_json import parse_imperfect_json
+from langroid.utils.configuration import settings
+from langroid.utils.constants import Colors
+from langroid.utils.system import friendly_error
+
+logging.getLogger("openai").setLevel(logging.ERROR)
+
+if "OLLAMA_HOST" in os.environ:
+    OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
+else:
+    OLLAMA_BASE_URL = "http://localhost:11434/v1"
+
+DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+# Provider prefixes that route to the Gemini OpenAI-compatible API.
+GEMINI_MODEL_PREFIXES = ("gemini/", "google/gemini-")
+GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+OLLAMA_API_KEY = "ollama"
+
+VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
+LLAMACPP_API_KEY = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
+
+
+openai_chat_model_pref_list = [
+    OpenAIChatModel.GPT4o,
+    OpenAIChatModel.GPT4_1_NANO,
+    OpenAIChatModel.GPT4_1_MINI,
+    OpenAIChatModel.GPT4_1,
+    OpenAIChatModel.GPT4o_MINI,
+    OpenAIChatModel.O1_MINI,
+    OpenAIChatModel.O3_MINI,
+    OpenAIChatModel.O1,
+]
+
+openai_completion_model_pref_list = [
+    OpenAICompletionModel.DAVINCI,
+    OpenAICompletionModel.BABBAGE,
+]
+
+
+if "OPENAI_API_KEY" in os.environ:
+    try:
+        available_models = set(map(lambda m: m.id, OpenAI().models.list()))
+    except openai.AuthenticationError as e:
+        if settings.debug:
+            logging.warning(
+                f"""
+            OpenAI Authentication Error: {e}.
+            ---
+            If you intended to use an OpenAI Model, you should fix this,
+            otherwise you can ignore this warning.
+            """
+            )
+        available_models = set()
+    except Exception as e:
+        if settings.debug:
+            logging.warning(
+                f"""
+            Error while fetching available OpenAI models: {e}.
+            Proceeding with an empty set of available models.
+            """
+            )
+        available_models = set()
+else:
+    available_models = set()
+
+default_openai_chat_model = next(
+    chain(
+        filter(
+            lambda m: m.value in available_models,
+            openai_chat_model_pref_list,
+        ),
+        [OpenAIChatModel.GPT4o],
+    )
+)
+default_openai_completion_model = next(
+    chain(
+        filter(
+            lambda m: m.value in available_models,
+            openai_completion_model_pref_list,
+        ),
+        [OpenAICompletionModel.DAVINCI],
+    )
+)
+
+
+class AccessWarning(Warning):
+    pass
+
+
+@cache
+def gpt_3_5_warning() -> None:
+    warnings.warn(
+        f"""
+        {OpenAIChatModel.GPT4o} is not available,
+        falling back to {OpenAIChatModel.GPT3_5_TURBO}.
+        Examples may not work properly and unexpected behavior may occur.
+        Adjustments to prompts may be necessary.
+        """,
+        AccessWarning,
+    )
+
+
+@cache
+def parallel_strict_warning() -> None:
+    logging.warning(
+        "OpenAI tool calling in strict mode is not supported when "
+        "parallel tool calls are made. Disable parallel tool calling "
+        "to ensure correct behavior."
+    )
+
+
+def noop() -> None:
+    """Does nothing."""
+    return None
+
+
+class OpenAICallParams(BaseModel):
+    """
+    Various params that can be sent to an OpenAI API chat-completion call.
+    When specified, any param here overrides the one with same name in the
+    OpenAIGPTConfig.
+    See OpenAI API Reference for details on the params:
+    https://platform.openai.com/docs/api-reference/chat
+    """
+
+    max_tokens: int | None = None
+    temperature: float | None = None
+    frequency_penalty: float | None = None  # between -2 and 2
+    presence_penalty: float | None = None  # between -2 and 2
+    response_format: Dict[str, str] | None = None
+    logit_bias: Dict[int, float] | None = None  # token_id -> bias
+    logprobs: bool | None = None
+    top_p: float | None = None
+    reasoning_effort: str | None = None  # or "low" or "high" or "medium"
+    top_logprobs: int | None = None  # if int, requires logprobs=True
+    n: int | None = None  # how many completions to generate (n > 1 is NOT handled now)
+    stop: str | List[str] | None = None  # (list of) stop sequence(s)
+    seed: int | None = None
+    user: str | None = None  # user id for tracking
+    extra_body: Dict[str, Any] | None = None  # additional params for API request body
+
+    def to_dict_exclude_none(self) -> Dict[str, Any]:
+        return {k: v for k, v in self.model_dump().items() if v is not None}
+
+
+class LiteLLMProxyConfig(BaseSettings):
+    """Configuration for LiteLLM proxy connection."""
+
+    api_key: str = ""  # read from env var LITELLM_API_KEY if set
+    api_base: str = ""  # read from env var LITELLM_API_BASE if set
+
+    model_config = SettingsConfigDict(env_prefix="LITELLM_")
+
+
+class OpenAIGPTConfig(LLMConfig):
+    """
+    Class for any LLM with an OpenAI-like API: besides the OpenAI models this includes:
+    (a) locally-served models behind an OpenAI-compatible API
+    (b) non-local models, using a proxy adaptor lib like litellm that provides
+        an OpenAI-compatible API.
+    (We could rename this class to OpenAILikeConfig, but we keep it as-is for now)
+
+    Important Note:
+    Due to the `env_prefix = "OPENAI_"` defined below,
+    all of the fields below can be set AND OVERRIDDEN via env vars,
+    # by upper-casing the name and prefixing with OPENAI_, e.g.
+    # OPENAI_MAX_OUTPUT_TOKENS=1000.
+    # If any of these is defined in this way in the environment
+    # (either via explicit setenv or export or via .env file + load_dotenv()),
+    # the environment variable takes precedence over the value in the config.
+    """
+
+    type: str = "openai"
+    api_key: str = DUMMY_API_KEY
+    # Callable returning a fresh API key/bearer token, for endpoints that
+    # authenticate with short-lived rotating credentials (e.g. Vertex AI
+    # OAuth tokens, Azure Entra ID). Resolved per-request by the OpenAI
+    # client, and excluded from the client-cache key (the cache is keyed on
+    # the provider's identity), so rotating tokens neither go stale nor grow
+    # the cache. Takes precedence over `api_key`. Only supported for models
+    # served via an OpenAI-compatible endpoint (not Groq/Cerebras/litellm).
+    # See docs/notes/rotating-api-keys.md.
+    api_key_provider: Optional[Callable[[], str]] = None
+    organization: str = ""
+    api_base: str | None = None  # used for local or other non-OpenAI models
+    litellm: bool = False  # use litellm api?
+    litellm_proxy: LiteLLMProxyConfig = LiteLLMProxyConfig()
+    ollama: bool = False  # use ollama's OpenAI-compatible endpoint?
+    min_output_tokens: int = 1
+    use_chat_for_completion: bool = True  # do not change this, for OpenAI models!
+    timeout: int = 20
+    temperature: float = 0.2
+    seed: int | None = 42
+    params: OpenAICallParams | None = None
+    use_cached_client: bool = (
+        True  # Whether to reuse cached clients (prevents resource exhaustion)
+    )
+    # these can be any model name that is served at an OpenAI-compatible API end point
+    chat_model: str = default_openai_chat_model
+    chat_model_orig: Optional[str] = None
+    completion_model: str = default_openai_completion_model
+    run_on_first_use: Callable[[], None] = noop
+    parallel_tool_calls: Optional[bool] = None
+    # Supports constrained decoding which enforces that the output of the LLM
+    # adheres to a JSON schema
+    supports_json_schema: Optional[bool] = None
+    # Supports strict decoding for the generation of tool calls with
+    # the OpenAI Tools API; this ensures that the generated tools
+    # adhere to the provided schema.
+    supports_strict_tools: Optional[bool] = None
+    # a string that roughly matches a HuggingFace chat_template,
+    # e.g. "mistral-instruct-v0.2 (a fuzzy search is done to find the closest match)
+    formatter: str | None = None
+    hf_formatter: HFFormatter | None = None
+    langdb_params: LangDBParams = LangDBParams()
+    portkey_params: PortkeyParams = PortkeyParams()
+    headers: Dict[str, str] = {}
+    http_client_factory: Optional[Callable[[], Any]] = (
+        None  # Factory: returns Client or (Client, AsyncClient)
+    )
+    http_verify_ssl: bool = True  # Simple flag for SSL verification
+    http_client_config: Optional[Dict[str, Any]] = None  # Config dict for httpx.Client
+    _api_base_was_supplied: bool = False
+
+    def __init__(self, **kwargs) -> None:  # type: ignore
+        api_base_was_supplied = "api_base" in kwargs
+        local_model = "api_base" in kwargs and kwargs["api_base"] is not None
+
+        chat_model = kwargs.get("chat_model", "")
+        local_prefixes = ["local/", "litellm/", "ollama/", "vllm/", "llamacpp/"]
+        if any(chat_model.startswith(prefix) for prefix in local_prefixes):
+            local_model = True
+
+        warn_gpt_3_5 = (
+            "chat_model" not in kwargs.keys()
+            and not local_model
+            and default_openai_chat_model == OpenAIChatModel.GPT3_5_TURBO
+        )
+
+        if warn_gpt_3_5:
+            existing_hook = kwargs.get("run_on_first_use", noop)
+
+            def with_warning() -> None:
+                existing_hook()
+                gpt_3_5_warning()
+
+            kwargs["run_on_first_use"] = with_warning
+
+        super().__init__(**kwargs)
+        env_prefix = self.model_config.get("env_prefix")
+        env_api_base_name = f"{env_prefix}API_BASE"
+        env_api_base = os.getenv(env_api_base_name)
+        if not self.model_config.get("case_sensitive"):
+            case_insensitive_env = {
+                name.lower(): value for name, value in os.environ.items()
+            }
+            env_api_base = case_insensitive_env.get(env_api_base_name.lower())
+        api_base_was_supplied = api_base_was_supplied or (
+            self.api_base is not None
+            and (env_prefix != "OPENAI_" or self.api_base != env_api_base)
+        )
+        self._api_base_was_supplied = api_base_was_supplied
+
+    model_config = SettingsConfigDict(env_prefix="OPENAI_")
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Track API bases assigned after config construction."""
+        super().__setattr__(name, value)
+        if name == "api_base":
+            self._api_base_was_supplied = True
+
+    def model_copy(
+        self, *, update: Mapping[str, Any] | None = None, deep: bool = False
+    ) -> "OpenAIGPTConfig":
+        """
+        Copy config while preserving nested model instances and subclasses.
+
+        Important: Avoid reconstructing via `model_dump` as that coerces nested
+        models to their annotated base types (dropping subclass-only fields).
+        Instead, defer to Pydantic's native `model_copy`, which keeps nested
+        `BaseModel` instances (and their concrete subclasses) intact.
+
+        An `api_base` supplied through `update` is caller configuration, so the
+        copy must retain that provenance for provider-specific routing.
+        """
+        # Delegate to BaseSettings/BaseModel implementation to preserve types
+        copied = super().model_copy(update=update, deep=deep)
+        if update is not None and "api_base" in update:
+            copied._api_base_was_supplied = True
+        return copied  # type: ignore[return-value]
+
+    def _validate_litellm(self) -> None:
+        """
+        When using liteLLM, validate whether all env vars required by the model
+        have been set.
+        """
+        if not self.litellm:
+            return
+        try:
+            import litellm
+        except ImportError:
+            raise LangroidImportError("litellm", "litellm")
+
+        litellm.telemetry = False
+        litellm.drop_params = True  # drop un-supported params without crashing
+        litellm.modify_params = True
+        self.seed = None  # some local mdls don't support seed
+
+        if self.api_key == DUMMY_API_KEY:
+            keys_dict = litellm.utils.validate_environment(self.chat_model)
+            missing_keys = keys_dict.get("missing_keys", [])
+            if len(missing_keys) > 0:
+                raise ValueError(
+                    f"""
+                    Missing environment variables for litellm-proxied model:
+                    {missing_keys}
+                    """
+                )
+
+    @classmethod
+    def create(cls, prefix: str) -> Type["OpenAIGPTConfig"]:
+        """Create a config class whose params can be set via a desired
+        prefix from the .env file or env vars.
+        E.g., using
+        ```python
+        OllamaConfig = OpenAIGPTConfig.create("ollama")
+        ollama_config = OllamaConfig()
+        ```
+        you can have a group of params prefixed by "OLLAMA_", to be used
+        with models served via `ollama`.
+        This way, you can maintain several setting-groups in your .env file,
+        one per model type.
+        """
+
+        class DynamicConfig(OpenAIGPTConfig):
+            pass
+
+        DynamicConfig.model_config = SettingsConfigDict(env_prefix=prefix.upper() + "_")
+        return DynamicConfig
+
+
+class OpenAIResponse(BaseModel):
+    """OpenAI response model, either completion or chat."""
+
+    choices: List[Dict]  # type: ignore
+    usage: Dict  # type: ignore
+
+
+def litellm_logging_fn(model_call_dict: Dict[str, Any]) -> None:
+    """Logging function for litellm"""
+    try:
+        api_input_dict = model_call_dict.get("additional_args", {}).get(
+            "complete_input_dict"
+        )
+        if api_input_dict is not None:
+            text = escape(json.dumps(api_input_dict, indent=2))
+            print(
+                f"[grey37]LITELLM: {text}[/grey37]",
+            )
+    except Exception:
+        pass
+
+
+# Define a class for OpenAI GPT models that extends the base class
+class OpenAIGPT(LanguageModel):
+    """
+    Class for OpenAI LLMs
+    """
+
+    client: OpenAI | Groq | Cerebras | None
+    async_client: AsyncOpenAI | AsyncGroq | AsyncCerebras | None
+
+    def __init__(self, config: OpenAIGPTConfig = OpenAIGPTConfig()):
+        """
+        Args:
+            config: configuration for openai-gpt model
+        """
+        # copy the config to avoid modifying the original; deep to decouple
+        # nested models while preserving their concrete subclasses
+        # The api_key_provider must NOT be deep-copied: the client cache is
+        # keyed on its identity (so a copy would defeat cache sharing), and it
+        # may hold non-copyable state (e.g. a threading.Lock). Clear it in a
+        # shallow copy first, then restore the original callable afterwards.
+        api_key_provider = config.api_key_provider
+        if api_key_provider is not None:
+            config = config.model_copy(update={"api_key_provider": None})
+        config = config.model_copy(deep=True)
+        if api_key_provider is not None:
+            config.api_key_provider = api_key_provider
+        super().__init__(config)
+        self.config: OpenAIGPTConfig = config
+        # save original model name such as `provider/model` before
+        # we strip out the `provider` - we retain the original in
+        # case some params are specific to a provider.
+        self.chat_model_orig = self.config.chat_model_orig or self.config.chat_model
+
+        # Run the first time the model is used
+        self.run_on_first_use = cache(self.config.run_on_first_use)
+
+        # global override of chat_model,
+        # to allow quick testing with other models
+        if settings.chat_model != "":
+            self.config.chat_model = settings.chat_model
+            self.chat_model_orig = settings.chat_model
+            self.config.completion_model = settings.chat_model
+
+        if len(parts := self.config.chat_model.split("//")) > 1:
+            # there is a formatter specified, e.g.
+            # "litellm/ollama/mistral//hf" or
+            # "local/localhost:8000/v1//mistral-instruct-v0.2"
+            formatter = parts[1]
+            self.config.chat_model = parts[0]
+            if formatter == "hf":
+                # e.g. "litellm/ollama/mistral//hf" -> "litellm/ollama/mistral"
+                formatter = find_hf_formatter(self.config.chat_model)
+                if formatter != "":
+                    # e.g. "mistral"
+                    self.config.formatter = formatter
+                    logging.warning(
+                        f"""
+                        Using completions (not chat) endpoint with HuggingFace
+                        chat_template for {formatter} for
+                        model {self.config.chat_model}
+                        """
+                    )
+            else:
+                # e.g. "local/localhost:8000/v1//mistral-instruct-v0.2"
+                self.config.formatter = formatter
+
+        if self.config.formatter is not None:
+            self.config.hf_formatter = HFFormatter(
+                HFPromptFormatterConfig(model_name=self.config.formatter)
+            )
+
+        self.supports_json_schema: bool = self.config.supports_json_schema or False
+        self.supports_strict_tools: bool = self.config.supports_strict_tools or False
+
+        OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", DUMMY_API_KEY)
+        self.api_key = config.api_key
+
+        # if model name starts with "litellm",
+        # set the actual model name by stripping the "litellm/" prefix
+        # and set the litellm flag to True
+        if self.config.chat_model.startswith("litellm/") or self.config.litellm:
+            # e.g. litellm/ollama/mistral
+            self.config.litellm = True
+            self.api_base = self.config.api_base
+            if self.config.chat_model.startswith("litellm/"):
+                # strip the "litellm/" prefix
+                # e.g. litellm/ollama/llama2 => ollama/llama2
+                self.config.chat_model = self.config.chat_model.split("/", 1)[1]
+        elif self.config.chat_model.startswith("local/"):
+            # expect this to be of the form "local/localhost:8000/v1",
+            # depending on how the model is launched locally.
+            # In this case the model served locally behind an OpenAI-compatible API
+            # so we can just use `openai.*` methods directly,
+            # and don't need a adaptor library like litellm
+            self.config.litellm = False
+            self.config.seed = None  # some models raise an error when seed is set
+            # Extract the api_base from the model name after the "local/" prefix
+            self.api_base = self.config.chat_model.split("/", 1)[1]
+            if not self.api_base.startswith("http"):
+                self.api_base = "http://" + self.api_base
+        elif self.config.chat_model.startswith("ollama/"):
+            self.config.ollama = True
+
+            # use api_base from config if set, else fall back on OLLAMA_BASE_URL
+            self.api_base = self.config.api_base or OLLAMA_BASE_URL
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = OLLAMA_API_KEY
+            self.config.chat_model = self.config.chat_model.replace("ollama/", "")
+        elif self.config.chat_model.startswith("vllm/"):
+            self.supports_json_schema = True
+            self.config.chat_model = self.config.chat_model.replace("vllm/", "")
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
+            self.api_base = self.config.api_base or "http://localhost:8000/v1"
+            if not self.api_base.startswith("http"):
+                self.api_base = "http://" + self.api_base
+            if not self.api_base.endswith("/v1"):
+                self.api_base = self.api_base + "/v1"
+        elif self.config.chat_model.startswith("llamacpp/"):
+            self.supports_json_schema = True
+            self.api_base = self.config.chat_model.split("/", 1)[1]
+            if not self.api_base.startswith("http"):
+                self.api_base = "http://" + self.api_base
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
+        else:
+            self.api_base = self.config.api_base
+            # If api_base is unset we use OpenAI's endpoint, which supports
+            # these features (with JSON schema restricted to a limited set of models)
+            self.supports_strict_tools = self.api_base is None
+            self.supports_json_schema = (
+                self.api_base is None and self.info().has_structured_output
+            )
+
+        if settings.chat_model != "":
+            # if we're overriding chat model globally, set completion model to same
+            self.config.completion_model = self.config.chat_model
+
+        if self.config.formatter is not None:
+            # we want to format chats -> completions using this specific formatter
+            self.config.use_completion_for_chat = True
+            self.config.completion_model = self.config.chat_model
+
+        if self.config.use_completion_for_chat:
+            self.config.use_chat_for_completion = False
+
+        self.is_groq = self.config.chat_model.startswith("groq/")
+        self.is_cerebras = self.config.chat_model.startswith("cerebras/")
+        self.is_gemini = self.is_gemini_model()
+        self.is_deepseek = self.is_deepseek_model()
+        self.is_minimax = self.is_minimax_model()
+        self.is_glhf = self.config.chat_model.startswith("glhf/")
+        self.is_openrouter = self.config.chat_model.startswith("openrouter/")
+        self.is_langdb = self.config.chat_model.startswith("langdb/")
+        self.is_portkey = self.config.chat_model.startswith("portkey/")
+        self.is_litellm_proxy = self.config.chat_model.startswith("litellm-proxy/")
+
+        if self.config.api_key_provider is not None and (
+            self.is_groq or self.is_cerebras or self.config.litellm
+        ):
+            raise ValueError(
+                "api_key_provider is only supported for models served via an "
+                "OpenAI-compatible endpoint (using the OpenAI client); it "
+                "cannot be used with Groq, Cerebras, or the litellm adapter."
+            )
+
+        if self.is_groq:
+            # use groq-specific client
+            self.config.chat_model = self.config.chat_model.replace("groq/", "")
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = os.getenv("GROQ_API_KEY", DUMMY_API_KEY)
+            if self.config.use_cached_client:
+                self.client = get_groq_client(api_key=self.api_key)
+                self.async_client = get_async_groq_client(api_key=self.api_key)
+            else:
+                # Create new clients without caching
+                self.client = Groq(api_key=self.api_key)
+                self.async_client = AsyncGroq(api_key=self.api_key)
+        elif self.is_cerebras:
+            # use cerebras-specific client
+            self.config.chat_model = self.config.chat_model.replace("cerebras/", "")
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = os.getenv("CEREBRAS_API_KEY", DUMMY_API_KEY)
+            if self.config.use_cached_client:
+                self.client = get_cerebras_client(api_key=self.api_key)
+                # TODO there is not async client, so should we do anything here?
+                self.async_client = get_async_cerebras_client(api_key=self.api_key)
+            else:
+                # Create new clients without caching
+                self.client = Cerebras(api_key=self.api_key)
+                self.async_client = AsyncCerebras(api_key=self.api_key)
+        else:
+            # in these cases, there's no specific client: OpenAI python client suffices
+            if self.is_litellm_proxy:
+                self.config.chat_model = self.config.chat_model.replace(
+                    "litellm-proxy/", ""
+                )
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = self.config.litellm_proxy.api_key or self.api_key
+                self.api_base = self.config.litellm_proxy.api_base or self.api_base
+            elif self.is_gemini:
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("GEMINI_API_KEY", DUMMY_API_KEY)
+                # Prefer caller config, then Gemini env, then the default.
+                gemini_api_base = os.getenv("GEMINI_API_BASE", "")
+                explicit_api_base = (
+                    self.config.api_base if self.config._api_base_was_supplied else None
+                )
+                self.api_base = explicit_api_base or gemini_api_base or GEMINI_BASE_URL
+                if (
+                    self.config.chat_model.startswith("gemini/")
+                    or self.api_base == GEMINI_BASE_URL
+                ):
+                    self.config.chat_model = self.config.chat_model.split("/", 1)[1]
+            elif self.is_glhf:
+                self.config.chat_model = self.config.chat_model.replace("glhf/", "")
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("GLHF_API_KEY", DUMMY_API_KEY)
+                self.api_base = GLHF_BASE_URL
+            elif self.is_openrouter:
+                self.config.chat_model = self.config.chat_model.replace(
+                    "openrouter/", ""
+                )
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("OPENROUTER_API_KEY", DUMMY_API_KEY)
+                self.api_base = OPENROUTER_BASE_URL
+            elif self.is_deepseek:
+                self.config.chat_model = self.config.chat_model.replace("deepseek/", "")
+                self.api_base = DEEPSEEK_BASE_URL
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("DEEPSEEK_API_KEY", DUMMY_API_KEY)
+            elif self.is_minimax:
+                self.config.chat_model = self.config.chat_model.replace("minimax/", "")
+                # Honor caller-supplied base URL (e.g. regional endpoints,
+                # proxies) instead of always forcing the default.
+                openai_api_base = os.getenv("OPENAI_API_BASE")
+                explicit_api_base = (
+                    self.config.api_base
+                    if self.config.api_base and self.config.api_base != openai_api_base
+                    else None
+                )
+                self.api_base = explicit_api_base or MINIMAX_BASE_URL
+                if self.api_key == OPENAI_API_KEY:
+                    # Only overwrite with MINIMAX_API_KEY when it is actually
+                    # set, so users who intentionally put their MiniMax key in
+                    # OPENAI_API_KEY are not silently downgraded to a dummy key.
+                    minimax_key = os.getenv("MINIMAX_API_KEY", "")
+                    if minimax_key:
+                        self.api_key = minimax_key
+                # Recompute capabilities now that the prefix has been stripped
+                # and self.info() can find the model in MODEL_INFO.
+                self.supports_strict_tools = True
+                self.supports_json_schema = self.info().has_structured_output
+            elif self.is_langdb:
+                self.config.chat_model = self.config.chat_model.replace("langdb/", "")
+                self.api_base = self.config.langdb_params.base_url
+                project_id = self.config.langdb_params.project_id
+                if project_id:
+                    self.api_base += "/" + project_id + "/v1"
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = self.config.langdb_params.api_key or DUMMY_API_KEY
+
+                if self.config.langdb_params:
+                    params = self.config.langdb_params
+                    if params.project_id:
+                        self.config.headers["x-project-id"] = params.project_id
+                    if params.label:
+                        self.config.headers["x-label"] = params.label
+                    if params.run_id:
+                        self.config.headers["x-run-id"] = params.run_id
+                    if params.thread_id:
+                        self.config.headers["x-thread-id"] = params.thread_id
+            elif self.is_portkey:
+                # Parse the model string and extract provider/model
+                provider, model = self.config.portkey_params.parse_model_string(
+                    self.config.chat_model
+                )
+                self.config.chat_model = model
+                if provider:
+                    self.config.portkey_params.provider = provider
+
+                # Set Portkey base URL
+                self.api_base = self.config.portkey_params.base_url + "/v1"
+
+                # Set API key - use provider's API key from env if available
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = self.config.portkey_params.get_provider_api_key(
+                        self.config.portkey_params.provider, DUMMY_API_KEY
+                    )
+
+                # Add Portkey-specific headers
+                self.config.headers.update(self.config.portkey_params.get_headers())
+
+            # Sanitize the API key: strip leading/trailing whitespace
+            # (including stray newlines from .env files or CI secrets).
+            self.api_key = self.api_key.strip()
+
+            # Create http_client if needed - Priority order:
+            # 1. http_client_factory (most flexibility, not cacheable)
+            # 2. http_client_config (cacheable, moderate flexibility)
+            # 3. http_verify_ssl=False (cacheable, simple SSL bypass)
+            http_client = None
+            async_http_client = None
+            http_client_config_used = None
+
+            if self.config.http_client_factory is not None:
+                # Use the factory to create http_client (not cacheable)
+                http_client = self.config.http_client_factory()
+                if isinstance(http_client, (list, tuple)):
+                    if len(http_client) != 2:
+                        raise ValueError(
+                            "http_client_factory must return either a single "
+                            "httpx.Client or a tuple of "
+                            "(httpx.Client, httpx.AsyncClient)"
+                        )
+                    http_client, async_http_client = http_client
+                else:
+                    # set async_http_client to None - so that it will
+                    # be created later
+                    async_http_client = None
+            elif self.config.http_client_config is not None:
+                # Use config dict (cacheable)
+                http_client_config_used = self.config.http_client_config
+            elif not self.config.http_verify_ssl:
+                # Simple SSL bypass (cacheable)
+                http_client_config_used = {"verify": False}
+                logging.warning(
+                    "SSL verification has been disabled. This is insecure and "
+                    "should only be used in trusted environments (e.g., "
+                    "corporate networks with self-signed certificates)."
+                )
+
+            # With an api_key_provider, hand the callable itself to the
+            # OpenAI client, which resolves a fresh token on each request.
+            openai_api_key: Union[str, Callable[[], str]] = (
+                self.config.api_key_provider
+                if self.config.api_key_provider is not None
+                else self.api_key
+            )
+
+            if self.config.use_cached_client:
+                self.client = get_openai_client(
+                    api_key=openai_api_key,
+                    base_url=self.api_base,
+                    organization=self.config.organization,
+                    timeout=Timeout(self.config.timeout),
+                    default_headers=self.config.headers,
+                    http_client=http_client,
+                    http_client_config=http_client_config_used,
+                )
+                self.async_client = get_async_openai_client(
+                    api_key=openai_api_key,
+                    base_url=self.api_base,
+                    organization=self.config.organization,
+                    timeout=Timeout(self.config.timeout),
+                    default_headers=self.config.headers,
+                    http_client=async_http_client,
+                    http_client_config=http_client_config_used,
+                )
+            else:
+                # Create new clients without caching
+                client_kwargs: Dict[str, Any] = dict(
+                    api_key=openai_api_key,
+                    base_url=self.api_base,
+                    organization=self.config.organization,
+                    timeout=Timeout(self.config.timeout),
+                    default_headers=self.config.headers,
+                )
+                if http_client is not None:
+                    client_kwargs["http_client"] = http_client
+                elif http_client_config_used is not None:
+                    # Create http_client from config for non-cached scenario
+                    try:
+                        from httpx import Client
+
+                        client_kwargs["http_client"] = Client(**http_client_config_used)
+                    except ImportError:
+                        raise ValueError(
+                            "httpx is required to use http_client_config. "
+                            "Install it with: pip install httpx"
+                        )
+                self.client = OpenAI(**client_kwargs)
+
+                async_client_kwargs: Dict[str, Any] = dict(
+                    api_key=(
+                        # AsyncOpenAI awaits its api_key callable
+                        wrap_api_key_provider_async(openai_api_key)
+                        if callable(openai_api_key)
+                        else openai_api_key
+                    ),
+                    base_url=self.api_base,
+                    organization=self.config.organization,
+                    timeout=Timeout(self.config.timeout),
+                    default_headers=self.config.headers,
+                )
+                if async_http_client is not None:
+                    async_client_kwargs["http_client"] = async_http_client
+                elif http_client_config_used is not None:
+                    # Create async http_client from config for non-cached scenario
+                    try:
+                        from httpx import AsyncClient
+
+                        async_client_kwargs["http_client"] = AsyncClient(
+                            **http_client_config_used
+                        )
+                    except ImportError:
+                        raise ValueError(
+                            "httpx is required to use http_client_config. "
+                            "Install it with: pip install httpx"
+                        )
+                self.async_client = AsyncOpenAI(**async_client_kwargs)
+
+        self.cache: CacheDB | None = None
+        use_cache = self.config.cache_config is not None
+        if "redis" in settings.cache_type and use_cache:
+            if config.cache_config is None or not isinstance(
+                config.cache_config,
+                RedisCacheConfig,
+            ):
+                # switch to fresh redis config if needed
+                config.cache_config = RedisCacheConfig(
+                    fake="fake" in settings.cache_type
+                )
+            if "fake" in settings.cache_type:
+                # force use of fake redis if global cache_type is "fakeredis"
+                config.cache_config.fake = True
+            self.cache = RedisCache(config.cache_config)
+        elif settings.cache_type != "none" and use_cache:
+            raise ValueError(
+                f"Invalid cache type {settings.cache_type}. "
+                "Valid types are redis, fakeredis, none"
+            )
+
+        self.config._validate_litellm()
+
+    def _openai_api_call_params(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Prep the params to be sent to the OpenAI API
+        (or any OpenAI-compatible API, e.g. from Ooba or LmStudio)
+        for chat-completion.
+
+        Order of priority:
+        - (1) Params (mainly max_tokens) in the chat/achat/generate/agenerate call
+                (these are passed in via kwargs)
+        - (2) Params in OpenAIGPTConfig.params (of class OpenAICallParams)
+        - (3) Specific Params in OpenAIGPTConfig (just temperature for now)
+        """
+        params = dict(
+            temperature=self.config.temperature,
+        )
+        if self.config.params is not None:
+            params.update(self.config.params.to_dict_exclude_none())
+        params.update(kwargs)
+        return params
+
+    def is_openai_chat_model(self) -> bool:
+        openai_chat_models = [e.value for e in OpenAIChatModel]
+        return self.config.chat_model in openai_chat_models
+
+    def is_openai_completion_model(self) -> bool:
+        openai_completion_models = [e.value for e in OpenAICompletionModel]
+        return self.config.completion_model in openai_completion_models
+
+    def is_gemini_model(self) -> bool:
+        """Are we using the gemini OpenAI-compatible API?"""
+        return self.chat_model_orig.startswith(GEMINI_MODEL_PREFIXES)
+
+    def is_deepseek_model(self) -> bool:
+        deepseek_models = [e.value for e in DeepSeekModel]
+        return (
+            self.chat_model_orig in deepseek_models
+            or self.chat_model_orig.startswith("deepseek/")
+        )
+
+    def is_minimax_model(self) -> bool:
+        """Are we using the MiniMax OpenAI-compatible API?"""
+        minimax_models = [e.value for e in MiniMaxModel]
+        return (
+            self.chat_model_orig in minimax_models
+            or self.chat_model_orig.startswith("minimax/")
+        )
+
+    def unsupported_params(self) -> List[str]:
+        """
+        List of params that are not supported by the current model
+        """
+        unsupported = set(self.info().unsupported_params)
+        return list(unsupported)
+
+    def rename_params(self) -> Dict[str, str]:
+        """
+        Map of param name -> new name for specific models.
+        Currently main troublemaker is o1* series.
+        """
+        return self.info().rename_params
+
+    def chat_context_length(self) -> int:
+        """
+        Context-length for chat-completion models/endpoints.
+        Get it from the config if explicitly given,
+         otherwise use model_info based on model name, and fall back to
+         generic model_info if there's no match.
+        """
+        return self.config.chat_context_length or self.info().context_length
+
+    def completion_context_length(self) -> int:
+        """
+        Context-length for completion models/endpoints.
+        Get it from the config if explicitly given,
+         otherwise use model_info based on model name, and fall back to
+         generic model_info if there's no match.
+        """
+        return (
+            self.config.completion_context_length
+            or self.completion_info().context_length
+        )
+
+    def chat_cost(self) -> Tuple[float, float, float]:
+        """
+        (Prompt, Cached, Generation) cost per 1000 tokens, for chat-completion
+        models/endpoints.
+        Get it from the dict, otherwise fail-over to general method
+        """
+        info = self.info()
+        cached_cost_per_million = info.cached_cost_per_million
+        if not cached_cost_per_million:
+            cached_cost_per_million = info.input_cost_per_million
+        return (
+            info.input_cost_per_million / 1000,
+            cached_cost_per_million / 1000,
+            info.output_cost_per_million / 1000,
+        )
+
+    def set_stream(self, stream: bool) -> bool:
+        """Enable or disable streaming output from API.
+        Args:
+            stream: enable streaming output from API
+        Returns: previous value of stream
+        """
+        tmp = self.config.stream
+        self.config.stream = stream
+        return tmp
+
+    def get_stream(self) -> bool:
+        """Get streaming status."""
+        return self.config.stream and settings.stream and self.info().allows_streaming
+
+    @staticmethod
+    def _split_inline_reasoning(
+        event_text: str,
+        event_reasoning: str,
+        in_reasoning: bool,
+        thought_delimiters: Tuple[str, str],
+    ) -> Tuple[str, str, bool]:
+        """Separate inline reasoning from text tokens in a streaming chunk.
+
+        When models embed thinking inside content (e.g. <think>...</think>)
+        rather than using a separate reasoning field, this splits the chunk
+        into text-only and reasoning-only portions for proper streamer routing.
+
+        Returns (text_tokens, reasoning_tokens, in_reasoning).
+        """
+        text_tokens = event_text
+        reasoning_tokens = event_reasoning
+
+        if not event_text or event_reasoning:
+            return text_tokens, reasoning_tokens, in_reasoning
+
+        start, end = thought_delimiters
+        remaining = event_text
+
+        if in_reasoning:
+            text_tokens = ""
+        elif start in event_text:
+            before, _, after = event_text.partition(start)
+            text_tokens = before
+            remaining = after
+            in_reasoning = True
+
+        if in_reasoning:
+            if end in remaining:
+                before, _, after = remaining.partition(end)
+                text_tokens += after
+                reasoning_tokens = before
+                in_reasoning = False
+            else:
+                reasoning_tokens = remaining
+
+        return text_tokens, reasoning_tokens, in_reasoning
+
+    @no_type_check
+    def _process_stream_event(
+        self,
+        event,
+        chat: bool = False,
+        tool_deltas: List[Dict[str, Any]] = [],
+        has_function: bool = False,
+        completion: str = "",
+        reasoning: str = "",
+        function_args: str = "",
+        function_name: str = "",
+        in_reasoning: bool = False,
+    ) -> Tuple[bool, bool, str, str, bool, Dict[str, int]]:
+        """Process state vars while processing a streaming API response.
+            Returns a tuple consisting of:
+        - is_break: whether to break out of the loop
+        - has_function: whether the response contains a function_call
+        - function_name: name of the function
+        - function_args: args of the function
+        - completion: completion text
+        - reasoning: reasoning text
+        - usage: usage dict
+        """
+        # convert event obj (of type ChatCompletionChunk) to dict so rest of code,
+        # which expects dicts, works as it did before switching to openai v1.x
+        if not isinstance(event, dict):
+            event = event.model_dump()
+
+        usage = event.get("usage", {}) or {}
+        choices = event.get("choices", [{}])
+        if choices is None or len(choices) == 0:
+            choices = [{}]
+        if len(usage) > 0 and len(choices[0]) == 0:
+            # we have a "usage" chunk, and empty choices, so we're done
+            # ASSUMPTION: a usage chunk ONLY arrives AFTER all normal completion text!
+            # If any API does not follow this, we need to change this code.
+            return (
+                True,
+                has_function,
+                function_name,
+                function_args,
+                completion,
+                reasoning,
+                in_reasoning,
+                usage,
+            )
+        event_args = ""
+        event_fn_name = ""
+        event_tool_deltas: Optional[List[Dict[str, Any]]] = None
+        silent = settings.quiet
+        # The first two events in the stream of Azure OpenAI is useless.
+        # In the 1st: choices list is empty, in the 2nd: the dict delta has null content
+        if chat:
+            delta = choices[0].get("delta", {}) or {}
+            # capture both content and reasoning_content
+            event_text = delta.get("content", "")
+            event_reasoning = delta.get(
+                "reasoning_content",
+                delta.get("reasoning", ""),
+            )
+            if "function_call" in delta and delta["function_call"] is not None:
+                if "name" in delta["function_call"]:
+                    event_fn_name = delta["function_call"]["name"]
+                if "arguments" in delta["function_call"]:
+                    event_args = delta["function_call"]["arguments"]
+            if "tool_calls" in delta and delta["tool_calls"] is not None:
+                # it's a list of deltas, usually just one
+                event_tool_deltas = delta["tool_calls"]
+                tool_deltas += event_tool_deltas
+        else:
+            event_text = choices[0]["text"]
+            event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
+
+        finish_reason = choices[0].get("finish_reason", "")
+        if not event_text and finish_reason == "content_filter":
+            filter_names = [
+                n
+                for n, r in choices[0].get("content_filter_results", {}).items()
+                if r.get("filtered")
+            ]
+            event_text = (
+                "Cannot respond due to content filters ["
+                + ", ".join(filter_names)
+                + "]"
+            )
+            logging.warning("LLM API returned content filter error: " + event_text)
+
+        event_text_tokens, event_reasoning_tokens, in_reasoning = (
+            self._split_inline_reasoning(
+                event_text,
+                event_reasoning,
+                in_reasoning,
+                self.config.thought_delimiters,
+            )
+        )
+
+        if event_text:
+            completion += event_text
+        if event_text_tokens:
+            if not silent:
+                sys.stdout.write(Colors().GREEN + event_text_tokens)
+                sys.stdout.flush()
+            self.config.streamer(event_text_tokens, StreamEventType.TEXT)
+
+        if event_reasoning:
+            reasoning += event_reasoning
+        if event_reasoning_tokens:
+            if not silent:
+                sys.stdout.write(Colors().GREEN_DIM + event_reasoning_tokens)
+                sys.stdout.flush()
+            self.config.streamer(event_reasoning_tokens, StreamEventType.REASONING)
+
+        if event_fn_name:
+            function_name = event_fn_name
+            has_function = True
+            if not silent:
+                sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
+                sys.stdout.flush()
+            self.config.streamer(event_fn_name, StreamEventType.FUNC_NAME)
+
+        if event_args:
+            function_args += event_args
+            if not silent:
+                sys.stdout.write(Colors().GREEN + event_args)
+                sys.stdout.flush()
+            self.config.streamer(event_args, StreamEventType.FUNC_ARGS)
+
+        if event_tool_deltas is not None:
+            # print out streaming tool calls, if not async
+            for td in event_tool_deltas:
+                if td["function"]["name"] is not None:
+                    tool_fn_name = td["function"]["name"]
+                    if not silent:
+                        sys.stdout.write(
+                            Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
+                        )
+                        sys.stdout.flush()
+                    self.config.streamer(tool_fn_name, StreamEventType.TOOL_NAME)
+                if td["function"]["arguments"] != "":
+                    tool_fn_args = td["function"]["arguments"]
+                    if not silent:
+                        sys.stdout.write(Colors().GREEN + tool_fn_args)
+                        sys.stdout.flush()
+                    self.config.streamer(tool_fn_args, StreamEventType.TOOL_ARGS)
+
+        # show this delta in the stream
+        is_break = finish_reason in [
+            "stop",
+            "function_call",
+            "tool_calls",
+        ]
+        # for function_call, finish_reason does not necessarily
+        # contain "function_call" as mentioned in the docs.
+        # So we check for "stop" or "function_call" here.
+        return (
+            is_break,
+            has_function,
+            function_name,
+            function_args,
+            completion,
+            reasoning,
+            in_reasoning,
+            usage,
+        )
+
+    @no_type_check
+    async def _process_stream_event_async(
+        self,
+        event,
+        chat: bool = False,
+        tool_deltas: List[Dict[str, Any]] = [],
+        has_function: bool = False,
+        completion: str = "",
+        reasoning: str = "",
+        function_args: str = "",
+        function_name: str = "",
+        in_reasoning: bool = False,
+    ) -> Tuple[bool, bool, str, str, bool, Dict[str, int]]:
+        """Process state vars while processing a streaming API response.
+            Returns a tuple consisting of:
+        - is_break: whether to break out of the loop
+        - has_function: whether the response contains a function_call
+        - function_name: name of the function
+        - function_args: args of the function
+        - completion: completion text
+        - reasoning: reasoning text
+        - usage: usage dict
+        """
+        # convert event obj (of type ChatCompletionChunk) to dict so rest of code,
+        # which expects dicts, works as it did before switching to openai v1.x
+        if not isinstance(event, dict):
+            event = event.model_dump()
+
+        usage = event.get("usage", {}) or {}
+        choices = event.get("choices", [{}])
+        if len(choices) == 0:
+            choices = [{}]
+        if len(usage) > 0 and len(choices[0]) == 0:
+            # we got usage chunk, and empty choices, so we're done
+            return (
+                True,
+                has_function,
+                function_name,
+                function_args,
+                completion,
+                reasoning,
+                in_reasoning,
+                usage,
+            )
+        event_args = ""
+        event_fn_name = ""
+        event_tool_deltas: Optional[List[Dict[str, Any]]] = None
+        silent = self.config.async_stream_quiet or settings.quiet
+        # The first two events in the stream of Azure OpenAI is useless.
+        # In the 1st: choices list is empty, in the 2nd: the dict delta has null content
+        if chat:
+            delta = choices[0].get("delta", {}) or {}
+            event_text = delta.get("content", "")
+            event_reasoning = delta.get(
+                "reasoning_content",
+                delta.get("reasoning", ""),
+            )
+            if "function_call" in delta and delta["function_call"] is not None:
+                if "name" in delta["function_call"]:
+                    event_fn_name = delta["function_call"]["name"]
+                if "arguments" in delta["function_call"]:
+                    event_args = delta["function_call"]["arguments"]
+            if "tool_calls" in delta and delta["tool_calls"] is not None:
+                # it's a list of deltas, usually just one
+                event_tool_deltas = delta["tool_calls"]
+                tool_deltas += event_tool_deltas
+        else:
+            event_text = choices[0]["text"]
+            event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
+
+        event_text_tokens, event_reasoning_tokens, in_reasoning = (
+            self._split_inline_reasoning(
+                event_text,
+                event_reasoning,
+                in_reasoning,
+                self.config.thought_delimiters,
+            )
+        )
+
+        if event_text:
+            completion += event_text
+        if event_text_tokens:
+            if not silent:
+                sys.stdout.write(Colors().GREEN + event_text_tokens)
+                sys.stdout.flush()
+            await self.config.streamer_async(event_text_tokens, StreamEventType.TEXT)
+
+        if event_reasoning:
+            reasoning += event_reasoning
+        if event_reasoning_tokens:
+            if not silent:
+                sys.stdout.write(Colors().GREEN_DIM + event_reasoning_tokens)
+                sys.stdout.flush()
+            await self.config.streamer_async(
+                event_reasoning_tokens, StreamEventType.REASONING
+            )
+
+        if event_fn_name:
+            function_name = event_fn_name
+            has_function = True
+            if not silent:
+                sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
+                sys.stdout.flush()
+            await self.config.streamer_async(event_fn_name, StreamEventType.FUNC_NAME)
+
+        if event_args:
+            function_args += event_args
+            if not silent:
+                sys.stdout.write(Colors().GREEN + event_args)
+                sys.stdout.flush()
+            await self.config.streamer_async(event_args, StreamEventType.FUNC_ARGS)
+
+        if event_tool_deltas is not None:
+            # print out streaming tool calls, if not async
+            for td in event_tool_deltas:
+                if td["function"]["name"] is not None:
+                    tool_fn_name = td["function"]["name"]
+                    if not silent:
+                        sys.stdout.write(
+                            Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
+                        )
+                        sys.stdout.flush()
+                    await self.config.streamer_async(
+                        tool_fn_name, StreamEventType.TOOL_NAME
+                    )
+                if td["function"]["arguments"] != "":
+                    tool_fn_args = td["function"]["arguments"]
+                    if not silent:
+                        sys.stdout.write(Colors().GREEN + tool_fn_args)
+                        sys.stdout.flush()
+                    await self.config.streamer_async(
+                        tool_fn_args, StreamEventType.TOOL_ARGS
+                    )
+
+        # show this delta in the stream
+        is_break = choices[0].get("finish_reason", "") in [
+            "stop",
+            "function_call",
+            "tool_calls",
+        ]
+        # for function_call, finish_reason does not necessarily
+        # contain "function_call" as mentioned in the docs.
+        # So we check for "stop" or "function_call" here.
+        return (
+            is_break,
+            has_function,
+            function_name,
+            function_args,
+            completion,
+            reasoning,
+            in_reasoning,
+            usage,
+        )
+
+    @retry_with_exponential_backoff
+    def _stream_response(  # type: ignore
+        self, response, chat: bool = False
+    ) -> Tuple[LLMResponse, Dict[str, Any]]:
+        """
+        Grab and print streaming response from API.
+        Args:
+            response: event-sequence emitted by API
+            chat: whether in chat-mode (or else completion-mode)
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                Dict version of OpenAIResponse object (with choices, usage)
+
+        """
+        completion = ""
+        reasoning = ""
+        function_args = ""
+        function_name = ""
+
+        sys.stdout.write(Colors().GREEN)
+        sys.stdout.flush()
+        has_function = False
+        tool_deltas: List[Dict[str, Any]] = []
+        token_usage: Dict[str, int] = {}
+        done: bool = False
+        in_reasoning: bool = False  # Track if we're inside reasoning delimiters
+        content_present = False
+        try:
+            for event in response:
+                event_dict = event if isinstance(event, dict) else event.model_dump()
+                choices = event_dict.get("choices") or []
+                if chat and choices:
+                    delta = choices[0].get("delta") or {}
+                    content_present = content_present or (
+                        "content" in delta and delta["content"] is not None
+                    )
+                (
+                    is_break,
+                    has_function,
+                    function_name,
+                    function_args,
+                    completion,
+                    reasoning,
+                    in_reasoning,
+                    usage,
+                ) = self._process_stream_event(
+                    event,
+                    chat=chat,
+                    tool_deltas=tool_deltas,
+                    has_function=has_function,
+                    completion=completion,
+                    reasoning=reasoning,
+                    function_args=function_args,
+                    function_name=function_name,
+                    in_reasoning=in_reasoning,
+                )
+                if len(usage) > 0:
+                    # capture the token usage when non-empty
+                    token_usage = usage
+                if is_break:
+                    if not self.get_stream() or done:
+                        # if not streaming, then we don't wait for last "usage" chunk
+                        break
+                    else:
+                        # mark done, so we quit after the last "usage" chunk
+                        done = True
+
+        except Exception as e:
+            logging.warning("Error while processing stream response: %s", str(e))
+
+        if not settings.quiet:
+            print("")
+        # TODO- get usage info in stream mode (?)
+
+        return self._create_stream_response(
+            chat=chat,
+            tool_deltas=tool_deltas,
+            has_function=has_function,
+            completion=completion,
+            reasoning=reasoning,
+            function_args=function_args,
+            function_name=function_name,
+            usage=token_usage,
+            content_present=content_present,
+        )
+
+    @async_retry_with_exponential_backoff
+    async def _stream_response_async(  # type: ignore
+        self, response, chat: bool = False
+    ) -> Tuple[LLMResponse, Dict[str, Any]]:
+        """
+        Grab and print streaming response from API.
+        Args:
+            response: event-sequence emitted by API
+            chat: whether in chat-mode (or else completion-mode)
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                OpenAIResponse object (with choices, usage)
+
+        """
+
+        completion = ""
+        reasoning = ""
+        function_args = ""
+        function_name = ""
+
+        sys.stdout.write(Colors().GREEN)
+        sys.stdout.flush()
+        has_function = False
+        tool_deltas: List[Dict[str, Any]] = []
+        token_usage: Dict[str, int] = {}
+        done: bool = False
+        in_reasoning: bool = False  # Track if we're inside reasoning delimiters
+        content_present = False
+        try:
+            async for event in response:
+                event_dict = event if isinstance(event, dict) else event.model_dump()
+                choices = event_dict.get("choices") or []
+                if chat and choices:
+                    delta = choices[0].get("delta") or {}
+                    content_present = content_present or (
+                        "content" in delta and delta["content"] is not None
+                    )
+                (
+                    is_break,
+                    has_function,
+                    function_name,
+                    function_args,
+                    completion,
+                    reasoning,
+                    in_reasoning,
+                    usage,
+                ) = await self._process_stream_event_async(
+                    event,
+                    chat=chat,
+                    tool_deltas=tool_deltas,
+                    has_function=has_function,
+                    completion=completion,
+                    reasoning=reasoning,
+                    function_args=function_args,
+                    function_name=function_name,
+                    in_reasoning=in_reasoning,
+                )
+                if len(usage) > 0:
+                    # capture the token usage when non-empty
+                    token_usage = usage
+                if is_break:
+                    if not self.get_stream() or done:
+                        # if not streaming, then we don't wait for last "usage" chunk
+                        break
+                    else:
+                        # mark done, so we quit after the next "usage" chunk
+                        done = True
+
+        except Exception as e:
+            logging.warning("Error while processing stream response: %s", str(e))
+
+        if not settings.quiet:
+            print("")
+        # TODO- get usage info in stream mode (?)
+
+        return self._create_stream_response(
+            chat=chat,
+            tool_deltas=tool_deltas,
+            has_function=has_function,
+            completion=completion,
+            reasoning=reasoning,
+            function_args=function_args,
+            function_name=function_name,
+            usage=token_usage,
+            content_present=content_present,
+        )
+
+    @staticmethod
+    def tool_deltas_to_tools(
+        tools: List[Dict[str, Any]],
+    ) -> Tuple[
+        str,
+        List[OpenAIToolCall],
+        List[Dict[str, Any]],
+    ]:
+        """
+        Convert accumulated tool-call deltas to OpenAIToolCall objects.
+        Adapted from this excellent code:
+         https://community.openai.com/t/help-for-function-calls-with-streaming/627170/2
+
+        Args:
+            tools: list of tool deltas received from streaming API
+
+        Returns:
+            str: plain text corresponding to tool calls that failed to parse
+            List[OpenAIToolCall]: list of OpenAIToolCall objects
+            List[Dict[str, Any]]: list of tool dicts
+                (to reconstruct OpenAI API response, so it can be cached)
+        """
+        # Initialize a dictionary with default values
+
+        # idx -> dict repr of tool
+        # (used to simulate OpenAIResponse object later, and also to
+        # accumulate function args as strings)
+        idx2tool_dict: Dict[str, Dict[str, Any]] = defaultdict(
+            lambda: {
+                "id": None,
+                "function": {"arguments": "", "name": None},
+                "type": None,
+                "extra_content": None,
+            }
+        )
+
+        for tool_delta in tools:
+            if tool_delta["id"] is not None:
+                idx2tool_dict[tool_delta["index"]]["id"] = tool_delta["id"]
+
+            if tool_delta["function"]["name"] is not None:
+                idx2tool_dict[tool_delta["index"]]["function"]["name"] = tool_delta[
+                    "function"
+                ]["name"]
+
+            idx2tool_dict[tool_delta["index"]]["function"]["arguments"] += tool_delta[
+                "function"
+            ]["arguments"]
+
+            if tool_delta["type"] is not None:
+                idx2tool_dict[tool_delta["index"]]["type"] = tool_delta["type"]
+
+            if tool_delta.get("extra_content") is not None:
+                idx2tool_dict[tool_delta["index"]]["extra_content"] = tool_delta[
+                    "extra_content"
+                ]
+
+        # (try to) parse the fn args of each tool
+        contents: List[str] = []
+        good_indices = []
+        id2args: Dict[str, None | Dict[str, Any]] = {}
+        for idx, tool_dict in idx2tool_dict.items():
+            failed_content, args_dict = OpenAIGPT._parse_function_args(
+                tool_dict["function"]["arguments"]
+            )
+            # used to build tool_calls_list below
+            id2args[tool_dict["id"]] = args_dict or None  # if {}, store as None
+            if failed_content != "":
+                contents.append(failed_content)
+            else:
+                good_indices.append(idx)
+
+        # remove the failed tool calls
+        idx2tool_dict = {
+            idx: tool_dict
+            for idx, tool_dict in idx2tool_dict.items()
+            if idx in good_indices
+        }
+
+        # create OpenAIToolCall list
+        tool_calls_list = [
+            OpenAIToolCall(
+                id=tool_dict["id"],
+                function=LLMFunctionCall(
+                    name=tool_dict["function"]["name"],
+                    arguments=id2args.get(tool_dict["id"]),
+                ),
+                type=tool_dict["type"],
+                extra_content=tool_dict.get("extra_content"),
+            )
+            for tool_dict in idx2tool_dict.values()
+        ]
+        return "\n".join(contents), tool_calls_list, list(idx2tool_dict.values())
+
+    @staticmethod
+    def _parse_function_args(args: str) -> Tuple[str, Dict[str, Any]]:
+        """
+        Try to parse the `args` string as function args.
+
+        Args:
+            args: string containing function args
+
+        Returns:
+            Tuple of content, function name and args dict.
+            If parsing unsuccessful, returns the original string as content,
+            else returns the args dict.
+        """
+        content = ""
+        args_dict = {}
+        try:
+            stripped_fn_args = args.strip()
+            dict_or_list = parse_imperfect_json(stripped_fn_args)
+            if not isinstance(dict_or_list, dict):
+                raise ValueError(
+                    f"""
+                        Invalid function args: {stripped_fn_args}
+                        parsed as {dict_or_list},
+                        which is not a valid dict.
+                        """
+                )
+            args_dict = dict_or_list
+        except (SyntaxError, ValueError) as e:
+            logging.warning(
+                f"""
+                    Parsing OpenAI function args failed: {args};
+                    treating args as normal message. Error detail:
+                    {e}
+                    """
+            )
+            content = args
+
+        return content, args_dict
+
+    def _create_stream_response(
+        self,
+        chat: bool = False,
+        tool_deltas: List[Dict[str, Any]] = [],
+        has_function: bool = False,
+        completion: str = "",
+        reasoning: str = "",
+        function_args: str = "",
+        function_name: str = "",
+        usage: Dict[str, int] = {},
+        content_present: bool = False,
+    ) -> Tuple[LLMResponse, Dict[str, Any]]:
+        """
+        Create an LLMResponse object from the streaming API response.
+
+        Args:
+            chat: whether in chat-mode (or else completion-mode)
+            tool_deltas: list of tool deltas received from streaming API
+            has_function: whether the response contains a function_call
+            completion: completion text
+            reasoning: reasoning text
+            function_args: string representing function args
+            function_name: name of the function
+            usage: token usage dict
+            content_present: whether a stream delta explicitly contained content
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                Dict version of OpenAIResponse object (with choices, usage)
+                    (this is needed so we can cache the response, as if it were
+                    a non-streaming response)
+        """
+        # check if function_call args are valid, if not,
+        # treat this as a normal msg, not a function call
+        args: Dict[str, Any] = {}
+        if has_function and function_args != "":
+            content, args = self._parse_function_args(function_args)
+            completion = completion + content
+            if content != "":
+                has_function = False
+
+        # mock openai response so we can cache it
+        if chat:
+            failed_content, tool_calls, tool_dicts = OpenAIGPT.tool_deltas_to_tools(
+                tool_deltas,
+            )
+            if failed_content:
+                completion += ("\n" if completion else "") + failed_content
+                content_present = True
+            has_valid_call = len(tool_dicts) > 0 or has_function
+            response_content = (
+                None
+                if has_valid_call and not content_present and completion == ""
+                else completion
+            )
+            msg: Dict[str, Any] = dict(
+                message=dict(
+                    content=response_content,
+                    reasoning_content=reasoning,
+                ),
+            )
+            if len(tool_dicts) > 0:
+                msg["message"]["tool_calls"] = tool_dicts
+
+            if has_function:
+                function_call = LLMFunctionCall(name=function_name)
+                function_call_dict = function_call.model_dump()
+                if function_args == "":
+                    function_call.arguments = None
+                else:
+                    function_call.arguments = args
+                    function_call_dict.update({"arguments": function_args.strip()})
+                msg["message"]["function_call"] = function_call_dict
+        else:
+            # non-chat mode has no function_call
+            msg = dict(text=completion)
+            response_content = completion
+            # TODO: Ignoring reasoning content for non-chat models
+
+        # create an OpenAIResponse object so we can cache it as if it were
+        # a non-streaming response
+        openai_response = OpenAIResponse(
+            choices=[msg],
+            usage=dict(total_tokens=0),
+        )
+        # Track whether we extracted inline thought tags from the text.
+        # Only set message_with_reasoning when get_reasoning_final()
+        # actually finds and extracts inline tags (e.g. <think>...</think>).
+        # When reasoning is already provided via a separate API field
+        # (e.g. reasoning_content), the message text doesn't contain
+        # thought signatures, so there's nothing extra to preserve.
+        message_with_reasoning = None
+        message: str | None
+        if reasoning == "" and response_content is not None:
+            # some LLM APIs may not return a separate reasoning field,
+            # and the reasoning may be included in the message content
+            # within delimiters like <think> ... </think>
+            reasoning, message = self.get_reasoning_final(response_content)
+            if reasoning:
+                # Inline tags were found and extracted; preserve the
+                # original text so it can be restored in message history.
+                message_with_reasoning = response_content
+        else:
+            message = response_content
+
+        prompt_tokens = usage.get("prompt_tokens", 0)
+        prompt_tokens_details: Any = usage.get("prompt_tokens_details", {})
+        cached_tokens = (
+            prompt_tokens_details.get("cached_tokens", 0)
+            if isinstance(prompt_tokens_details, dict)
+            else 0
+        )
+        completion_tokens = usage.get("completion_tokens", 0)
+
+        return (
+            LLMResponse(
+                message=message,
+                reasoning=reasoning,
+                message_with_reasoning=message_with_reasoning,
+                cached=False,
+                # don't allow empty list [] here
+                oai_tool_calls=tool_calls or None if len(tool_deltas) > 0 else None,
+                function_call=function_call if has_function else None,
+                usage=LLMTokenUsage(
+                    prompt_tokens=prompt_tokens or 0,
+                    cached_tokens=cached_tokens or 0,
+                    completion_tokens=completion_tokens or 0,
+                    cost=self._cost_chat_model(
+                        prompt_tokens or 0,
+                        cached_tokens or 0,
+                        completion_tokens or 0,
+                    ),
+                ),
+            ),
+            openai_response.model_dump(),
+        )
+
+    def _cache_store(self, k: str, v: Any) -> None:
+        if self.cache is None:
+            return
+        try:
+            self.cache.store(k, v)
+        except Exception as e:
+            logging.error(f"Error in OpenAIGPT._cache_store: {e}")
+            pass
+
+    def _cache_lookup(self, fn_name: str, **kwargs: Dict[str, Any]) -> Tuple[str, Any]:
+        if self.cache is None:
+            return "", None  # no cache, return empty key and None result
+        # Use the kwargs as the cache key
+        sorted_kwargs_str = str(sorted(kwargs.items()))
+        raw_key = f"{fn_name}:{sorted_kwargs_str}"
+
+        # Hash the key to a fixed length using SHA256
+        hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
+
+        if not settings.cache:
+            # when caching disabled, return the hashed_key and none result
+            return hashed_key, None
+        # Try to get the result from the cache
+        try:
+            cached_val = self.cache.retrieve(hashed_key)
+        except Exception as e:
+            logging.error(f"Error in OpenAIGPT._cache_lookup: {e}")
+            return hashed_key, None
+        return hashed_key, cached_val
+
+    def _cost_chat_model(self, prompt: int, cached: int, completion: int) -> float:
+        price = self.chat_cost()
+        return (
+            price[0] * (prompt - cached) + price[1] * cached + price[2] * completion
+        ) / 1000
+
+    def _get_non_stream_token_usage(
+        self, cached: bool, response: Dict[str, Any]
+    ) -> LLMTokenUsage:
+        """
+        Extracts token usage from ``response`` and computes cost, only when NOT
+        in streaming mode, since the LLM API (OpenAI currently) was not
+        populating the usage fields in streaming mode (but as of Sep 2024, streaming
+        responses include  usage info as well, so we should update the code
+        to directly use usage information from the streaming response, which is more
+        accurate, esp with "thinking" LLMs like o1 series which consume
+        thinking tokens).
+        In streaming mode, these are set to zero for
+        now, and will be updated later by the fn ``update_token_usage``.
+        """
+        cost = 0.0
+        prompt_tokens = 0
+        cached_tokens = 0
+        completion_tokens = 0
+
+        usage = response.get("usage")
+        if not cached and not self.get_stream() and usage is not None:
+            prompt_tokens = usage.get("prompt_tokens") or 0
+            prompt_tokens_details = usage.get("prompt_tokens_details", {}) or {}
+            cached_tokens = prompt_tokens_details.get("cached_tokens") or 0
+            completion_tokens = usage.get("completion_tokens") or 0
+            cost = self._cost_chat_model(
+                prompt_tokens or 0,
+                cached_tokens or 0,
+                completion_tokens or 0,
+            )
+
+        return LLMTokenUsage(
+            prompt_tokens=prompt_tokens,
+            cached_tokens=cached_tokens,
+            completion_tokens=completion_tokens,
+            cost=cost,
+        )
+
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        self.run_on_first_use()
+
+        try:
+            return self._generate(prompt, max_tokens)
+        except openai.APIStatusError as e:
+            # Catch HTTP-level API errors (400, 401, 403, 404, 422, 429, 5xx)
+            # without traceback — these originate server-side and a local
+            # stack trace adds no diagnostic value.
+            # Note: APIConnectionError/APITimeoutError are intentionally NOT
+            # caught here so they fall through to the generic handler below,
+            # where the full traceback aids in diagnosing local network issues.
+            logging.error(f"API error in OpenAIGPT.generate: {e}")
+            raise
+        except Exception as e:
+            # log and re-raise exception
+            logging.error(friendly_error(e, "Error in OpenAIGPT.generate: "))
+            raise
+
+    def _generate(self, prompt: str, max_tokens: int) -> LLMResponse:
+        if self.config.use_chat_for_completion:
+            return self.chat(messages=prompt, max_tokens=max_tokens)
+
+        if self.is_groq or self.is_cerebras:
+            raise ValueError("Groq, Cerebras do not support pure completions")
+
+        if settings.debug:
+            print(f"[grey37]PROMPT: {escape(prompt)}[/grey37]")
+
+        @retry_with_exponential_backoff
+        def completions_with_backoff(**kwargs):  # type: ignore
+            cached = False
+            hashed_key, result = self._cache_lookup("Completion", **kwargs)
+            if result is not None:
+                cached = True
+                if settings.debug:
+                    print("[grey37]CACHED[/grey37]")
+            else:
+                if self.config.litellm:
+                    from litellm import completion as litellm_completion
+
+                    completion_call = litellm_completion
+
+                    if self.api_key != DUMMY_API_KEY:
+                        kwargs["api_key"] = self.api_key
+                else:
+                    if self.client is None:
+                        raise ValueError(
+                            "OpenAI/equivalent chat-completion client not set"
+                        )
+                    assert isinstance(self.client, OpenAI)
+                    completion_call = self.client.completions.create
+                if self.config.litellm and settings.debug:
+                    kwargs["logger_fn"] = litellm_logging_fn
+                # If it's not in the cache, call the API
+                result = completion_call(**kwargs)
+                if self.get_stream():
+                    llm_response, openai_response = self._stream_response(
+                        result,
+                        chat=self.config.litellm,
+                    )
+                    self._cache_store(hashed_key, openai_response)
+                    return cached, hashed_key, openai_response
+                else:
+                    self._cache_store(hashed_key, result.model_dump())
+            return cached, hashed_key, result
+
+        kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
+        if self.config.litellm:
+            # TODO this is a temp fix, we should really be using a proper completion fn
+            # that takes a pre-formatted prompt, rather than mocking it as a sys msg.
+            kwargs["messages"] = [dict(content=prompt, role=Role.SYSTEM)]
+        else:  # any other OpenAI-compatible endpoint
+            kwargs["prompt"] = prompt
+        args = dict(
+            **kwargs,
+            max_tokens=max_tokens,  # for output/completion
+            stream=self.get_stream(),
+        )
+        args = self._openai_api_call_params(args)
+        cached, hashed_key, response = completions_with_backoff(**args)
+        # assume response is an actual response rather than a streaming event
+        if not isinstance(response, dict):
+            response = response.model_dump()
+        if "message" in response["choices"][0]:
+            msg = (response["choices"][0]["message"]["content"] or "").strip()
+        else:
+            msg = (response["choices"][0]["text"] or "").strip()
+        return LLMResponse(message=msg, cached=cached)
+
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        self.run_on_first_use()
+
+        try:
+            return await self._agenerate(prompt, max_tokens)
+        except openai.APIStatusError as e:
+            # Catch HTTP-level API errors (see comment in generate() above).
+            logging.error(f"API error in OpenAIGPT.agenerate: {e}")
+            raise
+        except Exception as e:
+            # log and re-raise exception
+            logging.error(friendly_error(e, "Error in OpenAIGPT.agenerate: "))
+            raise
+
+    async def _agenerate(self, prompt: str, max_tokens: int) -> LLMResponse:
+        # note we typically will not have self.config.stream = True
+        # when issuing several api calls concurrently/asynchronously.
+        # The calling fn should use the context `with Streaming(..., False)` to
+        # disable streaming.
+        if self.config.use_chat_for_completion:
+            return await self.achat(messages=prompt, max_tokens=max_tokens)
+
+        if self.is_groq or self.is_cerebras:
+            raise ValueError("Groq, Cerebras do not support pure completions")
+
+        if settings.debug:
+            print(f"[grey37]PROMPT: {escape(prompt)}[/grey37]")
+
+        # WARNING: .Completion.* endpoints are deprecated,
+        # and as of Sep 2023 only legacy models will work here,
+        # e.g. text-davinci-003, text-ada-001.
+        @async_retry_with_exponential_backoff
+        async def completions_with_backoff(**kwargs):  # type: ignore
+            cached = False
+            hashed_key, result = self._cache_lookup("AsyncCompletion", **kwargs)
+            if result is not None:
+                cached = True
+                if settings.debug:
+                    print("[grey37]CACHED[/grey37]")
+            else:
+                if self.config.litellm:
+                    from litellm import acompletion as litellm_acompletion
+
+                    if self.api_key != DUMMY_API_KEY:
+                        kwargs["api_key"] = self.api_key
+
+                # TODO this may not work: text_completion is not async,
+                # and we didn't find an async version in litellm
+                assert isinstance(self.async_client, AsyncOpenAI)
+                acompletion_call = (
+                    litellm_acompletion
+                    if self.config.litellm
+                    else self.async_client.completions.create
+                )
+                if self.config.litellm and settings.debug:
+                    kwargs["logger_fn"] = litellm_logging_fn
+                # If it's not in the cache, call the API
+                result = await acompletion_call(**kwargs)
+                self._cache_store(hashed_key, result.model_dump())
+            return cached, hashed_key, result
+
+        kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
+        if self.config.litellm:
+            # TODO this is a temp fix, we should really be using a proper completion fn
+            # that takes a pre-formatted prompt, rather than mocking it as a sys msg.
+            kwargs["messages"] = [dict(content=prompt, role=Role.SYSTEM)]
+        else:  # any other OpenAI-compatible endpoint
+            kwargs["prompt"] = prompt
+        cached, hashed_key, response = await completions_with_backoff(
+            **kwargs,
+            max_tokens=max_tokens,
+            stream=False,
+        )
+        # assume response is an actual response rather than a streaming event
+        if not isinstance(response, dict):
+            response = response.model_dump()
+        if "message" in response["choices"][0]:
+            msg = (response["choices"][0]["message"]["content"] or "").strip()
+        else:
+            msg = (response["choices"][0]["text"] or "").strip()
+        return LLMResponse(message=msg, cached=cached)
+
+    def chat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        self.run_on_first_use()
+
+        if self.config.use_completion_for_chat and not self.is_openai_chat_model():
+            # only makes sense for non-OpenAI models
+            if self.config.formatter is None or self.config.hf_formatter is None:
+                raise ValueError(
+                    """
+                    `formatter` must be specified in config to use completion for chat.
+                    """
+                )
+            if isinstance(messages, str):
+                messages = [
+                    LLMMessage(
+                        role=Role.SYSTEM, content="You are a helpful assistant."
+                    ),
+                    LLMMessage(role=Role.USER, content=messages),
+                ]
+            prompt = self.config.hf_formatter.format(messages)
+            return self.generate(prompt=prompt, max_tokens=max_tokens)
+        try:
+            return self._chat(
+                messages,
+                max_tokens,
+                tools,
+                tool_choice,
+                functions,
+                function_call,
+                response_format,
+            )
+        except openai.APIStatusError as e:
+            # Catch HTTP-level API errors (see comment in generate() above).
+            logging.error(f"API error in OpenAIGPT.chat: {e}")
+            raise
+        except Exception as e:
+            # log and re-raise exception
+            logging.error(friendly_error(e, "Error in OpenAIGPT.chat: "))
+            raise
+
+    async def achat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        self.run_on_first_use()
+
+        # turn off streaming for async calls
+        if (
+            self.config.use_completion_for_chat
+            and not self.is_openai_chat_model()
+            and not self.is_openai_completion_model()
+        ):
+            # only makes sense for local models, where we are trying to
+            # convert a chat dialog msg-sequence to a simple completion prompt.
+            if self.config.formatter is None:
+                raise ValueError(
+                    """
+                    `formatter` must be specified in config to use completion for chat.
+                    """
+                )
+            formatter = HFFormatter(
+                HFPromptFormatterConfig(model_name=self.config.formatter)
+            )
+            if isinstance(messages, str):
+                messages = [
+                    LLMMessage(
+                        role=Role.SYSTEM, content="You are a helpful assistant."
+                    ),
+                    LLMMessage(role=Role.USER, content=messages),
+                ]
+            prompt = formatter.format(messages)
+            return await self.agenerate(prompt=prompt, max_tokens=max_tokens)
+        try:
+            result = await self._achat(
+                messages,
+                max_tokens,
+                tools,
+                tool_choice,
+                functions,
+                function_call,
+                response_format,
+            )
+            return result
+        except openai.APIStatusError as e:
+            # Catch HTTP-level API errors (see comment in generate() above).
+            logging.error(f"API error in OpenAIGPT.achat: {e}")
+            raise
+        except Exception as e:
+            # log and re-raise exception
+            logging.error(friendly_error(e, "Error in OpenAIGPT.achat: "))
+            raise
+
+    def _chat_completions_with_backoff_body(self, **kwargs):  # type: ignore
+        cached = False
+        hashed_key, result = self._cache_lookup("Completion", **kwargs)
+        if result is not None:
+            cached = True
+            if settings.debug:
+                print("[grey37]CACHED[/grey37]")
+        else:
+            # If it's not in the cache, call the API
+            if self.config.litellm:
+                from litellm import completion as litellm_completion
+
+                completion_call = litellm_completion
+
+                if self.api_key != DUMMY_API_KEY:
+                    kwargs["api_key"] = self.api_key
+            else:
+                if self.client is None:
+                    raise ValueError("OpenAI/equivalent chat-completion client not set")
+                completion_call = self.client.chat.completions.create
+            if self.config.litellm and settings.debug:
+                kwargs["logger_fn"] = litellm_logging_fn
+            result = completion_call(**kwargs)
+
+            if self.get_stream():
+                # If streaming, cannot cache result
+                # since it is a generator. Instead,
+                # we hold on to the hashed_key and
+                # cache the result later
+
+                # Test if this is a stream with an exception by
+                # trying to get first chunk: Some providers like LiteLLM
+                # produce a valid stream object `result` instead of throwing a
+                # rate-limit error, and if we don't catch it here,
+                # we end up returning an empty response and not
+                # using the retry mechanism in the decorator.
+                try:
+                    # try to get the first chunk to check for errors
+                    test_iter = iter(result)
+                    first_chunk = next(test_iter)
+                    # If we get here without error, recreate the stream
+                    result = chain([first_chunk], test_iter)
+                except StopIteration:
+                    # Empty stream is fine
+                    pass
+                except Exception as e:
+                    # Propagate any errors in the stream
+                    raise e
+            else:
+                self._cache_store(hashed_key, result.model_dump())
+        return cached, hashed_key, result
+
+    def _chat_completions_with_backoff(self, **kwargs):  # type: ignore
+        retry_func = retry_with_exponential_backoff(
+            self._chat_completions_with_backoff_body,
+            initial_delay=self.config.retry_params.initial_delay,
+            max_retries=self.config.retry_params.max_retries,
+            exponential_base=self.config.retry_params.exponential_base,
+            jitter=self.config.retry_params.jitter,
+        )
+        return retry_func(**kwargs)
+
+    async def _achat_completions_with_backoff_body(self, **kwargs):  # type: ignore
+        cached = False
+        hashed_key, result = self._cache_lookup("Completion", **kwargs)
+        if result is not None:
+            cached = True
+            if settings.debug:
+                print("[grey37]CACHED[/grey37]")
+        else:
+            if self.config.litellm:
+                from litellm import acompletion as litellm_acompletion
+
+                acompletion_call = litellm_acompletion
+
+                if self.api_key != DUMMY_API_KEY:
+                    kwargs["api_key"] = self.api_key
+            else:
+                if self.async_client is None:
+                    raise ValueError(
+                        "OpenAI/equivalent async chat-completion client not set"
+                    )
+                acompletion_call = self.async_client.chat.completions.create
+            if self.config.litellm and settings.debug:
+                kwargs["logger_fn"] = litellm_logging_fn
+            # If it's not in the cache, call the API
+            result = await acompletion_call(**kwargs)
+            if self.get_stream():
+                try:
+                    # Try to peek at the first chunk to immediately catch any errors
+                    # Store the original result (the stream)
+                    original_stream = result
+
+                    # Manually create and advance the iterator to check for errors
+                    stream_iter = original_stream.__aiter__()
+                    try:
+                        # This will raise an exception if the stream is invalid
+                        first_chunk = await anext(stream_iter)
+
+                        # If we reach here, the stream started successfully
+                        # Now recreate a fresh stream from the original API result
+                        # Otherwise, return a new stream that yields the first chunk
+                        # and remaining items
+                        async def combined_stream():  # type: ignore
+                            yield first_chunk
+                            async for chunk in stream_iter:
+                                yield chunk
+
+                        result = combined_stream()  # type: ignore
+                    except StopAsyncIteration:
+                        # Empty stream is normal - nothing to do
+                        pass
+                except Exception as e:
+                    # Any exception here should be raised to trigger the retry mechanism
+                    raise e
+            else:
+                self._cache_store(hashed_key, result.model_dump())
+        return cached, hashed_key, result
+
+    async def _achat_completions_with_backoff(self, **kwargs):  # type: ignore
+        retry_func = async_retry_with_exponential_backoff(
+            self._achat_completions_with_backoff_body,
+            initial_delay=self.config.retry_params.initial_delay,
+            max_retries=self.config.retry_params.max_retries,
+            exponential_base=self.config.retry_params.exponential_base,
+            jitter=self.config.retry_params.jitter,
+        )
+        return await retry_func(**kwargs)
+
+    def _prep_chat_completion(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> Dict[str, Any]:
+        """Prepare args for LLM chat-completion API call"""
+        if isinstance(messages, str):
+            llm_messages = [
+                LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
+                LLMMessage(role=Role.USER, content=messages),
+            ]
+        else:
+            llm_messages = messages
+            if (
+                len(llm_messages) == 1
+                and llm_messages[0].role == Role.SYSTEM
+                # TODO: we will unconditionally insert a dummy user msg
+                # if the only msg is a system msg.
+                # We could make this conditional on ModelInfo.needs_first_user_message
+            ):
+                # some LLMs, notable Gemini as of 12/11/24,
+                # require the first message to be from the user,
+                # so insert a dummy user msg if needed.
+                llm_messages.insert(
+                    1,
+                    LLMMessage(
+                        role=Role.USER, content="Follow the above instructions."
+                    ),
+                )
+
+        chat_model = self.config.chat_model
+
+        args: Dict[str, Any] = dict(
+            model=chat_model,
+            messages=[
+                m.api_dict(
+                    self.config.chat_model,
+                    has_system_role=self.info().allows_system_message,
+                )
+                for m in (llm_messages)
+            ],
+            max_completion_tokens=max_tokens,
+            stream=self.get_stream(),
+        )
+        if self.get_stream() and "groq" not in self.chat_model_orig:
+            # groq fails when we include stream_options in the request
+            args.update(
+                dict(
+                    # get token-usage numbers in stream mode from OpenAI API,
+                    # and possibly other OpenAI-compatible APIs.
+                    stream_options=dict(include_usage=True),
+                )
+            )
+        args.update(self._openai_api_call_params(args))
+        # only include functions-related args if functions are provided
+        # since the OpenAI API will throw an error if `functions` is None or []
+        if functions is not None:
+            args.update(
+                dict(
+                    functions=[f.model_dump() for f in functions],
+                    function_call=function_call,
+                )
+            )
+        if tools is not None:
+            if self.config.parallel_tool_calls is not None:
+                args["parallel_tool_calls"] = self.config.parallel_tool_calls
+
+            if any(t.strict for t in tools) and (
+                self.config.parallel_tool_calls is None
+                or self.config.parallel_tool_calls
+            ):
+                parallel_strict_warning()
+            args.update(
+                dict(
+                    tools=[
+                        dict(
+                            type="function",
+                            function=t.function.model_dump()
+                            | ({"strict": t.strict} if t.strict is not None else {}),
+                        )
+                        for t in tools
+                    ],
+                    tool_choice=tool_choice,
+                )
+            )
+        if response_format is not None:
+            args["response_format"] = response_format.to_dict()
+
+        for p in self.unsupported_params():
+            # some models e.g. o1-mini (as of sep 2024) don't support some params,
+            # like temperature and stream, so we need to remove them.
+            args.pop(p, None)
+
+        param_rename_map = self.rename_params()
+        for old_param, new_param in param_rename_map.items():
+            if old_param in args:
+                args[new_param] = args.pop(old_param)
+
+        # finally, get rid of extra_body params exclusive to certain models
+        # Only apply allowlist restrictions for known models.
+        # Unknown/custom models are allowed to use all params by default.
+        is_known_model = self.info().name != "unknown"
+        extra_params = args.get("extra_body", {})
+        if extra_params and is_known_model:
+            for param, model_list in OpenAI_API_ParamInfo().extra_parameters.items():
+                if (
+                    self.config.chat_model not in model_list
+                    and self.chat_model_orig not in model_list
+                ):
+                    extra_params.pop(param, None)
+            if extra_params:
+                args["extra_body"] = extra_params
+        return args
+
+    def _process_chat_completion_response(
+        self,
+        cached: bool,
+        response: Dict[str, Any],
+    ) -> LLMResponse:
+        # openAI response will look like this:
+        """
+        {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1677652288,
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "name": "",
+                    "content": "\n\nHello there, how may I help you?",
+                    "reasoning_content": "Okay, let's see here, hmmm...",
+                    "function_call": {
+                        "name": "fun_name",
+                        "arguments: {
+                            "arg1": "val1",
+                            "arg2": "val2"
+                        }
+                    },
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 12,
+                "total_tokens": 21
+            }
+        }
+        """
+        choices = response.get("choices")
+        if isinstance(choices, list) and len(choices) > 0:
+            message = choices[0].get("message", {})
+        else:
+            message = {}
+        if message is None:
+            message = {}
+        content = message.get("content")
+        reasoning = message.get("reasoning_content", "")
+        # Track whether we extracted inline thought tags from the text.
+        # Only set message_with_reasoning when get_reasoning_final()
+        # actually finds and extracts inline tags (e.g. <think>...</think>).
+        # When reasoning is already provided via a separate API field
+        # (e.g. reasoning_content), the message text doesn't contain
+        # thought signatures, so there's nothing extra to preserve.
+        message_with_reasoning = None
+        if reasoning == "" and content is not None:
+            # some LLM APIs may not return a separate reasoning field,
+            # and the reasoning may be included in the message content
+            # within delimiters like <think> ... </think>
+            reasoning, msg = self.get_reasoning_final(content)
+            if reasoning:
+                # Inline tags were found and extracted; preserve the
+                # original text so it can be restored in message history.
+                message_with_reasoning = content
+        else:
+            msg = content
+
+        if message.get("function_call") is None:
+            fun_call = None
+        else:
+            try:
+                fun_call = LLMFunctionCall.from_dict(message["function_call"])
+            except (ValueError, SyntaxError):
+                logging.warning(
+                    "Could not parse function arguments: "
+                    f"{message['function_call']['arguments']} "
+                    f"for function {message['function_call']['name']} "
+                    "treating as normal non-function message"
+                )
+                fun_call = None
+                args_str = message["function_call"]["arguments"] or ""
+                msg_str = message["content"] or ""
+                msg = msg_str + args_str
+        oai_tool_calls = None
+        if message.get("tool_calls") is not None:
+            oai_tool_calls = []
+            for tool_call_dict in message["tool_calls"]:
+                try:
+                    tool_call = OpenAIToolCall.from_dict(tool_call_dict)
+                    oai_tool_calls.append(tool_call)
+                except (ValueError, SyntaxError):
+                    logging.warning(
+                        "Could not parse tool call: "
+                        f"{json.dumps(tool_call_dict)} "
+                        "treating as normal non-tool message"
+                    )
+                    serialized_tool_call = json.dumps(tool_call_dict)
+                    msg = (msg or "") + ("\n" if msg else "") + serialized_tool_call
+        return LLMResponse(
+            # None (no content, e.g. a tool-call-only response) is preserved as
+            # None rather than coerced to "", so the distinction survives
+            # downstream (see LLMMessage.content / ChatDocument.content_is_none).
+            message=msg.strip() if msg is not None else None,
+            reasoning=reasoning.strip() if reasoning is not None else "",
+            message_with_reasoning=message_with_reasoning,
+            function_call=fun_call,
+            oai_tool_calls=oai_tool_calls or None,  # don't allow empty list [] here
+            cached=cached,
+            usage=self._get_non_stream_token_usage(cached, response),
+        )
+
+    def _chat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """
+        ChatCompletion API call to OpenAI.
+        Args:
+            messages: list of messages  to send to the API, typically
+                represents back and forth dialogue between user and LLM, but could
+                also include "function"-role messages. If messages is a string,
+                it is assumed to be a user message.
+            max_tokens: max output tokens to generate
+            functions: list of LLMFunction specs available to the LLM, to possibly
+                use in its response
+            function_call: controls how the LLM uses `functions`:
+                - "auto": LLM decides whether to use `functions` or not,
+                - "none": LLM blocked from using any function
+                - a dict of {"name": "function_name"} which forces the LLM to use
+                    the specified function.
+        Returns:
+            LLMResponse object
+        """
+        args = self._prep_chat_completion(
+            messages,
+            max_tokens,
+            tools,
+            tool_choice,
+            functions,
+            function_call,
+            response_format,
+        )
+        cached, hashed_key, response = self._chat_completions_with_backoff(**args)  # type: ignore
+        if self.get_stream() and not cached:
+            llm_response, openai_response = self._stream_response(response, chat=True)
+            self._cache_store(hashed_key, openai_response)
+            return llm_response  # type: ignore
+        if isinstance(response, dict):
+            response_dict = response
+        else:
+            response_dict = response.model_dump()
+        return self._process_chat_completion_response(cached, response_dict)
+
+    async def _achat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """
+        Async version of _chat(). See that function for details.
+        """
+        args = self._prep_chat_completion(
+            messages,
+            max_tokens,
+            tools,
+            tool_choice,
+            functions,
+            function_call,
+            response_format,
+        )
+        cached, hashed_key, response = await self._achat_completions_with_backoff(  # type: ignore
+            **args
+        )
+        if self.get_stream() and not cached:
+            llm_response, openai_response = await self._stream_response_async(
+                response, chat=True
+            )
+            self._cache_store(hashed_key, openai_response)
+            return llm_response  # type: ignore
+        if isinstance(response, dict):
+            response_dict = response
+        else:
+            response_dict = response.model_dump()
+        return self._process_chat_completion_response(cached, response_dict)
+</file>
+
+<file path="langroid/vector_store/base.py">
+import copy
+import logging
+import re
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
+
+import numpy as np
+import pandas as pd
+from pydantic.fields import FieldInfo
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
+
+from langroid.embedding_models.base import EmbeddingModel, EmbeddingModelsConfig
+from langroid.embedding_models.models import OpenAIEmbeddingsConfig
+from langroid.mytypes import DocMetaData, Document, EmbeddingFunction
+from langroid.utils.algorithms.graph import components, topological_sort
+from langroid.utils.configuration import settings
+from langroid.utils.object_registry import ObjectRegistry
+from langroid.utils.output.printing import print_long_text
+from langroid.utils.pandas_utils import safe_eval_globals, sanitize_command, stringify
+from langroid.utils.pydantic_utils import flatten_dict
+
+logger = logging.getLogger(__name__)
+
+# the exact shape Kubernetes service links inject, e.g. tcp://10.0.0.8:6333
+# (\Z, not $: $ would match before a trailing newline, silently
+# discarding a value that should fail validation)
+_SERVICE_LINK_PORT_RE = re.compile(r"^tcp://\S+:\d+\Z")
+
+
+class _ServiceLinkPortFilter(PydanticBaseSettingsSource):
+    """Env-source wrapper dropping k8s/docker service-link `port` values.
+
+    With `enableServiceLinks` (on by default in Kubernetes), a service
+    named e.g. `qdrant` injects `QDRANT_PORT=tcp://IP:PORT` into every
+    pod, which would otherwise fail integer validation of the `port`
+    field. If the wrapped env source yields a `port` string matching
+    exactly that format, it is dropped (with a warning) so the class
+    default applies. Any other value — including malformed `tcp://`
+    junk, or a `tcp://` value passed to the constructor (which never
+    goes through this source) — still fails validation as usual.
+    """
+
+    def __init__(self, wrapped: PydanticBaseSettingsSource) -> None:
+        super().__init__(wrapped.settings_cls)
+        self._wrapped = wrapped
+
+    def get_field_value(
+        self, field: FieldInfo, field_name: str
+    ) -> Tuple[Any, str, bool]:
+        return self._wrapped.get_field_value(field, field_name)
+
+    def __call__(self) -> Dict[str, Any]:
+        values = self._wrapped()
+        port = values.get("port")
+        if isinstance(port, str) and _SERVICE_LINK_PORT_RE.match(port):
+            default = self.settings_cls.model_fields["port"].default
+            logger.warning(
+                f"Ignoring port value {port!r} from the environment: it "
+                f"looks like a Kubernetes/Docker service-link artifact "
+                f"(an injected <SERVICE>_PORT env var); using default "
+                f"port {default} instead."
+            )
+            values = {k: v for k, v in values.items() if k != "port"}
+        return values
+
+
+class VectorStoreConfig(BaseSettings):
+    # Without a prefix, every field name would itself be a
+    # case-insensitive env var (e.g. a bare HOST, PORT, or FULL_EVAL
+    # in the environment would silently override defaults); subclasses
+    # each set their own prefix (QDRANT_, LANCEDB_, ...).
+    model_config = SettingsConfigDict(env_prefix="VECDB_")
+
+    type: str = ""  # deprecated, keeping it for backward compatibility
+    collection_name: str | None = "temp"
+    replace_collection: bool = False  # replace collection if it already exists
+    storage_path: str = ".qdrant/data"
+    cloud: bool = False
+    batch_size: int = 200
+    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig(
+        model_type="openai",
+    )
+    embedding_model: Optional[EmbeddingModel] = None
+    timeout: int = 60
+    host: str = "127.0.0.1"
+    port: int = 6333
+    # used when parsing search results back as Document objects
+    document_class: Type[Document] = Document
+    metadata_class: Type[DocMetaData] = DocMetaData
+    # compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
+    full_eval: bool = False  # runs eval without sanitization. Use only on trusted input
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: Type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> Tuple[PydanticBaseSettingsSource, ...]:
+        """Wrap the env source to drop k8s service-link `port` values.
+
+        Source precedence is unchanged (init beats env, etc.); only the
+        env source is filtered — see `_ServiceLinkPortFilter`.
+        """
+        return (
+            init_settings,
+            _ServiceLinkPortFilter(env_settings),
+            dotenv_settings,
+            file_secret_settings,
+        )
+
+
+class VectorStore(ABC):
+    """
+    Abstract base class for a vector store.
+    """
+
+    def __init__(self, config: VectorStoreConfig):
+        self.config = config
+        if config.embedding_model is None:
+            self.embedding_model = EmbeddingModel.create(config.embedding)
+        else:
+            self.embedding_model = config.embedding_model
+        if hasattr(self.config, "embedding_model"):
+            self.config.embedding_model = None
+        self.embedding_fn: EmbeddingFunction = self.embedding_model.embedding_fn()
+
+    @staticmethod
+    def create(config: VectorStoreConfig) -> Optional["VectorStore"]:
+        from langroid.vector_store.chromadb import ChromaDB, ChromaDBConfig
+        from langroid.vector_store.lancedb import LanceDB, LanceDBConfig
+        from langroid.vector_store.meilisearch import MeiliSearch, MeiliSearchConfig
+        from langroid.vector_store.milvusdb import MilvusDB, MilvusDBConfig
+        from langroid.vector_store.pineconedb import PineconeDB, PineconeDBConfig
+        from langroid.vector_store.postgres import PostgresDB, PostgresDBConfig
+        from langroid.vector_store.qdrantdb import QdrantDB, QdrantDBConfig
+        from langroid.vector_store.weaviatedb import WeaviateDB, WeaviateDBConfig
+
+        if isinstance(config, QdrantDBConfig):
+            return QdrantDB(config)
+        elif isinstance(config, ChromaDBConfig):
+            return ChromaDB(config)
+        elif isinstance(config, LanceDBConfig):
+            return LanceDB(config)
+        elif isinstance(config, MeiliSearchConfig):
+            return MeiliSearch(config)
+        elif isinstance(config, PostgresDBConfig):
+            return PostgresDB(config)
+        elif isinstance(config, MilvusDBConfig):
+            return MilvusDB(config)
+        elif isinstance(config, WeaviateDBConfig):
+            return WeaviateDB(config)
+        elif isinstance(config, PineconeDBConfig):
+            return PineconeDB(config)
+
+        else:
+            logger.warning(
+                f"""
+                Unknown vector store config: {config.__class__.__name__},
+                so skipping vector store creation!
+                If you intended to use a vector-store, please set a specific 
+                vector-store in your script, typically in the `vecdb` field of a 
+                `ChatAgentConfig`, otherwise set it to None.
+                """
+            )
+            return None
+
+    @property
+    def embedding_dim(self) -> int:
+        return len(self.embedding_fn(["test"])[0])
+
+    def clone(self) -> "VectorStore":
+        """Return a vector-store clone suitable for agent cloning.
+
+        The default implementation deep-copies the configuration, reuses any
+        existing embedding model, and instantiates a fresh store of the same
+        type. Subclasses can override when sharing the instance is required
+        (e.g., embedded/local stores that rely on file locks).
+        """
+
+        config_class = self.config.__class__
+        config_data = self.config.model_dump(mode="python")
+        config_data["embedding_model"] = None
+        config_copy = config_class.model_validate(config_data)
+        logger.debug(
+            "Cloning VectorStore %s: original collection=%s, copied collection=%s",
+            type(self).__name__,
+            getattr(self.config, "collection_name", None),
+            getattr(config_copy, "collection_name", None),
+        )
+        # Preserve the calculated collection contents without forcing replaces
+        if hasattr(config_copy, "replace_collection"):
+            config_copy.replace_collection = False  # type: ignore[attr-defined]
+        cloned_embedding: Optional[EmbeddingModel] = None
+        if (
+            hasattr(self, "embedding_model")
+            and getattr(self, "embedding_model") is not None
+        ):
+            cloned_embedding = self.embedding_model.clone()  # type: ignore[attr-defined]
+            if hasattr(config_copy, "embedding_model"):
+                config_copy.embedding_model = cloned_embedding
+
+        cloned_store = type(self)(config_copy)  # type: ignore[call-arg]
+        if hasattr(cloned_store.config, "embedding_model"):
+            cloned_store.config.embedding_model = None
+        logger.debug(
+            "Cloned VectorStore %s: cloned collection=%s",
+            type(self).__name__,
+            getattr(cloned_store.config, "collection_name", None),
+        )
+        if hasattr(cloned_store.config, "replace_collection"):
+            cloned_store.config.replace_collection = False
+        # Some stores might not honour replace_collection; ensure same collection
+        if getattr(self.config, "collection_name", None) is not None:
+            setattr(
+                cloned_store.config,
+                "collection_name",
+                getattr(self.config, "collection_name", None),
+            )
+        return cloned_store
+
+    @abstractmethod
+    def clear_empty_collections(self) -> int:
+        """Clear all empty collections in the vector store.
+        Returns the number of collections deleted.
+        """
+        pass
+
+    @abstractmethod
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """
+        Clear all collections in the vector store.
+
+        Args:
+            really (bool, optional): Whether to really clear all collections.
+                Defaults to False.
+            prefix (str, optional): Prefix of collections to clear.
+        Returns:
+            int: Number of collections deleted.
+        """
+        pass
+
+    @abstractmethod
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """List all collections in the vector store
+        (only non empty collections if empty=False).
+        """
+        pass
+
+    def set_collection(self, collection_name: str, replace: bool = False) -> None:
+        """
+        Set the current collection to the given collection name.
+        Args:
+            collection_name (str): Name of the collection.
+            replace (bool, optional): Whether to replace the collection if it
+                already exists. Defaults to False.
+        """
+
+        self.config.collection_name = collection_name
+        self.config.replace_collection = replace
+        if replace:
+            self.create_collection(collection_name, replace=True)
+
+    @abstractmethod
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        """Create a collection with the given name.
+        Args:
+            collection_name (str): Name of the collection.
+            replace (bool, optional): Whether to replace the
+                collection if it already exists. Defaults to False.
+        """
+        pass
+
+    @abstractmethod
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        pass
+
+    def compute_from_docs(self, docs: List[Document], calc: str) -> str:
+        """Compute a result on a set of documents,
+        using a dataframe calc string like `df.groupby('state')['income'].mean()`.
+
+        If full_eval is False (default), the input expression is sanitized to prevent
+        most common code injection attack vectors.
+        If full_eval is True, sanitization is bypassed - use only with trusted input!
+        """
+        # convert each doc to a dict, using dotted paths for nested fields
+        dicts = [flatten_dict(doc.model_dump(by_alias=True)) for doc in docs]
+        df = pd.DataFrame(dicts)
+
+        try:
+            # SECURITY MITIGATION: Eval input is sanitized to prevent most common
+            # code injection attack vectors when full_eval is False. The globals
+            # dict also restricts ``__builtins__`` so that even with
+            # ``full_eval=True`` the expression cannot reach
+            # ``__import__``/``eval``/``exec`` via Python's implicit builtin
+            # injection (GHSA-q9p7-wqxg-mrhc).
+            vars = {"df": df}
+            if not self.config.full_eval:
+                calc = sanitize_command(calc)
+            code = compile(calc, "<calc>", "eval")
+            result = eval(code, safe_eval_globals(vars), {})
+        except Exception as e:
+            # return error message so LLM can fix the calc string if needed
+            err = f"""
+            Error encountered in pandas eval: {str(e)}
+            """
+            if isinstance(e, KeyError) and "not in index" in str(e):
+                # Pd.eval sometimes fails on a perfectly valid exprn like
+                # df.loc[..., 'column'] with a KeyError.
+                err += """
+                Maybe try a different way, e.g. 
+                instead of df.loc[..., 'column'], try df.loc[...]['column']
+                """
+            return err
+        return stringify(result)
+
+    def maybe_add_ids(self, documents: Sequence[Document]) -> None:
+        """Add ids to metadata if absent, since some
+        vecdbs don't like having blank ids."""
+        for d in documents:
+            if d.metadata.id in [None, ""]:
+                d.metadata.id = ObjectRegistry.new_id()
+
+    @abstractmethod
+    def similar_texts_with_scores(
+        self,
+        text: str,
+        k: int = 1,
+        where: Optional[str] = None,
+    ) -> List[Tuple[Document, float]]:
+        """
+        Find k most similar texts to the given text, in terms of vector distance metric
+        (e.g., cosine similarity).
+
+        Args:
+            text (str): The text to find similar texts for.
+            k (int, optional): Number of similar texts to retrieve. Defaults to 1.
+            where (Optional[str], optional): Where clause to filter the search.
+
+        Returns:
+            List[Tuple[Document,float]]: List of (Document, score) tuples.
+
+        """
+        pass
+
+    def add_context_window(
+        self, docs_scores: List[Tuple[Document, float]], neighbors: int = 0
+    ) -> List[Tuple[Document, float]]:
+        """
+        In each doc's metadata, there may be a window_ids field indicating
+        the ids of the chunks around the current chunk.
+        These window_ids may overlap, so we
+        - coalesce each overlapping groups into a single window (maintaining ordering),
+        - create a new document for each part, preserving metadata,
+
+        We may have stored a longer set of window_ids than we need during chunking.
+        Now, we just want `neighbors` on each side of the center of the window_ids list.
+
+        Args:
+            docs_scores (List[Tuple[Document, float]]): List of pairs of documents
+                to add context windows to together with their match scores.
+            neighbors (int, optional): Number of neighbors on "each side" of match to
+                retrieve. Defaults to 0.
+                "Each side" here means before and after the match,
+                in the original text.
+
+        Returns:
+            List[Tuple[Document, float]]: List of (Document, score) tuples.
+        """
+        # We return a larger context around each match, i.e.
+        # a window of `neighbors` on each side of the match.
+        docs = [d for d, s in docs_scores]
+        scores = [s for d, s in docs_scores]
+        if neighbors == 0:
+            return docs_scores
+        doc_chunks = [d for d in docs if d.metadata.is_chunk]
+        if len(doc_chunks) == 0:
+            return docs_scores
+        window_ids_list = []
+        id2metadata = {}
+        # id -> highest score of a doc it appears in
+        id2max_score: Dict[int | str, float] = {}
+        for i, d in enumerate(docs):
+            window_ids = d.metadata.window_ids
+            if len(window_ids) == 0:
+                window_ids = [d.id()]
+            id2metadata.update({id: d.metadata for id in window_ids})
+
+            id2max_score.update(
+                {id: max(id2max_score.get(id, 0), scores[i]) for id in window_ids}
+            )
+            n = len(window_ids)
+            chunk_idx = window_ids.index(d.id())
+            neighbor_ids = window_ids[
+                max(0, chunk_idx - neighbors) : min(n, chunk_idx + neighbors + 1)
+            ]
+            window_ids_list += [neighbor_ids]
+
+        # window_ids could be from different docs,
+        # and they may overlap, so we coalesce overlapping groups into
+        # separate windows.
+        window_ids_list = self.remove_overlaps(window_ids_list)
+        final_docs = []
+        final_scores = []
+        for w in window_ids_list:
+            metadata = copy.deepcopy(id2metadata[w[0]])
+            metadata.window_ids = w
+            document = Document(
+                content="".join([d.content for d in self.get_documents_by_ids(w)]),
+                metadata=metadata,
+            )
+            # make a fresh id since content is in general different
+            document.metadata.id = ObjectRegistry.new_id()
+            final_docs += [document]
+            final_scores += [max(id2max_score[id] for id in w)]
+        return list(zip(final_docs, final_scores))
+
+    @staticmethod
+    def remove_overlaps(windows: List[List[str]]) -> List[List[str]]:
+        """
+        Given a collection of windows, where each window is a sequence of ids,
+        identify groups of overlapping windows, and for each overlapping group,
+        order the chunk-ids using topological sort so they appear in the original
+        order in the text.
+
+        Args:
+            windows (List[int|str]): List of windows, where each window is a
+                sequence of ids.
+
+        Returns:
+            List[int|str]: List of windows, where each window is a sequence of ids,
+                and no two windows overlap.
+        """
+        ids = set(id for w in windows for id in w)
+        # id -> {win -> # pos}
+        id2win2pos: Dict[str, Dict[int, int]] = {id: {} for id in ids}
+
+        for i, w in enumerate(windows):
+            for j, id in enumerate(w):
+                id2win2pos[id][i] = j
+
+        n = len(windows)
+        # relation between windows:
+        order = np.zeros((n, n), dtype=np.int8)
+        for i, w in enumerate(windows):
+            for j, x in enumerate(windows):
+                if i == j:
+                    continue
+                if len(set(w).intersection(x)) == 0:
+                    continue
+                id = list(set(w).intersection(x))[0]  # any common id
+                if id2win2pos[id][i] > id2win2pos[id][j]:
+                    order[i, j] = -1  # win i is before win j
+                else:
+                    order[i, j] = 1  # win i is after win j
+
+        # find groups of windows that overlap, like connected components in a graph
+        groups = components(np.abs(order))
+
+        # order the chunk-ids in each group using topological sort
+        new_windows = []
+        for g in groups:
+            # find total ordering among windows in group based on order matrix
+            # (this is a topological sort)
+            _g = np.array(g)
+            order_matrix = order[_g][:, _g]
+            ordered_window_indices = topological_sort(order_matrix)
+            ordered_window_ids = [windows[i] for i in _g[ordered_window_indices]]
+            flattened = [id for w in ordered_window_ids for id in w]
+            flattened_deduped = list(dict.fromkeys(flattened))
+            # Note we are not going to split these, and instead we'll return
+            # larger windows from concatenating the connected groups.
+            # This ensures context is retained for LLM q/a
+            new_windows += [flattened_deduped]
+
+        return new_windows
+
+    @abstractmethod
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        """
+        Get all documents in the current collection, possibly filtered by `where`.
+        """
+        pass
+
+    @abstractmethod
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        """
+        Get documents by their ids.
+        Args:
+            ids (List[str]): List of document ids.
+
+        Returns:
+            List[Document]: List of documents
+        """
+        pass
+
+    @abstractmethod
+    def delete_collection(self, collection_name: str) -> None:
+        pass
+
+    def show_if_debug(self, doc_score_pairs: List[Tuple[Document, float]]) -> None:
+        if settings.debug:
+            for i, (d, s) in enumerate(doc_score_pairs):
+                print_long_text("red", "italic red", f"\nMATCH-{i}\n", d.content)
 </file>
 
 <file path="langroid/agent/special/sql/sql_chat_agent.py">
@@ -90452,2604 +93241,6 @@ def _model_name(model: str | ModelName) -> str:
     return model.value
 </file>
 
-<file path="langroid/language_models/openai_gpt.py">
-import hashlib
-import json
-import logging
-import os
-import sys
-import warnings
-from collections import defaultdict
-from functools import cache
-from itertools import chain
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Mapping,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    no_type_check,
-)
-
-import openai
-from cerebras.cloud.sdk import AsyncCerebras, Cerebras
-from groq import AsyncGroq, Groq
-from httpx import Timeout
-from openai import AsyncOpenAI, OpenAI
-from pydantic import BaseModel
-from pydantic_settings import BaseSettings, SettingsConfigDict
-from rich import print
-from rich.markup import escape
-
-from langroid.cachedb.base import CacheDB
-from langroid.cachedb.redis_cachedb import RedisCache, RedisCacheConfig
-from langroid.exceptions import LangroidImportError
-from langroid.language_models.base import (
-    LanguageModel,
-    LLMConfig,
-    LLMFunctionCall,
-    LLMFunctionSpec,
-    LLMMessage,
-    LLMResponse,
-    LLMTokenUsage,
-    OpenAIJsonSchemaSpec,
-    OpenAIToolCall,
-    OpenAIToolSpec,
-    Role,
-    StreamEventType,
-    ToolChoiceTypes,
-)
-from langroid.language_models.client_cache import (
-    get_async_cerebras_client,
-    get_async_groq_client,
-    get_async_openai_client,
-    get_cerebras_client,
-    get_groq_client,
-    get_openai_client,
-    wrap_api_key_provider_async,
-)
-from langroid.language_models.config import HFPromptFormatterConfig
-from langroid.language_models.model_info import (
-    DeepSeekModel,
-    MiniMaxModel,
-    OpenAI_API_ParamInfo,
-)
-from langroid.language_models.model_info import (
-    OpenAIChatModel as OpenAIChatModel,
-)
-from langroid.language_models.model_info import (
-    OpenAICompletionModel as OpenAICompletionModel,
-)
-from langroid.language_models.prompt_formatter.hf_formatter import (
-    HFFormatter,
-    find_hf_formatter,
-)
-from langroid.language_models.provider_params import (
-    DUMMY_API_KEY,
-    LangDBParams,
-    PortkeyParams,
-)
-from langroid.language_models.utils import (
-    async_retry_with_exponential_backoff,
-    retry_with_exponential_backoff,
-)
-from langroid.parsing.parse_json import parse_imperfect_json
-from langroid.utils.configuration import settings
-from langroid.utils.constants import Colors
-from langroid.utils.system import friendly_error
-
-logging.getLogger("openai").setLevel(logging.ERROR)
-
-if "OLLAMA_HOST" in os.environ:
-    OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
-else:
-    OLLAMA_BASE_URL = "http://localhost:11434/v1"
-
-DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
-# Provider prefixes that route to the Gemini OpenAI-compatible API.
-GEMINI_MODEL_PREFIXES = ("gemini/", "google/gemini-")
-GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
-MINIMAX_BASE_URL = "https://api.minimax.io/v1"
-OLLAMA_API_KEY = "ollama"
-
-VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
-LLAMACPP_API_KEY = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
-
-
-openai_chat_model_pref_list = [
-    OpenAIChatModel.GPT4o,
-    OpenAIChatModel.GPT4_1_NANO,
-    OpenAIChatModel.GPT4_1_MINI,
-    OpenAIChatModel.GPT4_1,
-    OpenAIChatModel.GPT4o_MINI,
-    OpenAIChatModel.O1_MINI,
-    OpenAIChatModel.O3_MINI,
-    OpenAIChatModel.O1,
-]
-
-openai_completion_model_pref_list = [
-    OpenAICompletionModel.DAVINCI,
-    OpenAICompletionModel.BABBAGE,
-]
-
-
-if "OPENAI_API_KEY" in os.environ:
-    try:
-        available_models = set(map(lambda m: m.id, OpenAI().models.list()))
-    except openai.AuthenticationError as e:
-        if settings.debug:
-            logging.warning(
-                f"""
-            OpenAI Authentication Error: {e}.
-            ---
-            If you intended to use an OpenAI Model, you should fix this,
-            otherwise you can ignore this warning.
-            """
-            )
-        available_models = set()
-    except Exception as e:
-        if settings.debug:
-            logging.warning(
-                f"""
-            Error while fetching available OpenAI models: {e}.
-            Proceeding with an empty set of available models.
-            """
-            )
-        available_models = set()
-else:
-    available_models = set()
-
-default_openai_chat_model = next(
-    chain(
-        filter(
-            lambda m: m.value in available_models,
-            openai_chat_model_pref_list,
-        ),
-        [OpenAIChatModel.GPT4o],
-    )
-)
-default_openai_completion_model = next(
-    chain(
-        filter(
-            lambda m: m.value in available_models,
-            openai_completion_model_pref_list,
-        ),
-        [OpenAICompletionModel.DAVINCI],
-    )
-)
-
-
-class AccessWarning(Warning):
-    pass
-
-
-@cache
-def gpt_3_5_warning() -> None:
-    warnings.warn(
-        f"""
-        {OpenAIChatModel.GPT4o} is not available,
-        falling back to {OpenAIChatModel.GPT3_5_TURBO}.
-        Examples may not work properly and unexpected behavior may occur.
-        Adjustments to prompts may be necessary.
-        """,
-        AccessWarning,
-    )
-
-
-@cache
-def parallel_strict_warning() -> None:
-    logging.warning(
-        "OpenAI tool calling in strict mode is not supported when "
-        "parallel tool calls are made. Disable parallel tool calling "
-        "to ensure correct behavior."
-    )
-
-
-def noop() -> None:
-    """Does nothing."""
-    return None
-
-
-class OpenAICallParams(BaseModel):
-    """
-    Various params that can be sent to an OpenAI API chat-completion call.
-    When specified, any param here overrides the one with same name in the
-    OpenAIGPTConfig.
-    See OpenAI API Reference for details on the params:
-    https://platform.openai.com/docs/api-reference/chat
-    """
-
-    max_tokens: int | None = None
-    temperature: float | None = None
-    frequency_penalty: float | None = None  # between -2 and 2
-    presence_penalty: float | None = None  # between -2 and 2
-    response_format: Dict[str, str] | None = None
-    logit_bias: Dict[int, float] | None = None  # token_id -> bias
-    logprobs: bool | None = None
-    top_p: float | None = None
-    reasoning_effort: str | None = None  # or "low" or "high" or "medium"
-    top_logprobs: int | None = None  # if int, requires logprobs=True
-    n: int | None = None  # how many completions to generate (n > 1 is NOT handled now)
-    stop: str | List[str] | None = None  # (list of) stop sequence(s)
-    seed: int | None = None
-    user: str | None = None  # user id for tracking
-    extra_body: Dict[str, Any] | None = None  # additional params for API request body
-
-    def to_dict_exclude_none(self) -> Dict[str, Any]:
-        return {k: v for k, v in self.model_dump().items() if v is not None}
-
-
-class LiteLLMProxyConfig(BaseSettings):
-    """Configuration for LiteLLM proxy connection."""
-
-    api_key: str = ""  # read from env var LITELLM_API_KEY if set
-    api_base: str = ""  # read from env var LITELLM_API_BASE if set
-
-    model_config = SettingsConfigDict(env_prefix="LITELLM_")
-
-
-class OpenAIGPTConfig(LLMConfig):
-    """
-    Class for any LLM with an OpenAI-like API: besides the OpenAI models this includes:
-    (a) locally-served models behind an OpenAI-compatible API
-    (b) non-local models, using a proxy adaptor lib like litellm that provides
-        an OpenAI-compatible API.
-    (We could rename this class to OpenAILikeConfig, but we keep it as-is for now)
-
-    Important Note:
-    Due to the `env_prefix = "OPENAI_"` defined below,
-    all of the fields below can be set AND OVERRIDDEN via env vars,
-    # by upper-casing the name and prefixing with OPENAI_, e.g.
-    # OPENAI_MAX_OUTPUT_TOKENS=1000.
-    # If any of these is defined in this way in the environment
-    # (either via explicit setenv or export or via .env file + load_dotenv()),
-    # the environment variable takes precedence over the value in the config.
-    """
-
-    type: str = "openai"
-    api_key: str = DUMMY_API_KEY
-    # Callable returning a fresh API key/bearer token, for endpoints that
-    # authenticate with short-lived rotating credentials (e.g. Vertex AI
-    # OAuth tokens, Azure Entra ID). Resolved per-request by the OpenAI
-    # client, and excluded from the client-cache key (the cache is keyed on
-    # the provider's identity), so rotating tokens neither go stale nor grow
-    # the cache. Takes precedence over `api_key`. Only supported for models
-    # served via an OpenAI-compatible endpoint (not Groq/Cerebras/litellm).
-    # See docs/notes/rotating-api-keys.md.
-    api_key_provider: Optional[Callable[[], str]] = None
-    organization: str = ""
-    api_base: str | None = None  # used for local or other non-OpenAI models
-    litellm: bool = False  # use litellm api?
-    litellm_proxy: LiteLLMProxyConfig = LiteLLMProxyConfig()
-    ollama: bool = False  # use ollama's OpenAI-compatible endpoint?
-    min_output_tokens: int = 1
-    use_chat_for_completion: bool = True  # do not change this, for OpenAI models!
-    timeout: int = 20
-    temperature: float = 0.2
-    seed: int | None = 42
-    params: OpenAICallParams | None = None
-    use_cached_client: bool = (
-        True  # Whether to reuse cached clients (prevents resource exhaustion)
-    )
-    # these can be any model name that is served at an OpenAI-compatible API end point
-    chat_model: str = default_openai_chat_model
-    chat_model_orig: Optional[str] = None
-    completion_model: str = default_openai_completion_model
-    run_on_first_use: Callable[[], None] = noop
-    parallel_tool_calls: Optional[bool] = None
-    # Supports constrained decoding which enforces that the output of the LLM
-    # adheres to a JSON schema
-    supports_json_schema: Optional[bool] = None
-    # Supports strict decoding for the generation of tool calls with
-    # the OpenAI Tools API; this ensures that the generated tools
-    # adhere to the provided schema.
-    supports_strict_tools: Optional[bool] = None
-    # a string that roughly matches a HuggingFace chat_template,
-    # e.g. "mistral-instruct-v0.2 (a fuzzy search is done to find the closest match)
-    formatter: str | None = None
-    hf_formatter: HFFormatter | None = None
-    langdb_params: LangDBParams = LangDBParams()
-    portkey_params: PortkeyParams = PortkeyParams()
-    headers: Dict[str, str] = {}
-    http_client_factory: Optional[Callable[[], Any]] = (
-        None  # Factory: returns Client or (Client, AsyncClient)
-    )
-    http_verify_ssl: bool = True  # Simple flag for SSL verification
-    http_client_config: Optional[Dict[str, Any]] = None  # Config dict for httpx.Client
-    _api_base_was_supplied: bool = False
-
-    def __init__(self, **kwargs) -> None:  # type: ignore
-        api_base_was_supplied = "api_base" in kwargs
-        local_model = "api_base" in kwargs and kwargs["api_base"] is not None
-
-        chat_model = kwargs.get("chat_model", "")
-        local_prefixes = ["local/", "litellm/", "ollama/", "vllm/", "llamacpp/"]
-        if any(chat_model.startswith(prefix) for prefix in local_prefixes):
-            local_model = True
-
-        warn_gpt_3_5 = (
-            "chat_model" not in kwargs.keys()
-            and not local_model
-            and default_openai_chat_model == OpenAIChatModel.GPT3_5_TURBO
-        )
-
-        if warn_gpt_3_5:
-            existing_hook = kwargs.get("run_on_first_use", noop)
-
-            def with_warning() -> None:
-                existing_hook()
-                gpt_3_5_warning()
-
-            kwargs["run_on_first_use"] = with_warning
-
-        super().__init__(**kwargs)
-        env_prefix = self.model_config.get("env_prefix")
-        env_api_base_name = f"{env_prefix}API_BASE"
-        env_api_base = os.getenv(env_api_base_name)
-        if not self.model_config.get("case_sensitive"):
-            case_insensitive_env = {
-                name.lower(): value for name, value in os.environ.items()
-            }
-            env_api_base = case_insensitive_env.get(env_api_base_name.lower())
-        api_base_was_supplied = api_base_was_supplied or (
-            self.api_base is not None
-            and (env_prefix != "OPENAI_" or self.api_base != env_api_base)
-        )
-        self._api_base_was_supplied = api_base_was_supplied
-
-    model_config = SettingsConfigDict(env_prefix="OPENAI_")
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        """Track API bases assigned after config construction."""
-        super().__setattr__(name, value)
-        if name == "api_base":
-            self._api_base_was_supplied = True
-
-    def model_copy(
-        self, *, update: Mapping[str, Any] | None = None, deep: bool = False
-    ) -> "OpenAIGPTConfig":
-        """
-        Copy config while preserving nested model instances and subclasses.
-
-        Important: Avoid reconstructing via `model_dump` as that coerces nested
-        models to their annotated base types (dropping subclass-only fields).
-        Instead, defer to Pydantic's native `model_copy`, which keeps nested
-        `BaseModel` instances (and their concrete subclasses) intact.
-
-        An `api_base` supplied through `update` is caller configuration, so the
-        copy must retain that provenance for provider-specific routing.
-        """
-        # Delegate to BaseSettings/BaseModel implementation to preserve types
-        copied = super().model_copy(update=update, deep=deep)
-        if update is not None and "api_base" in update:
-            copied._api_base_was_supplied = True
-        return copied  # type: ignore[return-value]
-
-    def _validate_litellm(self) -> None:
-        """
-        When using liteLLM, validate whether all env vars required by the model
-        have been set.
-        """
-        if not self.litellm:
-            return
-        try:
-            import litellm
-        except ImportError:
-            raise LangroidImportError("litellm", "litellm")
-
-        litellm.telemetry = False
-        litellm.drop_params = True  # drop un-supported params without crashing
-        litellm.modify_params = True
-        self.seed = None  # some local mdls don't support seed
-
-        if self.api_key == DUMMY_API_KEY:
-            keys_dict = litellm.utils.validate_environment(self.chat_model)
-            missing_keys = keys_dict.get("missing_keys", [])
-            if len(missing_keys) > 0:
-                raise ValueError(
-                    f"""
-                    Missing environment variables for litellm-proxied model:
-                    {missing_keys}
-                    """
-                )
-
-    @classmethod
-    def create(cls, prefix: str) -> Type["OpenAIGPTConfig"]:
-        """Create a config class whose params can be set via a desired
-        prefix from the .env file or env vars.
-        E.g., using
-        ```python
-        OllamaConfig = OpenAIGPTConfig.create("ollama")
-        ollama_config = OllamaConfig()
-        ```
-        you can have a group of params prefixed by "OLLAMA_", to be used
-        with models served via `ollama`.
-        This way, you can maintain several setting-groups in your .env file,
-        one per model type.
-        """
-
-        class DynamicConfig(OpenAIGPTConfig):
-            pass
-
-        DynamicConfig.model_config = SettingsConfigDict(env_prefix=prefix.upper() + "_")
-        return DynamicConfig
-
-
-class OpenAIResponse(BaseModel):
-    """OpenAI response model, either completion or chat."""
-
-    choices: List[Dict]  # type: ignore
-    usage: Dict  # type: ignore
-
-
-def litellm_logging_fn(model_call_dict: Dict[str, Any]) -> None:
-    """Logging function for litellm"""
-    try:
-        api_input_dict = model_call_dict.get("additional_args", {}).get(
-            "complete_input_dict"
-        )
-        if api_input_dict is not None:
-            text = escape(json.dumps(api_input_dict, indent=2))
-            print(
-                f"[grey37]LITELLM: {text}[/grey37]",
-            )
-    except Exception:
-        pass
-
-
-# Define a class for OpenAI GPT models that extends the base class
-class OpenAIGPT(LanguageModel):
-    """
-    Class for OpenAI LLMs
-    """
-
-    client: OpenAI | Groq | Cerebras | None
-    async_client: AsyncOpenAI | AsyncGroq | AsyncCerebras | None
-
-    def __init__(self, config: OpenAIGPTConfig = OpenAIGPTConfig()):
-        """
-        Args:
-            config: configuration for openai-gpt model
-        """
-        # copy the config to avoid modifying the original; deep to decouple
-        # nested models while preserving their concrete subclasses
-        # The api_key_provider must NOT be deep-copied: the client cache is
-        # keyed on its identity (so a copy would defeat cache sharing), and it
-        # may hold non-copyable state (e.g. a threading.Lock). Clear it in a
-        # shallow copy first, then restore the original callable afterwards.
-        api_key_provider = config.api_key_provider
-        if api_key_provider is not None:
-            config = config.model_copy(update={"api_key_provider": None})
-        config = config.model_copy(deep=True)
-        if api_key_provider is not None:
-            config.api_key_provider = api_key_provider
-        super().__init__(config)
-        self.config: OpenAIGPTConfig = config
-        # save original model name such as `provider/model` before
-        # we strip out the `provider` - we retain the original in
-        # case some params are specific to a provider.
-        self.chat_model_orig = self.config.chat_model_orig or self.config.chat_model
-
-        # Run the first time the model is used
-        self.run_on_first_use = cache(self.config.run_on_first_use)
-
-        # global override of chat_model,
-        # to allow quick testing with other models
-        if settings.chat_model != "":
-            self.config.chat_model = settings.chat_model
-            self.chat_model_orig = settings.chat_model
-            self.config.completion_model = settings.chat_model
-
-        if len(parts := self.config.chat_model.split("//")) > 1:
-            # there is a formatter specified, e.g.
-            # "litellm/ollama/mistral//hf" or
-            # "local/localhost:8000/v1//mistral-instruct-v0.2"
-            formatter = parts[1]
-            self.config.chat_model = parts[0]
-            if formatter == "hf":
-                # e.g. "litellm/ollama/mistral//hf" -> "litellm/ollama/mistral"
-                formatter = find_hf_formatter(self.config.chat_model)
-                if formatter != "":
-                    # e.g. "mistral"
-                    self.config.formatter = formatter
-                    logging.warning(
-                        f"""
-                        Using completions (not chat) endpoint with HuggingFace
-                        chat_template for {formatter} for
-                        model {self.config.chat_model}
-                        """
-                    )
-            else:
-                # e.g. "local/localhost:8000/v1//mistral-instruct-v0.2"
-                self.config.formatter = formatter
-
-        if self.config.formatter is not None:
-            self.config.hf_formatter = HFFormatter(
-                HFPromptFormatterConfig(model_name=self.config.formatter)
-            )
-
-        self.supports_json_schema: bool = self.config.supports_json_schema or False
-        self.supports_strict_tools: bool = self.config.supports_strict_tools or False
-
-        OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", DUMMY_API_KEY)
-        self.api_key = config.api_key
-
-        # if model name starts with "litellm",
-        # set the actual model name by stripping the "litellm/" prefix
-        # and set the litellm flag to True
-        if self.config.chat_model.startswith("litellm/") or self.config.litellm:
-            # e.g. litellm/ollama/mistral
-            self.config.litellm = True
-            self.api_base = self.config.api_base
-            if self.config.chat_model.startswith("litellm/"):
-                # strip the "litellm/" prefix
-                # e.g. litellm/ollama/llama2 => ollama/llama2
-                self.config.chat_model = self.config.chat_model.split("/", 1)[1]
-        elif self.config.chat_model.startswith("local/"):
-            # expect this to be of the form "local/localhost:8000/v1",
-            # depending on how the model is launched locally.
-            # In this case the model served locally behind an OpenAI-compatible API
-            # so we can just use `openai.*` methods directly,
-            # and don't need a adaptor library like litellm
-            self.config.litellm = False
-            self.config.seed = None  # some models raise an error when seed is set
-            # Extract the api_base from the model name after the "local/" prefix
-            self.api_base = self.config.chat_model.split("/", 1)[1]
-            if not self.api_base.startswith("http"):
-                self.api_base = "http://" + self.api_base
-        elif self.config.chat_model.startswith("ollama/"):
-            self.config.ollama = True
-
-            # use api_base from config if set, else fall back on OLLAMA_BASE_URL
-            self.api_base = self.config.api_base or OLLAMA_BASE_URL
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = OLLAMA_API_KEY
-            self.config.chat_model = self.config.chat_model.replace("ollama/", "")
-        elif self.config.chat_model.startswith("vllm/"):
-            self.supports_json_schema = True
-            self.config.chat_model = self.config.chat_model.replace("vllm/", "")
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
-            self.api_base = self.config.api_base or "http://localhost:8000/v1"
-            if not self.api_base.startswith("http"):
-                self.api_base = "http://" + self.api_base
-            if not self.api_base.endswith("/v1"):
-                self.api_base = self.api_base + "/v1"
-        elif self.config.chat_model.startswith("llamacpp/"):
-            self.supports_json_schema = True
-            self.api_base = self.config.chat_model.split("/", 1)[1]
-            if not self.api_base.startswith("http"):
-                self.api_base = "http://" + self.api_base
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
-        else:
-            self.api_base = self.config.api_base
-            # If api_base is unset we use OpenAI's endpoint, which supports
-            # these features (with JSON schema restricted to a limited set of models)
-            self.supports_strict_tools = self.api_base is None
-            self.supports_json_schema = (
-                self.api_base is None and self.info().has_structured_output
-            )
-
-        if settings.chat_model != "":
-            # if we're overriding chat model globally, set completion model to same
-            self.config.completion_model = self.config.chat_model
-
-        if self.config.formatter is not None:
-            # we want to format chats -> completions using this specific formatter
-            self.config.use_completion_for_chat = True
-            self.config.completion_model = self.config.chat_model
-
-        if self.config.use_completion_for_chat:
-            self.config.use_chat_for_completion = False
-
-        self.is_groq = self.config.chat_model.startswith("groq/")
-        self.is_cerebras = self.config.chat_model.startswith("cerebras/")
-        self.is_gemini = self.is_gemini_model()
-        self.is_deepseek = self.is_deepseek_model()
-        self.is_minimax = self.is_minimax_model()
-        self.is_glhf = self.config.chat_model.startswith("glhf/")
-        self.is_openrouter = self.config.chat_model.startswith("openrouter/")
-        self.is_langdb = self.config.chat_model.startswith("langdb/")
-        self.is_portkey = self.config.chat_model.startswith("portkey/")
-        self.is_litellm_proxy = self.config.chat_model.startswith("litellm-proxy/")
-
-        if self.config.api_key_provider is not None and (
-            self.is_groq or self.is_cerebras or self.config.litellm
-        ):
-            raise ValueError(
-                "api_key_provider is only supported for models served via an "
-                "OpenAI-compatible endpoint (using the OpenAI client); it "
-                "cannot be used with Groq, Cerebras, or the litellm adapter."
-            )
-
-        if self.is_groq:
-            # use groq-specific client
-            self.config.chat_model = self.config.chat_model.replace("groq/", "")
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = os.getenv("GROQ_API_KEY", DUMMY_API_KEY)
-            if self.config.use_cached_client:
-                self.client = get_groq_client(api_key=self.api_key)
-                self.async_client = get_async_groq_client(api_key=self.api_key)
-            else:
-                # Create new clients without caching
-                self.client = Groq(api_key=self.api_key)
-                self.async_client = AsyncGroq(api_key=self.api_key)
-        elif self.is_cerebras:
-            # use cerebras-specific client
-            self.config.chat_model = self.config.chat_model.replace("cerebras/", "")
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = os.getenv("CEREBRAS_API_KEY", DUMMY_API_KEY)
-            if self.config.use_cached_client:
-                self.client = get_cerebras_client(api_key=self.api_key)
-                # TODO there is not async client, so should we do anything here?
-                self.async_client = get_async_cerebras_client(api_key=self.api_key)
-            else:
-                # Create new clients without caching
-                self.client = Cerebras(api_key=self.api_key)
-                self.async_client = AsyncCerebras(api_key=self.api_key)
-        else:
-            # in these cases, there's no specific client: OpenAI python client suffices
-            if self.is_litellm_proxy:
-                self.config.chat_model = self.config.chat_model.replace(
-                    "litellm-proxy/", ""
-                )
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = self.config.litellm_proxy.api_key or self.api_key
-                self.api_base = self.config.litellm_proxy.api_base or self.api_base
-            elif self.is_gemini:
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = os.getenv("GEMINI_API_KEY", DUMMY_API_KEY)
-                # Prefer caller config, then Gemini env, then the default.
-                gemini_api_base = os.getenv("GEMINI_API_BASE", "")
-                explicit_api_base = (
-                    self.config.api_base if self.config._api_base_was_supplied else None
-                )
-                self.api_base = explicit_api_base or gemini_api_base or GEMINI_BASE_URL
-                if (
-                    self.config.chat_model.startswith("gemini/")
-                    or self.api_base == GEMINI_BASE_URL
-                ):
-                    self.config.chat_model = self.config.chat_model.split("/", 1)[1]
-            elif self.is_glhf:
-                self.config.chat_model = self.config.chat_model.replace("glhf/", "")
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = os.getenv("GLHF_API_KEY", DUMMY_API_KEY)
-                self.api_base = GLHF_BASE_URL
-            elif self.is_openrouter:
-                self.config.chat_model = self.config.chat_model.replace(
-                    "openrouter/", ""
-                )
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = os.getenv("OPENROUTER_API_KEY", DUMMY_API_KEY)
-                self.api_base = OPENROUTER_BASE_URL
-            elif self.is_deepseek:
-                self.config.chat_model = self.config.chat_model.replace("deepseek/", "")
-                self.api_base = DEEPSEEK_BASE_URL
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = os.getenv("DEEPSEEK_API_KEY", DUMMY_API_KEY)
-            elif self.is_minimax:
-                self.config.chat_model = self.config.chat_model.replace("minimax/", "")
-                # Honor caller-supplied base URL (e.g. regional endpoints,
-                # proxies) instead of always forcing the default.
-                openai_api_base = os.getenv("OPENAI_API_BASE")
-                explicit_api_base = (
-                    self.config.api_base
-                    if self.config.api_base and self.config.api_base != openai_api_base
-                    else None
-                )
-                self.api_base = explicit_api_base or MINIMAX_BASE_URL
-                if self.api_key == OPENAI_API_KEY:
-                    # Only overwrite with MINIMAX_API_KEY when it is actually
-                    # set, so users who intentionally put their MiniMax key in
-                    # OPENAI_API_KEY are not silently downgraded to a dummy key.
-                    minimax_key = os.getenv("MINIMAX_API_KEY", "")
-                    if minimax_key:
-                        self.api_key = minimax_key
-                # Recompute capabilities now that the prefix has been stripped
-                # and self.info() can find the model in MODEL_INFO.
-                self.supports_strict_tools = True
-                self.supports_json_schema = self.info().has_structured_output
-            elif self.is_langdb:
-                self.config.chat_model = self.config.chat_model.replace("langdb/", "")
-                self.api_base = self.config.langdb_params.base_url
-                project_id = self.config.langdb_params.project_id
-                if project_id:
-                    self.api_base += "/" + project_id + "/v1"
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = self.config.langdb_params.api_key or DUMMY_API_KEY
-
-                if self.config.langdb_params:
-                    params = self.config.langdb_params
-                    if params.project_id:
-                        self.config.headers["x-project-id"] = params.project_id
-                    if params.label:
-                        self.config.headers["x-label"] = params.label
-                    if params.run_id:
-                        self.config.headers["x-run-id"] = params.run_id
-                    if params.thread_id:
-                        self.config.headers["x-thread-id"] = params.thread_id
-            elif self.is_portkey:
-                # Parse the model string and extract provider/model
-                provider, model = self.config.portkey_params.parse_model_string(
-                    self.config.chat_model
-                )
-                self.config.chat_model = model
-                if provider:
-                    self.config.portkey_params.provider = provider
-
-                # Set Portkey base URL
-                self.api_base = self.config.portkey_params.base_url + "/v1"
-
-                # Set API key - use provider's API key from env if available
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = self.config.portkey_params.get_provider_api_key(
-                        self.config.portkey_params.provider, DUMMY_API_KEY
-                    )
-
-                # Add Portkey-specific headers
-                self.config.headers.update(self.config.portkey_params.get_headers())
-
-            # Sanitize the API key: strip leading/trailing whitespace
-            # (including stray newlines from .env files or CI secrets).
-            self.api_key = self.api_key.strip()
-
-            # Create http_client if needed - Priority order:
-            # 1. http_client_factory (most flexibility, not cacheable)
-            # 2. http_client_config (cacheable, moderate flexibility)
-            # 3. http_verify_ssl=False (cacheable, simple SSL bypass)
-            http_client = None
-            async_http_client = None
-            http_client_config_used = None
-
-            if self.config.http_client_factory is not None:
-                # Use the factory to create http_client (not cacheable)
-                http_client = self.config.http_client_factory()
-                if isinstance(http_client, (list, tuple)):
-                    if len(http_client) != 2:
-                        raise ValueError(
-                            "http_client_factory must return either a single "
-                            "httpx.Client or a tuple of "
-                            "(httpx.Client, httpx.AsyncClient)"
-                        )
-                    http_client, async_http_client = http_client
-                else:
-                    # set async_http_client to None - so that it will
-                    # be created later
-                    async_http_client = None
-            elif self.config.http_client_config is not None:
-                # Use config dict (cacheable)
-                http_client_config_used = self.config.http_client_config
-            elif not self.config.http_verify_ssl:
-                # Simple SSL bypass (cacheable)
-                http_client_config_used = {"verify": False}
-                logging.warning(
-                    "SSL verification has been disabled. This is insecure and "
-                    "should only be used in trusted environments (e.g., "
-                    "corporate networks with self-signed certificates)."
-                )
-
-            # With an api_key_provider, hand the callable itself to the
-            # OpenAI client, which resolves a fresh token on each request.
-            openai_api_key: Union[str, Callable[[], str]] = (
-                self.config.api_key_provider
-                if self.config.api_key_provider is not None
-                else self.api_key
-            )
-
-            if self.config.use_cached_client:
-                self.client = get_openai_client(
-                    api_key=openai_api_key,
-                    base_url=self.api_base,
-                    organization=self.config.organization,
-                    timeout=Timeout(self.config.timeout),
-                    default_headers=self.config.headers,
-                    http_client=http_client,
-                    http_client_config=http_client_config_used,
-                )
-                self.async_client = get_async_openai_client(
-                    api_key=openai_api_key,
-                    base_url=self.api_base,
-                    organization=self.config.organization,
-                    timeout=Timeout(self.config.timeout),
-                    default_headers=self.config.headers,
-                    http_client=async_http_client,
-                    http_client_config=http_client_config_used,
-                )
-            else:
-                # Create new clients without caching
-                client_kwargs: Dict[str, Any] = dict(
-                    api_key=openai_api_key,
-                    base_url=self.api_base,
-                    organization=self.config.organization,
-                    timeout=Timeout(self.config.timeout),
-                    default_headers=self.config.headers,
-                )
-                if http_client is not None:
-                    client_kwargs["http_client"] = http_client
-                elif http_client_config_used is not None:
-                    # Create http_client from config for non-cached scenario
-                    try:
-                        from httpx import Client
-
-                        client_kwargs["http_client"] = Client(**http_client_config_used)
-                    except ImportError:
-                        raise ValueError(
-                            "httpx is required to use http_client_config. "
-                            "Install it with: pip install httpx"
-                        )
-                self.client = OpenAI(**client_kwargs)
-
-                async_client_kwargs: Dict[str, Any] = dict(
-                    api_key=(
-                        # AsyncOpenAI awaits its api_key callable
-                        wrap_api_key_provider_async(openai_api_key)
-                        if callable(openai_api_key)
-                        else openai_api_key
-                    ),
-                    base_url=self.api_base,
-                    organization=self.config.organization,
-                    timeout=Timeout(self.config.timeout),
-                    default_headers=self.config.headers,
-                )
-                if async_http_client is not None:
-                    async_client_kwargs["http_client"] = async_http_client
-                elif http_client_config_used is not None:
-                    # Create async http_client from config for non-cached scenario
-                    try:
-                        from httpx import AsyncClient
-
-                        async_client_kwargs["http_client"] = AsyncClient(
-                            **http_client_config_used
-                        )
-                    except ImportError:
-                        raise ValueError(
-                            "httpx is required to use http_client_config. "
-                            "Install it with: pip install httpx"
-                        )
-                self.async_client = AsyncOpenAI(**async_client_kwargs)
-
-        self.cache: CacheDB | None = None
-        use_cache = self.config.cache_config is not None
-        if "redis" in settings.cache_type and use_cache:
-            if config.cache_config is None or not isinstance(
-                config.cache_config,
-                RedisCacheConfig,
-            ):
-                # switch to fresh redis config if needed
-                config.cache_config = RedisCacheConfig(
-                    fake="fake" in settings.cache_type
-                )
-            if "fake" in settings.cache_type:
-                # force use of fake redis if global cache_type is "fakeredis"
-                config.cache_config.fake = True
-            self.cache = RedisCache(config.cache_config)
-        elif settings.cache_type != "none" and use_cache:
-            raise ValueError(
-                f"Invalid cache type {settings.cache_type}. "
-                "Valid types are redis, fakeredis, none"
-            )
-
-        self.config._validate_litellm()
-
-    def _openai_api_call_params(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Prep the params to be sent to the OpenAI API
-        (or any OpenAI-compatible API, e.g. from Ooba or LmStudio)
-        for chat-completion.
-
-        Order of priority:
-        - (1) Params (mainly max_tokens) in the chat/achat/generate/agenerate call
-                (these are passed in via kwargs)
-        - (2) Params in OpenAIGPTConfig.params (of class OpenAICallParams)
-        - (3) Specific Params in OpenAIGPTConfig (just temperature for now)
-        """
-        params = dict(
-            temperature=self.config.temperature,
-        )
-        if self.config.params is not None:
-            params.update(self.config.params.to_dict_exclude_none())
-        params.update(kwargs)
-        return params
-
-    def is_openai_chat_model(self) -> bool:
-        openai_chat_models = [e.value for e in OpenAIChatModel]
-        return self.config.chat_model in openai_chat_models
-
-    def is_openai_completion_model(self) -> bool:
-        openai_completion_models = [e.value for e in OpenAICompletionModel]
-        return self.config.completion_model in openai_completion_models
-
-    def is_gemini_model(self) -> bool:
-        """Are we using the gemini OpenAI-compatible API?"""
-        return self.chat_model_orig.startswith(GEMINI_MODEL_PREFIXES)
-
-    def is_deepseek_model(self) -> bool:
-        deepseek_models = [e.value for e in DeepSeekModel]
-        return (
-            self.chat_model_orig in deepseek_models
-            or self.chat_model_orig.startswith("deepseek/")
-        )
-
-    def is_minimax_model(self) -> bool:
-        """Are we using the MiniMax OpenAI-compatible API?"""
-        minimax_models = [e.value for e in MiniMaxModel]
-        return (
-            self.chat_model_orig in minimax_models
-            or self.chat_model_orig.startswith("minimax/")
-        )
-
-    def unsupported_params(self) -> List[str]:
-        """
-        List of params that are not supported by the current model
-        """
-        unsupported = set(self.info().unsupported_params)
-        return list(unsupported)
-
-    def rename_params(self) -> Dict[str, str]:
-        """
-        Map of param name -> new name for specific models.
-        Currently main troublemaker is o1* series.
-        """
-        return self.info().rename_params
-
-    def chat_context_length(self) -> int:
-        """
-        Context-length for chat-completion models/endpoints.
-        Get it from the config if explicitly given,
-         otherwise use model_info based on model name, and fall back to
-         generic model_info if there's no match.
-        """
-        return self.config.chat_context_length or self.info().context_length
-
-    def completion_context_length(self) -> int:
-        """
-        Context-length for completion models/endpoints.
-        Get it from the config if explicitly given,
-         otherwise use model_info based on model name, and fall back to
-         generic model_info if there's no match.
-        """
-        return (
-            self.config.completion_context_length
-            or self.completion_info().context_length
-        )
-
-    def chat_cost(self) -> Tuple[float, float, float]:
-        """
-        (Prompt, Cached, Generation) cost per 1000 tokens, for chat-completion
-        models/endpoints.
-        Get it from the dict, otherwise fail-over to general method
-        """
-        info = self.info()
-        cached_cost_per_million = info.cached_cost_per_million
-        if not cached_cost_per_million:
-            cached_cost_per_million = info.input_cost_per_million
-        return (
-            info.input_cost_per_million / 1000,
-            cached_cost_per_million / 1000,
-            info.output_cost_per_million / 1000,
-        )
-
-    def set_stream(self, stream: bool) -> bool:
-        """Enable or disable streaming output from API.
-        Args:
-            stream: enable streaming output from API
-        Returns: previous value of stream
-        """
-        tmp = self.config.stream
-        self.config.stream = stream
-        return tmp
-
-    def get_stream(self) -> bool:
-        """Get streaming status."""
-        return self.config.stream and settings.stream and self.info().allows_streaming
-
-    @staticmethod
-    def _split_inline_reasoning(
-        event_text: str,
-        event_reasoning: str,
-        in_reasoning: bool,
-        thought_delimiters: Tuple[str, str],
-    ) -> Tuple[str, str, bool]:
-        """Separate inline reasoning from text tokens in a streaming chunk.
-
-        When models embed thinking inside content (e.g. <think>...</think>)
-        rather than using a separate reasoning field, this splits the chunk
-        into text-only and reasoning-only portions for proper streamer routing.
-
-        Returns (text_tokens, reasoning_tokens, in_reasoning).
-        """
-        text_tokens = event_text
-        reasoning_tokens = event_reasoning
-
-        if not event_text or event_reasoning:
-            return text_tokens, reasoning_tokens, in_reasoning
-
-        start, end = thought_delimiters
-        remaining = event_text
-
-        if in_reasoning:
-            text_tokens = ""
-        elif start in event_text:
-            before, _, after = event_text.partition(start)
-            text_tokens = before
-            remaining = after
-            in_reasoning = True
-
-        if in_reasoning:
-            if end in remaining:
-                before, _, after = remaining.partition(end)
-                text_tokens += after
-                reasoning_tokens = before
-                in_reasoning = False
-            else:
-                reasoning_tokens = remaining
-
-        return text_tokens, reasoning_tokens, in_reasoning
-
-    @no_type_check
-    def _process_stream_event(
-        self,
-        event,
-        chat: bool = False,
-        tool_deltas: List[Dict[str, Any]] = [],
-        has_function: bool = False,
-        completion: str = "",
-        reasoning: str = "",
-        function_args: str = "",
-        function_name: str = "",
-        in_reasoning: bool = False,
-    ) -> Tuple[bool, bool, str, str, bool, Dict[str, int]]:
-        """Process state vars while processing a streaming API response.
-            Returns a tuple consisting of:
-        - is_break: whether to break out of the loop
-        - has_function: whether the response contains a function_call
-        - function_name: name of the function
-        - function_args: args of the function
-        - completion: completion text
-        - reasoning: reasoning text
-        - usage: usage dict
-        """
-        # convert event obj (of type ChatCompletionChunk) to dict so rest of code,
-        # which expects dicts, works as it did before switching to openai v1.x
-        if not isinstance(event, dict):
-            event = event.model_dump()
-
-        usage = event.get("usage", {}) or {}
-        choices = event.get("choices", [{}])
-        if choices is None or len(choices) == 0:
-            choices = [{}]
-        if len(usage) > 0 and len(choices[0]) == 0:
-            # we have a "usage" chunk, and empty choices, so we're done
-            # ASSUMPTION: a usage chunk ONLY arrives AFTER all normal completion text!
-            # If any API does not follow this, we need to change this code.
-            return (
-                True,
-                has_function,
-                function_name,
-                function_args,
-                completion,
-                reasoning,
-                in_reasoning,
-                usage,
-            )
-        event_args = ""
-        event_fn_name = ""
-        event_tool_deltas: Optional[List[Dict[str, Any]]] = None
-        silent = settings.quiet
-        # The first two events in the stream of Azure OpenAI is useless.
-        # In the 1st: choices list is empty, in the 2nd: the dict delta has null content
-        if chat:
-            delta = choices[0].get("delta", {}) or {}
-            # capture both content and reasoning_content
-            event_text = delta.get("content", "")
-            event_reasoning = delta.get(
-                "reasoning_content",
-                delta.get("reasoning", ""),
-            )
-            if "function_call" in delta and delta["function_call"] is not None:
-                if "name" in delta["function_call"]:
-                    event_fn_name = delta["function_call"]["name"]
-                if "arguments" in delta["function_call"]:
-                    event_args = delta["function_call"]["arguments"]
-            if "tool_calls" in delta and delta["tool_calls"] is not None:
-                # it's a list of deltas, usually just one
-                event_tool_deltas = delta["tool_calls"]
-                tool_deltas += event_tool_deltas
-        else:
-            event_text = choices[0]["text"]
-            event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
-
-        finish_reason = choices[0].get("finish_reason", "")
-        if not event_text and finish_reason == "content_filter":
-            filter_names = [
-                n
-                for n, r in choices[0].get("content_filter_results", {}).items()
-                if r.get("filtered")
-            ]
-            event_text = (
-                "Cannot respond due to content filters ["
-                + ", ".join(filter_names)
-                + "]"
-            )
-            logging.warning("LLM API returned content filter error: " + event_text)
-
-        event_text_tokens, event_reasoning_tokens, in_reasoning = (
-            self._split_inline_reasoning(
-                event_text,
-                event_reasoning,
-                in_reasoning,
-                self.config.thought_delimiters,
-            )
-        )
-
-        if event_text:
-            completion += event_text
-        if event_text_tokens:
-            if not silent:
-                sys.stdout.write(Colors().GREEN + event_text_tokens)
-                sys.stdout.flush()
-            self.config.streamer(event_text_tokens, StreamEventType.TEXT)
-
-        if event_reasoning:
-            reasoning += event_reasoning
-        if event_reasoning_tokens:
-            if not silent:
-                sys.stdout.write(Colors().GREEN_DIM + event_reasoning_tokens)
-                sys.stdout.flush()
-            self.config.streamer(event_reasoning_tokens, StreamEventType.REASONING)
-
-        if event_fn_name:
-            function_name = event_fn_name
-            has_function = True
-            if not silent:
-                sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
-                sys.stdout.flush()
-            self.config.streamer(event_fn_name, StreamEventType.FUNC_NAME)
-
-        if event_args:
-            function_args += event_args
-            if not silent:
-                sys.stdout.write(Colors().GREEN + event_args)
-                sys.stdout.flush()
-            self.config.streamer(event_args, StreamEventType.FUNC_ARGS)
-
-        if event_tool_deltas is not None:
-            # print out streaming tool calls, if not async
-            for td in event_tool_deltas:
-                if td["function"]["name"] is not None:
-                    tool_fn_name = td["function"]["name"]
-                    if not silent:
-                        sys.stdout.write(
-                            Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
-                        )
-                        sys.stdout.flush()
-                    self.config.streamer(tool_fn_name, StreamEventType.TOOL_NAME)
-                if td["function"]["arguments"] != "":
-                    tool_fn_args = td["function"]["arguments"]
-                    if not silent:
-                        sys.stdout.write(Colors().GREEN + tool_fn_args)
-                        sys.stdout.flush()
-                    self.config.streamer(tool_fn_args, StreamEventType.TOOL_ARGS)
-
-        # show this delta in the stream
-        is_break = finish_reason in [
-            "stop",
-            "function_call",
-            "tool_calls",
-        ]
-        # for function_call, finish_reason does not necessarily
-        # contain "function_call" as mentioned in the docs.
-        # So we check for "stop" or "function_call" here.
-        return (
-            is_break,
-            has_function,
-            function_name,
-            function_args,
-            completion,
-            reasoning,
-            in_reasoning,
-            usage,
-        )
-
-    @no_type_check
-    async def _process_stream_event_async(
-        self,
-        event,
-        chat: bool = False,
-        tool_deltas: List[Dict[str, Any]] = [],
-        has_function: bool = False,
-        completion: str = "",
-        reasoning: str = "",
-        function_args: str = "",
-        function_name: str = "",
-        in_reasoning: bool = False,
-    ) -> Tuple[bool, bool, str, str, bool, Dict[str, int]]:
-        """Process state vars while processing a streaming API response.
-            Returns a tuple consisting of:
-        - is_break: whether to break out of the loop
-        - has_function: whether the response contains a function_call
-        - function_name: name of the function
-        - function_args: args of the function
-        - completion: completion text
-        - reasoning: reasoning text
-        - usage: usage dict
-        """
-        # convert event obj (of type ChatCompletionChunk) to dict so rest of code,
-        # which expects dicts, works as it did before switching to openai v1.x
-        if not isinstance(event, dict):
-            event = event.model_dump()
-
-        usage = event.get("usage", {}) or {}
-        choices = event.get("choices", [{}])
-        if len(choices) == 0:
-            choices = [{}]
-        if len(usage) > 0 and len(choices[0]) == 0:
-            # we got usage chunk, and empty choices, so we're done
-            return (
-                True,
-                has_function,
-                function_name,
-                function_args,
-                completion,
-                reasoning,
-                in_reasoning,
-                usage,
-            )
-        event_args = ""
-        event_fn_name = ""
-        event_tool_deltas: Optional[List[Dict[str, Any]]] = None
-        silent = self.config.async_stream_quiet or settings.quiet
-        # The first two events in the stream of Azure OpenAI is useless.
-        # In the 1st: choices list is empty, in the 2nd: the dict delta has null content
-        if chat:
-            delta = choices[0].get("delta", {}) or {}
-            event_text = delta.get("content", "")
-            event_reasoning = delta.get(
-                "reasoning_content",
-                delta.get("reasoning", ""),
-            )
-            if "function_call" in delta and delta["function_call"] is not None:
-                if "name" in delta["function_call"]:
-                    event_fn_name = delta["function_call"]["name"]
-                if "arguments" in delta["function_call"]:
-                    event_args = delta["function_call"]["arguments"]
-            if "tool_calls" in delta and delta["tool_calls"] is not None:
-                # it's a list of deltas, usually just one
-                event_tool_deltas = delta["tool_calls"]
-                tool_deltas += event_tool_deltas
-        else:
-            event_text = choices[0]["text"]
-            event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
-
-        event_text_tokens, event_reasoning_tokens, in_reasoning = (
-            self._split_inline_reasoning(
-                event_text,
-                event_reasoning,
-                in_reasoning,
-                self.config.thought_delimiters,
-            )
-        )
-
-        if event_text:
-            completion += event_text
-        if event_text_tokens:
-            if not silent:
-                sys.stdout.write(Colors().GREEN + event_text_tokens)
-                sys.stdout.flush()
-            await self.config.streamer_async(event_text_tokens, StreamEventType.TEXT)
-
-        if event_reasoning:
-            reasoning += event_reasoning
-        if event_reasoning_tokens:
-            if not silent:
-                sys.stdout.write(Colors().GREEN_DIM + event_reasoning_tokens)
-                sys.stdout.flush()
-            await self.config.streamer_async(
-                event_reasoning_tokens, StreamEventType.REASONING
-            )
-
-        if event_fn_name:
-            function_name = event_fn_name
-            has_function = True
-            if not silent:
-                sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
-                sys.stdout.flush()
-            await self.config.streamer_async(event_fn_name, StreamEventType.FUNC_NAME)
-
-        if event_args:
-            function_args += event_args
-            if not silent:
-                sys.stdout.write(Colors().GREEN + event_args)
-                sys.stdout.flush()
-            await self.config.streamer_async(event_args, StreamEventType.FUNC_ARGS)
-
-        if event_tool_deltas is not None:
-            # print out streaming tool calls, if not async
-            for td in event_tool_deltas:
-                if td["function"]["name"] is not None:
-                    tool_fn_name = td["function"]["name"]
-                    if not silent:
-                        sys.stdout.write(
-                            Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
-                        )
-                        sys.stdout.flush()
-                    await self.config.streamer_async(
-                        tool_fn_name, StreamEventType.TOOL_NAME
-                    )
-                if td["function"]["arguments"] != "":
-                    tool_fn_args = td["function"]["arguments"]
-                    if not silent:
-                        sys.stdout.write(Colors().GREEN + tool_fn_args)
-                        sys.stdout.flush()
-                    await self.config.streamer_async(
-                        tool_fn_args, StreamEventType.TOOL_ARGS
-                    )
-
-        # show this delta in the stream
-        is_break = choices[0].get("finish_reason", "") in [
-            "stop",
-            "function_call",
-            "tool_calls",
-        ]
-        # for function_call, finish_reason does not necessarily
-        # contain "function_call" as mentioned in the docs.
-        # So we check for "stop" or "function_call" here.
-        return (
-            is_break,
-            has_function,
-            function_name,
-            function_args,
-            completion,
-            reasoning,
-            in_reasoning,
-            usage,
-        )
-
-    @retry_with_exponential_backoff
-    def _stream_response(  # type: ignore
-        self, response, chat: bool = False
-    ) -> Tuple[LLMResponse, Dict[str, Any]]:
-        """
-        Grab and print streaming response from API.
-        Args:
-            response: event-sequence emitted by API
-            chat: whether in chat-mode (or else completion-mode)
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                Dict version of OpenAIResponse object (with choices, usage)
-
-        """
-        completion = ""
-        reasoning = ""
-        function_args = ""
-        function_name = ""
-
-        sys.stdout.write(Colors().GREEN)
-        sys.stdout.flush()
-        has_function = False
-        tool_deltas: List[Dict[str, Any]] = []
-        token_usage: Dict[str, int] = {}
-        done: bool = False
-        in_reasoning: bool = False  # Track if we're inside reasoning delimiters
-        content_present = False
-        try:
-            for event in response:
-                event_dict = event if isinstance(event, dict) else event.model_dump()
-                choices = event_dict.get("choices") or []
-                if chat and choices:
-                    delta = choices[0].get("delta") or {}
-                    content_present = content_present or (
-                        "content" in delta and delta["content"] is not None
-                    )
-                (
-                    is_break,
-                    has_function,
-                    function_name,
-                    function_args,
-                    completion,
-                    reasoning,
-                    in_reasoning,
-                    usage,
-                ) = self._process_stream_event(
-                    event,
-                    chat=chat,
-                    tool_deltas=tool_deltas,
-                    has_function=has_function,
-                    completion=completion,
-                    reasoning=reasoning,
-                    function_args=function_args,
-                    function_name=function_name,
-                    in_reasoning=in_reasoning,
-                )
-                if len(usage) > 0:
-                    # capture the token usage when non-empty
-                    token_usage = usage
-                if is_break:
-                    if not self.get_stream() or done:
-                        # if not streaming, then we don't wait for last "usage" chunk
-                        break
-                    else:
-                        # mark done, so we quit after the last "usage" chunk
-                        done = True
-
-        except Exception as e:
-            logging.warning("Error while processing stream response: %s", str(e))
-
-        if not settings.quiet:
-            print("")
-        # TODO- get usage info in stream mode (?)
-
-        return self._create_stream_response(
-            chat=chat,
-            tool_deltas=tool_deltas,
-            has_function=has_function,
-            completion=completion,
-            reasoning=reasoning,
-            function_args=function_args,
-            function_name=function_name,
-            usage=token_usage,
-            content_present=content_present,
-        )
-
-    @async_retry_with_exponential_backoff
-    async def _stream_response_async(  # type: ignore
-        self, response, chat: bool = False
-    ) -> Tuple[LLMResponse, Dict[str, Any]]:
-        """
-        Grab and print streaming response from API.
-        Args:
-            response: event-sequence emitted by API
-            chat: whether in chat-mode (or else completion-mode)
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                OpenAIResponse object (with choices, usage)
-
-        """
-
-        completion = ""
-        reasoning = ""
-        function_args = ""
-        function_name = ""
-
-        sys.stdout.write(Colors().GREEN)
-        sys.stdout.flush()
-        has_function = False
-        tool_deltas: List[Dict[str, Any]] = []
-        token_usage: Dict[str, int] = {}
-        done: bool = False
-        in_reasoning: bool = False  # Track if we're inside reasoning delimiters
-        content_present = False
-        try:
-            async for event in response:
-                event_dict = event if isinstance(event, dict) else event.model_dump()
-                choices = event_dict.get("choices") or []
-                if chat and choices:
-                    delta = choices[0].get("delta") or {}
-                    content_present = content_present or (
-                        "content" in delta and delta["content"] is not None
-                    )
-                (
-                    is_break,
-                    has_function,
-                    function_name,
-                    function_args,
-                    completion,
-                    reasoning,
-                    in_reasoning,
-                    usage,
-                ) = await self._process_stream_event_async(
-                    event,
-                    chat=chat,
-                    tool_deltas=tool_deltas,
-                    has_function=has_function,
-                    completion=completion,
-                    reasoning=reasoning,
-                    function_args=function_args,
-                    function_name=function_name,
-                    in_reasoning=in_reasoning,
-                )
-                if len(usage) > 0:
-                    # capture the token usage when non-empty
-                    token_usage = usage
-                if is_break:
-                    if not self.get_stream() or done:
-                        # if not streaming, then we don't wait for last "usage" chunk
-                        break
-                    else:
-                        # mark done, so we quit after the next "usage" chunk
-                        done = True
-
-        except Exception as e:
-            logging.warning("Error while processing stream response: %s", str(e))
-
-        if not settings.quiet:
-            print("")
-        # TODO- get usage info in stream mode (?)
-
-        return self._create_stream_response(
-            chat=chat,
-            tool_deltas=tool_deltas,
-            has_function=has_function,
-            completion=completion,
-            reasoning=reasoning,
-            function_args=function_args,
-            function_name=function_name,
-            usage=token_usage,
-            content_present=content_present,
-        )
-
-    @staticmethod
-    def tool_deltas_to_tools(
-        tools: List[Dict[str, Any]],
-    ) -> Tuple[
-        str,
-        List[OpenAIToolCall],
-        List[Dict[str, Any]],
-    ]:
-        """
-        Convert accumulated tool-call deltas to OpenAIToolCall objects.
-        Adapted from this excellent code:
-         https://community.openai.com/t/help-for-function-calls-with-streaming/627170/2
-
-        Args:
-            tools: list of tool deltas received from streaming API
-
-        Returns:
-            str: plain text corresponding to tool calls that failed to parse
-            List[OpenAIToolCall]: list of OpenAIToolCall objects
-            List[Dict[str, Any]]: list of tool dicts
-                (to reconstruct OpenAI API response, so it can be cached)
-        """
-        # Initialize a dictionary with default values
-
-        # idx -> dict repr of tool
-        # (used to simulate OpenAIResponse object later, and also to
-        # accumulate function args as strings)
-        idx2tool_dict: Dict[str, Dict[str, Any]] = defaultdict(
-            lambda: {
-                "id": None,
-                "function": {"arguments": "", "name": None},
-                "type": None,
-                "extra_content": None,
-            }
-        )
-
-        for tool_delta in tools:
-            if tool_delta["id"] is not None:
-                idx2tool_dict[tool_delta["index"]]["id"] = tool_delta["id"]
-
-            if tool_delta["function"]["name"] is not None:
-                idx2tool_dict[tool_delta["index"]]["function"]["name"] = tool_delta[
-                    "function"
-                ]["name"]
-
-            idx2tool_dict[tool_delta["index"]]["function"]["arguments"] += tool_delta[
-                "function"
-            ]["arguments"]
-
-            if tool_delta["type"] is not None:
-                idx2tool_dict[tool_delta["index"]]["type"] = tool_delta["type"]
-
-            if tool_delta.get("extra_content") is not None:
-                idx2tool_dict[tool_delta["index"]]["extra_content"] = tool_delta[
-                    "extra_content"
-                ]
-
-        # (try to) parse the fn args of each tool
-        contents: List[str] = []
-        good_indices = []
-        id2args: Dict[str, None | Dict[str, Any]] = {}
-        for idx, tool_dict in idx2tool_dict.items():
-            failed_content, args_dict = OpenAIGPT._parse_function_args(
-                tool_dict["function"]["arguments"]
-            )
-            # used to build tool_calls_list below
-            id2args[tool_dict["id"]] = args_dict or None  # if {}, store as None
-            if failed_content != "":
-                contents.append(failed_content)
-            else:
-                good_indices.append(idx)
-
-        # remove the failed tool calls
-        idx2tool_dict = {
-            idx: tool_dict
-            for idx, tool_dict in idx2tool_dict.items()
-            if idx in good_indices
-        }
-
-        # create OpenAIToolCall list
-        tool_calls_list = [
-            OpenAIToolCall(
-                id=tool_dict["id"],
-                function=LLMFunctionCall(
-                    name=tool_dict["function"]["name"],
-                    arguments=id2args.get(tool_dict["id"]),
-                ),
-                type=tool_dict["type"],
-                extra_content=tool_dict.get("extra_content"),
-            )
-            for tool_dict in idx2tool_dict.values()
-        ]
-        return "\n".join(contents), tool_calls_list, list(idx2tool_dict.values())
-
-    @staticmethod
-    def _parse_function_args(args: str) -> Tuple[str, Dict[str, Any]]:
-        """
-        Try to parse the `args` string as function args.
-
-        Args:
-            args: string containing function args
-
-        Returns:
-            Tuple of content, function name and args dict.
-            If parsing unsuccessful, returns the original string as content,
-            else returns the args dict.
-        """
-        content = ""
-        args_dict = {}
-        try:
-            stripped_fn_args = args.strip()
-            dict_or_list = parse_imperfect_json(stripped_fn_args)
-            if not isinstance(dict_or_list, dict):
-                raise ValueError(
-                    f"""
-                        Invalid function args: {stripped_fn_args}
-                        parsed as {dict_or_list},
-                        which is not a valid dict.
-                        """
-                )
-            args_dict = dict_or_list
-        except (SyntaxError, ValueError) as e:
-            logging.warning(
-                f"""
-                    Parsing OpenAI function args failed: {args};
-                    treating args as normal message. Error detail:
-                    {e}
-                    """
-            )
-            content = args
-
-        return content, args_dict
-
-    def _create_stream_response(
-        self,
-        chat: bool = False,
-        tool_deltas: List[Dict[str, Any]] = [],
-        has_function: bool = False,
-        completion: str = "",
-        reasoning: str = "",
-        function_args: str = "",
-        function_name: str = "",
-        usage: Dict[str, int] = {},
-        content_present: bool = False,
-    ) -> Tuple[LLMResponse, Dict[str, Any]]:
-        """
-        Create an LLMResponse object from the streaming API response.
-
-        Args:
-            chat: whether in chat-mode (or else completion-mode)
-            tool_deltas: list of tool deltas received from streaming API
-            has_function: whether the response contains a function_call
-            completion: completion text
-            reasoning: reasoning text
-            function_args: string representing function args
-            function_name: name of the function
-            usage: token usage dict
-            content_present: whether a stream delta explicitly contained content
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                Dict version of OpenAIResponse object (with choices, usage)
-                    (this is needed so we can cache the response, as if it were
-                    a non-streaming response)
-        """
-        # check if function_call args are valid, if not,
-        # treat this as a normal msg, not a function call
-        args: Dict[str, Any] = {}
-        if has_function and function_args != "":
-            content, args = self._parse_function_args(function_args)
-            completion = completion + content
-            if content != "":
-                has_function = False
-
-        # mock openai response so we can cache it
-        if chat:
-            failed_content, tool_calls, tool_dicts = OpenAIGPT.tool_deltas_to_tools(
-                tool_deltas,
-            )
-            if failed_content:
-                completion += ("\n" if completion else "") + failed_content
-                content_present = True
-            has_valid_call = len(tool_dicts) > 0 or has_function
-            response_content = (
-                None
-                if has_valid_call and not content_present and completion == ""
-                else completion
-            )
-            msg: Dict[str, Any] = dict(
-                message=dict(
-                    content=response_content,
-                    reasoning_content=reasoning,
-                ),
-            )
-            if len(tool_dicts) > 0:
-                msg["message"]["tool_calls"] = tool_dicts
-
-            if has_function:
-                function_call = LLMFunctionCall(name=function_name)
-                function_call_dict = function_call.model_dump()
-                if function_args == "":
-                    function_call.arguments = None
-                else:
-                    function_call.arguments = args
-                    function_call_dict.update({"arguments": function_args.strip()})
-                msg["message"]["function_call"] = function_call_dict
-        else:
-            # non-chat mode has no function_call
-            msg = dict(text=completion)
-            response_content = completion
-            # TODO: Ignoring reasoning content for non-chat models
-
-        # create an OpenAIResponse object so we can cache it as if it were
-        # a non-streaming response
-        openai_response = OpenAIResponse(
-            choices=[msg],
-            usage=dict(total_tokens=0),
-        )
-        # Track whether we extracted inline thought tags from the text.
-        # Only set message_with_reasoning when get_reasoning_final()
-        # actually finds and extracts inline tags (e.g. <think>...</think>).
-        # When reasoning is already provided via a separate API field
-        # (e.g. reasoning_content), the message text doesn't contain
-        # thought signatures, so there's nothing extra to preserve.
-        message_with_reasoning = None
-        message: str | None
-        if reasoning == "" and response_content is not None:
-            # some LLM APIs may not return a separate reasoning field,
-            # and the reasoning may be included in the message content
-            # within delimiters like <think> ... </think>
-            reasoning, message = self.get_reasoning_final(response_content)
-            if reasoning:
-                # Inline tags were found and extracted; preserve the
-                # original text so it can be restored in message history.
-                message_with_reasoning = response_content
-        else:
-            message = response_content
-
-        prompt_tokens = usage.get("prompt_tokens", 0)
-        prompt_tokens_details: Any = usage.get("prompt_tokens_details", {})
-        cached_tokens = (
-            prompt_tokens_details.get("cached_tokens", 0)
-            if isinstance(prompt_tokens_details, dict)
-            else 0
-        )
-        completion_tokens = usage.get("completion_tokens", 0)
-
-        return (
-            LLMResponse(
-                message=message,
-                reasoning=reasoning,
-                message_with_reasoning=message_with_reasoning,
-                cached=False,
-                # don't allow empty list [] here
-                oai_tool_calls=tool_calls or None if len(tool_deltas) > 0 else None,
-                function_call=function_call if has_function else None,
-                usage=LLMTokenUsage(
-                    prompt_tokens=prompt_tokens or 0,
-                    cached_tokens=cached_tokens or 0,
-                    completion_tokens=completion_tokens or 0,
-                    cost=self._cost_chat_model(
-                        prompt_tokens or 0,
-                        cached_tokens or 0,
-                        completion_tokens or 0,
-                    ),
-                ),
-            ),
-            openai_response.model_dump(),
-        )
-
-    def _cache_store(self, k: str, v: Any) -> None:
-        if self.cache is None:
-            return
-        try:
-            self.cache.store(k, v)
-        except Exception as e:
-            logging.error(f"Error in OpenAIGPT._cache_store: {e}")
-            pass
-
-    def _cache_lookup(self, fn_name: str, **kwargs: Dict[str, Any]) -> Tuple[str, Any]:
-        if self.cache is None:
-            return "", None  # no cache, return empty key and None result
-        # Use the kwargs as the cache key
-        sorted_kwargs_str = str(sorted(kwargs.items()))
-        raw_key = f"{fn_name}:{sorted_kwargs_str}"
-
-        # Hash the key to a fixed length using SHA256
-        hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
-
-        if not settings.cache:
-            # when caching disabled, return the hashed_key and none result
-            return hashed_key, None
-        # Try to get the result from the cache
-        try:
-            cached_val = self.cache.retrieve(hashed_key)
-        except Exception as e:
-            logging.error(f"Error in OpenAIGPT._cache_lookup: {e}")
-            return hashed_key, None
-        return hashed_key, cached_val
-
-    def _cost_chat_model(self, prompt: int, cached: int, completion: int) -> float:
-        price = self.chat_cost()
-        return (
-            price[0] * (prompt - cached) + price[1] * cached + price[2] * completion
-        ) / 1000
-
-    def _get_non_stream_token_usage(
-        self, cached: bool, response: Dict[str, Any]
-    ) -> LLMTokenUsage:
-        """
-        Extracts token usage from ``response`` and computes cost, only when NOT
-        in streaming mode, since the LLM API (OpenAI currently) was not
-        populating the usage fields in streaming mode (but as of Sep 2024, streaming
-        responses include  usage info as well, so we should update the code
-        to directly use usage information from the streaming response, which is more
-        accurate, esp with "thinking" LLMs like o1 series which consume
-        thinking tokens).
-        In streaming mode, these are set to zero for
-        now, and will be updated later by the fn ``update_token_usage``.
-        """
-        cost = 0.0
-        prompt_tokens = 0
-        cached_tokens = 0
-        completion_tokens = 0
-
-        usage = response.get("usage")
-        if not cached and not self.get_stream() and usage is not None:
-            prompt_tokens = usage.get("prompt_tokens") or 0
-            prompt_tokens_details = usage.get("prompt_tokens_details", {}) or {}
-            cached_tokens = prompt_tokens_details.get("cached_tokens") or 0
-            completion_tokens = usage.get("completion_tokens") or 0
-            cost = self._cost_chat_model(
-                prompt_tokens or 0,
-                cached_tokens or 0,
-                completion_tokens or 0,
-            )
-
-        return LLMTokenUsage(
-            prompt_tokens=prompt_tokens,
-            cached_tokens=cached_tokens,
-            completion_tokens=completion_tokens,
-            cost=cost,
-        )
-
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        self.run_on_first_use()
-
-        try:
-            return self._generate(prompt, max_tokens)
-        except openai.APIStatusError as e:
-            # Catch HTTP-level API errors (400, 401, 403, 404, 422, 429, 5xx)
-            # without traceback — these originate server-side and a local
-            # stack trace adds no diagnostic value.
-            # Note: APIConnectionError/APITimeoutError are intentionally NOT
-            # caught here so they fall through to the generic handler below,
-            # where the full traceback aids in diagnosing local network issues.
-            logging.error(f"API error in OpenAIGPT.generate: {e}")
-            raise
-        except Exception as e:
-            # log and re-raise exception
-            logging.error(friendly_error(e, "Error in OpenAIGPT.generate: "))
-            raise
-
-    def _generate(self, prompt: str, max_tokens: int) -> LLMResponse:
-        if self.config.use_chat_for_completion:
-            return self.chat(messages=prompt, max_tokens=max_tokens)
-
-        if self.is_groq or self.is_cerebras:
-            raise ValueError("Groq, Cerebras do not support pure completions")
-
-        if settings.debug:
-            print(f"[grey37]PROMPT: {escape(prompt)}[/grey37]")
-
-        @retry_with_exponential_backoff
-        def completions_with_backoff(**kwargs):  # type: ignore
-            cached = False
-            hashed_key, result = self._cache_lookup("Completion", **kwargs)
-            if result is not None:
-                cached = True
-                if settings.debug:
-                    print("[grey37]CACHED[/grey37]")
-            else:
-                if self.config.litellm:
-                    from litellm import completion as litellm_completion
-
-                    completion_call = litellm_completion
-
-                    if self.api_key != DUMMY_API_KEY:
-                        kwargs["api_key"] = self.api_key
-                else:
-                    if self.client is None:
-                        raise ValueError(
-                            "OpenAI/equivalent chat-completion client not set"
-                        )
-                    assert isinstance(self.client, OpenAI)
-                    completion_call = self.client.completions.create
-                if self.config.litellm and settings.debug:
-                    kwargs["logger_fn"] = litellm_logging_fn
-                # If it's not in the cache, call the API
-                result = completion_call(**kwargs)
-                if self.get_stream():
-                    llm_response, openai_response = self._stream_response(
-                        result,
-                        chat=self.config.litellm,
-                    )
-                    self._cache_store(hashed_key, openai_response)
-                    return cached, hashed_key, openai_response
-                else:
-                    self._cache_store(hashed_key, result.model_dump())
-            return cached, hashed_key, result
-
-        kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
-        if self.config.litellm:
-            # TODO this is a temp fix, we should really be using a proper completion fn
-            # that takes a pre-formatted prompt, rather than mocking it as a sys msg.
-            kwargs["messages"] = [dict(content=prompt, role=Role.SYSTEM)]
-        else:  # any other OpenAI-compatible endpoint
-            kwargs["prompt"] = prompt
-        args = dict(
-            **kwargs,
-            max_tokens=max_tokens,  # for output/completion
-            stream=self.get_stream(),
-        )
-        args = self._openai_api_call_params(args)
-        cached, hashed_key, response = completions_with_backoff(**args)
-        # assume response is an actual response rather than a streaming event
-        if not isinstance(response, dict):
-            response = response.model_dump()
-        if "message" in response["choices"][0]:
-            msg = (response["choices"][0]["message"]["content"] or "").strip()
-        else:
-            msg = (response["choices"][0]["text"] or "").strip()
-        return LLMResponse(message=msg, cached=cached)
-
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        self.run_on_first_use()
-
-        try:
-            return await self._agenerate(prompt, max_tokens)
-        except openai.APIStatusError as e:
-            # Catch HTTP-level API errors (see comment in generate() above).
-            logging.error(f"API error in OpenAIGPT.agenerate: {e}")
-            raise
-        except Exception as e:
-            # log and re-raise exception
-            logging.error(friendly_error(e, "Error in OpenAIGPT.agenerate: "))
-            raise
-
-    async def _agenerate(self, prompt: str, max_tokens: int) -> LLMResponse:
-        # note we typically will not have self.config.stream = True
-        # when issuing several api calls concurrently/asynchronously.
-        # The calling fn should use the context `with Streaming(..., False)` to
-        # disable streaming.
-        if self.config.use_chat_for_completion:
-            return await self.achat(messages=prompt, max_tokens=max_tokens)
-
-        if self.is_groq or self.is_cerebras:
-            raise ValueError("Groq, Cerebras do not support pure completions")
-
-        if settings.debug:
-            print(f"[grey37]PROMPT: {escape(prompt)}[/grey37]")
-
-        # WARNING: .Completion.* endpoints are deprecated,
-        # and as of Sep 2023 only legacy models will work here,
-        # e.g. text-davinci-003, text-ada-001.
-        @async_retry_with_exponential_backoff
-        async def completions_with_backoff(**kwargs):  # type: ignore
-            cached = False
-            hashed_key, result = self._cache_lookup("AsyncCompletion", **kwargs)
-            if result is not None:
-                cached = True
-                if settings.debug:
-                    print("[grey37]CACHED[/grey37]")
-            else:
-                if self.config.litellm:
-                    from litellm import acompletion as litellm_acompletion
-
-                    if self.api_key != DUMMY_API_KEY:
-                        kwargs["api_key"] = self.api_key
-
-                # TODO this may not work: text_completion is not async,
-                # and we didn't find an async version in litellm
-                assert isinstance(self.async_client, AsyncOpenAI)
-                acompletion_call = (
-                    litellm_acompletion
-                    if self.config.litellm
-                    else self.async_client.completions.create
-                )
-                if self.config.litellm and settings.debug:
-                    kwargs["logger_fn"] = litellm_logging_fn
-                # If it's not in the cache, call the API
-                result = await acompletion_call(**kwargs)
-                self._cache_store(hashed_key, result.model_dump())
-            return cached, hashed_key, result
-
-        kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
-        if self.config.litellm:
-            # TODO this is a temp fix, we should really be using a proper completion fn
-            # that takes a pre-formatted prompt, rather than mocking it as a sys msg.
-            kwargs["messages"] = [dict(content=prompt, role=Role.SYSTEM)]
-        else:  # any other OpenAI-compatible endpoint
-            kwargs["prompt"] = prompt
-        cached, hashed_key, response = await completions_with_backoff(
-            **kwargs,
-            max_tokens=max_tokens,
-            stream=False,
-        )
-        # assume response is an actual response rather than a streaming event
-        if not isinstance(response, dict):
-            response = response.model_dump()
-        if "message" in response["choices"][0]:
-            msg = (response["choices"][0]["message"]["content"] or "").strip()
-        else:
-            msg = (response["choices"][0]["text"] or "").strip()
-        return LLMResponse(message=msg, cached=cached)
-
-    def chat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        self.run_on_first_use()
-
-        if self.config.use_completion_for_chat and not self.is_openai_chat_model():
-            # only makes sense for non-OpenAI models
-            if self.config.formatter is None or self.config.hf_formatter is None:
-                raise ValueError(
-                    """
-                    `formatter` must be specified in config to use completion for chat.
-                    """
-                )
-            if isinstance(messages, str):
-                messages = [
-                    LLMMessage(
-                        role=Role.SYSTEM, content="You are a helpful assistant."
-                    ),
-                    LLMMessage(role=Role.USER, content=messages),
-                ]
-            prompt = self.config.hf_formatter.format(messages)
-            return self.generate(prompt=prompt, max_tokens=max_tokens)
-        try:
-            return self._chat(
-                messages,
-                max_tokens,
-                tools,
-                tool_choice,
-                functions,
-                function_call,
-                response_format,
-            )
-        except openai.APIStatusError as e:
-            # Catch HTTP-level API errors (see comment in generate() above).
-            logging.error(f"API error in OpenAIGPT.chat: {e}")
-            raise
-        except Exception as e:
-            # log and re-raise exception
-            logging.error(friendly_error(e, "Error in OpenAIGPT.chat: "))
-            raise
-
-    async def achat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        self.run_on_first_use()
-
-        # turn off streaming for async calls
-        if (
-            self.config.use_completion_for_chat
-            and not self.is_openai_chat_model()
-            and not self.is_openai_completion_model()
-        ):
-            # only makes sense for local models, where we are trying to
-            # convert a chat dialog msg-sequence to a simple completion prompt.
-            if self.config.formatter is None:
-                raise ValueError(
-                    """
-                    `formatter` must be specified in config to use completion for chat.
-                    """
-                )
-            formatter = HFFormatter(
-                HFPromptFormatterConfig(model_name=self.config.formatter)
-            )
-            if isinstance(messages, str):
-                messages = [
-                    LLMMessage(
-                        role=Role.SYSTEM, content="You are a helpful assistant."
-                    ),
-                    LLMMessage(role=Role.USER, content=messages),
-                ]
-            prompt = formatter.format(messages)
-            return await self.agenerate(prompt=prompt, max_tokens=max_tokens)
-        try:
-            result = await self._achat(
-                messages,
-                max_tokens,
-                tools,
-                tool_choice,
-                functions,
-                function_call,
-                response_format,
-            )
-            return result
-        except openai.APIStatusError as e:
-            # Catch HTTP-level API errors (see comment in generate() above).
-            logging.error(f"API error in OpenAIGPT.achat: {e}")
-            raise
-        except Exception as e:
-            # log and re-raise exception
-            logging.error(friendly_error(e, "Error in OpenAIGPT.achat: "))
-            raise
-
-    def _chat_completions_with_backoff_body(self, **kwargs):  # type: ignore
-        cached = False
-        hashed_key, result = self._cache_lookup("Completion", **kwargs)
-        if result is not None:
-            cached = True
-            if settings.debug:
-                print("[grey37]CACHED[/grey37]")
-        else:
-            # If it's not in the cache, call the API
-            if self.config.litellm:
-                from litellm import completion as litellm_completion
-
-                completion_call = litellm_completion
-
-                if self.api_key != DUMMY_API_KEY:
-                    kwargs["api_key"] = self.api_key
-            else:
-                if self.client is None:
-                    raise ValueError("OpenAI/equivalent chat-completion client not set")
-                completion_call = self.client.chat.completions.create
-            if self.config.litellm and settings.debug:
-                kwargs["logger_fn"] = litellm_logging_fn
-            result = completion_call(**kwargs)
-
-            if self.get_stream():
-                # If streaming, cannot cache result
-                # since it is a generator. Instead,
-                # we hold on to the hashed_key and
-                # cache the result later
-
-                # Test if this is a stream with an exception by
-                # trying to get first chunk: Some providers like LiteLLM
-                # produce a valid stream object `result` instead of throwing a
-                # rate-limit error, and if we don't catch it here,
-                # we end up returning an empty response and not
-                # using the retry mechanism in the decorator.
-                try:
-                    # try to get the first chunk to check for errors
-                    test_iter = iter(result)
-                    first_chunk = next(test_iter)
-                    # If we get here without error, recreate the stream
-                    result = chain([first_chunk], test_iter)
-                except StopIteration:
-                    # Empty stream is fine
-                    pass
-                except Exception as e:
-                    # Propagate any errors in the stream
-                    raise e
-            else:
-                self._cache_store(hashed_key, result.model_dump())
-        return cached, hashed_key, result
-
-    def _chat_completions_with_backoff(self, **kwargs):  # type: ignore
-        retry_func = retry_with_exponential_backoff(
-            self._chat_completions_with_backoff_body,
-            initial_delay=self.config.retry_params.initial_delay,
-            max_retries=self.config.retry_params.max_retries,
-            exponential_base=self.config.retry_params.exponential_base,
-            jitter=self.config.retry_params.jitter,
-        )
-        return retry_func(**kwargs)
-
-    async def _achat_completions_with_backoff_body(self, **kwargs):  # type: ignore
-        cached = False
-        hashed_key, result = self._cache_lookup("Completion", **kwargs)
-        if result is not None:
-            cached = True
-            if settings.debug:
-                print("[grey37]CACHED[/grey37]")
-        else:
-            if self.config.litellm:
-                from litellm import acompletion as litellm_acompletion
-
-                acompletion_call = litellm_acompletion
-
-                if self.api_key != DUMMY_API_KEY:
-                    kwargs["api_key"] = self.api_key
-            else:
-                if self.async_client is None:
-                    raise ValueError(
-                        "OpenAI/equivalent async chat-completion client not set"
-                    )
-                acompletion_call = self.async_client.chat.completions.create
-            if self.config.litellm and settings.debug:
-                kwargs["logger_fn"] = litellm_logging_fn
-            # If it's not in the cache, call the API
-            result = await acompletion_call(**kwargs)
-            if self.get_stream():
-                try:
-                    # Try to peek at the first chunk to immediately catch any errors
-                    # Store the original result (the stream)
-                    original_stream = result
-
-                    # Manually create and advance the iterator to check for errors
-                    stream_iter = original_stream.__aiter__()
-                    try:
-                        # This will raise an exception if the stream is invalid
-                        first_chunk = await anext(stream_iter)
-
-                        # If we reach here, the stream started successfully
-                        # Now recreate a fresh stream from the original API result
-                        # Otherwise, return a new stream that yields the first chunk
-                        # and remaining items
-                        async def combined_stream():  # type: ignore
-                            yield first_chunk
-                            async for chunk in stream_iter:
-                                yield chunk
-
-                        result = combined_stream()  # type: ignore
-                    except StopAsyncIteration:
-                        # Empty stream is normal - nothing to do
-                        pass
-                except Exception as e:
-                    # Any exception here should be raised to trigger the retry mechanism
-                    raise e
-            else:
-                self._cache_store(hashed_key, result.model_dump())
-        return cached, hashed_key, result
-
-    async def _achat_completions_with_backoff(self, **kwargs):  # type: ignore
-        retry_func = async_retry_with_exponential_backoff(
-            self._achat_completions_with_backoff_body,
-            initial_delay=self.config.retry_params.initial_delay,
-            max_retries=self.config.retry_params.max_retries,
-            exponential_base=self.config.retry_params.exponential_base,
-            jitter=self.config.retry_params.jitter,
-        )
-        return await retry_func(**kwargs)
-
-    def _prep_chat_completion(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> Dict[str, Any]:
-        """Prepare args for LLM chat-completion API call"""
-        if isinstance(messages, str):
-            llm_messages = [
-                LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
-                LLMMessage(role=Role.USER, content=messages),
-            ]
-        else:
-            llm_messages = messages
-            if (
-                len(llm_messages) == 1
-                and llm_messages[0].role == Role.SYSTEM
-                # TODO: we will unconditionally insert a dummy user msg
-                # if the only msg is a system msg.
-                # We could make this conditional on ModelInfo.needs_first_user_message
-            ):
-                # some LLMs, notable Gemini as of 12/11/24,
-                # require the first message to be from the user,
-                # so insert a dummy user msg if needed.
-                llm_messages.insert(
-                    1,
-                    LLMMessage(
-                        role=Role.USER, content="Follow the above instructions."
-                    ),
-                )
-
-        chat_model = self.config.chat_model
-
-        args: Dict[str, Any] = dict(
-            model=chat_model,
-            messages=[
-                m.api_dict(
-                    self.config.chat_model,
-                    has_system_role=self.info().allows_system_message,
-                )
-                for m in (llm_messages)
-            ],
-            max_completion_tokens=max_tokens,
-            stream=self.get_stream(),
-        )
-        if self.get_stream() and "groq" not in self.chat_model_orig:
-            # groq fails when we include stream_options in the request
-            args.update(
-                dict(
-                    # get token-usage numbers in stream mode from OpenAI API,
-                    # and possibly other OpenAI-compatible APIs.
-                    stream_options=dict(include_usage=True),
-                )
-            )
-        args.update(self._openai_api_call_params(args))
-        # only include functions-related args if functions are provided
-        # since the OpenAI API will throw an error if `functions` is None or []
-        if functions is not None:
-            args.update(
-                dict(
-                    functions=[f.model_dump() for f in functions],
-                    function_call=function_call,
-                )
-            )
-        if tools is not None:
-            if self.config.parallel_tool_calls is not None:
-                args["parallel_tool_calls"] = self.config.parallel_tool_calls
-
-            if any(t.strict for t in tools) and (
-                self.config.parallel_tool_calls is None
-                or self.config.parallel_tool_calls
-            ):
-                parallel_strict_warning()
-            args.update(
-                dict(
-                    tools=[
-                        dict(
-                            type="function",
-                            function=t.function.model_dump()
-                            | ({"strict": t.strict} if t.strict is not None else {}),
-                        )
-                        for t in tools
-                    ],
-                    tool_choice=tool_choice,
-                )
-            )
-        if response_format is not None:
-            args["response_format"] = response_format.to_dict()
-
-        for p in self.unsupported_params():
-            # some models e.g. o1-mini (as of sep 2024) don't support some params,
-            # like temperature and stream, so we need to remove them.
-            args.pop(p, None)
-
-        param_rename_map = self.rename_params()
-        for old_param, new_param in param_rename_map.items():
-            if old_param in args:
-                args[new_param] = args.pop(old_param)
-
-        # finally, get rid of extra_body params exclusive to certain models
-        # Only apply allowlist restrictions for known models.
-        # Unknown/custom models are allowed to use all params by default.
-        is_known_model = self.info().name != "unknown"
-        extra_params = args.get("extra_body", {})
-        if extra_params and is_known_model:
-            for param, model_list in OpenAI_API_ParamInfo().extra_parameters.items():
-                if (
-                    self.config.chat_model not in model_list
-                    and self.chat_model_orig not in model_list
-                ):
-                    extra_params.pop(param, None)
-            if extra_params:
-                args["extra_body"] = extra_params
-        return args
-
-    def _process_chat_completion_response(
-        self,
-        cached: bool,
-        response: Dict[str, Any],
-    ) -> LLMResponse:
-        # openAI response will look like this:
-        """
-        {
-            "id": "chatcmpl-123",
-            "object": "chat.completion",
-            "created": 1677652288,
-            "choices": [{
-                "index": 0,
-                "message": {
-                    "role": "assistant",
-                    "name": "",
-                    "content": "\n\nHello there, how may I help you?",
-                    "reasoning_content": "Okay, let's see here, hmmm...",
-                    "function_call": {
-                        "name": "fun_name",
-                        "arguments: {
-                            "arg1": "val1",
-                            "arg2": "val2"
-                        }
-                    },
-                },
-                "finish_reason": "stop"
-            }],
-            "usage": {
-                "prompt_tokens": 9,
-                "completion_tokens": 12,
-                "total_tokens": 21
-            }
-        }
-        """
-        choices = response.get("choices")
-        if isinstance(choices, list) and len(choices) > 0:
-            message = choices[0].get("message", {})
-        else:
-            message = {}
-        if message is None:
-            message = {}
-        content = message.get("content")
-        reasoning = message.get("reasoning_content", "")
-        # Track whether we extracted inline thought tags from the text.
-        # Only set message_with_reasoning when get_reasoning_final()
-        # actually finds and extracts inline tags (e.g. <think>...</think>).
-        # When reasoning is already provided via a separate API field
-        # (e.g. reasoning_content), the message text doesn't contain
-        # thought signatures, so there's nothing extra to preserve.
-        message_with_reasoning = None
-        if reasoning == "" and content is not None:
-            # some LLM APIs may not return a separate reasoning field,
-            # and the reasoning may be included in the message content
-            # within delimiters like <think> ... </think>
-            reasoning, msg = self.get_reasoning_final(content)
-            if reasoning:
-                # Inline tags were found and extracted; preserve the
-                # original text so it can be restored in message history.
-                message_with_reasoning = content
-        else:
-            msg = content
-
-        if message.get("function_call") is None:
-            fun_call = None
-        else:
-            try:
-                fun_call = LLMFunctionCall.from_dict(message["function_call"])
-            except (ValueError, SyntaxError):
-                logging.warning(
-                    "Could not parse function arguments: "
-                    f"{message['function_call']['arguments']} "
-                    f"for function {message['function_call']['name']} "
-                    "treating as normal non-function message"
-                )
-                fun_call = None
-                args_str = message["function_call"]["arguments"] or ""
-                msg_str = message["content"] or ""
-                msg = msg_str + args_str
-        oai_tool_calls = None
-        if message.get("tool_calls") is not None:
-            oai_tool_calls = []
-            for tool_call_dict in message["tool_calls"]:
-                try:
-                    tool_call = OpenAIToolCall.from_dict(tool_call_dict)
-                    oai_tool_calls.append(tool_call)
-                except (ValueError, SyntaxError):
-                    logging.warning(
-                        "Could not parse tool call: "
-                        f"{json.dumps(tool_call_dict)} "
-                        "treating as normal non-tool message"
-                    )
-                    serialized_tool_call = json.dumps(tool_call_dict)
-                    msg = (msg or "") + ("\n" if msg else "") + serialized_tool_call
-        return LLMResponse(
-            # None (no content, e.g. a tool-call-only response) is preserved as
-            # None rather than coerced to "", so the distinction survives
-            # downstream (see LLMMessage.content / ChatDocument.content_is_none).
-            message=msg.strip() if msg is not None else None,
-            reasoning=reasoning.strip() if reasoning is not None else "",
-            message_with_reasoning=message_with_reasoning,
-            function_call=fun_call,
-            oai_tool_calls=oai_tool_calls or None,  # don't allow empty list [] here
-            cached=cached,
-            usage=self._get_non_stream_token_usage(cached, response),
-        )
-
-    def _chat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """
-        ChatCompletion API call to OpenAI.
-        Args:
-            messages: list of messages  to send to the API, typically
-                represents back and forth dialogue between user and LLM, but could
-                also include "function"-role messages. If messages is a string,
-                it is assumed to be a user message.
-            max_tokens: max output tokens to generate
-            functions: list of LLMFunction specs available to the LLM, to possibly
-                use in its response
-            function_call: controls how the LLM uses `functions`:
-                - "auto": LLM decides whether to use `functions` or not,
-                - "none": LLM blocked from using any function
-                - a dict of {"name": "function_name"} which forces the LLM to use
-                    the specified function.
-        Returns:
-            LLMResponse object
-        """
-        args = self._prep_chat_completion(
-            messages,
-            max_tokens,
-            tools,
-            tool_choice,
-            functions,
-            function_call,
-            response_format,
-        )
-        cached, hashed_key, response = self._chat_completions_with_backoff(**args)  # type: ignore
-        if self.get_stream() and not cached:
-            llm_response, openai_response = self._stream_response(response, chat=True)
-            self._cache_store(hashed_key, openai_response)
-            return llm_response  # type: ignore
-        if isinstance(response, dict):
-            response_dict = response
-        else:
-            response_dict = response.model_dump()
-        return self._process_chat_completion_response(cached, response_dict)
-
-    async def _achat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """
-        Async version of _chat(). See that function for details.
-        """
-        args = self._prep_chat_completion(
-            messages,
-            max_tokens,
-            tools,
-            tool_choice,
-            functions,
-            function_call,
-            response_format,
-        )
-        cached, hashed_key, response = await self._achat_completions_with_backoff(  # type: ignore
-            **args
-        )
-        if self.get_stream() and not cached:
-            llm_response, openai_response = await self._stream_response_async(
-                response, chat=True
-            )
-            self._cache_store(hashed_key, openai_response)
-            return llm_response  # type: ignore
-        if isinstance(response, dict):
-            response_dict = response
-        else:
-            response_dict = response.model_dump()
-        return self._process_chat_completion_response(cached, response_dict)
-</file>
-
 <file path=".pre-commit-config.yaml">
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -95963,6 +96154,7 @@ nav:
       - Context-Overflow Handling: notes/context-overflow.md
       - Batch Processing: notes/batch-processing.md
       - Attachment Token Preflight: notes/attachment-token-preflight.md
+      - Vector-Store Env Prefixes: notes/vecstore-env-prefix.md
 
   - Examples:
     - Guide: examples/guide.md

--- a/llms.txt
+++ b/llms.txt
@@ -154,6 +154,7 @@ docs/
     tool-message-handler.md
     twitter-search.md
     url_loader.md
+    vecstore-env-prefix.md
     weaviate.md
     xml-tools.md
   overrides/
@@ -790,6 +791,7 @@ tests/
     test_tool_origin_taint.py
     test_tool_taint_laundering.py
     test_url_loader.py
+    test_vecstore_env_prefix.py
     test_vector_stores.py
     test_web_search_tools.py
     test_xml_tool_message.py
@@ -5207,6 +5209,207 @@ config = OpenAIGPTConfig(
 - Implements singleton pattern with lazy initialization
 - Automatically cleans up clients on program exit via atexit hooks
 - Compatible with both sync and async OpenAI clients
+</file>
+
+<file path="docs/notes/openai-http-client.md">
+# OpenAI HTTP Client Configuration
+
+When using OpenAI models through Langroid in corporate environments or behind proxies, you may encounter SSL certificate verification errors. Langroid provides three flexible options to configure the HTTP client used for OpenAI API calls.
+
+## Configuration Options
+
+### 1. Simple SSL Verification Bypass
+
+The quickest solution for development or trusted environments:
+
+```python
+import langroid.language_models as lm
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_verify_ssl=False  # Disables SSL certificate verification
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+!!! warning "Security Notice"
+    Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks. Only use this in trusted environments.
+
+### 2. HTTP Client Configuration Dictionary
+
+For common scenarios like proxies or custom certificates, use a configuration dictionary:
+
+```python
+import langroid.language_models as lm
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_config={
+        "verify": False,  # Or path to CA bundle: "/path/to/ca-bundle.pem"
+        "proxy": "http://proxy.company.com:8080",
+        "timeout": 30.0,
+        "headers": {
+            "User-Agent": "MyApp/1.0"
+        }
+    }
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+**Benefits**: This approach enables client caching, improving performance when creating multiple agents.
+
+### 3. Custom HTTP Client Factory
+
+For advanced scenarios requiring dynamic behavior or custom authentication:
+
+```python
+import langroid.language_models as lm
+from httpx import Client
+
+def create_custom_client():
+    """Factory function to create a custom HTTP client."""
+    client = Client(
+        verify="/path/to/corporate-ca-bundle.pem",
+        proxies={
+            "http": "http://proxy.corp.com:8080",
+            "https": "http://proxy.corp.com:8080"
+        },
+        timeout=30.0
+    )
+
+    # Add custom event hooks for logging
+    def log_request(request):
+        print(f"API Request: {request.method} {request.url}")
+
+    client.event_hooks = {"request": [log_request]}
+
+    return client
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_factory=create_custom_client
+)
+
+llm = lm.OpenAIGPT(config)
+```
+
+If you are using `async` methods, return a tuple of `(Client, AsyncClient)` from your factory:
+
+```python
+from httpx import AsyncClient, Client
+
+def create_custom_client():
+    """Factory function to create a custom sync and async HTTP clients."""
+    client_args = {
+        "verify": "/path/to/corporate-ca-bundle.pem",
+        "proxy": "http://proxy.corp.com:8080",
+        "timeout": 30.0,
+    }
+    client = Client(**client_args)
+    async_client = AsyncClient(**client_args)
+
+    return client, async_client
+```
+
+**Note**: Custom factories bypass client caching. Each `OpenAIGPT` instance creates a new client.
+
+## Priority Order
+
+When multiple options are specified, they are applied in this order:
+1. `http_client_factory` (highest priority)
+2. `http_client_config`
+3. `http_verify_ssl` (lowest priority)
+
+## Common Use Cases
+
+### Corporate Proxy with Custom CA Certificate
+
+```python
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_config={
+        "verify": "/path/to/corporate-ca-bundle.pem",
+        "proxies": {
+            "http": "http://proxy.corp.com:8080",
+            "https": "https://proxy.corp.com:8443"
+        }
+    }
+)
+```
+
+### Debugging API Calls
+
+```python
+def debug_client_factory():
+    from httpx import Client
+
+    client = Client(verify=False)
+
+    def log_response(response):
+        print(f"Status: {response.status_code}")
+        print(f"Headers: {response.headers}")
+
+    client.event_hooks = {
+        "response": [log_response]
+    }
+
+    return client
+
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    http_client_factory=debug_client_factory
+)
+```
+
+### Local Development with Self-Signed Certificates
+
+```python
+# For local OpenAI-compatible APIs
+config = lm.OpenAIGPTConfig(
+    chat_model="gpt-4",
+    api_base="https://localhost:8443/v1",
+    http_verify_ssl=False
+)
+```
+
+
+## Best Practices
+
+1. **Use the simplest option that meets your needs**:
+   - Development/testing: `http_verify_ssl=False`
+   - Corporate environments: `http_client_config` with proper CA bundle
+   - Complex requirements: `http_client_factory`
+
+2. **Prefer configuration over factories for better performance** - configured clients are cached and reused
+
+3. **Always use proper CA certificates in production** instead of disabling SSL verification
+
+4. **Test your configuration** with a simple API call before deploying:
+   ```python
+   llm = lm.OpenAIGPT(config)
+   response = llm.chat("Hello")
+   print(response.content)
+   ```
+
+## Troubleshooting
+
+### SSL Certificate Errors
+```
+ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
+```
+**Solution**: Use one of the three configuration options above.
+
+
+### Proxy Connection Issues
+- Verify proxy URL format: `http://proxy:port` or `https://proxy:port`
+- Check if proxy requires authentication
+- Ensure proxy allows connections to `api.openai.com`
+
+## See Also
+
+- [OpenAI API Reference](https://platform.openai.com/docs/api-reference) - Official OpenAI documentation
 </file>
 
 <file path="docs/notes/overview.md">
@@ -51359,148 +51562,6 @@ __all__ = [
 ]
 </file>
 
-<file path="langroid/utils/configuration.py">
-import os
-import threading
-from contextlib import contextmanager
-from typing import Any, Dict, Iterator, List, Literal, cast
-
-from dotenv import find_dotenv, load_dotenv
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
-# Global reentrant lock to serialize any modifications to the global settings.
-_global_lock = threading.RLock()
-
-
-class Settings(BaseSettings):
-    debug: bool = False  # show debug messages?
-    max_turns: int = -1  # maximum number of turns in a task (to avoid inf loop)
-    progress: bool = False  # show progress spinners/bars?
-    stream: bool = True  # stream output?
-    cache: bool = True  # use cache?
-    cache_type: Literal["redis", "fakeredis", "none"] = "redis"  # cache type
-    chat_model: str = ""  # language model name, e.g. litellm/ollama/llama2
-    quiet: bool = False  # quiet mode (i.e. suppress all output)?
-    notebook: bool = False  # running in a notebook?
-
-    model_config = SettingsConfigDict(extra="forbid")
-
-
-# Load environment variables from .env file.
-load_dotenv(find_dotenv(usecwd=True))
-
-# The global (default) settings instance.
-# This is updated by update_global_settings() and set_global().
-_global_settings = Settings()
-
-# Thread-local storage for temporary (per-thread) settings overrides.
-_thread_local = threading.local()
-
-
-class SettingsProxy:
-    """
-    A proxy for the settings that returns a thread‐local override if set,
-    or else falls back to the global settings.
-    """
-
-    def __getattr__(self, name: str) -> Any:
-        # If the calling thread has set an override, use that.
-        if hasattr(_thread_local, "override"):
-            return getattr(_thread_local.override, name)
-        return getattr(_global_settings, name)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        # All writes go to the global settings.
-        setattr(_global_settings, name, value)
-
-    def update(self, new_settings: Settings) -> None:
-        _global_settings.__dict__.update(new_settings.__dict__)
-
-    def dict(self) -> Dict[str, Any]:
-        # Return a dict view of the settings as seen by the caller.
-        # Note that temporary overrides are not “merged” with global settings.
-        if hasattr(_thread_local, "override"):
-            return cast(
-                Dict[str, Any], cast(Settings, _thread_local.override.model_dump())
-            )
-        return _global_settings.model_dump()
-
-
-settings = SettingsProxy()
-
-
-def update_global_settings(cfg: BaseSettings, keys: List[str]) -> None:
-    """
-    Update global settings so that modules can later access them via, e.g.,
-
-        from langroid.utils.configuration import settings
-        if settings.debug: ...
-
-    This updates the global default.
-    """
-    config_dict = cfg.model_dump()
-    filtered_config = {key: config_dict[key] for key in keys if key in config_dict}
-    new_settings = Settings(**filtered_config)
-    _global_settings.__dict__.update(new_settings.__dict__)
-
-
-def set_global(key_vals: Settings) -> None:
-    """
-    Update the global settings object.
-    """
-    _global_settings.__dict__.update(key_vals.__dict__)
-
-
-@contextmanager
-def temporary_settings(temp_settings: Settings) -> Iterator[None]:
-    """
-    Temporarily override the settings for the calling thread.
-
-    Within the context, any access to "settings" will use the provided temporary
-    settings. Once the context is exited, the thread reverts to the global settings.
-    """
-    saved = getattr(_thread_local, "override", None)
-    _thread_local.override = temp_settings
-    try:
-        yield
-    finally:
-        if saved is not None:
-            _thread_local.override = saved
-        else:
-            del _thread_local.override
-
-
-@contextmanager
-def quiet_mode(quiet: bool = True) -> Iterator[None]:
-    """
-    Temporarily override settings.quiet for the current thread.
-    This implementation builds on the thread‑local temporary_settings context manager.
-    The effective quiet mode is merged:
-    if quiet is already True (from an outer context),
-    then it remains True even if a nested context passes quiet=False.
-    """
-    current_effective = (
-        settings.model_dump()
-    )  # get the current thread's effective settings
-    # Create a new settings instance from the current effective state.
-    temp = Settings(**current_effective)
-    # Merge the new flag: once quiet is enabled, it stays enabled.
-    temp.quiet = settings.quiet or quiet
-    with temporary_settings(temp):
-        yield
-
-
-def set_env(settings_instance: BaseSettings) -> None:
-    """
-    Set environment variables from a BaseSettings instance.
-
-    Each field in the settings is written to os.environ.
-    """
-    for field_name, field in settings_instance.__class__.model_fields.items():
-        env_var_name = field.alias or field_name.upper()
-        os.environ[env_var_name] = str(settings_instance.model_dump()[field_name])
-</file>
-
 <file path="langroid/utils/constants.py">
 from pydantic import BaseModel
 
@@ -74530,207 +74591,6 @@ matches = agent.vecdb.similar_texts_with_scores(
 ```
 </file>
 
-<file path="docs/notes/openai-http-client.md">
-# OpenAI HTTP Client Configuration
-
-When using OpenAI models through Langroid in corporate environments or behind proxies, you may encounter SSL certificate verification errors. Langroid provides three flexible options to configure the HTTP client used for OpenAI API calls.
-
-## Configuration Options
-
-### 1. Simple SSL Verification Bypass
-
-The quickest solution for development or trusted environments:
-
-```python
-import langroid.language_models as lm
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_verify_ssl=False  # Disables SSL certificate verification
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-!!! warning "Security Notice"
-    Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks. Only use this in trusted environments.
-
-### 2. HTTP Client Configuration Dictionary
-
-For common scenarios like proxies or custom certificates, use a configuration dictionary:
-
-```python
-import langroid.language_models as lm
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_config={
-        "verify": False,  # Or path to CA bundle: "/path/to/ca-bundle.pem"
-        "proxy": "http://proxy.company.com:8080",
-        "timeout": 30.0,
-        "headers": {
-            "User-Agent": "MyApp/1.0"
-        }
-    }
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-**Benefits**: This approach enables client caching, improving performance when creating multiple agents.
-
-### 3. Custom HTTP Client Factory
-
-For advanced scenarios requiring dynamic behavior or custom authentication:
-
-```python
-import langroid.language_models as lm
-from httpx import Client
-
-def create_custom_client():
-    """Factory function to create a custom HTTP client."""
-    client = Client(
-        verify="/path/to/corporate-ca-bundle.pem",
-        proxies={
-            "http": "http://proxy.corp.com:8080",
-            "https": "http://proxy.corp.com:8080"
-        },
-        timeout=30.0
-    )
-
-    # Add custom event hooks for logging
-    def log_request(request):
-        print(f"API Request: {request.method} {request.url}")
-
-    client.event_hooks = {"request": [log_request]}
-
-    return client
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_factory=create_custom_client
-)
-
-llm = lm.OpenAIGPT(config)
-```
-
-If you are using `async` methods, return a tuple of `(Client, AsyncClient)` from your factory:
-
-```python
-from httpx import AsyncClient, Client
-
-def create_custom_client():
-    """Factory function to create a custom sync and async HTTP clients."""
-    client_args = {
-        "verify": "/path/to/corporate-ca-bundle.pem",
-        "proxy": "http://proxy.corp.com:8080",
-        "timeout": 30.0,
-    }
-    client = Client(**client_args)
-    async_client = AsyncClient(**client_args)
-
-    return client, async_client
-```
-
-**Note**: Custom factories bypass client caching. Each `OpenAIGPT` instance creates a new client.
-
-## Priority Order
-
-When multiple options are specified, they are applied in this order:
-1. `http_client_factory` (highest priority)
-2. `http_client_config`
-3. `http_verify_ssl` (lowest priority)
-
-## Common Use Cases
-
-### Corporate Proxy with Custom CA Certificate
-
-```python
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_config={
-        "verify": "/path/to/corporate-ca-bundle.pem",
-        "proxies": {
-            "http": "http://proxy.corp.com:8080",
-            "https": "https://proxy.corp.com:8443"
-        }
-    }
-)
-```
-
-### Debugging API Calls
-
-```python
-def debug_client_factory():
-    from httpx import Client
-
-    client = Client(verify=False)
-
-    def log_response(response):
-        print(f"Status: {response.status_code}")
-        print(f"Headers: {response.headers}")
-
-    client.event_hooks = {
-        "response": [log_response]
-    }
-
-    return client
-
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    http_client_factory=debug_client_factory
-)
-```
-
-### Local Development with Self-Signed Certificates
-
-```python
-# For local OpenAI-compatible APIs
-config = lm.OpenAIGPTConfig(
-    chat_model="gpt-4",
-    api_base="https://localhost:8443/v1",
-    http_verify_ssl=False
-)
-```
-
-
-## Best Practices
-
-1. **Use the simplest option that meets your needs**:
-   - Development/testing: `http_verify_ssl=False`
-   - Corporate environments: `http_client_config` with proper CA bundle
-   - Complex requirements: `http_client_factory`
-
-2. **Prefer configuration over factories for better performance** - configured clients are cached and reused
-
-3. **Always use proper CA certificates in production** instead of disabling SSL verification
-
-4. **Test your configuration** with a simple API call before deploying:
-   ```python
-   llm = lm.OpenAIGPT(config)
-   response = llm.chat("Hello")
-   print(response.content)
-   ```
-
-## Troubleshooting
-
-### SSL Certificate Errors
-```
-ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
-```
-**Solution**: Use one of the three configuration options above.
-
-
-### Proxy Connection Issues
-- Verify proxy URL format: `http://proxy:port` or `https://proxy:port`
-- Check if proxy requires authentication
-- Ensure proxy allows connections to `api.openai.com`
-
-## See Also
-
-- [OpenAI API Reference](https://platform.openai.com/docs/api-reference) - Official OpenAI documentation
-</file>
-
 <file path="docs/notes/rotating-api-keys.md">
 # Rotating / Short-Lived API Keys
 
@@ -83972,6 +83832,152 @@ def seltz_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
     return results
 </file>
 
+<file path="langroid/utils/configuration.py">
+import os
+import threading
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Literal, cast
+
+from dotenv import find_dotenv, load_dotenv
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Global reentrant lock to serialize any modifications to the global settings.
+_global_lock = threading.RLock()
+
+
+class Settings(BaseSettings):
+    debug: bool = False  # show debug messages?
+    max_turns: int = -1  # maximum number of turns in a task (to avoid inf loop)
+    progress: bool = False  # show progress spinners/bars?
+    stream: bool = True  # stream output?
+    cache: bool = True  # use cache?
+    cache_type: Literal["redis", "fakeredis", "none"] = "redis"  # cache type
+    chat_model: str = ""  # language model name, e.g. litellm/ollama/llama2
+    quiet: bool = False  # quiet mode (i.e. suppress all output)?
+    notebook: bool = False  # running in a notebook?
+
+    model_config = SettingsConfigDict(extra="forbid")
+
+
+# Load environment variables from .env file.
+load_dotenv(find_dotenv(usecwd=True))
+
+# The global (default) settings instance.
+# This is updated by update_global_settings() and set_global().
+_global_settings = Settings()
+
+# Thread-local storage for temporary (per-thread) settings overrides.
+_thread_local = threading.local()
+
+
+class SettingsProxy:
+    """
+    A proxy for the settings that returns a thread‐local override if set,
+    or else falls back to the global settings.
+    """
+
+    def __getattr__(self, name: str) -> Any:
+        # If the calling thread has set an override, use that.
+        if hasattr(_thread_local, "override"):
+            return getattr(_thread_local.override, name)
+        return getattr(_global_settings, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        # All writes go to the global settings.
+        setattr(_global_settings, name, value)
+
+    def update(self, new_settings: Settings) -> None:
+        _global_settings.__dict__.update(new_settings.__dict__)
+
+    def dict(self) -> Dict[str, Any]:
+        # Return a dict view of the settings as seen by the caller.
+        # Note that temporary overrides are not “merged” with global settings.
+        if hasattr(_thread_local, "override"):
+            return cast(
+                Dict[str, Any], cast(Settings, _thread_local.override.model_dump())
+            )
+        return _global_settings.model_dump()
+
+
+settings = SettingsProxy()
+
+
+def update_global_settings(cfg: BaseSettings, keys: List[str]) -> None:
+    """
+    Update global settings so that modules can later access them via, e.g.,
+
+        from langroid.utils.configuration import settings
+        if settings.debug: ...
+
+    This updates the global default.
+    """
+    config_dict = cfg.model_dump()
+    filtered_config = {key: config_dict[key] for key in keys if key in config_dict}
+    new_settings = Settings(**filtered_config)
+    _global_settings.__dict__.update(new_settings.__dict__)
+
+
+def set_global(key_vals: Settings) -> None:
+    """
+    Update the global settings object.
+    """
+    _global_settings.__dict__.update(key_vals.__dict__)
+
+
+@contextmanager
+def temporary_settings(temp_settings: Settings) -> Iterator[None]:
+    """
+    Temporarily override the settings for the calling thread.
+
+    Within the context, any access to "settings" will use the provided temporary
+    settings. Once the context is exited, the thread reverts to the global settings.
+    """
+    saved = getattr(_thread_local, "override", None)
+    _thread_local.override = temp_settings
+    try:
+        yield
+    finally:
+        if saved is not None:
+            _thread_local.override = saved
+        else:
+            del _thread_local.override
+
+
+@contextmanager
+def quiet_mode(quiet: bool = True) -> Iterator[None]:
+    """
+    Temporarily override settings.quiet for the current thread.
+    This implementation builds on the thread‑local temporary_settings context manager.
+    The effective quiet mode is merged:
+    if quiet is already True (from an outer context),
+    then it remains True even if a nested context passes quiet=False.
+    """
+    current_effective = (
+        settings.model_dump()
+    )  # get the current thread's effective settings
+    # Create a new settings instance from the current effective state.
+    temp = Settings(**current_effective)
+    # Merge the new flag: once quiet is enabled, it stays enabled.
+    temp.quiet = settings.quiet or quiet
+    with temporary_settings(temp):
+        yield
+
+
+def set_env(settings_instance: BaseSettings) -> None:
+    """
+    Set environment variables from a BaseSettings instance.
+
+    Each field in the settings is written to os.environ, under the name
+    the settings class itself reads: `<env_prefix><FIELD_NAME_UPPER>`,
+    or the field's explicit alias (which, per pydantic-settings
+    semantics, is the full env name and is not prefixed).
+    """
+    env_prefix = settings_instance.model_config.get("env_prefix", "")
+    for field_name, field in settings_instance.__class__.model_fields.items():
+        env_var_name = field.alias or f"{env_prefix}{field_name.upper()}"
+        os.environ[env_var_name] = str(settings_instance.model_dump()[field_name])
+</file>
+
 <file path="langroid/utils/pandas_utils.py">
 import ast
 from typing import Any, Dict
@@ -85386,945 +85392,6 @@ except ImportError:
     pass
 </file>
 
-<file path="langroid/vector_store/chromadb.py">
-import json
-import logging
-from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
-
-from langroid.embedding_models.base import (
-    EmbeddingModelsConfig,
-)
-from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.exceptions import LangroidImportError
-from langroid.mytypes import Document
-from langroid.utils.configuration import settings
-from langroid.utils.output.printing import print_long_text
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-logger = logging.getLogger(__name__)
-
-
-class ChromaDBConfig(VectorStoreConfig):
-    collection_name: str = "temp"
-    storage_path: str = ".chroma/data"
-    distance: Literal["cosine", "l2", "ip"] = "cosine"
-    construction_ef: int = 100
-    search_ef: int = 100
-    max_neighbors: int = 16
-    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    host: str = "127.0.0.1"
-    port: int = 6333
-
-
-class ChromaDB(VectorStore):
-    def __init__(self, config: ChromaDBConfig | None = None):
-        config = config if config is not None else ChromaDBConfig()
-        super().__init__(config)
-        try:
-            import chromadb
-        except ImportError:
-            raise LangroidImportError("chromadb", "chromadb")
-        self.config = config
-        self.client = chromadb.Client(
-            chromadb.config.Settings(
-                # chroma_db_impl="duckdb+parquet",
-                # is_persistent=bool(config.storage_path),
-                persist_directory=config.storage_path,
-            )
-        )
-        if self.config.collection_name is not None:
-            self.create_collection(
-                self.config.collection_name,
-                replace=self.config.replace_collection,
-            )
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """Clear all collections in the vector store with the given prefix."""
-
-        if not really:
-            logger.warning("Not deleting all collections, set really=True to confirm")
-            return 0
-        coll = [c for c in self.client.list_collections() if c.name.startswith(prefix)]
-        if len(coll) == 0:
-            logger.warning(f"No collections found with prefix {prefix}")
-            return 0
-        n_empty_deletes = 0
-        n_non_empty_deletes = 0
-        for c in coll:
-            n_empty_deletes += c.count() == 0
-            n_non_empty_deletes += c.count() > 0
-            self.client.delete_collection(name=c.name)
-        logger.warning(
-            f"""
-            Deleted {n_empty_deletes} empty collections and
-            {n_non_empty_deletes} non-empty collections.
-            """
-        )
-        return n_empty_deletes + n_non_empty_deletes
-
-    def clear_empty_collections(self) -> int:
-        colls = self.client.list_collections()
-        n_deletes = 0
-        for coll in colls:
-            if coll.count() == 0:
-                n_deletes += 1
-                self.client.delete_collection(name=coll.name)
-        return n_deletes
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """
-        List non-empty collections in the vector store.
-        Args:
-            empty (bool, optional): Whether to list empty collections.
-        Returns:
-            List[str]: List of non-empty collection names.
-        """
-        colls = self.client.list_collections()
-        if empty:
-            return [coll.name for coll in colls]
-        return [coll.name for coll in colls if coll.count() > 0]
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        """
-        Create a collection in the vector store, optionally replacing an existing
-            collection if `replace` is True.
-        Args:
-            collection_name (str): Name of the collection to create or replace.
-            replace (bool, optional): Whether to replace an existing collection.
-                Defaults to False.
-
-        """
-        self.config.collection_name = collection_name
-        if collection_name in self.list_collections(empty=True) and replace:
-            logger.warning(f"Replacing existing collection {collection_name}")
-            self.client.delete_collection(collection_name)
-        self.collection = self.client.create_collection(
-            name=self.config.collection_name,
-            embedding_function=self.embedding_fn,
-            get_or_create=not replace,
-            metadata={
-                "hnsw:space": self.config.distance,
-                "hnsw:construction_ef": self.config.construction_ef,
-                "hnsw:search_ef": self.config.search_ef,
-                # we could expose other configs, see:
-                # https://docs.trychroma.com/docs/collections/configure
-            },
-        )
-
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        super().maybe_add_ids(documents)
-        if documents is None:
-            return
-        contents: List[str] = [document.content for document in documents]
-        # convert metadatas to dicts so chroma can handle them
-        metadata_dicts: List[dict[str, Any]] = [
-            d.metadata.dict_bool_int() for d in documents
-        ]
-        for m in metadata_dicts:
-            # chroma does not handle non-atomic types in metadata
-            m["window_ids"] = ",".join(m["window_ids"])
-
-        ids = [str(d.id()) for d in documents]
-
-        colls = self.list_collections(empty=True)
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-        if self.config.collection_name not in colls:
-            self.create_collection(self.config.collection_name, replace=True)
-
-        self.collection.add(
-            # embedding_models=embedding_models,
-            documents=contents,
-            metadatas=metadata_dicts,
-            ids=ids,
-        )
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        filter = json.loads(where) if where else None
-        results = self.collection.get(
-            include=["documents", "metadatas"],
-            where=filter,
-        )
-        results["documents"] = [results["documents"]]
-        results["metadatas"] = [results["metadatas"]]
-        return self._docs_from_results(results)
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        # get them one by one since chroma mangles the order of the results
-        # when fetched from a list of ids.
-        results = [
-            self.collection.get(ids=[id], include=["documents", "metadatas"])
-            for id in ids
-        ]
-        final_results = {}
-        final_results["documents"] = [[r["documents"][0] for r in results]]
-        final_results["metadatas"] = [[r["metadatas"][0] for r in results]]
-        return self._docs_from_results(final_results)
-
-    def delete_collection(self, collection_name: str) -> None:
-        try:
-            self.client.delete_collection(name=collection_name)
-        except Exception:
-            pass
-
-    def similar_texts_with_scores(
-        self, text: str, k: int = 1, where: Optional[str] = None
-    ) -> List[Tuple[Document, float]]:
-        n = self.collection.count()
-        filter = json.loads(where) if where else None
-        results = self.collection.query(
-            query_texts=[text],
-            n_results=min(n, k),
-            where=filter,
-            include=["documents", "distances", "metadatas"],
-        )
-        docs = self._docs_from_results(results)
-        # chroma distances are 1 - cosine.
-        scores = [1 - s for s in results["distances"][0]]
-        return list(zip(docs, scores))
-
-    def _docs_from_results(self, results: Dict[str, Any]) -> List[Document]:
-        """
-        Helper function to convert results from ChromaDB to a list of Documents
-        Args:
-            results (dict): results from ChromaDB
-
-        Returns:
-            List[Document]: list of Documents
-        """
-        if len(results["documents"][0]) == 0:
-            return []
-        contents = results["documents"][0]
-        if settings.debug:
-            for i, c in enumerate(contents):
-                print_long_text("red", "italic red", f"MATCH-{i}", c)
-        metadatas = results["metadatas"][0]
-        for m in metadatas:
-            # restore the stringified list of window_ids into the original List[str]
-            if m["window_ids"].strip() == "":
-                m["window_ids"] = []
-            else:
-                m["window_ids"] = m["window_ids"].split(",")
-        docs = [
-            self.config.document_class(
-                content=d, metadata=self.config.metadata_class(**m)
-            )
-            for d, m in zip(contents, metadatas)
-        ]
-        return docs
-</file>
-
-<file path="langroid/vector_store/lancedb.py">
-from __future__ import annotations
-
-import logging
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Generator,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-)
-
-import pandas as pd
-from dotenv import load_dotenv
-from pydantic import BaseModel, ValidationError, create_model
-
-if TYPE_CHECKING:
-    from lancedb.query import LanceVectorQueryBuilder
-
-from langroid.embedding_models.base import (
-    EmbeddingModelsConfig,
-)
-from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.exceptions import LangroidImportError
-from langroid.mytypes import Document
-from langroid.utils.configuration import settings
-from langroid.utils.pydantic_utils import (
-    dataframe_to_document_model,
-    dataframe_to_documents,
-)
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-try:
-    import lancedb
-    from lancedb.pydantic import LanceModel, Vector
-
-    has_lancedb = True
-except ImportError:
-    has_lancedb = False
-
-logger = logging.getLogger(__name__)
-
-
-class LanceDBConfig(VectorStoreConfig):
-    cloud: bool = False
-    collection_name: str | None = "temp"
-    storage_path: str = ".lancedb/data"
-    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    distance: str = "cosine"
-
-
-class LanceDB(VectorStore):
-    def __init__(self, config: LanceDBConfig | None = None):
-        config = config if config is not None else LanceDBConfig()
-        super().__init__(config)
-        if not has_lancedb:
-            raise LangroidImportError("lancedb", "lancedb")
-
-        self.config: LanceDBConfig = config
-        self.host = config.host
-        self.port = config.port
-        self.is_from_dataframe = False  # were docs ingested from a dataframe?
-        self.df_metadata_columns: List[str] = []  # metadata columns from dataframe
-
-        load_dotenv()
-        if self.config.cloud:
-            logger.warning(
-                "LanceDB Cloud is not available yet. Switching to local storage."
-            )
-            config.cloud = False
-        else:
-            try:
-                self.client = lancedb.connect(
-                    uri=config.storage_path,
-                )
-            except Exception as e:
-                new_storage_path = config.storage_path + ".new"
-                logger.warning(
-                    f"""
-                    Error connecting to local LanceDB at {config.storage_path}:
-                    {e}
-                    Switching to {new_storage_path}
-                    """
-                )
-                self.client = lancedb.connect(
-                    uri=new_storage_path,
-                )
-
-    def clear_empty_collections(self) -> int:
-        coll_names = self.list_collections()
-        n_deletes = 0
-        for name in coll_names:
-            nr = self.client.open_table(name).head(1).shape[0]
-            if nr == 0:
-                n_deletes += 1
-                self.client.drop_table(name)
-        return n_deletes
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """Clear all collections with the given prefix."""
-        if not really:
-            logger.warning("Not deleting all collections, set really=True to confirm")
-            return 0
-        coll_names = [
-            c for c in self.list_collections(empty=True) if c.startswith(prefix)
-        ]
-        if len(coll_names) == 0:
-            logger.warning(f"No collections found with prefix {prefix}")
-            return 0
-        n_empty_deletes = 0
-        n_non_empty_deletes = 0
-        for name in coll_names:
-            nr = self.client.open_table(name).head(1).shape[0]
-            n_empty_deletes += nr == 0
-            n_non_empty_deletes += nr > 0
-            self.client.drop_table(name)
-        logger.warning(
-            f"""
-            Deleted {n_empty_deletes} empty collections and
-            {n_non_empty_deletes} non-empty collections.
-            """
-        )
-        return n_empty_deletes + n_non_empty_deletes
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """
-        Returns:
-            List of collection names that have at least one vector.
-
-        Args:
-            empty (bool, optional): Whether to include empty collections.
-        """
-        colls = self.client.table_names(limit=None)
-        if len(colls) == 0:
-            return []
-        if empty:  # include empty tbls
-            return colls  # type: ignore
-        counts = [self.client.open_table(coll).head(1).shape[0] for coll in colls]
-        return [coll for coll, count in zip(colls, counts) if count > 0]
-
-    def _create_lance_schema(self, doc_cls: Type[Document]) -> Type[BaseModel]:
-        """
-        NOTE: NOT USED, but leaving it here as it may be useful.
-
-        Create a subclass of LanceModel with fields:
-         - id (str)
-         - Vector field that has dims equal to
-            the embedding dimension of the embedding model, and a data field of type
-            DocClass.
-         - other fields from doc_cls
-
-        Args:
-            doc_cls (Type[Document]): A Pydantic model which should be a subclass of
-                Document, to be used as the type for the data field.
-
-        Returns:
-            Type[BaseModel]: A new Pydantic model subclassing from LanceModel.
-
-        Raises:
-            ValueError: If `n` is not a non-negative integer or if `DocClass` is not a
-                subclass of Document.
-        """
-        if not issubclass(doc_cls, Document):
-            raise ValueError("DocClass must be a subclass of Document")
-
-        if not has_lancedb:
-            raise LangroidImportError("lancedb", "lancedb")
-
-        n = self.embedding_dim
-
-        # Prepare fields for the new model
-        fields = {"id": (str, ...), "vector": (Vector(n), ...)}
-
-        sorted_fields = dict(
-            sorted(doc_cls.model_fields.items(), key=lambda item: item[0])
-        )
-        # Add both statically and dynamically defined fields from doc_cls
-        for field_name, field in sorted_fields.items():
-            field_type = field.annotation if hasattr(field, "annotation") else field
-            fields[field_name] = (field_type, field.default)
-
-        # Create the new model with dynamic fields
-        NewModel = create_model(
-            "NewModel", __base__=LanceModel, **fields
-        )  # type: ignore
-        return NewModel  # type: ignore
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        self.config.replace_collection = replace
-        self.config.collection_name = collection_name
-        if replace:
-            self.delete_collection(collection_name)
-
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        super().maybe_add_ids(documents)
-        colls = self.list_collections(empty=True)
-        if len(documents) == 0:
-            return
-        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-        coll_name = self.config.collection_name
-        if coll_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-        # self._maybe_set_doc_class_schema(documents[0])
-        table_exists = False
-        if (
-            coll_name in colls
-            and self.client.open_table(coll_name).head(1).shape[0] > 0
-        ):
-            # collection exists and  is not empty:
-            # if replace_collection is True, we'll overwrite the existing collection,
-            # else we'll append to it.
-            if self.config.replace_collection:
-                self.client.drop_table(coll_name)
-            else:
-                table_exists = True
-
-        ids = [str(d.id()) for d in documents]
-        # don't insert all at once, batch in chunks of b,
-        # else we get an API error
-        b = self.config.batch_size
-
-        def make_batches() -> Generator[List[Dict[str, Any]], None, None]:
-            for i in range(0, len(ids), b):
-                batch = [
-                    dict(
-                        id=ids[i + j],
-                        vector=embedding_vecs[i + j],
-                        **doc.model_dump(),
-                    )
-                    for j, doc in enumerate(documents[i : i + b])
-                ]
-                yield batch
-
-        try:
-            if table_exists:
-                tbl = self.client.open_table(coll_name)
-                tbl.add(make_batches())
-            else:
-                batch_gen = make_batches()
-                batch = next(batch_gen)
-                # use first batch to create table...
-                tbl = self.client.create_table(
-                    coll_name,
-                    data=batch,
-                    mode="create",
-                )
-                # ... and add the rest
-                tbl.add(batch_gen)
-        except Exception as e:
-            logger.error(
-                f"""
-                Error adding documents to LanceDB: {e}
-                POSSIBLE REMEDY: Delete the LancdDB storage directory
-                {self.config.storage_path} and try again.
-                """
-            )
-
-    def add_dataframe(
-        self,
-        df: pd.DataFrame,
-        content: str = "content",
-        metadata: List[str] = [],
-    ) -> None:
-        """
-        Add a dataframe to the collection.
-        Args:
-            df (pd.DataFrame): A dataframe
-            content (str): The name of the column in the dataframe that contains the
-                text content to be embedded using the embedding model.
-            metadata (List[str]): A list of column names in the dataframe that contain
-                metadata to be stored in the database. Defaults to [].
-        """
-        self.is_from_dataframe = True
-        actual_metadata = metadata.copy()
-        self.df_metadata_columns = actual_metadata  # could be updated below
-        # get content column
-        content_values = df[content].values.tolist()
-        embedding_vecs = self.embedding_fn(content_values)
-
-        # add vector column
-        df["vector"] = embedding_vecs
-        if content != "content":
-            # rename content column to "content", leave existing column intact
-            df = df.rename(columns={content: "content"}, inplace=False)
-
-        if "id" not in df.columns:
-            docs = dataframe_to_documents(df, content="content", metadata=metadata)
-            ids = [str(d.id()) for d in docs]
-            df["id"] = ids
-
-        if "id" not in actual_metadata:
-            actual_metadata += ["id"]
-
-        colls = self.list_collections(empty=True)
-        coll_name = self.config.collection_name
-        if (
-            coll_name not in colls
-            or self.client.open_table(coll_name).head(1).shape[0] == 0
-        ):
-            # collection either doesn't exist or is empty, so replace it
-            # and set new schema from df
-            self.client.create_table(
-                self.config.collection_name,
-                data=df,
-                mode="overwrite",
-            )
-            doc_cls = dataframe_to_document_model(
-                df,
-                content=content,
-                metadata=actual_metadata,
-                exclude=["vector"],
-            )
-            self.config.document_class = doc_cls  # type: ignore
-        else:
-            # collection exists and is not empty, so append to it
-            tbl = self.client.open_table(self.config.collection_name)
-            tbl.add(df)
-
-    def delete_collection(self, collection_name: str) -> None:
-        self.client.drop_table(collection_name, ignore_missing=True)
-
-    def _lance_result_to_docs(
-        self, result: "LanceVectorQueryBuilder"
-    ) -> List[Document]:
-        if self.is_from_dataframe:
-            df = result.to_pandas()
-            return dataframe_to_documents(
-                df,
-                content="content",
-                metadata=self.df_metadata_columns,
-                doc_cls=self.config.document_class,
-            )
-        else:
-            records = result.to_arrow().to_pylist()
-            return self._records_to_docs(records)
-
-    def _records_to_docs(self, records: List[Dict[str, Any]]) -> List[Document]:
-        try:
-            docs = [self.config.document_class(**rec) for rec in records]
-        except ValidationError as e:
-            raise ValueError(
-                f"""
-            Error validating LanceDB result: {e}
-            HINT: This could happen when you're re-using an
-            existing LanceDB store with a different schema.
-            Try deleting your local lancedb storage at `{self.config.storage_path}`
-            re-ingesting your documents and/or replacing the collections.
-            """
-            )
-        return docs
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        if self.config.collection_name not in self.list_collections(empty=True):
-            return []
-        tbl = self.client.open_table(self.config.collection_name)
-        pre_result = tbl.search(None).where(where or None).limit(None)
-        return self._lance_result_to_docs(pre_result)
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        _ids = [str(id) for id in ids]
-        tbl = self.client.open_table(self.config.collection_name)
-        docs = []
-        for _id in _ids:
-            results = self._lance_result_to_docs(tbl.search().where(f"id == '{_id}'"))
-            if len(results) > 0:
-                docs.append(results[0])
-        return docs
-
-    def similar_texts_with_scores(
-        self,
-        text: str,
-        k: int = 1,
-        where: Optional[str] = None,
-    ) -> List[Tuple[Document, float]]:
-        embedding = self.embedding_fn([text])[0]
-        tbl = self.client.open_table(self.config.collection_name)
-        result = (
-            tbl.search(embedding)
-            .metric(self.config.distance)
-            .where(where, prefilter=True)
-            .limit(k)
-        )
-        docs = self._lance_result_to_docs(result)
-        # note _distance is 1 - cosine
-        if self.is_from_dataframe:
-            scores = [
-                1 - rec["_distance"] for rec in result.to_pandas().to_dict("records")
-            ]
-        else:
-            scores = [1 - rec["_distance"] for rec in result.to_arrow().to_pylist()]
-        if len(docs) == 0:
-            logger.warning(f"No matches found for {text}")
-            return []
-        if settings.debug:
-            logger.info(f"Found {len(docs)} matches, max score: {max(scores)}")
-        doc_score_pairs = list(zip(docs, scores))
-        self.show_if_debug(doc_score_pairs)
-        return doc_score_pairs
-</file>
-
-<file path="langroid/vector_store/meilisearch.py">
-"""
-MeiliSearch as a pure document store, without its
-(experimental) vector-store functionality.
-We aim to use MeiliSearch for fast lexical search.
-Note that what we call "Collection" in Langroid is referred to as
-"Index" in MeiliSearch. Each data-store has its own terminology,
-but for uniformity we use the Langroid terminology here.
-"""
-
-from __future__ import annotations
-
-import asyncio
-import logging
-import os
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple
-
-from dotenv import load_dotenv
-
-if TYPE_CHECKING:
-    from meilisearch_python_sdk.index import AsyncIndex
-    from meilisearch_python_sdk.models.documents import DocumentsInfo
-
-
-from langroid.exceptions import LangroidImportError
-from langroid.mytypes import DocMetaData, Document
-from langroid.utils.configuration import settings
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-logger = logging.getLogger(__name__)
-
-
-class MeiliSearchConfig(VectorStoreConfig):
-    cloud: bool = False
-    collection_name: str | None = None
-    primary_key: str = "id"
-    port: int = 7700
-
-
-class MeiliSearch(VectorStore):
-    def __init__(self, config: MeiliSearchConfig | None = None):
-        config = config if config is not None else MeiliSearchConfig()
-        super().__init__(config)
-        try:
-            import meilisearch_python_sdk as meilisearch
-        except ImportError:
-            raise LangroidImportError("meilisearch", "meilisearch")
-
-        self.config: MeiliSearchConfig = config
-        self.host = config.host
-        self.port = config.port
-        load_dotenv()
-        self.key = os.getenv("MEILISEARCH_API_KEY") or "masterKey"
-        self.url = os.getenv("MEILISEARCH_API_URL") or f"http://{self.host}:{self.port}"
-        if config.cloud and None in [self.key, self.url]:
-            logger.warning(
-                f"""MEILISEARCH_API_KEY, MEILISEARCH_API_URL env variable must be set 
-                to use MeiliSearch in cloud mode. Please set these values 
-                in your .env file. Switching to local MeiliSearch at 
-                {self.url} 
-                """
-            )
-            config.cloud = False
-
-        self.client: Callable[[], meilisearch.AsyncClient] = lambda: (
-            meilisearch.AsyncClient(url=self.url, api_key=self.key)
-        )
-
-        # Note: Only create collection if a non-null collection name is provided.
-        # This is useful to delay creation of db until we have a suitable
-        # collection name (e.g. we could get it from the url or folder path).
-        if config.collection_name is not None:
-            self.create_collection(
-                config.collection_name, replace=config.replace_collection
-            )
-
-    def clear_empty_collections(self) -> int:
-        """All collections are treated as non-empty in MeiliSearch, so this is a
-        no-op"""
-        return 0
-
-    async def _async_delete_indices(self, uids: List[str]) -> List[bool]:
-        """Delete any indicecs in `uids` that exist.
-        Returns list of bools indicating whether the index has been deleted"""
-        async with self.client() as client:
-            result = await asyncio.gather(
-                *[client.delete_index_if_exists(uid=uid) for uid in uids]
-            )
-        return result
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """Delete all indices whose names start with `prefix`"""
-        if not really:
-            logger.warning("Not deleting all collections, set really=True to confirm")
-            return 0
-        coll_names = [c for c in self.list_collections() if c.startswith(prefix)]
-        deletes = asyncio.run(self._async_delete_indices(coll_names))
-        n_deletes = sum(deletes)
-        logger.warning(f"Deleted {n_deletes} indices in MeiliSearch")
-        return n_deletes
-
-    def _list_all_collections(self) -> List[str]:
-        """
-        List all collections, including empty ones.
-        Returns:
-            List of collection names.
-        """
-        return self.list_collections()
-
-    async def _async_get_indexes(self) -> List[AsyncIndex]:
-        async with self.client() as client:
-            indexes = await client.get_indexes(limit=10_000)
-        return [] if indexes is None else indexes  # type: ignore
-
-    async def _async_get_index(self, index_uid: str) -> "AsyncIndex":
-        async with self.client() as client:
-            index = await client.get_index(index_uid)
-        return index  # type: ignore
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """
-        Returns:
-            List of index names stored. We treat any existing index as non-empty.
-        """
-        indexes = asyncio.run(self._async_get_indexes())
-        if len(indexes) == 0:
-            return []
-        else:
-            return [ind.uid for ind in indexes]
-
-    async def _async_create_index(self, collection_name: str) -> "AsyncIndex":
-        async with self.client() as client:
-            index = await client.create_index(
-                uid=collection_name,
-                primary_key=self.config.primary_key,
-            )
-        return index
-
-    async def _async_delete_index(self, collection_name: str) -> bool:
-        """Delete index if it exists. Returns True iff index was deleted"""
-        async with self.client() as client:
-            result = await client.delete_index_if_exists(uid=collection_name)
-        return result  # type: ignore
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        """
-        Create a collection with the given name, optionally replacing an existing
-            collection if `replace` is True.
-        Args:
-            collection_name (str): Name of the collection to create.
-            replace (bool): Whether to replace an existing collection
-                with the same name. Defaults to False.
-        """
-        self.config.collection_name = collection_name
-        collections = self.list_collections()
-        if collection_name in collections:
-            logger.warning(
-                f"MeiliSearch Non-empty Index {collection_name} already exists"
-            )
-            if not replace:
-                logger.warning("Not replacing collection")
-                return
-            else:
-                logger.warning("Recreating fresh collection")
-                asyncio.run(self._async_delete_index(collection_name))
-        asyncio.run(self._async_create_index(collection_name))
-        collection_info = asyncio.run(self._async_get_index(collection_name))
-        if settings.debug:
-            level = logger.getEffectiveLevel()
-            logger.setLevel(logging.INFO)
-            logger.info(collection_info)
-            logger.setLevel(level)
-
-    async def _async_add_documents(
-        self, collection_name: str, documents: Sequence[Dict[str, Any]]
-    ) -> None:
-        async with self.client() as client:
-            index = client.index(collection_name)
-            await index.add_documents_in_batches(
-                documents=documents,
-                batch_size=self.config.batch_size,
-                primary_key=self.config.primary_key,
-            )
-
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        super().maybe_add_ids(documents)
-        if len(documents) == 0:
-            return
-        colls = self._list_all_collections()
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-        if self.config.collection_name not in colls:
-            self.create_collection(self.config.collection_name, replace=True)
-        docs = [
-            dict(
-                id=d.id(),
-                content=d.content,
-                metadata=d.metadata.model_dump(),
-            )
-            for d in documents
-        ]
-        asyncio.run(self._async_add_documents(self.config.collection_name, docs))
-
-    def delete_collection(self, collection_name: str) -> None:
-        asyncio.run(self._async_delete_index(collection_name))
-
-    def _to_int_or_uuid(self, id: str) -> int | str:
-        try:
-            return int(id)
-        except ValueError:
-            return id
-
-    async def _async_get_documents(self, where: str = "") -> "DocumentsInfo":
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        filter = [] if where is None else where
-        async with self.client() as client:
-            index = client.index(self.config.collection_name)
-            documents = await index.get_documents(limit=10_000, filter=filter)
-        return documents
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        docs = asyncio.run(self._async_get_documents(where))
-        if docs is None:
-            return []
-        doc_results = docs.results
-        return [
-            Document(
-                content=d["content"],
-                metadata=DocMetaData(**d["metadata"]),
-            )
-            for d in doc_results
-        ]
-
-    async def _async_get_documents_by_ids(self, ids: List[str]) -> List[Dict[str, Any]]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        async with self.client() as client:
-            index = client.index(self.config.collection_name)
-            documents = await asyncio.gather(*[index.get_document(id) for id in ids])
-        return documents
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        docs = asyncio.run(self._async_get_documents_by_ids(ids))
-        return [
-            Document(
-                content=d["content"],
-                metadata=DocMetaData(**d["metadata"]),
-            )
-            for d in docs
-        ]
-
-    async def _async_search(
-        self,
-        query: str,
-        k: int = 20,
-        filter: str | list[str | list[str]] | None = None,
-    ) -> List[Dict[str, Any]]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot search")
-        async with self.client() as client:
-            index = client.index(self.config.collection_name)
-            results = await index.search(
-                query,
-                limit=k,
-                show_ranking_score=True,
-                filter=filter,
-            )
-        return results.hits  # type: ignore
-
-    def similar_texts_with_scores(
-        self,
-        text: str,
-        k: int = 20,
-        where: Optional[str] = None,
-        neighbors: int = 0,  # ignored
-    ) -> List[Tuple[Document, float]]:
-        filter = [] if where is None else where
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot search")
-        _docs = asyncio.run(self._async_search(text, k, filter))  # type: ignore
-        if len(_docs) == 0:
-            logger.warning(f"No matches found for {text}")
-            return []
-        scores = [h["_rankingScore"] for h in _docs]
-        if settings.debug:
-            logger.info(f"Found {len(_docs)} matches, max score: {max(scores)}")
-        docs = [
-            Document(
-                content=d["content"],
-                metadata=DocMetaData(**d["metadata"]),
-            )
-            for d in _docs
-        ]
-        doc_score_pairs = list(zip(docs, scores))
-        self.show_if_debug(doc_score_pairs)
-        return doc_score_pairs
-</file>
-
 <file path="langroid/vector_store/milvusdb.py">
 import json
 import logging
@@ -86825,752 +85892,6 @@ class MilvusDB(VectorStore):
                 raise ValueError("Milvus filters do not support NaN or infinity")
             return repr(value)
         raise ValueError(f"Unsupported Milvus filter value: {value!r}")
-</file>
-
-<file path="langroid/vector_store/pineconedb.py">
-import json
-import logging
-import os
-import re
-from dataclasses import dataclass
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-)
-
-from dotenv import load_dotenv
-
-# import dataclass
-from pydantic import BaseModel
-
-from langroid import LangroidImportError
-from langroid.mytypes import Document
-from langroid.utils.configuration import settings
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-logger = logging.getLogger(__name__)
-
-
-has_pinecone: bool = True
-try:
-    from pinecone import Pinecone, PineconeApiException, ServerlessSpec
-except ImportError:
-
-    if not TYPE_CHECKING:
-
-        class ServerlessSpec(BaseModel):
-            """
-            Fallback Serverless specification configuration to avoid import errors.
-            """
-
-            cloud: str
-            region: str
-
-        PineconeApiException = Any  # type: ignore
-        Pinecone = Any  # type: ignore
-        has_pinecone = False
-
-
-@dataclass(frozen=True)
-class IndexMeta:
-    name: str
-    total_vector_count: int
-
-
-class PineconeDBConfig(VectorStoreConfig):
-    cloud: bool = True
-    collection_name: str | None = "temp"
-    spec: ServerlessSpec = ServerlessSpec(cloud="aws", region="us-east-1")
-    deletion_protection: Literal["enabled", "disabled"] | None = None
-    metric: str = "cosine"
-    pagination_size: int = 100
-
-
-class PineconeDB(VectorStore):
-    def __init__(self, config: PineconeDBConfig | None = None):
-        config = config if config is not None else PineconeDBConfig()
-        super().__init__(config)
-        if not has_pinecone:
-            raise LangroidImportError("pinecone", "pinecone")
-        self.config: PineconeDBConfig = config
-        load_dotenv()
-        key = os.getenv("PINECONE_API_KEY")
-
-        if not key:
-            raise ValueError("PINECONE_API_KEY not set, could not instantiate client")
-        self.client = Pinecone(api_key=key)
-
-        if config.collection_name:
-            self.create_collection(
-                collection_name=config.collection_name,
-                replace=config.replace_collection,
-            )
-
-    def clear_empty_collections(self) -> int:
-        indexes = self._list_index_metas(empty=True)
-        n_deletes = 0
-        for index in indexes:
-            if index.total_vector_count == -1:
-                logger.warning(
-                    f"Error fetching details for {index.name} when scanning indexes"
-                )
-            n_deletes += 1
-            self.delete_collection(collection_name=index.name)
-        return n_deletes
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """
-        Returns:
-            Number of Pinecone indexes that were deleted
-
-        Args:
-            really: Optional[bool] - whether to really delete all Pinecone collections
-            prefix: Optional[str] - string to match potential Pinecone
-                indexes for deletion
-        """
-        if not really:
-            logger.warning("Not deleting all collections, set really=True to confirm")
-            return 0
-        indexes = [
-            c for c in self._list_index_metas(empty=True) if c.name.startswith(prefix)
-        ]
-        if len(indexes) == 0:
-            logger.warning(f"No collections found with prefix {prefix}")
-            return 0
-        n_empty_deletes, n_non_empty_deletes = 0, 0
-        for index_desc in indexes:
-            self.delete_collection(collection_name=index_desc.name)
-            n_empty_deletes += index_desc.total_vector_count == 0
-            n_non_empty_deletes += index_desc.total_vector_count > 0
-        logger.warning(
-            f"""
-            Deleted {n_empty_deletes} empty indexes and
-            {n_non_empty_deletes} non-empty indexes
-            """
-        )
-        return n_empty_deletes + n_non_empty_deletes
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """
-        Returns:
-            List of Pinecone indices that have at least one vector.
-
-        Args:
-            empty: Optional[bool] - whether to include empty collections
-        """
-        indexes = self.client.list_indexes()
-        res: List[str] = []
-        if empty:
-            res.extend(indexes.names())
-            return res
-
-        for index in indexes.names():
-            index_meta = self.client.Index(name=index)
-            if index_meta.describe_index_stats().get("total_vector_count", 0) > 0:
-                res.append(index)
-        return res
-
-    def _list_index_metas(self, empty: bool = False) -> List[IndexMeta]:
-        """
-        Returns:
-            List of objects describing Pinecone indices
-
-        Args:
-            empty: Optional[bool] - whether to include empty collections
-        """
-        indexes = self.client.list_indexes()
-        res = []
-        for index in indexes.names():
-            index_meta = self._fetch_index_meta(index)
-            if empty:
-                res.append(index_meta)
-            elif index_meta.total_vector_count > 0:
-                res.append(index_meta)
-        return res
-
-    def _fetch_index_meta(self, index_name: str) -> IndexMeta:
-        """
-        Returns:
-            A dataclass describing the input Index by name and vector count
-            to save a bit on index description calls
-
-        Args:
-            index_name: str - Name of the index in Pinecone
-        """
-        try:
-            index = self.client.Index(name=index_name)
-            stats = index.describe_index_stats()
-            return IndexMeta(
-                name=index_name, total_vector_count=stats.get("total_vector_count", 0)
-            )
-        except PineconeApiException as e:
-            logger.warning(f"Error fetching details for index {index_name}")
-            logger.warning(e)
-            return IndexMeta(name=index_name, total_vector_count=-1)
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        """
-        Create a collection with the given name, optionally replacing an existing
-        collection if `replace` is True.
-
-        Args:
-            collection_name: str - Configuration of the collection to create.
-            replace: Optional[Bool] - Whether to replace an existing collection
-                with the same name. Defaults to False.
-        """
-        pattern = re.compile(r"^[a-z0-9-]+$")
-        if not pattern.match(collection_name):
-            raise ValueError(
-                "Pinecone index names must be lowercase alphanumeric characters or '-'"
-            )
-        self.config.collection_name = collection_name
-        if collection_name in self.list_collections(empty=True):
-            index = self.client.Index(name=collection_name)
-            stats = index.describe_index_stats()
-            status = self.client.describe_index(name=collection_name)
-            if status["status"]["ready"] and stats["total_vector_count"] > 0:
-                logger.warning(f"Non-empty collection {collection_name} already exists")
-                if not replace:
-                    logger.warning("Not replacing collection")
-                    return
-                else:
-                    logger.warning("Recreating fresh collection")
-            self.delete_collection(collection_name=collection_name)
-
-        payload = {
-            "name": collection_name,
-            "dimension": self.embedding_dim,
-            "spec": self.config.spec,
-            "metric": self.config.metric,
-            "timeout": self.config.timeout,
-        }
-
-        if self.config.deletion_protection:
-            payload["deletion_protection"] = self.config.deletion_protection
-
-        try:
-            self.client.create_index(**payload)
-        except PineconeApiException as e:
-            logger.error(e)
-
-    def delete_collection(self, collection_name: str) -> None:
-        logger.info(f"Attempting to delete {collection_name}")
-        try:
-            self.client.delete_index(name=collection_name)
-        except PineconeApiException as e:
-            logger.error(f"Failed to delete {collection_name}")
-            logger.error(e)
-
-    def add_documents(self, documents: Sequence[Document], namespace: str = "") -> None:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-
-        if len(documents) == 0:
-            logger.warning("Empty list of documents passed into add_documents")
-            return
-
-        super().maybe_add_ids(documents)
-        document_dicts = [doc.model_dump() for doc in documents]
-        document_ids = [doc.id() for doc in documents]
-        embedding_vectors = self.embedding_fn([doc.content for doc in documents])
-        vectors = [
-            {
-                "id": document_id,
-                "values": embedding_vector,
-                "metadata": {
-                    **document_dict["metadata"],
-                    **{
-                        key: value
-                        for key, value in document_dict.items()
-                        if key != "metadata"
-                    },
-                },
-            }
-            for document_dict, document_id, embedding_vector in zip(
-                document_dicts, document_ids, embedding_vectors
-            )
-        ]
-
-        if self.config.collection_name not in self.list_collections(empty=True):
-            self.create_collection(
-                collection_name=self.config.collection_name, replace=True
-            )
-
-        index = self.client.Index(name=self.config.collection_name)
-        batch_size = self.config.batch_size
-
-        for i in range(0, len(documents), batch_size):
-            try:
-                if namespace:
-                    index.upsert(
-                        vectors=vectors[i : i + batch_size], namespace=namespace
-                    )
-                else:
-                    index.upsert(vectors=vectors[i : i + batch_size])
-            except PineconeApiException as e:
-                logger.error(
-                    f"Unable to add of docs between indices {i} and {batch_size}"
-                )
-                logger.error(e)
-
-    def get_all_documents(
-        self, prefix: str = "", namespace: str = ""
-    ) -> List[Document]:
-        """
-        Returns:
-            All documents for the collection currently defined in
-            the configuration object
-
-        Args:
-            prefix: str - document id prefix to search for
-            namespace: str - partition of vectors to search within the index
-        """
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        docs = []
-
-        request_filters: Dict[str, Union[str, int]] = {
-            "limit": self.config.pagination_size
-        }
-        if prefix:
-            request_filters["prefix"] = prefix
-        if namespace:
-            request_filters["namespace"] = namespace
-
-        index = self.client.Index(name=self.config.collection_name)
-
-        while True:
-            response = index.list_paginated(**request_filters)
-            vectors = response.get("vectors", [])
-
-            if not vectors:
-                logger.warning("Received empty list while requesting for vector ids")
-                logger.warning("Halting fetch requests")
-                if settings.debug:
-                    logger.debug(f"Request for failed fetch was: {request_filters}")
-                break
-
-            docs.extend(
-                self.get_documents_by_ids(
-                    ids=[vector.get("id") for vector in vectors],
-                    namespace=namespace if namespace else "",
-                )
-            )
-
-            pagination_token = response.get("pagination", {}).get("next", None)
-
-            if not pagination_token:
-                break
-
-            request_filters["pagination_token"] = pagination_token
-
-        return docs
-
-    def get_documents_by_ids(
-        self, ids: List[str], namespace: str = ""
-    ) -> List[Document]:
-        """
-        Returns:
-            Fetches document text embedded in Pinecone index metadata
-
-        Args:
-            ids: List[str] - vector data object ids to retrieve
-            namespace: str - partition of vectors to search within the index
-        """
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        index = self.client.Index(name=self.config.collection_name)
-
-        if namespace:
-            records = index.fetch(ids=ids, namespace=namespace)
-        else:
-            records = index.fetch(ids=ids)
-
-        id_mapping = {key: value for key, value in records["vectors"].items()}
-        ordered_payloads = [id_mapping[_id] for _id in ids if _id in id_mapping]
-        return [
-            self.transform_pinecone_vector(payload.get("metadata", {}))
-            for payload in ordered_payloads
-        ]
-
-    def similar_texts_with_scores(
-        self,
-        text: str,
-        k: int = 1,
-        where: Optional[str] = None,
-        namespace: Optional[str] = None,
-    ) -> List[Tuple[Document, float]]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot search")
-
-        if k < 1 or k > 9999:
-            raise ValueError(
-                f"TopK for Pinecone vector search must be 1 < k < 10000, k was {k}"
-            )
-
-        vector_search_request = {
-            "top_k": k,
-            "include_metadata": True,
-            "vector": self.embedding_fn([text])[0],
-        }
-        if where:
-            vector_search_request["filter"] = json.loads(where) if where else None
-        if namespace:
-            vector_search_request["namespace"] = namespace
-
-        index = self.client.Index(name=self.config.collection_name)
-        response = index.query(**vector_search_request)
-        doc_score_pairs = [
-            (
-                self.transform_pinecone_vector(match.get("metadata", {})),
-                match.get("score", 0),
-            )
-            for match in response.get("matches", [])
-        ]
-        if settings.debug:
-            max_score = max([pair[1] for pair in doc_score_pairs])
-            logger.info(f"Found {len(doc_score_pairs)} matches, max score: {max_score}")
-        self.show_if_debug(doc_score_pairs)
-        return doc_score_pairs
-
-    def transform_pinecone_vector(self, metadata_dict: Dict[str, Any]) -> Document:
-        """
-        Parses the metadata response from the Pinecone vector query and
-        formats it into a dictionary that can be parsed by the Document class
-        associated with the PineconeDBConfig class
-
-        Returns:
-            Well formed dictionary object to be transformed into a Document
-
-        Args:
-            metadata_dict: Dict - the metadata dictionary from the Pinecone
-                vector query match
-        """
-        return self.config.document_class(
-            **{**metadata_dict, "metadata": {**metadata_dict}}
-        )
-</file>
-
-<file path="langroid/vector_store/weaviatedb.py">
-import logging
-import os
-import re
-from typing import Any, List, Optional, Sequence, Tuple
-
-from dotenv import load_dotenv
-
-from langroid.embedding_models.base import (
-    EmbeddingModelsConfig,
-)
-from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.exceptions import LangroidImportError
-from langroid.mytypes import DocMetaData, Document
-from langroid.utils.configuration import settings
-from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-logger = logging.getLogger(__name__)
-
-
-class VectorDistances:
-    """
-    Fallback class when weaviate is not installed, to avoid import errors.
-    """
-
-    COSINE: str = "cosine"
-    DOTPRODUCT: str = "dot"
-    L2: str = "l2"
-
-
-class WeaviateDBConfig(VectorStoreConfig):
-    collection_name: str | None = "temp"
-    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    distance: str = VectorDistances.COSINE
-    cloud: bool = False
-    docker: bool = False
-    host: str = "127.0.0.1"
-    port: int = 8080
-    storage_path: str = ".weaviate_embedded/data"
-
-
-class WeaviateDB(VectorStore):
-    def __init__(self, config: WeaviateDBConfig | None = None):
-        config = config if config is not None else WeaviateDBConfig()
-        super().__init__(config)
-        try:
-            import weaviate
-            from weaviate.classes.init import Auth
-        except ImportError:
-            raise LangroidImportError("weaviate", "weaviate")
-
-        self.config: WeaviateDBConfig = config
-        load_dotenv()
-        if self.config.docker:
-            self.client = weaviate.connect_to_local(
-                host=self.config.host,
-                port=self.config.port,
-            )
-            self.config.cloud = False
-        elif self.config.cloud:
-            key = os.getenv("WEAVIATE_API_KEY")
-            url = os.getenv("WEAVIATE_API_URL")
-            if url is None or key is None:
-                raise ValueError(
-                    """WEAVIATE_API_KEY, WEAVIATE_API_URL env variables must be set to 
-                    use WeaviateDB in cloud mode. Please set these values
-                    in your .env file.
-                    """
-                )
-            self.client = weaviate.connect_to_weaviate_cloud(
-                cluster_url=url,
-                auth_credentials=Auth.api_key(key),
-            )
-        else:
-            self.client = weaviate.connect_to_embedded(
-                version="latest", persistence_data_path=self.config.storage_path
-            )
-
-        if config.collection_name is not None:
-            WeaviateDB.validate_and_format_collection_name(config.collection_name)
-
-    def clear_empty_collections(self) -> int:
-        colls = self.client.collections.list_all()
-        n_deletes = 0
-        for coll_name, _ in colls.items():
-            val = self.client.collections.get(coll_name)
-            if len(val) == 0:
-                n_deletes += 1
-                self.client.collections.delete(coll_name)
-        return n_deletes
-
-    def list_collections(self, empty: bool = False) -> List[str]:
-        colls = self.client.collections.list_all()
-        if empty:
-            return list(colls.keys())
-        non_empty_colls = [
-            coll_name
-            for coll_name in colls.keys()
-            if len(self.client.collections.get(coll_name)) > 0
-        ]
-
-        return non_empty_colls
-
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        if not really:
-            logger.warning(
-                "Not really deleting all collections ,set really=True to confirm"
-            )
-            return 0
-        coll_names = [
-            c for c in self.list_collections(empty=True) if c.startswith(prefix)
-        ]
-        if len(coll_names) == 0:
-            logger.warning(f"No collections found with prefix {prefix}")
-            return 0
-        n_empty_deletes = 0
-        n_non_empty_deletes = 0
-        for name in coll_names:
-            info = self.client.collections.get(name)
-            points_count = len(info)
-
-            n_empty_deletes += points_count == 0
-            n_non_empty_deletes += points_count > 0
-            self.client.collections.delete(name)
-        logger.warning(
-            f"""
-            Deleted {n_empty_deletes} empty collections and
-            {n_non_empty_deletes} non-empty collections.
-            """
-        )
-        return n_empty_deletes + n_non_empty_deletes
-
-    def delete_collection(self, collection_name: str) -> None:
-        self.client.collections.delete(name=collection_name)
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        try:
-            from weaviate.classes.config import (
-                Configure,
-                VectorDistances,
-            )
-        except ImportError:
-            raise LangroidImportError("weaviate", "weaviate")
-        collection_name = WeaviateDB.validate_and_format_collection_name(
-            collection_name
-        )
-        self.config.collection_name = collection_name
-        if self.client.collections.exists(name=collection_name):
-            coll = self.client.collections.get(name=collection_name)
-            if len(coll) > 0:
-                logger.warning(f"Non-empty Collection {collection_name} already exists")
-                if not replace:
-                    logger.warning("Not replacing collection")
-                    return
-                else:
-                    logger.warning("Recreating fresh collection")
-            self.client.collections.delete(name=collection_name)
-
-        vector_index_config = Configure.VectorIndex.hnsw(
-            distance_metric=VectorDistances.COSINE,
-        )
-        if isinstance(self.config.embedding, OpenAIEmbeddingsConfig):
-            vectorizer_config = Configure.Vectorizer.text2vec_openai(
-                model=self.config.embedding.model_name,
-            )
-        else:
-            vectorizer_config = None
-
-        collection_info = self.client.collections.create(
-            name=collection_name,
-            vector_index_config=vector_index_config,
-            vectorizer_config=vectorizer_config,
-        )
-        collection_info = self.client.collections.get(name=collection_name)
-        assert len(collection_info) in [0, None]
-        if settings.debug:
-            level = logger.getEffectiveLevel()
-            logger.setLevel(logging.INFO)
-            logger.info(collection_info)
-            logger.setLevel(level)
-
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        super().maybe_add_ids(documents)
-        colls = self.list_collections(empty=True)
-        for doc in documents:
-            doc.metadata.id = str(self._create_valid_uuid_id(doc.metadata.id))
-        if len(documents) == 0:
-            return
-
-        document_dicts = [doc.model_dump() for doc in documents]
-        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot ingest docs")
-        if self.config.collection_name not in colls:
-            self.create_collection(self.config.collection_name, replace=True)
-        coll_name = self.client.collections.get(self.config.collection_name)
-        with coll_name.batch.dynamic() as batch:
-            for i, doc_dict in enumerate(document_dicts):
-                id = doc_dict["metadata"].pop("id", None)
-                batch.add_object(properties=doc_dict, uuid=id, vector=embedding_vecs[i])
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-        # cannot use filter as client does not support json type queries
-        coll = self.client.collections.get(self.config.collection_name)
-        return [self.weaviate_obj_to_doc(item) for item in coll.iterator()]
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        from weaviate.classes.query import Filter
-
-        if self.config.collection_name is None:
-            raise ValueError("No collection name set, cannot retrieve docs")
-
-        docs = []
-        coll_name = self.client.collections.get(self.config.collection_name)
-
-        result = coll_name.query.fetch_objects(
-            filters=Filter.by_property("_id").contains_any(ids), limit=len(coll_name)
-        )
-
-        id_to_doc = {}
-        for item in result.objects:
-            doc = self.weaviate_obj_to_doc(item)
-            id_to_doc[doc.metadata.id] = doc
-
-        # Reconstruct the list of documents in the original order of input ids
-        docs = [id_to_doc[id] for id in ids if id in id_to_doc]
-
-        return docs
-
-    def similar_texts_with_scores(
-        self, text: str, k: int = 1, where: Optional[str] = None
-    ) -> List[Tuple[Document, float]]:
-        from weaviate.classes.query import MetadataQuery
-
-        embedding = self.embedding_fn([text])[0]
-        if self.config.collection_name is None:
-            raise ValueError("No collections name set,cannot search")
-        coll = self.client.collections.get(self.config.collection_name)
-        response = coll.query.near_vector(
-            near_vector=embedding,
-            limit=k,
-            return_properties=True,
-            return_metadata=MetadataQuery(distance=True),
-        )
-        maybe_distances = [item.metadata.distance for item in response.objects]
-        similarities = [0 if d is None else 1 - d for d in maybe_distances]
-        docs = [self.weaviate_obj_to_doc(item) for item in response.objects]
-        return list(zip(docs, similarities))
-
-    def _create_valid_uuid_id(self, id: str) -> Any:
-        from weaviate.util import generate_uuid5, get_valid_uuid
-
-        try:
-            id = get_valid_uuid(id)
-            return id
-        except Exception:
-            return generate_uuid5(id)
-
-    def weaviate_obj_to_doc(self, input_object: Any) -> Document:
-        from weaviate.util import get_valid_uuid
-
-        content = input_object.properties.get("content", "")
-        metadata_dict = input_object.properties.get("metadata", {})
-
-        window_ids = metadata_dict.pop("window_ids", [])
-        window_ids = [str(uuid) for uuid in window_ids]
-
-        # Ensure the id is a valid UUID string
-        id_value = get_valid_uuid(input_object.uuid)
-
-        metadata = DocMetaData(id=id_value, window_ids=window_ids, **metadata_dict)
-
-        return Document(content=content, metadata=metadata)
-
-    @staticmethod
-    def validate_and_format_collection_name(name: str) -> str:
-        """
-        Formats the collection name to comply with Weaviate's naming rules:
-        - Name must start with a capital letter.
-        - Name can only contain letters, numbers, and underscores.
-        - Replaces invalid characters with underscores.
-        """
-        if not name:
-            raise ValueError("Collection name cannot be empty.")
-
-        formatted_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
-
-        # Ensure the first letter is capitalized
-        if not formatted_name[0].isupper():
-            formatted_name = formatted_name.capitalize()
-
-        # Check if the name now meets the criteria
-        if not re.match(r"^[A-Z][A-Za-z0-9_]*$", formatted_name):
-            raise ValueError(
-                f"Invalid collection name '{name}'."
-                " Names must start with a capital letter "
-                "and contain only letters, numbers, and underscores."
-            )
-
-        if formatted_name != name:
-            logger.warning(
-                f"Collection name '{name}' was reformatted to '{formatted_name}' "
-                "to comply with Weaviate's rules."
-            )
-
-        return formatted_name
-
-    def __del__(self) -> None:
-        # Gracefully close the connection with local client
-        if not self.config.cloud:
-            self.client.close()
 </file>
 
 <file path="tests/main/sql_chat/test_sql_chat_agent.py">
@@ -100135,6 +98456,92 @@ def test_end_to_end_agent_response_does_not_fire_secret_tool(
     assert "SECRET:pwned" not in text
 </file>
 
+<file path="docs/notes/vecstore-env-prefix.md">
+# Vector-Store Config Env-Var Prefixes
+
+Vector-store configs are `pydantic-settings` classes, which means their
+fields can be set via environment variables. Prior to this change (see
+issue #1078), `VectorStoreConfig` and its subclasses declared **no
+`env_prefix`**, so every field name was itself a case-insensitive
+environment variable. A bare `HOST`, `PORT`, `CLOUD`, `TIMEOUT`,
+`BATCH_SIZE`, `STORAGE_PATH`, `COLLECTION_NAME`, or `FULL_EVAL` in the
+environment silently overrode the default for *every* vector-store
+config:
+
+```bash
+HOST=evil.example.com PORT=9999 FULL_EVAL=true \
+  python -c "from langroid.vector_store.qdrantdb import QdrantDBConfig; \
+             c = QdrantDBConfig(); print(c.host, c.port, c.full_eval)"
+# old behavior: evil.example.com 9999 True
+```
+
+This was dangerous for two reasons:
+
+- `HOST` and `PORT` are routinely set by shells, containers, and CI
+  systems, so vector-store clients could silently point at the wrong
+  server.
+- `FULL_EVAL=true` disabled the code-injection guard (see
+  [code-injection-protection](code-injection-protection.md)) with no
+  explicit opt-in anywhere in the user's code.
+
+## New behavior
+
+Each vector-store config now has its own env prefix, consistent with
+the rest of the codebase (`OPENAI_`, `AZURE_OPENAI_`, `NEO4J_`, ...):
+
+| Config class        | Env prefix     |
+|---------------------|----------------|
+| `VectorStoreConfig` | `VECDB_`       |
+| `QdrantDBConfig`    | `QDRANT_`      |
+| `ChromaDBConfig`    | `CHROMA_`      |
+| `LanceDBConfig`     | `LANCEDB_`     |
+| `PineconeDBConfig`  | `PINECONE_`    |
+| `PostgresDBConfig`  | `POSTGRES_`    |
+| `MeiliSearchConfig` | `MEILISEARCH_` |
+| `WeaviateDBConfig`  | `WEAVIATE_`    |
+
+Bare env vars (`HOST`, `FULL_EVAL`, ...) are now ignored by all of
+these configs. To set a field via the environment, use the prefix of
+the specific config class, e.g. `QDRANT_HOST=my.qdrant.example` or
+`QDRANT_FULL_EVAL=true` for `QdrantDBConfig`. Every provider subclass
+in langroid overrides the prefix with its own, so within langroid
+`VECDB_*` vars affect only direct `VectorStoreConfig` instances.
+However, pydantic inherits `model_config`, so a third-party subclass
+of `VectorStoreConfig` that does not set its own `env_prefix` will
+read `VECDB_*` vars.
+
+A `port` value coming from the *environment* that matches the exact
+Kubernetes service-link format `tcp://<host>:<digits>` (e.g.
+`QDRANT_PORT=tcp://10.0.0.8:6333`, injected into every pod by a
+service named `qdrant` when `enableServiceLinks` is on) is ignored
+with a warning and the default port is used. This exception applies
+only to the env settings source and only to that full format:
+malformed `tcp://` junk in the environment, and any `tcp://...` value
+passed explicitly to the constructor, fail validation as usual.
+
+Explicit constructor arguments always take priority over environment
+values (standard `pydantic-settings` precedence):
+
+```python
+config = QdrantDBConfig(host="10.0.0.5")  # wins over QDRANT_HOST
+```
+
+## Migration
+
+If you (deliberately) relied on bare env vars to configure a
+vector store, rename them with the appropriate prefix from the table
+above, e.g. `COLLECTION_NAME=mydocs` becomes
+`QDRANT_COLLECTION_NAME=mydocs`.
+
+Env vars read via `os.getenv` outside the config classes are
+unaffected, e.g. `QDRANT_API_KEY`, `PINECONE_API_KEY`,
+`MEILISEARCH_API_KEY`, `MEILISEARCH_API_URL`, `WEAVIATE_API_KEY`, and
+`WEAVIATE_API_URL` keep their existing meanings. Note that the
+`QDRANT_*` and `PINECONE_*` prefixes overlap with those existing
+names, but the config classes have no `api_key`/`api_url` fields, so
+extra prefixed vars are ignored.
+</file>
+
 <file path="docs/tutorials/non-openai-llms.md">
 # Using Langroid with Non-OpenAI LLMs
 
@@ -103922,1072 +102329,346 @@ class RepoLoader:
         return contents
 </file>
 
-<file path="langroid/vector_store/base.py">
-import copy
-import logging
-from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Sequence, Tuple, Type
-
-import numpy as np
-import pandas as pd
-from pydantic_settings import BaseSettings
-
-from langroid.embedding_models.base import EmbeddingModel, EmbeddingModelsConfig
-from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.mytypes import DocMetaData, Document, EmbeddingFunction
-from langroid.utils.algorithms.graph import components, topological_sort
-from langroid.utils.configuration import settings
-from langroid.utils.object_registry import ObjectRegistry
-from langroid.utils.output.printing import print_long_text
-from langroid.utils.pandas_utils import safe_eval_globals, sanitize_command, stringify
-from langroid.utils.pydantic_utils import flatten_dict
-
-logger = logging.getLogger(__name__)
-
-
-class VectorStoreConfig(BaseSettings):
-    type: str = ""  # deprecated, keeping it for backward compatibility
-    collection_name: str | None = "temp"
-    replace_collection: bool = False  # replace collection if it already exists
-    storage_path: str = ".qdrant/data"
-    cloud: bool = False
-    batch_size: int = 200
-    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig(
-        model_type="openai",
-    )
-    embedding_model: Optional[EmbeddingModel] = None
-    timeout: int = 60
-    host: str = "127.0.0.1"
-    port: int = 6333
-    # used when parsing search results back as Document objects
-    document_class: Type[Document] = Document
-    metadata_class: Type[DocMetaData] = DocMetaData
-    # compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
-    full_eval: bool = False  # runs eval without sanitization. Use only on trusted input
-
-
-class VectorStore(ABC):
-    """
-    Abstract base class for a vector store.
-    """
-
-    def __init__(self, config: VectorStoreConfig):
-        self.config = config
-        if config.embedding_model is None:
-            self.embedding_model = EmbeddingModel.create(config.embedding)
-        else:
-            self.embedding_model = config.embedding_model
-        if hasattr(self.config, "embedding_model"):
-            self.config.embedding_model = None
-        self.embedding_fn: EmbeddingFunction = self.embedding_model.embedding_fn()
-
-    @staticmethod
-    def create(config: VectorStoreConfig) -> Optional["VectorStore"]:
-        from langroid.vector_store.chromadb import ChromaDB, ChromaDBConfig
-        from langroid.vector_store.lancedb import LanceDB, LanceDBConfig
-        from langroid.vector_store.meilisearch import MeiliSearch, MeiliSearchConfig
-        from langroid.vector_store.milvusdb import MilvusDB, MilvusDBConfig
-        from langroid.vector_store.pineconedb import PineconeDB, PineconeDBConfig
-        from langroid.vector_store.postgres import PostgresDB, PostgresDBConfig
-        from langroid.vector_store.qdrantdb import QdrantDB, QdrantDBConfig
-        from langroid.vector_store.weaviatedb import WeaviateDB, WeaviateDBConfig
-
-        if isinstance(config, QdrantDBConfig):
-            return QdrantDB(config)
-        elif isinstance(config, ChromaDBConfig):
-            return ChromaDB(config)
-        elif isinstance(config, LanceDBConfig):
-            return LanceDB(config)
-        elif isinstance(config, MeiliSearchConfig):
-            return MeiliSearch(config)
-        elif isinstance(config, PostgresDBConfig):
-            return PostgresDB(config)
-        elif isinstance(config, MilvusDBConfig):
-            return MilvusDB(config)
-        elif isinstance(config, WeaviateDBConfig):
-            return WeaviateDB(config)
-        elif isinstance(config, PineconeDBConfig):
-            return PineconeDB(config)
-
-        else:
-            logger.warning(
-                f"""
-                Unknown vector store config: {config.__class__.__name__},
-                so skipping vector store creation!
-                If you intended to use a vector-store, please set a specific 
-                vector-store in your script, typically in the `vecdb` field of a 
-                `ChatAgentConfig`, otherwise set it to None.
-                """
-            )
-            return None
-
-    @property
-    def embedding_dim(self) -> int:
-        return len(self.embedding_fn(["test"])[0])
-
-    def clone(self) -> "VectorStore":
-        """Return a vector-store clone suitable for agent cloning.
-
-        The default implementation deep-copies the configuration, reuses any
-        existing embedding model, and instantiates a fresh store of the same
-        type. Subclasses can override when sharing the instance is required
-        (e.g., embedded/local stores that rely on file locks).
-        """
-
-        config_class = self.config.__class__
-        config_data = self.config.model_dump(mode="python")
-        config_data["embedding_model"] = None
-        config_copy = config_class.model_validate(config_data)
-        logger.debug(
-            "Cloning VectorStore %s: original collection=%s, copied collection=%s",
-            type(self).__name__,
-            getattr(self.config, "collection_name", None),
-            getattr(config_copy, "collection_name", None),
-        )
-        # Preserve the calculated collection contents without forcing replaces
-        if hasattr(config_copy, "replace_collection"):
-            config_copy.replace_collection = False  # type: ignore[attr-defined]
-        cloned_embedding: Optional[EmbeddingModel] = None
-        if (
-            hasattr(self, "embedding_model")
-            and getattr(self, "embedding_model") is not None
-        ):
-            cloned_embedding = self.embedding_model.clone()  # type: ignore[attr-defined]
-            if hasattr(config_copy, "embedding_model"):
-                config_copy.embedding_model = cloned_embedding
-
-        cloned_store = type(self)(config_copy)  # type: ignore[call-arg]
-        if hasattr(cloned_store.config, "embedding_model"):
-            cloned_store.config.embedding_model = None
-        logger.debug(
-            "Cloned VectorStore %s: cloned collection=%s",
-            type(self).__name__,
-            getattr(cloned_store.config, "collection_name", None),
-        )
-        if hasattr(cloned_store.config, "replace_collection"):
-            cloned_store.config.replace_collection = False
-        # Some stores might not honour replace_collection; ensure same collection
-        if getattr(self.config, "collection_name", None) is not None:
-            setattr(
-                cloned_store.config,
-                "collection_name",
-                getattr(self.config, "collection_name", None),
-            )
-        return cloned_store
-
-    @abstractmethod
-    def clear_empty_collections(self) -> int:
-        """Clear all empty collections in the vector store.
-        Returns the number of collections deleted.
-        """
-        pass
-
-    @abstractmethod
-    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
-        """
-        Clear all collections in the vector store.
-
-        Args:
-            really (bool, optional): Whether to really clear all collections.
-                Defaults to False.
-            prefix (str, optional): Prefix of collections to clear.
-        Returns:
-            int: Number of collections deleted.
-        """
-        pass
-
-    @abstractmethod
-    def list_collections(self, empty: bool = False) -> List[str]:
-        """List all collections in the vector store
-        (only non empty collections if empty=False).
-        """
-        pass
-
-    def set_collection(self, collection_name: str, replace: bool = False) -> None:
-        """
-        Set the current collection to the given collection name.
-        Args:
-            collection_name (str): Name of the collection.
-            replace (bool, optional): Whether to replace the collection if it
-                already exists. Defaults to False.
-        """
-
-        self.config.collection_name = collection_name
-        self.config.replace_collection = replace
-        if replace:
-            self.create_collection(collection_name, replace=True)
-
-    @abstractmethod
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        """Create a collection with the given name.
-        Args:
-            collection_name (str): Name of the collection.
-            replace (bool, optional): Whether to replace the
-                collection if it already exists. Defaults to False.
-        """
-        pass
-
-    @abstractmethod
-    def add_documents(self, documents: Sequence[Document]) -> None:
-        pass
-
-    def compute_from_docs(self, docs: List[Document], calc: str) -> str:
-        """Compute a result on a set of documents,
-        using a dataframe calc string like `df.groupby('state')['income'].mean()`.
-
-        If full_eval is False (default), the input expression is sanitized to prevent
-        most common code injection attack vectors.
-        If full_eval is True, sanitization is bypassed - use only with trusted input!
-        """
-        # convert each doc to a dict, using dotted paths for nested fields
-        dicts = [flatten_dict(doc.model_dump(by_alias=True)) for doc in docs]
-        df = pd.DataFrame(dicts)
-
-        try:
-            # SECURITY MITIGATION: Eval input is sanitized to prevent most common
-            # code injection attack vectors when full_eval is False. The globals
-            # dict also restricts ``__builtins__`` so that even with
-            # ``full_eval=True`` the expression cannot reach
-            # ``__import__``/``eval``/``exec`` via Python's implicit builtin
-            # injection (GHSA-q9p7-wqxg-mrhc).
-            vars = {"df": df}
-            if not self.config.full_eval:
-                calc = sanitize_command(calc)
-            code = compile(calc, "<calc>", "eval")
-            result = eval(code, safe_eval_globals(vars), {})
-        except Exception as e:
-            # return error message so LLM can fix the calc string if needed
-            err = f"""
-            Error encountered in pandas eval: {str(e)}
-            """
-            if isinstance(e, KeyError) and "not in index" in str(e):
-                # Pd.eval sometimes fails on a perfectly valid exprn like
-                # df.loc[..., 'column'] with a KeyError.
-                err += """
-                Maybe try a different way, e.g. 
-                instead of df.loc[..., 'column'], try df.loc[...]['column']
-                """
-            return err
-        return stringify(result)
-
-    def maybe_add_ids(self, documents: Sequence[Document]) -> None:
-        """Add ids to metadata if absent, since some
-        vecdbs don't like having blank ids."""
-        for d in documents:
-            if d.metadata.id in [None, ""]:
-                d.metadata.id = ObjectRegistry.new_id()
-
-    @abstractmethod
-    def similar_texts_with_scores(
-        self,
-        text: str,
-        k: int = 1,
-        where: Optional[str] = None,
-    ) -> List[Tuple[Document, float]]:
-        """
-        Find k most similar texts to the given text, in terms of vector distance metric
-        (e.g., cosine similarity).
-
-        Args:
-            text (str): The text to find similar texts for.
-            k (int, optional): Number of similar texts to retrieve. Defaults to 1.
-            where (Optional[str], optional): Where clause to filter the search.
-
-        Returns:
-            List[Tuple[Document,float]]: List of (Document, score) tuples.
-
-        """
-        pass
-
-    def add_context_window(
-        self, docs_scores: List[Tuple[Document, float]], neighbors: int = 0
-    ) -> List[Tuple[Document, float]]:
-        """
-        In each doc's metadata, there may be a window_ids field indicating
-        the ids of the chunks around the current chunk.
-        These window_ids may overlap, so we
-        - coalesce each overlapping groups into a single window (maintaining ordering),
-        - create a new document for each part, preserving metadata,
-
-        We may have stored a longer set of window_ids than we need during chunking.
-        Now, we just want `neighbors` on each side of the center of the window_ids list.
-
-        Args:
-            docs_scores (List[Tuple[Document, float]]): List of pairs of documents
-                to add context windows to together with their match scores.
-            neighbors (int, optional): Number of neighbors on "each side" of match to
-                retrieve. Defaults to 0.
-                "Each side" here means before and after the match,
-                in the original text.
-
-        Returns:
-            List[Tuple[Document, float]]: List of (Document, score) tuples.
-        """
-        # We return a larger context around each match, i.e.
-        # a window of `neighbors` on each side of the match.
-        docs = [d for d, s in docs_scores]
-        scores = [s for d, s in docs_scores]
-        if neighbors == 0:
-            return docs_scores
-        doc_chunks = [d for d in docs if d.metadata.is_chunk]
-        if len(doc_chunks) == 0:
-            return docs_scores
-        window_ids_list = []
-        id2metadata = {}
-        # id -> highest score of a doc it appears in
-        id2max_score: Dict[int | str, float] = {}
-        for i, d in enumerate(docs):
-            window_ids = d.metadata.window_ids
-            if len(window_ids) == 0:
-                window_ids = [d.id()]
-            id2metadata.update({id: d.metadata for id in window_ids})
-
-            id2max_score.update(
-                {id: max(id2max_score.get(id, 0), scores[i]) for id in window_ids}
-            )
-            n = len(window_ids)
-            chunk_idx = window_ids.index(d.id())
-            neighbor_ids = window_ids[
-                max(0, chunk_idx - neighbors) : min(n, chunk_idx + neighbors + 1)
-            ]
-            window_ids_list += [neighbor_ids]
-
-        # window_ids could be from different docs,
-        # and they may overlap, so we coalesce overlapping groups into
-        # separate windows.
-        window_ids_list = self.remove_overlaps(window_ids_list)
-        final_docs = []
-        final_scores = []
-        for w in window_ids_list:
-            metadata = copy.deepcopy(id2metadata[w[0]])
-            metadata.window_ids = w
-            document = Document(
-                content="".join([d.content for d in self.get_documents_by_ids(w)]),
-                metadata=metadata,
-            )
-            # make a fresh id since content is in general different
-            document.metadata.id = ObjectRegistry.new_id()
-            final_docs += [document]
-            final_scores += [max(id2max_score[id] for id in w)]
-        return list(zip(final_docs, final_scores))
-
-    @staticmethod
-    def remove_overlaps(windows: List[List[str]]) -> List[List[str]]:
-        """
-        Given a collection of windows, where each window is a sequence of ids,
-        identify groups of overlapping windows, and for each overlapping group,
-        order the chunk-ids using topological sort so they appear in the original
-        order in the text.
-
-        Args:
-            windows (List[int|str]): List of windows, where each window is a
-                sequence of ids.
-
-        Returns:
-            List[int|str]: List of windows, where each window is a sequence of ids,
-                and no two windows overlap.
-        """
-        ids = set(id for w in windows for id in w)
-        # id -> {win -> # pos}
-        id2win2pos: Dict[str, Dict[int, int]] = {id: {} for id in ids}
-
-        for i, w in enumerate(windows):
-            for j, id in enumerate(w):
-                id2win2pos[id][i] = j
-
-        n = len(windows)
-        # relation between windows:
-        order = np.zeros((n, n), dtype=np.int8)
-        for i, w in enumerate(windows):
-            for j, x in enumerate(windows):
-                if i == j:
-                    continue
-                if len(set(w).intersection(x)) == 0:
-                    continue
-                id = list(set(w).intersection(x))[0]  # any common id
-                if id2win2pos[id][i] > id2win2pos[id][j]:
-                    order[i, j] = -1  # win i is before win j
-                else:
-                    order[i, j] = 1  # win i is after win j
-
-        # find groups of windows that overlap, like connected components in a graph
-        groups = components(np.abs(order))
-
-        # order the chunk-ids in each group using topological sort
-        new_windows = []
-        for g in groups:
-            # find total ordering among windows in group based on order matrix
-            # (this is a topological sort)
-            _g = np.array(g)
-            order_matrix = order[_g][:, _g]
-            ordered_window_indices = topological_sort(order_matrix)
-            ordered_window_ids = [windows[i] for i in _g[ordered_window_indices]]
-            flattened = [id for w in ordered_window_ids for id in w]
-            flattened_deduped = list(dict.fromkeys(flattened))
-            # Note we are not going to split these, and instead we'll return
-            # larger windows from concatenating the connected groups.
-            # This ensures context is retained for LLM q/a
-            new_windows += [flattened_deduped]
-
-        return new_windows
-
-    @abstractmethod
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        """
-        Get all documents in the current collection, possibly filtered by `where`.
-        """
-        pass
-
-    @abstractmethod
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        """
-        Get documents by their ids.
-        Args:
-            ids (List[str]): List of document ids.
-
-        Returns:
-            List[Document]: List of documents
-        """
-        pass
-
-    @abstractmethod
-    def delete_collection(self, collection_name: str) -> None:
-        pass
-
-    def show_if_debug(self, doc_score_pairs: List[Tuple[Document, float]]) -> None:
-        if settings.debug:
-            for i, (d, s) in enumerate(doc_score_pairs):
-                print_long_text("red", "italic red", f"\nMATCH-{i}\n", d.content)
-</file>
-
-<file path="langroid/vector_store/postgres.py">
-import hashlib
+<file path="langroid/vector_store/chromadb.py">
 import json
 import logging
-import os
-import uuid
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
+
+from pydantic_settings import SettingsConfigDict
 
 from langroid.embedding_models.base import (
     EmbeddingModelsConfig,
 )
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
 from langroid.exceptions import LangroidImportError
-from langroid.mytypes import DocMetaData, Document
+from langroid.mytypes import Document
+from langroid.utils.configuration import settings
+from langroid.utils.output.printing import print_long_text
 from langroid.vector_store.base import VectorStore, VectorStoreConfig
-
-has_postgres: bool = True
-try:
-    from sqlalchemy import (
-        Column,
-        MetaData,
-        String,
-        Table,
-        case,
-        create_engine,
-        inspect,
-        text,
-    )
-    from sqlalchemy.dialects.postgresql import JSONB
-    from sqlalchemy.engine import Connection, Engine
-    from sqlalchemy.sql.expression import insert
-except ImportError:
-    Engine = Any  # type: ignore
-    Connection = Any  # type: ignore
-    has_postgres = False
 
 logger = logging.getLogger(__name__)
 
 
-def _quote_ident(name: str) -> str:
-    """Quote a SQL identifier (table/index name) for use in raw DDL, so a name
-    containing characters that are invalid in an unquoted identifier -- e.g.
-    the ``-`` in a pytest-xdist worker suffix like ``mycollection-gw1`` -- does
-    not produce a syntax error. Embedded double-quotes are escaped per the SQL
-    standard.
-    """
-    return '"' + name.replace('"', '""') + '"'
+class ChromaDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="CHROMA_")
 
-
-class PostgresDBConfig(VectorStoreConfig):
-    collection_name: str = "embeddings"
-    cloud: bool = False
-    docker: bool = True
-    host: str = "127.0.0.1"
-    port: int = 5432
-    replace_collection: bool = False
+    collection_name: str = "temp"
+    storage_path: str = ".chroma/data"
+    distance: Literal["cosine", "l2", "ip"] = "cosine"
+    construction_ef: int = 100
+    search_ef: int = 100
+    max_neighbors: int = 16
     embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    pool_size: int = 10
-    max_overflow: int = 20
-    hnsw_m: int = 16
-    hnsw_ef_construction: int = 200
+    host: str = "127.0.0.1"
+    port: int = 6333
 
 
-class PostgresDB(VectorStore):
-    def __init__(self, config: PostgresDBConfig | None = None):
-        config = config if config is not None else PostgresDBConfig()
+class ChromaDB(VectorStore):
+    def __init__(self, config: ChromaDBConfig | None = None):
+        config = config if config is not None else ChromaDBConfig()
         super().__init__(config)
-        if not has_postgres:
-            raise LangroidImportError("pgvector", "postgres")
         try:
-            from sqlalchemy.orm import sessionmaker
+            import chromadb
         except ImportError:
-            raise LangroidImportError("sqlalchemy", "postgres")
-
-        self.config: PostgresDBConfig = config
-        self.engine = self._create_engine()
-        PostgresDB._create_vector_extension(self.engine)
-        self.SessionLocal = sessionmaker(
-            autocommit=False, autoflush=False, bind=self.engine
-        )
-        self.metadata = MetaData()
-        self._setup_table()
-
-    def _create_engine(self) -> Engine:
-        """Creates a SQLAlchemy engine based on the configuration."""
-
-        connection_string: str | None = None  # Ensure variable is always defined
-
-        if self.config.cloud:
-            connection_string = os.getenv("POSTGRES_CONNECTION_STRING")
-
-            if connection_string and connection_string.startswith("postgres://"):
-                connection_string = connection_string.replace(
-                    "postgres://", "postgresql+psycopg2://", 1
-                )
-            elif not connection_string:
-                raise ValueError("Provide the POSTGRES_CONNECTION_STRING.")
-
-        elif self.config.docker:
-            username = os.getenv("POSTGRES_USER", "postgres")
-            password = os.getenv("POSTGRES_PASSWORD", "postgres")
-            database = os.getenv("POSTGRES_DB", "langroid")
-
-            if not (username and password and database):
-                raise ValueError(
-                    "Provide POSTGRES_USER, POSTGRES_PASSWORD, " "POSTGRES_DB. "
-                )
-
-            connection_string = (
-                f"postgresql+psycopg2://{username}:{password}@"
-                f"{self.config.host}:{self.config.port}/{database}"
+            raise LangroidImportError("chromadb", "chromadb")
+        self.config = config
+        self.client = chromadb.Client(
+            chromadb.config.Settings(
+                # chroma_db_impl="duckdb+parquet",
+                # is_persistent=bool(config.storage_path),
+                persist_directory=config.storage_path,
             )
-            self.config.cloud = False  # Ensures cloud is disabled if using Docker
-
-        else:
-            raise ValueError(
-                "Provide either Docker or Cloud config to connect to the database."
-            )
-
-        return create_engine(
-            connection_string,
-            pool_size=self.config.pool_size,
-            max_overflow=self.config.max_overflow,
         )
-
-    def _setup_table(self) -> None:
-        try:
-            from pgvector.sqlalchemy import Vector
-        except ImportError as e:
-            raise LangroidImportError(extra="postgres", error=str(e))
-
-        if self.config.replace_collection:
-            self.delete_collection(self.config.collection_name)
-
-        self.embeddings_table = Table(
-            self.config.collection_name,
-            self.metadata,
-            Column("id", String, primary_key=True, nullable=False, unique=True),
-            Column("embedding", Vector(self.embedding_dim)),
-            Column("document", String),
-            Column("cmetadata", JSONB),
-            extend_existing=True,
-        )
-
-        self.metadata.create_all(self.engine)
-        self.metadata.reflect(bind=self.engine, only=[self.config.collection_name])
-
-        # Create HNSW index for embeddings column if it doesn't exist.
-        # This index enables efficient nearest-neighbor search using cosine similarity.
-        # PostgreSQL automatically builds the index after creation;
-        # no manual step required.
-        # Read more about pgvector hnsw index here:
-        # https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw
-
-        index_name = f"hnsw_index_{self.config.collection_name}_embedding"
-        with self.engine.connect() as connection:
-            if not self.index_exists(connection, index_name):
-                connection.execute(text("COMMIT"))
-                create_index_query = text(
-                    f"""
-                    CREATE INDEX CONCURRENTLY IF NOT EXISTS {_quote_ident(index_name)}
-                    ON {_quote_ident(self.config.collection_name)}
-                    USING hnsw (embedding vector_cosine_ops)
-                    WITH (
-                        m = {self.config.hnsw_m},
-                        ef_construction = {self.config.hnsw_ef_construction}
-                    );
-                    """
-                )
-                connection.execute(create_index_query)
-
-    def index_exists(self, connection: Connection, index_name: str) -> bool:
-        """Check if an index exists."""
-        query = text(
-            "SELECT 1 FROM pg_indexes WHERE indexname = :index_name"
-        ).bindparams(index_name=index_name)
-        result = connection.execute(query).scalar()
-        return bool(result)
-
-    @staticmethod
-    def _create_vector_extension(conn: Engine) -> None:
-
-        with conn.connect() as connection:
-            with connection.begin():
-                # The number is a unique identifier used to lock a specific resource
-                # during transaction. Any 64-bit integer can be used for advisory locks.
-                # Acquire advisory lock to ensure atomic, isolated setup
-                # and prevent race conditions.
-
-                statement = text(
-                    "SELECT pg_advisory_xact_lock(1573678846307946496);"
-                    "CREATE EXTENSION IF NOT EXISTS vector;"
-                )
-                connection.execute(statement)
-
-    def set_collection(self, collection_name: str, replace: bool = False) -> None:
-        inspector = inspect(self.engine)
-        table_exists = collection_name in inspector.get_table_names()
-
-        if (
-            collection_name == self.config.collection_name
-            and table_exists
-            and not replace
-        ):
-            return
-        else:
-            self.config.collection_name = collection_name
-            self.config.replace_collection = replace
-            self._setup_table()
-
-    def list_collections(self, empty: bool = True) -> List[str]:
-        inspector = inspect(self.engine)
-        table_names = inspector.get_table_names()
-
-        with self.SessionLocal() as session:
-            collections = []
-            for table_name in table_names:
-                table = Table(table_name, self.metadata, autoload_with=self.engine)
-                if empty:
-                    collections.append(table_name)
-                else:
-                    # Efficiently check for non-emptiness
-                    if session.query(table.select().limit(1).exists()).scalar():
-                        collections.append(table_name)
-            return collections
-
-    def create_collection(self, collection_name: str, replace: bool = False) -> None:
-        self.set_collection(collection_name, replace=replace)
-
-    def delete_collection(self, collection_name: str) -> None:
-        """
-        Deletes a collection and its associated HNSW index, handling metadata
-        synchronization issues.
-        """
-        with self.engine.connect() as connection:
-            connection.execute(text("COMMIT"))
-            index_name = f"hnsw_index_{collection_name}_embedding"
-            drop_index_query = text(
-                f"DROP INDEX CONCURRENTLY IF EXISTS {_quote_ident(index_name)}"
+        if self.config.collection_name is not None:
+            self.create_collection(
+                self.config.collection_name,
+                replace=self.config.replace_collection,
             )
-            connection.execute(drop_index_query)
-
-            # 3. Now, drop the table using SQLAlchemy
-            table = Table(collection_name, self.metadata)
-            table.drop(self.engine, checkfirst=True)
-
-            # 4. Refresh metadata again after dropping the table
-            self.metadata.clear()
-            self.metadata.reflect(bind=self.engine)
 
     def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """Clear all collections in the vector store with the given prefix."""
+
         if not really:
-            logger.warning("Not deleting all tables, set really=True to confirm")
+            logger.warning("Not deleting all collections, set really=True to confirm")
             return 0
-
-        inspector = inspect(self.engine)
-        table_names = inspector.get_table_names()
-
-        with self.SessionLocal() as session:
-            deleted_count = 0
-            for table_name in table_names:
-                if table_name.startswith(prefix):
-                    # Use delete_collection to handle index and table deletion
-                    self.delete_collection(table_name)
-                    deleted_count += 1
-            session.commit()
-            logger.warning(f"Deleted {deleted_count} tables with prefix '{prefix}'.")
-            return deleted_count
+        coll = [c for c in self.client.list_collections() if c.name.startswith(prefix)]
+        if len(coll) == 0:
+            logger.warning(f"No collections found with prefix {prefix}")
+            return 0
+        n_empty_deletes = 0
+        n_non_empty_deletes = 0
+        for c in coll:
+            n_empty_deletes += c.count() == 0
+            n_non_empty_deletes += c.count() > 0
+            self.client.delete_collection(name=c.name)
+        logger.warning(
+            f"""
+            Deleted {n_empty_deletes} empty collections and
+            {n_non_empty_deletes} non-empty collections.
+            """
+        )
+        return n_empty_deletes + n_non_empty_deletes
 
     def clear_empty_collections(self) -> int:
-        inspector = inspect(self.engine)
-        table_names = inspector.get_table_names()
+        colls = self.client.list_collections()
+        n_deletes = 0
+        for coll in colls:
+            if coll.count() == 0:
+                n_deletes += 1
+                self.client.delete_collection(name=coll.name)
+        return n_deletes
 
-        with self.SessionLocal() as session:
-            deleted_count = 0
-            for table_name in table_names:
-                table = Table(table_name, self.metadata, autoload_with=self.engine)
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """
+        List non-empty collections in the vector store.
+        Args:
+            empty (bool, optional): Whether to list empty collections.
+        Returns:
+            List[str]: List of non-empty collection names.
+        """
+        colls = self.client.list_collections()
+        if empty:
+            return [coll.name for coll in colls]
+        return [coll.name for coll in colls if coll.count() > 0]
 
-                # Efficiently check for emptiness without fetching all rows
-                if session.query(table.select().limit(1).exists()).scalar():
-                    continue
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        """
+        Create a collection in the vector store, optionally replacing an existing
+            collection if `replace` is True.
+        Args:
+            collection_name (str): Name of the collection to create or replace.
+            replace (bool, optional): Whether to replace an existing collection.
+                Defaults to False.
 
-                # Use delete_collection to handle index and table deletion
-                self.delete_collection(table_name)
-                deleted_count += 1
-
-            session.commit()  # Commit is likely not needed here
-            logger.warning(f"Deleted {deleted_count} empty tables.")
-            return deleted_count
-
-    def _parse_embedding_store_record(self, res: Any) -> Dict[str, Any]:
-        metadata = res.cmetadata or {}
-        metadata["id"] = res.id
-        return {
-            "content": res.document,
-            "metadata": DocMetaData(**metadata),
-        }
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        with self.SessionLocal() as session:
-            query = session.query(self.embeddings_table)
-
-            # Apply 'where' clause if provided
-            if where:
-                try:
-                    where_json = json.loads(where)
-                    query = query.filter(
-                        self.embeddings_table.c.cmetadata.contains(where_json)
-                    )
-                except json.JSONDecodeError:
-                    logger.error(f"Invalid JSON in 'where' clause: {where}")
-                    return []  # Return empty list or handle error as appropriate
-
-            results = query.all()
-            documents = [
-                Document(**self._parse_embedding_store_record(res)) for res in results
-            ]
-            return documents
-
-    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
-        with self.SessionLocal() as session:
-            # Add a CASE statement to preserve the order of IDs
-            case_stmt = case(
-                {id_: index for index, id_ in enumerate(ids)},
-                value=self.embeddings_table.c.id,
-            )
-
-            query = (
-                session.query(self.embeddings_table)
-                .filter(self.embeddings_table.c.id.in_(ids))
-                .order_by(case_stmt)  # Order by the CASE statement
-            )
-            results = query.all()
-
-            documents = [
-                Document(**self._parse_embedding_store_record(row)) for row in results
-            ]
-            return documents
+        """
+        self.config.collection_name = collection_name
+        if collection_name in self.list_collections(empty=True) and replace:
+            logger.warning(f"Replacing existing collection {collection_name}")
+            self.client.delete_collection(collection_name)
+        self.collection = self.client.create_collection(
+            name=self.config.collection_name,
+            embedding_function=self.embedding_fn,
+            get_or_create=not replace,
+            metadata={
+                "hnsw:space": self.config.distance,
+                "hnsw:construction_ef": self.config.construction_ef,
+                "hnsw:search_ef": self.config.search_ef,
+                # we could expose other configs, see:
+                # https://docs.trychroma.com/docs/collections/configure
+            },
+        )
 
     def add_documents(self, documents: Sequence[Document]) -> None:
         super().maybe_add_ids(documents)
-        for doc in documents:
-            doc.metadata.id = str(PostgresDB._id_to_uuid(doc.metadata.id, doc.metadata))
+        if documents is None:
+            return
+        contents: List[str] = [document.content for document in documents]
+        # convert metadatas to dicts so chroma can handle them
+        metadata_dicts: List[dict[str, Any]] = [
+            d.metadata.dict_bool_int() for d in documents
+        ]
+        for m in metadata_dicts:
+            # chroma does not handle non-atomic types in metadata
+            m["window_ids"] = ",".join(m["window_ids"])
 
-        embeddings = self.embedding_fn([doc.content for doc in documents])
+        ids = [str(d.id()) for d in documents]
 
-        batch_size = self.config.batch_size
-        with self.SessionLocal() as session:
-            for i in range(0, len(documents), batch_size):
-                batch_docs = documents[i : i + batch_size]
-                batch_embeddings = embeddings[i : i + batch_size]
+        colls = self.list_collections(empty=True)
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        if self.config.collection_name not in colls:
+            self.create_collection(self.config.collection_name, replace=True)
 
-                new_records = [
-                    {
-                        "id": doc.metadata.id,
-                        "embedding": embedding,
-                        "document": doc.content,
-                        "cmetadata": doc.metadata.model_dump(),
-                    }
-                    for doc, embedding in zip(batch_docs, batch_embeddings)
-                ]
+        self.collection.add(
+            # embedding_models=embedding_models,
+            documents=contents,
+            metadatas=metadata_dicts,
+            ids=ids,
+        )
 
-                if new_records:
-                    stmt = insert(self.embeddings_table).values(new_records)
-                    session.execute(stmt)
-                session.commit()
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        filter = json.loads(where) if where else None
+        results = self.collection.get(
+            include=["documents", "metadatas"],
+            where=filter,
+        )
+        results["documents"] = [results["documents"]]
+        results["metadatas"] = [results["metadatas"]]
+        return self._docs_from_results(results)
 
-    @staticmethod
-    def _id_to_uuid(id: str, obj: object) -> str:
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        # get them one by one since chroma mangles the order of the results
+        # when fetched from a list of ids.
+        results = [
+            self.collection.get(ids=[id], include=["documents", "metadatas"])
+            for id in ids
+        ]
+        final_results = {}
+        final_results["documents"] = [[r["documents"][0] for r in results]]
+        final_results["metadatas"] = [[r["metadatas"][0] for r in results]]
+        return self._docs_from_results(final_results)
+
+    def delete_collection(self, collection_name: str) -> None:
         try:
-            doc_id = str(uuid.UUID(id))
-        except ValueError:
-            obj_repr = repr(obj)
-
-            obj_hash = hashlib.sha256(obj_repr.encode()).hexdigest()
-
-            combined = f"{id}-{obj_hash}"
-
-            doc_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, combined))
-
-        return doc_id
+            self.client.delete_collection(name=collection_name)
+        except Exception:
+            pass
 
     def similar_texts_with_scores(
-        self,
-        query: str,
-        k: int = 1,
-        where: Optional[str] = None,
-        neighbors: int = 1,  # Parameter not used in this implementation
+        self, text: str, k: int = 1, where: Optional[str] = None
     ) -> List[Tuple[Document, float]]:
-        embedding = self.embedding_fn([query])[0]
+        n = self.collection.count()
+        filter = json.loads(where) if where else None
+        results = self.collection.query(
+            query_texts=[text],
+            n_results=min(n, k),
+            where=filter,
+            include=["documents", "distances", "metadatas"],
+        )
+        docs = self._docs_from_results(results)
+        # chroma distances are 1 - cosine.
+        scores = [1 - s for s in results["distances"][0]]
+        return list(zip(docs, scores))
 
-        with self.SessionLocal() as session:
-            # Calculate the score (1 - cosine_distance) and label it as "score"
-            score = (
-                1 - (self.embeddings_table.c.embedding.cosine_distance(embedding))
-            ).label("score")
+    def _docs_from_results(self, results: Dict[str, Any]) -> List[Document]:
+        """
+        Helper function to convert results from ChromaDB to a list of Documents
+        Args:
+            results (dict): results from ChromaDB
 
-            if where is not None:
-                try:
-                    json_query = json.loads(where)
-                except json.JSONDecodeError:
-                    raise ValueError(f"Invalid JSON in 'where' clause: {where}")
-
-                results = (
-                    session.query(
-                        self.embeddings_table.c.id,
-                        self.embeddings_table.c.document,
-                        self.embeddings_table.c.cmetadata,
-                        score,  # Select the calculated score
-                    )
-                    .filter(self.embeddings_table.c.cmetadata.contains(json_query))
-                    .order_by(score.desc())  # Order by score in descending order
-                    .limit(k)
-                    .all()
-                )
+        Returns:
+            List[Document]: list of Documents
+        """
+        if len(results["documents"][0]) == 0:
+            return []
+        contents = results["documents"][0]
+        if settings.debug:
+            for i, c in enumerate(contents):
+                print_long_text("red", "italic red", f"MATCH-{i}", c)
+        metadatas = results["metadatas"][0]
+        for m in metadatas:
+            # restore the stringified list of window_ids into the original List[str]
+            if m["window_ids"].strip() == "":
+                m["window_ids"] = []
             else:
-                results = (
-                    session.query(
-                        self.embeddings_table.c.id,
-                        self.embeddings_table.c.document,
-                        self.embeddings_table.c.cmetadata,
-                        score,  # Select the calculated score
-                    )
-                    .order_by(score.desc())  # Order by score in descending order
-                    .limit(k)
-                    .all()
-                )
-
-            documents_with_scores = [
-                (
-                    Document(
-                        content=result.document,
-                        metadata=DocMetaData(**(result.cmetadata or {})),
-                    ),
-                    result.score,  # Use the score from the query result
-                )
-                for result in results
-            ]
-
-            return documents_with_scores
+                m["window_ids"] = m["window_ids"].split(",")
+        docs = [
+            self.config.document_class(
+                content=d, metadata=self.config.metadata_class(**m)
+            )
+            for d, m in zip(contents, metadatas)
+        ]
+        return docs
 </file>
 
-<file path="langroid/vector_store/qdrantdb.py">
-import hashlib
-import json
-import logging
-import os
-import time
-import uuid
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, TypeVar
+<file path="langroid/vector_store/lancedb.py">
+from __future__ import annotations
 
+import logging
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+)
+
+import pandas as pd
 from dotenv import load_dotenv
+from pydantic import BaseModel, ValidationError, create_model
+
+if TYPE_CHECKING:
+    from lancedb.query import LanceVectorQueryBuilder
+
+from pydantic_settings import SettingsConfigDict
 
 from langroid.embedding_models.base import (
     EmbeddingModelsConfig,
 )
 from langroid.embedding_models.models import OpenAIEmbeddingsConfig
-from langroid.mytypes import Document, Embeddings
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import Document
 from langroid.utils.configuration import settings
+from langroid.utils.pydantic_utils import (
+    dataframe_to_document_model,
+    dataframe_to_documents,
+)
 from langroid.vector_store.base import VectorStore, VectorStoreConfig
 
+try:
+    import lancedb
+    from lancedb.pydantic import LanceModel, Vector
+
+    has_lancedb = True
+except ImportError:
+    has_lancedb = False
+
 logger = logging.getLogger(__name__)
-if TYPE_CHECKING:
-    from qdrant_client.http.models import SparseVector
 
 
-T = TypeVar("T")
+class LanceDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="LANCEDB_")
 
-
-def from_optional(x: Optional[T], default: T) -> T:
-    if x is None:
-        return default
-
-    return x
-
-
-def is_valid_uuid(uuid_to_test: str) -> bool:
-    """
-    Check if a given string is a valid UUID.
-    """
-    try:
-        uuid_obj = uuid.UUID(uuid_to_test)
-        return str(uuid_obj) == uuid_to_test
-    except Exception:
-        pass
-    # Check for valid unsigned 64-bit integer
-    try:
-        int_value = int(uuid_to_test)
-        return 0 <= int_value <= 18446744073709551615
-    except ValueError:
-        return False
-
-
-class QdrantDBConfig(VectorStoreConfig):
-    cloud: bool = True
-    docker: bool = False
+    cloud: bool = False
     collection_name: str | None = "temp"
-    storage_path: str = ".qdrant/data"
+    storage_path: str = ".lancedb/data"
     embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
-    use_sparse_embeddings: bool = False
-    sparse_embedding_model: str = "naver/splade-v3-distilbert"
-    sparse_limit: int = 3
     distance: str = "cosine"
 
 
-class QdrantDB(VectorStore):
-    def __init__(self, config: QdrantDBConfig | None = None):
-        config = config if config is not None else QdrantDBConfig()
+class LanceDB(VectorStore):
+    def __init__(self, config: LanceDBConfig | None = None):
+        config = config if config is not None else LanceDBConfig()
         super().__init__(config)
-        self.config: QdrantDBConfig = config
-        from qdrant_client import QdrantClient
+        if not has_lancedb:
+            raise LangroidImportError("lancedb", "lancedb")
 
-        if self.config.use_sparse_embeddings:
-            try:
-                from transformers import AutoModelForMaskedLM, AutoTokenizer
-            except ImportError:
-                raise ImportError(
-                    """
-                    To use sparse embeddings,
-                    you must install langroid with the [transformers] extra, e.g.:
-                    pip install "langroid[transformers]"
-                    """
-                )
-
-            self.sparse_tokenizer = AutoTokenizer.from_pretrained(  # type: ignore
-                self.config.sparse_embedding_model
-            )
-            self.sparse_model = AutoModelForMaskedLM.from_pretrained(
-                self.config.sparse_embedding_model
-            )
+        self.config: LanceDBConfig = config
         self.host = config.host
         self.port = config.port
+        self.is_from_dataframe = False  # were docs ingested from a dataframe?
+        self.df_metadata_columns: List[str] = []  # metadata columns from dataframe
+
         load_dotenv()
-        key = os.getenv("QDRANT_API_KEY")
-        url = os.getenv("QDRANT_API_URL")
-        if config.docker:
-            if url is None:
-                logger.warning(
-                    f"""The QDRANT_API_URL env variable must be set to use
-                    QdrantDB in local docker mode. Please set this
-                    value in your .env file.
-                    Switching to local storage at {config.storage_path}
-                    """
-                )
-                config.cloud = False
-            else:
-                config.cloud = True
-        elif config.cloud and None in [key, url]:
+        if self.config.cloud:
             logger.warning(
-                f"""QDRANT_API_KEY, QDRANT_API_URL env variable must be set to use
-                QdrantDB in cloud mode. Please set these values
-                in your .env file.
-                Switching to local storage at {config.storage_path}
-                """
+                "LanceDB Cloud is not available yet. Switching to local storage."
             )
             config.cloud = False
-
-        if config.cloud:
-            self.client = QdrantClient(
-                url=url,
-                api_key=key,
-                timeout=config.timeout,
-            )
         else:
             try:
-                self.client = QdrantClient(
-                    path=config.storage_path,
+                self.client = lancedb.connect(
+                    uri=config.storage_path,
                 )
             except Exception as e:
                 new_storage_path = config.storage_path + ".new"
                 logger.warning(
                     f"""
-                    Error connecting to local QdrantDB at {config.storage_path}:
+                    Error connecting to local LanceDB at {config.storage_path}:
                     {e}
                     Switching to {new_storage_path}
                     """
                 )
-                self.client = QdrantClient(
-                    path=new_storage_path,
+                self.client = lancedb.connect(
+                    uri=new_storage_path,
                 )
-
-        # Note: Only create collection if a non-null collection name is provided.
-        # This is useful to delay creation of vecdb until we have a suitable
-        # collection name (e.g. we could get it from the url or folder path).
-        if config.collection_name is not None:
-            self.create_collection(
-                config.collection_name, replace=config.replace_collection
-            )
-
-    def clone(self) -> "QdrantDB":
-        """Create an independent Qdrant client when running against Qdrant Cloud."""
-        if not self.config.cloud:
-            return self
-        cloned = super().clone()
-        assert isinstance(cloned, QdrantDB)
-        return cloned
-
-    def close(self) -> None:
-        """
-        Close the QdrantDB client and release any resources (e.g., file locks).
-        This is especially important for local storage to release the .lock file.
-        """
-        if hasattr(self.client, "close"):
-            # QdrantLocal has a close method that releases the lock
-            self.client.close()
-            logger.info(f"Closed QdrantDB connection for {self.config.storage_path}")
-
-    def __enter__(self) -> "QdrantDB":
-        """Context manager entry."""
-        return self
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        """Context manager exit - ensure cleanup even if an exception occurred."""
-        self.close()
 
     def clear_empty_collections(self) -> int:
         coll_names = self.list_collections()
         n_deletes = 0
         for name in coll_names:
-            info = self.client.get_collection(collection_name=name)
-            if info.points_count == 0:
+            nr = self.client.open_table(name).head(1).shape[0]
+            if nr == 0:
                 n_deletes += 1
-                self.client.delete_collection(collection_name=name)
+                self.client.drop_table(name)
         return n_deletes
 
     def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
         """Clear all collections with the given prefix."""
-
         if not really:
             logger.warning("Not deleting all collections, set really=True to confirm")
             return 0
@@ -105000,12 +102681,10 @@ class QdrantDB(VectorStore):
         n_empty_deletes = 0
         n_non_empty_deletes = 0
         for name in coll_names:
-            info = self.client.get_collection(collection_name=name)
-            points_count = from_optional(info.points_count, 0)
-
-            n_empty_deletes += points_count == 0
-            n_non_empty_deletes += points_count > 0
-            self.client.delete_collection(collection_name=name)
+            nr = self.client.open_table(name).head(1).shape[0]
+            n_empty_deletes += nr == 0
+            n_non_empty_deletes += nr > 0
+            self.client.drop_table(name)
         logger.warning(
             f"""
             Deleted {n_empty_deletes} empty collections and
@@ -105022,25 +102701,425 @@ class QdrantDB(VectorStore):
         Args:
             empty (bool, optional): Whether to include empty collections.
         """
+        colls = self.client.table_names(limit=None)
+        if len(colls) == 0:
+            return []
+        if empty:  # include empty tbls
+            return colls  # type: ignore
+        counts = [self.client.open_table(coll).head(1).shape[0] for coll in colls]
+        return [coll for coll, count in zip(colls, counts) if count > 0]
 
-        colls = list(self.client.get_collections())[0][1]
-        if empty:
-            return [coll.name for coll in colls]
-        counts = []
-        for coll in colls:
-            try:
-                counts.append(
-                    from_optional(
-                        self.client.get_collection(
-                            collection_name=coll.name
-                        ).points_count,
-                        0,
+    def _create_lance_schema(self, doc_cls: Type[Document]) -> Type[BaseModel]:
+        """
+        NOTE: NOT USED, but leaving it here as it may be useful.
+
+        Create a subclass of LanceModel with fields:
+         - id (str)
+         - Vector field that has dims equal to
+            the embedding dimension of the embedding model, and a data field of type
+            DocClass.
+         - other fields from doc_cls
+
+        Args:
+            doc_cls (Type[Document]): A Pydantic model which should be a subclass of
+                Document, to be used as the type for the data field.
+
+        Returns:
+            Type[BaseModel]: A new Pydantic model subclassing from LanceModel.
+
+        Raises:
+            ValueError: If `n` is not a non-negative integer or if `DocClass` is not a
+                subclass of Document.
+        """
+        if not issubclass(doc_cls, Document):
+            raise ValueError("DocClass must be a subclass of Document")
+
+        if not has_lancedb:
+            raise LangroidImportError("lancedb", "lancedb")
+
+        n = self.embedding_dim
+
+        # Prepare fields for the new model
+        fields = {"id": (str, ...), "vector": (Vector(n), ...)}
+
+        sorted_fields = dict(
+            sorted(doc_cls.model_fields.items(), key=lambda item: item[0])
+        )
+        # Add both statically and dynamically defined fields from doc_cls
+        for field_name, field in sorted_fields.items():
+            field_type = field.annotation if hasattr(field, "annotation") else field
+            fields[field_name] = (field_type, field.default)
+
+        # Create the new model with dynamic fields
+        NewModel = create_model(
+            "NewModel", __base__=LanceModel, **fields
+        )  # type: ignore
+        return NewModel  # type: ignore
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        self.config.replace_collection = replace
+        self.config.collection_name = collection_name
+        if replace:
+            self.delete_collection(collection_name)
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        super().maybe_add_ids(documents)
+        colls = self.list_collections(empty=True)
+        if len(documents) == 0:
+            return
+        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+        coll_name = self.config.collection_name
+        if coll_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        # self._maybe_set_doc_class_schema(documents[0])
+        table_exists = False
+        if (
+            coll_name in colls
+            and self.client.open_table(coll_name).head(1).shape[0] > 0
+        ):
+            # collection exists and  is not empty:
+            # if replace_collection is True, we'll overwrite the existing collection,
+            # else we'll append to it.
+            if self.config.replace_collection:
+                self.client.drop_table(coll_name)
+            else:
+                table_exists = True
+
+        ids = [str(d.id()) for d in documents]
+        # don't insert all at once, batch in chunks of b,
+        # else we get an API error
+        b = self.config.batch_size
+
+        def make_batches() -> Generator[List[Dict[str, Any]], None, None]:
+            for i in range(0, len(ids), b):
+                batch = [
+                    dict(
+                        id=ids[i + j],
+                        vector=embedding_vecs[i + j],
+                        **doc.model_dump(),
                     )
+                    for j, doc in enumerate(documents[i : i + b])
+                ]
+                yield batch
+
+        try:
+            if table_exists:
+                tbl = self.client.open_table(coll_name)
+                tbl.add(make_batches())
+            else:
+                batch_gen = make_batches()
+                batch = next(batch_gen)
+                # use first batch to create table...
+                tbl = self.client.create_table(
+                    coll_name,
+                    data=batch,
+                    mode="create",
                 )
-            except Exception:
-                logger.warning(f"Error getting collection {coll.name}")
-                counts.append(0)
-        return [coll.name for coll, count in zip(colls, counts) if (count or 0) > 0]
+                # ... and add the rest
+                tbl.add(batch_gen)
+        except Exception as e:
+            logger.error(
+                f"""
+                Error adding documents to LanceDB: {e}
+                POSSIBLE REMEDY: Delete the LancdDB storage directory
+                {self.config.storage_path} and try again.
+                """
+            )
+
+    def add_dataframe(
+        self,
+        df: pd.DataFrame,
+        content: str = "content",
+        metadata: List[str] = [],
+    ) -> None:
+        """
+        Add a dataframe to the collection.
+        Args:
+            df (pd.DataFrame): A dataframe
+            content (str): The name of the column in the dataframe that contains the
+                text content to be embedded using the embedding model.
+            metadata (List[str]): A list of column names in the dataframe that contain
+                metadata to be stored in the database. Defaults to [].
+        """
+        self.is_from_dataframe = True
+        actual_metadata = metadata.copy()
+        self.df_metadata_columns = actual_metadata  # could be updated below
+        # get content column
+        content_values = df[content].values.tolist()
+        embedding_vecs = self.embedding_fn(content_values)
+
+        # add vector column
+        df["vector"] = embedding_vecs
+        if content != "content":
+            # rename content column to "content", leave existing column intact
+            df = df.rename(columns={content: "content"}, inplace=False)
+
+        if "id" not in df.columns:
+            docs = dataframe_to_documents(df, content="content", metadata=metadata)
+            ids = [str(d.id()) for d in docs]
+            df["id"] = ids
+
+        if "id" not in actual_metadata:
+            actual_metadata += ["id"]
+
+        colls = self.list_collections(empty=True)
+        coll_name = self.config.collection_name
+        if (
+            coll_name not in colls
+            or self.client.open_table(coll_name).head(1).shape[0] == 0
+        ):
+            # collection either doesn't exist or is empty, so replace it
+            # and set new schema from df
+            self.client.create_table(
+                self.config.collection_name,
+                data=df,
+                mode="overwrite",
+            )
+            doc_cls = dataframe_to_document_model(
+                df,
+                content=content,
+                metadata=actual_metadata,
+                exclude=["vector"],
+            )
+            self.config.document_class = doc_cls  # type: ignore
+        else:
+            # collection exists and is not empty, so append to it
+            tbl = self.client.open_table(self.config.collection_name)
+            tbl.add(df)
+
+    def delete_collection(self, collection_name: str) -> None:
+        self.client.drop_table(collection_name, ignore_missing=True)
+
+    def _lance_result_to_docs(
+        self, result: "LanceVectorQueryBuilder"
+    ) -> List[Document]:
+        if self.is_from_dataframe:
+            df = result.to_pandas()
+            return dataframe_to_documents(
+                df,
+                content="content",
+                metadata=self.df_metadata_columns,
+                doc_cls=self.config.document_class,
+            )
+        else:
+            records = result.to_arrow().to_pylist()
+            return self._records_to_docs(records)
+
+    def _records_to_docs(self, records: List[Dict[str, Any]]) -> List[Document]:
+        try:
+            docs = [self.config.document_class(**rec) for rec in records]
+        except ValidationError as e:
+            raise ValueError(
+                f"""
+            Error validating LanceDB result: {e}
+            HINT: This could happen when you're re-using an
+            existing LanceDB store with a different schema.
+            Try deleting your local lancedb storage at `{self.config.storage_path}`
+            re-ingesting your documents and/or replacing the collections.
+            """
+            )
+        return docs
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        if self.config.collection_name not in self.list_collections(empty=True):
+            return []
+        tbl = self.client.open_table(self.config.collection_name)
+        pre_result = tbl.search(None).where(where or None).limit(None)
+        return self._lance_result_to_docs(pre_result)
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        _ids = [str(id) for id in ids]
+        tbl = self.client.open_table(self.config.collection_name)
+        docs = []
+        for _id in _ids:
+            results = self._lance_result_to_docs(tbl.search().where(f"id == '{_id}'"))
+            if len(results) > 0:
+                docs.append(results[0])
+        return docs
+
+    def similar_texts_with_scores(
+        self,
+        text: str,
+        k: int = 1,
+        where: Optional[str] = None,
+    ) -> List[Tuple[Document, float]]:
+        embedding = self.embedding_fn([text])[0]
+        tbl = self.client.open_table(self.config.collection_name)
+        result = (
+            tbl.search(embedding)
+            .metric(self.config.distance)
+            .where(where, prefilter=True)
+            .limit(k)
+        )
+        docs = self._lance_result_to_docs(result)
+        # note _distance is 1 - cosine
+        if self.is_from_dataframe:
+            scores = [
+                1 - rec["_distance"] for rec in result.to_pandas().to_dict("records")
+            ]
+        else:
+            scores = [1 - rec["_distance"] for rec in result.to_arrow().to_pylist()]
+        if len(docs) == 0:
+            logger.warning(f"No matches found for {text}")
+            return []
+        if settings.debug:
+            logger.info(f"Found {len(docs)} matches, max score: {max(scores)}")
+        doc_score_pairs = list(zip(docs, scores))
+        self.show_if_debug(doc_score_pairs)
+        return doc_score_pairs
+</file>
+
+<file path="langroid/vector_store/meilisearch.py">
+"""
+MeiliSearch as a pure document store, without its
+(experimental) vector-store functionality.
+We aim to use MeiliSearch for fast lexical search.
+Note that what we call "Collection" in Langroid is referred to as
+"Index" in MeiliSearch. Each data-store has its own terminology,
+but for uniformity we use the Langroid terminology here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+from dotenv import load_dotenv
+
+if TYPE_CHECKING:
+    from meilisearch_python_sdk.index import AsyncIndex
+    from meilisearch_python_sdk.models.documents import DocumentsInfo
+
+
+from pydantic_settings import SettingsConfigDict
+
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import DocMetaData, Document
+from langroid.utils.configuration import settings
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+
+
+class MeiliSearchConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="MEILISEARCH_")
+
+    cloud: bool = False
+    collection_name: str | None = None
+    primary_key: str = "id"
+    port: int = 7700
+
+
+class MeiliSearch(VectorStore):
+    def __init__(self, config: MeiliSearchConfig | None = None):
+        config = config if config is not None else MeiliSearchConfig()
+        super().__init__(config)
+        try:
+            import meilisearch_python_sdk as meilisearch
+        except ImportError:
+            raise LangroidImportError("meilisearch", "meilisearch")
+
+        self.config: MeiliSearchConfig = config
+        self.host = config.host
+        self.port = config.port
+        load_dotenv()
+        self.key = os.getenv("MEILISEARCH_API_KEY") or "masterKey"
+        self.url = os.getenv("MEILISEARCH_API_URL") or f"http://{self.host}:{self.port}"
+        if config.cloud and None in [self.key, self.url]:
+            logger.warning(
+                f"""MEILISEARCH_API_KEY, MEILISEARCH_API_URL env variable must be set 
+                to use MeiliSearch in cloud mode. Please set these values 
+                in your .env file. Switching to local MeiliSearch at 
+                {self.url} 
+                """
+            )
+            config.cloud = False
+
+        self.client: Callable[[], meilisearch.AsyncClient] = lambda: (
+            meilisearch.AsyncClient(url=self.url, api_key=self.key)
+        )
+
+        # Note: Only create collection if a non-null collection name is provided.
+        # This is useful to delay creation of db until we have a suitable
+        # collection name (e.g. we could get it from the url or folder path).
+        if config.collection_name is not None:
+            self.create_collection(
+                config.collection_name, replace=config.replace_collection
+            )
+
+    def clear_empty_collections(self) -> int:
+        """All collections are treated as non-empty in MeiliSearch, so this is a
+        no-op"""
+        return 0
+
+    async def _async_delete_indices(self, uids: List[str]) -> List[bool]:
+        """Delete any indicecs in `uids` that exist.
+        Returns list of bools indicating whether the index has been deleted"""
+        async with self.client() as client:
+            result = await asyncio.gather(
+                *[client.delete_index_if_exists(uid=uid) for uid in uids]
+            )
+        return result
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """Delete all indices whose names start with `prefix`"""
+        if not really:
+            logger.warning("Not deleting all collections, set really=True to confirm")
+            return 0
+        coll_names = [c for c in self.list_collections() if c.startswith(prefix)]
+        deletes = asyncio.run(self._async_delete_indices(coll_names))
+        n_deletes = sum(deletes)
+        logger.warning(f"Deleted {n_deletes} indices in MeiliSearch")
+        return n_deletes
+
+    def _list_all_collections(self) -> List[str]:
+        """
+        List all collections, including empty ones.
+        Returns:
+            List of collection names.
+        """
+        return self.list_collections()
+
+    async def _async_get_indexes(self) -> List[AsyncIndex]:
+        async with self.client() as client:
+            indexes = await client.get_indexes(limit=10_000)
+        return [] if indexes is None else indexes  # type: ignore
+
+    async def _async_get_index(self, index_uid: str) -> "AsyncIndex":
+        async with self.client() as client:
+            index = await client.get_index(index_uid)
+        return index  # type: ignore
+
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """
+        Returns:
+            List of index names stored. We treat any existing index as non-empty.
+        """
+        indexes = asyncio.run(self._async_get_indexes())
+        if len(indexes) == 0:
+            return []
+        else:
+            return [ind.uid for ind in indexes]
+
+    async def _async_create_index(self, collection_name: str) -> "AsyncIndex":
+        async with self.client() as client:
+            index = await client.create_index(
+                uid=collection_name,
+                primary_key=self.config.primary_key,
+            )
+        return index
+
+    async def _async_delete_index(self, collection_name: str) -> bool:
+        """Delete index if it exists. Returns True iff index was deleted"""
+        async with self.client() as client:
+            result = await client.delete_index_if_exists(uid=collection_name)
+        return result  # type: ignore
 
     def create_collection(self, collection_name: str, replace: bool = False) -> None:
         """
@@ -105051,291 +103130,906 @@ class QdrantDB(VectorStore):
             replace (bool): Whether to replace an existing collection
                 with the same name. Defaults to False.
         """
-        from qdrant_client.http.models import (
-            CollectionStatus,
-            Distance,
-            SparseIndexParams,
-            SparseVectorParams,
-            VectorParams,
-        )
-
         self.config.collection_name = collection_name
-        if self.client.collection_exists(collection_name=collection_name):
-            coll = self.client.get_collection(collection_name=collection_name)
-            if (
-                coll.status == CollectionStatus.GREEN
-                and from_optional(coll.points_count, 0) > 0
-            ):
-                logger.warning(f"Non-empty Collection {collection_name} already exists")
-                if not replace:
-                    logger.warning("Not replacing collection")
-                    return
-                else:
-                    logger.warning("Recreating fresh collection")
-            self.client.delete_collection(collection_name=collection_name)
-
-        vectors_config = {
-            "": VectorParams(
-                size=self.embedding_dim,
-                distance=Distance.COSINE,
+        collections = self.list_collections()
+        if collection_name in collections:
+            logger.warning(
+                f"MeiliSearch Non-empty Index {collection_name} already exists"
             )
-        }
-        sparse_vectors_config = None
-        if self.config.use_sparse_embeddings:
-            sparse_vectors_config = {
-                "text-sparse": SparseVectorParams(index=SparseIndexParams())
-            }
-        self.client.create_collection(
-            collection_name=collection_name,
-            vectors_config=vectors_config,
-            sparse_vectors_config=sparse_vectors_config,
-        )
-        collection_info = self.client.get_collection(collection_name=collection_name)
-        assert collection_info.status == CollectionStatus.GREEN
-        assert collection_info.vectors_count in [0, None]
+            if not replace:
+                logger.warning("Not replacing collection")
+                return
+            else:
+                logger.warning("Recreating fresh collection")
+                asyncio.run(self._async_delete_index(collection_name))
+        asyncio.run(self._async_create_index(collection_name))
+        collection_info = asyncio.run(self._async_get_index(collection_name))
         if settings.debug:
             level = logger.getEffectiveLevel()
             logger.setLevel(logging.INFO)
             logger.info(collection_info)
             logger.setLevel(level)
 
-    def get_sparse_embeddings(self, inputs: List[str]) -> List["SparseVector"]:
-        from qdrant_client.http.models import SparseVector
-
-        if not self.config.use_sparse_embeddings:
-            return []
-        import torch
-
-        tokens = self.sparse_tokenizer(
-            inputs, return_tensors="pt", truncation=True, padding=True
-        )
-        output = self.sparse_model(**tokens)
-        vectors = torch.max(
-            torch.log(torch.relu(output.logits) + torch.tensor(1.0))
-            * tokens.attention_mask.unsqueeze(-1),
-            dim=1,
-        )[0].squeeze(dim=1)
-        sparse_embeddings = []
-        for vec in vectors:
-            cols = vec.nonzero().squeeze().cpu().tolist()
-            weights = vec[cols].cpu().tolist()
-            sparse_embeddings.append(
-                SparseVector(
-                    indices=cols,
-                    values=weights,
-                )
+    async def _async_add_documents(
+        self, collection_name: str, documents: Sequence[Dict[str, Any]]
+    ) -> None:
+        async with self.client() as client:
+            index = client.index(collection_name)
+            await index.add_documents_in_batches(
+                documents=documents,
+                batch_size=self.config.batch_size,
+                primary_key=self.config.primary_key,
             )
-        return sparse_embeddings
 
     def add_documents(self, documents: Sequence[Document]) -> None:
-        from qdrant_client.http.models import (
-            Batch,
-            CollectionStatus,
-            SparseVector,
-        )
-
-        # Add id to metadata if not already present
         super().maybe_add_ids(documents)
-        # Fix the ids due to qdrant finickiness
-        for doc in documents:
-            doc.metadata.id = str(self._to_int_or_uuid(doc.metadata.id))
-        colls = self.list_collections(empty=True)
         if len(documents) == 0:
             return
-        document_dicts = [doc.model_dump() for doc in documents]
-        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
-        sparse_embedding_vecs = self.get_sparse_embeddings(
-            [doc.content for doc in documents]
-        )
+        colls = self._list_all_collections()
         if self.config.collection_name is None:
             raise ValueError("No collection name set, cannot ingest docs")
         if self.config.collection_name not in colls:
             self.create_collection(self.config.collection_name, replace=True)
-        ids = [self._to_int_or_uuid(d.id()) for d in documents]
-        # don't insert all at once, batch in chunks of b,
-        # else we get an API error
-        b = self.config.batch_size
-        for i in range(0, len(ids), b):
-            vectors: Dict[str, Embeddings | List[SparseVector]] = {
-                "": embedding_vecs[i : i + b]
-            }
-            if self.config.use_sparse_embeddings:
-                vectors["text-sparse"] = sparse_embedding_vecs[i : i + b]
-            coll_found: bool = False
-            for _ in range(3):
-                # poll until collection is ready
-                if (
-                    self.client.collection_exists(self.config.collection_name)
-                    and self.client.get_collection(self.config.collection_name).status
-                    == CollectionStatus.GREEN
-                ):
-                    coll_found = True
-                    break
-                time.sleep(1)
-
-            if not coll_found:
-                raise ValueError(
-                    f"""
-                    QdrantDB Collection {self.config.collection_name} 
-                    not found or not ready
-                    """
-                )
-
-            self.client.upsert(
-                collection_name=self.config.collection_name,
-                points=Batch(
-                    ids=ids[i : i + b],
-                    vectors=vectors,
-                    payloads=document_dicts[i : i + b],
-                ),
+        docs = [
+            dict(
+                id=d.id(),
+                content=d.content,
+                metadata=d.metadata.model_dump(),
             )
+            for d in documents
+        ]
+        asyncio.run(self._async_add_documents(self.config.collection_name, docs))
 
     def delete_collection(self, collection_name: str) -> None:
-        self.client.delete_collection(collection_name=collection_name)
+        asyncio.run(self._async_delete_index(collection_name))
 
     def _to_int_or_uuid(self, id: str) -> int | str:
         try:
-            int_val = int(id)
-            if is_valid_uuid(id):
-                return int_val
+            return int(id)
         except ValueError:
-            pass
-
-        # If doc_id is already a valid UUID, return it as is
-        if isinstance(id, str) and is_valid_uuid(id):
             return id
 
-        # Otherwise, generate a UUID from the doc_id
-        # Convert doc_id to string if it's not already
-        id_str = str(id)
-
-        # Hash the document ID using SHA-1
-        hash_object = hashlib.sha1(id_str.encode())
-        hash_digest = hash_object.hexdigest()
-
-        # Truncate or manipulate the hash to fit into a UUID (128 bits)
-        uuid_str = hash_digest[:32]
-
-        # Format this string into a UUID format
-        formatted_uuid = uuid.UUID(uuid_str)
-
-        return str(formatted_uuid)
-
-    def get_all_documents(self, where: str = "") -> List[Document]:
-        from qdrant_client.http.models import (
-            Filter,
-        )
-
+    async def _async_get_documents(self, where: str = "") -> "DocumentsInfo":
         if self.config.collection_name is None:
             raise ValueError("No collection name set, cannot retrieve docs")
-        docs = []
-        offset = 0
-        filter = Filter() if where == "" else Filter.model_validate(json.loads(where))
-        while True:
-            results, next_page_offset = self.client.scroll(
-                collection_name=self.config.collection_name,
-                scroll_filter=filter,
-                offset=offset,
-                limit=10_000,  # try getting all at once, if not we keep paging
-                with_payload=True,
-                with_vectors=False,
+        filter = [] if where is None else where
+        async with self.client() as client:
+            index = client.index(self.config.collection_name)
+            documents = await index.get_documents(limit=10_000, filter=filter)
+        return documents
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        docs = asyncio.run(self._async_get_documents(where))
+        if docs is None:
+            return []
+        doc_results = docs.results
+        return [
+            Document(
+                content=d["content"],
+                metadata=DocMetaData(**d["metadata"]),
             )
-            docs += [
-                self.config.document_class(**record.payload)  # type: ignore
-                for record in results
-            ]
-            # ignore
-            if next_page_offset is None:
-                break
-            offset = next_page_offset  # type: ignore
-        return docs
+            for d in doc_results
+        ]
+
+    async def _async_get_documents_by_ids(self, ids: List[str]) -> List[Dict[str, Any]]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        async with self.client() as client:
+            index = client.index(self.config.collection_name)
+            documents = await asyncio.gather(*[index.get_document(id) for id in ids])
+        return documents
 
     def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
         if self.config.collection_name is None:
             raise ValueError("No collection name set, cannot retrieve docs")
-        _ids = [self._to_int_or_uuid(id) for id in ids]
-        records = self.client.retrieve(
-            collection_name=self.config.collection_name,
-            ids=_ids,
-            with_vectors=False,
-            with_payload=True,
+        docs = asyncio.run(self._async_get_documents_by_ids(ids))
+        return [
+            Document(
+                content=d["content"],
+                metadata=DocMetaData(**d["metadata"]),
+            )
+            for d in docs
+        ]
+
+    async def _async_search(
+        self,
+        query: str,
+        k: int = 20,
+        filter: str | list[str | list[str]] | None = None,
+    ) -> List[Dict[str, Any]]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot search")
+        async with self.client() as client:
+            index = client.index(self.config.collection_name)
+            results = await index.search(
+                query,
+                limit=k,
+                show_ranking_score=True,
+                filter=filter,
+            )
+        return results.hits  # type: ignore
+
+    def similar_texts_with_scores(
+        self,
+        text: str,
+        k: int = 20,
+        where: Optional[str] = None,
+        neighbors: int = 0,  # ignored
+    ) -> List[Tuple[Document, float]]:
+        filter = [] if where is None else where
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot search")
+        _docs = asyncio.run(self._async_search(text, k, filter))  # type: ignore
+        if len(_docs) == 0:
+            logger.warning(f"No matches found for {text}")
+            return []
+        scores = [h["_rankingScore"] for h in _docs]
+        if settings.debug:
+            logger.info(f"Found {len(_docs)} matches, max score: {max(scores)}")
+        docs = [
+            Document(
+                content=d["content"],
+                metadata=DocMetaData(**d["metadata"]),
+            )
+            for d in _docs
+        ]
+        doc_score_pairs = list(zip(docs, scores))
+        self.show_if_debug(doc_score_pairs)
+        return doc_score_pairs
+</file>
+
+<file path="langroid/vector_store/pineconedb.py">
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+from dotenv import load_dotenv
+
+# import dataclass
+from pydantic import BaseModel
+from pydantic_settings import SettingsConfigDict
+
+from langroid import LangroidImportError
+from langroid.mytypes import Document
+from langroid.utils.configuration import settings
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+
+
+has_pinecone: bool = True
+try:
+    from pinecone import Pinecone, PineconeApiException, ServerlessSpec
+except ImportError:
+
+    if not TYPE_CHECKING:
+
+        class ServerlessSpec(BaseModel):
+            """
+            Fallback Serverless specification configuration to avoid import errors.
+            """
+
+            cloud: str
+            region: str
+
+        PineconeApiException = Any  # type: ignore
+        Pinecone = Any  # type: ignore
+        has_pinecone = False
+
+
+@dataclass(frozen=True)
+class IndexMeta:
+    name: str
+    total_vector_count: int
+
+
+class PineconeDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="PINECONE_")
+
+    cloud: bool = True
+    collection_name: str | None = "temp"
+    spec: ServerlessSpec = ServerlessSpec(cloud="aws", region="us-east-1")
+    deletion_protection: Literal["enabled", "disabled"] | None = None
+    metric: str = "cosine"
+    pagination_size: int = 100
+
+
+class PineconeDB(VectorStore):
+    def __init__(self, config: PineconeDBConfig | None = None):
+        config = config if config is not None else PineconeDBConfig()
+        super().__init__(config)
+        if not has_pinecone:
+            raise LangroidImportError("pinecone", "pinecone")
+        self.config: PineconeDBConfig = config
+        load_dotenv()
+        key = os.getenv("PINECONE_API_KEY")
+
+        if not key:
+            raise ValueError("PINECONE_API_KEY not set, could not instantiate client")
+        self.client = Pinecone(api_key=key)
+
+        if config.collection_name:
+            self.create_collection(
+                collection_name=config.collection_name,
+                replace=config.replace_collection,
+            )
+
+    def clear_empty_collections(self) -> int:
+        indexes = self._list_index_metas(empty=True)
+        n_deletes = 0
+        for index in indexes:
+            if index.total_vector_count == -1:
+                logger.warning(
+                    f"Error fetching details for {index.name} when scanning indexes"
+                )
+            n_deletes += 1
+            self.delete_collection(collection_name=index.name)
+        return n_deletes
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """
+        Returns:
+            Number of Pinecone indexes that were deleted
+
+        Args:
+            really: Optional[bool] - whether to really delete all Pinecone collections
+            prefix: Optional[str] - string to match potential Pinecone
+                indexes for deletion
+        """
+        if not really:
+            logger.warning("Not deleting all collections, set really=True to confirm")
+            return 0
+        indexes = [
+            c for c in self._list_index_metas(empty=True) if c.name.startswith(prefix)
+        ]
+        if len(indexes) == 0:
+            logger.warning(f"No collections found with prefix {prefix}")
+            return 0
+        n_empty_deletes, n_non_empty_deletes = 0, 0
+        for index_desc in indexes:
+            self.delete_collection(collection_name=index_desc.name)
+            n_empty_deletes += index_desc.total_vector_count == 0
+            n_non_empty_deletes += index_desc.total_vector_count > 0
+        logger.warning(
+            f"""
+            Deleted {n_empty_deletes} empty indexes and
+            {n_non_empty_deletes} non-empty indexes
+            """
         )
-        # Note the records may NOT be in the order of the ids,
-        # so we re-order them here.
-        id2payload = {record.id: record.payload for record in records}
-        ordered_payloads = [id2payload[id] for id in _ids if id in id2payload]
-        docs = [Document(**payload) for payload in ordered_payloads]  # type: ignore
+        return n_empty_deletes + n_non_empty_deletes
+
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """
+        Returns:
+            List of Pinecone indices that have at least one vector.
+
+        Args:
+            empty: Optional[bool] - whether to include empty collections
+        """
+        indexes = self.client.list_indexes()
+        res: List[str] = []
+        if empty:
+            res.extend(indexes.names())
+            return res
+
+        for index in indexes.names():
+            index_meta = self.client.Index(name=index)
+            if index_meta.describe_index_stats().get("total_vector_count", 0) > 0:
+                res.append(index)
+        return res
+
+    def _list_index_metas(self, empty: bool = False) -> List[IndexMeta]:
+        """
+        Returns:
+            List of objects describing Pinecone indices
+
+        Args:
+            empty: Optional[bool] - whether to include empty collections
+        """
+        indexes = self.client.list_indexes()
+        res = []
+        for index in indexes.names():
+            index_meta = self._fetch_index_meta(index)
+            if empty:
+                res.append(index_meta)
+            elif index_meta.total_vector_count > 0:
+                res.append(index_meta)
+        return res
+
+    def _fetch_index_meta(self, index_name: str) -> IndexMeta:
+        """
+        Returns:
+            A dataclass describing the input Index by name and vector count
+            to save a bit on index description calls
+
+        Args:
+            index_name: str - Name of the index in Pinecone
+        """
+        try:
+            index = self.client.Index(name=index_name)
+            stats = index.describe_index_stats()
+            return IndexMeta(
+                name=index_name, total_vector_count=stats.get("total_vector_count", 0)
+            )
+        except PineconeApiException as e:
+            logger.warning(f"Error fetching details for index {index_name}")
+            logger.warning(e)
+            return IndexMeta(name=index_name, total_vector_count=-1)
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        """
+        Create a collection with the given name, optionally replacing an existing
+        collection if `replace` is True.
+
+        Args:
+            collection_name: str - Configuration of the collection to create.
+            replace: Optional[Bool] - Whether to replace an existing collection
+                with the same name. Defaults to False.
+        """
+        pattern = re.compile(r"^[a-z0-9-]+$")
+        if not pattern.match(collection_name):
+            raise ValueError(
+                "Pinecone index names must be lowercase alphanumeric characters or '-'"
+            )
+        self.config.collection_name = collection_name
+        if collection_name in self.list_collections(empty=True):
+            index = self.client.Index(name=collection_name)
+            stats = index.describe_index_stats()
+            status = self.client.describe_index(name=collection_name)
+            if status["status"]["ready"] and stats["total_vector_count"] > 0:
+                logger.warning(f"Non-empty collection {collection_name} already exists")
+                if not replace:
+                    logger.warning("Not replacing collection")
+                    return
+                else:
+                    logger.warning("Recreating fresh collection")
+            self.delete_collection(collection_name=collection_name)
+
+        payload = {
+            "name": collection_name,
+            "dimension": self.embedding_dim,
+            "spec": self.config.spec,
+            "metric": self.config.metric,
+            "timeout": self.config.timeout,
+        }
+
+        if self.config.deletion_protection:
+            payload["deletion_protection"] = self.config.deletion_protection
+
+        try:
+            self.client.create_index(**payload)
+        except PineconeApiException as e:
+            logger.error(e)
+
+    def delete_collection(self, collection_name: str) -> None:
+        logger.info(f"Attempting to delete {collection_name}")
+        try:
+            self.client.delete_index(name=collection_name)
+        except PineconeApiException as e:
+            logger.error(f"Failed to delete {collection_name}")
+            logger.error(e)
+
+    def add_documents(self, documents: Sequence[Document], namespace: str = "") -> None:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+
+        if len(documents) == 0:
+            logger.warning("Empty list of documents passed into add_documents")
+            return
+
+        super().maybe_add_ids(documents)
+        document_dicts = [doc.model_dump() for doc in documents]
+        document_ids = [doc.id() for doc in documents]
+        embedding_vectors = self.embedding_fn([doc.content for doc in documents])
+        vectors = [
+            {
+                "id": document_id,
+                "values": embedding_vector,
+                "metadata": {
+                    **document_dict["metadata"],
+                    **{
+                        key: value
+                        for key, value in document_dict.items()
+                        if key != "metadata"
+                    },
+                },
+            }
+            for document_dict, document_id, embedding_vector in zip(
+                document_dicts, document_ids, embedding_vectors
+            )
+        ]
+
+        if self.config.collection_name not in self.list_collections(empty=True):
+            self.create_collection(
+                collection_name=self.config.collection_name, replace=True
+            )
+
+        index = self.client.Index(name=self.config.collection_name)
+        batch_size = self.config.batch_size
+
+        for i in range(0, len(documents), batch_size):
+            try:
+                if namespace:
+                    index.upsert(
+                        vectors=vectors[i : i + batch_size], namespace=namespace
+                    )
+                else:
+                    index.upsert(vectors=vectors[i : i + batch_size])
+            except PineconeApiException as e:
+                logger.error(
+                    f"Unable to add of docs between indices {i} and {batch_size}"
+                )
+                logger.error(e)
+
+    def get_all_documents(
+        self, prefix: str = "", namespace: str = ""
+    ) -> List[Document]:
+        """
+        Returns:
+            All documents for the collection currently defined in
+            the configuration object
+
+        Args:
+            prefix: str - document id prefix to search for
+            namespace: str - partition of vectors to search within the index
+        """
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        docs = []
+
+        request_filters: Dict[str, Union[str, int]] = {
+            "limit": self.config.pagination_size
+        }
+        if prefix:
+            request_filters["prefix"] = prefix
+        if namespace:
+            request_filters["namespace"] = namespace
+
+        index = self.client.Index(name=self.config.collection_name)
+
+        while True:
+            response = index.list_paginated(**request_filters)
+            vectors = response.get("vectors", [])
+
+            if not vectors:
+                logger.warning("Received empty list while requesting for vector ids")
+                logger.warning("Halting fetch requests")
+                if settings.debug:
+                    logger.debug(f"Request for failed fetch was: {request_filters}")
+                break
+
+            docs.extend(
+                self.get_documents_by_ids(
+                    ids=[vector.get("id") for vector in vectors],
+                    namespace=namespace if namespace else "",
+                )
+            )
+
+            pagination_token = response.get("pagination", {}).get("next", None)
+
+            if not pagination_token:
+                break
+
+            request_filters["pagination_token"] = pagination_token
+
         return docs
+
+    def get_documents_by_ids(
+        self, ids: List[str], namespace: str = ""
+    ) -> List[Document]:
+        """
+        Returns:
+            Fetches document text embedded in Pinecone index metadata
+
+        Args:
+            ids: List[str] - vector data object ids to retrieve
+            namespace: str - partition of vectors to search within the index
+        """
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        index = self.client.Index(name=self.config.collection_name)
+
+        if namespace:
+            records = index.fetch(ids=ids, namespace=namespace)
+        else:
+            records = index.fetch(ids=ids)
+
+        id_mapping = {key: value for key, value in records["vectors"].items()}
+        ordered_payloads = [id_mapping[_id] for _id in ids if _id in id_mapping]
+        return [
+            self.transform_pinecone_vector(payload.get("metadata", {}))
+            for payload in ordered_payloads
+        ]
 
     def similar_texts_with_scores(
         self,
         text: str,
         k: int = 1,
         where: Optional[str] = None,
-        neighbors: int = 0,
+        namespace: Optional[str] = None,
     ) -> List[Tuple[Document, float]]:
-        from qdrant_client.conversions.common_types import ScoredPoint
-        from qdrant_client.http.models import (
-            Filter,
-            NamedSparseVector,
-            NamedVector,
-            SearchRequest,
-        )
-
-        embedding = self.embedding_fn([text])[0]
-        # TODO filter may not work yet
-        if where is None or where == "":
-            filter = Filter()
-        else:
-            filter = Filter.model_validate(json.loads(where))
-        requests = [
-            SearchRequest(
-                vector=NamedVector(
-                    name="",
-                    vector=embedding,
-                ),
-                limit=k,
-                with_payload=True,
-                filter=filter,
-            )
-        ]
-        if self.config.use_sparse_embeddings:
-            sparse_embedding = self.get_sparse_embeddings([text])[0]
-            requests.append(
-                SearchRequest(
-                    vector=NamedSparseVector(
-                        name="text-sparse",
-                        vector=sparse_embedding,
-                    ),
-                    limit=self.config.sparse_limit,
-                    with_payload=True,
-                    filter=filter,
-                )
-            )
         if self.config.collection_name is None:
             raise ValueError("No collection name set, cannot search")
-        search_result_lists: List[List[ScoredPoint]] = self.client.search_batch(
-            collection_name=self.config.collection_name, requests=requests
-        )
 
-        search_result = [
-            match for result in search_result_lists for match in result
-        ]  # 2D list -> 1D list
-        scores = [match.score for match in search_result if match is not None]
-        docs = [
-            self.config.document_class(**(match.payload))  # type: ignore
-            for match in search_result
-            if match is not None
+        if k < 1 or k > 9999:
+            raise ValueError(
+                f"TopK for Pinecone vector search must be 1 < k < 10000, k was {k}"
+            )
+
+        vector_search_request = {
+            "top_k": k,
+            "include_metadata": True,
+            "vector": self.embedding_fn([text])[0],
+        }
+        if where:
+            vector_search_request["filter"] = json.loads(where) if where else None
+        if namespace:
+            vector_search_request["namespace"] = namespace
+
+        index = self.client.Index(name=self.config.collection_name)
+        response = index.query(**vector_search_request)
+        doc_score_pairs = [
+            (
+                self.transform_pinecone_vector(match.get("metadata", {})),
+                match.get("score", 0),
+            )
+            for match in response.get("matches", [])
         ]
-        if len(docs) == 0:
-            logger.warning(f"No matches found for {text}")
-            return []
-        doc_score_pairs = list(zip(docs, scores))
-        max_score = max(ds[1] for ds in doc_score_pairs)
         if settings.debug:
+            max_score = max([pair[1] for pair in doc_score_pairs])
             logger.info(f"Found {len(doc_score_pairs)} matches, max score: {max_score}")
         self.show_if_debug(doc_score_pairs)
         return doc_score_pairs
+
+    def transform_pinecone_vector(self, metadata_dict: Dict[str, Any]) -> Document:
+        """
+        Parses the metadata response from the Pinecone vector query and
+        formats it into a dictionary that can be parsed by the Document class
+        associated with the PineconeDBConfig class
+
+        Returns:
+            Well formed dictionary object to be transformed into a Document
+
+        Args:
+            metadata_dict: Dict - the metadata dictionary from the Pinecone
+                vector query match
+        """
+        return self.config.document_class(
+            **{**metadata_dict, "metadata": {**metadata_dict}}
+        )
+</file>
+
+<file path="langroid/vector_store/weaviatedb.py">
+import logging
+import os
+import re
+from typing import Any, List, Optional, Sequence, Tuple
+
+from dotenv import load_dotenv
+from pydantic_settings import SettingsConfigDict
+
+from langroid.embedding_models.base import (
+    EmbeddingModelsConfig,
+)
+from langroid.embedding_models.models import OpenAIEmbeddingsConfig
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import DocMetaData, Document
+from langroid.utils.configuration import settings
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+
+
+class VectorDistances:
+    """
+    Fallback class when weaviate is not installed, to avoid import errors.
+    """
+
+    COSINE: str = "cosine"
+    DOTPRODUCT: str = "dot"
+    L2: str = "l2"
+
+
+class WeaviateDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="WEAVIATE_")
+
+    collection_name: str | None = "temp"
+    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+    distance: str = VectorDistances.COSINE
+    cloud: bool = False
+    docker: bool = False
+    host: str = "127.0.0.1"
+    port: int = 8080
+    storage_path: str = ".weaviate_embedded/data"
+
+
+class WeaviateDB(VectorStore):
+    def __init__(self, config: WeaviateDBConfig | None = None):
+        config = config if config is not None else WeaviateDBConfig()
+        super().__init__(config)
+        try:
+            import weaviate
+            from weaviate.classes.init import Auth
+        except ImportError:
+            raise LangroidImportError("weaviate", "weaviate")
+
+        self.config: WeaviateDBConfig = config
+        load_dotenv()
+        if self.config.docker:
+            self.client = weaviate.connect_to_local(
+                host=self.config.host,
+                port=self.config.port,
+            )
+            self.config.cloud = False
+        elif self.config.cloud:
+            key = os.getenv("WEAVIATE_API_KEY")
+            url = os.getenv("WEAVIATE_API_URL")
+            if url is None or key is None:
+                raise ValueError(
+                    """WEAVIATE_API_KEY, WEAVIATE_API_URL env variables must be set to 
+                    use WeaviateDB in cloud mode. Please set these values
+                    in your .env file.
+                    """
+                )
+            self.client = weaviate.connect_to_weaviate_cloud(
+                cluster_url=url,
+                auth_credentials=Auth.api_key(key),
+            )
+        else:
+            self.client = weaviate.connect_to_embedded(
+                version="latest", persistence_data_path=self.config.storage_path
+            )
+
+        if config.collection_name is not None:
+            WeaviateDB.validate_and_format_collection_name(config.collection_name)
+
+    def clear_empty_collections(self) -> int:
+        colls = self.client.collections.list_all()
+        n_deletes = 0
+        for coll_name, _ in colls.items():
+            val = self.client.collections.get(coll_name)
+            if len(val) == 0:
+                n_deletes += 1
+                self.client.collections.delete(coll_name)
+        return n_deletes
+
+    def list_collections(self, empty: bool = False) -> List[str]:
+        colls = self.client.collections.list_all()
+        if empty:
+            return list(colls.keys())
+        non_empty_colls = [
+            coll_name
+            for coll_name in colls.keys()
+            if len(self.client.collections.get(coll_name)) > 0
+        ]
+
+        return non_empty_colls
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        if not really:
+            logger.warning(
+                "Not really deleting all collections ,set really=True to confirm"
+            )
+            return 0
+        coll_names = [
+            c for c in self.list_collections(empty=True) if c.startswith(prefix)
+        ]
+        if len(coll_names) == 0:
+            logger.warning(f"No collections found with prefix {prefix}")
+            return 0
+        n_empty_deletes = 0
+        n_non_empty_deletes = 0
+        for name in coll_names:
+            info = self.client.collections.get(name)
+            points_count = len(info)
+
+            n_empty_deletes += points_count == 0
+            n_non_empty_deletes += points_count > 0
+            self.client.collections.delete(name)
+        logger.warning(
+            f"""
+            Deleted {n_empty_deletes} empty collections and
+            {n_non_empty_deletes} non-empty collections.
+            """
+        )
+        return n_empty_deletes + n_non_empty_deletes
+
+    def delete_collection(self, collection_name: str) -> None:
+        self.client.collections.delete(name=collection_name)
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        try:
+            from weaviate.classes.config import (
+                Configure,
+                VectorDistances,
+            )
+        except ImportError:
+            raise LangroidImportError("weaviate", "weaviate")
+        collection_name = WeaviateDB.validate_and_format_collection_name(
+            collection_name
+        )
+        self.config.collection_name = collection_name
+        if self.client.collections.exists(name=collection_name):
+            coll = self.client.collections.get(name=collection_name)
+            if len(coll) > 0:
+                logger.warning(f"Non-empty Collection {collection_name} already exists")
+                if not replace:
+                    logger.warning("Not replacing collection")
+                    return
+                else:
+                    logger.warning("Recreating fresh collection")
+            self.client.collections.delete(name=collection_name)
+
+        vector_index_config = Configure.VectorIndex.hnsw(
+            distance_metric=VectorDistances.COSINE,
+        )
+        if isinstance(self.config.embedding, OpenAIEmbeddingsConfig):
+            vectorizer_config = Configure.Vectorizer.text2vec_openai(
+                model=self.config.embedding.model_name,
+            )
+        else:
+            vectorizer_config = None
+
+        collection_info = self.client.collections.create(
+            name=collection_name,
+            vector_index_config=vector_index_config,
+            vectorizer_config=vectorizer_config,
+        )
+        collection_info = self.client.collections.get(name=collection_name)
+        assert len(collection_info) in [0, None]
+        if settings.debug:
+            level = logger.getEffectiveLevel()
+            logger.setLevel(logging.INFO)
+            logger.info(collection_info)
+            logger.setLevel(level)
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        super().maybe_add_ids(documents)
+        colls = self.list_collections(empty=True)
+        for doc in documents:
+            doc.metadata.id = str(self._create_valid_uuid_id(doc.metadata.id))
+        if len(documents) == 0:
+            return
+
+        document_dicts = [doc.model_dump() for doc in documents]
+        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        if self.config.collection_name not in colls:
+            self.create_collection(self.config.collection_name, replace=True)
+        coll_name = self.client.collections.get(self.config.collection_name)
+        with coll_name.batch.dynamic() as batch:
+            for i, doc_dict in enumerate(document_dicts):
+                id = doc_dict["metadata"].pop("id", None)
+                batch.add_object(properties=doc_dict, uuid=id, vector=embedding_vecs[i])
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        # cannot use filter as client does not support json type queries
+        coll = self.client.collections.get(self.config.collection_name)
+        return [self.weaviate_obj_to_doc(item) for item in coll.iterator()]
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        from weaviate.classes.query import Filter
+
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+
+        docs = []
+        coll_name = self.client.collections.get(self.config.collection_name)
+
+        result = coll_name.query.fetch_objects(
+            filters=Filter.by_property("_id").contains_any(ids), limit=len(coll_name)
+        )
+
+        id_to_doc = {}
+        for item in result.objects:
+            doc = self.weaviate_obj_to_doc(item)
+            id_to_doc[doc.metadata.id] = doc
+
+        # Reconstruct the list of documents in the original order of input ids
+        docs = [id_to_doc[id] for id in ids if id in id_to_doc]
+
+        return docs
+
+    def similar_texts_with_scores(
+        self, text: str, k: int = 1, where: Optional[str] = None
+    ) -> List[Tuple[Document, float]]:
+        from weaviate.classes.query import MetadataQuery
+
+        embedding = self.embedding_fn([text])[0]
+        if self.config.collection_name is None:
+            raise ValueError("No collections name set,cannot search")
+        coll = self.client.collections.get(self.config.collection_name)
+        response = coll.query.near_vector(
+            near_vector=embedding,
+            limit=k,
+            return_properties=True,
+            return_metadata=MetadataQuery(distance=True),
+        )
+        maybe_distances = [item.metadata.distance for item in response.objects]
+        similarities = [0 if d is None else 1 - d for d in maybe_distances]
+        docs = [self.weaviate_obj_to_doc(item) for item in response.objects]
+        return list(zip(docs, similarities))
+
+    def _create_valid_uuid_id(self, id: str) -> Any:
+        from weaviate.util import generate_uuid5, get_valid_uuid
+
+        try:
+            id = get_valid_uuid(id)
+            return id
+        except Exception:
+            return generate_uuid5(id)
+
+    def weaviate_obj_to_doc(self, input_object: Any) -> Document:
+        from weaviate.util import get_valid_uuid
+
+        content = input_object.properties.get("content", "")
+        metadata_dict = input_object.properties.get("metadata", {})
+
+        window_ids = metadata_dict.pop("window_ids", [])
+        window_ids = [str(uuid) for uuid in window_ids]
+
+        # Ensure the id is a valid UUID string
+        id_value = get_valid_uuid(input_object.uuid)
+
+        metadata = DocMetaData(id=id_value, window_ids=window_ids, **metadata_dict)
+
+        return Document(content=content, metadata=metadata)
+
+    @staticmethod
+    def validate_and_format_collection_name(name: str) -> str:
+        """
+        Formats the collection name to comply with Weaviate's naming rules:
+        - Name must start with a capital letter.
+        - Name can only contain letters, numbers, and underscores.
+        - Replaces invalid characters with underscores.
+        """
+        if not name:
+            raise ValueError("Collection name cannot be empty.")
+
+        formatted_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+
+        # Ensure the first letter is capitalized
+        if not formatted_name[0].isupper():
+            formatted_name = formatted_name.capitalize()
+
+        # Check if the name now meets the criteria
+        if not re.match(r"^[A-Z][A-Za-z0-9_]*$", formatted_name):
+            raise ValueError(
+                f"Invalid collection name '{name}'."
+                " Names must start with a capital letter "
+                "and contain only letters, numbers, and underscores."
+            )
+
+        if formatted_name != name:
+            logger.warning(
+                f"Collection name '{name}' was reformatted to '{formatted_name}' "
+                "to comply with Weaviate's rules."
+            )
+
+        return formatted_name
+
+    def __del__(self) -> None:
+        # Gracefully close the connection with local client
+        if not self.config.cloud:
+            self.client.close()
 </file>
 
 <file path="tests/main/test_arangodb_chat_agent.py">
@@ -107554,6 +106248,296 @@ def test_unresolvable_symlinks_are_skipped_without_aborting(
     make_bad(base)
 
     assert INSIDE in _all_text(loader(base))
+</file>
+
+<file path="tests/main/test_vecstore_env_prefix.py">
+"""Tests for env-var prefixes on vector-store configs (issue #1078).
+
+`VectorStoreConfig` extends `BaseSettings`, so without an `env_prefix`
+every field name was itself a case-insensitive environment variable:
+a bare `HOST`, `PORT`, or worst `FULL_EVAL` in the environment silently
+overrode the default for every vector-store config. These tests assert
+that bare env vars no longer leak in, that properly prefixed env vars
+(`VECDB_*` for the base config, `QDRANT_*` etc. per provider) do work,
+and that explicit constructor arguments beat env values.
+
+No live vector-store connections are needed: config construction only.
+"""
+
+import logging
+import os
+from typing import Type
+
+import pytest
+from pydantic import ValidationError
+from pydantic_settings import BaseSettings
+
+from langroid.utils.configuration import set_env
+from langroid.vector_store.base import VectorStoreConfig
+from langroid.vector_store.chromadb import ChromaDBConfig
+from langroid.vector_store.lancedb import LanceDBConfig
+from langroid.vector_store.meilisearch import MeiliSearchConfig
+from langroid.vector_store.pineconedb import PineconeDBConfig
+from langroid.vector_store.postgres import PostgresDBConfig
+from langroid.vector_store.qdrantdb import QdrantDBConfig
+from langroid.vector_store.weaviatedb import WeaviateDBConfig
+
+ALL_CONFIGS: list[Type[VectorStoreConfig]] = [
+    VectorStoreConfig,
+    QdrantDBConfig,
+    ChromaDBConfig,
+    LanceDBConfig,
+    PineconeDBConfig,
+    PostgresDBConfig,
+    MeiliSearchConfig,
+    WeaviateDBConfig,
+]
+
+# provider config -> (its env prefix, a str field to probe with)
+PREFIXED_CASES: list[tuple[Type[VectorStoreConfig], str, str]] = [
+    (VectorStoreConfig, "VECDB_", "host"),
+    (QdrantDBConfig, "QDRANT_", "host"),
+    (ChromaDBConfig, "CHROMA_", "host"),
+    (LanceDBConfig, "LANCEDB_", "storage_path"),
+    (PineconeDBConfig, "PINECONE_", "metric"),
+    (PostgresDBConfig, "POSTGRES_", "host"),
+    (MeiliSearchConfig, "MEILISEARCH_", "primary_key"),
+    (WeaviateDBConfig, "WEAVIATE_", "host"),
+]
+
+
+# every field name these tests assert on, in env-var (upper) form
+FIELD_VARS: list[str] = [
+    "HOST",
+    "PORT",
+    "CLOUD",
+    "TIMEOUT",
+    "BATCH_SIZE",
+    "TYPE",
+    "STORAGE_PATH",
+    "COLLECTION_NAME",
+    "FULL_EVAL",
+    "METRIC",
+    "PRIMARY_KEY",
+]
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove ambient bare and prefixed env vars before each test.
+
+    A runner may legitimately have e.g. `POSTGRES_HOST` set (docker/CI)
+    or a stray `QDRANT_FULL_EVAL`; without this cleanup those would make
+    the default-value assertions below fail spuriously. Runs before each
+    test body, so tests that intentionally `setenv` still work.
+    """
+    prefixes = [""] + [prefix for _, prefix, _ in PREFIXED_CASES]
+    for prefix in prefixes:
+        for field_var in FIELD_VARS:
+            monkeypatch.delenv(f"{prefix}{field_var}", raising=False)
+
+
+@pytest.mark.parametrize("config_cls", ALL_CONFIGS)
+def test_bare_env_vars_do_not_leak(
+    config_cls: Type[VectorStoreConfig],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bare (unprefixed) env vars must not override config defaults."""
+    monkeypatch.setenv("HOST", "evil.example.com")
+    monkeypatch.setenv("PORT", "9999")
+    monkeypatch.setenv("FULL_EVAL", "true")
+    monkeypatch.setenv("COLLECTION_NAME", "hijacked")
+    monkeypatch.setenv("CLOUD", "true")
+    monkeypatch.setenv("STORAGE_PATH", "/evil/path")
+
+    defaults = config_cls.model_fields
+    config = config_cls()
+    assert config.host == defaults["host"].default
+    assert config.port == defaults["port"].default
+    assert config.full_eval is False
+    assert config.collection_name == defaults["collection_name"].default
+    assert config.cloud == defaults["cloud"].default
+    assert config.storage_path == defaults["storage_path"].default
+
+
+@pytest.mark.parametrize("config_cls,prefix,field", PREFIXED_CASES)
+def test_prefixed_env_vars_are_honored(
+    config_cls: Type[VectorStoreConfig],
+    prefix: str,
+    field: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env vars with the class's own prefix DO override defaults."""
+    monkeypatch.setenv(f"{prefix}{field.upper()}", "from-env")
+    monkeypatch.setenv(f"{prefix}FULL_EVAL", "true")
+
+    config = config_cls()
+    assert getattr(config, field) == "from-env"
+    assert config.full_eval is True
+
+
+@pytest.mark.parametrize("config_cls,prefix,field", PREFIXED_CASES)
+def test_constructor_args_beat_env_vars(
+    config_cls: Type[VectorStoreConfig],
+    prefix: str,
+    field: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit constructor kwargs take priority over prefixed env vars."""
+    monkeypatch.setenv(f"{prefix}{field.upper()}", "from-env")
+    monkeypatch.setenv(f"{prefix}FULL_EVAL", "true")
+
+    config = config_cls(**{field: "explicit", "full_eval": False})
+    assert getattr(config, field) == "explicit"
+    assert config.full_eval is False
+
+
+@pytest.mark.parametrize("config_cls,prefix,field", PREFIXED_CASES)
+def test_other_providers_prefix_does_not_leak(
+    config_cls: Type[VectorStoreConfig],
+    prefix: str,
+    field: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One provider's prefixed env vars must not affect other providers."""
+    monkeypatch.setenv(f"{prefix}FULL_EVAL", "true")
+    for other_cls, other_prefix, _ in PREFIXED_CASES:
+        if other_prefix == prefix:
+            continue
+        assert (
+            other_cls().full_eval is False
+        ), f"{prefix}FULL_EVAL leaked into {other_cls.__name__}"
+
+
+@pytest.mark.parametrize(
+    "config_cls,env_var",
+    [
+        (QdrantDBConfig, "QDRANT_PORT"),
+        (PostgresDBConfig, "POSTGRES_PORT"),
+    ],
+)
+def test_service_link_port_is_ignored_with_warning(
+    config_cls: Type[VectorStoreConfig],
+    env_var: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A k8s/docker service-link `tcp://...` port is ignored with a warning.
+
+    With `enableServiceLinks` (on by default in Kubernetes), a service
+    named e.g. `qdrant` injects `QDRANT_PORT=tcp://10.0.0.8:6333` into
+    every pod; construction must succeed with the default port.
+    """
+    monkeypatch.setenv(env_var, "tcp://10.0.0.8:6333")
+    default_port = config_cls.model_fields["port"].default
+    with caplog.at_level(logging.WARNING, logger="langroid.vector_store.base"):
+        config = config_cls()
+    assert config.port == default_port
+    assert "tcp://10.0.0.8:6333" in caplog.text
+    assert "ignor" in caplog.text.lower()
+
+
+def test_non_service_link_bad_port_still_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the `tcp://` service-link format is forgiven; other junk fails."""
+    monkeypatch.setenv("QDRANT_PORT", "not-a-port")
+    with pytest.raises(ValidationError):
+        QdrantDBConfig()
+
+
+def test_malformed_tcp_env_port_still_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A `tcp://` value NOT matching the full service-link shape fails.
+
+    Only `tcp://<host>:<digits>` (the exact k8s injection format) is
+    forgiven; malformed `tcp://` junk must fail validation loudly.
+    """
+    monkeypatch.setenv("QDRANT_PORT", "tcp://garbage")
+    with pytest.raises(ValidationError):
+        QdrantDBConfig()
+
+
+def test_constructor_tcp_port_still_fails() -> None:
+    """The service-link exception applies to the env source ONLY.
+
+    An explicit constructor value is a programming error, not a k8s
+    artifact, so it must fail validation rather than be silently
+    replaced with the default.
+    """
+    with pytest.raises(ValidationError):
+        QdrantDBConfig(port="tcp://10.0.0.8:6333")  # type: ignore[arg-type]
+
+
+def test_valid_env_port_still_works(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A normal numeric prefixed port env var is honored as before."""
+    monkeypatch.setenv("QDRANT_PORT", "7777")
+    assert QdrantDBConfig().port == 7777
+
+
+def test_valid_constructor_port_still_works() -> None:
+    """A normal explicit constructor port is honored as before."""
+    assert QdrantDBConfig(port=7777).port == 7777
+
+
+def test_trailing_newline_tcp_port_still_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A service-link-like value with a trailing newline fails validation.
+
+    The full-format check must anchor at the true end of the string
+    (`\\Z`), not `$` (which matches before a trailing newline), so this
+    value is NOT silently discarded.
+    """
+    monkeypatch.setenv("QDRANT_PORT", "tcp://10.0.0.8:6333\n")
+    with pytest.raises(ValidationError):
+        QdrantDBConfig()
+
+
+def test_set_env_writes_prefixed_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`set_env` writes names a fresh config actually reads back.
+
+    `set_env` used to write bare upper-cased field names (`HOST`),
+    which prefixed configs no longer read; it must write
+    `<PREFIX><FIELD>` (e.g. `QDRANT_HOST`).
+    """
+    config = QdrantDBConfig(host="example.internal")
+    # pre-register every var set_env will write, so monkeypatch teardown
+    # restores each to its original (absent) state after the test
+    for field_name, field in QdrantDBConfig.model_fields.items():
+        name = field.alias or f"QDRANT_{field_name.upper()}"
+        monkeypatch.setenv(name, "placeholder")
+    set_env(config)
+    assert os.environ["QDRANT_HOST"] == "example.internal"
+    # pre-existing set_env limitation, unrelated to prefixes: complex
+    # fields (nested configs, classes) are written as non-JSON python
+    # reprs the env source cannot parse back; clear them so the fresh
+    # construction below exercises the simple fields
+    for name in (
+        "QDRANT_EMBEDDING",
+        "QDRANT_EMBEDDING_MODEL",
+        "QDRANT_DOCUMENT_CLASS",
+        "QDRANT_METADATA_CLASS",
+    ):
+        monkeypatch.delenv(name)
+    assert QdrantDBConfig().host == "example.internal"
+
+
+def test_set_env_bare_names_for_prefixless_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A settings class without env_prefix still gets bare var names."""
+
+    class PlainSettings(BaseSettings):
+        some_field: str = "default"
+
+    monkeypatch.setenv("SOME_FIELD", "placeholder")
+    set_env(PlainSettings(some_field="written"))
+    assert os.environ["SOME_FIELD"] == "written"
+    assert PlainSettings().some_field == "written"
 </file>
 
 <file path="tests/main/test_vector_stores.py">
@@ -116071,6 +115055,991 @@ class MarkerPdfParser(DocumentParser):
         )
 </file>
 
+<file path="langroid/vector_store/postgres.py">
+import hashlib
+import json
+import logging
+import os
+import uuid
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from pydantic_settings import SettingsConfigDict
+
+from langroid.embedding_models.base import (
+    EmbeddingModelsConfig,
+)
+from langroid.embedding_models.models import OpenAIEmbeddingsConfig
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import DocMetaData, Document
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+has_postgres: bool = True
+try:
+    from sqlalchemy import (
+        Column,
+        MetaData,
+        String,
+        Table,
+        case,
+        create_engine,
+        inspect,
+        text,
+    )
+    from sqlalchemy.dialects.postgresql import JSONB
+    from sqlalchemy.engine import Connection, Engine
+    from sqlalchemy.sql.expression import insert
+except ImportError:
+    Engine = Any  # type: ignore
+    Connection = Any  # type: ignore
+    has_postgres = False
+
+logger = logging.getLogger(__name__)
+
+
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier (table/index name) for use in raw DDL, so a name
+    containing characters that are invalid in an unquoted identifier -- e.g.
+    the ``-`` in a pytest-xdist worker suffix like ``mycollection-gw1`` -- does
+    not produce a syntax error. Embedded double-quotes are escaped per the SQL
+    standard.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
+class PostgresDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="POSTGRES_")
+
+    collection_name: str = "embeddings"
+    cloud: bool = False
+    docker: bool = True
+    host: str = "127.0.0.1"
+    port: int = 5432
+    replace_collection: bool = False
+    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+    pool_size: int = 10
+    max_overflow: int = 20
+    hnsw_m: int = 16
+    hnsw_ef_construction: int = 200
+
+
+class PostgresDB(VectorStore):
+    def __init__(self, config: PostgresDBConfig | None = None):
+        config = config if config is not None else PostgresDBConfig()
+        super().__init__(config)
+        if not has_postgres:
+            raise LangroidImportError("pgvector", "postgres")
+        try:
+            from sqlalchemy.orm import sessionmaker
+        except ImportError:
+            raise LangroidImportError("sqlalchemy", "postgres")
+
+        self.config: PostgresDBConfig = config
+        self.engine = self._create_engine()
+        PostgresDB._create_vector_extension(self.engine)
+        self.SessionLocal = sessionmaker(
+            autocommit=False, autoflush=False, bind=self.engine
+        )
+        self.metadata = MetaData()
+        self._setup_table()
+
+    def _create_engine(self) -> Engine:
+        """Creates a SQLAlchemy engine based on the configuration."""
+
+        connection_string: str | None = None  # Ensure variable is always defined
+
+        if self.config.cloud:
+            connection_string = os.getenv("POSTGRES_CONNECTION_STRING")
+
+            if connection_string and connection_string.startswith("postgres://"):
+                connection_string = connection_string.replace(
+                    "postgres://", "postgresql+psycopg2://", 1
+                )
+            elif not connection_string:
+                raise ValueError("Provide the POSTGRES_CONNECTION_STRING.")
+
+        elif self.config.docker:
+            username = os.getenv("POSTGRES_USER", "postgres")
+            password = os.getenv("POSTGRES_PASSWORD", "postgres")
+            database = os.getenv("POSTGRES_DB", "langroid")
+
+            if not (username and password and database):
+                raise ValueError(
+                    "Provide POSTGRES_USER, POSTGRES_PASSWORD, " "POSTGRES_DB. "
+                )
+
+            connection_string = (
+                f"postgresql+psycopg2://{username}:{password}@"
+                f"{self.config.host}:{self.config.port}/{database}"
+            )
+            self.config.cloud = False  # Ensures cloud is disabled if using Docker
+
+        else:
+            raise ValueError(
+                "Provide either Docker or Cloud config to connect to the database."
+            )
+
+        return create_engine(
+            connection_string,
+            pool_size=self.config.pool_size,
+            max_overflow=self.config.max_overflow,
+        )
+
+    def _setup_table(self) -> None:
+        try:
+            from pgvector.sqlalchemy import Vector
+        except ImportError as e:
+            raise LangroidImportError(extra="postgres", error=str(e))
+
+        if self.config.replace_collection:
+            self.delete_collection(self.config.collection_name)
+
+        self.embeddings_table = Table(
+            self.config.collection_name,
+            self.metadata,
+            Column("id", String, primary_key=True, nullable=False, unique=True),
+            Column("embedding", Vector(self.embedding_dim)),
+            Column("document", String),
+            Column("cmetadata", JSONB),
+            extend_existing=True,
+        )
+
+        self.metadata.create_all(self.engine)
+        self.metadata.reflect(bind=self.engine, only=[self.config.collection_name])
+
+        # Create HNSW index for embeddings column if it doesn't exist.
+        # This index enables efficient nearest-neighbor search using cosine similarity.
+        # PostgreSQL automatically builds the index after creation;
+        # no manual step required.
+        # Read more about pgvector hnsw index here:
+        # https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw
+
+        index_name = f"hnsw_index_{self.config.collection_name}_embedding"
+        with self.engine.connect() as connection:
+            if not self.index_exists(connection, index_name):
+                connection.execute(text("COMMIT"))
+                create_index_query = text(
+                    f"""
+                    CREATE INDEX CONCURRENTLY IF NOT EXISTS {_quote_ident(index_name)}
+                    ON {_quote_ident(self.config.collection_name)}
+                    USING hnsw (embedding vector_cosine_ops)
+                    WITH (
+                        m = {self.config.hnsw_m},
+                        ef_construction = {self.config.hnsw_ef_construction}
+                    );
+                    """
+                )
+                connection.execute(create_index_query)
+
+    def index_exists(self, connection: Connection, index_name: str) -> bool:
+        """Check if an index exists."""
+        query = text(
+            "SELECT 1 FROM pg_indexes WHERE indexname = :index_name"
+        ).bindparams(index_name=index_name)
+        result = connection.execute(query).scalar()
+        return bool(result)
+
+    @staticmethod
+    def _create_vector_extension(conn: Engine) -> None:
+
+        with conn.connect() as connection:
+            with connection.begin():
+                # The number is a unique identifier used to lock a specific resource
+                # during transaction. Any 64-bit integer can be used for advisory locks.
+                # Acquire advisory lock to ensure atomic, isolated setup
+                # and prevent race conditions.
+
+                statement = text(
+                    "SELECT pg_advisory_xact_lock(1573678846307946496);"
+                    "CREATE EXTENSION IF NOT EXISTS vector;"
+                )
+                connection.execute(statement)
+
+    def set_collection(self, collection_name: str, replace: bool = False) -> None:
+        inspector = inspect(self.engine)
+        table_exists = collection_name in inspector.get_table_names()
+
+        if (
+            collection_name == self.config.collection_name
+            and table_exists
+            and not replace
+        ):
+            return
+        else:
+            self.config.collection_name = collection_name
+            self.config.replace_collection = replace
+            self._setup_table()
+
+    def list_collections(self, empty: bool = True) -> List[str]:
+        inspector = inspect(self.engine)
+        table_names = inspector.get_table_names()
+
+        with self.SessionLocal() as session:
+            collections = []
+            for table_name in table_names:
+                table = Table(table_name, self.metadata, autoload_with=self.engine)
+                if empty:
+                    collections.append(table_name)
+                else:
+                    # Efficiently check for non-emptiness
+                    if session.query(table.select().limit(1).exists()).scalar():
+                        collections.append(table_name)
+            return collections
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        self.set_collection(collection_name, replace=replace)
+
+    def delete_collection(self, collection_name: str) -> None:
+        """
+        Deletes a collection and its associated HNSW index, handling metadata
+        synchronization issues.
+        """
+        with self.engine.connect() as connection:
+            connection.execute(text("COMMIT"))
+            index_name = f"hnsw_index_{collection_name}_embedding"
+            drop_index_query = text(
+                f"DROP INDEX CONCURRENTLY IF EXISTS {_quote_ident(index_name)}"
+            )
+            connection.execute(drop_index_query)
+
+            # 3. Now, drop the table using SQLAlchemy
+            table = Table(collection_name, self.metadata)
+            table.drop(self.engine, checkfirst=True)
+
+            # 4. Refresh metadata again after dropping the table
+            self.metadata.clear()
+            self.metadata.reflect(bind=self.engine)
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        if not really:
+            logger.warning("Not deleting all tables, set really=True to confirm")
+            return 0
+
+        inspector = inspect(self.engine)
+        table_names = inspector.get_table_names()
+
+        with self.SessionLocal() as session:
+            deleted_count = 0
+            for table_name in table_names:
+                if table_name.startswith(prefix):
+                    # Use delete_collection to handle index and table deletion
+                    self.delete_collection(table_name)
+                    deleted_count += 1
+            session.commit()
+            logger.warning(f"Deleted {deleted_count} tables with prefix '{prefix}'.")
+            return deleted_count
+
+    def clear_empty_collections(self) -> int:
+        inspector = inspect(self.engine)
+        table_names = inspector.get_table_names()
+
+        with self.SessionLocal() as session:
+            deleted_count = 0
+            for table_name in table_names:
+                table = Table(table_name, self.metadata, autoload_with=self.engine)
+
+                # Efficiently check for emptiness without fetching all rows
+                if session.query(table.select().limit(1).exists()).scalar():
+                    continue
+
+                # Use delete_collection to handle index and table deletion
+                self.delete_collection(table_name)
+                deleted_count += 1
+
+            session.commit()  # Commit is likely not needed here
+            logger.warning(f"Deleted {deleted_count} empty tables.")
+            return deleted_count
+
+    def _parse_embedding_store_record(self, res: Any) -> Dict[str, Any]:
+        metadata = res.cmetadata or {}
+        metadata["id"] = res.id
+        return {
+            "content": res.document,
+            "metadata": DocMetaData(**metadata),
+        }
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        with self.SessionLocal() as session:
+            query = session.query(self.embeddings_table)
+
+            # Apply 'where' clause if provided
+            if where:
+                try:
+                    where_json = json.loads(where)
+                    query = query.filter(
+                        self.embeddings_table.c.cmetadata.contains(where_json)
+                    )
+                except json.JSONDecodeError:
+                    logger.error(f"Invalid JSON in 'where' clause: {where}")
+                    return []  # Return empty list or handle error as appropriate
+
+            results = query.all()
+            documents = [
+                Document(**self._parse_embedding_store_record(res)) for res in results
+            ]
+            return documents
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        with self.SessionLocal() as session:
+            # Add a CASE statement to preserve the order of IDs
+            case_stmt = case(
+                {id_: index for index, id_ in enumerate(ids)},
+                value=self.embeddings_table.c.id,
+            )
+
+            query = (
+                session.query(self.embeddings_table)
+                .filter(self.embeddings_table.c.id.in_(ids))
+                .order_by(case_stmt)  # Order by the CASE statement
+            )
+            results = query.all()
+
+            documents = [
+                Document(**self._parse_embedding_store_record(row)) for row in results
+            ]
+            return documents
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        super().maybe_add_ids(documents)
+        for doc in documents:
+            doc.metadata.id = str(PostgresDB._id_to_uuid(doc.metadata.id, doc.metadata))
+
+        embeddings = self.embedding_fn([doc.content for doc in documents])
+
+        batch_size = self.config.batch_size
+        with self.SessionLocal() as session:
+            for i in range(0, len(documents), batch_size):
+                batch_docs = documents[i : i + batch_size]
+                batch_embeddings = embeddings[i : i + batch_size]
+
+                new_records = [
+                    {
+                        "id": doc.metadata.id,
+                        "embedding": embedding,
+                        "document": doc.content,
+                        "cmetadata": doc.metadata.model_dump(),
+                    }
+                    for doc, embedding in zip(batch_docs, batch_embeddings)
+                ]
+
+                if new_records:
+                    stmt = insert(self.embeddings_table).values(new_records)
+                    session.execute(stmt)
+                session.commit()
+
+    @staticmethod
+    def _id_to_uuid(id: str, obj: object) -> str:
+        try:
+            doc_id = str(uuid.UUID(id))
+        except ValueError:
+            obj_repr = repr(obj)
+
+            obj_hash = hashlib.sha256(obj_repr.encode()).hexdigest()
+
+            combined = f"{id}-{obj_hash}"
+
+            doc_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, combined))
+
+        return doc_id
+
+    def similar_texts_with_scores(
+        self,
+        query: str,
+        k: int = 1,
+        where: Optional[str] = None,
+        neighbors: int = 1,  # Parameter not used in this implementation
+    ) -> List[Tuple[Document, float]]:
+        embedding = self.embedding_fn([query])[0]
+
+        with self.SessionLocal() as session:
+            # Calculate the score (1 - cosine_distance) and label it as "score"
+            score = (
+                1 - (self.embeddings_table.c.embedding.cosine_distance(embedding))
+            ).label("score")
+
+            if where is not None:
+                try:
+                    json_query = json.loads(where)
+                except json.JSONDecodeError:
+                    raise ValueError(f"Invalid JSON in 'where' clause: {where}")
+
+                results = (
+                    session.query(
+                        self.embeddings_table.c.id,
+                        self.embeddings_table.c.document,
+                        self.embeddings_table.c.cmetadata,
+                        score,  # Select the calculated score
+                    )
+                    .filter(self.embeddings_table.c.cmetadata.contains(json_query))
+                    .order_by(score.desc())  # Order by score in descending order
+                    .limit(k)
+                    .all()
+                )
+            else:
+                results = (
+                    session.query(
+                        self.embeddings_table.c.id,
+                        self.embeddings_table.c.document,
+                        self.embeddings_table.c.cmetadata,
+                        score,  # Select the calculated score
+                    )
+                    .order_by(score.desc())  # Order by score in descending order
+                    .limit(k)
+                    .all()
+                )
+
+            documents_with_scores = [
+                (
+                    Document(
+                        content=result.document,
+                        metadata=DocMetaData(**(result.cmetadata or {})),
+                    ),
+                    result.score,  # Use the score from the query result
+                )
+                for result in results
+            ]
+
+            return documents_with_scores
+</file>
+
+<file path="langroid/vector_store/qdrantdb.py">
+import hashlib
+import json
+import logging
+import os
+import time
+import uuid
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, TypeVar
+
+from dotenv import load_dotenv
+from pydantic_settings import SettingsConfigDict
+
+from langroid.embedding_models.base import (
+    EmbeddingModelsConfig,
+)
+from langroid.embedding_models.models import OpenAIEmbeddingsConfig
+from langroid.mytypes import Document, Embeddings
+from langroid.utils.configuration import settings
+from langroid.vector_store.base import VectorStore, VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from qdrant_client.http.models import SparseVector
+
+
+T = TypeVar("T")
+
+
+def from_optional(x: Optional[T], default: T) -> T:
+    if x is None:
+        return default
+
+    return x
+
+
+def is_valid_uuid(uuid_to_test: str) -> bool:
+    """
+    Check if a given string is a valid UUID.
+    """
+    try:
+        uuid_obj = uuid.UUID(uuid_to_test)
+        return str(uuid_obj) == uuid_to_test
+    except Exception:
+        pass
+    # Check for valid unsigned 64-bit integer
+    try:
+        int_value = int(uuid_to_test)
+        return 0 <= int_value <= 18446744073709551615
+    except ValueError:
+        return False
+
+
+class QdrantDBConfig(VectorStoreConfig):
+    model_config = SettingsConfigDict(env_prefix="QDRANT_")
+
+    cloud: bool = True
+    docker: bool = False
+    collection_name: str | None = "temp"
+    storage_path: str = ".qdrant/data"
+    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig()
+    use_sparse_embeddings: bool = False
+    sparse_embedding_model: str = "naver/splade-v3-distilbert"
+    sparse_limit: int = 3
+    distance: str = "cosine"
+
+
+class QdrantDB(VectorStore):
+    def __init__(self, config: QdrantDBConfig | None = None):
+        config = config if config is not None else QdrantDBConfig()
+        super().__init__(config)
+        self.config: QdrantDBConfig = config
+        from qdrant_client import QdrantClient
+
+        if self.config.use_sparse_embeddings:
+            try:
+                from transformers import AutoModelForMaskedLM, AutoTokenizer
+            except ImportError:
+                raise ImportError(
+                    """
+                    To use sparse embeddings,
+                    you must install langroid with the [transformers] extra, e.g.:
+                    pip install "langroid[transformers]"
+                    """
+                )
+
+            self.sparse_tokenizer = AutoTokenizer.from_pretrained(  # type: ignore
+                self.config.sparse_embedding_model
+            )
+            self.sparse_model = AutoModelForMaskedLM.from_pretrained(
+                self.config.sparse_embedding_model
+            )
+        self.host = config.host
+        self.port = config.port
+        load_dotenv()
+        key = os.getenv("QDRANT_API_KEY")
+        url = os.getenv("QDRANT_API_URL")
+        if config.docker:
+            if url is None:
+                logger.warning(
+                    f"""The QDRANT_API_URL env variable must be set to use
+                    QdrantDB in local docker mode. Please set this
+                    value in your .env file.
+                    Switching to local storage at {config.storage_path}
+                    """
+                )
+                config.cloud = False
+            else:
+                config.cloud = True
+        elif config.cloud and None in [key, url]:
+            logger.warning(
+                f"""QDRANT_API_KEY, QDRANT_API_URL env variable must be set to use
+                QdrantDB in cloud mode. Please set these values
+                in your .env file.
+                Switching to local storage at {config.storage_path}
+                """
+            )
+            config.cloud = False
+
+        if config.cloud:
+            self.client = QdrantClient(
+                url=url,
+                api_key=key,
+                timeout=config.timeout,
+            )
+        else:
+            try:
+                self.client = QdrantClient(
+                    path=config.storage_path,
+                )
+            except Exception as e:
+                new_storage_path = config.storage_path + ".new"
+                logger.warning(
+                    f"""
+                    Error connecting to local QdrantDB at {config.storage_path}:
+                    {e}
+                    Switching to {new_storage_path}
+                    """
+                )
+                self.client = QdrantClient(
+                    path=new_storage_path,
+                )
+
+        # Note: Only create collection if a non-null collection name is provided.
+        # This is useful to delay creation of vecdb until we have a suitable
+        # collection name (e.g. we could get it from the url or folder path).
+        if config.collection_name is not None:
+            self.create_collection(
+                config.collection_name, replace=config.replace_collection
+            )
+
+    def clone(self) -> "QdrantDB":
+        """Create an independent Qdrant client when running against Qdrant Cloud."""
+        if not self.config.cloud:
+            return self
+        cloned = super().clone()
+        assert isinstance(cloned, QdrantDB)
+        return cloned
+
+    def close(self) -> None:
+        """
+        Close the QdrantDB client and release any resources (e.g., file locks).
+        This is especially important for local storage to release the .lock file.
+        """
+        if hasattr(self.client, "close"):
+            # QdrantLocal has a close method that releases the lock
+            self.client.close()
+            logger.info(f"Closed QdrantDB connection for {self.config.storage_path}")
+
+    def __enter__(self) -> "QdrantDB":
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Context manager exit - ensure cleanup even if an exception occurred."""
+        self.close()
+
+    def clear_empty_collections(self) -> int:
+        coll_names = self.list_collections()
+        n_deletes = 0
+        for name in coll_names:
+            info = self.client.get_collection(collection_name=name)
+            if info.points_count == 0:
+                n_deletes += 1
+                self.client.delete_collection(collection_name=name)
+        return n_deletes
+
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """Clear all collections with the given prefix."""
+
+        if not really:
+            logger.warning("Not deleting all collections, set really=True to confirm")
+            return 0
+        coll_names = [
+            c for c in self.list_collections(empty=True) if c.startswith(prefix)
+        ]
+        if len(coll_names) == 0:
+            logger.warning(f"No collections found with prefix {prefix}")
+            return 0
+        n_empty_deletes = 0
+        n_non_empty_deletes = 0
+        for name in coll_names:
+            info = self.client.get_collection(collection_name=name)
+            points_count = from_optional(info.points_count, 0)
+
+            n_empty_deletes += points_count == 0
+            n_non_empty_deletes += points_count > 0
+            self.client.delete_collection(collection_name=name)
+        logger.warning(
+            f"""
+            Deleted {n_empty_deletes} empty collections and
+            {n_non_empty_deletes} non-empty collections.
+            """
+        )
+        return n_empty_deletes + n_non_empty_deletes
+
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """
+        Returns:
+            List of collection names that have at least one vector.
+
+        Args:
+            empty (bool, optional): Whether to include empty collections.
+        """
+
+        colls = list(self.client.get_collections())[0][1]
+        if empty:
+            return [coll.name for coll in colls]
+        counts = []
+        for coll in colls:
+            try:
+                counts.append(
+                    from_optional(
+                        self.client.get_collection(
+                            collection_name=coll.name
+                        ).points_count,
+                        0,
+                    )
+                )
+            except Exception:
+                logger.warning(f"Error getting collection {coll.name}")
+                counts.append(0)
+        return [coll.name for coll, count in zip(colls, counts) if (count or 0) > 0]
+
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        """
+        Create a collection with the given name, optionally replacing an existing
+            collection if `replace` is True.
+        Args:
+            collection_name (str): Name of the collection to create.
+            replace (bool): Whether to replace an existing collection
+                with the same name. Defaults to False.
+        """
+        from qdrant_client.http.models import (
+            CollectionStatus,
+            Distance,
+            SparseIndexParams,
+            SparseVectorParams,
+            VectorParams,
+        )
+
+        self.config.collection_name = collection_name
+        if self.client.collection_exists(collection_name=collection_name):
+            coll = self.client.get_collection(collection_name=collection_name)
+            if (
+                coll.status == CollectionStatus.GREEN
+                and from_optional(coll.points_count, 0) > 0
+            ):
+                logger.warning(f"Non-empty Collection {collection_name} already exists")
+                if not replace:
+                    logger.warning("Not replacing collection")
+                    return
+                else:
+                    logger.warning("Recreating fresh collection")
+            self.client.delete_collection(collection_name=collection_name)
+
+        vectors_config = {
+            "": VectorParams(
+                size=self.embedding_dim,
+                distance=Distance.COSINE,
+            )
+        }
+        sparse_vectors_config = None
+        if self.config.use_sparse_embeddings:
+            sparse_vectors_config = {
+                "text-sparse": SparseVectorParams(index=SparseIndexParams())
+            }
+        self.client.create_collection(
+            collection_name=collection_name,
+            vectors_config=vectors_config,
+            sparse_vectors_config=sparse_vectors_config,
+        )
+        collection_info = self.client.get_collection(collection_name=collection_name)
+        assert collection_info.status == CollectionStatus.GREEN
+        assert collection_info.vectors_count in [0, None]
+        if settings.debug:
+            level = logger.getEffectiveLevel()
+            logger.setLevel(logging.INFO)
+            logger.info(collection_info)
+            logger.setLevel(level)
+
+    def get_sparse_embeddings(self, inputs: List[str]) -> List["SparseVector"]:
+        from qdrant_client.http.models import SparseVector
+
+        if not self.config.use_sparse_embeddings:
+            return []
+        import torch
+
+        tokens = self.sparse_tokenizer(
+            inputs, return_tensors="pt", truncation=True, padding=True
+        )
+        output = self.sparse_model(**tokens)
+        vectors = torch.max(
+            torch.log(torch.relu(output.logits) + torch.tensor(1.0))
+            * tokens.attention_mask.unsqueeze(-1),
+            dim=1,
+        )[0].squeeze(dim=1)
+        sparse_embeddings = []
+        for vec in vectors:
+            cols = vec.nonzero().squeeze().cpu().tolist()
+            weights = vec[cols].cpu().tolist()
+            sparse_embeddings.append(
+                SparseVector(
+                    indices=cols,
+                    values=weights,
+                )
+            )
+        return sparse_embeddings
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        from qdrant_client.http.models import (
+            Batch,
+            CollectionStatus,
+            SparseVector,
+        )
+
+        # Add id to metadata if not already present
+        super().maybe_add_ids(documents)
+        # Fix the ids due to qdrant finickiness
+        for doc in documents:
+            doc.metadata.id = str(self._to_int_or_uuid(doc.metadata.id))
+        colls = self.list_collections(empty=True)
+        if len(documents) == 0:
+            return
+        document_dicts = [doc.model_dump() for doc in documents]
+        embedding_vecs = self.embedding_fn([doc.content for doc in documents])
+        sparse_embedding_vecs = self.get_sparse_embeddings(
+            [doc.content for doc in documents]
+        )
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot ingest docs")
+        if self.config.collection_name not in colls:
+            self.create_collection(self.config.collection_name, replace=True)
+        ids = [self._to_int_or_uuid(d.id()) for d in documents]
+        # don't insert all at once, batch in chunks of b,
+        # else we get an API error
+        b = self.config.batch_size
+        for i in range(0, len(ids), b):
+            vectors: Dict[str, Embeddings | List[SparseVector]] = {
+                "": embedding_vecs[i : i + b]
+            }
+            if self.config.use_sparse_embeddings:
+                vectors["text-sparse"] = sparse_embedding_vecs[i : i + b]
+            coll_found: bool = False
+            for _ in range(3):
+                # poll until collection is ready
+                if (
+                    self.client.collection_exists(self.config.collection_name)
+                    and self.client.get_collection(self.config.collection_name).status
+                    == CollectionStatus.GREEN
+                ):
+                    coll_found = True
+                    break
+                time.sleep(1)
+
+            if not coll_found:
+                raise ValueError(
+                    f"""
+                    QdrantDB Collection {self.config.collection_name} 
+                    not found or not ready
+                    """
+                )
+
+            self.client.upsert(
+                collection_name=self.config.collection_name,
+                points=Batch(
+                    ids=ids[i : i + b],
+                    vectors=vectors,
+                    payloads=document_dicts[i : i + b],
+                ),
+            )
+
+    def delete_collection(self, collection_name: str) -> None:
+        self.client.delete_collection(collection_name=collection_name)
+
+    def _to_int_or_uuid(self, id: str) -> int | str:
+        try:
+            int_val = int(id)
+            if is_valid_uuid(id):
+                return int_val
+        except ValueError:
+            pass
+
+        # If doc_id is already a valid UUID, return it as is
+        if isinstance(id, str) and is_valid_uuid(id):
+            return id
+
+        # Otherwise, generate a UUID from the doc_id
+        # Convert doc_id to string if it's not already
+        id_str = str(id)
+
+        # Hash the document ID using SHA-1
+        hash_object = hashlib.sha1(id_str.encode())
+        hash_digest = hash_object.hexdigest()
+
+        # Truncate or manipulate the hash to fit into a UUID (128 bits)
+        uuid_str = hash_digest[:32]
+
+        # Format this string into a UUID format
+        formatted_uuid = uuid.UUID(uuid_str)
+
+        return str(formatted_uuid)
+
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        from qdrant_client.http.models import (
+            Filter,
+        )
+
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        docs = []
+        offset = 0
+        filter = Filter() if where == "" else Filter.model_validate(json.loads(where))
+        while True:
+            results, next_page_offset = self.client.scroll(
+                collection_name=self.config.collection_name,
+                scroll_filter=filter,
+                offset=offset,
+                limit=10_000,  # try getting all at once, if not we keep paging
+                with_payload=True,
+                with_vectors=False,
+            )
+            docs += [
+                self.config.document_class(**record.payload)  # type: ignore
+                for record in results
+            ]
+            # ignore
+            if next_page_offset is None:
+                break
+            offset = next_page_offset  # type: ignore
+        return docs
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot retrieve docs")
+        _ids = [self._to_int_or_uuid(id) for id in ids]
+        records = self.client.retrieve(
+            collection_name=self.config.collection_name,
+            ids=_ids,
+            with_vectors=False,
+            with_payload=True,
+        )
+        # Note the records may NOT be in the order of the ids,
+        # so we re-order them here.
+        id2payload = {record.id: record.payload for record in records}
+        ordered_payloads = [id2payload[id] for id in _ids if id in id2payload]
+        docs = [Document(**payload) for payload in ordered_payloads]  # type: ignore
+        return docs
+
+    def similar_texts_with_scores(
+        self,
+        text: str,
+        k: int = 1,
+        where: Optional[str] = None,
+        neighbors: int = 0,
+    ) -> List[Tuple[Document, float]]:
+        from qdrant_client.conversions.common_types import ScoredPoint
+        from qdrant_client.http.models import (
+            Filter,
+            NamedSparseVector,
+            NamedVector,
+            SearchRequest,
+        )
+
+        embedding = self.embedding_fn([text])[0]
+        # TODO filter may not work yet
+        if where is None or where == "":
+            filter = Filter()
+        else:
+            filter = Filter.model_validate(json.loads(where))
+        requests = [
+            SearchRequest(
+                vector=NamedVector(
+                    name="",
+                    vector=embedding,
+                ),
+                limit=k,
+                with_payload=True,
+                filter=filter,
+            )
+        ]
+        if self.config.use_sparse_embeddings:
+            sparse_embedding = self.get_sparse_embeddings([text])[0]
+            requests.append(
+                SearchRequest(
+                    vector=NamedSparseVector(
+                        name="text-sparse",
+                        vector=sparse_embedding,
+                    ),
+                    limit=self.config.sparse_limit,
+                    with_payload=True,
+                    filter=filter,
+                )
+            )
+        if self.config.collection_name is None:
+            raise ValueError("No collection name set, cannot search")
+        search_result_lists: List[List[ScoredPoint]] = self.client.search_batch(
+            collection_name=self.config.collection_name, requests=requests
+        )
+
+        search_result = [
+            match for result in search_result_lists for match in result
+        ]  # 2D list -> 1D list
+        scores = [match.score for match in search_result if match is not None]
+        docs = [
+            self.config.document_class(**(match.payload))  # type: ignore
+            for match in search_result
+            if match is not None
+        ]
+        if len(docs) == 0:
+            logger.warning(f"No matches found for {text}")
+            return []
+        doc_score_pairs = list(zip(docs, scores))
+        max_score = max(ds[1] for ds in doc_score_pairs)
+        if settings.debug:
+            logger.info(f"Found {len(doc_score_pairs)} matches, max score: {max_score}")
+        self.show_if_debug(doc_score_pairs)
+        return doc_score_pairs
+</file>
+
 <file path="tests/main/test_mcp_tools.py">
 import asyncio
 import os
@@ -120718,6 +120687,3117 @@ it, and if it was a denylist gap it is out of scope.
 
 Security fixes ship in the latest release. Please upgrade to the current
 version of `langroid` rather than requesting backports.
+</file>
+
+<file path="langroid/language_models/openai_gpt.py">
+import hashlib
+import json
+import logging
+import os
+import sys
+import warnings
+from collections import defaultdict
+from functools import cache
+from itertools import chain
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    no_type_check,
+)
+
+import openai
+from cerebras.cloud.sdk import AsyncCerebras, Cerebras
+from groq import AsyncGroq, Groq
+from httpx import Timeout
+from openai import AsyncOpenAI, OpenAI
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from rich import print
+from rich.markup import escape
+
+from langroid.cachedb.base import CacheDB
+from langroid.cachedb.redis_cachedb import RedisCache, RedisCacheConfig
+from langroid.exceptions import LangroidImportError
+from langroid.language_models.base import (
+    LanguageModel,
+    LLMConfig,
+    LLMFunctionCall,
+    LLMFunctionSpec,
+    LLMMessage,
+    LLMResponse,
+    LLMTokenUsage,
+    OpenAIJsonSchemaSpec,
+    OpenAIToolCall,
+    OpenAIToolSpec,
+    Role,
+    StreamEventType,
+    ToolChoiceTypes,
+)
+from langroid.language_models.client_cache import (
+    get_async_cerebras_client,
+    get_async_groq_client,
+    get_async_openai_client,
+    get_cerebras_client,
+    get_groq_client,
+    get_openai_client,
+    wrap_api_key_provider_async,
+)
+from langroid.language_models.config import HFPromptFormatterConfig
+from langroid.language_models.model_info import (
+    DeepSeekModel,
+    MiniMaxModel,
+    OpenAI_API_ParamInfo,
+)
+from langroid.language_models.model_info import (
+    OpenAIChatModel as OpenAIChatModel,
+)
+from langroid.language_models.model_info import (
+    OpenAICompletionModel as OpenAICompletionModel,
+)
+from langroid.language_models.prompt_formatter.hf_formatter import (
+    HFFormatter,
+    find_hf_formatter,
+)
+from langroid.language_models.provider_params import (
+    DUMMY_API_KEY,
+    LangDBParams,
+    PortkeyParams,
+)
+from langroid.language_models.utils import (
+    async_retry_with_exponential_backoff,
+    retry_with_exponential_backoff,
+)
+from langroid.parsing.parse_json import parse_imperfect_json
+from langroid.utils.configuration import settings
+from langroid.utils.constants import Colors
+from langroid.utils.system import friendly_error
+
+logging.getLogger("openai").setLevel(logging.ERROR)
+
+if "OLLAMA_HOST" in os.environ:
+    OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
+else:
+    OLLAMA_BASE_URL = "http://localhost:11434/v1"
+
+DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+# Provider prefixes that route to the Gemini OpenAI-compatible API.
+GEMINI_MODEL_PREFIXES = ("gemini/", "google/gemini-")
+GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+OLLAMA_API_KEY = "ollama"
+
+VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
+LLAMACPP_API_KEY = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
+
+
+openai_chat_model_pref_list = [
+    OpenAIChatModel.GPT4o,
+    OpenAIChatModel.GPT4_1_NANO,
+    OpenAIChatModel.GPT4_1_MINI,
+    OpenAIChatModel.GPT4_1,
+    OpenAIChatModel.GPT4o_MINI,
+    OpenAIChatModel.O1_MINI,
+    OpenAIChatModel.O3_MINI,
+    OpenAIChatModel.O1,
+]
+
+openai_completion_model_pref_list = [
+    OpenAICompletionModel.DAVINCI,
+    OpenAICompletionModel.BABBAGE,
+]
+
+
+if "OPENAI_API_KEY" in os.environ:
+    try:
+        available_models = set(map(lambda m: m.id, OpenAI().models.list()))
+    except openai.AuthenticationError as e:
+        if settings.debug:
+            logging.warning(
+                f"""
+            OpenAI Authentication Error: {e}.
+            ---
+            If you intended to use an OpenAI Model, you should fix this,
+            otherwise you can ignore this warning.
+            """
+            )
+        available_models = set()
+    except Exception as e:
+        if settings.debug:
+            logging.warning(
+                f"""
+            Error while fetching available OpenAI models: {e}.
+            Proceeding with an empty set of available models.
+            """
+            )
+        available_models = set()
+else:
+    available_models = set()
+
+default_openai_chat_model = next(
+    chain(
+        filter(
+            lambda m: m.value in available_models,
+            openai_chat_model_pref_list,
+        ),
+        [OpenAIChatModel.GPT4o],
+    )
+)
+default_openai_completion_model = next(
+    chain(
+        filter(
+            lambda m: m.value in available_models,
+            openai_completion_model_pref_list,
+        ),
+        [OpenAICompletionModel.DAVINCI],
+    )
+)
+
+
+class AccessWarning(Warning):
+    pass
+
+
+@cache
+def gpt_3_5_warning() -> None:
+    warnings.warn(
+        f"""
+        {OpenAIChatModel.GPT4o} is not available,
+        falling back to {OpenAIChatModel.GPT3_5_TURBO}.
+        Examples may not work properly and unexpected behavior may occur.
+        Adjustments to prompts may be necessary.
+        """,
+        AccessWarning,
+    )
+
+
+@cache
+def parallel_strict_warning() -> None:
+    logging.warning(
+        "OpenAI tool calling in strict mode is not supported when "
+        "parallel tool calls are made. Disable parallel tool calling "
+        "to ensure correct behavior."
+    )
+
+
+def noop() -> None:
+    """Does nothing."""
+    return None
+
+
+class OpenAICallParams(BaseModel):
+    """
+    Various params that can be sent to an OpenAI API chat-completion call.
+    When specified, any param here overrides the one with same name in the
+    OpenAIGPTConfig.
+    See OpenAI API Reference for details on the params:
+    https://platform.openai.com/docs/api-reference/chat
+    """
+
+    max_tokens: int | None = None
+    temperature: float | None = None
+    frequency_penalty: float | None = None  # between -2 and 2
+    presence_penalty: float | None = None  # between -2 and 2
+    response_format: Dict[str, str] | None = None
+    logit_bias: Dict[int, float] | None = None  # token_id -> bias
+    logprobs: bool | None = None
+    top_p: float | None = None
+    reasoning_effort: str | None = None  # or "low" or "high" or "medium"
+    top_logprobs: int | None = None  # if int, requires logprobs=True
+    n: int | None = None  # how many completions to generate (n > 1 is NOT handled now)
+    stop: str | List[str] | None = None  # (list of) stop sequence(s)
+    seed: int | None = None
+    user: str | None = None  # user id for tracking
+    extra_body: Dict[str, Any] | None = None  # additional params for API request body
+
+    def to_dict_exclude_none(self) -> Dict[str, Any]:
+        return {k: v for k, v in self.model_dump().items() if v is not None}
+
+
+class LiteLLMProxyConfig(BaseSettings):
+    """Configuration for LiteLLM proxy connection."""
+
+    api_key: str = ""  # read from env var LITELLM_API_KEY if set
+    api_base: str = ""  # read from env var LITELLM_API_BASE if set
+
+    model_config = SettingsConfigDict(env_prefix="LITELLM_")
+
+
+class OpenAIGPTConfig(LLMConfig):
+    """
+    Class for any LLM with an OpenAI-like API: besides the OpenAI models this includes:
+    (a) locally-served models behind an OpenAI-compatible API
+    (b) non-local models, using a proxy adaptor lib like litellm that provides
+        an OpenAI-compatible API.
+    (We could rename this class to OpenAILikeConfig, but we keep it as-is for now)
+
+    Important Note:
+    Due to the `env_prefix = "OPENAI_"` defined below,
+    all of the fields below can be set AND OVERRIDDEN via env vars,
+    # by upper-casing the name and prefixing with OPENAI_, e.g.
+    # OPENAI_MAX_OUTPUT_TOKENS=1000.
+    # If any of these is defined in this way in the environment
+    # (either via explicit setenv or export or via .env file + load_dotenv()),
+    # the environment variable takes precedence over the value in the config.
+    """
+
+    type: str = "openai"
+    api_key: str = DUMMY_API_KEY
+    # Callable returning a fresh API key/bearer token, for endpoints that
+    # authenticate with short-lived rotating credentials (e.g. Vertex AI
+    # OAuth tokens, Azure Entra ID). Resolved per-request by the OpenAI
+    # client, and excluded from the client-cache key (the cache is keyed on
+    # the provider's identity), so rotating tokens neither go stale nor grow
+    # the cache. Takes precedence over `api_key`. Only supported for models
+    # served via an OpenAI-compatible endpoint (not Groq/Cerebras/litellm).
+    # See docs/notes/rotating-api-keys.md.
+    api_key_provider: Optional[Callable[[], str]] = None
+    organization: str = ""
+    api_base: str | None = None  # used for local or other non-OpenAI models
+    litellm: bool = False  # use litellm api?
+    litellm_proxy: LiteLLMProxyConfig = LiteLLMProxyConfig()
+    ollama: bool = False  # use ollama's OpenAI-compatible endpoint?
+    min_output_tokens: int = 1
+    use_chat_for_completion: bool = True  # do not change this, for OpenAI models!
+    timeout: int = 20
+    temperature: float = 0.2
+    seed: int | None = 42
+    params: OpenAICallParams | None = None
+    use_cached_client: bool = (
+        True  # Whether to reuse cached clients (prevents resource exhaustion)
+    )
+    # these can be any model name that is served at an OpenAI-compatible API end point
+    chat_model: str = default_openai_chat_model
+    chat_model_orig: Optional[str] = None
+    completion_model: str = default_openai_completion_model
+    run_on_first_use: Callable[[], None] = noop
+    parallel_tool_calls: Optional[bool] = None
+    # Supports constrained decoding which enforces that the output of the LLM
+    # adheres to a JSON schema
+    supports_json_schema: Optional[bool] = None
+    # Supports strict decoding for the generation of tool calls with
+    # the OpenAI Tools API; this ensures that the generated tools
+    # adhere to the provided schema.
+    supports_strict_tools: Optional[bool] = None
+    # a string that roughly matches a HuggingFace chat_template,
+    # e.g. "mistral-instruct-v0.2 (a fuzzy search is done to find the closest match)
+    formatter: str | None = None
+    hf_formatter: HFFormatter | None = None
+    langdb_params: LangDBParams = LangDBParams()
+    portkey_params: PortkeyParams = PortkeyParams()
+    headers: Dict[str, str] = {}
+    http_client_factory: Optional[Callable[[], Any]] = (
+        None  # Factory: returns Client or (Client, AsyncClient)
+    )
+    http_verify_ssl: bool = True  # Simple flag for SSL verification
+    http_client_config: Optional[Dict[str, Any]] = None  # Config dict for httpx.Client
+    _api_base_was_supplied: bool = False
+
+    def __init__(self, **kwargs) -> None:  # type: ignore
+        api_base_was_supplied = "api_base" in kwargs
+        local_model = "api_base" in kwargs and kwargs["api_base"] is not None
+
+        chat_model = kwargs.get("chat_model", "")
+        local_prefixes = ["local/", "litellm/", "ollama/", "vllm/", "llamacpp/"]
+        if any(chat_model.startswith(prefix) for prefix in local_prefixes):
+            local_model = True
+
+        warn_gpt_3_5 = (
+            "chat_model" not in kwargs.keys()
+            and not local_model
+            and default_openai_chat_model == OpenAIChatModel.GPT3_5_TURBO
+        )
+
+        if warn_gpt_3_5:
+            existing_hook = kwargs.get("run_on_first_use", noop)
+
+            def with_warning() -> None:
+                existing_hook()
+                gpt_3_5_warning()
+
+            kwargs["run_on_first_use"] = with_warning
+
+        super().__init__(**kwargs)
+        env_prefix = self.model_config.get("env_prefix")
+        env_api_base_name = f"{env_prefix}API_BASE"
+        env_api_base = os.getenv(env_api_base_name)
+        if not self.model_config.get("case_sensitive"):
+            case_insensitive_env = {
+                name.lower(): value for name, value in os.environ.items()
+            }
+            env_api_base = case_insensitive_env.get(env_api_base_name.lower())
+        api_base_was_supplied = api_base_was_supplied or (
+            self.api_base is not None
+            and (env_prefix != "OPENAI_" or self.api_base != env_api_base)
+        )
+        self._api_base_was_supplied = api_base_was_supplied
+
+    model_config = SettingsConfigDict(env_prefix="OPENAI_")
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Track API bases assigned after config construction."""
+        super().__setattr__(name, value)
+        if name == "api_base":
+            self._api_base_was_supplied = True
+
+    def model_copy(
+        self, *, update: Mapping[str, Any] | None = None, deep: bool = False
+    ) -> "OpenAIGPTConfig":
+        """
+        Copy config while preserving nested model instances and subclasses.
+
+        Important: Avoid reconstructing via `model_dump` as that coerces nested
+        models to their annotated base types (dropping subclass-only fields).
+        Instead, defer to Pydantic's native `model_copy`, which keeps nested
+        `BaseModel` instances (and their concrete subclasses) intact.
+
+        An `api_base` supplied through `update` is caller configuration, so the
+        copy must retain that provenance for provider-specific routing.
+        """
+        # Delegate to BaseSettings/BaseModel implementation to preserve types
+        copied = super().model_copy(update=update, deep=deep)
+        if update is not None and "api_base" in update:
+            copied._api_base_was_supplied = True
+        return copied  # type: ignore[return-value]
+
+    def _validate_litellm(self) -> None:
+        """
+        When using liteLLM, validate whether all env vars required by the model
+        have been set.
+        """
+        if not self.litellm:
+            return
+        try:
+            import litellm
+        except ImportError:
+            raise LangroidImportError("litellm", "litellm")
+
+        litellm.telemetry = False
+        litellm.drop_params = True  # drop un-supported params without crashing
+        litellm.modify_params = True
+        self.seed = None  # some local mdls don't support seed
+
+        if self.api_key == DUMMY_API_KEY:
+            keys_dict = litellm.utils.validate_environment(self.chat_model)
+            missing_keys = keys_dict.get("missing_keys", [])
+            if len(missing_keys) > 0:
+                raise ValueError(
+                    f"""
+                    Missing environment variables for litellm-proxied model:
+                    {missing_keys}
+                    """
+                )
+
+    @classmethod
+    def create(cls, prefix: str) -> Type["OpenAIGPTConfig"]:
+        """Create a config class whose params can be set via a desired
+        prefix from the .env file or env vars.
+        E.g., using
+        ```python
+        OllamaConfig = OpenAIGPTConfig.create("ollama")
+        ollama_config = OllamaConfig()
+        ```
+        you can have a group of params prefixed by "OLLAMA_", to be used
+        with models served via `ollama`.
+        This way, you can maintain several setting-groups in your .env file,
+        one per model type.
+        """
+
+        class DynamicConfig(OpenAIGPTConfig):
+            pass
+
+        DynamicConfig.model_config = SettingsConfigDict(env_prefix=prefix.upper() + "_")
+        return DynamicConfig
+
+
+class OpenAIResponse(BaseModel):
+    """OpenAI response model, either completion or chat."""
+
+    choices: List[Dict]  # type: ignore
+    usage: Dict  # type: ignore
+
+
+def litellm_logging_fn(model_call_dict: Dict[str, Any]) -> None:
+    """Logging function for litellm"""
+    try:
+        api_input_dict = model_call_dict.get("additional_args", {}).get(
+            "complete_input_dict"
+        )
+        if api_input_dict is not None:
+            text = escape(json.dumps(api_input_dict, indent=2))
+            print(
+                f"[grey37]LITELLM: {text}[/grey37]",
+            )
+    except Exception:
+        pass
+
+
+# Define a class for OpenAI GPT models that extends the base class
+class OpenAIGPT(LanguageModel):
+    """
+    Class for OpenAI LLMs
+    """
+
+    client: OpenAI | Groq | Cerebras | None
+    async_client: AsyncOpenAI | AsyncGroq | AsyncCerebras | None
+
+    def __init__(self, config: OpenAIGPTConfig = OpenAIGPTConfig()):
+        """
+        Args:
+            config: configuration for openai-gpt model
+        """
+        # copy the config to avoid modifying the original; deep to decouple
+        # nested models while preserving their concrete subclasses
+        # The api_key_provider must NOT be deep-copied: the client cache is
+        # keyed on its identity (so a copy would defeat cache sharing), and it
+        # may hold non-copyable state (e.g. a threading.Lock). Clear it in a
+        # shallow copy first, then restore the original callable afterwards.
+        api_key_provider = config.api_key_provider
+        if api_key_provider is not None:
+            config = config.model_copy(update={"api_key_provider": None})
+        config = config.model_copy(deep=True)
+        if api_key_provider is not None:
+            config.api_key_provider = api_key_provider
+        super().__init__(config)
+        self.config: OpenAIGPTConfig = config
+        # save original model name such as `provider/model` before
+        # we strip out the `provider` - we retain the original in
+        # case some params are specific to a provider.
+        self.chat_model_orig = self.config.chat_model_orig or self.config.chat_model
+
+        # Run the first time the model is used
+        self.run_on_first_use = cache(self.config.run_on_first_use)
+
+        # global override of chat_model,
+        # to allow quick testing with other models
+        if settings.chat_model != "":
+            self.config.chat_model = settings.chat_model
+            self.chat_model_orig = settings.chat_model
+            self.config.completion_model = settings.chat_model
+
+        if len(parts := self.config.chat_model.split("//")) > 1:
+            # there is a formatter specified, e.g.
+            # "litellm/ollama/mistral//hf" or
+            # "local/localhost:8000/v1//mistral-instruct-v0.2"
+            formatter = parts[1]
+            self.config.chat_model = parts[0]
+            if formatter == "hf":
+                # e.g. "litellm/ollama/mistral//hf" -> "litellm/ollama/mistral"
+                formatter = find_hf_formatter(self.config.chat_model)
+                if formatter != "":
+                    # e.g. "mistral"
+                    self.config.formatter = formatter
+                    logging.warning(
+                        f"""
+                        Using completions (not chat) endpoint with HuggingFace
+                        chat_template for {formatter} for
+                        model {self.config.chat_model}
+                        """
+                    )
+            else:
+                # e.g. "local/localhost:8000/v1//mistral-instruct-v0.2"
+                self.config.formatter = formatter
+
+        if self.config.formatter is not None:
+            self.config.hf_formatter = HFFormatter(
+                HFPromptFormatterConfig(model_name=self.config.formatter)
+            )
+
+        self.supports_json_schema: bool = self.config.supports_json_schema or False
+        self.supports_strict_tools: bool = self.config.supports_strict_tools or False
+
+        OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", DUMMY_API_KEY)
+        self.api_key = config.api_key
+
+        # if model name starts with "litellm",
+        # set the actual model name by stripping the "litellm/" prefix
+        # and set the litellm flag to True
+        if self.config.chat_model.startswith("litellm/") or self.config.litellm:
+            # e.g. litellm/ollama/mistral
+            self.config.litellm = True
+            self.api_base = self.config.api_base
+            if self.config.chat_model.startswith("litellm/"):
+                # strip the "litellm/" prefix
+                # e.g. litellm/ollama/llama2 => ollama/llama2
+                self.config.chat_model = self.config.chat_model.split("/", 1)[1]
+        elif self.config.chat_model.startswith("local/"):
+            # expect this to be of the form "local/localhost:8000/v1",
+            # depending on how the model is launched locally.
+            # In this case the model served locally behind an OpenAI-compatible API
+            # so we can just use `openai.*` methods directly,
+            # and don't need a adaptor library like litellm
+            self.config.litellm = False
+            self.config.seed = None  # some models raise an error when seed is set
+            # Extract the api_base from the model name after the "local/" prefix
+            self.api_base = self.config.chat_model.split("/", 1)[1]
+            if not self.api_base.startswith("http"):
+                self.api_base = "http://" + self.api_base
+        elif self.config.chat_model.startswith("ollama/"):
+            self.config.ollama = True
+
+            # use api_base from config if set, else fall back on OLLAMA_BASE_URL
+            self.api_base = self.config.api_base or OLLAMA_BASE_URL
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = OLLAMA_API_KEY
+            self.config.chat_model = self.config.chat_model.replace("ollama/", "")
+        elif self.config.chat_model.startswith("vllm/"):
+            self.supports_json_schema = True
+            self.config.chat_model = self.config.chat_model.replace("vllm/", "")
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
+            self.api_base = self.config.api_base or "http://localhost:8000/v1"
+            if not self.api_base.startswith("http"):
+                self.api_base = "http://" + self.api_base
+            if not self.api_base.endswith("/v1"):
+                self.api_base = self.api_base + "/v1"
+        elif self.config.chat_model.startswith("llamacpp/"):
+            self.supports_json_schema = True
+            self.api_base = self.config.chat_model.split("/", 1)[1]
+            if not self.api_base.startswith("http"):
+                self.api_base = "http://" + self.api_base
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
+        else:
+            self.api_base = self.config.api_base
+            # If api_base is unset we use OpenAI's endpoint, which supports
+            # these features (with JSON schema restricted to a limited set of models)
+            self.supports_strict_tools = self.api_base is None
+            self.supports_json_schema = (
+                self.api_base is None and self.info().has_structured_output
+            )
+
+        if settings.chat_model != "":
+            # if we're overriding chat model globally, set completion model to same
+            self.config.completion_model = self.config.chat_model
+
+        if self.config.formatter is not None:
+            # we want to format chats -> completions using this specific formatter
+            self.config.use_completion_for_chat = True
+            self.config.completion_model = self.config.chat_model
+
+        if self.config.use_completion_for_chat:
+            self.config.use_chat_for_completion = False
+
+        self.is_groq = self.config.chat_model.startswith("groq/")
+        self.is_cerebras = self.config.chat_model.startswith("cerebras/")
+        self.is_gemini = self.is_gemini_model()
+        self.is_deepseek = self.is_deepseek_model()
+        self.is_minimax = self.is_minimax_model()
+        self.is_glhf = self.config.chat_model.startswith("glhf/")
+        self.is_openrouter = self.config.chat_model.startswith("openrouter/")
+        self.is_langdb = self.config.chat_model.startswith("langdb/")
+        self.is_portkey = self.config.chat_model.startswith("portkey/")
+        self.is_litellm_proxy = self.config.chat_model.startswith("litellm-proxy/")
+
+        if self.config.api_key_provider is not None and (
+            self.is_groq or self.is_cerebras or self.config.litellm
+        ):
+            raise ValueError(
+                "api_key_provider is only supported for models served via an "
+                "OpenAI-compatible endpoint (using the OpenAI client); it "
+                "cannot be used with Groq, Cerebras, or the litellm adapter."
+            )
+
+        if self.is_groq:
+            # use groq-specific client
+            self.config.chat_model = self.config.chat_model.replace("groq/", "")
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = os.getenv("GROQ_API_KEY", DUMMY_API_KEY)
+            if self.config.use_cached_client:
+                self.client = get_groq_client(api_key=self.api_key)
+                self.async_client = get_async_groq_client(api_key=self.api_key)
+            else:
+                # Create new clients without caching
+                self.client = Groq(api_key=self.api_key)
+                self.async_client = AsyncGroq(api_key=self.api_key)
+        elif self.is_cerebras:
+            # use cerebras-specific client
+            self.config.chat_model = self.config.chat_model.replace("cerebras/", "")
+            if self.api_key == OPENAI_API_KEY:
+                self.api_key = os.getenv("CEREBRAS_API_KEY", DUMMY_API_KEY)
+            if self.config.use_cached_client:
+                self.client = get_cerebras_client(api_key=self.api_key)
+                # TODO there is not async client, so should we do anything here?
+                self.async_client = get_async_cerebras_client(api_key=self.api_key)
+            else:
+                # Create new clients without caching
+                self.client = Cerebras(api_key=self.api_key)
+                self.async_client = AsyncCerebras(api_key=self.api_key)
+        else:
+            # in these cases, there's no specific client: OpenAI python client suffices
+            if self.is_litellm_proxy:
+                self.config.chat_model = self.config.chat_model.replace(
+                    "litellm-proxy/", ""
+                )
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = self.config.litellm_proxy.api_key or self.api_key
+                self.api_base = self.config.litellm_proxy.api_base or self.api_base
+            elif self.is_gemini:
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("GEMINI_API_KEY", DUMMY_API_KEY)
+                # Prefer caller config, then Gemini env, then the default.
+                gemini_api_base = os.getenv("GEMINI_API_BASE", "")
+                explicit_api_base = (
+                    self.config.api_base if self.config._api_base_was_supplied else None
+                )
+                self.api_base = explicit_api_base or gemini_api_base or GEMINI_BASE_URL
+                if (
+                    self.config.chat_model.startswith("gemini/")
+                    or self.api_base == GEMINI_BASE_URL
+                ):
+                    self.config.chat_model = self.config.chat_model.split("/", 1)[1]
+            elif self.is_glhf:
+                self.config.chat_model = self.config.chat_model.replace("glhf/", "")
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("GLHF_API_KEY", DUMMY_API_KEY)
+                self.api_base = GLHF_BASE_URL
+            elif self.is_openrouter:
+                self.config.chat_model = self.config.chat_model.replace(
+                    "openrouter/", ""
+                )
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("OPENROUTER_API_KEY", DUMMY_API_KEY)
+                self.api_base = OPENROUTER_BASE_URL
+            elif self.is_deepseek:
+                self.config.chat_model = self.config.chat_model.replace("deepseek/", "")
+                self.api_base = DEEPSEEK_BASE_URL
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = os.getenv("DEEPSEEK_API_KEY", DUMMY_API_KEY)
+            elif self.is_minimax:
+                self.config.chat_model = self.config.chat_model.replace("minimax/", "")
+                # Honor caller-supplied base URL (e.g. regional endpoints,
+                # proxies) instead of always forcing the default.
+                openai_api_base = os.getenv("OPENAI_API_BASE")
+                explicit_api_base = (
+                    self.config.api_base
+                    if self.config.api_base and self.config.api_base != openai_api_base
+                    else None
+                )
+                self.api_base = explicit_api_base or MINIMAX_BASE_URL
+                if self.api_key == OPENAI_API_KEY:
+                    # Only overwrite with MINIMAX_API_KEY when it is actually
+                    # set, so users who intentionally put their MiniMax key in
+                    # OPENAI_API_KEY are not silently downgraded to a dummy key.
+                    minimax_key = os.getenv("MINIMAX_API_KEY", "")
+                    if minimax_key:
+                        self.api_key = minimax_key
+                # Recompute capabilities now that the prefix has been stripped
+                # and self.info() can find the model in MODEL_INFO.
+                self.supports_strict_tools = True
+                self.supports_json_schema = self.info().has_structured_output
+            elif self.is_langdb:
+                self.config.chat_model = self.config.chat_model.replace("langdb/", "")
+                self.api_base = self.config.langdb_params.base_url
+                project_id = self.config.langdb_params.project_id
+                if project_id:
+                    self.api_base += "/" + project_id + "/v1"
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = self.config.langdb_params.api_key or DUMMY_API_KEY
+
+                if self.config.langdb_params:
+                    params = self.config.langdb_params
+                    if params.project_id:
+                        self.config.headers["x-project-id"] = params.project_id
+                    if params.label:
+                        self.config.headers["x-label"] = params.label
+                    if params.run_id:
+                        self.config.headers["x-run-id"] = params.run_id
+                    if params.thread_id:
+                        self.config.headers["x-thread-id"] = params.thread_id
+            elif self.is_portkey:
+                # Parse the model string and extract provider/model
+                provider, model = self.config.portkey_params.parse_model_string(
+                    self.config.chat_model
+                )
+                self.config.chat_model = model
+                if provider:
+                    self.config.portkey_params.provider = provider
+
+                # Set Portkey base URL
+                self.api_base = self.config.portkey_params.base_url + "/v1"
+
+                # Set API key - use provider's API key from env if available
+                if self.api_key == OPENAI_API_KEY:
+                    self.api_key = self.config.portkey_params.get_provider_api_key(
+                        self.config.portkey_params.provider, DUMMY_API_KEY
+                    )
+
+                # Add Portkey-specific headers
+                self.config.headers.update(self.config.portkey_params.get_headers())
+
+            # Sanitize the API key: strip leading/trailing whitespace
+            # (including stray newlines from .env files or CI secrets).
+            self.api_key = self.api_key.strip()
+
+            # Create http_client if needed - Priority order:
+            # 1. http_client_factory (most flexibility, not cacheable)
+            # 2. http_client_config (cacheable, moderate flexibility)
+            # 3. http_verify_ssl=False (cacheable, simple SSL bypass)
+            http_client = None
+            async_http_client = None
+            http_client_config_used = None
+
+            if self.config.http_client_factory is not None:
+                # Use the factory to create http_client (not cacheable)
+                http_client = self.config.http_client_factory()
+                if isinstance(http_client, (list, tuple)):
+                    if len(http_client) != 2:
+                        raise ValueError(
+                            "http_client_factory must return either a single "
+                            "httpx.Client or a tuple of "
+                            "(httpx.Client, httpx.AsyncClient)"
+                        )
+                    http_client, async_http_client = http_client
+                else:
+                    # set async_http_client to None - so that it will
+                    # be created later
+                    async_http_client = None
+            elif self.config.http_client_config is not None:
+                # Use config dict (cacheable)
+                http_client_config_used = self.config.http_client_config
+            elif not self.config.http_verify_ssl:
+                # Simple SSL bypass (cacheable)
+                http_client_config_used = {"verify": False}
+                logging.warning(
+                    "SSL verification has been disabled. This is insecure and "
+                    "should only be used in trusted environments (e.g., "
+                    "corporate networks with self-signed certificates)."
+                )
+
+            # With an api_key_provider, hand the callable itself to the
+            # OpenAI client, which resolves a fresh token on each request.
+            openai_api_key: Union[str, Callable[[], str]] = (
+                self.config.api_key_provider
+                if self.config.api_key_provider is not None
+                else self.api_key
+            )
+
+            if self.config.use_cached_client:
+                self.client = get_openai_client(
+                    api_key=openai_api_key,
+                    base_url=self.api_base,
+                    organization=self.config.organization,
+                    timeout=Timeout(self.config.timeout),
+                    default_headers=self.config.headers,
+                    http_client=http_client,
+                    http_client_config=http_client_config_used,
+                )
+                self.async_client = get_async_openai_client(
+                    api_key=openai_api_key,
+                    base_url=self.api_base,
+                    organization=self.config.organization,
+                    timeout=Timeout(self.config.timeout),
+                    default_headers=self.config.headers,
+                    http_client=async_http_client,
+                    http_client_config=http_client_config_used,
+                )
+            else:
+                # Create new clients without caching
+                client_kwargs: Dict[str, Any] = dict(
+                    api_key=openai_api_key,
+                    base_url=self.api_base,
+                    organization=self.config.organization,
+                    timeout=Timeout(self.config.timeout),
+                    default_headers=self.config.headers,
+                )
+                if http_client is not None:
+                    client_kwargs["http_client"] = http_client
+                elif http_client_config_used is not None:
+                    # Create http_client from config for non-cached scenario
+                    try:
+                        from httpx import Client
+
+                        client_kwargs["http_client"] = Client(**http_client_config_used)
+                    except ImportError:
+                        raise ValueError(
+                            "httpx is required to use http_client_config. "
+                            "Install it with: pip install httpx"
+                        )
+                self.client = OpenAI(**client_kwargs)
+
+                async_client_kwargs: Dict[str, Any] = dict(
+                    api_key=(
+                        # AsyncOpenAI awaits its api_key callable
+                        wrap_api_key_provider_async(openai_api_key)
+                        if callable(openai_api_key)
+                        else openai_api_key
+                    ),
+                    base_url=self.api_base,
+                    organization=self.config.organization,
+                    timeout=Timeout(self.config.timeout),
+                    default_headers=self.config.headers,
+                )
+                if async_http_client is not None:
+                    async_client_kwargs["http_client"] = async_http_client
+                elif http_client_config_used is not None:
+                    # Create async http_client from config for non-cached scenario
+                    try:
+                        from httpx import AsyncClient
+
+                        async_client_kwargs["http_client"] = AsyncClient(
+                            **http_client_config_used
+                        )
+                    except ImportError:
+                        raise ValueError(
+                            "httpx is required to use http_client_config. "
+                            "Install it with: pip install httpx"
+                        )
+                self.async_client = AsyncOpenAI(**async_client_kwargs)
+
+        self.cache: CacheDB | None = None
+        use_cache = self.config.cache_config is not None
+        if "redis" in settings.cache_type and use_cache:
+            if config.cache_config is None or not isinstance(
+                config.cache_config,
+                RedisCacheConfig,
+            ):
+                # switch to fresh redis config if needed
+                config.cache_config = RedisCacheConfig(
+                    fake="fake" in settings.cache_type
+                )
+            if "fake" in settings.cache_type:
+                # force use of fake redis if global cache_type is "fakeredis"
+                config.cache_config.fake = True
+            self.cache = RedisCache(config.cache_config)
+        elif settings.cache_type != "none" and use_cache:
+            raise ValueError(
+                f"Invalid cache type {settings.cache_type}. "
+                "Valid types are redis, fakeredis, none"
+            )
+
+        self.config._validate_litellm()
+
+    def _openai_api_call_params(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Prep the params to be sent to the OpenAI API
+        (or any OpenAI-compatible API, e.g. from Ooba or LmStudio)
+        for chat-completion.
+
+        Order of priority:
+        - (1) Params (mainly max_tokens) in the chat/achat/generate/agenerate call
+                (these are passed in via kwargs)
+        - (2) Params in OpenAIGPTConfig.params (of class OpenAICallParams)
+        - (3) Specific Params in OpenAIGPTConfig (just temperature for now)
+        """
+        params = dict(
+            temperature=self.config.temperature,
+        )
+        if self.config.params is not None:
+            params.update(self.config.params.to_dict_exclude_none())
+        params.update(kwargs)
+        return params
+
+    def is_openai_chat_model(self) -> bool:
+        openai_chat_models = [e.value for e in OpenAIChatModel]
+        return self.config.chat_model in openai_chat_models
+
+    def is_openai_completion_model(self) -> bool:
+        openai_completion_models = [e.value for e in OpenAICompletionModel]
+        return self.config.completion_model in openai_completion_models
+
+    def is_gemini_model(self) -> bool:
+        """Are we using the gemini OpenAI-compatible API?"""
+        return self.chat_model_orig.startswith(GEMINI_MODEL_PREFIXES)
+
+    def is_deepseek_model(self) -> bool:
+        deepseek_models = [e.value for e in DeepSeekModel]
+        return (
+            self.chat_model_orig in deepseek_models
+            or self.chat_model_orig.startswith("deepseek/")
+        )
+
+    def is_minimax_model(self) -> bool:
+        """Are we using the MiniMax OpenAI-compatible API?"""
+        minimax_models = [e.value for e in MiniMaxModel]
+        return (
+            self.chat_model_orig in minimax_models
+            or self.chat_model_orig.startswith("minimax/")
+        )
+
+    def unsupported_params(self) -> List[str]:
+        """
+        List of params that are not supported by the current model
+        """
+        unsupported = set(self.info().unsupported_params)
+        return list(unsupported)
+
+    def rename_params(self) -> Dict[str, str]:
+        """
+        Map of param name -> new name for specific models.
+        Currently main troublemaker is o1* series.
+        """
+        return self.info().rename_params
+
+    def chat_context_length(self) -> int:
+        """
+        Context-length for chat-completion models/endpoints.
+        Get it from the config if explicitly given,
+         otherwise use model_info based on model name, and fall back to
+         generic model_info if there's no match.
+        """
+        return self.config.chat_context_length or self.info().context_length
+
+    def completion_context_length(self) -> int:
+        """
+        Context-length for completion models/endpoints.
+        Get it from the config if explicitly given,
+         otherwise use model_info based on model name, and fall back to
+         generic model_info if there's no match.
+        """
+        return (
+            self.config.completion_context_length
+            or self.completion_info().context_length
+        )
+
+    def chat_cost(self) -> Tuple[float, float, float]:
+        """
+        (Prompt, Cached, Generation) cost per 1000 tokens, for chat-completion
+        models/endpoints.
+        Get it from the dict, otherwise fail-over to general method
+        """
+        info = self.info()
+        cached_cost_per_million = info.cached_cost_per_million
+        if not cached_cost_per_million:
+            cached_cost_per_million = info.input_cost_per_million
+        return (
+            info.input_cost_per_million / 1000,
+            cached_cost_per_million / 1000,
+            info.output_cost_per_million / 1000,
+        )
+
+    def set_stream(self, stream: bool) -> bool:
+        """Enable or disable streaming output from API.
+        Args:
+            stream: enable streaming output from API
+        Returns: previous value of stream
+        """
+        tmp = self.config.stream
+        self.config.stream = stream
+        return tmp
+
+    def get_stream(self) -> bool:
+        """Get streaming status."""
+        return self.config.stream and settings.stream and self.info().allows_streaming
+
+    @staticmethod
+    def _split_inline_reasoning(
+        event_text: str,
+        event_reasoning: str,
+        in_reasoning: bool,
+        thought_delimiters: Tuple[str, str],
+    ) -> Tuple[str, str, bool]:
+        """Separate inline reasoning from text tokens in a streaming chunk.
+
+        When models embed thinking inside content (e.g. <think>...</think>)
+        rather than using a separate reasoning field, this splits the chunk
+        into text-only and reasoning-only portions for proper streamer routing.
+
+        Returns (text_tokens, reasoning_tokens, in_reasoning).
+        """
+        text_tokens = event_text
+        reasoning_tokens = event_reasoning
+
+        if not event_text or event_reasoning:
+            return text_tokens, reasoning_tokens, in_reasoning
+
+        start, end = thought_delimiters
+        remaining = event_text
+
+        if in_reasoning:
+            text_tokens = ""
+        elif start in event_text:
+            before, _, after = event_text.partition(start)
+            text_tokens = before
+            remaining = after
+            in_reasoning = True
+
+        if in_reasoning:
+            if end in remaining:
+                before, _, after = remaining.partition(end)
+                text_tokens += after
+                reasoning_tokens = before
+                in_reasoning = False
+            else:
+                reasoning_tokens = remaining
+
+        return text_tokens, reasoning_tokens, in_reasoning
+
+    @no_type_check
+    def _process_stream_event(
+        self,
+        event,
+        chat: bool = False,
+        tool_deltas: List[Dict[str, Any]] = [],
+        has_function: bool = False,
+        completion: str = "",
+        reasoning: str = "",
+        function_args: str = "",
+        function_name: str = "",
+        in_reasoning: bool = False,
+    ) -> Tuple[bool, bool, str, str, bool, Dict[str, int]]:
+        """Process state vars while processing a streaming API response.
+            Returns a tuple consisting of:
+        - is_break: whether to break out of the loop
+        - has_function: whether the response contains a function_call
+        - function_name: name of the function
+        - function_args: args of the function
+        - completion: completion text
+        - reasoning: reasoning text
+        - usage: usage dict
+        """
+        # convert event obj (of type ChatCompletionChunk) to dict so rest of code,
+        # which expects dicts, works as it did before switching to openai v1.x
+        if not isinstance(event, dict):
+            event = event.model_dump()
+
+        usage = event.get("usage", {}) or {}
+        choices = event.get("choices", [{}])
+        if choices is None or len(choices) == 0:
+            choices = [{}]
+        if len(usage) > 0 and len(choices[0]) == 0:
+            # we have a "usage" chunk, and empty choices, so we're done
+            # ASSUMPTION: a usage chunk ONLY arrives AFTER all normal completion text!
+            # If any API does not follow this, we need to change this code.
+            return (
+                True,
+                has_function,
+                function_name,
+                function_args,
+                completion,
+                reasoning,
+                in_reasoning,
+                usage,
+            )
+        event_args = ""
+        event_fn_name = ""
+        event_tool_deltas: Optional[List[Dict[str, Any]]] = None
+        silent = settings.quiet
+        # The first two events in the stream of Azure OpenAI is useless.
+        # In the 1st: choices list is empty, in the 2nd: the dict delta has null content
+        if chat:
+            delta = choices[0].get("delta", {}) or {}
+            # capture both content and reasoning_content
+            event_text = delta.get("content", "")
+            event_reasoning = delta.get(
+                "reasoning_content",
+                delta.get("reasoning", ""),
+            )
+            if "function_call" in delta and delta["function_call"] is not None:
+                if "name" in delta["function_call"]:
+                    event_fn_name = delta["function_call"]["name"]
+                if "arguments" in delta["function_call"]:
+                    event_args = delta["function_call"]["arguments"]
+            if "tool_calls" in delta and delta["tool_calls"] is not None:
+                # it's a list of deltas, usually just one
+                event_tool_deltas = delta["tool_calls"]
+                tool_deltas += event_tool_deltas
+        else:
+            event_text = choices[0]["text"]
+            event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
+
+        finish_reason = choices[0].get("finish_reason", "")
+        if not event_text and finish_reason == "content_filter":
+            filter_names = [
+                n
+                for n, r in choices[0].get("content_filter_results", {}).items()
+                if r.get("filtered")
+            ]
+            event_text = (
+                "Cannot respond due to content filters ["
+                + ", ".join(filter_names)
+                + "]"
+            )
+            logging.warning("LLM API returned content filter error: " + event_text)
+
+        event_text_tokens, event_reasoning_tokens, in_reasoning = (
+            self._split_inline_reasoning(
+                event_text,
+                event_reasoning,
+                in_reasoning,
+                self.config.thought_delimiters,
+            )
+        )
+
+        if event_text:
+            completion += event_text
+        if event_text_tokens:
+            if not silent:
+                sys.stdout.write(Colors().GREEN + event_text_tokens)
+                sys.stdout.flush()
+            self.config.streamer(event_text_tokens, StreamEventType.TEXT)
+
+        if event_reasoning:
+            reasoning += event_reasoning
+        if event_reasoning_tokens:
+            if not silent:
+                sys.stdout.write(Colors().GREEN_DIM + event_reasoning_tokens)
+                sys.stdout.flush()
+            self.config.streamer(event_reasoning_tokens, StreamEventType.REASONING)
+
+        if event_fn_name:
+            function_name = event_fn_name
+            has_function = True
+            if not silent:
+                sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
+                sys.stdout.flush()
+            self.config.streamer(event_fn_name, StreamEventType.FUNC_NAME)
+
+        if event_args:
+            function_args += event_args
+            if not silent:
+                sys.stdout.write(Colors().GREEN + event_args)
+                sys.stdout.flush()
+            self.config.streamer(event_args, StreamEventType.FUNC_ARGS)
+
+        if event_tool_deltas is not None:
+            # print out streaming tool calls, if not async
+            for td in event_tool_deltas:
+                if td["function"]["name"] is not None:
+                    tool_fn_name = td["function"]["name"]
+                    if not silent:
+                        sys.stdout.write(
+                            Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
+                        )
+                        sys.stdout.flush()
+                    self.config.streamer(tool_fn_name, StreamEventType.TOOL_NAME)
+                if td["function"]["arguments"] != "":
+                    tool_fn_args = td["function"]["arguments"]
+                    if not silent:
+                        sys.stdout.write(Colors().GREEN + tool_fn_args)
+                        sys.stdout.flush()
+                    self.config.streamer(tool_fn_args, StreamEventType.TOOL_ARGS)
+
+        # show this delta in the stream
+        is_break = finish_reason in [
+            "stop",
+            "function_call",
+            "tool_calls",
+        ]
+        # for function_call, finish_reason does not necessarily
+        # contain "function_call" as mentioned in the docs.
+        # So we check for "stop" or "function_call" here.
+        return (
+            is_break,
+            has_function,
+            function_name,
+            function_args,
+            completion,
+            reasoning,
+            in_reasoning,
+            usage,
+        )
+
+    @no_type_check
+    async def _process_stream_event_async(
+        self,
+        event,
+        chat: bool = False,
+        tool_deltas: List[Dict[str, Any]] = [],
+        has_function: bool = False,
+        completion: str = "",
+        reasoning: str = "",
+        function_args: str = "",
+        function_name: str = "",
+        in_reasoning: bool = False,
+    ) -> Tuple[bool, bool, str, str, bool, Dict[str, int]]:
+        """Process state vars while processing a streaming API response.
+            Returns a tuple consisting of:
+        - is_break: whether to break out of the loop
+        - has_function: whether the response contains a function_call
+        - function_name: name of the function
+        - function_args: args of the function
+        - completion: completion text
+        - reasoning: reasoning text
+        - usage: usage dict
+        """
+        # convert event obj (of type ChatCompletionChunk) to dict so rest of code,
+        # which expects dicts, works as it did before switching to openai v1.x
+        if not isinstance(event, dict):
+            event = event.model_dump()
+
+        usage = event.get("usage", {}) or {}
+        choices = event.get("choices", [{}])
+        if len(choices) == 0:
+            choices = [{}]
+        if len(usage) > 0 and len(choices[0]) == 0:
+            # we got usage chunk, and empty choices, so we're done
+            return (
+                True,
+                has_function,
+                function_name,
+                function_args,
+                completion,
+                reasoning,
+                in_reasoning,
+                usage,
+            )
+        event_args = ""
+        event_fn_name = ""
+        event_tool_deltas: Optional[List[Dict[str, Any]]] = None
+        silent = self.config.async_stream_quiet or settings.quiet
+        # The first two events in the stream of Azure OpenAI is useless.
+        # In the 1st: choices list is empty, in the 2nd: the dict delta has null content
+        if chat:
+            delta = choices[0].get("delta", {}) or {}
+            event_text = delta.get("content", "")
+            event_reasoning = delta.get(
+                "reasoning_content",
+                delta.get("reasoning", ""),
+            )
+            if "function_call" in delta and delta["function_call"] is not None:
+                if "name" in delta["function_call"]:
+                    event_fn_name = delta["function_call"]["name"]
+                if "arguments" in delta["function_call"]:
+                    event_args = delta["function_call"]["arguments"]
+            if "tool_calls" in delta and delta["tool_calls"] is not None:
+                # it's a list of deltas, usually just one
+                event_tool_deltas = delta["tool_calls"]
+                tool_deltas += event_tool_deltas
+        else:
+            event_text = choices[0]["text"]
+            event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
+
+        event_text_tokens, event_reasoning_tokens, in_reasoning = (
+            self._split_inline_reasoning(
+                event_text,
+                event_reasoning,
+                in_reasoning,
+                self.config.thought_delimiters,
+            )
+        )
+
+        if event_text:
+            completion += event_text
+        if event_text_tokens:
+            if not silent:
+                sys.stdout.write(Colors().GREEN + event_text_tokens)
+                sys.stdout.flush()
+            await self.config.streamer_async(event_text_tokens, StreamEventType.TEXT)
+
+        if event_reasoning:
+            reasoning += event_reasoning
+        if event_reasoning_tokens:
+            if not silent:
+                sys.stdout.write(Colors().GREEN_DIM + event_reasoning_tokens)
+                sys.stdout.flush()
+            await self.config.streamer_async(
+                event_reasoning_tokens, StreamEventType.REASONING
+            )
+
+        if event_fn_name:
+            function_name = event_fn_name
+            has_function = True
+            if not silent:
+                sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
+                sys.stdout.flush()
+            await self.config.streamer_async(event_fn_name, StreamEventType.FUNC_NAME)
+
+        if event_args:
+            function_args += event_args
+            if not silent:
+                sys.stdout.write(Colors().GREEN + event_args)
+                sys.stdout.flush()
+            await self.config.streamer_async(event_args, StreamEventType.FUNC_ARGS)
+
+        if event_tool_deltas is not None:
+            # print out streaming tool calls, if not async
+            for td in event_tool_deltas:
+                if td["function"]["name"] is not None:
+                    tool_fn_name = td["function"]["name"]
+                    if not silent:
+                        sys.stdout.write(
+                            Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
+                        )
+                        sys.stdout.flush()
+                    await self.config.streamer_async(
+                        tool_fn_name, StreamEventType.TOOL_NAME
+                    )
+                if td["function"]["arguments"] != "":
+                    tool_fn_args = td["function"]["arguments"]
+                    if not silent:
+                        sys.stdout.write(Colors().GREEN + tool_fn_args)
+                        sys.stdout.flush()
+                    await self.config.streamer_async(
+                        tool_fn_args, StreamEventType.TOOL_ARGS
+                    )
+
+        # show this delta in the stream
+        is_break = choices[0].get("finish_reason", "") in [
+            "stop",
+            "function_call",
+            "tool_calls",
+        ]
+        # for function_call, finish_reason does not necessarily
+        # contain "function_call" as mentioned in the docs.
+        # So we check for "stop" or "function_call" here.
+        return (
+            is_break,
+            has_function,
+            function_name,
+            function_args,
+            completion,
+            reasoning,
+            in_reasoning,
+            usage,
+        )
+
+    @retry_with_exponential_backoff
+    def _stream_response(  # type: ignore
+        self, response, chat: bool = False
+    ) -> Tuple[LLMResponse, Dict[str, Any]]:
+        """
+        Grab and print streaming response from API.
+        Args:
+            response: event-sequence emitted by API
+            chat: whether in chat-mode (or else completion-mode)
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                Dict version of OpenAIResponse object (with choices, usage)
+
+        """
+        completion = ""
+        reasoning = ""
+        function_args = ""
+        function_name = ""
+
+        sys.stdout.write(Colors().GREEN)
+        sys.stdout.flush()
+        has_function = False
+        tool_deltas: List[Dict[str, Any]] = []
+        token_usage: Dict[str, int] = {}
+        done: bool = False
+        in_reasoning: bool = False  # Track if we're inside reasoning delimiters
+        content_present = False
+        try:
+            for event in response:
+                event_dict = event if isinstance(event, dict) else event.model_dump()
+                choices = event_dict.get("choices") or []
+                if chat and choices:
+                    delta = choices[0].get("delta") or {}
+                    content_present = content_present or (
+                        "content" in delta and delta["content"] is not None
+                    )
+                (
+                    is_break,
+                    has_function,
+                    function_name,
+                    function_args,
+                    completion,
+                    reasoning,
+                    in_reasoning,
+                    usage,
+                ) = self._process_stream_event(
+                    event,
+                    chat=chat,
+                    tool_deltas=tool_deltas,
+                    has_function=has_function,
+                    completion=completion,
+                    reasoning=reasoning,
+                    function_args=function_args,
+                    function_name=function_name,
+                    in_reasoning=in_reasoning,
+                )
+                if len(usage) > 0:
+                    # capture the token usage when non-empty
+                    token_usage = usage
+                if is_break:
+                    if not self.get_stream() or done:
+                        # if not streaming, then we don't wait for last "usage" chunk
+                        break
+                    else:
+                        # mark done, so we quit after the last "usage" chunk
+                        done = True
+
+        except Exception as e:
+            logging.warning("Error while processing stream response: %s", str(e))
+
+        if not settings.quiet:
+            print("")
+        # TODO- get usage info in stream mode (?)
+
+        return self._create_stream_response(
+            chat=chat,
+            tool_deltas=tool_deltas,
+            has_function=has_function,
+            completion=completion,
+            reasoning=reasoning,
+            function_args=function_args,
+            function_name=function_name,
+            usage=token_usage,
+            content_present=content_present,
+        )
+
+    @async_retry_with_exponential_backoff
+    async def _stream_response_async(  # type: ignore
+        self, response, chat: bool = False
+    ) -> Tuple[LLMResponse, Dict[str, Any]]:
+        """
+        Grab and print streaming response from API.
+        Args:
+            response: event-sequence emitted by API
+            chat: whether in chat-mode (or else completion-mode)
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                OpenAIResponse object (with choices, usage)
+
+        """
+
+        completion = ""
+        reasoning = ""
+        function_args = ""
+        function_name = ""
+
+        sys.stdout.write(Colors().GREEN)
+        sys.stdout.flush()
+        has_function = False
+        tool_deltas: List[Dict[str, Any]] = []
+        token_usage: Dict[str, int] = {}
+        done: bool = False
+        in_reasoning: bool = False  # Track if we're inside reasoning delimiters
+        content_present = False
+        try:
+            async for event in response:
+                event_dict = event if isinstance(event, dict) else event.model_dump()
+                choices = event_dict.get("choices") or []
+                if chat and choices:
+                    delta = choices[0].get("delta") or {}
+                    content_present = content_present or (
+                        "content" in delta and delta["content"] is not None
+                    )
+                (
+                    is_break,
+                    has_function,
+                    function_name,
+                    function_args,
+                    completion,
+                    reasoning,
+                    in_reasoning,
+                    usage,
+                ) = await self._process_stream_event_async(
+                    event,
+                    chat=chat,
+                    tool_deltas=tool_deltas,
+                    has_function=has_function,
+                    completion=completion,
+                    reasoning=reasoning,
+                    function_args=function_args,
+                    function_name=function_name,
+                    in_reasoning=in_reasoning,
+                )
+                if len(usage) > 0:
+                    # capture the token usage when non-empty
+                    token_usage = usage
+                if is_break:
+                    if not self.get_stream() or done:
+                        # if not streaming, then we don't wait for last "usage" chunk
+                        break
+                    else:
+                        # mark done, so we quit after the next "usage" chunk
+                        done = True
+
+        except Exception as e:
+            logging.warning("Error while processing stream response: %s", str(e))
+
+        if not settings.quiet:
+            print("")
+        # TODO- get usage info in stream mode (?)
+
+        return self._create_stream_response(
+            chat=chat,
+            tool_deltas=tool_deltas,
+            has_function=has_function,
+            completion=completion,
+            reasoning=reasoning,
+            function_args=function_args,
+            function_name=function_name,
+            usage=token_usage,
+            content_present=content_present,
+        )
+
+    @staticmethod
+    def tool_deltas_to_tools(
+        tools: List[Dict[str, Any]],
+    ) -> Tuple[
+        str,
+        List[OpenAIToolCall],
+        List[Dict[str, Any]],
+    ]:
+        """
+        Convert accumulated tool-call deltas to OpenAIToolCall objects.
+        Adapted from this excellent code:
+         https://community.openai.com/t/help-for-function-calls-with-streaming/627170/2
+
+        Args:
+            tools: list of tool deltas received from streaming API
+
+        Returns:
+            str: plain text corresponding to tool calls that failed to parse
+            List[OpenAIToolCall]: list of OpenAIToolCall objects
+            List[Dict[str, Any]]: list of tool dicts
+                (to reconstruct OpenAI API response, so it can be cached)
+        """
+        # Initialize a dictionary with default values
+
+        # idx -> dict repr of tool
+        # (used to simulate OpenAIResponse object later, and also to
+        # accumulate function args as strings)
+        idx2tool_dict: Dict[str, Dict[str, Any]] = defaultdict(
+            lambda: {
+                "id": None,
+                "function": {"arguments": "", "name": None},
+                "type": None,
+                "extra_content": None,
+            }
+        )
+
+        for tool_delta in tools:
+            if tool_delta["id"] is not None:
+                idx2tool_dict[tool_delta["index"]]["id"] = tool_delta["id"]
+
+            if tool_delta["function"]["name"] is not None:
+                idx2tool_dict[tool_delta["index"]]["function"]["name"] = tool_delta[
+                    "function"
+                ]["name"]
+
+            idx2tool_dict[tool_delta["index"]]["function"]["arguments"] += tool_delta[
+                "function"
+            ]["arguments"]
+
+            if tool_delta["type"] is not None:
+                idx2tool_dict[tool_delta["index"]]["type"] = tool_delta["type"]
+
+            if tool_delta.get("extra_content") is not None:
+                idx2tool_dict[tool_delta["index"]]["extra_content"] = tool_delta[
+                    "extra_content"
+                ]
+
+        # (try to) parse the fn args of each tool
+        contents: List[str] = []
+        good_indices = []
+        id2args: Dict[str, None | Dict[str, Any]] = {}
+        for idx, tool_dict in idx2tool_dict.items():
+            failed_content, args_dict = OpenAIGPT._parse_function_args(
+                tool_dict["function"]["arguments"]
+            )
+            # used to build tool_calls_list below
+            id2args[tool_dict["id"]] = args_dict or None  # if {}, store as None
+            if failed_content != "":
+                contents.append(failed_content)
+            else:
+                good_indices.append(idx)
+
+        # remove the failed tool calls
+        idx2tool_dict = {
+            idx: tool_dict
+            for idx, tool_dict in idx2tool_dict.items()
+            if idx in good_indices
+        }
+
+        # create OpenAIToolCall list
+        tool_calls_list = [
+            OpenAIToolCall(
+                id=tool_dict["id"],
+                function=LLMFunctionCall(
+                    name=tool_dict["function"]["name"],
+                    arguments=id2args.get(tool_dict["id"]),
+                ),
+                type=tool_dict["type"],
+                extra_content=tool_dict.get("extra_content"),
+            )
+            for tool_dict in idx2tool_dict.values()
+        ]
+        return "\n".join(contents), tool_calls_list, list(idx2tool_dict.values())
+
+    @staticmethod
+    def _parse_function_args(args: str) -> Tuple[str, Dict[str, Any]]:
+        """
+        Try to parse the `args` string as function args.
+
+        Args:
+            args: string containing function args
+
+        Returns:
+            Tuple of content, function name and args dict.
+            If parsing unsuccessful, returns the original string as content,
+            else returns the args dict.
+        """
+        content = ""
+        args_dict = {}
+        try:
+            stripped_fn_args = args.strip()
+            dict_or_list = parse_imperfect_json(stripped_fn_args)
+            if not isinstance(dict_or_list, dict):
+                raise ValueError(
+                    f"""
+                        Invalid function args: {stripped_fn_args}
+                        parsed as {dict_or_list},
+                        which is not a valid dict.
+                        """
+                )
+            args_dict = dict_or_list
+        except (SyntaxError, ValueError) as e:
+            logging.warning(
+                f"""
+                    Parsing OpenAI function args failed: {args};
+                    treating args as normal message. Error detail:
+                    {e}
+                    """
+            )
+            content = args
+
+        return content, args_dict
+
+    def _create_stream_response(
+        self,
+        chat: bool = False,
+        tool_deltas: List[Dict[str, Any]] = [],
+        has_function: bool = False,
+        completion: str = "",
+        reasoning: str = "",
+        function_args: str = "",
+        function_name: str = "",
+        usage: Dict[str, int] = {},
+        content_present: bool = False,
+    ) -> Tuple[LLMResponse, Dict[str, Any]]:
+        """
+        Create an LLMResponse object from the streaming API response.
+
+        Args:
+            chat: whether in chat-mode (or else completion-mode)
+            tool_deltas: list of tool deltas received from streaming API
+            has_function: whether the response contains a function_call
+            completion: completion text
+            reasoning: reasoning text
+            function_args: string representing function args
+            function_name: name of the function
+            usage: token usage dict
+            content_present: whether a stream delta explicitly contained content
+        Returns:
+            Tuple consisting of:
+                LLMResponse object (with message, usage),
+                Dict version of OpenAIResponse object (with choices, usage)
+                    (this is needed so we can cache the response, as if it were
+                    a non-streaming response)
+        """
+        # check if function_call args are valid, if not,
+        # treat this as a normal msg, not a function call
+        args: Dict[str, Any] = {}
+        if has_function and function_args != "":
+            content, args = self._parse_function_args(function_args)
+            completion = completion + content
+            if content != "":
+                has_function = False
+
+        # mock openai response so we can cache it
+        if chat:
+            failed_content, tool_calls, tool_dicts = OpenAIGPT.tool_deltas_to_tools(
+                tool_deltas,
+            )
+            if failed_content:
+                completion += ("\n" if completion else "") + failed_content
+                content_present = True
+            has_valid_call = len(tool_dicts) > 0 or has_function
+            response_content = (
+                None
+                if has_valid_call and not content_present and completion == ""
+                else completion
+            )
+            msg: Dict[str, Any] = dict(
+                message=dict(
+                    content=response_content,
+                    reasoning_content=reasoning,
+                ),
+            )
+            if len(tool_dicts) > 0:
+                msg["message"]["tool_calls"] = tool_dicts
+
+            if has_function:
+                function_call = LLMFunctionCall(name=function_name)
+                function_call_dict = function_call.model_dump()
+                if function_args == "":
+                    function_call.arguments = None
+                else:
+                    function_call.arguments = args
+                    function_call_dict.update({"arguments": function_args.strip()})
+                msg["message"]["function_call"] = function_call_dict
+        else:
+            # non-chat mode has no function_call
+            msg = dict(text=completion)
+            response_content = completion
+            # TODO: Ignoring reasoning content for non-chat models
+
+        # create an OpenAIResponse object so we can cache it as if it were
+        # a non-streaming response
+        openai_response = OpenAIResponse(
+            choices=[msg],
+            usage=dict(total_tokens=0),
+        )
+        # Track whether we extracted inline thought tags from the text.
+        # Only set message_with_reasoning when get_reasoning_final()
+        # actually finds and extracts inline tags (e.g. <think>...</think>).
+        # When reasoning is already provided via a separate API field
+        # (e.g. reasoning_content), the message text doesn't contain
+        # thought signatures, so there's nothing extra to preserve.
+        message_with_reasoning = None
+        message: str | None
+        if reasoning == "" and response_content is not None:
+            # some LLM APIs may not return a separate reasoning field,
+            # and the reasoning may be included in the message content
+            # within delimiters like <think> ... </think>
+            reasoning, message = self.get_reasoning_final(response_content)
+            if reasoning:
+                # Inline tags were found and extracted; preserve the
+                # original text so it can be restored in message history.
+                message_with_reasoning = response_content
+        else:
+            message = response_content
+
+        prompt_tokens = usage.get("prompt_tokens", 0)
+        prompt_tokens_details: Any = usage.get("prompt_tokens_details", {})
+        cached_tokens = (
+            prompt_tokens_details.get("cached_tokens", 0)
+            if isinstance(prompt_tokens_details, dict)
+            else 0
+        )
+        completion_tokens = usage.get("completion_tokens", 0)
+
+        return (
+            LLMResponse(
+                message=message,
+                reasoning=reasoning,
+                message_with_reasoning=message_with_reasoning,
+                cached=False,
+                # don't allow empty list [] here
+                oai_tool_calls=tool_calls or None if len(tool_deltas) > 0 else None,
+                function_call=function_call if has_function else None,
+                usage=LLMTokenUsage(
+                    prompt_tokens=prompt_tokens or 0,
+                    cached_tokens=cached_tokens or 0,
+                    completion_tokens=completion_tokens or 0,
+                    cost=self._cost_chat_model(
+                        prompt_tokens or 0,
+                        cached_tokens or 0,
+                        completion_tokens or 0,
+                    ),
+                ),
+            ),
+            openai_response.model_dump(),
+        )
+
+    def _cache_store(self, k: str, v: Any) -> None:
+        if self.cache is None:
+            return
+        try:
+            self.cache.store(k, v)
+        except Exception as e:
+            logging.error(f"Error in OpenAIGPT._cache_store: {e}")
+            pass
+
+    def _cache_lookup(self, fn_name: str, **kwargs: Dict[str, Any]) -> Tuple[str, Any]:
+        if self.cache is None:
+            return "", None  # no cache, return empty key and None result
+        # Use the kwargs as the cache key
+        sorted_kwargs_str = str(sorted(kwargs.items()))
+        raw_key = f"{fn_name}:{sorted_kwargs_str}"
+
+        # Hash the key to a fixed length using SHA256
+        hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
+
+        if not settings.cache:
+            # when caching disabled, return the hashed_key and none result
+            return hashed_key, None
+        # Try to get the result from the cache
+        try:
+            cached_val = self.cache.retrieve(hashed_key)
+        except Exception as e:
+            logging.error(f"Error in OpenAIGPT._cache_lookup: {e}")
+            return hashed_key, None
+        return hashed_key, cached_val
+
+    def _cost_chat_model(self, prompt: int, cached: int, completion: int) -> float:
+        price = self.chat_cost()
+        return (
+            price[0] * (prompt - cached) + price[1] * cached + price[2] * completion
+        ) / 1000
+
+    def _get_non_stream_token_usage(
+        self, cached: bool, response: Dict[str, Any]
+    ) -> LLMTokenUsage:
+        """
+        Extracts token usage from ``response`` and computes cost, only when NOT
+        in streaming mode, since the LLM API (OpenAI currently) was not
+        populating the usage fields in streaming mode (but as of Sep 2024, streaming
+        responses include  usage info as well, so we should update the code
+        to directly use usage information from the streaming response, which is more
+        accurate, esp with "thinking" LLMs like o1 series which consume
+        thinking tokens).
+        In streaming mode, these are set to zero for
+        now, and will be updated later by the fn ``update_token_usage``.
+        """
+        cost = 0.0
+        prompt_tokens = 0
+        cached_tokens = 0
+        completion_tokens = 0
+
+        usage = response.get("usage")
+        if not cached and not self.get_stream() and usage is not None:
+            prompt_tokens = usage.get("prompt_tokens") or 0
+            prompt_tokens_details = usage.get("prompt_tokens_details", {}) or {}
+            cached_tokens = prompt_tokens_details.get("cached_tokens") or 0
+            completion_tokens = usage.get("completion_tokens") or 0
+            cost = self._cost_chat_model(
+                prompt_tokens or 0,
+                cached_tokens or 0,
+                completion_tokens or 0,
+            )
+
+        return LLMTokenUsage(
+            prompt_tokens=prompt_tokens,
+            cached_tokens=cached_tokens,
+            completion_tokens=completion_tokens,
+            cost=cost,
+        )
+
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        self.run_on_first_use()
+
+        try:
+            return self._generate(prompt, max_tokens)
+        except openai.APIStatusError as e:
+            # Catch HTTP-level API errors (400, 401, 403, 404, 422, 429, 5xx)
+            # without traceback — these originate server-side and a local
+            # stack trace adds no diagnostic value.
+            # Note: APIConnectionError/APITimeoutError are intentionally NOT
+            # caught here so they fall through to the generic handler below,
+            # where the full traceback aids in diagnosing local network issues.
+            logging.error(f"API error in OpenAIGPT.generate: {e}")
+            raise
+        except Exception as e:
+            # log and re-raise exception
+            logging.error(friendly_error(e, "Error in OpenAIGPT.generate: "))
+            raise
+
+    def _generate(self, prompt: str, max_tokens: int) -> LLMResponse:
+        if self.config.use_chat_for_completion:
+            return self.chat(messages=prompt, max_tokens=max_tokens)
+
+        if self.is_groq or self.is_cerebras:
+            raise ValueError("Groq, Cerebras do not support pure completions")
+
+        if settings.debug:
+            print(f"[grey37]PROMPT: {escape(prompt)}[/grey37]")
+
+        @retry_with_exponential_backoff
+        def completions_with_backoff(**kwargs):  # type: ignore
+            cached = False
+            hashed_key, result = self._cache_lookup("Completion", **kwargs)
+            if result is not None:
+                cached = True
+                if settings.debug:
+                    print("[grey37]CACHED[/grey37]")
+            else:
+                if self.config.litellm:
+                    from litellm import completion as litellm_completion
+
+                    completion_call = litellm_completion
+
+                    if self.api_key != DUMMY_API_KEY:
+                        kwargs["api_key"] = self.api_key
+                else:
+                    if self.client is None:
+                        raise ValueError(
+                            "OpenAI/equivalent chat-completion client not set"
+                        )
+                    assert isinstance(self.client, OpenAI)
+                    completion_call = self.client.completions.create
+                if self.config.litellm and settings.debug:
+                    kwargs["logger_fn"] = litellm_logging_fn
+                # If it's not in the cache, call the API
+                result = completion_call(**kwargs)
+                if self.get_stream():
+                    llm_response, openai_response = self._stream_response(
+                        result,
+                        chat=self.config.litellm,
+                    )
+                    self._cache_store(hashed_key, openai_response)
+                    return cached, hashed_key, openai_response
+                else:
+                    self._cache_store(hashed_key, result.model_dump())
+            return cached, hashed_key, result
+
+        kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
+        if self.config.litellm:
+            # TODO this is a temp fix, we should really be using a proper completion fn
+            # that takes a pre-formatted prompt, rather than mocking it as a sys msg.
+            kwargs["messages"] = [dict(content=prompt, role=Role.SYSTEM)]
+        else:  # any other OpenAI-compatible endpoint
+            kwargs["prompt"] = prompt
+        args = dict(
+            **kwargs,
+            max_tokens=max_tokens,  # for output/completion
+            stream=self.get_stream(),
+        )
+        args = self._openai_api_call_params(args)
+        cached, hashed_key, response = completions_with_backoff(**args)
+        # assume response is an actual response rather than a streaming event
+        if not isinstance(response, dict):
+            response = response.model_dump()
+        if "message" in response["choices"][0]:
+            msg = (response["choices"][0]["message"]["content"] or "").strip()
+        else:
+            msg = (response["choices"][0]["text"] or "").strip()
+        return LLMResponse(message=msg, cached=cached)
+
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        self.run_on_first_use()
+
+        try:
+            return await self._agenerate(prompt, max_tokens)
+        except openai.APIStatusError as e:
+            # Catch HTTP-level API errors (see comment in generate() above).
+            logging.error(f"API error in OpenAIGPT.agenerate: {e}")
+            raise
+        except Exception as e:
+            # log and re-raise exception
+            logging.error(friendly_error(e, "Error in OpenAIGPT.agenerate: "))
+            raise
+
+    async def _agenerate(self, prompt: str, max_tokens: int) -> LLMResponse:
+        # note we typically will not have self.config.stream = True
+        # when issuing several api calls concurrently/asynchronously.
+        # The calling fn should use the context `with Streaming(..., False)` to
+        # disable streaming.
+        if self.config.use_chat_for_completion:
+            return await self.achat(messages=prompt, max_tokens=max_tokens)
+
+        if self.is_groq or self.is_cerebras:
+            raise ValueError("Groq, Cerebras do not support pure completions")
+
+        if settings.debug:
+            print(f"[grey37]PROMPT: {escape(prompt)}[/grey37]")
+
+        # WARNING: .Completion.* endpoints are deprecated,
+        # and as of Sep 2023 only legacy models will work here,
+        # e.g. text-davinci-003, text-ada-001.
+        @async_retry_with_exponential_backoff
+        async def completions_with_backoff(**kwargs):  # type: ignore
+            cached = False
+            hashed_key, result = self._cache_lookup("AsyncCompletion", **kwargs)
+            if result is not None:
+                cached = True
+                if settings.debug:
+                    print("[grey37]CACHED[/grey37]")
+            else:
+                if self.config.litellm:
+                    from litellm import acompletion as litellm_acompletion
+
+                    if self.api_key != DUMMY_API_KEY:
+                        kwargs["api_key"] = self.api_key
+
+                # TODO this may not work: text_completion is not async,
+                # and we didn't find an async version in litellm
+                assert isinstance(self.async_client, AsyncOpenAI)
+                acompletion_call = (
+                    litellm_acompletion
+                    if self.config.litellm
+                    else self.async_client.completions.create
+                )
+                if self.config.litellm and settings.debug:
+                    kwargs["logger_fn"] = litellm_logging_fn
+                # If it's not in the cache, call the API
+                result = await acompletion_call(**kwargs)
+                self._cache_store(hashed_key, result.model_dump())
+            return cached, hashed_key, result
+
+        kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
+        if self.config.litellm:
+            # TODO this is a temp fix, we should really be using a proper completion fn
+            # that takes a pre-formatted prompt, rather than mocking it as a sys msg.
+            kwargs["messages"] = [dict(content=prompt, role=Role.SYSTEM)]
+        else:  # any other OpenAI-compatible endpoint
+            kwargs["prompt"] = prompt
+        cached, hashed_key, response = await completions_with_backoff(
+            **kwargs,
+            max_tokens=max_tokens,
+            stream=False,
+        )
+        # assume response is an actual response rather than a streaming event
+        if not isinstance(response, dict):
+            response = response.model_dump()
+        if "message" in response["choices"][0]:
+            msg = (response["choices"][0]["message"]["content"] or "").strip()
+        else:
+            msg = (response["choices"][0]["text"] or "").strip()
+        return LLMResponse(message=msg, cached=cached)
+
+    def chat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        self.run_on_first_use()
+
+        if self.config.use_completion_for_chat and not self.is_openai_chat_model():
+            # only makes sense for non-OpenAI models
+            if self.config.formatter is None or self.config.hf_formatter is None:
+                raise ValueError(
+                    """
+                    `formatter` must be specified in config to use completion for chat.
+                    """
+                )
+            if isinstance(messages, str):
+                messages = [
+                    LLMMessage(
+                        role=Role.SYSTEM, content="You are a helpful assistant."
+                    ),
+                    LLMMessage(role=Role.USER, content=messages),
+                ]
+            prompt = self.config.hf_formatter.format(messages)
+            return self.generate(prompt=prompt, max_tokens=max_tokens)
+        try:
+            return self._chat(
+                messages,
+                max_tokens,
+                tools,
+                tool_choice,
+                functions,
+                function_call,
+                response_format,
+            )
+        except openai.APIStatusError as e:
+            # Catch HTTP-level API errors (see comment in generate() above).
+            logging.error(f"API error in OpenAIGPT.chat: {e}")
+            raise
+        except Exception as e:
+            # log and re-raise exception
+            logging.error(friendly_error(e, "Error in OpenAIGPT.chat: "))
+            raise
+
+    async def achat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        self.run_on_first_use()
+
+        # turn off streaming for async calls
+        if (
+            self.config.use_completion_for_chat
+            and not self.is_openai_chat_model()
+            and not self.is_openai_completion_model()
+        ):
+            # only makes sense for local models, where we are trying to
+            # convert a chat dialog msg-sequence to a simple completion prompt.
+            if self.config.formatter is None:
+                raise ValueError(
+                    """
+                    `formatter` must be specified in config to use completion for chat.
+                    """
+                )
+            formatter = HFFormatter(
+                HFPromptFormatterConfig(model_name=self.config.formatter)
+            )
+            if isinstance(messages, str):
+                messages = [
+                    LLMMessage(
+                        role=Role.SYSTEM, content="You are a helpful assistant."
+                    ),
+                    LLMMessage(role=Role.USER, content=messages),
+                ]
+            prompt = formatter.format(messages)
+            return await self.agenerate(prompt=prompt, max_tokens=max_tokens)
+        try:
+            result = await self._achat(
+                messages,
+                max_tokens,
+                tools,
+                tool_choice,
+                functions,
+                function_call,
+                response_format,
+            )
+            return result
+        except openai.APIStatusError as e:
+            # Catch HTTP-level API errors (see comment in generate() above).
+            logging.error(f"API error in OpenAIGPT.achat: {e}")
+            raise
+        except Exception as e:
+            # log and re-raise exception
+            logging.error(friendly_error(e, "Error in OpenAIGPT.achat: "))
+            raise
+
+    def _chat_completions_with_backoff_body(self, **kwargs):  # type: ignore
+        cached = False
+        hashed_key, result = self._cache_lookup("Completion", **kwargs)
+        if result is not None:
+            cached = True
+            if settings.debug:
+                print("[grey37]CACHED[/grey37]")
+        else:
+            # If it's not in the cache, call the API
+            if self.config.litellm:
+                from litellm import completion as litellm_completion
+
+                completion_call = litellm_completion
+
+                if self.api_key != DUMMY_API_KEY:
+                    kwargs["api_key"] = self.api_key
+            else:
+                if self.client is None:
+                    raise ValueError("OpenAI/equivalent chat-completion client not set")
+                completion_call = self.client.chat.completions.create
+            if self.config.litellm and settings.debug:
+                kwargs["logger_fn"] = litellm_logging_fn
+            result = completion_call(**kwargs)
+
+            if self.get_stream():
+                # If streaming, cannot cache result
+                # since it is a generator. Instead,
+                # we hold on to the hashed_key and
+                # cache the result later
+
+                # Test if this is a stream with an exception by
+                # trying to get first chunk: Some providers like LiteLLM
+                # produce a valid stream object `result` instead of throwing a
+                # rate-limit error, and if we don't catch it here,
+                # we end up returning an empty response and not
+                # using the retry mechanism in the decorator.
+                try:
+                    # try to get the first chunk to check for errors
+                    test_iter = iter(result)
+                    first_chunk = next(test_iter)
+                    # If we get here without error, recreate the stream
+                    result = chain([first_chunk], test_iter)
+                except StopIteration:
+                    # Empty stream is fine
+                    pass
+                except Exception as e:
+                    # Propagate any errors in the stream
+                    raise e
+            else:
+                self._cache_store(hashed_key, result.model_dump())
+        return cached, hashed_key, result
+
+    def _chat_completions_with_backoff(self, **kwargs):  # type: ignore
+        retry_func = retry_with_exponential_backoff(
+            self._chat_completions_with_backoff_body,
+            initial_delay=self.config.retry_params.initial_delay,
+            max_retries=self.config.retry_params.max_retries,
+            exponential_base=self.config.retry_params.exponential_base,
+            jitter=self.config.retry_params.jitter,
+        )
+        return retry_func(**kwargs)
+
+    async def _achat_completions_with_backoff_body(self, **kwargs):  # type: ignore
+        cached = False
+        hashed_key, result = self._cache_lookup("Completion", **kwargs)
+        if result is not None:
+            cached = True
+            if settings.debug:
+                print("[grey37]CACHED[/grey37]")
+        else:
+            if self.config.litellm:
+                from litellm import acompletion as litellm_acompletion
+
+                acompletion_call = litellm_acompletion
+
+                if self.api_key != DUMMY_API_KEY:
+                    kwargs["api_key"] = self.api_key
+            else:
+                if self.async_client is None:
+                    raise ValueError(
+                        "OpenAI/equivalent async chat-completion client not set"
+                    )
+                acompletion_call = self.async_client.chat.completions.create
+            if self.config.litellm and settings.debug:
+                kwargs["logger_fn"] = litellm_logging_fn
+            # If it's not in the cache, call the API
+            result = await acompletion_call(**kwargs)
+            if self.get_stream():
+                try:
+                    # Try to peek at the first chunk to immediately catch any errors
+                    # Store the original result (the stream)
+                    original_stream = result
+
+                    # Manually create and advance the iterator to check for errors
+                    stream_iter = original_stream.__aiter__()
+                    try:
+                        # This will raise an exception if the stream is invalid
+                        first_chunk = await anext(stream_iter)
+
+                        # If we reach here, the stream started successfully
+                        # Now recreate a fresh stream from the original API result
+                        # Otherwise, return a new stream that yields the first chunk
+                        # and remaining items
+                        async def combined_stream():  # type: ignore
+                            yield first_chunk
+                            async for chunk in stream_iter:
+                                yield chunk
+
+                        result = combined_stream()  # type: ignore
+                    except StopAsyncIteration:
+                        # Empty stream is normal - nothing to do
+                        pass
+                except Exception as e:
+                    # Any exception here should be raised to trigger the retry mechanism
+                    raise e
+            else:
+                self._cache_store(hashed_key, result.model_dump())
+        return cached, hashed_key, result
+
+    async def _achat_completions_with_backoff(self, **kwargs):  # type: ignore
+        retry_func = async_retry_with_exponential_backoff(
+            self._achat_completions_with_backoff_body,
+            initial_delay=self.config.retry_params.initial_delay,
+            max_retries=self.config.retry_params.max_retries,
+            exponential_base=self.config.retry_params.exponential_base,
+            jitter=self.config.retry_params.jitter,
+        )
+        return await retry_func(**kwargs)
+
+    def _prep_chat_completion(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> Dict[str, Any]:
+        """Prepare args for LLM chat-completion API call"""
+        if isinstance(messages, str):
+            llm_messages = [
+                LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
+                LLMMessage(role=Role.USER, content=messages),
+            ]
+        else:
+            llm_messages = messages
+            if (
+                len(llm_messages) == 1
+                and llm_messages[0].role == Role.SYSTEM
+                # TODO: we will unconditionally insert a dummy user msg
+                # if the only msg is a system msg.
+                # We could make this conditional on ModelInfo.needs_first_user_message
+            ):
+                # some LLMs, notable Gemini as of 12/11/24,
+                # require the first message to be from the user,
+                # so insert a dummy user msg if needed.
+                llm_messages.insert(
+                    1,
+                    LLMMessage(
+                        role=Role.USER, content="Follow the above instructions."
+                    ),
+                )
+
+        chat_model = self.config.chat_model
+
+        args: Dict[str, Any] = dict(
+            model=chat_model,
+            messages=[
+                m.api_dict(
+                    self.config.chat_model,
+                    has_system_role=self.info().allows_system_message,
+                )
+                for m in (llm_messages)
+            ],
+            max_completion_tokens=max_tokens,
+            stream=self.get_stream(),
+        )
+        if self.get_stream() and "groq" not in self.chat_model_orig:
+            # groq fails when we include stream_options in the request
+            args.update(
+                dict(
+                    # get token-usage numbers in stream mode from OpenAI API,
+                    # and possibly other OpenAI-compatible APIs.
+                    stream_options=dict(include_usage=True),
+                )
+            )
+        args.update(self._openai_api_call_params(args))
+        # only include functions-related args if functions are provided
+        # since the OpenAI API will throw an error if `functions` is None or []
+        if functions is not None:
+            args.update(
+                dict(
+                    functions=[f.model_dump() for f in functions],
+                    function_call=function_call,
+                )
+            )
+        if tools is not None:
+            if self.config.parallel_tool_calls is not None:
+                args["parallel_tool_calls"] = self.config.parallel_tool_calls
+
+            if any(t.strict for t in tools) and (
+                self.config.parallel_tool_calls is None
+                or self.config.parallel_tool_calls
+            ):
+                parallel_strict_warning()
+            args.update(
+                dict(
+                    tools=[
+                        dict(
+                            type="function",
+                            function=t.function.model_dump()
+                            | ({"strict": t.strict} if t.strict is not None else {}),
+                        )
+                        for t in tools
+                    ],
+                    tool_choice=tool_choice,
+                )
+            )
+        if response_format is not None:
+            args["response_format"] = response_format.to_dict()
+
+        for p in self.unsupported_params():
+            # some models e.g. o1-mini (as of sep 2024) don't support some params,
+            # like temperature and stream, so we need to remove them.
+            args.pop(p, None)
+
+        param_rename_map = self.rename_params()
+        for old_param, new_param in param_rename_map.items():
+            if old_param in args:
+                args[new_param] = args.pop(old_param)
+
+        # finally, get rid of extra_body params exclusive to certain models
+        # Only apply allowlist restrictions for known models.
+        # Unknown/custom models are allowed to use all params by default.
+        is_known_model = self.info().name != "unknown"
+        extra_params = args.get("extra_body", {})
+        if extra_params and is_known_model:
+            for param, model_list in OpenAI_API_ParamInfo().extra_parameters.items():
+                if (
+                    self.config.chat_model not in model_list
+                    and self.chat_model_orig not in model_list
+                ):
+                    extra_params.pop(param, None)
+            if extra_params:
+                args["extra_body"] = extra_params
+        return args
+
+    def _process_chat_completion_response(
+        self,
+        cached: bool,
+        response: Dict[str, Any],
+    ) -> LLMResponse:
+        # openAI response will look like this:
+        """
+        {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1677652288,
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "name": "",
+                    "content": "\n\nHello there, how may I help you?",
+                    "reasoning_content": "Okay, let's see here, hmmm...",
+                    "function_call": {
+                        "name": "fun_name",
+                        "arguments: {
+                            "arg1": "val1",
+                            "arg2": "val2"
+                        }
+                    },
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 12,
+                "total_tokens": 21
+            }
+        }
+        """
+        choices = response.get("choices")
+        if isinstance(choices, list) and len(choices) > 0:
+            message = choices[0].get("message", {})
+        else:
+            message = {}
+        if message is None:
+            message = {}
+        content = message.get("content")
+        reasoning = message.get("reasoning_content", "")
+        # Track whether we extracted inline thought tags from the text.
+        # Only set message_with_reasoning when get_reasoning_final()
+        # actually finds and extracts inline tags (e.g. <think>...</think>).
+        # When reasoning is already provided via a separate API field
+        # (e.g. reasoning_content), the message text doesn't contain
+        # thought signatures, so there's nothing extra to preserve.
+        message_with_reasoning = None
+        if reasoning == "" and content is not None:
+            # some LLM APIs may not return a separate reasoning field,
+            # and the reasoning may be included in the message content
+            # within delimiters like <think> ... </think>
+            reasoning, msg = self.get_reasoning_final(content)
+            if reasoning:
+                # Inline tags were found and extracted; preserve the
+                # original text so it can be restored in message history.
+                message_with_reasoning = content
+        else:
+            msg = content
+
+        if message.get("function_call") is None:
+            fun_call = None
+        else:
+            try:
+                fun_call = LLMFunctionCall.from_dict(message["function_call"])
+            except (ValueError, SyntaxError):
+                logging.warning(
+                    "Could not parse function arguments: "
+                    f"{message['function_call']['arguments']} "
+                    f"for function {message['function_call']['name']} "
+                    "treating as normal non-function message"
+                )
+                fun_call = None
+                args_str = message["function_call"]["arguments"] or ""
+                msg_str = message["content"] or ""
+                msg = msg_str + args_str
+        oai_tool_calls = None
+        if message.get("tool_calls") is not None:
+            oai_tool_calls = []
+            for tool_call_dict in message["tool_calls"]:
+                try:
+                    tool_call = OpenAIToolCall.from_dict(tool_call_dict)
+                    oai_tool_calls.append(tool_call)
+                except (ValueError, SyntaxError):
+                    logging.warning(
+                        "Could not parse tool call: "
+                        f"{json.dumps(tool_call_dict)} "
+                        "treating as normal non-tool message"
+                    )
+                    serialized_tool_call = json.dumps(tool_call_dict)
+                    msg = (msg or "") + ("\n" if msg else "") + serialized_tool_call
+        return LLMResponse(
+            # None (no content, e.g. a tool-call-only response) is preserved as
+            # None rather than coerced to "", so the distinction survives
+            # downstream (see LLMMessage.content / ChatDocument.content_is_none).
+            message=msg.strip() if msg is not None else None,
+            reasoning=reasoning.strip() if reasoning is not None else "",
+            message_with_reasoning=message_with_reasoning,
+            function_call=fun_call,
+            oai_tool_calls=oai_tool_calls or None,  # don't allow empty list [] here
+            cached=cached,
+            usage=self._get_non_stream_token_usage(cached, response),
+        )
+
+    def _chat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """
+        ChatCompletion API call to OpenAI.
+        Args:
+            messages: list of messages  to send to the API, typically
+                represents back and forth dialogue between user and LLM, but could
+                also include "function"-role messages. If messages is a string,
+                it is assumed to be a user message.
+            max_tokens: max output tokens to generate
+            functions: list of LLMFunction specs available to the LLM, to possibly
+                use in its response
+            function_call: controls how the LLM uses `functions`:
+                - "auto": LLM decides whether to use `functions` or not,
+                - "none": LLM blocked from using any function
+                - a dict of {"name": "function_name"} which forces the LLM to use
+                    the specified function.
+        Returns:
+            LLMResponse object
+        """
+        args = self._prep_chat_completion(
+            messages,
+            max_tokens,
+            tools,
+            tool_choice,
+            functions,
+            function_call,
+            response_format,
+        )
+        cached, hashed_key, response = self._chat_completions_with_backoff(**args)  # type: ignore
+        if self.get_stream() and not cached:
+            llm_response, openai_response = self._stream_response(response, chat=True)
+            self._cache_store(hashed_key, openai_response)
+            return llm_response  # type: ignore
+        if isinstance(response, dict):
+            response_dict = response
+        else:
+            response_dict = response.model_dump()
+        return self._process_chat_completion_response(cached, response_dict)
+
+    async def _achat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """
+        Async version of _chat(). See that function for details.
+        """
+        args = self._prep_chat_completion(
+            messages,
+            max_tokens,
+            tools,
+            tool_choice,
+            functions,
+            function_call,
+            response_format,
+        )
+        cached, hashed_key, response = await self._achat_completions_with_backoff(  # type: ignore
+            **args
+        )
+        if self.get_stream() and not cached:
+            llm_response, openai_response = await self._stream_response_async(
+                response, chat=True
+            )
+            self._cache_store(hashed_key, openai_response)
+            return llm_response  # type: ignore
+        if isinstance(response, dict):
+            response_dict = response
+        else:
+            response_dict = response.model_dump()
+        return self._process_chat_completion_response(cached, response_dict)
+</file>
+
+<file path="langroid/vector_store/base.py">
+import copy
+import logging
+import re
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
+
+import numpy as np
+import pandas as pd
+from pydantic.fields import FieldInfo
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
+
+from langroid.embedding_models.base import EmbeddingModel, EmbeddingModelsConfig
+from langroid.embedding_models.models import OpenAIEmbeddingsConfig
+from langroid.mytypes import DocMetaData, Document, EmbeddingFunction
+from langroid.utils.algorithms.graph import components, topological_sort
+from langroid.utils.configuration import settings
+from langroid.utils.object_registry import ObjectRegistry
+from langroid.utils.output.printing import print_long_text
+from langroid.utils.pandas_utils import safe_eval_globals, sanitize_command, stringify
+from langroid.utils.pydantic_utils import flatten_dict
+
+logger = logging.getLogger(__name__)
+
+# the exact shape Kubernetes service links inject, e.g. tcp://10.0.0.8:6333
+# (\Z, not $: $ would match before a trailing newline, silently
+# discarding a value that should fail validation)
+_SERVICE_LINK_PORT_RE = re.compile(r"^tcp://\S+:\d+\Z")
+
+
+class _ServiceLinkPortFilter(PydanticBaseSettingsSource):
+    """Env-source wrapper dropping k8s/docker service-link `port` values.
+
+    With `enableServiceLinks` (on by default in Kubernetes), a service
+    named e.g. `qdrant` injects `QDRANT_PORT=tcp://IP:PORT` into every
+    pod, which would otherwise fail integer validation of the `port`
+    field. If the wrapped env source yields a `port` string matching
+    exactly that format, it is dropped (with a warning) so the class
+    default applies. Any other value — including malformed `tcp://`
+    junk, or a `tcp://` value passed to the constructor (which never
+    goes through this source) — still fails validation as usual.
+    """
+
+    def __init__(self, wrapped: PydanticBaseSettingsSource) -> None:
+        super().__init__(wrapped.settings_cls)
+        self._wrapped = wrapped
+
+    def get_field_value(
+        self, field: FieldInfo, field_name: str
+    ) -> Tuple[Any, str, bool]:
+        return self._wrapped.get_field_value(field, field_name)
+
+    def __call__(self) -> Dict[str, Any]:
+        values = self._wrapped()
+        port = values.get("port")
+        if isinstance(port, str) and _SERVICE_LINK_PORT_RE.match(port):
+            default = self.settings_cls.model_fields["port"].default
+            logger.warning(
+                f"Ignoring port value {port!r} from the environment: it "
+                f"looks like a Kubernetes/Docker service-link artifact "
+                f"(an injected <SERVICE>_PORT env var); using default "
+                f"port {default} instead."
+            )
+            values = {k: v for k, v in values.items() if k != "port"}
+        return values
+
+
+class VectorStoreConfig(BaseSettings):
+    # Without a prefix, every field name would itself be a
+    # case-insensitive env var (e.g. a bare HOST, PORT, or FULL_EVAL
+    # in the environment would silently override defaults); subclasses
+    # each set their own prefix (QDRANT_, LANCEDB_, ...).
+    model_config = SettingsConfigDict(env_prefix="VECDB_")
+
+    type: str = ""  # deprecated, keeping it for backward compatibility
+    collection_name: str | None = "temp"
+    replace_collection: bool = False  # replace collection if it already exists
+    storage_path: str = ".qdrant/data"
+    cloud: bool = False
+    batch_size: int = 200
+    embedding: EmbeddingModelsConfig = OpenAIEmbeddingsConfig(
+        model_type="openai",
+    )
+    embedding_model: Optional[EmbeddingModel] = None
+    timeout: int = 60
+    host: str = "127.0.0.1"
+    port: int = 6333
+    # used when parsing search results back as Document objects
+    document_class: Type[Document] = Document
+    metadata_class: Type[DocMetaData] = DocMetaData
+    # compose_file: str = "langroid/vector_store/docker-compose-qdrant.yml"
+    full_eval: bool = False  # runs eval without sanitization. Use only on trusted input
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: Type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> Tuple[PydanticBaseSettingsSource, ...]:
+        """Wrap the env source to drop k8s service-link `port` values.
+
+        Source precedence is unchanged (init beats env, etc.); only the
+        env source is filtered — see `_ServiceLinkPortFilter`.
+        """
+        return (
+            init_settings,
+            _ServiceLinkPortFilter(env_settings),
+            dotenv_settings,
+            file_secret_settings,
+        )
+
+
+class VectorStore(ABC):
+    """
+    Abstract base class for a vector store.
+    """
+
+    def __init__(self, config: VectorStoreConfig):
+        self.config = config
+        if config.embedding_model is None:
+            self.embedding_model = EmbeddingModel.create(config.embedding)
+        else:
+            self.embedding_model = config.embedding_model
+        if hasattr(self.config, "embedding_model"):
+            self.config.embedding_model = None
+        self.embedding_fn: EmbeddingFunction = self.embedding_model.embedding_fn()
+
+    @staticmethod
+    def create(config: VectorStoreConfig) -> Optional["VectorStore"]:
+        from langroid.vector_store.chromadb import ChromaDB, ChromaDBConfig
+        from langroid.vector_store.lancedb import LanceDB, LanceDBConfig
+        from langroid.vector_store.meilisearch import MeiliSearch, MeiliSearchConfig
+        from langroid.vector_store.milvusdb import MilvusDB, MilvusDBConfig
+        from langroid.vector_store.pineconedb import PineconeDB, PineconeDBConfig
+        from langroid.vector_store.postgres import PostgresDB, PostgresDBConfig
+        from langroid.vector_store.qdrantdb import QdrantDB, QdrantDBConfig
+        from langroid.vector_store.weaviatedb import WeaviateDB, WeaviateDBConfig
+
+        if isinstance(config, QdrantDBConfig):
+            return QdrantDB(config)
+        elif isinstance(config, ChromaDBConfig):
+            return ChromaDB(config)
+        elif isinstance(config, LanceDBConfig):
+            return LanceDB(config)
+        elif isinstance(config, MeiliSearchConfig):
+            return MeiliSearch(config)
+        elif isinstance(config, PostgresDBConfig):
+            return PostgresDB(config)
+        elif isinstance(config, MilvusDBConfig):
+            return MilvusDB(config)
+        elif isinstance(config, WeaviateDBConfig):
+            return WeaviateDB(config)
+        elif isinstance(config, PineconeDBConfig):
+            return PineconeDB(config)
+
+        else:
+            logger.warning(
+                f"""
+                Unknown vector store config: {config.__class__.__name__},
+                so skipping vector store creation!
+                If you intended to use a vector-store, please set a specific 
+                vector-store in your script, typically in the `vecdb` field of a 
+                `ChatAgentConfig`, otherwise set it to None.
+                """
+            )
+            return None
+
+    @property
+    def embedding_dim(self) -> int:
+        return len(self.embedding_fn(["test"])[0])
+
+    def clone(self) -> "VectorStore":
+        """Return a vector-store clone suitable for agent cloning.
+
+        The default implementation deep-copies the configuration, reuses any
+        existing embedding model, and instantiates a fresh store of the same
+        type. Subclasses can override when sharing the instance is required
+        (e.g., embedded/local stores that rely on file locks).
+        """
+
+        config_class = self.config.__class__
+        config_data = self.config.model_dump(mode="python")
+        config_data["embedding_model"] = None
+        config_copy = config_class.model_validate(config_data)
+        logger.debug(
+            "Cloning VectorStore %s: original collection=%s, copied collection=%s",
+            type(self).__name__,
+            getattr(self.config, "collection_name", None),
+            getattr(config_copy, "collection_name", None),
+        )
+        # Preserve the calculated collection contents without forcing replaces
+        if hasattr(config_copy, "replace_collection"):
+            config_copy.replace_collection = False  # type: ignore[attr-defined]
+        cloned_embedding: Optional[EmbeddingModel] = None
+        if (
+            hasattr(self, "embedding_model")
+            and getattr(self, "embedding_model") is not None
+        ):
+            cloned_embedding = self.embedding_model.clone()  # type: ignore[attr-defined]
+            if hasattr(config_copy, "embedding_model"):
+                config_copy.embedding_model = cloned_embedding
+
+        cloned_store = type(self)(config_copy)  # type: ignore[call-arg]
+        if hasattr(cloned_store.config, "embedding_model"):
+            cloned_store.config.embedding_model = None
+        logger.debug(
+            "Cloned VectorStore %s: cloned collection=%s",
+            type(self).__name__,
+            getattr(cloned_store.config, "collection_name", None),
+        )
+        if hasattr(cloned_store.config, "replace_collection"):
+            cloned_store.config.replace_collection = False
+        # Some stores might not honour replace_collection; ensure same collection
+        if getattr(self.config, "collection_name", None) is not None:
+            setattr(
+                cloned_store.config,
+                "collection_name",
+                getattr(self.config, "collection_name", None),
+            )
+        return cloned_store
+
+    @abstractmethod
+    def clear_empty_collections(self) -> int:
+        """Clear all empty collections in the vector store.
+        Returns the number of collections deleted.
+        """
+        pass
+
+    @abstractmethod
+    def clear_all_collections(self, really: bool = False, prefix: str = "") -> int:
+        """
+        Clear all collections in the vector store.
+
+        Args:
+            really (bool, optional): Whether to really clear all collections.
+                Defaults to False.
+            prefix (str, optional): Prefix of collections to clear.
+        Returns:
+            int: Number of collections deleted.
+        """
+        pass
+
+    @abstractmethod
+    def list_collections(self, empty: bool = False) -> List[str]:
+        """List all collections in the vector store
+        (only non empty collections if empty=False).
+        """
+        pass
+
+    def set_collection(self, collection_name: str, replace: bool = False) -> None:
+        """
+        Set the current collection to the given collection name.
+        Args:
+            collection_name (str): Name of the collection.
+            replace (bool, optional): Whether to replace the collection if it
+                already exists. Defaults to False.
+        """
+
+        self.config.collection_name = collection_name
+        self.config.replace_collection = replace
+        if replace:
+            self.create_collection(collection_name, replace=True)
+
+    @abstractmethod
+    def create_collection(self, collection_name: str, replace: bool = False) -> None:
+        """Create a collection with the given name.
+        Args:
+            collection_name (str): Name of the collection.
+            replace (bool, optional): Whether to replace the
+                collection if it already exists. Defaults to False.
+        """
+        pass
+
+    @abstractmethod
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        pass
+
+    def compute_from_docs(self, docs: List[Document], calc: str) -> str:
+        """Compute a result on a set of documents,
+        using a dataframe calc string like `df.groupby('state')['income'].mean()`.
+
+        If full_eval is False (default), the input expression is sanitized to prevent
+        most common code injection attack vectors.
+        If full_eval is True, sanitization is bypassed - use only with trusted input!
+        """
+        # convert each doc to a dict, using dotted paths for nested fields
+        dicts = [flatten_dict(doc.model_dump(by_alias=True)) for doc in docs]
+        df = pd.DataFrame(dicts)
+
+        try:
+            # SECURITY MITIGATION: Eval input is sanitized to prevent most common
+            # code injection attack vectors when full_eval is False. The globals
+            # dict also restricts ``__builtins__`` so that even with
+            # ``full_eval=True`` the expression cannot reach
+            # ``__import__``/``eval``/``exec`` via Python's implicit builtin
+            # injection (GHSA-q9p7-wqxg-mrhc).
+            vars = {"df": df}
+            if not self.config.full_eval:
+                calc = sanitize_command(calc)
+            code = compile(calc, "<calc>", "eval")
+            result = eval(code, safe_eval_globals(vars), {})
+        except Exception as e:
+            # return error message so LLM can fix the calc string if needed
+            err = f"""
+            Error encountered in pandas eval: {str(e)}
+            """
+            if isinstance(e, KeyError) and "not in index" in str(e):
+                # Pd.eval sometimes fails on a perfectly valid exprn like
+                # df.loc[..., 'column'] with a KeyError.
+                err += """
+                Maybe try a different way, e.g. 
+                instead of df.loc[..., 'column'], try df.loc[...]['column']
+                """
+            return err
+        return stringify(result)
+
+    def maybe_add_ids(self, documents: Sequence[Document]) -> None:
+        """Add ids to metadata if absent, since some
+        vecdbs don't like having blank ids."""
+        for d in documents:
+            if d.metadata.id in [None, ""]:
+                d.metadata.id = ObjectRegistry.new_id()
+
+    @abstractmethod
+    def similar_texts_with_scores(
+        self,
+        text: str,
+        k: int = 1,
+        where: Optional[str] = None,
+    ) -> List[Tuple[Document, float]]:
+        """
+        Find k most similar texts to the given text, in terms of vector distance metric
+        (e.g., cosine similarity).
+
+        Args:
+            text (str): The text to find similar texts for.
+            k (int, optional): Number of similar texts to retrieve. Defaults to 1.
+            where (Optional[str], optional): Where clause to filter the search.
+
+        Returns:
+            List[Tuple[Document,float]]: List of (Document, score) tuples.
+
+        """
+        pass
+
+    def add_context_window(
+        self, docs_scores: List[Tuple[Document, float]], neighbors: int = 0
+    ) -> List[Tuple[Document, float]]:
+        """
+        In each doc's metadata, there may be a window_ids field indicating
+        the ids of the chunks around the current chunk.
+        These window_ids may overlap, so we
+        - coalesce each overlapping groups into a single window (maintaining ordering),
+        - create a new document for each part, preserving metadata,
+
+        We may have stored a longer set of window_ids than we need during chunking.
+        Now, we just want `neighbors` on each side of the center of the window_ids list.
+
+        Args:
+            docs_scores (List[Tuple[Document, float]]): List of pairs of documents
+                to add context windows to together with their match scores.
+            neighbors (int, optional): Number of neighbors on "each side" of match to
+                retrieve. Defaults to 0.
+                "Each side" here means before and after the match,
+                in the original text.
+
+        Returns:
+            List[Tuple[Document, float]]: List of (Document, score) tuples.
+        """
+        # We return a larger context around each match, i.e.
+        # a window of `neighbors` on each side of the match.
+        docs = [d for d, s in docs_scores]
+        scores = [s for d, s in docs_scores]
+        if neighbors == 0:
+            return docs_scores
+        doc_chunks = [d for d in docs if d.metadata.is_chunk]
+        if len(doc_chunks) == 0:
+            return docs_scores
+        window_ids_list = []
+        id2metadata = {}
+        # id -> highest score of a doc it appears in
+        id2max_score: Dict[int | str, float] = {}
+        for i, d in enumerate(docs):
+            window_ids = d.metadata.window_ids
+            if len(window_ids) == 0:
+                window_ids = [d.id()]
+            id2metadata.update({id: d.metadata for id in window_ids})
+
+            id2max_score.update(
+                {id: max(id2max_score.get(id, 0), scores[i]) for id in window_ids}
+            )
+            n = len(window_ids)
+            chunk_idx = window_ids.index(d.id())
+            neighbor_ids = window_ids[
+                max(0, chunk_idx - neighbors) : min(n, chunk_idx + neighbors + 1)
+            ]
+            window_ids_list += [neighbor_ids]
+
+        # window_ids could be from different docs,
+        # and they may overlap, so we coalesce overlapping groups into
+        # separate windows.
+        window_ids_list = self.remove_overlaps(window_ids_list)
+        final_docs = []
+        final_scores = []
+        for w in window_ids_list:
+            metadata = copy.deepcopy(id2metadata[w[0]])
+            metadata.window_ids = w
+            document = Document(
+                content="".join([d.content for d in self.get_documents_by_ids(w)]),
+                metadata=metadata,
+            )
+            # make a fresh id since content is in general different
+            document.metadata.id = ObjectRegistry.new_id()
+            final_docs += [document]
+            final_scores += [max(id2max_score[id] for id in w)]
+        return list(zip(final_docs, final_scores))
+
+    @staticmethod
+    def remove_overlaps(windows: List[List[str]]) -> List[List[str]]:
+        """
+        Given a collection of windows, where each window is a sequence of ids,
+        identify groups of overlapping windows, and for each overlapping group,
+        order the chunk-ids using topological sort so they appear in the original
+        order in the text.
+
+        Args:
+            windows (List[int|str]): List of windows, where each window is a
+                sequence of ids.
+
+        Returns:
+            List[int|str]: List of windows, where each window is a sequence of ids,
+                and no two windows overlap.
+        """
+        ids = set(id for w in windows for id in w)
+        # id -> {win -> # pos}
+        id2win2pos: Dict[str, Dict[int, int]] = {id: {} for id in ids}
+
+        for i, w in enumerate(windows):
+            for j, id in enumerate(w):
+                id2win2pos[id][i] = j
+
+        n = len(windows)
+        # relation between windows:
+        order = np.zeros((n, n), dtype=np.int8)
+        for i, w in enumerate(windows):
+            for j, x in enumerate(windows):
+                if i == j:
+                    continue
+                if len(set(w).intersection(x)) == 0:
+                    continue
+                id = list(set(w).intersection(x))[0]  # any common id
+                if id2win2pos[id][i] > id2win2pos[id][j]:
+                    order[i, j] = -1  # win i is before win j
+                else:
+                    order[i, j] = 1  # win i is after win j
+
+        # find groups of windows that overlap, like connected components in a graph
+        groups = components(np.abs(order))
+
+        # order the chunk-ids in each group using topological sort
+        new_windows = []
+        for g in groups:
+            # find total ordering among windows in group based on order matrix
+            # (this is a topological sort)
+            _g = np.array(g)
+            order_matrix = order[_g][:, _g]
+            ordered_window_indices = topological_sort(order_matrix)
+            ordered_window_ids = [windows[i] for i in _g[ordered_window_indices]]
+            flattened = [id for w in ordered_window_ids for id in w]
+            flattened_deduped = list(dict.fromkeys(flattened))
+            # Note we are not going to split these, and instead we'll return
+            # larger windows from concatenating the connected groups.
+            # This ensures context is retained for LLM q/a
+            new_windows += [flattened_deduped]
+
+        return new_windows
+
+    @abstractmethod
+    def get_all_documents(self, where: str = "") -> List[Document]:
+        """
+        Get all documents in the current collection, possibly filtered by `where`.
+        """
+        pass
+
+    @abstractmethod
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        """
+        Get documents by their ids.
+        Args:
+            ids (List[str]): List of document ids.
+
+        Returns:
+            List[Document]: List of documents
+        """
+        pass
+
+    @abstractmethod
+    def delete_collection(self, collection_name: str) -> None:
+        pass
+
+    def show_if_debug(self, doc_score_pairs: List[Tuple[Document, float]]) -> None:
+        if settings.debug:
+            for i, (d, s) in enumerate(doc_score_pairs):
+                print_long_text("red", "italic red", f"\nMATCH-{i}\n", d.content)
 </file>
 
 <file path="tests/main/sql_chat/test_sql_chat_security.py">
@@ -129073,2604 +132153,6 @@ def _model_name(model: str | ModelName) -> str:
     return model.value
 </file>
 
-<file path="langroid/language_models/openai_gpt.py">
-import hashlib
-import json
-import logging
-import os
-import sys
-import warnings
-from collections import defaultdict
-from functools import cache
-from itertools import chain
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Mapping,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    no_type_check,
-)
-
-import openai
-from cerebras.cloud.sdk import AsyncCerebras, Cerebras
-from groq import AsyncGroq, Groq
-from httpx import Timeout
-from openai import AsyncOpenAI, OpenAI
-from pydantic import BaseModel
-from pydantic_settings import BaseSettings, SettingsConfigDict
-from rich import print
-from rich.markup import escape
-
-from langroid.cachedb.base import CacheDB
-from langroid.cachedb.redis_cachedb import RedisCache, RedisCacheConfig
-from langroid.exceptions import LangroidImportError
-from langroid.language_models.base import (
-    LanguageModel,
-    LLMConfig,
-    LLMFunctionCall,
-    LLMFunctionSpec,
-    LLMMessage,
-    LLMResponse,
-    LLMTokenUsage,
-    OpenAIJsonSchemaSpec,
-    OpenAIToolCall,
-    OpenAIToolSpec,
-    Role,
-    StreamEventType,
-    ToolChoiceTypes,
-)
-from langroid.language_models.client_cache import (
-    get_async_cerebras_client,
-    get_async_groq_client,
-    get_async_openai_client,
-    get_cerebras_client,
-    get_groq_client,
-    get_openai_client,
-    wrap_api_key_provider_async,
-)
-from langroid.language_models.config import HFPromptFormatterConfig
-from langroid.language_models.model_info import (
-    DeepSeekModel,
-    MiniMaxModel,
-    OpenAI_API_ParamInfo,
-)
-from langroid.language_models.model_info import (
-    OpenAIChatModel as OpenAIChatModel,
-)
-from langroid.language_models.model_info import (
-    OpenAICompletionModel as OpenAICompletionModel,
-)
-from langroid.language_models.prompt_formatter.hf_formatter import (
-    HFFormatter,
-    find_hf_formatter,
-)
-from langroid.language_models.provider_params import (
-    DUMMY_API_KEY,
-    LangDBParams,
-    PortkeyParams,
-)
-from langroid.language_models.utils import (
-    async_retry_with_exponential_backoff,
-    retry_with_exponential_backoff,
-)
-from langroid.parsing.parse_json import parse_imperfect_json
-from langroid.utils.configuration import settings
-from langroid.utils.constants import Colors
-from langroid.utils.system import friendly_error
-
-logging.getLogger("openai").setLevel(logging.ERROR)
-
-if "OLLAMA_HOST" in os.environ:
-    OLLAMA_BASE_URL = f"http://{os.environ['OLLAMA_HOST']}/v1"
-else:
-    OLLAMA_BASE_URL = "http://localhost:11434/v1"
-
-DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
-# Provider prefixes that route to the Gemini OpenAI-compatible API.
-GEMINI_MODEL_PREFIXES = ("gemini/", "google/gemini-")
-GLHF_BASE_URL = "https://glhf.chat/api/openai/v1"
-MINIMAX_BASE_URL = "https://api.minimax.io/v1"
-OLLAMA_API_KEY = "ollama"
-
-VLLM_API_KEY = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
-LLAMACPP_API_KEY = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
-
-
-openai_chat_model_pref_list = [
-    OpenAIChatModel.GPT4o,
-    OpenAIChatModel.GPT4_1_NANO,
-    OpenAIChatModel.GPT4_1_MINI,
-    OpenAIChatModel.GPT4_1,
-    OpenAIChatModel.GPT4o_MINI,
-    OpenAIChatModel.O1_MINI,
-    OpenAIChatModel.O3_MINI,
-    OpenAIChatModel.O1,
-]
-
-openai_completion_model_pref_list = [
-    OpenAICompletionModel.DAVINCI,
-    OpenAICompletionModel.BABBAGE,
-]
-
-
-if "OPENAI_API_KEY" in os.environ:
-    try:
-        available_models = set(map(lambda m: m.id, OpenAI().models.list()))
-    except openai.AuthenticationError as e:
-        if settings.debug:
-            logging.warning(
-                f"""
-            OpenAI Authentication Error: {e}.
-            ---
-            If you intended to use an OpenAI Model, you should fix this,
-            otherwise you can ignore this warning.
-            """
-            )
-        available_models = set()
-    except Exception as e:
-        if settings.debug:
-            logging.warning(
-                f"""
-            Error while fetching available OpenAI models: {e}.
-            Proceeding with an empty set of available models.
-            """
-            )
-        available_models = set()
-else:
-    available_models = set()
-
-default_openai_chat_model = next(
-    chain(
-        filter(
-            lambda m: m.value in available_models,
-            openai_chat_model_pref_list,
-        ),
-        [OpenAIChatModel.GPT4o],
-    )
-)
-default_openai_completion_model = next(
-    chain(
-        filter(
-            lambda m: m.value in available_models,
-            openai_completion_model_pref_list,
-        ),
-        [OpenAICompletionModel.DAVINCI],
-    )
-)
-
-
-class AccessWarning(Warning):
-    pass
-
-
-@cache
-def gpt_3_5_warning() -> None:
-    warnings.warn(
-        f"""
-        {OpenAIChatModel.GPT4o} is not available,
-        falling back to {OpenAIChatModel.GPT3_5_TURBO}.
-        Examples may not work properly and unexpected behavior may occur.
-        Adjustments to prompts may be necessary.
-        """,
-        AccessWarning,
-    )
-
-
-@cache
-def parallel_strict_warning() -> None:
-    logging.warning(
-        "OpenAI tool calling in strict mode is not supported when "
-        "parallel tool calls are made. Disable parallel tool calling "
-        "to ensure correct behavior."
-    )
-
-
-def noop() -> None:
-    """Does nothing."""
-    return None
-
-
-class OpenAICallParams(BaseModel):
-    """
-    Various params that can be sent to an OpenAI API chat-completion call.
-    When specified, any param here overrides the one with same name in the
-    OpenAIGPTConfig.
-    See OpenAI API Reference for details on the params:
-    https://platform.openai.com/docs/api-reference/chat
-    """
-
-    max_tokens: int | None = None
-    temperature: float | None = None
-    frequency_penalty: float | None = None  # between -2 and 2
-    presence_penalty: float | None = None  # between -2 and 2
-    response_format: Dict[str, str] | None = None
-    logit_bias: Dict[int, float] | None = None  # token_id -> bias
-    logprobs: bool | None = None
-    top_p: float | None = None
-    reasoning_effort: str | None = None  # or "low" or "high" or "medium"
-    top_logprobs: int | None = None  # if int, requires logprobs=True
-    n: int | None = None  # how many completions to generate (n > 1 is NOT handled now)
-    stop: str | List[str] | None = None  # (list of) stop sequence(s)
-    seed: int | None = None
-    user: str | None = None  # user id for tracking
-    extra_body: Dict[str, Any] | None = None  # additional params for API request body
-
-    def to_dict_exclude_none(self) -> Dict[str, Any]:
-        return {k: v for k, v in self.model_dump().items() if v is not None}
-
-
-class LiteLLMProxyConfig(BaseSettings):
-    """Configuration for LiteLLM proxy connection."""
-
-    api_key: str = ""  # read from env var LITELLM_API_KEY if set
-    api_base: str = ""  # read from env var LITELLM_API_BASE if set
-
-    model_config = SettingsConfigDict(env_prefix="LITELLM_")
-
-
-class OpenAIGPTConfig(LLMConfig):
-    """
-    Class for any LLM with an OpenAI-like API: besides the OpenAI models this includes:
-    (a) locally-served models behind an OpenAI-compatible API
-    (b) non-local models, using a proxy adaptor lib like litellm that provides
-        an OpenAI-compatible API.
-    (We could rename this class to OpenAILikeConfig, but we keep it as-is for now)
-
-    Important Note:
-    Due to the `env_prefix = "OPENAI_"` defined below,
-    all of the fields below can be set AND OVERRIDDEN via env vars,
-    # by upper-casing the name and prefixing with OPENAI_, e.g.
-    # OPENAI_MAX_OUTPUT_TOKENS=1000.
-    # If any of these is defined in this way in the environment
-    # (either via explicit setenv or export or via .env file + load_dotenv()),
-    # the environment variable takes precedence over the value in the config.
-    """
-
-    type: str = "openai"
-    api_key: str = DUMMY_API_KEY
-    # Callable returning a fresh API key/bearer token, for endpoints that
-    # authenticate with short-lived rotating credentials (e.g. Vertex AI
-    # OAuth tokens, Azure Entra ID). Resolved per-request by the OpenAI
-    # client, and excluded from the client-cache key (the cache is keyed on
-    # the provider's identity), so rotating tokens neither go stale nor grow
-    # the cache. Takes precedence over `api_key`. Only supported for models
-    # served via an OpenAI-compatible endpoint (not Groq/Cerebras/litellm).
-    # See docs/notes/rotating-api-keys.md.
-    api_key_provider: Optional[Callable[[], str]] = None
-    organization: str = ""
-    api_base: str | None = None  # used for local or other non-OpenAI models
-    litellm: bool = False  # use litellm api?
-    litellm_proxy: LiteLLMProxyConfig = LiteLLMProxyConfig()
-    ollama: bool = False  # use ollama's OpenAI-compatible endpoint?
-    min_output_tokens: int = 1
-    use_chat_for_completion: bool = True  # do not change this, for OpenAI models!
-    timeout: int = 20
-    temperature: float = 0.2
-    seed: int | None = 42
-    params: OpenAICallParams | None = None
-    use_cached_client: bool = (
-        True  # Whether to reuse cached clients (prevents resource exhaustion)
-    )
-    # these can be any model name that is served at an OpenAI-compatible API end point
-    chat_model: str = default_openai_chat_model
-    chat_model_orig: Optional[str] = None
-    completion_model: str = default_openai_completion_model
-    run_on_first_use: Callable[[], None] = noop
-    parallel_tool_calls: Optional[bool] = None
-    # Supports constrained decoding which enforces that the output of the LLM
-    # adheres to a JSON schema
-    supports_json_schema: Optional[bool] = None
-    # Supports strict decoding for the generation of tool calls with
-    # the OpenAI Tools API; this ensures that the generated tools
-    # adhere to the provided schema.
-    supports_strict_tools: Optional[bool] = None
-    # a string that roughly matches a HuggingFace chat_template,
-    # e.g. "mistral-instruct-v0.2 (a fuzzy search is done to find the closest match)
-    formatter: str | None = None
-    hf_formatter: HFFormatter | None = None
-    langdb_params: LangDBParams = LangDBParams()
-    portkey_params: PortkeyParams = PortkeyParams()
-    headers: Dict[str, str] = {}
-    http_client_factory: Optional[Callable[[], Any]] = (
-        None  # Factory: returns Client or (Client, AsyncClient)
-    )
-    http_verify_ssl: bool = True  # Simple flag for SSL verification
-    http_client_config: Optional[Dict[str, Any]] = None  # Config dict for httpx.Client
-    _api_base_was_supplied: bool = False
-
-    def __init__(self, **kwargs) -> None:  # type: ignore
-        api_base_was_supplied = "api_base" in kwargs
-        local_model = "api_base" in kwargs and kwargs["api_base"] is not None
-
-        chat_model = kwargs.get("chat_model", "")
-        local_prefixes = ["local/", "litellm/", "ollama/", "vllm/", "llamacpp/"]
-        if any(chat_model.startswith(prefix) for prefix in local_prefixes):
-            local_model = True
-
-        warn_gpt_3_5 = (
-            "chat_model" not in kwargs.keys()
-            and not local_model
-            and default_openai_chat_model == OpenAIChatModel.GPT3_5_TURBO
-        )
-
-        if warn_gpt_3_5:
-            existing_hook = kwargs.get("run_on_first_use", noop)
-
-            def with_warning() -> None:
-                existing_hook()
-                gpt_3_5_warning()
-
-            kwargs["run_on_first_use"] = with_warning
-
-        super().__init__(**kwargs)
-        env_prefix = self.model_config.get("env_prefix")
-        env_api_base_name = f"{env_prefix}API_BASE"
-        env_api_base = os.getenv(env_api_base_name)
-        if not self.model_config.get("case_sensitive"):
-            case_insensitive_env = {
-                name.lower(): value for name, value in os.environ.items()
-            }
-            env_api_base = case_insensitive_env.get(env_api_base_name.lower())
-        api_base_was_supplied = api_base_was_supplied or (
-            self.api_base is not None
-            and (env_prefix != "OPENAI_" or self.api_base != env_api_base)
-        )
-        self._api_base_was_supplied = api_base_was_supplied
-
-    model_config = SettingsConfigDict(env_prefix="OPENAI_")
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        """Track API bases assigned after config construction."""
-        super().__setattr__(name, value)
-        if name == "api_base":
-            self._api_base_was_supplied = True
-
-    def model_copy(
-        self, *, update: Mapping[str, Any] | None = None, deep: bool = False
-    ) -> "OpenAIGPTConfig":
-        """
-        Copy config while preserving nested model instances and subclasses.
-
-        Important: Avoid reconstructing via `model_dump` as that coerces nested
-        models to their annotated base types (dropping subclass-only fields).
-        Instead, defer to Pydantic's native `model_copy`, which keeps nested
-        `BaseModel` instances (and their concrete subclasses) intact.
-
-        An `api_base` supplied through `update` is caller configuration, so the
-        copy must retain that provenance for provider-specific routing.
-        """
-        # Delegate to BaseSettings/BaseModel implementation to preserve types
-        copied = super().model_copy(update=update, deep=deep)
-        if update is not None and "api_base" in update:
-            copied._api_base_was_supplied = True
-        return copied  # type: ignore[return-value]
-
-    def _validate_litellm(self) -> None:
-        """
-        When using liteLLM, validate whether all env vars required by the model
-        have been set.
-        """
-        if not self.litellm:
-            return
-        try:
-            import litellm
-        except ImportError:
-            raise LangroidImportError("litellm", "litellm")
-
-        litellm.telemetry = False
-        litellm.drop_params = True  # drop un-supported params without crashing
-        litellm.modify_params = True
-        self.seed = None  # some local mdls don't support seed
-
-        if self.api_key == DUMMY_API_KEY:
-            keys_dict = litellm.utils.validate_environment(self.chat_model)
-            missing_keys = keys_dict.get("missing_keys", [])
-            if len(missing_keys) > 0:
-                raise ValueError(
-                    f"""
-                    Missing environment variables for litellm-proxied model:
-                    {missing_keys}
-                    """
-                )
-
-    @classmethod
-    def create(cls, prefix: str) -> Type["OpenAIGPTConfig"]:
-        """Create a config class whose params can be set via a desired
-        prefix from the .env file or env vars.
-        E.g., using
-        ```python
-        OllamaConfig = OpenAIGPTConfig.create("ollama")
-        ollama_config = OllamaConfig()
-        ```
-        you can have a group of params prefixed by "OLLAMA_", to be used
-        with models served via `ollama`.
-        This way, you can maintain several setting-groups in your .env file,
-        one per model type.
-        """
-
-        class DynamicConfig(OpenAIGPTConfig):
-            pass
-
-        DynamicConfig.model_config = SettingsConfigDict(env_prefix=prefix.upper() + "_")
-        return DynamicConfig
-
-
-class OpenAIResponse(BaseModel):
-    """OpenAI response model, either completion or chat."""
-
-    choices: List[Dict]  # type: ignore
-    usage: Dict  # type: ignore
-
-
-def litellm_logging_fn(model_call_dict: Dict[str, Any]) -> None:
-    """Logging function for litellm"""
-    try:
-        api_input_dict = model_call_dict.get("additional_args", {}).get(
-            "complete_input_dict"
-        )
-        if api_input_dict is not None:
-            text = escape(json.dumps(api_input_dict, indent=2))
-            print(
-                f"[grey37]LITELLM: {text}[/grey37]",
-            )
-    except Exception:
-        pass
-
-
-# Define a class for OpenAI GPT models that extends the base class
-class OpenAIGPT(LanguageModel):
-    """
-    Class for OpenAI LLMs
-    """
-
-    client: OpenAI | Groq | Cerebras | None
-    async_client: AsyncOpenAI | AsyncGroq | AsyncCerebras | None
-
-    def __init__(self, config: OpenAIGPTConfig = OpenAIGPTConfig()):
-        """
-        Args:
-            config: configuration for openai-gpt model
-        """
-        # copy the config to avoid modifying the original; deep to decouple
-        # nested models while preserving their concrete subclasses
-        # The api_key_provider must NOT be deep-copied: the client cache is
-        # keyed on its identity (so a copy would defeat cache sharing), and it
-        # may hold non-copyable state (e.g. a threading.Lock). Clear it in a
-        # shallow copy first, then restore the original callable afterwards.
-        api_key_provider = config.api_key_provider
-        if api_key_provider is not None:
-            config = config.model_copy(update={"api_key_provider": None})
-        config = config.model_copy(deep=True)
-        if api_key_provider is not None:
-            config.api_key_provider = api_key_provider
-        super().__init__(config)
-        self.config: OpenAIGPTConfig = config
-        # save original model name such as `provider/model` before
-        # we strip out the `provider` - we retain the original in
-        # case some params are specific to a provider.
-        self.chat_model_orig = self.config.chat_model_orig or self.config.chat_model
-
-        # Run the first time the model is used
-        self.run_on_first_use = cache(self.config.run_on_first_use)
-
-        # global override of chat_model,
-        # to allow quick testing with other models
-        if settings.chat_model != "":
-            self.config.chat_model = settings.chat_model
-            self.chat_model_orig = settings.chat_model
-            self.config.completion_model = settings.chat_model
-
-        if len(parts := self.config.chat_model.split("//")) > 1:
-            # there is a formatter specified, e.g.
-            # "litellm/ollama/mistral//hf" or
-            # "local/localhost:8000/v1//mistral-instruct-v0.2"
-            formatter = parts[1]
-            self.config.chat_model = parts[0]
-            if formatter == "hf":
-                # e.g. "litellm/ollama/mistral//hf" -> "litellm/ollama/mistral"
-                formatter = find_hf_formatter(self.config.chat_model)
-                if formatter != "":
-                    # e.g. "mistral"
-                    self.config.formatter = formatter
-                    logging.warning(
-                        f"""
-                        Using completions (not chat) endpoint with HuggingFace
-                        chat_template for {formatter} for
-                        model {self.config.chat_model}
-                        """
-                    )
-            else:
-                # e.g. "local/localhost:8000/v1//mistral-instruct-v0.2"
-                self.config.formatter = formatter
-
-        if self.config.formatter is not None:
-            self.config.hf_formatter = HFFormatter(
-                HFPromptFormatterConfig(model_name=self.config.formatter)
-            )
-
-        self.supports_json_schema: bool = self.config.supports_json_schema or False
-        self.supports_strict_tools: bool = self.config.supports_strict_tools or False
-
-        OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", DUMMY_API_KEY)
-        self.api_key = config.api_key
-
-        # if model name starts with "litellm",
-        # set the actual model name by stripping the "litellm/" prefix
-        # and set the litellm flag to True
-        if self.config.chat_model.startswith("litellm/") or self.config.litellm:
-            # e.g. litellm/ollama/mistral
-            self.config.litellm = True
-            self.api_base = self.config.api_base
-            if self.config.chat_model.startswith("litellm/"):
-                # strip the "litellm/" prefix
-                # e.g. litellm/ollama/llama2 => ollama/llama2
-                self.config.chat_model = self.config.chat_model.split("/", 1)[1]
-        elif self.config.chat_model.startswith("local/"):
-            # expect this to be of the form "local/localhost:8000/v1",
-            # depending on how the model is launched locally.
-            # In this case the model served locally behind an OpenAI-compatible API
-            # so we can just use `openai.*` methods directly,
-            # and don't need a adaptor library like litellm
-            self.config.litellm = False
-            self.config.seed = None  # some models raise an error when seed is set
-            # Extract the api_base from the model name after the "local/" prefix
-            self.api_base = self.config.chat_model.split("/", 1)[1]
-            if not self.api_base.startswith("http"):
-                self.api_base = "http://" + self.api_base
-        elif self.config.chat_model.startswith("ollama/"):
-            self.config.ollama = True
-
-            # use api_base from config if set, else fall back on OLLAMA_BASE_URL
-            self.api_base = self.config.api_base or OLLAMA_BASE_URL
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = OLLAMA_API_KEY
-            self.config.chat_model = self.config.chat_model.replace("ollama/", "")
-        elif self.config.chat_model.startswith("vllm/"):
-            self.supports_json_schema = True
-            self.config.chat_model = self.config.chat_model.replace("vllm/", "")
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = os.environ.get("VLLM_API_KEY", DUMMY_API_KEY)
-            self.api_base = self.config.api_base or "http://localhost:8000/v1"
-            if not self.api_base.startswith("http"):
-                self.api_base = "http://" + self.api_base
-            if not self.api_base.endswith("/v1"):
-                self.api_base = self.api_base + "/v1"
-        elif self.config.chat_model.startswith("llamacpp/"):
-            self.supports_json_schema = True
-            self.api_base = self.config.chat_model.split("/", 1)[1]
-            if not self.api_base.startswith("http"):
-                self.api_base = "http://" + self.api_base
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = os.environ.get("LLAMA_API_KEY", DUMMY_API_KEY)
-        else:
-            self.api_base = self.config.api_base
-            # If api_base is unset we use OpenAI's endpoint, which supports
-            # these features (with JSON schema restricted to a limited set of models)
-            self.supports_strict_tools = self.api_base is None
-            self.supports_json_schema = (
-                self.api_base is None and self.info().has_structured_output
-            )
-
-        if settings.chat_model != "":
-            # if we're overriding chat model globally, set completion model to same
-            self.config.completion_model = self.config.chat_model
-
-        if self.config.formatter is not None:
-            # we want to format chats -> completions using this specific formatter
-            self.config.use_completion_for_chat = True
-            self.config.completion_model = self.config.chat_model
-
-        if self.config.use_completion_for_chat:
-            self.config.use_chat_for_completion = False
-
-        self.is_groq = self.config.chat_model.startswith("groq/")
-        self.is_cerebras = self.config.chat_model.startswith("cerebras/")
-        self.is_gemini = self.is_gemini_model()
-        self.is_deepseek = self.is_deepseek_model()
-        self.is_minimax = self.is_minimax_model()
-        self.is_glhf = self.config.chat_model.startswith("glhf/")
-        self.is_openrouter = self.config.chat_model.startswith("openrouter/")
-        self.is_langdb = self.config.chat_model.startswith("langdb/")
-        self.is_portkey = self.config.chat_model.startswith("portkey/")
-        self.is_litellm_proxy = self.config.chat_model.startswith("litellm-proxy/")
-
-        if self.config.api_key_provider is not None and (
-            self.is_groq or self.is_cerebras or self.config.litellm
-        ):
-            raise ValueError(
-                "api_key_provider is only supported for models served via an "
-                "OpenAI-compatible endpoint (using the OpenAI client); it "
-                "cannot be used with Groq, Cerebras, or the litellm adapter."
-            )
-
-        if self.is_groq:
-            # use groq-specific client
-            self.config.chat_model = self.config.chat_model.replace("groq/", "")
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = os.getenv("GROQ_API_KEY", DUMMY_API_KEY)
-            if self.config.use_cached_client:
-                self.client = get_groq_client(api_key=self.api_key)
-                self.async_client = get_async_groq_client(api_key=self.api_key)
-            else:
-                # Create new clients without caching
-                self.client = Groq(api_key=self.api_key)
-                self.async_client = AsyncGroq(api_key=self.api_key)
-        elif self.is_cerebras:
-            # use cerebras-specific client
-            self.config.chat_model = self.config.chat_model.replace("cerebras/", "")
-            if self.api_key == OPENAI_API_KEY:
-                self.api_key = os.getenv("CEREBRAS_API_KEY", DUMMY_API_KEY)
-            if self.config.use_cached_client:
-                self.client = get_cerebras_client(api_key=self.api_key)
-                # TODO there is not async client, so should we do anything here?
-                self.async_client = get_async_cerebras_client(api_key=self.api_key)
-            else:
-                # Create new clients without caching
-                self.client = Cerebras(api_key=self.api_key)
-                self.async_client = AsyncCerebras(api_key=self.api_key)
-        else:
-            # in these cases, there's no specific client: OpenAI python client suffices
-            if self.is_litellm_proxy:
-                self.config.chat_model = self.config.chat_model.replace(
-                    "litellm-proxy/", ""
-                )
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = self.config.litellm_proxy.api_key or self.api_key
-                self.api_base = self.config.litellm_proxy.api_base or self.api_base
-            elif self.is_gemini:
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = os.getenv("GEMINI_API_KEY", DUMMY_API_KEY)
-                # Prefer caller config, then Gemini env, then the default.
-                gemini_api_base = os.getenv("GEMINI_API_BASE", "")
-                explicit_api_base = (
-                    self.config.api_base if self.config._api_base_was_supplied else None
-                )
-                self.api_base = explicit_api_base or gemini_api_base or GEMINI_BASE_URL
-                if (
-                    self.config.chat_model.startswith("gemini/")
-                    or self.api_base == GEMINI_BASE_URL
-                ):
-                    self.config.chat_model = self.config.chat_model.split("/", 1)[1]
-            elif self.is_glhf:
-                self.config.chat_model = self.config.chat_model.replace("glhf/", "")
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = os.getenv("GLHF_API_KEY", DUMMY_API_KEY)
-                self.api_base = GLHF_BASE_URL
-            elif self.is_openrouter:
-                self.config.chat_model = self.config.chat_model.replace(
-                    "openrouter/", ""
-                )
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = os.getenv("OPENROUTER_API_KEY", DUMMY_API_KEY)
-                self.api_base = OPENROUTER_BASE_URL
-            elif self.is_deepseek:
-                self.config.chat_model = self.config.chat_model.replace("deepseek/", "")
-                self.api_base = DEEPSEEK_BASE_URL
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = os.getenv("DEEPSEEK_API_KEY", DUMMY_API_KEY)
-            elif self.is_minimax:
-                self.config.chat_model = self.config.chat_model.replace("minimax/", "")
-                # Honor caller-supplied base URL (e.g. regional endpoints,
-                # proxies) instead of always forcing the default.
-                openai_api_base = os.getenv("OPENAI_API_BASE")
-                explicit_api_base = (
-                    self.config.api_base
-                    if self.config.api_base and self.config.api_base != openai_api_base
-                    else None
-                )
-                self.api_base = explicit_api_base or MINIMAX_BASE_URL
-                if self.api_key == OPENAI_API_KEY:
-                    # Only overwrite with MINIMAX_API_KEY when it is actually
-                    # set, so users who intentionally put their MiniMax key in
-                    # OPENAI_API_KEY are not silently downgraded to a dummy key.
-                    minimax_key = os.getenv("MINIMAX_API_KEY", "")
-                    if minimax_key:
-                        self.api_key = minimax_key
-                # Recompute capabilities now that the prefix has been stripped
-                # and self.info() can find the model in MODEL_INFO.
-                self.supports_strict_tools = True
-                self.supports_json_schema = self.info().has_structured_output
-            elif self.is_langdb:
-                self.config.chat_model = self.config.chat_model.replace("langdb/", "")
-                self.api_base = self.config.langdb_params.base_url
-                project_id = self.config.langdb_params.project_id
-                if project_id:
-                    self.api_base += "/" + project_id + "/v1"
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = self.config.langdb_params.api_key or DUMMY_API_KEY
-
-                if self.config.langdb_params:
-                    params = self.config.langdb_params
-                    if params.project_id:
-                        self.config.headers["x-project-id"] = params.project_id
-                    if params.label:
-                        self.config.headers["x-label"] = params.label
-                    if params.run_id:
-                        self.config.headers["x-run-id"] = params.run_id
-                    if params.thread_id:
-                        self.config.headers["x-thread-id"] = params.thread_id
-            elif self.is_portkey:
-                # Parse the model string and extract provider/model
-                provider, model = self.config.portkey_params.parse_model_string(
-                    self.config.chat_model
-                )
-                self.config.chat_model = model
-                if provider:
-                    self.config.portkey_params.provider = provider
-
-                # Set Portkey base URL
-                self.api_base = self.config.portkey_params.base_url + "/v1"
-
-                # Set API key - use provider's API key from env if available
-                if self.api_key == OPENAI_API_KEY:
-                    self.api_key = self.config.portkey_params.get_provider_api_key(
-                        self.config.portkey_params.provider, DUMMY_API_KEY
-                    )
-
-                # Add Portkey-specific headers
-                self.config.headers.update(self.config.portkey_params.get_headers())
-
-            # Sanitize the API key: strip leading/trailing whitespace
-            # (including stray newlines from .env files or CI secrets).
-            self.api_key = self.api_key.strip()
-
-            # Create http_client if needed - Priority order:
-            # 1. http_client_factory (most flexibility, not cacheable)
-            # 2. http_client_config (cacheable, moderate flexibility)
-            # 3. http_verify_ssl=False (cacheable, simple SSL bypass)
-            http_client = None
-            async_http_client = None
-            http_client_config_used = None
-
-            if self.config.http_client_factory is not None:
-                # Use the factory to create http_client (not cacheable)
-                http_client = self.config.http_client_factory()
-                if isinstance(http_client, (list, tuple)):
-                    if len(http_client) != 2:
-                        raise ValueError(
-                            "http_client_factory must return either a single "
-                            "httpx.Client or a tuple of "
-                            "(httpx.Client, httpx.AsyncClient)"
-                        )
-                    http_client, async_http_client = http_client
-                else:
-                    # set async_http_client to None - so that it will
-                    # be created later
-                    async_http_client = None
-            elif self.config.http_client_config is not None:
-                # Use config dict (cacheable)
-                http_client_config_used = self.config.http_client_config
-            elif not self.config.http_verify_ssl:
-                # Simple SSL bypass (cacheable)
-                http_client_config_used = {"verify": False}
-                logging.warning(
-                    "SSL verification has been disabled. This is insecure and "
-                    "should only be used in trusted environments (e.g., "
-                    "corporate networks with self-signed certificates)."
-                )
-
-            # With an api_key_provider, hand the callable itself to the
-            # OpenAI client, which resolves a fresh token on each request.
-            openai_api_key: Union[str, Callable[[], str]] = (
-                self.config.api_key_provider
-                if self.config.api_key_provider is not None
-                else self.api_key
-            )
-
-            if self.config.use_cached_client:
-                self.client = get_openai_client(
-                    api_key=openai_api_key,
-                    base_url=self.api_base,
-                    organization=self.config.organization,
-                    timeout=Timeout(self.config.timeout),
-                    default_headers=self.config.headers,
-                    http_client=http_client,
-                    http_client_config=http_client_config_used,
-                )
-                self.async_client = get_async_openai_client(
-                    api_key=openai_api_key,
-                    base_url=self.api_base,
-                    organization=self.config.organization,
-                    timeout=Timeout(self.config.timeout),
-                    default_headers=self.config.headers,
-                    http_client=async_http_client,
-                    http_client_config=http_client_config_used,
-                )
-            else:
-                # Create new clients without caching
-                client_kwargs: Dict[str, Any] = dict(
-                    api_key=openai_api_key,
-                    base_url=self.api_base,
-                    organization=self.config.organization,
-                    timeout=Timeout(self.config.timeout),
-                    default_headers=self.config.headers,
-                )
-                if http_client is not None:
-                    client_kwargs["http_client"] = http_client
-                elif http_client_config_used is not None:
-                    # Create http_client from config for non-cached scenario
-                    try:
-                        from httpx import Client
-
-                        client_kwargs["http_client"] = Client(**http_client_config_used)
-                    except ImportError:
-                        raise ValueError(
-                            "httpx is required to use http_client_config. "
-                            "Install it with: pip install httpx"
-                        )
-                self.client = OpenAI(**client_kwargs)
-
-                async_client_kwargs: Dict[str, Any] = dict(
-                    api_key=(
-                        # AsyncOpenAI awaits its api_key callable
-                        wrap_api_key_provider_async(openai_api_key)
-                        if callable(openai_api_key)
-                        else openai_api_key
-                    ),
-                    base_url=self.api_base,
-                    organization=self.config.organization,
-                    timeout=Timeout(self.config.timeout),
-                    default_headers=self.config.headers,
-                )
-                if async_http_client is not None:
-                    async_client_kwargs["http_client"] = async_http_client
-                elif http_client_config_used is not None:
-                    # Create async http_client from config for non-cached scenario
-                    try:
-                        from httpx import AsyncClient
-
-                        async_client_kwargs["http_client"] = AsyncClient(
-                            **http_client_config_used
-                        )
-                    except ImportError:
-                        raise ValueError(
-                            "httpx is required to use http_client_config. "
-                            "Install it with: pip install httpx"
-                        )
-                self.async_client = AsyncOpenAI(**async_client_kwargs)
-
-        self.cache: CacheDB | None = None
-        use_cache = self.config.cache_config is not None
-        if "redis" in settings.cache_type and use_cache:
-            if config.cache_config is None or not isinstance(
-                config.cache_config,
-                RedisCacheConfig,
-            ):
-                # switch to fresh redis config if needed
-                config.cache_config = RedisCacheConfig(
-                    fake="fake" in settings.cache_type
-                )
-            if "fake" in settings.cache_type:
-                # force use of fake redis if global cache_type is "fakeredis"
-                config.cache_config.fake = True
-            self.cache = RedisCache(config.cache_config)
-        elif settings.cache_type != "none" and use_cache:
-            raise ValueError(
-                f"Invalid cache type {settings.cache_type}. "
-                "Valid types are redis, fakeredis, none"
-            )
-
-        self.config._validate_litellm()
-
-    def _openai_api_call_params(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Prep the params to be sent to the OpenAI API
-        (or any OpenAI-compatible API, e.g. from Ooba or LmStudio)
-        for chat-completion.
-
-        Order of priority:
-        - (1) Params (mainly max_tokens) in the chat/achat/generate/agenerate call
-                (these are passed in via kwargs)
-        - (2) Params in OpenAIGPTConfig.params (of class OpenAICallParams)
-        - (3) Specific Params in OpenAIGPTConfig (just temperature for now)
-        """
-        params = dict(
-            temperature=self.config.temperature,
-        )
-        if self.config.params is not None:
-            params.update(self.config.params.to_dict_exclude_none())
-        params.update(kwargs)
-        return params
-
-    def is_openai_chat_model(self) -> bool:
-        openai_chat_models = [e.value for e in OpenAIChatModel]
-        return self.config.chat_model in openai_chat_models
-
-    def is_openai_completion_model(self) -> bool:
-        openai_completion_models = [e.value for e in OpenAICompletionModel]
-        return self.config.completion_model in openai_completion_models
-
-    def is_gemini_model(self) -> bool:
-        """Are we using the gemini OpenAI-compatible API?"""
-        return self.chat_model_orig.startswith(GEMINI_MODEL_PREFIXES)
-
-    def is_deepseek_model(self) -> bool:
-        deepseek_models = [e.value for e in DeepSeekModel]
-        return (
-            self.chat_model_orig in deepseek_models
-            or self.chat_model_orig.startswith("deepseek/")
-        )
-
-    def is_minimax_model(self) -> bool:
-        """Are we using the MiniMax OpenAI-compatible API?"""
-        minimax_models = [e.value for e in MiniMaxModel]
-        return (
-            self.chat_model_orig in minimax_models
-            or self.chat_model_orig.startswith("minimax/")
-        )
-
-    def unsupported_params(self) -> List[str]:
-        """
-        List of params that are not supported by the current model
-        """
-        unsupported = set(self.info().unsupported_params)
-        return list(unsupported)
-
-    def rename_params(self) -> Dict[str, str]:
-        """
-        Map of param name -> new name for specific models.
-        Currently main troublemaker is o1* series.
-        """
-        return self.info().rename_params
-
-    def chat_context_length(self) -> int:
-        """
-        Context-length for chat-completion models/endpoints.
-        Get it from the config if explicitly given,
-         otherwise use model_info based on model name, and fall back to
-         generic model_info if there's no match.
-        """
-        return self.config.chat_context_length or self.info().context_length
-
-    def completion_context_length(self) -> int:
-        """
-        Context-length for completion models/endpoints.
-        Get it from the config if explicitly given,
-         otherwise use model_info based on model name, and fall back to
-         generic model_info if there's no match.
-        """
-        return (
-            self.config.completion_context_length
-            or self.completion_info().context_length
-        )
-
-    def chat_cost(self) -> Tuple[float, float, float]:
-        """
-        (Prompt, Cached, Generation) cost per 1000 tokens, for chat-completion
-        models/endpoints.
-        Get it from the dict, otherwise fail-over to general method
-        """
-        info = self.info()
-        cached_cost_per_million = info.cached_cost_per_million
-        if not cached_cost_per_million:
-            cached_cost_per_million = info.input_cost_per_million
-        return (
-            info.input_cost_per_million / 1000,
-            cached_cost_per_million / 1000,
-            info.output_cost_per_million / 1000,
-        )
-
-    def set_stream(self, stream: bool) -> bool:
-        """Enable or disable streaming output from API.
-        Args:
-            stream: enable streaming output from API
-        Returns: previous value of stream
-        """
-        tmp = self.config.stream
-        self.config.stream = stream
-        return tmp
-
-    def get_stream(self) -> bool:
-        """Get streaming status."""
-        return self.config.stream and settings.stream and self.info().allows_streaming
-
-    @staticmethod
-    def _split_inline_reasoning(
-        event_text: str,
-        event_reasoning: str,
-        in_reasoning: bool,
-        thought_delimiters: Tuple[str, str],
-    ) -> Tuple[str, str, bool]:
-        """Separate inline reasoning from text tokens in a streaming chunk.
-
-        When models embed thinking inside content (e.g. <think>...</think>)
-        rather than using a separate reasoning field, this splits the chunk
-        into text-only and reasoning-only portions for proper streamer routing.
-
-        Returns (text_tokens, reasoning_tokens, in_reasoning).
-        """
-        text_tokens = event_text
-        reasoning_tokens = event_reasoning
-
-        if not event_text or event_reasoning:
-            return text_tokens, reasoning_tokens, in_reasoning
-
-        start, end = thought_delimiters
-        remaining = event_text
-
-        if in_reasoning:
-            text_tokens = ""
-        elif start in event_text:
-            before, _, after = event_text.partition(start)
-            text_tokens = before
-            remaining = after
-            in_reasoning = True
-
-        if in_reasoning:
-            if end in remaining:
-                before, _, after = remaining.partition(end)
-                text_tokens += after
-                reasoning_tokens = before
-                in_reasoning = False
-            else:
-                reasoning_tokens = remaining
-
-        return text_tokens, reasoning_tokens, in_reasoning
-
-    @no_type_check
-    def _process_stream_event(
-        self,
-        event,
-        chat: bool = False,
-        tool_deltas: List[Dict[str, Any]] = [],
-        has_function: bool = False,
-        completion: str = "",
-        reasoning: str = "",
-        function_args: str = "",
-        function_name: str = "",
-        in_reasoning: bool = False,
-    ) -> Tuple[bool, bool, str, str, bool, Dict[str, int]]:
-        """Process state vars while processing a streaming API response.
-            Returns a tuple consisting of:
-        - is_break: whether to break out of the loop
-        - has_function: whether the response contains a function_call
-        - function_name: name of the function
-        - function_args: args of the function
-        - completion: completion text
-        - reasoning: reasoning text
-        - usage: usage dict
-        """
-        # convert event obj (of type ChatCompletionChunk) to dict so rest of code,
-        # which expects dicts, works as it did before switching to openai v1.x
-        if not isinstance(event, dict):
-            event = event.model_dump()
-
-        usage = event.get("usage", {}) or {}
-        choices = event.get("choices", [{}])
-        if choices is None or len(choices) == 0:
-            choices = [{}]
-        if len(usage) > 0 and len(choices[0]) == 0:
-            # we have a "usage" chunk, and empty choices, so we're done
-            # ASSUMPTION: a usage chunk ONLY arrives AFTER all normal completion text!
-            # If any API does not follow this, we need to change this code.
-            return (
-                True,
-                has_function,
-                function_name,
-                function_args,
-                completion,
-                reasoning,
-                in_reasoning,
-                usage,
-            )
-        event_args = ""
-        event_fn_name = ""
-        event_tool_deltas: Optional[List[Dict[str, Any]]] = None
-        silent = settings.quiet
-        # The first two events in the stream of Azure OpenAI is useless.
-        # In the 1st: choices list is empty, in the 2nd: the dict delta has null content
-        if chat:
-            delta = choices[0].get("delta", {}) or {}
-            # capture both content and reasoning_content
-            event_text = delta.get("content", "")
-            event_reasoning = delta.get(
-                "reasoning_content",
-                delta.get("reasoning", ""),
-            )
-            if "function_call" in delta and delta["function_call"] is not None:
-                if "name" in delta["function_call"]:
-                    event_fn_name = delta["function_call"]["name"]
-                if "arguments" in delta["function_call"]:
-                    event_args = delta["function_call"]["arguments"]
-            if "tool_calls" in delta and delta["tool_calls"] is not None:
-                # it's a list of deltas, usually just one
-                event_tool_deltas = delta["tool_calls"]
-                tool_deltas += event_tool_deltas
-        else:
-            event_text = choices[0]["text"]
-            event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
-
-        finish_reason = choices[0].get("finish_reason", "")
-        if not event_text and finish_reason == "content_filter":
-            filter_names = [
-                n
-                for n, r in choices[0].get("content_filter_results", {}).items()
-                if r.get("filtered")
-            ]
-            event_text = (
-                "Cannot respond due to content filters ["
-                + ", ".join(filter_names)
-                + "]"
-            )
-            logging.warning("LLM API returned content filter error: " + event_text)
-
-        event_text_tokens, event_reasoning_tokens, in_reasoning = (
-            self._split_inline_reasoning(
-                event_text,
-                event_reasoning,
-                in_reasoning,
-                self.config.thought_delimiters,
-            )
-        )
-
-        if event_text:
-            completion += event_text
-        if event_text_tokens:
-            if not silent:
-                sys.stdout.write(Colors().GREEN + event_text_tokens)
-                sys.stdout.flush()
-            self.config.streamer(event_text_tokens, StreamEventType.TEXT)
-
-        if event_reasoning:
-            reasoning += event_reasoning
-        if event_reasoning_tokens:
-            if not silent:
-                sys.stdout.write(Colors().GREEN_DIM + event_reasoning_tokens)
-                sys.stdout.flush()
-            self.config.streamer(event_reasoning_tokens, StreamEventType.REASONING)
-
-        if event_fn_name:
-            function_name = event_fn_name
-            has_function = True
-            if not silent:
-                sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
-                sys.stdout.flush()
-            self.config.streamer(event_fn_name, StreamEventType.FUNC_NAME)
-
-        if event_args:
-            function_args += event_args
-            if not silent:
-                sys.stdout.write(Colors().GREEN + event_args)
-                sys.stdout.flush()
-            self.config.streamer(event_args, StreamEventType.FUNC_ARGS)
-
-        if event_tool_deltas is not None:
-            # print out streaming tool calls, if not async
-            for td in event_tool_deltas:
-                if td["function"]["name"] is not None:
-                    tool_fn_name = td["function"]["name"]
-                    if not silent:
-                        sys.stdout.write(
-                            Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
-                        )
-                        sys.stdout.flush()
-                    self.config.streamer(tool_fn_name, StreamEventType.TOOL_NAME)
-                if td["function"]["arguments"] != "":
-                    tool_fn_args = td["function"]["arguments"]
-                    if not silent:
-                        sys.stdout.write(Colors().GREEN + tool_fn_args)
-                        sys.stdout.flush()
-                    self.config.streamer(tool_fn_args, StreamEventType.TOOL_ARGS)
-
-        # show this delta in the stream
-        is_break = finish_reason in [
-            "stop",
-            "function_call",
-            "tool_calls",
-        ]
-        # for function_call, finish_reason does not necessarily
-        # contain "function_call" as mentioned in the docs.
-        # So we check for "stop" or "function_call" here.
-        return (
-            is_break,
-            has_function,
-            function_name,
-            function_args,
-            completion,
-            reasoning,
-            in_reasoning,
-            usage,
-        )
-
-    @no_type_check
-    async def _process_stream_event_async(
-        self,
-        event,
-        chat: bool = False,
-        tool_deltas: List[Dict[str, Any]] = [],
-        has_function: bool = False,
-        completion: str = "",
-        reasoning: str = "",
-        function_args: str = "",
-        function_name: str = "",
-        in_reasoning: bool = False,
-    ) -> Tuple[bool, bool, str, str, bool, Dict[str, int]]:
-        """Process state vars while processing a streaming API response.
-            Returns a tuple consisting of:
-        - is_break: whether to break out of the loop
-        - has_function: whether the response contains a function_call
-        - function_name: name of the function
-        - function_args: args of the function
-        - completion: completion text
-        - reasoning: reasoning text
-        - usage: usage dict
-        """
-        # convert event obj (of type ChatCompletionChunk) to dict so rest of code,
-        # which expects dicts, works as it did before switching to openai v1.x
-        if not isinstance(event, dict):
-            event = event.model_dump()
-
-        usage = event.get("usage", {}) or {}
-        choices = event.get("choices", [{}])
-        if len(choices) == 0:
-            choices = [{}]
-        if len(usage) > 0 and len(choices[0]) == 0:
-            # we got usage chunk, and empty choices, so we're done
-            return (
-                True,
-                has_function,
-                function_name,
-                function_args,
-                completion,
-                reasoning,
-                in_reasoning,
-                usage,
-            )
-        event_args = ""
-        event_fn_name = ""
-        event_tool_deltas: Optional[List[Dict[str, Any]]] = None
-        silent = self.config.async_stream_quiet or settings.quiet
-        # The first two events in the stream of Azure OpenAI is useless.
-        # In the 1st: choices list is empty, in the 2nd: the dict delta has null content
-        if chat:
-            delta = choices[0].get("delta", {}) or {}
-            event_text = delta.get("content", "")
-            event_reasoning = delta.get(
-                "reasoning_content",
-                delta.get("reasoning", ""),
-            )
-            if "function_call" in delta and delta["function_call"] is not None:
-                if "name" in delta["function_call"]:
-                    event_fn_name = delta["function_call"]["name"]
-                if "arguments" in delta["function_call"]:
-                    event_args = delta["function_call"]["arguments"]
-            if "tool_calls" in delta and delta["tool_calls"] is not None:
-                # it's a list of deltas, usually just one
-                event_tool_deltas = delta["tool_calls"]
-                tool_deltas += event_tool_deltas
-        else:
-            event_text = choices[0]["text"]
-            event_reasoning = ""  # TODO: Ignoring reasoning for non-chat models
-
-        event_text_tokens, event_reasoning_tokens, in_reasoning = (
-            self._split_inline_reasoning(
-                event_text,
-                event_reasoning,
-                in_reasoning,
-                self.config.thought_delimiters,
-            )
-        )
-
-        if event_text:
-            completion += event_text
-        if event_text_tokens:
-            if not silent:
-                sys.stdout.write(Colors().GREEN + event_text_tokens)
-                sys.stdout.flush()
-            await self.config.streamer_async(event_text_tokens, StreamEventType.TEXT)
-
-        if event_reasoning:
-            reasoning += event_reasoning
-        if event_reasoning_tokens:
-            if not silent:
-                sys.stdout.write(Colors().GREEN_DIM + event_reasoning_tokens)
-                sys.stdout.flush()
-            await self.config.streamer_async(
-                event_reasoning_tokens, StreamEventType.REASONING
-            )
-
-        if event_fn_name:
-            function_name = event_fn_name
-            has_function = True
-            if not silent:
-                sys.stdout.write(Colors().GREEN + "FUNC: " + event_fn_name + ": ")
-                sys.stdout.flush()
-            await self.config.streamer_async(event_fn_name, StreamEventType.FUNC_NAME)
-
-        if event_args:
-            function_args += event_args
-            if not silent:
-                sys.stdout.write(Colors().GREEN + event_args)
-                sys.stdout.flush()
-            await self.config.streamer_async(event_args, StreamEventType.FUNC_ARGS)
-
-        if event_tool_deltas is not None:
-            # print out streaming tool calls, if not async
-            for td in event_tool_deltas:
-                if td["function"]["name"] is not None:
-                    tool_fn_name = td["function"]["name"]
-                    if not silent:
-                        sys.stdout.write(
-                            Colors().GREEN + "OAI-TOOL: " + tool_fn_name + ": "
-                        )
-                        sys.stdout.flush()
-                    await self.config.streamer_async(
-                        tool_fn_name, StreamEventType.TOOL_NAME
-                    )
-                if td["function"]["arguments"] != "":
-                    tool_fn_args = td["function"]["arguments"]
-                    if not silent:
-                        sys.stdout.write(Colors().GREEN + tool_fn_args)
-                        sys.stdout.flush()
-                    await self.config.streamer_async(
-                        tool_fn_args, StreamEventType.TOOL_ARGS
-                    )
-
-        # show this delta in the stream
-        is_break = choices[0].get("finish_reason", "") in [
-            "stop",
-            "function_call",
-            "tool_calls",
-        ]
-        # for function_call, finish_reason does not necessarily
-        # contain "function_call" as mentioned in the docs.
-        # So we check for "stop" or "function_call" here.
-        return (
-            is_break,
-            has_function,
-            function_name,
-            function_args,
-            completion,
-            reasoning,
-            in_reasoning,
-            usage,
-        )
-
-    @retry_with_exponential_backoff
-    def _stream_response(  # type: ignore
-        self, response, chat: bool = False
-    ) -> Tuple[LLMResponse, Dict[str, Any]]:
-        """
-        Grab and print streaming response from API.
-        Args:
-            response: event-sequence emitted by API
-            chat: whether in chat-mode (or else completion-mode)
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                Dict version of OpenAIResponse object (with choices, usage)
-
-        """
-        completion = ""
-        reasoning = ""
-        function_args = ""
-        function_name = ""
-
-        sys.stdout.write(Colors().GREEN)
-        sys.stdout.flush()
-        has_function = False
-        tool_deltas: List[Dict[str, Any]] = []
-        token_usage: Dict[str, int] = {}
-        done: bool = False
-        in_reasoning: bool = False  # Track if we're inside reasoning delimiters
-        content_present = False
-        try:
-            for event in response:
-                event_dict = event if isinstance(event, dict) else event.model_dump()
-                choices = event_dict.get("choices") or []
-                if chat and choices:
-                    delta = choices[0].get("delta") or {}
-                    content_present = content_present or (
-                        "content" in delta and delta["content"] is not None
-                    )
-                (
-                    is_break,
-                    has_function,
-                    function_name,
-                    function_args,
-                    completion,
-                    reasoning,
-                    in_reasoning,
-                    usage,
-                ) = self._process_stream_event(
-                    event,
-                    chat=chat,
-                    tool_deltas=tool_deltas,
-                    has_function=has_function,
-                    completion=completion,
-                    reasoning=reasoning,
-                    function_args=function_args,
-                    function_name=function_name,
-                    in_reasoning=in_reasoning,
-                )
-                if len(usage) > 0:
-                    # capture the token usage when non-empty
-                    token_usage = usage
-                if is_break:
-                    if not self.get_stream() or done:
-                        # if not streaming, then we don't wait for last "usage" chunk
-                        break
-                    else:
-                        # mark done, so we quit after the last "usage" chunk
-                        done = True
-
-        except Exception as e:
-            logging.warning("Error while processing stream response: %s", str(e))
-
-        if not settings.quiet:
-            print("")
-        # TODO- get usage info in stream mode (?)
-
-        return self._create_stream_response(
-            chat=chat,
-            tool_deltas=tool_deltas,
-            has_function=has_function,
-            completion=completion,
-            reasoning=reasoning,
-            function_args=function_args,
-            function_name=function_name,
-            usage=token_usage,
-            content_present=content_present,
-        )
-
-    @async_retry_with_exponential_backoff
-    async def _stream_response_async(  # type: ignore
-        self, response, chat: bool = False
-    ) -> Tuple[LLMResponse, Dict[str, Any]]:
-        """
-        Grab and print streaming response from API.
-        Args:
-            response: event-sequence emitted by API
-            chat: whether in chat-mode (or else completion-mode)
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                OpenAIResponse object (with choices, usage)
-
-        """
-
-        completion = ""
-        reasoning = ""
-        function_args = ""
-        function_name = ""
-
-        sys.stdout.write(Colors().GREEN)
-        sys.stdout.flush()
-        has_function = False
-        tool_deltas: List[Dict[str, Any]] = []
-        token_usage: Dict[str, int] = {}
-        done: bool = False
-        in_reasoning: bool = False  # Track if we're inside reasoning delimiters
-        content_present = False
-        try:
-            async for event in response:
-                event_dict = event if isinstance(event, dict) else event.model_dump()
-                choices = event_dict.get("choices") or []
-                if chat and choices:
-                    delta = choices[0].get("delta") or {}
-                    content_present = content_present or (
-                        "content" in delta and delta["content"] is not None
-                    )
-                (
-                    is_break,
-                    has_function,
-                    function_name,
-                    function_args,
-                    completion,
-                    reasoning,
-                    in_reasoning,
-                    usage,
-                ) = await self._process_stream_event_async(
-                    event,
-                    chat=chat,
-                    tool_deltas=tool_deltas,
-                    has_function=has_function,
-                    completion=completion,
-                    reasoning=reasoning,
-                    function_args=function_args,
-                    function_name=function_name,
-                    in_reasoning=in_reasoning,
-                )
-                if len(usage) > 0:
-                    # capture the token usage when non-empty
-                    token_usage = usage
-                if is_break:
-                    if not self.get_stream() or done:
-                        # if not streaming, then we don't wait for last "usage" chunk
-                        break
-                    else:
-                        # mark done, so we quit after the next "usage" chunk
-                        done = True
-
-        except Exception as e:
-            logging.warning("Error while processing stream response: %s", str(e))
-
-        if not settings.quiet:
-            print("")
-        # TODO- get usage info in stream mode (?)
-
-        return self._create_stream_response(
-            chat=chat,
-            tool_deltas=tool_deltas,
-            has_function=has_function,
-            completion=completion,
-            reasoning=reasoning,
-            function_args=function_args,
-            function_name=function_name,
-            usage=token_usage,
-            content_present=content_present,
-        )
-
-    @staticmethod
-    def tool_deltas_to_tools(
-        tools: List[Dict[str, Any]],
-    ) -> Tuple[
-        str,
-        List[OpenAIToolCall],
-        List[Dict[str, Any]],
-    ]:
-        """
-        Convert accumulated tool-call deltas to OpenAIToolCall objects.
-        Adapted from this excellent code:
-         https://community.openai.com/t/help-for-function-calls-with-streaming/627170/2
-
-        Args:
-            tools: list of tool deltas received from streaming API
-
-        Returns:
-            str: plain text corresponding to tool calls that failed to parse
-            List[OpenAIToolCall]: list of OpenAIToolCall objects
-            List[Dict[str, Any]]: list of tool dicts
-                (to reconstruct OpenAI API response, so it can be cached)
-        """
-        # Initialize a dictionary with default values
-
-        # idx -> dict repr of tool
-        # (used to simulate OpenAIResponse object later, and also to
-        # accumulate function args as strings)
-        idx2tool_dict: Dict[str, Dict[str, Any]] = defaultdict(
-            lambda: {
-                "id": None,
-                "function": {"arguments": "", "name": None},
-                "type": None,
-                "extra_content": None,
-            }
-        )
-
-        for tool_delta in tools:
-            if tool_delta["id"] is not None:
-                idx2tool_dict[tool_delta["index"]]["id"] = tool_delta["id"]
-
-            if tool_delta["function"]["name"] is not None:
-                idx2tool_dict[tool_delta["index"]]["function"]["name"] = tool_delta[
-                    "function"
-                ]["name"]
-
-            idx2tool_dict[tool_delta["index"]]["function"]["arguments"] += tool_delta[
-                "function"
-            ]["arguments"]
-
-            if tool_delta["type"] is not None:
-                idx2tool_dict[tool_delta["index"]]["type"] = tool_delta["type"]
-
-            if tool_delta.get("extra_content") is not None:
-                idx2tool_dict[tool_delta["index"]]["extra_content"] = tool_delta[
-                    "extra_content"
-                ]
-
-        # (try to) parse the fn args of each tool
-        contents: List[str] = []
-        good_indices = []
-        id2args: Dict[str, None | Dict[str, Any]] = {}
-        for idx, tool_dict in idx2tool_dict.items():
-            failed_content, args_dict = OpenAIGPT._parse_function_args(
-                tool_dict["function"]["arguments"]
-            )
-            # used to build tool_calls_list below
-            id2args[tool_dict["id"]] = args_dict or None  # if {}, store as None
-            if failed_content != "":
-                contents.append(failed_content)
-            else:
-                good_indices.append(idx)
-
-        # remove the failed tool calls
-        idx2tool_dict = {
-            idx: tool_dict
-            for idx, tool_dict in idx2tool_dict.items()
-            if idx in good_indices
-        }
-
-        # create OpenAIToolCall list
-        tool_calls_list = [
-            OpenAIToolCall(
-                id=tool_dict["id"],
-                function=LLMFunctionCall(
-                    name=tool_dict["function"]["name"],
-                    arguments=id2args.get(tool_dict["id"]),
-                ),
-                type=tool_dict["type"],
-                extra_content=tool_dict.get("extra_content"),
-            )
-            for tool_dict in idx2tool_dict.values()
-        ]
-        return "\n".join(contents), tool_calls_list, list(idx2tool_dict.values())
-
-    @staticmethod
-    def _parse_function_args(args: str) -> Tuple[str, Dict[str, Any]]:
-        """
-        Try to parse the `args` string as function args.
-
-        Args:
-            args: string containing function args
-
-        Returns:
-            Tuple of content, function name and args dict.
-            If parsing unsuccessful, returns the original string as content,
-            else returns the args dict.
-        """
-        content = ""
-        args_dict = {}
-        try:
-            stripped_fn_args = args.strip()
-            dict_or_list = parse_imperfect_json(stripped_fn_args)
-            if not isinstance(dict_or_list, dict):
-                raise ValueError(
-                    f"""
-                        Invalid function args: {stripped_fn_args}
-                        parsed as {dict_or_list},
-                        which is not a valid dict.
-                        """
-                )
-            args_dict = dict_or_list
-        except (SyntaxError, ValueError) as e:
-            logging.warning(
-                f"""
-                    Parsing OpenAI function args failed: {args};
-                    treating args as normal message. Error detail:
-                    {e}
-                    """
-            )
-            content = args
-
-        return content, args_dict
-
-    def _create_stream_response(
-        self,
-        chat: bool = False,
-        tool_deltas: List[Dict[str, Any]] = [],
-        has_function: bool = False,
-        completion: str = "",
-        reasoning: str = "",
-        function_args: str = "",
-        function_name: str = "",
-        usage: Dict[str, int] = {},
-        content_present: bool = False,
-    ) -> Tuple[LLMResponse, Dict[str, Any]]:
-        """
-        Create an LLMResponse object from the streaming API response.
-
-        Args:
-            chat: whether in chat-mode (or else completion-mode)
-            tool_deltas: list of tool deltas received from streaming API
-            has_function: whether the response contains a function_call
-            completion: completion text
-            reasoning: reasoning text
-            function_args: string representing function args
-            function_name: name of the function
-            usage: token usage dict
-            content_present: whether a stream delta explicitly contained content
-        Returns:
-            Tuple consisting of:
-                LLMResponse object (with message, usage),
-                Dict version of OpenAIResponse object (with choices, usage)
-                    (this is needed so we can cache the response, as if it were
-                    a non-streaming response)
-        """
-        # check if function_call args are valid, if not,
-        # treat this as a normal msg, not a function call
-        args: Dict[str, Any] = {}
-        if has_function and function_args != "":
-            content, args = self._parse_function_args(function_args)
-            completion = completion + content
-            if content != "":
-                has_function = False
-
-        # mock openai response so we can cache it
-        if chat:
-            failed_content, tool_calls, tool_dicts = OpenAIGPT.tool_deltas_to_tools(
-                tool_deltas,
-            )
-            if failed_content:
-                completion += ("\n" if completion else "") + failed_content
-                content_present = True
-            has_valid_call = len(tool_dicts) > 0 or has_function
-            response_content = (
-                None
-                if has_valid_call and not content_present and completion == ""
-                else completion
-            )
-            msg: Dict[str, Any] = dict(
-                message=dict(
-                    content=response_content,
-                    reasoning_content=reasoning,
-                ),
-            )
-            if len(tool_dicts) > 0:
-                msg["message"]["tool_calls"] = tool_dicts
-
-            if has_function:
-                function_call = LLMFunctionCall(name=function_name)
-                function_call_dict = function_call.model_dump()
-                if function_args == "":
-                    function_call.arguments = None
-                else:
-                    function_call.arguments = args
-                    function_call_dict.update({"arguments": function_args.strip()})
-                msg["message"]["function_call"] = function_call_dict
-        else:
-            # non-chat mode has no function_call
-            msg = dict(text=completion)
-            response_content = completion
-            # TODO: Ignoring reasoning content for non-chat models
-
-        # create an OpenAIResponse object so we can cache it as if it were
-        # a non-streaming response
-        openai_response = OpenAIResponse(
-            choices=[msg],
-            usage=dict(total_tokens=0),
-        )
-        # Track whether we extracted inline thought tags from the text.
-        # Only set message_with_reasoning when get_reasoning_final()
-        # actually finds and extracts inline tags (e.g. <think>...</think>).
-        # When reasoning is already provided via a separate API field
-        # (e.g. reasoning_content), the message text doesn't contain
-        # thought signatures, so there's nothing extra to preserve.
-        message_with_reasoning = None
-        message: str | None
-        if reasoning == "" and response_content is not None:
-            # some LLM APIs may not return a separate reasoning field,
-            # and the reasoning may be included in the message content
-            # within delimiters like <think> ... </think>
-            reasoning, message = self.get_reasoning_final(response_content)
-            if reasoning:
-                # Inline tags were found and extracted; preserve the
-                # original text so it can be restored in message history.
-                message_with_reasoning = response_content
-        else:
-            message = response_content
-
-        prompt_tokens = usage.get("prompt_tokens", 0)
-        prompt_tokens_details: Any = usage.get("prompt_tokens_details", {})
-        cached_tokens = (
-            prompt_tokens_details.get("cached_tokens", 0)
-            if isinstance(prompt_tokens_details, dict)
-            else 0
-        )
-        completion_tokens = usage.get("completion_tokens", 0)
-
-        return (
-            LLMResponse(
-                message=message,
-                reasoning=reasoning,
-                message_with_reasoning=message_with_reasoning,
-                cached=False,
-                # don't allow empty list [] here
-                oai_tool_calls=tool_calls or None if len(tool_deltas) > 0 else None,
-                function_call=function_call if has_function else None,
-                usage=LLMTokenUsage(
-                    prompt_tokens=prompt_tokens or 0,
-                    cached_tokens=cached_tokens or 0,
-                    completion_tokens=completion_tokens or 0,
-                    cost=self._cost_chat_model(
-                        prompt_tokens or 0,
-                        cached_tokens or 0,
-                        completion_tokens or 0,
-                    ),
-                ),
-            ),
-            openai_response.model_dump(),
-        )
-
-    def _cache_store(self, k: str, v: Any) -> None:
-        if self.cache is None:
-            return
-        try:
-            self.cache.store(k, v)
-        except Exception as e:
-            logging.error(f"Error in OpenAIGPT._cache_store: {e}")
-            pass
-
-    def _cache_lookup(self, fn_name: str, **kwargs: Dict[str, Any]) -> Tuple[str, Any]:
-        if self.cache is None:
-            return "", None  # no cache, return empty key and None result
-        # Use the kwargs as the cache key
-        sorted_kwargs_str = str(sorted(kwargs.items()))
-        raw_key = f"{fn_name}:{sorted_kwargs_str}"
-
-        # Hash the key to a fixed length using SHA256
-        hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
-
-        if not settings.cache:
-            # when caching disabled, return the hashed_key and none result
-            return hashed_key, None
-        # Try to get the result from the cache
-        try:
-            cached_val = self.cache.retrieve(hashed_key)
-        except Exception as e:
-            logging.error(f"Error in OpenAIGPT._cache_lookup: {e}")
-            return hashed_key, None
-        return hashed_key, cached_val
-
-    def _cost_chat_model(self, prompt: int, cached: int, completion: int) -> float:
-        price = self.chat_cost()
-        return (
-            price[0] * (prompt - cached) + price[1] * cached + price[2] * completion
-        ) / 1000
-
-    def _get_non_stream_token_usage(
-        self, cached: bool, response: Dict[str, Any]
-    ) -> LLMTokenUsage:
-        """
-        Extracts token usage from ``response`` and computes cost, only when NOT
-        in streaming mode, since the LLM API (OpenAI currently) was not
-        populating the usage fields in streaming mode (but as of Sep 2024, streaming
-        responses include  usage info as well, so we should update the code
-        to directly use usage information from the streaming response, which is more
-        accurate, esp with "thinking" LLMs like o1 series which consume
-        thinking tokens).
-        In streaming mode, these are set to zero for
-        now, and will be updated later by the fn ``update_token_usage``.
-        """
-        cost = 0.0
-        prompt_tokens = 0
-        cached_tokens = 0
-        completion_tokens = 0
-
-        usage = response.get("usage")
-        if not cached and not self.get_stream() and usage is not None:
-            prompt_tokens = usage.get("prompt_tokens") or 0
-            prompt_tokens_details = usage.get("prompt_tokens_details", {}) or {}
-            cached_tokens = prompt_tokens_details.get("cached_tokens") or 0
-            completion_tokens = usage.get("completion_tokens") or 0
-            cost = self._cost_chat_model(
-                prompt_tokens or 0,
-                cached_tokens or 0,
-                completion_tokens or 0,
-            )
-
-        return LLMTokenUsage(
-            prompt_tokens=prompt_tokens,
-            cached_tokens=cached_tokens,
-            completion_tokens=completion_tokens,
-            cost=cost,
-        )
-
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        self.run_on_first_use()
-
-        try:
-            return self._generate(prompt, max_tokens)
-        except openai.APIStatusError as e:
-            # Catch HTTP-level API errors (400, 401, 403, 404, 422, 429, 5xx)
-            # without traceback — these originate server-side and a local
-            # stack trace adds no diagnostic value.
-            # Note: APIConnectionError/APITimeoutError are intentionally NOT
-            # caught here so they fall through to the generic handler below,
-            # where the full traceback aids in diagnosing local network issues.
-            logging.error(f"API error in OpenAIGPT.generate: {e}")
-            raise
-        except Exception as e:
-            # log and re-raise exception
-            logging.error(friendly_error(e, "Error in OpenAIGPT.generate: "))
-            raise
-
-    def _generate(self, prompt: str, max_tokens: int) -> LLMResponse:
-        if self.config.use_chat_for_completion:
-            return self.chat(messages=prompt, max_tokens=max_tokens)
-
-        if self.is_groq or self.is_cerebras:
-            raise ValueError("Groq, Cerebras do not support pure completions")
-
-        if settings.debug:
-            print(f"[grey37]PROMPT: {escape(prompt)}[/grey37]")
-
-        @retry_with_exponential_backoff
-        def completions_with_backoff(**kwargs):  # type: ignore
-            cached = False
-            hashed_key, result = self._cache_lookup("Completion", **kwargs)
-            if result is not None:
-                cached = True
-                if settings.debug:
-                    print("[grey37]CACHED[/grey37]")
-            else:
-                if self.config.litellm:
-                    from litellm import completion as litellm_completion
-
-                    completion_call = litellm_completion
-
-                    if self.api_key != DUMMY_API_KEY:
-                        kwargs["api_key"] = self.api_key
-                else:
-                    if self.client is None:
-                        raise ValueError(
-                            "OpenAI/equivalent chat-completion client not set"
-                        )
-                    assert isinstance(self.client, OpenAI)
-                    completion_call = self.client.completions.create
-                if self.config.litellm and settings.debug:
-                    kwargs["logger_fn"] = litellm_logging_fn
-                # If it's not in the cache, call the API
-                result = completion_call(**kwargs)
-                if self.get_stream():
-                    llm_response, openai_response = self._stream_response(
-                        result,
-                        chat=self.config.litellm,
-                    )
-                    self._cache_store(hashed_key, openai_response)
-                    return cached, hashed_key, openai_response
-                else:
-                    self._cache_store(hashed_key, result.model_dump())
-            return cached, hashed_key, result
-
-        kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
-        if self.config.litellm:
-            # TODO this is a temp fix, we should really be using a proper completion fn
-            # that takes a pre-formatted prompt, rather than mocking it as a sys msg.
-            kwargs["messages"] = [dict(content=prompt, role=Role.SYSTEM)]
-        else:  # any other OpenAI-compatible endpoint
-            kwargs["prompt"] = prompt
-        args = dict(
-            **kwargs,
-            max_tokens=max_tokens,  # for output/completion
-            stream=self.get_stream(),
-        )
-        args = self._openai_api_call_params(args)
-        cached, hashed_key, response = completions_with_backoff(**args)
-        # assume response is an actual response rather than a streaming event
-        if not isinstance(response, dict):
-            response = response.model_dump()
-        if "message" in response["choices"][0]:
-            msg = (response["choices"][0]["message"]["content"] or "").strip()
-        else:
-            msg = (response["choices"][0]["text"] or "").strip()
-        return LLMResponse(message=msg, cached=cached)
-
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        self.run_on_first_use()
-
-        try:
-            return await self._agenerate(prompt, max_tokens)
-        except openai.APIStatusError as e:
-            # Catch HTTP-level API errors (see comment in generate() above).
-            logging.error(f"API error in OpenAIGPT.agenerate: {e}")
-            raise
-        except Exception as e:
-            # log and re-raise exception
-            logging.error(friendly_error(e, "Error in OpenAIGPT.agenerate: "))
-            raise
-
-    async def _agenerate(self, prompt: str, max_tokens: int) -> LLMResponse:
-        # note we typically will not have self.config.stream = True
-        # when issuing several api calls concurrently/asynchronously.
-        # The calling fn should use the context `with Streaming(..., False)` to
-        # disable streaming.
-        if self.config.use_chat_for_completion:
-            return await self.achat(messages=prompt, max_tokens=max_tokens)
-
-        if self.is_groq or self.is_cerebras:
-            raise ValueError("Groq, Cerebras do not support pure completions")
-
-        if settings.debug:
-            print(f"[grey37]PROMPT: {escape(prompt)}[/grey37]")
-
-        # WARNING: .Completion.* endpoints are deprecated,
-        # and as of Sep 2023 only legacy models will work here,
-        # e.g. text-davinci-003, text-ada-001.
-        @async_retry_with_exponential_backoff
-        async def completions_with_backoff(**kwargs):  # type: ignore
-            cached = False
-            hashed_key, result = self._cache_lookup("AsyncCompletion", **kwargs)
-            if result is not None:
-                cached = True
-                if settings.debug:
-                    print("[grey37]CACHED[/grey37]")
-            else:
-                if self.config.litellm:
-                    from litellm import acompletion as litellm_acompletion
-
-                    if self.api_key != DUMMY_API_KEY:
-                        kwargs["api_key"] = self.api_key
-
-                # TODO this may not work: text_completion is not async,
-                # and we didn't find an async version in litellm
-                assert isinstance(self.async_client, AsyncOpenAI)
-                acompletion_call = (
-                    litellm_acompletion
-                    if self.config.litellm
-                    else self.async_client.completions.create
-                )
-                if self.config.litellm and settings.debug:
-                    kwargs["logger_fn"] = litellm_logging_fn
-                # If it's not in the cache, call the API
-                result = await acompletion_call(**kwargs)
-                self._cache_store(hashed_key, result.model_dump())
-            return cached, hashed_key, result
-
-        kwargs: Dict[str, Any] = dict(model=self.config.completion_model)
-        if self.config.litellm:
-            # TODO this is a temp fix, we should really be using a proper completion fn
-            # that takes a pre-formatted prompt, rather than mocking it as a sys msg.
-            kwargs["messages"] = [dict(content=prompt, role=Role.SYSTEM)]
-        else:  # any other OpenAI-compatible endpoint
-            kwargs["prompt"] = prompt
-        cached, hashed_key, response = await completions_with_backoff(
-            **kwargs,
-            max_tokens=max_tokens,
-            stream=False,
-        )
-        # assume response is an actual response rather than a streaming event
-        if not isinstance(response, dict):
-            response = response.model_dump()
-        if "message" in response["choices"][0]:
-            msg = (response["choices"][0]["message"]["content"] or "").strip()
-        else:
-            msg = (response["choices"][0]["text"] or "").strip()
-        return LLMResponse(message=msg, cached=cached)
-
-    def chat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        self.run_on_first_use()
-
-        if self.config.use_completion_for_chat and not self.is_openai_chat_model():
-            # only makes sense for non-OpenAI models
-            if self.config.formatter is None or self.config.hf_formatter is None:
-                raise ValueError(
-                    """
-                    `formatter` must be specified in config to use completion for chat.
-                    """
-                )
-            if isinstance(messages, str):
-                messages = [
-                    LLMMessage(
-                        role=Role.SYSTEM, content="You are a helpful assistant."
-                    ),
-                    LLMMessage(role=Role.USER, content=messages),
-                ]
-            prompt = self.config.hf_formatter.format(messages)
-            return self.generate(prompt=prompt, max_tokens=max_tokens)
-        try:
-            return self._chat(
-                messages,
-                max_tokens,
-                tools,
-                tool_choice,
-                functions,
-                function_call,
-                response_format,
-            )
-        except openai.APIStatusError as e:
-            # Catch HTTP-level API errors (see comment in generate() above).
-            logging.error(f"API error in OpenAIGPT.chat: {e}")
-            raise
-        except Exception as e:
-            # log and re-raise exception
-            logging.error(friendly_error(e, "Error in OpenAIGPT.chat: "))
-            raise
-
-    async def achat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        self.run_on_first_use()
-
-        # turn off streaming for async calls
-        if (
-            self.config.use_completion_for_chat
-            and not self.is_openai_chat_model()
-            and not self.is_openai_completion_model()
-        ):
-            # only makes sense for local models, where we are trying to
-            # convert a chat dialog msg-sequence to a simple completion prompt.
-            if self.config.formatter is None:
-                raise ValueError(
-                    """
-                    `formatter` must be specified in config to use completion for chat.
-                    """
-                )
-            formatter = HFFormatter(
-                HFPromptFormatterConfig(model_name=self.config.formatter)
-            )
-            if isinstance(messages, str):
-                messages = [
-                    LLMMessage(
-                        role=Role.SYSTEM, content="You are a helpful assistant."
-                    ),
-                    LLMMessage(role=Role.USER, content=messages),
-                ]
-            prompt = formatter.format(messages)
-            return await self.agenerate(prompt=prompt, max_tokens=max_tokens)
-        try:
-            result = await self._achat(
-                messages,
-                max_tokens,
-                tools,
-                tool_choice,
-                functions,
-                function_call,
-                response_format,
-            )
-            return result
-        except openai.APIStatusError as e:
-            # Catch HTTP-level API errors (see comment in generate() above).
-            logging.error(f"API error in OpenAIGPT.achat: {e}")
-            raise
-        except Exception as e:
-            # log and re-raise exception
-            logging.error(friendly_error(e, "Error in OpenAIGPT.achat: "))
-            raise
-
-    def _chat_completions_with_backoff_body(self, **kwargs):  # type: ignore
-        cached = False
-        hashed_key, result = self._cache_lookup("Completion", **kwargs)
-        if result is not None:
-            cached = True
-            if settings.debug:
-                print("[grey37]CACHED[/grey37]")
-        else:
-            # If it's not in the cache, call the API
-            if self.config.litellm:
-                from litellm import completion as litellm_completion
-
-                completion_call = litellm_completion
-
-                if self.api_key != DUMMY_API_KEY:
-                    kwargs["api_key"] = self.api_key
-            else:
-                if self.client is None:
-                    raise ValueError("OpenAI/equivalent chat-completion client not set")
-                completion_call = self.client.chat.completions.create
-            if self.config.litellm and settings.debug:
-                kwargs["logger_fn"] = litellm_logging_fn
-            result = completion_call(**kwargs)
-
-            if self.get_stream():
-                # If streaming, cannot cache result
-                # since it is a generator. Instead,
-                # we hold on to the hashed_key and
-                # cache the result later
-
-                # Test if this is a stream with an exception by
-                # trying to get first chunk: Some providers like LiteLLM
-                # produce a valid stream object `result` instead of throwing a
-                # rate-limit error, and if we don't catch it here,
-                # we end up returning an empty response and not
-                # using the retry mechanism in the decorator.
-                try:
-                    # try to get the first chunk to check for errors
-                    test_iter = iter(result)
-                    first_chunk = next(test_iter)
-                    # If we get here without error, recreate the stream
-                    result = chain([first_chunk], test_iter)
-                except StopIteration:
-                    # Empty stream is fine
-                    pass
-                except Exception as e:
-                    # Propagate any errors in the stream
-                    raise e
-            else:
-                self._cache_store(hashed_key, result.model_dump())
-        return cached, hashed_key, result
-
-    def _chat_completions_with_backoff(self, **kwargs):  # type: ignore
-        retry_func = retry_with_exponential_backoff(
-            self._chat_completions_with_backoff_body,
-            initial_delay=self.config.retry_params.initial_delay,
-            max_retries=self.config.retry_params.max_retries,
-            exponential_base=self.config.retry_params.exponential_base,
-            jitter=self.config.retry_params.jitter,
-        )
-        return retry_func(**kwargs)
-
-    async def _achat_completions_with_backoff_body(self, **kwargs):  # type: ignore
-        cached = False
-        hashed_key, result = self._cache_lookup("Completion", **kwargs)
-        if result is not None:
-            cached = True
-            if settings.debug:
-                print("[grey37]CACHED[/grey37]")
-        else:
-            if self.config.litellm:
-                from litellm import acompletion as litellm_acompletion
-
-                acompletion_call = litellm_acompletion
-
-                if self.api_key != DUMMY_API_KEY:
-                    kwargs["api_key"] = self.api_key
-            else:
-                if self.async_client is None:
-                    raise ValueError(
-                        "OpenAI/equivalent async chat-completion client not set"
-                    )
-                acompletion_call = self.async_client.chat.completions.create
-            if self.config.litellm and settings.debug:
-                kwargs["logger_fn"] = litellm_logging_fn
-            # If it's not in the cache, call the API
-            result = await acompletion_call(**kwargs)
-            if self.get_stream():
-                try:
-                    # Try to peek at the first chunk to immediately catch any errors
-                    # Store the original result (the stream)
-                    original_stream = result
-
-                    # Manually create and advance the iterator to check for errors
-                    stream_iter = original_stream.__aiter__()
-                    try:
-                        # This will raise an exception if the stream is invalid
-                        first_chunk = await anext(stream_iter)
-
-                        # If we reach here, the stream started successfully
-                        # Now recreate a fresh stream from the original API result
-                        # Otherwise, return a new stream that yields the first chunk
-                        # and remaining items
-                        async def combined_stream():  # type: ignore
-                            yield first_chunk
-                            async for chunk in stream_iter:
-                                yield chunk
-
-                        result = combined_stream()  # type: ignore
-                    except StopAsyncIteration:
-                        # Empty stream is normal - nothing to do
-                        pass
-                except Exception as e:
-                    # Any exception here should be raised to trigger the retry mechanism
-                    raise e
-            else:
-                self._cache_store(hashed_key, result.model_dump())
-        return cached, hashed_key, result
-
-    async def _achat_completions_with_backoff(self, **kwargs):  # type: ignore
-        retry_func = async_retry_with_exponential_backoff(
-            self._achat_completions_with_backoff_body,
-            initial_delay=self.config.retry_params.initial_delay,
-            max_retries=self.config.retry_params.max_retries,
-            exponential_base=self.config.retry_params.exponential_base,
-            jitter=self.config.retry_params.jitter,
-        )
-        return await retry_func(**kwargs)
-
-    def _prep_chat_completion(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> Dict[str, Any]:
-        """Prepare args for LLM chat-completion API call"""
-        if isinstance(messages, str):
-            llm_messages = [
-                LLMMessage(role=Role.SYSTEM, content="You are a helpful assistant."),
-                LLMMessage(role=Role.USER, content=messages),
-            ]
-        else:
-            llm_messages = messages
-            if (
-                len(llm_messages) == 1
-                and llm_messages[0].role == Role.SYSTEM
-                # TODO: we will unconditionally insert a dummy user msg
-                # if the only msg is a system msg.
-                # We could make this conditional on ModelInfo.needs_first_user_message
-            ):
-                # some LLMs, notable Gemini as of 12/11/24,
-                # require the first message to be from the user,
-                # so insert a dummy user msg if needed.
-                llm_messages.insert(
-                    1,
-                    LLMMessage(
-                        role=Role.USER, content="Follow the above instructions."
-                    ),
-                )
-
-        chat_model = self.config.chat_model
-
-        args: Dict[str, Any] = dict(
-            model=chat_model,
-            messages=[
-                m.api_dict(
-                    self.config.chat_model,
-                    has_system_role=self.info().allows_system_message,
-                )
-                for m in (llm_messages)
-            ],
-            max_completion_tokens=max_tokens,
-            stream=self.get_stream(),
-        )
-        if self.get_stream() and "groq" not in self.chat_model_orig:
-            # groq fails when we include stream_options in the request
-            args.update(
-                dict(
-                    # get token-usage numbers in stream mode from OpenAI API,
-                    # and possibly other OpenAI-compatible APIs.
-                    stream_options=dict(include_usage=True),
-                )
-            )
-        args.update(self._openai_api_call_params(args))
-        # only include functions-related args if functions are provided
-        # since the OpenAI API will throw an error if `functions` is None or []
-        if functions is not None:
-            args.update(
-                dict(
-                    functions=[f.model_dump() for f in functions],
-                    function_call=function_call,
-                )
-            )
-        if tools is not None:
-            if self.config.parallel_tool_calls is not None:
-                args["parallel_tool_calls"] = self.config.parallel_tool_calls
-
-            if any(t.strict for t in tools) and (
-                self.config.parallel_tool_calls is None
-                or self.config.parallel_tool_calls
-            ):
-                parallel_strict_warning()
-            args.update(
-                dict(
-                    tools=[
-                        dict(
-                            type="function",
-                            function=t.function.model_dump()
-                            | ({"strict": t.strict} if t.strict is not None else {}),
-                        )
-                        for t in tools
-                    ],
-                    tool_choice=tool_choice,
-                )
-            )
-        if response_format is not None:
-            args["response_format"] = response_format.to_dict()
-
-        for p in self.unsupported_params():
-            # some models e.g. o1-mini (as of sep 2024) don't support some params,
-            # like temperature and stream, so we need to remove them.
-            args.pop(p, None)
-
-        param_rename_map = self.rename_params()
-        for old_param, new_param in param_rename_map.items():
-            if old_param in args:
-                args[new_param] = args.pop(old_param)
-
-        # finally, get rid of extra_body params exclusive to certain models
-        # Only apply allowlist restrictions for known models.
-        # Unknown/custom models are allowed to use all params by default.
-        is_known_model = self.info().name != "unknown"
-        extra_params = args.get("extra_body", {})
-        if extra_params and is_known_model:
-            for param, model_list in OpenAI_API_ParamInfo().extra_parameters.items():
-                if (
-                    self.config.chat_model not in model_list
-                    and self.chat_model_orig not in model_list
-                ):
-                    extra_params.pop(param, None)
-            if extra_params:
-                args["extra_body"] = extra_params
-        return args
-
-    def _process_chat_completion_response(
-        self,
-        cached: bool,
-        response: Dict[str, Any],
-    ) -> LLMResponse:
-        # openAI response will look like this:
-        """
-        {
-            "id": "chatcmpl-123",
-            "object": "chat.completion",
-            "created": 1677652288,
-            "choices": [{
-                "index": 0,
-                "message": {
-                    "role": "assistant",
-                    "name": "",
-                    "content": "\n\nHello there, how may I help you?",
-                    "reasoning_content": "Okay, let's see here, hmmm...",
-                    "function_call": {
-                        "name": "fun_name",
-                        "arguments: {
-                            "arg1": "val1",
-                            "arg2": "val2"
-                        }
-                    },
-                },
-                "finish_reason": "stop"
-            }],
-            "usage": {
-                "prompt_tokens": 9,
-                "completion_tokens": 12,
-                "total_tokens": 21
-            }
-        }
-        """
-        choices = response.get("choices")
-        if isinstance(choices, list) and len(choices) > 0:
-            message = choices[0].get("message", {})
-        else:
-            message = {}
-        if message is None:
-            message = {}
-        content = message.get("content")
-        reasoning = message.get("reasoning_content", "")
-        # Track whether we extracted inline thought tags from the text.
-        # Only set message_with_reasoning when get_reasoning_final()
-        # actually finds and extracts inline tags (e.g. <think>...</think>).
-        # When reasoning is already provided via a separate API field
-        # (e.g. reasoning_content), the message text doesn't contain
-        # thought signatures, so there's nothing extra to preserve.
-        message_with_reasoning = None
-        if reasoning == "" and content is not None:
-            # some LLM APIs may not return a separate reasoning field,
-            # and the reasoning may be included in the message content
-            # within delimiters like <think> ... </think>
-            reasoning, msg = self.get_reasoning_final(content)
-            if reasoning:
-                # Inline tags were found and extracted; preserve the
-                # original text so it can be restored in message history.
-                message_with_reasoning = content
-        else:
-            msg = content
-
-        if message.get("function_call") is None:
-            fun_call = None
-        else:
-            try:
-                fun_call = LLMFunctionCall.from_dict(message["function_call"])
-            except (ValueError, SyntaxError):
-                logging.warning(
-                    "Could not parse function arguments: "
-                    f"{message['function_call']['arguments']} "
-                    f"for function {message['function_call']['name']} "
-                    "treating as normal non-function message"
-                )
-                fun_call = None
-                args_str = message["function_call"]["arguments"] or ""
-                msg_str = message["content"] or ""
-                msg = msg_str + args_str
-        oai_tool_calls = None
-        if message.get("tool_calls") is not None:
-            oai_tool_calls = []
-            for tool_call_dict in message["tool_calls"]:
-                try:
-                    tool_call = OpenAIToolCall.from_dict(tool_call_dict)
-                    oai_tool_calls.append(tool_call)
-                except (ValueError, SyntaxError):
-                    logging.warning(
-                        "Could not parse tool call: "
-                        f"{json.dumps(tool_call_dict)} "
-                        "treating as normal non-tool message"
-                    )
-                    serialized_tool_call = json.dumps(tool_call_dict)
-                    msg = (msg or "") + ("\n" if msg else "") + serialized_tool_call
-        return LLMResponse(
-            # None (no content, e.g. a tool-call-only response) is preserved as
-            # None rather than coerced to "", so the distinction survives
-            # downstream (see LLMMessage.content / ChatDocument.content_is_none).
-            message=msg.strip() if msg is not None else None,
-            reasoning=reasoning.strip() if reasoning is not None else "",
-            message_with_reasoning=message_with_reasoning,
-            function_call=fun_call,
-            oai_tool_calls=oai_tool_calls or None,  # don't allow empty list [] here
-            cached=cached,
-            usage=self._get_non_stream_token_usage(cached, response),
-        )
-
-    def _chat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """
-        ChatCompletion API call to OpenAI.
-        Args:
-            messages: list of messages  to send to the API, typically
-                represents back and forth dialogue between user and LLM, but could
-                also include "function"-role messages. If messages is a string,
-                it is assumed to be a user message.
-            max_tokens: max output tokens to generate
-            functions: list of LLMFunction specs available to the LLM, to possibly
-                use in its response
-            function_call: controls how the LLM uses `functions`:
-                - "auto": LLM decides whether to use `functions` or not,
-                - "none": LLM blocked from using any function
-                - a dict of {"name": "function_name"} which forces the LLM to use
-                    the specified function.
-        Returns:
-            LLMResponse object
-        """
-        args = self._prep_chat_completion(
-            messages,
-            max_tokens,
-            tools,
-            tool_choice,
-            functions,
-            function_call,
-            response_format,
-        )
-        cached, hashed_key, response = self._chat_completions_with_backoff(**args)  # type: ignore
-        if self.get_stream() and not cached:
-            llm_response, openai_response = self._stream_response(response, chat=True)
-            self._cache_store(hashed_key, openai_response)
-            return llm_response  # type: ignore
-        if isinstance(response, dict):
-            response_dict = response
-        else:
-            response_dict = response.model_dump()
-        return self._process_chat_completion_response(cached, response_dict)
-
-    async def _achat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """
-        Async version of _chat(). See that function for details.
-        """
-        args = self._prep_chat_completion(
-            messages,
-            max_tokens,
-            tools,
-            tool_choice,
-            functions,
-            function_call,
-            response_format,
-        )
-        cached, hashed_key, response = await self._achat_completions_with_backoff(  # type: ignore
-            **args
-        )
-        if self.get_stream() and not cached:
-            llm_response, openai_response = await self._stream_response_async(
-                response, chat=True
-            )
-            self._cache_store(hashed_key, openai_response)
-            return llm_response  # type: ignore
-        if isinstance(response, dict):
-            response_dict = response
-        else:
-            response_dict = response.model_dump()
-        return self._process_chat_completion_response(cached, response_dict)
-</file>
-
 <file path="tests/main/test_llm.py">
 import io
 import logging.handlers
@@ -135603,6 +136085,7 @@ nav:
       - Context-Overflow Handling: notes/context-overflow.md
       - Batch Processing: notes/batch-processing.md
       - Attachment Token Preflight: notes/attachment-token-preflight.md
+      - Vector-Store Env Prefixes: notes/vecstore-env-prefix.md
 
   - Examples:
     - Guide: examples/guide.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,6 +150,7 @@ nav:
       - Context-Overflow Handling: notes/context-overflow.md
       - Batch Processing: notes/batch-processing.md
       - Attachment Token Preflight: notes/attachment-token-preflight.md
+      - Vector-Store Env Prefixes: notes/vecstore-env-prefix.md
 
   - Examples:
     - Guide: examples/guide.md

--- a/tests/main/test_vecstore_env_prefix.py
+++ b/tests/main/test_vecstore_env_prefix.py
@@ -1,0 +1,196 @@
+"""Tests for env-var prefixes on vector-store configs (issue #1078).
+
+`VectorStoreConfig` extends `BaseSettings`, so without an `env_prefix`
+every field name was itself a case-insensitive environment variable:
+a bare `HOST`, `PORT`, or worst `FULL_EVAL` in the environment silently
+overrode the default for every vector-store config. These tests assert
+that bare env vars no longer leak in, that properly prefixed env vars
+(`VECDB_*` for the base config, `QDRANT_*` etc. per provider) do work,
+and that explicit constructor arguments beat env values.
+
+No live vector-store connections are needed: config construction only.
+"""
+
+import logging
+from typing import Type
+
+import pytest
+from pydantic import ValidationError
+
+from langroid.vector_store.base import VectorStoreConfig
+from langroid.vector_store.chromadb import ChromaDBConfig
+from langroid.vector_store.lancedb import LanceDBConfig
+from langroid.vector_store.meilisearch import MeiliSearchConfig
+from langroid.vector_store.pineconedb import PineconeDBConfig
+from langroid.vector_store.postgres import PostgresDBConfig
+from langroid.vector_store.qdrantdb import QdrantDBConfig
+from langroid.vector_store.weaviatedb import WeaviateDBConfig
+
+ALL_CONFIGS: list[Type[VectorStoreConfig]] = [
+    VectorStoreConfig,
+    QdrantDBConfig,
+    ChromaDBConfig,
+    LanceDBConfig,
+    PineconeDBConfig,
+    PostgresDBConfig,
+    MeiliSearchConfig,
+    WeaviateDBConfig,
+]
+
+# provider config -> (its env prefix, a str field to probe with)
+PREFIXED_CASES: list[tuple[Type[VectorStoreConfig], str, str]] = [
+    (VectorStoreConfig, "VECDB_", "host"),
+    (QdrantDBConfig, "QDRANT_", "host"),
+    (ChromaDBConfig, "CHROMA_", "host"),
+    (LanceDBConfig, "LANCEDB_", "storage_path"),
+    (PineconeDBConfig, "PINECONE_", "metric"),
+    (PostgresDBConfig, "POSTGRES_", "host"),
+    (MeiliSearchConfig, "MEILISEARCH_", "primary_key"),
+    (WeaviateDBConfig, "WEAVIATE_", "host"),
+]
+
+
+# every field name these tests assert on, in env-var (upper) form
+FIELD_VARS: list[str] = [
+    "HOST",
+    "PORT",
+    "CLOUD",
+    "TIMEOUT",
+    "BATCH_SIZE",
+    "TYPE",
+    "STORAGE_PATH",
+    "COLLECTION_NAME",
+    "FULL_EVAL",
+    "METRIC",
+    "PRIMARY_KEY",
+]
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove ambient bare and prefixed env vars before each test.
+
+    A runner may legitimately have e.g. `POSTGRES_HOST` set (docker/CI)
+    or a stray `QDRANT_FULL_EVAL`; without this cleanup those would make
+    the default-value assertions below fail spuriously. Runs before each
+    test body, so tests that intentionally `setenv` still work.
+    """
+    prefixes = [""] + [prefix for _, prefix, _ in PREFIXED_CASES]
+    for prefix in prefixes:
+        for field_var in FIELD_VARS:
+            monkeypatch.delenv(f"{prefix}{field_var}", raising=False)
+
+
+@pytest.mark.parametrize("config_cls", ALL_CONFIGS)
+def test_bare_env_vars_do_not_leak(
+    config_cls: Type[VectorStoreConfig],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bare (unprefixed) env vars must not override config defaults."""
+    monkeypatch.setenv("HOST", "evil.example.com")
+    monkeypatch.setenv("PORT", "9999")
+    monkeypatch.setenv("FULL_EVAL", "true")
+    monkeypatch.setenv("COLLECTION_NAME", "hijacked")
+    monkeypatch.setenv("CLOUD", "true")
+    monkeypatch.setenv("STORAGE_PATH", "/evil/path")
+
+    defaults = config_cls.model_fields
+    config = config_cls()
+    assert config.host == defaults["host"].default
+    assert config.port == defaults["port"].default
+    assert config.full_eval is False
+    assert config.collection_name == defaults["collection_name"].default
+    assert config.cloud == defaults["cloud"].default
+    assert config.storage_path == defaults["storage_path"].default
+
+
+@pytest.mark.parametrize("config_cls,prefix,field", PREFIXED_CASES)
+def test_prefixed_env_vars_are_honored(
+    config_cls: Type[VectorStoreConfig],
+    prefix: str,
+    field: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env vars with the class's own prefix DO override defaults."""
+    monkeypatch.setenv(f"{prefix}{field.upper()}", "from-env")
+    monkeypatch.setenv(f"{prefix}FULL_EVAL", "true")
+
+    config = config_cls()
+    assert getattr(config, field) == "from-env"
+    assert config.full_eval is True
+
+
+@pytest.mark.parametrize("config_cls,prefix,field", PREFIXED_CASES)
+def test_constructor_args_beat_env_vars(
+    config_cls: Type[VectorStoreConfig],
+    prefix: str,
+    field: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit constructor kwargs take priority over prefixed env vars."""
+    monkeypatch.setenv(f"{prefix}{field.upper()}", "from-env")
+    monkeypatch.setenv(f"{prefix}FULL_EVAL", "true")
+
+    config = config_cls(**{field: "explicit", "full_eval": False})
+    assert getattr(config, field) == "explicit"
+    assert config.full_eval is False
+
+
+@pytest.mark.parametrize("config_cls,prefix,field", PREFIXED_CASES)
+def test_other_providers_prefix_does_not_leak(
+    config_cls: Type[VectorStoreConfig],
+    prefix: str,
+    field: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One provider's prefixed env vars must not affect other providers."""
+    monkeypatch.setenv(f"{prefix}FULL_EVAL", "true")
+    for other_cls, other_prefix, _ in PREFIXED_CASES:
+        if other_prefix == prefix:
+            continue
+        assert (
+            other_cls().full_eval is False
+        ), f"{prefix}FULL_EVAL leaked into {other_cls.__name__}"
+
+
+@pytest.mark.parametrize(
+    "config_cls,env_var",
+    [
+        (QdrantDBConfig, "QDRANT_PORT"),
+        (PostgresDBConfig, "POSTGRES_PORT"),
+    ],
+)
+def test_service_link_port_is_ignored_with_warning(
+    config_cls: Type[VectorStoreConfig],
+    env_var: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A k8s/docker service-link `tcp://...` port is ignored with a warning.
+
+    With `enableServiceLinks` (on by default in Kubernetes), a service
+    named e.g. `qdrant` injects `QDRANT_PORT=tcp://10.0.0.8:6333` into
+    every pod; construction must succeed with the default port.
+    """
+    monkeypatch.setenv(env_var, "tcp://10.0.0.8:6333")
+    default_port = config_cls.model_fields["port"].default
+    with caplog.at_level(logging.WARNING, logger="langroid.vector_store.base"):
+        config = config_cls()
+    assert config.port == default_port
+    assert "tcp://10.0.0.8:6333" in caplog.text
+    assert "ignor" in caplog.text.lower()
+
+
+def test_non_service_link_bad_port_still_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the `tcp://` service-link format is forgiven; other junk fails."""
+    monkeypatch.setenv("QDRANT_PORT", "not-a-port")
+    with pytest.raises(ValidationError):
+        QdrantDBConfig()
+
+
+def test_valid_env_port_still_works(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A normal numeric prefixed port env var is honored as before."""
+    monkeypatch.setenv("QDRANT_PORT", "7777")
+    assert QdrantDBConfig().port == 7777

--- a/tests/main/test_vecstore_env_prefix.py
+++ b/tests/main/test_vecstore_env_prefix.py
@@ -12,11 +12,14 @@ No live vector-store connections are needed: config construction only.
 """
 
 import logging
+import os
 from typing import Type
 
 import pytest
 from pydantic import ValidationError
+from pydantic_settings import BaseSettings
 
+from langroid.utils.configuration import set_env
 from langroid.vector_store.base import VectorStoreConfig
 from langroid.vector_store.chromadb import ChromaDBConfig
 from langroid.vector_store.lancedb import LanceDBConfig
@@ -190,7 +193,95 @@ def test_non_service_link_bad_port_still_fails(
         QdrantDBConfig()
 
 
+def test_malformed_tcp_env_port_still_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A `tcp://` value NOT matching the full service-link shape fails.
+
+    Only `tcp://<host>:<digits>` (the exact k8s injection format) is
+    forgiven; malformed `tcp://` junk must fail validation loudly.
+    """
+    monkeypatch.setenv("QDRANT_PORT", "tcp://garbage")
+    with pytest.raises(ValidationError):
+        QdrantDBConfig()
+
+
+def test_constructor_tcp_port_still_fails() -> None:
+    """The service-link exception applies to the env source ONLY.
+
+    An explicit constructor value is a programming error, not a k8s
+    artifact, so it must fail validation rather than be silently
+    replaced with the default.
+    """
+    with pytest.raises(ValidationError):
+        QdrantDBConfig(port="tcp://10.0.0.8:6333")  # type: ignore[arg-type]
+
+
 def test_valid_env_port_still_works(monkeypatch: pytest.MonkeyPatch) -> None:
     """A normal numeric prefixed port env var is honored as before."""
     monkeypatch.setenv("QDRANT_PORT", "7777")
     assert QdrantDBConfig().port == 7777
+
+
+def test_valid_constructor_port_still_works() -> None:
+    """A normal explicit constructor port is honored as before."""
+    assert QdrantDBConfig(port=7777).port == 7777
+
+
+def test_trailing_newline_tcp_port_still_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A service-link-like value with a trailing newline fails validation.
+
+    The full-format check must anchor at the true end of the string
+    (`\\Z`), not `$` (which matches before a trailing newline), so this
+    value is NOT silently discarded.
+    """
+    monkeypatch.setenv("QDRANT_PORT", "tcp://10.0.0.8:6333\n")
+    with pytest.raises(ValidationError):
+        QdrantDBConfig()
+
+
+def test_set_env_writes_prefixed_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`set_env` writes names a fresh config actually reads back.
+
+    `set_env` used to write bare upper-cased field names (`HOST`),
+    which prefixed configs no longer read; it must write
+    `<PREFIX><FIELD>` (e.g. `QDRANT_HOST`).
+    """
+    config = QdrantDBConfig(host="example.internal")
+    # pre-register every var set_env will write, so monkeypatch teardown
+    # restores each to its original (absent) state after the test
+    for field_name, field in QdrantDBConfig.model_fields.items():
+        name = field.alias or f"QDRANT_{field_name.upper()}"
+        monkeypatch.setenv(name, "placeholder")
+    set_env(config)
+    assert os.environ["QDRANT_HOST"] == "example.internal"
+    # pre-existing set_env limitation, unrelated to prefixes: complex
+    # fields (nested configs, classes) are written as non-JSON python
+    # reprs the env source cannot parse back; clear them so the fresh
+    # construction below exercises the simple fields
+    for name in (
+        "QDRANT_EMBEDDING",
+        "QDRANT_EMBEDDING_MODEL",
+        "QDRANT_DOCUMENT_CLASS",
+        "QDRANT_METADATA_CLASS",
+    ):
+        monkeypatch.delenv(name)
+    assert QdrantDBConfig().host == "example.internal"
+
+
+def test_set_env_bare_names_for_prefixless_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A settings class without env_prefix still gets bare var names."""
+
+    class PlainSettings(BaseSettings):
+        some_field: str = "default"
+
+    monkeypatch.setenv("SOME_FIELD", "placeholder")
+    set_env(PlainSettings(some_field="written"))
+    assert os.environ["SOME_FIELD"] == "written"
+    assert PlainSettings().some_field == "written"


### PR DESCRIPTION
Closes #1078.

`VectorStoreConfig` extended `pydantic_settings.BaseSettings` with no `env_prefix`, so every field name was a bare, case-insensitive env var: an ambient `HOST`, `PORT`, `CLOUD`, `STORAGE_PATH`, `COLLECTION_NAME` — or worst, `FULL_EVAL=true`, which disables the code-injection guard — silently overrode the defaults of every vector-store config.

## Changes

- Base `VectorStoreConfig` now uses prefix `VECDB_`; each provider gets its own, mirroring the convention used everywhere else in the codebase: `QDRANT_`, `CHROMA_`, `LANCEDB_`, `PINECONE_`, `POSTGRES_`, `MEILISEARCH_`, `WEAVIATE_`.
- Kubernetes/Docker service-link guard: in a pod with a service named e.g. `qdrant`, the auto-injected `QDRANT_PORT=tcp://10.0.0.8:6333` would now feed the integer `port` field and crash config construction. A `mode="before"` validator on the base config detects the `tcp://` docker-link format, logs a warning, and falls back to the provider's default port. Any other invalid value still raises `ValidationError`.
- `docs/notes/vecstore-env-prefix.md`: new prefixes, migration note (this is a behavior change for anyone relying on the undocumented bare names — a repo-wide search found no such reliance), the service-link guard, and the inheritance caveat for third-party subclasses that don't set their own `env_prefix`.

## Verification

- `tests/main/test_vecstore_env_prefix.py` (36 tests, written TDD): bare vars no longer leak into any of the 8 provider configs; prefixed vars are honored; constructor kwargs beat env; no cross-provider prefix leakage; service-link `tcp://` values construct with default port + warning while other junk still fails validation. The suite clears ambient env first, so it passes even on machines with `POSTGRES_HOST` etc. set.
- The issue's exact repro now prints correct defaults.
- `make check` clean; `llms*.txt` bundles regenerated.