### PR TITLE
feat: provider-neutral pre-execution tool policy hook (#1095)

### DIFF
--- a/docs/notes/tool-policy-hook.md
+++ b/docs/notes/tool-policy-hook.md
@@ -1,0 +1,150 @@
+# Pre-execution Tool Policy Hook
+
+When Langroid agents are embedded in larger systems, operators often need a
+central place to decide whether a tool call the LLM just made should actually
+run: authorization checks, human-approval gates, DLP scanning, command
+policies, budget limits, and so on. The `AgentConfig.tool_policy` hook
+provides the smallest possible interception point for this: a single optional
+callback, consulted immediately before the selected tool handler executes.
+No policy engine, rules, or registries live in Langroid itself — you plug in
+whatever external engine you like.
+
+## API
+
+```python
+import langroid as lr
+
+class RunCommandTool(lr.ToolMessage):
+    request: str = "run_command"
+    purpose: str = "To run a shell <command>"
+    command: str
+
+def my_policy(tool: lr.ToolMessage, agent: lr.Agent) -> bool | str | None:
+    if isinstance(tool, RunCommandTool) and "rm" in tool.command:
+        return "destructive commands are not allowed"
+    return True  # allow
+
+config = lr.ChatAgentConfig(
+    # ... other params ...
+    tool_policy=my_policy,
+)
+```
+
+The callback is invoked as `tool_policy(tool, agent)` — or as
+`tool_policy(tool, agent, chat_doc=...)` if the callable's signature has a
+`chat_doc` parameter (mirroring the convention for tool handlers). It
+receives:
+
+- `tool`: the final parsed `ToolMessage` instance about to be handled — its
+  `request` field is the tool name, and its other fields are the fully
+  validated arguments
+- `agent`: the agent that is about to run the handler
+- `chat_doc` (optional): the `ChatDocument` containing the tool call, when
+  available
+
+The return value decides what happens:
+
+- `True` or `None` — allow: the selected handler runs exactly once, as usual
+- `False` — reject: the handler is NOT run; the LLM receives a rejection
+  message naming the tool
+- a `str` — reject, with that string included as the reason in the
+  LLM-visible rejection message
+
+The hook cannot modify the tool: argument transformation is deliberately out
+of scope, and the hook receives deep copies of both the `ToolMessage` and
+the `chat_doc`, so any mutation it makes has no effect on what the handler
+sees. It only decides allow vs. reject. It is consulted only when a real
+handler has been selected: a tool with no handler returns `None` as before,
+without the policy being called.
+
+The policy is enforced at the framework's dispatch call sites, ABOVE
+`Agent.handle_tool_message` / `handle_tool_message_async` — so it gates
+tool execution even when a subclass overrides those methods. Three
+consequences of that placement:
+
+- when dispatch IS overridden, the framework cannot know whether the
+  override will execute anything, so the policy is consulted even if the
+  override ends up returning `None` (the no-handler shortcut applies only
+  to un-overridden dispatch)
+- direct calls that YOUR code makes to `agent.handle_tool_message(...)`
+  are your own seam and are not gated by the hook
+- the strict-recovery `AnyTool` wrapper is a parsing shim, not a tool
+  execution, so it is exempt from the hook; the recovered actual tool is
+  policy-checked exactly once when dispatched
+
+## Failure semantics: fail-closed
+
+If the policy callback itself raises an exception, the tool is treated as
+rejected — the handler does not run. This is deliberate: a broken policy
+must never silently become a bypassed policy.
+
+The rejection message sent back to the LLM includes only the tool name and
+the exception's class name — never the exception message or the tool's
+arguments, since either could leak payload contents into the conversation.
+The full exception is logged (via the `langroid.agent.tool_policy` logger)
+for the operator. Similarly, a decision value of an unrecognized type (anything other
+than `True`, `False`, `None`, or `str`) is treated as a rejection rather
+than an allow.
+
+## Sync and async
+
+The hook works on both dispatch paths, with both kinds of callables:
+
+- a sync callback works with both `handle_message` (sync dispatch) and
+  `handle_message_async` (async dispatch)
+- an async callback is awaited on the caller's event loop everywhere on the
+  async path — including when the tool only has a sync handler — so it may
+  safely use loop-bound resources (locks, clients, futures). On the sync
+  path it is run to completion via `asyncio.run()` — or, when an event loop
+  is already running in the calling thread (e.g. sync dispatch invoked from
+  inside async code), on a fresh event loop in a helper thread. Any failure
+  while doing so is handled fail-closed like any other hook error.
+
+On each dispatch, the policy is consulted exactly once per tool call,
+including when async dispatch falls back to a tool's sync handler.
+
+## What the hook does NOT change
+
+- With no `tool_policy` configured (the default), behavior is exactly as
+  before — the hook adds negligible overhead (a None check per dispatch)
+  and no semantic change.
+- The USER-origin tool security filter (see
+  [Code-Injection Protection](code-injection-protection.md) and
+  GHSA-gjgq-w2m6-wr5q) runs first and is unaffected: tools vetoed by that
+  filter are never even shown to the policy, and an allow-everything policy
+  cannot resurrect them.
+- Rejections flow back into the conversation like any other tool-handling
+  result (e.g. validation errors), so the LLM sees why the call was refused
+  and can adjust.
+
+## Caveats
+
+The policy callback is trusted operator code, not a sandbox:
+
+- The deep copies guard against mutation through the `tool` and `chat_doc`
+  arguments; a policy determined to tamper could still reach live state via
+  `agent`. Don't do that — the hook's contract is allow/reject only.
+- Everywhere the framework deep-copies an agent config —
+  `ChatAgent.clone()`, `Task` construction, and batch processing — the
+  policy callable is shared by REFERENCE (exempted from the copy via a
+  pre-seeded deepcopy memo; the live config is never mutated). A stateful
+  policy (a budget counter, an approval list) is therefore consulted
+  globally across the original and all copies, and a policy holding
+  unpicklable resources (e.g. a lock) does not break copying. If you copy
+  a config through some other route (`copy.deepcopy` yourself), that copy
+  is not exempted.
+- An async policy evaluated from purely-sync dispatch that is itself
+  running inside an event loop (a rare nested case) runs on a fresh event
+  loop in a helper thread; loop-bound awaitables can fail there, which
+  blocks the tool (fail-closed) rather than bypassing it.
+- A tool payload carrying a non-copyable value (a lock, a client object)
+  prevents the pre-policy deep copy and causes a fail-closed rejection
+  even under an allow-all policy, with a distinct operator-log diagnostic
+  ("tool payload could not be copied for policy evaluation"). The remedy
+  is keeping tool fields to plain data.
+
+## Example
+
+A runnable example is in `examples/basic/tool-policy-hook.py`, showing a
+policy that blocks payments above a limit, with the LLM reacting to the
+rejection.

--- a/examples/basic/tool-policy-hook.py
+++ b/examples/basic/tool-policy-hook.py
@@ -1,0 +1,67 @@
+"""
+Example of the pre-execution tool policy hook (`AgentConfig.tool_policy`).
+
+A single agent has a `payment` tool. A policy callback (standing in for an
+external authorization/policy engine) rejects any payment above $100; the
+handler is then NOT run, and the LLM sees a rejection naming the tool and
+the reason, so it can react (here, by telling the user).
+
+See docs/notes/tool-policy-hook.md for the full semantics (allow / reject /
+fail-closed on policy errors, sync + async support).
+
+Run like this, optionally specifying an LLM:
+
+python3 examples/basic/tool-policy-hook.py
+
+or
+
+python3 examples/basic/tool-policy-hook.py -m ollama/mistral:7b-instruct-v0.2-q8_0
+"""
+
+from fire import Fire
+
+import langroid as lr
+import langroid.language_models as lm
+
+
+class PaymentTool(lr.agent.ToolMessage):
+    request: str = "payment"
+    purpose: str = "To pay <amount> dollars to <payee>."
+    amount: float
+    payee: str
+
+    def handle(self) -> str:
+        # In real life this would call a payment API
+        return f"Paid ${self.amount:.2f} to {self.payee}."
+
+
+def payment_policy(tool: lr.ToolMessage, agent: lr.Agent) -> bool | str:
+    """Reject payments above $100; allow everything else."""
+    if isinstance(tool, PaymentTool) and tool.amount > 100:
+        return "payments above $100 require manager approval"
+    return True
+
+
+def main(model: str = "") -> None:
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            name="Payer",
+            llm=lm.OpenAIGPTConfig(chat_model=model or lm.OpenAIChatModel.GPT4o),
+            system_message="""
+            You help the user make payments, using the `payment` tool.
+            If a payment is blocked by policy, apologize to the user and
+            state the reason; do NOT retry the same payment.
+            """,
+            tool_policy=payment_policy,
+            handle_llm_no_tool="user",  # fwd to user when LLM sends non-tool msg
+        )
+    )
+    agent.enable_message(PaymentTool)
+    task = lr.Task(agent, interactive=True)
+    # Try asking: "pay $50 to Alice" (allowed),
+    # then: "pay $500 to Bob" (blocked by policy; LLM sees the reason)
+    task.run("Ask me what payment I'd like to make.")
+
+
+if __name__ == "__main__":
+    Fire(main)

--- a/langroid/agent/base.py
+++ b/langroid/agent/base.py
@@ -99,6 +99,17 @@ class AgentConfig(BaseSettings):
     respond_tools_only: bool = False  # respond only to tool messages (not plain text)?
     # allow multiple tool messages in a single response?
     allow_multiple_tools: bool = True
+    # Optional pre-execution tool policy hook, called with the final parsed
+    # ToolMessage just BEFORE its selected handler runs, as
+    # ``tool_policy(tool, agent)`` -- or ``tool_policy(tool, agent, chat_doc=...)``
+    # when the callable has a ``chat_doc`` parameter. May be sync or async.
+    # Return True or None to ALLOW (the handler runs exactly once); return
+    # False or a str reason to REJECT (the handler is NOT run, and the LLM
+    # sees a rejection naming the tool and the reason). The hook cannot modify
+    # the tool. If the hook itself raises, the tool is blocked (fail-closed)
+    # and the rejection deliberately excludes the exception message and tool
+    # arguments. See docs/notes/tool-policy-hook.md.
+    tool_policy: Optional[Callable[..., Any]] = None
     human_prompt: str = (
         "Human (respond or q, x to exit current level, " "or hit enter to continue)"
     )
@@ -1778,7 +1789,7 @@ class Agent(ABC):
         results = self._get_multiple_orch_tool_errs(tools)
         if not results:
             results = [
-                await self.handle_tool_message_async(t, chat_doc=chat_doc)
+                await self._handle_tool_message_with_policy_async(t, chat_doc=chat_doc)
                 for t in tools
             ]
             # if there's a solitary ChatDocument|str result, return it as is
@@ -1846,7 +1857,10 @@ class Agent(ABC):
             results = self._get_multiple_orch_tool_errs(tools)
         if not results:
             chat_doc = msg if isinstance(msg, ChatDocument) else None
-            results = [self.handle_tool_message(t, chat_doc=chat_doc) for t in tools]
+            results = [
+                self._handle_tool_message_with_policy(t, chat_doc=chat_doc)
+                for t in tools
+            ]
             # if there's a solitary ChatDocument|str result, return it as is
             if len(results) == 1 and isinstance(results[0], (str, ChatDocument)):
                 return results[0]
@@ -2024,7 +2038,7 @@ class Agent(ABC):
                 #     msg in chat_doc.tool_messages):
                 #    chat_doc.tool_messages.remove(msg)
                 # if we can handle it, do so
-                result = self.handle_tool_message(msg, chat_doc=chat_doc)
+                result = self._handle_tool_message_with_policy(msg, chat_doc=chat_doc)
                 if result is not None and isinstance(result, ChatDocument):
                     return result
             else:
@@ -2129,6 +2143,88 @@ class Agent(ABC):
             ) + truncate_warning
             return result
 
+    def _handle_tool_message_with_policy(
+        self,
+        tool: ToolMessage,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> None | str | ChatDocument:
+        """Framework entry point for sync tool dispatch, enforcing `tool_policy`.
+
+        Consults the `tool_policy` hook (see `AgentConfig.tool_policy`) and,
+        if the tool is allowed, delegates to `handle_tool_message` -- which a
+        subclass may override -- exactly as before, so the policy gates tool
+        execution even through such overrides.
+
+        When dispatch is NOT overridden and the tool has no handler, the
+        policy is not consulted (nothing can execute). When dispatch IS
+        overridden, the base cannot know what the override will do, so the
+        policy is consulted regardless, even though the override may end up
+        returning None.
+
+        Args:
+            tool: ToolMessage object representing the tool request.
+            chat_doc: Optional ChatDocument object containing the tool request.
+
+        Returns:
+            The dispatch result, or the policy's LLM-visible rejection.
+        """
+        from langroid.agent.tool_policy import (
+            check_tool_policy,
+            dispatch_overridden,
+            handler_exists,
+            policy_exempt,
+        )
+
+        if self.config.tool_policy is not None and not policy_exempt(tool):
+            if not dispatch_overridden(self, use_async=False) and not handler_exists(
+                self, tool, use_async=False
+            ):
+                # base dispatch would execute nothing; don't consult the policy
+                return None
+            rejection = check_tool_policy(self.config.tool_policy, tool, self, chat_doc)
+            if rejection is not None:
+                return rejection
+        return self.handle_tool_message(tool, chat_doc=chat_doc)
+
+    async def _handle_tool_message_with_policy_async(
+        self,
+        tool: ToolMessage,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> None | str | ChatDocument:
+        """Async version of `_handle_tool_message_with_policy`.
+
+        The policy is awaited on the CALLER's event loop (so it can use
+        loop-bound resources), then dispatch proceeds via
+        `handle_tool_message_async` -- which a subclass may override --
+        exactly as before.
+
+        Args:
+            tool: ToolMessage object representing the tool request.
+            chat_doc: Optional ChatDocument object containing the tool request.
+
+        Returns:
+            The dispatch result, or the policy's LLM-visible rejection.
+        """
+        from langroid.agent.tool_policy import (
+            check_tool_policy_async,
+            dispatch_overridden,
+            handler_exists,
+            policy_exempt,
+        )
+
+        if self.config.tool_policy is not None and not policy_exempt(tool):
+            if not dispatch_overridden(self, use_async=True) and not handler_exists(
+                self, tool, use_async=True
+            ):
+                # base dispatch would execute nothing; don't consult the policy
+                return None
+            rejection = await check_tool_policy_async(
+                self.config.tool_policy, tool, self, chat_doc
+            )
+            if rejection is not None:
+                return rejection
+        return await self.handle_tool_message_async(tool, chat_doc=chat_doc)
+
     async def handle_tool_message_async(
         self,
         tool: ToolMessage,
@@ -2171,6 +2267,12 @@ class Agent(ABC):
     ) -> None | str | ChatDocument:
         """
         Respond to a tool request from the LLM, in the form of an ToolMessage object.
+
+        NOTE: framework dispatch reaches this method through
+        `_handle_tool_message_with_policy`, which enforces the optional
+        `tool_policy` hook BEFORE delegating here; direct calls to this
+        method by user code are the caller's own seam and are not gated.
+
         Args:
             tool: ToolMessage object representing the tool request.
             chat_doc: Optional ChatDocument object containing the tool request.

--- a/langroid/agent/batch.py
+++ b/langroid/agent/batch.py
@@ -1,5 +1,4 @@
 import asyncio
-import copy
 import inspect
 import warnings
 from enum import Enum
@@ -483,8 +482,11 @@ def run_batch_agent_method(
     if not inspect.iscoroutinefunction(method):
         raise ValueError(f"The method {method_name} is not async.")
 
+    from langroid.agent.tool_policy import deepcopy_config_sharing_policy
+
     inputs = [input_map(item) for item in items]
-    agent_cfg = copy.deepcopy(agent.config)
+    # tool_policy hook shared by reference so its state stays global
+    agent_cfg = deepcopy_config_sharing_policy(agent.config)
     assert agent_cfg.llm is not None, "agent must have llm config"
     agent_cfg.llm.stream = False
     agent_cfg.show_stats = False

--- a/langroid/agent/chat_agent.py
+++ b/langroid/agent/chat_agent.py
@@ -335,10 +335,14 @@ class ChatAgent(Agent):
         changed in possibly many ways. Below is an imperfect solution. Caution advised.
         Revisit later.
         """
+        from langroid.agent.tool_policy import deepcopy_config_sharing_policy
+
         agent_cls = type(self)
-        # Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
-        # instead of deepcopy which loses subclass information
-        config_copy = self.config.model_copy(deep=True)
+        # Deep-copy the config WITHOUT mutating it, sharing the tool_policy
+        # hook by REFERENCE (memo-seeded deepcopy): copying the policy would
+        # fork any state it holds (budgets, approval lists) and can fail
+        # outright on unpicklable callables (e.g. objects holding locks).
+        config_copy = deepcopy_config_sharing_policy(self.config)
         config_copy.name = f"{config_copy.name}-{i}"
         new_agent = agent_cls(config_copy)
         new_agent.system_tool_instructions = self.system_tool_instructions
@@ -1266,27 +1270,10 @@ class ChatAgent(Agent):
             request: str = "tool_or_function"
             tool: maybe_optional_type  # type: ignore
 
-            def response(self, agent: ChatAgent) -> None | str | ChatDocument:
-                # One-time use
-                agent.set_output_format(None)
-
-                if self.tool is None:
-                    return None
-
-                # As the ToolMessage schema accepts invalid
-                # `tool.request` values, reparse with the
-                # corresponding tool
-                request = self.tool.request
-                if request not in agent.llm_tools_map:
-                    return None
-                tool = agent.llm_tools_map[request].model_validate_json(
-                    self.tool.to_json()
-                )
-
-                return agent.handle_tool_message(tool)
-
-            async def response_async(
-                self, agent: ChatAgent
+            def response(
+                self,
+                agent: ChatAgent,
+                chat_doc: Optional[ChatDocument] = None,
             ) -> None | str | ChatDocument:
                 # One-time use
                 agent.set_output_format(None)
@@ -1304,7 +1291,43 @@ class ChatAgent(Agent):
                     self.tool.to_json()
                 )
 
-                return await agent.handle_tool_message_async(tool)
+                # pass the chat_doc through, so the recovered tool's policy
+                # check sees the same message context a normal dispatch would
+                return agent._handle_tool_message_with_policy(tool, chat_doc=chat_doc)
+
+            async def response_async(
+                self,
+                agent: ChatAgent,
+                chat_doc: Optional[ChatDocument] = None,
+            ) -> None | str | ChatDocument:
+                # One-time use
+                agent.set_output_format(None)
+
+                if self.tool is None:
+                    return None
+
+                # As the ToolMessage schema accepts invalid
+                # `tool.request` values, reparse with the
+                # corresponding tool
+                request = self.tool.request
+                if request not in agent.llm_tools_map:
+                    return None
+                tool = agent.llm_tools_map[request].model_validate_json(
+                    self.tool.to_json()
+                )
+
+                # pass the chat_doc through, so the recovered tool's policy
+                # check sees the same message context a normal dispatch would
+                return await agent._handle_tool_message_with_policy_async(
+                    tool, chat_doc=chat_doc
+                )
+
+        # This wrapper is a parsing shim for strict recovery, NOT a tool
+        # execution, so it is exempt from the `tool_policy` hook -- which
+        # also guarantees `set_output_format(None)` above always runs. The
+        # re-parsed ACTUAL tool is dispatched through the policy-checked
+        # path, so the policy is consulted exactly once per logical call.
+        AnyTool._tool_policy_exempt = True  # type: ignore[attr-defined]
 
         return AnyTool
 

--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -322,7 +322,11 @@ class Task:
         # copy the agent's config, so that we don't modify the original agent's config,
         # which may be shared by other agents.
         try:
-            config_copy = copy.deepcopy(agent.config)
+            from langroid.agent.tool_policy import deepcopy_config_sharing_policy
+
+            # the tool_policy hook is shared by reference (never deep-copied),
+            # so its state (budgets, approvals) stays global across copies
+            config_copy = deepcopy_config_sharing_policy(agent.config)
             agent.config = config_copy
         except Exception:
             logger.warning(

--- a/langroid/agent/tool_policy.py
+++ b/langroid/agent/tool_policy.py
@@ -1,0 +1,343 @@
+"""Machinery for the pre-execution tool policy hook.
+
+The public surface is the ``tool_policy`` field on
+:class:`langroid.agent.base.AgentConfig`: an optional callable consulted
+just before a parsed ``ToolMessage``'s selected handler runs, deciding
+whether the handler executes (allow) or an LLM-visible rejection is
+returned instead (reject). The functions here evaluate that hook; see
+``docs/notes/tool-policy-hook.md`` for the full semantics.
+"""
+
+import asyncio
+import copy
+import inspect
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
+
+if TYPE_CHECKING:
+    from langroid.agent.base import Agent, AgentConfig
+    from langroid.agent.chat_document import ChatDocument
+    from langroid.agent.tool_message import ToolMessage
+
+logger = logging.getLogger(__name__)
+
+C = TypeVar("C", bound="AgentConfig")
+
+
+class _PolicyCopyError(Exception):
+    """Internal marker: the tool/chat_doc could not be copied for the policy.
+
+    Distinguishes a payload-copy failure (e.g. a tool field holding a lock
+    or client object) from an exception raised by the policy itself, so the
+    operator log can say precisely which happened. Both fail closed.
+    """
+
+
+def dispatch_overridden(agent: "Agent", use_async: bool) -> bool:
+    """Whether the agent's tool-dispatch method is overridden by a subclass.
+
+    Async dispatch falls back into `handle_tool_message` when a tool has no
+    async handler, so for the async path an override of EITHER method counts.
+
+    Args:
+        agent: The agent whose dispatch is being examined.
+        use_async: True for the async dispatch path.
+
+    Returns:
+        True if a subclass overrides the relevant dispatch method(s).
+    """
+    from langroid.agent.base import Agent
+
+    if (
+        use_async
+        and type(agent).handle_tool_message_async is not Agent.handle_tool_message_async
+    ):
+        return True
+    return type(agent).handle_tool_message is not Agent.handle_tool_message
+
+
+def handler_exists(agent: "Agent", tool: "ToolMessage", use_async: bool) -> bool:
+    """Whether base dispatch would find a handler for this tool.
+
+    Args:
+        agent: The agent that would dispatch the tool.
+        tool: The parsed ToolMessage.
+        use_async: True for the async dispatch path, which looks for an
+            `<name>_async` handler first and falls back to the sync one.
+
+    Returns:
+        True if a handler method exists on the agent.
+    """
+    tool_name = tool.default_value("request")
+    if hasattr(tool, "_handler"):
+        handler_name = getattr(tool, "_handler", tool_name)
+    else:
+        handler_name = tool_name
+    if use_async and getattr(agent, handler_name + "_async", None) is not None:
+        return True
+    return getattr(agent, handler_name, None) is not None
+
+
+def policy_exempt(tool: "ToolMessage") -> bool:
+    """Whether this tool is structurally exempt from the `tool_policy` hook.
+
+    Framework-internal parsing shims declare ``_tool_policy_exempt = True``
+    on their class (e.g. the strict-recovery ``AnyTool`` wrapper): such a
+    shim is not a tool execution itself -- the actual tool it carries is
+    re-parsed and dispatched through the policy-checked path, so the policy
+    is consulted exactly once per logical tool call.
+
+    Args:
+        tool: The parsed ToolMessage about to be dispatched.
+
+    Returns:
+        True if the tool's class carries the exemption marker.
+    """
+    # SECURITY: resolve the marker on the CLASS only, never the instance.
+    # ToolMessage has ``extra="allow"``, so LLM-controlled tool JSON such
+    # as ``{"_tool_policy_exempt": true, ...}`` lands on the INSTANCE as an
+    # extra field; trusting instance attributes would let the LLM spoof the
+    # exemption and bypass the policy.
+    return getattr(type(tool), "_tool_policy_exempt", False) is True
+
+
+def deepcopy_config_sharing_policy(config: C) -> C:
+    """Deep-copy an AgentConfig, sharing `tool_policy` by REFERENCE.
+
+    A `tool_policy` hook may be stateful (budgets, approval lists) or hold
+    unpicklable resources (locks, clients), so wherever the framework
+    deep-copies an agent config (agent cloning, Task construction, batch
+    processing) the policy must be exempted from the copy: the copy and the
+    original consult the SAME policy object. The live `config` is never
+    mutated (the exemption is done by pre-seeding the deepcopy memo).
+
+    Args:
+        config: The config to copy.
+
+    Returns:
+        A deep copy of `config` whose `tool_policy` is the same object as
+        `config.tool_policy`.
+    """
+    memo: dict[int, Any] = {}
+    policy = config.tool_policy
+    if policy is not None:
+        memo[id(policy)] = policy
+    config_copy: C = copy.deepcopy(config, memo)
+    return config_copy
+
+
+def _invoke_policy(
+    policy: Callable[..., Any],
+    tool: "ToolMessage",
+    agent: "Agent",
+    chat_doc: Optional["ChatDocument"],
+) -> Any:
+    """Call the `tool_policy` hook with (tool, agent[, chat_doc]).
+
+    The `chat_doc` is passed only if the callable's signature has a
+    `chat_doc` parameter, mirroring the tool-handler convention. The hook
+    decides allow/reject only, so it receives deep COPIES of the tool and
+    the chat_doc: mutating them cannot change what the handler executes.
+
+    Args:
+        policy: The configured `tool_policy` callable.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        The policy's decision, possibly an awaitable if the policy
+        is async.
+    """
+    try:
+        has_chat_doc_param = "chat_doc" in inspect.signature(policy).parameters
+    except (ValueError, TypeError):
+        has_chat_doc_param = False
+    try:
+        tool = tool.model_copy(deep=True)
+        if has_chat_doc_param and chat_doc is not None:
+            chat_doc = copy.deepcopy(chat_doc)
+    except Exception as e:
+        raise _PolicyCopyError() from e
+    if has_chat_doc_param:
+        return policy(tool, agent, chat_doc=chat_doc)
+    return policy(tool, agent)
+
+
+def run_awaitable_sync(awaitable: Any) -> Any:
+    """Run an awaitable to completion from sync code.
+
+    Uses `asyncio.run()` when no event loop is running in this thread;
+    otherwise runs it on a fresh event loop in a helper thread, so sync
+    dispatch nested inside async code (e.g. a sync tool handler invoked
+    from async code calling back into sync dispatch) still works.
+
+    Args:
+        awaitable: The awaitable to run.
+
+    Returns:
+        The awaitable's result.
+    """
+
+    async def _await() -> Any:
+        return await awaitable
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(_await())
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(asyncio.run, _await()).result()
+
+
+def _decision_msg(tool_name: str, decision: Any) -> Optional[str]:
+    """Convert a `tool_policy` decision into an optional rejection message.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        decision: The value returned by the `tool_policy` hook.
+
+    Returns:
+        None if the tool is allowed (decision is True or None), else an
+        LLM-visible rejection message naming the tool and the reason.
+        Any decision of an unrecognized type is treated as a rejection
+        (fail-closed).
+    """
+    if decision is None or decision is True:
+        return None
+    if decision is False:
+        reason = "(no reason given)"
+    elif isinstance(decision, str):
+        reason = decision
+    else:
+        reason = (
+            f"policy returned unrecognized decision of type "
+            f"{type(decision).__name__}; failing closed"
+        )
+    return f"Tool `{tool_name}` was NOT executed: blocked by tool policy: {reason}"
+
+
+def _copy_failure_msg(tool_name: str, e: BaseException | None) -> str:
+    """Fail-closed rejection for a payload that could not be copied.
+
+    A tool field carrying a non-copyable object (a lock, a client, ...)
+    prevents the pre-policy deep copy; the tool is blocked (fail-closed),
+    with an operator-log diagnostic distinct from "the policy raised". The
+    LLM-visible message still names only the tool and the exception class.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        e: The underlying copy exception, if known.
+
+    Returns:
+        An LLM-visible rejection message.
+    """
+    exc_name = type(e).__name__ if e is not None else "Exception"
+    logger.error(
+        f"tool payload could not be copied for policy evaluation for tool "
+        f"`{tool_name}`; blocking the tool (fail-closed): "
+        f"{exc_name}: {e}"
+    )
+    return (
+        f"Tool `{tool_name}` was NOT executed: its arguments could not be "
+        f"copied for policy evaluation ({exc_name}); failing closed "
+        f"(tool blocked)."
+    )
+
+
+def _failure_msg(tool_name: str, e: Exception) -> str:
+    """Fail-closed rejection message for a `tool_policy` hook that raised.
+
+    The exception message is deliberately NOT included, since it may
+    embed raw tool arguments; only the exception class name is exposed.
+    The full exception is logged for the operator.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        e: The exception raised by the hook.
+
+    Returns:
+        An LLM-visible rejection message.
+    """
+    logger.error(
+        f"tool_policy hook raised {type(e).__name__} while checking tool "
+        f"`{tool_name}`; blocking the tool (fail-closed): {e}"
+    )
+    return (
+        f"Tool `{tool_name}` was NOT executed: the tool policy hook "
+        f"failed with {type(e).__name__}; failing closed (tool blocked)."
+    )
+
+
+def check_tool_policy(
+    policy: Optional[Callable[..., Any]],
+    tool: "ToolMessage",
+    agent: "Agent",
+    chat_doc: Optional["ChatDocument"],
+) -> Optional[str]:
+    """Evaluate the `tool_policy` hook on the sync dispatch path.
+
+    An async policy is run to completion via `run_awaitable_sync` (which
+    works whether or not an event loop is already running in this thread);
+    any failure while doing so is treated like any other hook failure:
+    the tool is blocked (fail-closed).
+
+    Args:
+        policy: The configured `tool_policy` callable, or None.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        None if no policy is configured or the policy allows the tool,
+        else an LLM-visible rejection message.
+    """
+    if policy is None:
+        return None
+    tool_name = tool.default_value("request")
+    try:
+        decision = _invoke_policy(policy, tool, agent, chat_doc)
+        if inspect.isawaitable(decision):
+            decision = run_awaitable_sync(decision)
+    except _PolicyCopyError as ce:
+        return _copy_failure_msg(tool_name, ce.__cause__)
+    except Exception as e:
+        return _failure_msg(tool_name, e)
+    return _decision_msg(tool_name, decision)
+
+
+async def check_tool_policy_async(
+    policy: Optional[Callable[..., Any]],
+    tool: "ToolMessage",
+    agent: "Agent",
+    chat_doc: Optional["ChatDocument"],
+) -> Optional[str]:
+    """Async version of `check_tool_policy`.
+
+    An async policy is awaited on the CALLING event loop, so it may safely
+    use loop-bound resources (locks, clients, futures).
+
+    Args:
+        policy: The configured `tool_policy` callable, or None.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        None if no policy is configured or the policy allows the tool,
+        else an LLM-visible rejection message.
+    """
+    if policy is None:
+        return None
+    tool_name = tool.default_value("request")
+    try:
+        decision = _invoke_policy(policy, tool, agent, chat_doc)
+        if inspect.isawaitable(decision):
+            decision = await decision
+    except _PolicyCopyError as ce:
+        return _copy_failure_msg(tool_name, ce.__cause__)
+    except Exception as e:
+        return _failure_msg(tool_name, e)
+    return _decision_msg(tool_name, decision)

--- a/llms-compressed.txt
+++ b/llms-compressed.txt
@@ -149,6 +149,7 @@ docs/
     task-tool.md
     tavily_search.md
     tool-message-handler.md
+    tool-policy-hook.md
     twitter-search.md
     url_loader.md
     weaviate.md
@@ -254,6 +255,7 @@ examples/
     text-to-structured.py
     tool-custom-handler.py
     tool-extract-short-example.py
+    tool-policy-hook.py
     xml_tool.py
   chainlit/
     non-callback/
@@ -520,6 +522,7 @@ langroid/
     openai_assistant.py
     task.py
     tool_message.py
+    tool_policy.py
     xml_tool_message.py
   cachedb/
     __init__.py
@@ -772,6 +775,7 @@ tests/
     test_tool_messages.py
     test_tool_orchestration.py
     test_tool_origin_taint.py
+    test_tool_policy_hook.py
     test_tool_taint_laundering.py
     test_url_loader.py
     test_vector_stores.py
@@ -49618,6 +49622,159 @@ python3 examples/basic/chat-search-seltz.py
 ---
 </file>
 
+<file path="docs/notes/tool-policy-hook.md">
+# Pre-execution Tool Policy Hook
+
+When Langroid agents are embedded in larger systems, operators often need a
+central place to decide whether a tool call the LLM just made should actually
+run: authorization checks, human-approval gates, DLP scanning, command
+policies, budget limits, and so on. The `AgentConfig.tool_policy` hook
+provides the smallest possible interception point for this: a single optional
+callback, consulted immediately before the selected tool handler executes.
+No policy engine, rules, or registries live in Langroid itself — you plug in
+whatever external engine you like.
+
+## API
+
+```python
+import langroid as lr
+
+class RunCommandTool(lr.ToolMessage):
+    request: str = "run_command"
+    purpose: str = "To run a shell <command>"
+    command: str
+
+def my_policy(tool: lr.ToolMessage, agent: lr.Agent) -> bool | str | None:
+    if isinstance(tool, RunCommandTool) and "rm" in tool.command:
+        return "destructive commands are not allowed"
+    return True  # allow
+
+config = lr.ChatAgentConfig(
+    # ... other params ...
+    tool_policy=my_policy,
+)
+```
+
+The callback is invoked as `tool_policy(tool, agent)` — or as
+`tool_policy(tool, agent, chat_doc=...)` if the callable's signature has a
+`chat_doc` parameter (mirroring the convention for tool handlers). It
+receives:
+
+- `tool`: the final parsed `ToolMessage` instance about to be handled — its
+  `request` field is the tool name, and its other fields are the fully
+  validated arguments
+- `agent`: the agent that is about to run the handler
+- `chat_doc` (optional): the `ChatDocument` containing the tool call, when
+  available
+
+The return value decides what happens:
+
+- `True` or `None` — allow: the selected handler runs exactly once, as usual
+- `False` — reject: the handler is NOT run; the LLM receives a rejection
+  message naming the tool
+- a `str` — reject, with that string included as the reason in the
+  LLM-visible rejection message
+
+The hook cannot modify the tool: argument transformation is deliberately out
+of scope, and the hook receives deep copies of both the `ToolMessage` and
+the `chat_doc`, so any mutation it makes has no effect on what the handler
+sees. It only decides allow vs. reject. It is consulted only when a real
+handler has been selected: a tool with no handler returns `None` as before,
+without the policy being called.
+
+The policy is enforced at the framework's dispatch call sites, ABOVE
+`Agent.handle_tool_message` / `handle_tool_message_async` — so it gates
+tool execution even when a subclass overrides those methods. Three
+consequences of that placement:
+
+- when dispatch IS overridden, the framework cannot know whether the
+  override will execute anything, so the policy is consulted even if the
+  override ends up returning `None` (the no-handler shortcut applies only
+  to un-overridden dispatch)
+- direct calls that YOUR code makes to `agent.handle_tool_message(...)`
+  are your own seam and are not gated by the hook
+- the strict-recovery `AnyTool` wrapper is a parsing shim, not a tool
+  execution, so it is exempt from the hook; the recovered actual tool is
+  policy-checked exactly once when dispatched
+
+## Failure semantics: fail-closed
+
+If the policy callback itself raises an exception, the tool is treated as
+rejected — the handler does not run. This is deliberate: a broken policy
+must never silently become a bypassed policy.
+
+The rejection message sent back to the LLM includes only the tool name and
+the exception's class name — never the exception message or the tool's
+arguments, since either could leak payload contents into the conversation.
+The full exception is logged (via the `langroid.agent.tool_policy` logger)
+for the operator. Similarly, a decision value of an unrecognized type (anything other
+than `True`, `False`, `None`, or `str`) is treated as a rejection rather
+than an allow.
+
+## Sync and async
+
+The hook works on both dispatch paths, with both kinds of callables:
+
+- a sync callback works with both `handle_message` (sync dispatch) and
+  `handle_message_async` (async dispatch)
+- an async callback is awaited on the caller's event loop everywhere on the
+  async path — including when the tool only has a sync handler — so it may
+  safely use loop-bound resources (locks, clients, futures). On the sync
+  path it is run to completion via `asyncio.run()` — or, when an event loop
+  is already running in the calling thread (e.g. sync dispatch invoked from
+  inside async code), on a fresh event loop in a helper thread. Any failure
+  while doing so is handled fail-closed like any other hook error.
+
+On each dispatch, the policy is consulted exactly once per tool call,
+including when async dispatch falls back to a tool's sync handler.
+
+## What the hook does NOT change
+
+- With no `tool_policy` configured (the default), behavior is exactly as
+  before — the hook adds negligible overhead (a None check per dispatch)
+  and no semantic change.
+- The USER-origin tool security filter (see
+  [Code-Injection Protection](code-injection-protection.md) and
+  GHSA-gjgq-w2m6-wr5q) runs first and is unaffected: tools vetoed by that
+  filter are never even shown to the policy, and an allow-everything policy
+  cannot resurrect them.
+- Rejections flow back into the conversation like any other tool-handling
+  result (e.g. validation errors), so the LLM sees why the call was refused
+  and can adjust.
+
+## Caveats
+
+The policy callback is trusted operator code, not a sandbox:
+
+- The deep copies guard against mutation through the `tool` and `chat_doc`
+  arguments; a policy determined to tamper could still reach live state via
+  `agent`. Don't do that — the hook's contract is allow/reject only.
+- Everywhere the framework deep-copies an agent config —
+  `ChatAgent.clone()`, `Task` construction, and batch processing — the
+  policy callable is shared by REFERENCE (exempted from the copy via a
+  pre-seeded deepcopy memo; the live config is never mutated). A stateful
+  policy (a budget counter, an approval list) is therefore consulted
+  globally across the original and all copies, and a policy holding
+  unpicklable resources (e.g. a lock) does not break copying. If you copy
+  a config through some other route (`copy.deepcopy` yourself), that copy
+  is not exempted.
+- An async policy evaluated from purely-sync dispatch that is itself
+  running inside an event loop (a rare nested case) runs on a fresh event
+  loop in a helper thread; loop-bound awaitables can fail there, which
+  blocks the tool (fail-closed) rather than bypassing it.
+- A tool payload carrying a non-copyable value (a lock, a client object)
+  prevents the pre-policy deep copy and causes a fail-closed rejection
+  even under an allow-all policy, with a distinct operator-log diagnostic
+  ("tool payload could not be copied for policy evaluation"). The remedy
+  is keeping tool fields to plain data.
+
+## Example
+
+A runnable example is in `examples/basic/tool-policy-hook.py`, showing a
+policy that blocks payments above a limit, with the LLM reacting to the
+rejection.
+</file>
+
 <file path="docs/notes/twitter-search.md">
 # Twitter Search via Xquik MCP
 
@@ -50371,6 +50528,53 @@ task = lr.Task(agent, interactive=False)
 ⋮----
 # local models do not like the first message to be empty
 user_message = "Can you help me with some questions?"
+</file>
+
+<file path="examples/basic/tool-policy-hook.py">
+"""
+Example of the pre-execution tool policy hook (`AgentConfig.tool_policy`).
+
+A single agent has a `payment` tool. A policy callback (standing in for an
+external authorization/policy engine) rejects any payment above $100; the
+handler is then NOT run, and the LLM sees a rejection naming the tool and
+the reason, so it can react (here, by telling the user).
+
+See docs/notes/tool-policy-hook.md for the full semantics (allow / reject /
+fail-closed on policy errors, sync + async support).
+
+Run like this, optionally specifying an LLM:
+
+python3 examples/basic/tool-policy-hook.py
+
+or
+
+python3 examples/basic/tool-policy-hook.py -m ollama/mistral:7b-instruct-v0.2-q8_0
+"""
+⋮----
+class PaymentTool(lr.agent.ToolMessage)
+⋮----
+request: str = "payment"
+purpose: str = "To pay <amount> dollars to <payee>."
+amount: float
+payee: str
+⋮----
+def handle(self) -> str
+⋮----
+# In real life this would call a payment API
+⋮----
+def payment_policy(tool: lr.ToolMessage, agent: lr.Agent) -> bool | str
+⋮----
+"""Reject payments above $100; allow everything else."""
+⋮----
+def main(model: str = "") -> None
+⋮----
+agent = lr.ChatAgent(
+⋮----
+handle_llm_no_tool="user",  # fwd to user when LLM sends non-tool msg
+⋮----
+task = lr.Task(agent, interactive=True)
+# Try asking: "pay $50 to Alice" (allowed),
+# then: "pay $500 to Bob" (blocked by policy; LLM sees the reason)
 </file>
 
 <file path="examples/mcp/xquik-twitter-search.py">
@@ -53099,271 +53303,6 @@ results_str = "\n\n".join(str(result) for result in search_results)
     def examples(cls) -> List["ToolMessage" | Tuple[str, "ToolMessage"]]
 </file>
 
-<file path="langroid/agent/batch.py">
-T = TypeVar("T")
-U = TypeVar("U")
-⋮----
-class ExceptionHandling(str, Enum)
-⋮----
-"""Enum for exception handling options."""
-⋮----
-RAISE = "raise"
-RETURN_NONE = "return_none"
-RETURN_EXCEPTION = "return_exception"
-⋮----
-"""Convert legacy boolean handle_exceptions to ExceptionHandling enum."""
-⋮----
-"""
-    Unified batch processing logic for both agent methods and tasks.
-
-    Args:
-        inputs: Iterable of inputs to process
-        do_task: Task execution function that takes (input, index) and returns result
-        start_idx: Starting index for the batch
-        stop_on_first_result: Whether to stop after first valid result
-        sequential: Whether to process sequentially
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        output_map: Function to map results to final output format
-    """
-exception_handling = _convert_exception_handling(handle_exceptions)
-⋮----
-def handle_error(e: BaseException) -> Any
-⋮----
-"""Handle exceptions based on exception_handling."""
-⋮----
-results: List[Optional[ChatDocument] | BaseException] = []
-pending: set[asyncio.Task[Any]] = set()
-# Create task-to-index mapping
-task_indices: dict[asyncio.Task[Any], int] = {}
-⋮----
-tasks = [
-task_indices = {task: i for i, task in enumerate(tasks)}
-results = [None] * len(tasks)
-⋮----
-pending = set(tasks)
-⋮----
-# Process completed tasks
-⋮----
-index = task_indices[task]
-⋮----
-result = await task
-⋮----
-results = []
-⋮----
-result = await do_task(input, i + start_idx)
-⋮----
-# Parallel execution
-⋮----
-return_exceptions = exception_handling != ExceptionHandling.RAISE
-⋮----
-results_with_exceptions = cast(
-⋮----
-results = [
-else:  # ExceptionHandling.RETURN_EXCEPTION
-results = results_with_exceptions
-⋮----
-results = [handle_error(e) for _ in inputs]
-⋮----
-"""
-    Common batch processing logic for both agent methods and tasks.
-
-    Args:
-        inputs: List of inputs to process
-        do_task: Task execution function
-        batch_size: Size of batches, if None process all at once
-        stop_on_first_result: Whether to stop after first valid result
-        sequential: Whether to process sequentially
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        output_map: Function to map results
-        message_template: Template for status message
-        message: Optional override for status message
-    """
-⋮----
-"""Extra wrap to run asyncio.run one single time and not once per loop
-
-        Args:
-            inputs (List[str  |  ChatDocument]): inputs to process
-            batch_size (int | None): batch size
-
-        Returns:
-            List[Any]: results
-        """
-results: List[Any] = []
-⋮----
-msg = message or message_template.format(total=len(inputs))
-⋮----
-results = await _process_batch_async(
-⋮----
-batches = batched(inputs, batch_size)
-⋮----
-start_idx = len(results)
-complete_str = f", {start_idx} complete" if start_idx > 0 else ""
-msg = (
-⋮----
-output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
-⋮----
-"""
-    Generate and run copies of a task async/concurrently one per item in `items` list.
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-    Args:
-        gen_task (Callable[[int], Task]): generates the tasks to run
-        items (list[T]): list of items to process
-        input_map (Callable[[T], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], U]): function to map result
-            to final result. If stop_on_first_result is enabled, then
-            map any invalid output to None. We continue until some non-None
-            result is obtained.
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None) result. Successful results are evaluated after
-            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
-            exception object is itself non-None and also stops the batch.
-            Processing continues past None results; once a non-None result
-            appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        batch_size (Optional[int]): The number of tasks to run at a time,
-            if None, unbatched
-        turns (int): number of turns to run, -1 for infinite
-        message (Optional[str]): optionally overrides the console status messages
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
-        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
-
-
-    Returns:
-        list[Optional[U]]: list of final results. Always list[U] if
-        `stop_on_first_result` is disabled
-    """
-inputs = [input_map(item) for item in items]
-⋮----
-task_i = gen_task(i)
-⋮----
-result = await task_i.run_async(
-⋮----
-# exception will be handled by the caller
-⋮----
-# ----------------------------------------
-# Propagate any exception stored on the task that may have been
-# swallowed inside `Task.run_async`, so that the upper-level
-# exception-handling logic works as expected.
-⋮----
-exc = getattr(task_i, attr, None)
-⋮----
-# Fallback: treat a KILL-status result as an error
-⋮----
-"""
-    Run copies of `task` async/concurrently one per item in `items` list.
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-    Args:
-        task (Task): task to run
-        items (list[T]): list of items to process
-        input_map (Callable[[T], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], U]): function to map result
-            to final result
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None, after `output_map`) result. Processing continues past
-            None-mapped results; exceptions propagate, since this function
-            always uses the default `RAISE` exception handling. Once a non-None
-            result appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        batch_size (Optional[int]): The number of tasks to run at a time,
-            if None, unbatched
-        turns (int): number of turns to run, -1 for infinite
-        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
-        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
-
-    Returns:
-        list[Optional[U]]: list of final results. Always list[U] if
-        `stop_on_first_result` is disabled
-    """
-message = f"[bold green]Running {len(items)} copies of {task.name}..."
-⋮----
-"""
-    Run the `method` on copies of `agent`, async/concurrently one per
-    item in `items` list.
-    ASSUMPTION: The `method` is an async method and has signature:
-        method(self, input: str|ChatDocument|None) -> ChatDocument|None
-    So this would typically be used for the agent's "responder" methods,
-    e.g. `llm_response_async` or `agent_responder_async`.
-
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-
-    Args:
-        agent (Agent): agent whose method to run
-        method (str): Async method to run on copies of `agent`.
-            The method is assumed to have signature:
-            `method(self, input: str|ChatDocument|None) -> ChatDocument|None`
-        input_map (Callable[[Any], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], Any]): function to map result
-            to final result
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None) result. Successful results are evaluated after
-            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
-            exception object is itself non-None and also stops the batch.
-            Processing continues past None results; once a non-None result
-            appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        batch_size (Optional[int]): The number of items to process in each batch.
-            If None, process all items at once.
-    Returns:
-        List[Any]: list of final results
-    """
-# Check if the method is async
-method_name = method.__name__
-⋮----
-agent_cfg = copy.deepcopy(agent.config)
-⋮----
-agent_cls = type(agent)
-agent_name = agent_cfg.name
-⋮----
-async def _do_task(input: str | ChatDocument, i: int) -> Any
-⋮----
-agent_i = agent_cls(agent_cfg)
-method_i = getattr(agent_i, method_name, None)
-⋮----
-result = await method_i(input)
-⋮----
-async def _do_task(item: T) -> U
-⋮----
-async def _do_all(items: Iterable[T]) -> List[U]
-⋮----
-result = await _do_task(item)
-⋮----
-results: List[U] = []
-⋮----
-results = asyncio.run(_do_all(items))
-⋮----
-batches = batched(items, batch_size)
-</file>
-
 <file path="langroid/agent/tool_message.py">
 """
 Structured messages to an agent, typically from an LLM, to be handled by
@@ -53618,6 +53557,249 @@ excludes = excludes.union({"request"})
             Dict[str, Any]: simplified schema
         """
 schema = generate_simple_schema(
+</file>
+
+<file path="langroid/agent/tool_policy.py">
+"""Machinery for the pre-execution tool policy hook.
+
+The public surface is the ``tool_policy`` field on
+:class:`langroid.agent.base.AgentConfig`: an optional callable consulted
+just before a parsed ``ToolMessage``'s selected handler runs, deciding
+whether the handler executes (allow) or an LLM-visible rejection is
+returned instead (reject). The functions here evaluate that hook; see
+``docs/notes/tool-policy-hook.md`` for the full semantics.
+"""
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+C = TypeVar("C", bound="AgentConfig")
+⋮----
+class _PolicyCopyError(Exception)
+⋮----
+"""Internal marker: the tool/chat_doc could not be copied for the policy.
+
+    Distinguishes a payload-copy failure (e.g. a tool field holding a lock
+    or client object) from an exception raised by the policy itself, so the
+    operator log can say precisely which happened. Both fail closed.
+    """
+⋮----
+def dispatch_overridden(agent: "Agent", use_async: bool) -> bool
+⋮----
+"""Whether the agent's tool-dispatch method is overridden by a subclass.
+
+    Async dispatch falls back into `handle_tool_message` when a tool has no
+    async handler, so for the async path an override of EITHER method counts.
+
+    Args:
+        agent: The agent whose dispatch is being examined.
+        use_async: True for the async dispatch path.
+
+    Returns:
+        True if a subclass overrides the relevant dispatch method(s).
+    """
+⋮----
+def handler_exists(agent: "Agent", tool: "ToolMessage", use_async: bool) -> bool
+⋮----
+"""Whether base dispatch would find a handler for this tool.
+
+    Args:
+        agent: The agent that would dispatch the tool.
+        tool: The parsed ToolMessage.
+        use_async: True for the async dispatch path, which looks for an
+            `<name>_async` handler first and falls back to the sync one.
+
+    Returns:
+        True if a handler method exists on the agent.
+    """
+tool_name = tool.default_value("request")
+⋮----
+handler_name = getattr(tool, "_handler", tool_name)
+⋮----
+handler_name = tool_name
+⋮----
+def policy_exempt(tool: "ToolMessage") -> bool
+⋮----
+"""Whether this tool is structurally exempt from the `tool_policy` hook.
+
+    Framework-internal parsing shims declare ``_tool_policy_exempt = True``
+    on their class (e.g. the strict-recovery ``AnyTool`` wrapper): such a
+    shim is not a tool execution itself -- the actual tool it carries is
+    re-parsed and dispatched through the policy-checked path, so the policy
+    is consulted exactly once per logical tool call.
+
+    Args:
+        tool: The parsed ToolMessage about to be dispatched.
+
+    Returns:
+        True if the tool's class carries the exemption marker.
+    """
+# SECURITY: resolve the marker on the CLASS only, never the instance.
+# ToolMessage has ``extra="allow"``, so LLM-controlled tool JSON such
+# as ``{"_tool_policy_exempt": true, ...}`` lands on the INSTANCE as an
+# extra field; trusting instance attributes would let the LLM spoof the
+# exemption and bypass the policy.
+⋮----
+def deepcopy_config_sharing_policy(config: C) -> C
+⋮----
+"""Deep-copy an AgentConfig, sharing `tool_policy` by REFERENCE.
+
+    A `tool_policy` hook may be stateful (budgets, approval lists) or hold
+    unpicklable resources (locks, clients), so wherever the framework
+    deep-copies an agent config (agent cloning, Task construction, batch
+    processing) the policy must be exempted from the copy: the copy and the
+    original consult the SAME policy object. The live `config` is never
+    mutated (the exemption is done by pre-seeding the deepcopy memo).
+
+    Args:
+        config: The config to copy.
+
+    Returns:
+        A deep copy of `config` whose `tool_policy` is the same object as
+        `config.tool_policy`.
+    """
+memo: dict[int, Any] = {}
+policy = config.tool_policy
+⋮----
+config_copy: C = copy.deepcopy(config, memo)
+⋮----
+"""Call the `tool_policy` hook with (tool, agent[, chat_doc]).
+
+    The `chat_doc` is passed only if the callable's signature has a
+    `chat_doc` parameter, mirroring the tool-handler convention. The hook
+    decides allow/reject only, so it receives deep COPIES of the tool and
+    the chat_doc: mutating them cannot change what the handler executes.
+
+    Args:
+        policy: The configured `tool_policy` callable.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        The policy's decision, possibly an awaitable if the policy
+        is async.
+    """
+⋮----
+has_chat_doc_param = "chat_doc" in inspect.signature(policy).parameters
+⋮----
+has_chat_doc_param = False
+⋮----
+tool = tool.model_copy(deep=True)
+⋮----
+chat_doc = copy.deepcopy(chat_doc)
+⋮----
+def run_awaitable_sync(awaitable: Any) -> Any
+⋮----
+"""Run an awaitable to completion from sync code.
+
+    Uses `asyncio.run()` when no event loop is running in this thread;
+    otherwise runs it on a fresh event loop in a helper thread, so sync
+    dispatch nested inside async code (e.g. a sync tool handler invoked
+    from async code calling back into sync dispatch) still works.
+
+    Args:
+        awaitable: The awaitable to run.
+
+    Returns:
+        The awaitable's result.
+    """
+⋮----
+async def _await() -> Any
+⋮----
+def _decision_msg(tool_name: str, decision: Any) -> Optional[str]
+⋮----
+"""Convert a `tool_policy` decision into an optional rejection message.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        decision: The value returned by the `tool_policy` hook.
+
+    Returns:
+        None if the tool is allowed (decision is True or None), else an
+        LLM-visible rejection message naming the tool and the reason.
+        Any decision of an unrecognized type is treated as a rejection
+        (fail-closed).
+    """
+⋮----
+reason = "(no reason given)"
+⋮----
+reason = decision
+⋮----
+reason = (
+⋮----
+def _copy_failure_msg(tool_name: str, e: BaseException | None) -> str
+⋮----
+"""Fail-closed rejection for a payload that could not be copied.
+
+    A tool field carrying a non-copyable object (a lock, a client, ...)
+    prevents the pre-policy deep copy; the tool is blocked (fail-closed),
+    with an operator-log diagnostic distinct from "the policy raised". The
+    LLM-visible message still names only the tool and the exception class.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        e: The underlying copy exception, if known.
+
+    Returns:
+        An LLM-visible rejection message.
+    """
+exc_name = type(e).__name__ if e is not None else "Exception"
+⋮----
+def _failure_msg(tool_name: str, e: Exception) -> str
+⋮----
+"""Fail-closed rejection message for a `tool_policy` hook that raised.
+
+    The exception message is deliberately NOT included, since it may
+    embed raw tool arguments; only the exception class name is exposed.
+    The full exception is logged for the operator.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        e: The exception raised by the hook.
+
+    Returns:
+        An LLM-visible rejection message.
+    """
+⋮----
+"""Evaluate the `tool_policy` hook on the sync dispatch path.
+
+    An async policy is run to completion via `run_awaitable_sync` (which
+    works whether or not an event loop is already running in this thread);
+    any failure while doing so is treated like any other hook failure:
+    the tool is blocked (fail-closed).
+
+    Args:
+        policy: The configured `tool_policy` callable, or None.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        None if no policy is configured or the policy allows the tool,
+        else an LLM-visible rejection message.
+    """
+⋮----
+decision = _invoke_policy(policy, tool, agent, chat_doc)
+⋮----
+decision = run_awaitable_sync(decision)
+⋮----
+"""Async version of `check_tool_policy`.
+
+    An async policy is awaited on the CALLING event loop, so it may safely
+    use loop-bound resources (locks, clients, futures).
+
+    Args:
+        policy: The configured `tool_policy` callable, or None.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        None if no policy is configured or the policy allows the tool,
+        else an LLM-visible rejection message.
+    """
+⋮----
+decision = await decision
 </file>
 
 <file path="langroid/language_models/__init__.py">
@@ -57609,6 +57791,103 @@ def test_seltz_search_tool_real_query(self)
 tool = SeltzSearchTool(query="Python programming language", num_results=3)
 </file>
 
+<file path="tests/main/test_split_inline_reasoning.py">
+"""
+Tests for OpenAIGPT._split_inline_reasoning, which separates inline
+thought-delimiter tags (e.g. <think>...</think>) from text content
+during streaming.
+"""
+⋮----
+split = OpenAIGPT._split_inline_reasoning
+DELIMS = ("<think>", "</think>")
+⋮----
+class TestSplitInlineReasoning
+⋮----
+"""Unit tests for the streaming inline-reasoning splitter."""
+⋮----
+# --- no-op cases: nothing to parse ---
+⋮----
+def test_empty_text(self)
+⋮----
+"""Empty event_text should pass through unchanged."""
+⋮----
+def test_plain_text_no_delimiters(self)
+⋮----
+"""Text without any delimiters should pass through as-is."""
+⋮----
+def test_already_has_reasoning_field(self)
+⋮----
+"""When the API already provides separate reasoning, skip parsing."""
+⋮----
+# --- single chunk contains full <think>...</think> ---
+⋮----
+def test_full_think_block_in_one_chunk(self)
+⋮----
+"""Complete <think>reasoning</think> in a single chunk."""
+⋮----
+def test_text_before_and_after_think(self)
+⋮----
+"""Text surrounding a complete think block."""
+⋮----
+def test_text_before_think_only(self)
+⋮----
+"""Text before think block, nothing after."""
+⋮----
+def test_text_after_think_only(self)
+⋮----
+"""Think block followed by text, no prefix."""
+⋮----
+# --- multi-chunk: start delimiter in one chunk, end in another ---
+⋮----
+def test_start_delimiter_only(self)
+⋮----
+"""Chunk has <think> but no </think> — enters reasoning state."""
+⋮----
+def test_continuation_mid_reasoning(self)
+⋮----
+"""Chunk arrives while already in reasoning (no delimiters)."""
+⋮----
+def test_end_delimiter_while_in_reasoning(self)
+⋮----
+"""Chunk has </think> while in reasoning state."""
+⋮----
+def test_end_delimiter_no_trailing_text(self)
+⋮----
+"""End delimiter with nothing after it."""
+⋮----
+# --- multi-chunk sequence simulating a real stream ---
+⋮----
+def test_three_chunk_sequence(self)
+⋮----
+"""Simulate: chunk1 opens thinking, chunk2 continues, chunk3 closes."""
+# chunk 1: start of thinking
+⋮----
+# chunk 2: still thinking
+⋮----
+# chunk 3: done thinking, answer follows
+⋮----
+# --- custom delimiters ---
+⋮----
+def test_custom_delimiters(self)
+⋮----
+"""Works with non-default delimiters like <thinking>...</thinking>."""
+custom = ("<thinking>", "</thinking>")
+⋮----
+# --- edge cases ---
+⋮----
+def test_empty_think_block(self)
+⋮----
+"""<think></think> with nothing inside."""
+⋮----
+def test_only_start_delimiter(self)
+⋮----
+"""Chunk is exactly the start delimiter, nothing else."""
+⋮----
+def test_only_end_delimiter_while_reasoning(self)
+⋮----
+"""Chunk is exactly the end delimiter."""
+</file>
+
 <file path="tests/main/test_tool_messages.py">
 class CountryCapitalMessage(ToolMessage)
 ⋮----
@@ -58664,6 +58943,455 @@ laundered = agent.agent_response(_handoff_doc(tainted=True))
 content = laundered.content if laundered is not None else ""
 ⋮----
 legit = agent.agent_response(_handoff_doc(tainted=False))
+</file>
+
+<file path="tests/main/test_tool_policy_hook.py">
+"""
+Tests for the pre-execution tool policy hook (`AgentConfig.tool_policy`),
+issue #1095.
+
+Contract:
+
+1. No hook configured => tool dispatch behaves exactly as before (sync + async).
+2. Hook allows (returns True or None) => the selected handler runs exactly once.
+3. Hook denies (returns False or a str reason) => the handler runs zero times,
+   and an LLM-visible rejection (tool name + reason) is produced.
+4. The hook receives the final parsed ToolMessage (identity + payload) plus
+   bounded context (the agent, and the chat_doc when available), BEFORE
+   execution.
+5. Hook failure (exception) => fail-closed rejection; raw tool arguments do
+   NOT leak into the rejection message.
+6. Composes with (does not weaken) the USER-origin tool security filter.
+
+The hook must work on both sync and async dispatch paths, with both sync and
+async callables. It cannot mutate what the handler executes, it is consulted
+only when a real handler is selected, and it is shared by reference across
+agent clones.
+"""
+⋮----
+HandleResult = Union[None, str, OrderedDict[str, str], ChatDocument]
+⋮----
+class SquareTool(ToolMessage)
+⋮----
+request: str = "square"
+purpose: str = "To compute the square of a number <x>"
+x: int
+⋮----
+class NoHandlerTool(ToolMessage)
+⋮----
+request: str = "orphan_tool"
+purpose: str = "A tool with no handler anywhere"
+y: int
+⋮----
+class CountingAgent(ChatAgent)
+⋮----
+"""Agent with a sync handler for SquareTool that counts invocations."""
+⋮----
+def __init__(self, config: ChatAgentConfig)
+⋮----
+def square(self, msg: SquareTool) -> str
+⋮----
+class CountingAsyncAgent(CountingAgent)
+⋮----
+"""Agent with a genuine async handler for SquareTool."""
+⋮----
+async def square_async(self, msg: SquareTool) -> str
+⋮----
+agent = agent_cls(
+⋮----
+def llm_tool_msg(agent: ChatAgent, x: int = 3) -> ChatDocument
+⋮----
+"""An LLM-origin ChatDocument containing a SquareTool call."""
+⋮----
+def result_content(result: HandleResult) -> str
+⋮----
+# -------------------- contract 1: no hook => unchanged --------------------
+⋮----
+def test_no_policy_sync_dispatch_unchanged() -> None
+⋮----
+agent = mk_agent()
+⋮----
+result = agent.handle_message(llm_tool_msg(agent))
+⋮----
+@pytest.mark.asyncio
+async def test_no_policy_async_dispatch_unchanged() -> None
+⋮----
+agent = mk_agent(agent_cls=CountingAsyncAgent)
+result = await agent.handle_message_async(llm_tool_msg(agent))
+⋮----
+# -------------------- contract 2: allow => handler runs once --------------------
+⋮----
+@pytest.mark.parametrize("decision", [True, None])
+def test_allow_sync(decision: Optional[bool]) -> None
+⋮----
+agent = mk_agent(
+result = agent.handle_message(llm_tool_msg(agent, x=5))
+⋮----
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", [True, None])
+async def test_allow_async(decision: Optional[bool]) -> None
+⋮----
+result = await agent.handle_message_async(llm_tool_msg(agent, x=5))
+⋮----
+# ---------------- contract 3: deny => zero runs, LLM-visible rejection ----------
+⋮----
+def test_deny_with_reason_sync() -> None
+⋮----
+agent = mk_agent(tool_policy=lambda tool, agent: "budget exceeded")
+⋮----
+content = result_content(result)
+⋮----
+assert "square" in content  # tool name
+assert "budget exceeded" in content  # policy's reason
+⋮----
+def test_deny_with_false_sync() -> None
+⋮----
+agent = mk_agent(tool_policy=lambda tool, agent: False)
+⋮----
+@pytest.mark.asyncio
+async def test_deny_with_reason_async() -> None
+⋮----
+def test_deny_unrecognized_decision_fails_closed() -> None
+⋮----
+"""A decision of an unrecognized type must NOT be treated as allow."""
+agent = mk_agent(tool_policy=lambda tool, agent: 42)
+⋮----
+# ------------- contract 4: hook sees parsed tool + bounded context -------------
+⋮----
+def test_policy_receives_parsed_tool_and_context() -> None
+⋮----
+seen: List[Tuple[ToolMessage, ChatAgent, Optional[ChatDocument]]] = []
+⋮----
+agent = mk_agent(tool_policy=policy)
+msg = llm_tool_msg(agent, x=7)
+⋮----
+assert tool.x == 7  # final parsed payload
+⋮----
+def test_policy_without_chat_doc_param() -> None
+⋮----
+"""A 2-arg policy (tool, agent) is supported."""
+seen: List[SquareTool] = []
+⋮----
+def policy(tool: ToolMessage, agent: ChatAgent) -> bool
+⋮----
+# ---------- contract 5: hook failure => fail-closed, no argument leak ----------
+⋮----
+SECRET = "31337"
+⋮----
+def failing_policy(tool: ToolMessage, agent: ChatAgent) -> bool
+⋮----
+# a sloppy policy that embeds tool arguments in its exception
+⋮----
+def test_policy_exception_fails_closed_sync() -> None
+⋮----
+agent = mk_agent(tool_policy=failing_policy)
+result = agent.handle_message(llm_tool_msg(agent, x=int(SECRET)))
+⋮----
+assert agent.calls == 0  # handler never ran
+assert "square" in content  # tool name present
+assert SECRET not in content  # raw tool args must not leak
+assert "policy blew up" not in content  # nor the exception message
+⋮----
+@pytest.mark.asyncio
+async def test_policy_exception_fails_closed_async() -> None
+⋮----
+result = await agent.handle_message_async(llm_tool_msg(agent, x=int(SECRET)))
+⋮----
+# -------------------- sync/async callback x dispatch matrix --------------------
+⋮----
+@pytest.mark.parametrize("decision", [True, "denied by async policy"])
+def test_async_policy_sync_dispatch(decision: Union[bool, str]) -> None
+⋮----
+async def policy(tool: ToolMessage, agent: ChatAgent) -> Union[bool, str]
+⋮----
+result = agent.handle_message(llm_tool_msg(agent, x=4))
+⋮----
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", [True, "denied by async policy"])
+async def test_async_policy_async_dispatch(decision: Union[bool, str]) -> None
+⋮----
+agent = mk_agent(tool_policy=policy, agent_cls=CountingAsyncAgent)
+result = await agent.handle_message_async(llm_tool_msg(agent, x=4))
+⋮----
+"""Async policy + async dispatch falling back to a SYNC handler: the
+    policy must be evaluated correctly on this route too."""
+⋮----
+agent = mk_agent(tool_policy=policy)  # sync handler only
+⋮----
+@pytest.mark.asyncio
+async def test_async_policy_loop_bound_state_async_dispatch_sync_handler() -> None
+⋮----
+"""On the async-dispatch-to-sync-handler route, an async policy must be
+    awaited on the CALLER's event loop: a policy awaiting a Future created
+    on that loop (a loop-bound resource) must evaluate correctly rather
+    than spuriously failing closed."""
+loop = asyncio.get_running_loop()
+fut: "asyncio.Future[bool]" = loop.create_future()
+⋮----
+async def policy(tool: ToolMessage, agent: ChatAgent) -> bool
+⋮----
+result = await agent.handle_message_async(llm_tool_msg(agent, x=3))
+⋮----
+@pytest.mark.asyncio
+async def test_sync_policy_async_dispatch_sync_handler() -> None
+⋮----
+"""Async dispatch falling back to a sync handler still runs the
+    policy exactly once."""
+seen: List[ToolMessage] = []
+⋮----
+assert len(seen) == 1  # policy consulted exactly once
+⋮----
+# ------------------- the hook cannot mutate what executes -------------------
+⋮----
+def test_policy_cannot_mutate_tool() -> None
+⋮----
+"""The hook sees copies of the tool AND the chat_doc: mutations through
+    either must not reach the handler (no argument transformation)."""
+⋮----
+tool.x = 999  # tamper via the tool param
+⋮----
+for t in chat_doc.tool_messages:  # tamper via the chat_doc route
+⋮----
+msg = llm_tool_msg(agent, x=3)
+result = agent.handle_message(msg)
+assert "SQUARE_RESULT: 9" in result_content(result)  # 3**2, not 999**2
+⋮----
+# the real chat_doc's parsed tool is untouched too
+⋮----
+# ------------- non-copyable payload => distinct fail-closed rejection -------------
+⋮----
+class LockCarrierTool(ToolMessage)
+⋮----
+request: str = "lock_carrier"
+purpose: str = "A tool whose payload holds a non-copyable object"
+payload: Any = None
+⋮----
+class LockCarrierAgent(CountingAgent)
+⋮----
+def lock_carrier(self, msg: LockCarrierTool) -> str
+⋮----
+"""A payload the pre-policy deep copy cannot copy (here: a thread lock)
+    fails CLOSED even under an allow-all policy, with an operator-log
+    diagnostic distinct from 'the policy raised', and an LLM message naming
+    only the tool and exception class."""
+agent = LockCarrierAgent(
+⋮----
+tool_policy=lambda tool, agent: True,  # allow-all
+⋮----
+tool = LockCarrierTool(payload=threading.Lock())
+msg = agent.create_llm_response(content="calling tool", tool_messages=[tool])
+⋮----
+assert "TypeError" in content  # exception class only...
+assert "_thread.lock" not in content  # ...no payload repr in LLM message
+⋮----
+assert "policy hook raised" not in caplog.text  # distinct diagnostic
+⋮----
+# --------------- policy consulted only when a handler exists ---------------
+⋮----
+def test_no_handler_policy_not_called_sync() -> None
+⋮----
+msg = agent.create_llm_response(NoHandlerTool(y=1).to_json())
+⋮----
+@pytest.mark.asyncio
+async def test_no_handler_policy_not_called_async() -> None
+⋮----
+# ---------- policy gates dispatch even through subclass overrides ----------
+⋮----
+class OverridingAgent(CountingAgent)
+⋮----
+"""Subclass with a GENERIC handle_tool_message override, as user code
+    sometimes does (e.g. to log or wrap every tool execution)."""
+⋮----
+def test_override_gated_by_policy_sync() -> None
+⋮----
+result = agent.handle_message(llm_tool_msg(agent, x=3))
+⋮----
+assert agent.override_calls == 0  # override never ran
+⋮----
+@pytest.mark.asyncio
+async def test_override_gated_by_policy_async() -> None
+⋮----
+def test_override_allowed_by_policy_sync() -> None
+⋮----
+assert "OVERRIDE_RESULT: 4" in result_content(result)  # override honored
+⋮----
+@pytest.mark.asyncio
+async def test_override_allowed_by_policy_async() -> None
+⋮----
+def test_override_no_policy_unchanged_sync() -> None
+⋮----
+agent = mk_agent(agent_cls=OverridingAgent)
+⋮----
+@pytest.mark.asyncio
+async def test_override_no_policy_unchanged_async() -> None
+⋮----
+# ------------------- policy shared by reference across clones -------------------
+⋮----
+class BudgetPolicy
+⋮----
+"""Stateful one-use budget: only the first tool call (across ALL agents
+    sharing this policy object) is allowed."""
+⋮----
+def __init__(self) -> None
+⋮----
+def __call__(self, tool: ToolMessage, agent: ChatAgent) -> bool
+⋮----
+def test_policy_state_shared_across_clones() -> None
+⋮----
+budget = BudgetPolicy()
+agent = mk_agent(tool_policy=budget)
+clone = agent.clone(1)
+⋮----
+assert clone.config.tool_policy is budget  # shared by reference
+⋮----
+r1 = agent.handle_message(llm_tool_msg(agent, x=2))
+⋮----
+# the clone consults the SAME budget, which is now exhausted
+r2 = clone.handle_message(llm_tool_msg(clone, x=3))
+⋮----
+def test_policy_shared_across_task_wrapped_clone() -> None
+⋮----
+"""Task construction deep-copies the agent's config; the policy must
+    stay shared by reference so budget state is enforced globally."""
+⋮----
+Task(clone, interactive=False)  # triggers the config copy in Task.__init__
+assert clone.config.tool_policy is budget  # still shared, not forked
+⋮----
+_POLICY_SETS: List[Any] = []
+⋮----
+class SetRecordingConfig(ChatAgentConfig)
+⋮----
+"""Records every post-construction assignment to `tool_policy`."""
+⋮----
+def __setattr__(self, name: str, value: Any) -> None
+⋮----
+def test_clone_never_mutates_live_policy() -> None
+⋮----
+"""Structural (not timing) check: clone() must never mutate the live
+    config's tool_policy -- in particular never set it to None mid-copy,
+    which a concurrent dispatch could otherwise observe."""
+⋮----
+cfg = SetRecordingConfig(
+agent = CountingAgent(cfg)
+⋮----
+before = agent.config.tool_policy
+⋮----
+assert _POLICY_SETS == []  # no code path assigned tool_policy on the live cfg
+⋮----
+class LockingPolicy
+⋮----
+"""Policy object holding an unpicklable resource (a thread lock)."""
+⋮----
+def __deepcopy__(self, memo: Any) -> "LockingPolicy"
+⋮----
+def test_clone_with_unpicklable_policy() -> None
+⋮----
+policy = LockingPolicy()
+⋮----
+clone = agent.clone(1)  # must not raise
+⋮----
+result = clone.handle_message(llm_tool_msg(clone, x=2))
+⋮----
+# --------- strict-recovery AnyTool shim: exempt; inner tool checked once ---------
+⋮----
+def _strict_recovery_wrapper(agent: CountingAgent, x: int) -> ToolMessage
+⋮----
+"""Enable strict recovery's AnyTool on `agent` (as the recovery code
+    does) and return a wrapper instance carrying a SquareTool call."""
+any_tool_class = agent._get_any_tool_message()
+⋮----
+assert agent.output_format is not None  # strict mode is on
+# the dynamic AnyTool class defaults `request`/`purpose`, which mypy
+# cannot see through type[ToolMessage]
+return any_tool_class(tool=SquareTool(x=x))  # type: ignore[call-arg]
+⋮----
+def test_strict_recovery_policy_consulted_once() -> None
+⋮----
+"""The AnyTool wrapper is a parsing shim, not a tool execution: a
+    one-use budget must be consumed only by the INNER re-parsed tool."""
+⋮----
+wrapper = _strict_recovery_wrapper(agent, x=5)
+result = agent.handle_message(agent.create_llm_response(wrapper.to_json()))
+⋮----
+assert budget.used == 1  # consulted exactly once, on the real tool
+assert agent.output_format is None  # recovery reset strict mode
+⋮----
+@pytest.mark.asyncio
+async def test_strict_recovery_policy_consulted_once_async() -> None
+⋮----
+result = await agent.handle_message_async(
+⋮----
+def test_strict_recovery_denied_inner_tool() -> None
+⋮----
+"""A deny-all policy blocks the INNER tool (normal rejection), but the
+    shim itself must still run so strict mode is reset."""
+agent = mk_agent(tool_policy=lambda tool, agent: "no tools allowed")
+⋮----
+assert agent.output_format is None  # set_output_format(None) still ran
+⋮----
+"""A policy whose decision depends on message context: it denies when
+    no chat_doc is provided, allows when the chat_doc is present."""
+⋮----
+def test_strict_recovery_policy_receives_chat_doc() -> None
+⋮----
+"""The recovered inner tool's policy check must see the same chat_doc
+    a normal dispatch would, not None."""
+seen_docs: List[Optional[ChatDocument]] = []
+agent = mk_agent(tool_policy=_chat_doc_aware_policy(seen_docs))
+⋮----
+msg = agent.create_llm_response(wrapper.to_json())
+⋮----
+# the policy saw the real message context (as a copy), not None
+⋮----
+@pytest.mark.asyncio
+async def test_strict_recovery_policy_receives_chat_doc_async() -> None
+⋮----
+result = await agent.handle_message_async(msg)
+⋮----
+def test_injected_exemption_marker_does_not_bypass_policy() -> None
+⋮----
+"""ToolMessage allows extra fields, so an LLM could emit
+    `"_tool_policy_exempt": true` inside its tool JSON, planting the marker
+    as an INSTANCE attribute. The exemption must resolve on the CLASS only,
+    so this spoof must not bypass a deny-all policy."""
+agent = mk_agent(tool_policy=lambda tool, agent: "denied")
+spoofed_json = (
+msg = agent.create_llm_response(spoofed_json)
+parsed = agent.try_get_tool_messages(msg, all_tools=True)
+# the spoofed marker really lands on the parsed instance...
+⋮----
+def test_strict_recovery_no_policy_unchanged() -> None
+⋮----
+# ---------------- contract 6: composes with USER-origin filter ----------------
+⋮----
+def test_policy_does_not_weaken_user_origin_filter() -> None
+⋮----
+"""A handle-only tool arriving as raw USER input must stay vetoed by
+    `_filter_user_origin_tools`; the policy hook never even sees it, and
+    an allow-everything policy cannot resurrect it."""
+policy_calls: List[ToolMessage] = []
+⋮----
+agent = CountingAgent(
+# handle-only: LLM cannot use it, so raw USER input must not trigger it
+⋮----
+user_msg = agent.create_user_response(SquareTool(x=3).to_json())
+⋮----
+result = agent.handle_message(user_msg)
+⋮----
+# ------------------- end-to-end: LLM sees the rejection -------------------
+⋮----
+def test_rejection_is_seen_by_llm_in_task_loop() -> None
+⋮----
+llm_inputs: List[str] = []
+⋮----
+def mock_llm(x: str) -> str
+⋮----
+# the tool argument IS the secret sentinel, so a leak of the
+# raw argument into the rejection would fail the assertion below
+⋮----
+task = Task(agent, interactive=False)
+⋮----
+# the LLM's second input is the policy rejection
 </file>
 
 <file path="tests/main/test_tool_taint_laundering.py">
@@ -60811,6 +61539,272 @@ results = self._convert_tool_result(tool_name, result)
     Returns:
         A list of raw `mcp.types.Tool` objects available on the server.
     """
+</file>
+
+<file path="langroid/agent/batch.py">
+T = TypeVar("T")
+U = TypeVar("U")
+⋮----
+class ExceptionHandling(str, Enum)
+⋮----
+"""Enum for exception handling options."""
+⋮----
+RAISE = "raise"
+RETURN_NONE = "return_none"
+RETURN_EXCEPTION = "return_exception"
+⋮----
+"""Convert legacy boolean handle_exceptions to ExceptionHandling enum."""
+⋮----
+"""
+    Unified batch processing logic for both agent methods and tasks.
+
+    Args:
+        inputs: Iterable of inputs to process
+        do_task: Task execution function that takes (input, index) and returns result
+        start_idx: Starting index for the batch
+        stop_on_first_result: Whether to stop after first valid result
+        sequential: Whether to process sequentially
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        output_map: Function to map results to final output format
+    """
+exception_handling = _convert_exception_handling(handle_exceptions)
+⋮----
+def handle_error(e: BaseException) -> Any
+⋮----
+"""Handle exceptions based on exception_handling."""
+⋮----
+results: List[Optional[ChatDocument] | BaseException] = []
+pending: set[asyncio.Task[Any]] = set()
+# Create task-to-index mapping
+task_indices: dict[asyncio.Task[Any], int] = {}
+⋮----
+tasks = [
+task_indices = {task: i for i, task in enumerate(tasks)}
+results = [None] * len(tasks)
+⋮----
+pending = set(tasks)
+⋮----
+# Process completed tasks
+⋮----
+index = task_indices[task]
+⋮----
+result = await task
+⋮----
+results = []
+⋮----
+result = await do_task(input, i + start_idx)
+⋮----
+# Parallel execution
+⋮----
+return_exceptions = exception_handling != ExceptionHandling.RAISE
+⋮----
+results_with_exceptions = cast(
+⋮----
+results = [
+else:  # ExceptionHandling.RETURN_EXCEPTION
+results = results_with_exceptions
+⋮----
+results = [handle_error(e) for _ in inputs]
+⋮----
+"""
+    Common batch processing logic for both agent methods and tasks.
+
+    Args:
+        inputs: List of inputs to process
+        do_task: Task execution function
+        batch_size: Size of batches, if None process all at once
+        stop_on_first_result: Whether to stop after first valid result
+        sequential: Whether to process sequentially
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        output_map: Function to map results
+        message_template: Template for status message
+        message: Optional override for status message
+    """
+⋮----
+"""Extra wrap to run asyncio.run one single time and not once per loop
+
+        Args:
+            inputs (List[str  |  ChatDocument]): inputs to process
+            batch_size (int | None): batch size
+
+        Returns:
+            List[Any]: results
+        """
+results: List[Any] = []
+⋮----
+msg = message or message_template.format(total=len(inputs))
+⋮----
+results = await _process_batch_async(
+⋮----
+batches = batched(inputs, batch_size)
+⋮----
+start_idx = len(results)
+complete_str = f", {start_idx} complete" if start_idx > 0 else ""
+msg = (
+⋮----
+output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
+⋮----
+"""
+    Generate and run copies of a task async/concurrently one per item in `items` list.
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+    Args:
+        gen_task (Callable[[int], Task]): generates the tasks to run
+        items (list[T]): list of items to process
+        input_map (Callable[[T], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], U]): function to map result
+            to final result. If stop_on_first_result is enabled, then
+            map any invalid output to None. We continue until some non-None
+            result is obtained.
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        batch_size (Optional[int]): The number of tasks to run at a time,
+            if None, unbatched
+        turns (int): number of turns to run, -1 for infinite
+        message (Optional[str]): optionally overrides the console status messages
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
+        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
+
+
+    Returns:
+        list[Optional[U]]: list of final results. Always list[U] if
+        `stop_on_first_result` is disabled
+    """
+inputs = [input_map(item) for item in items]
+⋮----
+task_i = gen_task(i)
+⋮----
+result = await task_i.run_async(
+⋮----
+# exception will be handled by the caller
+⋮----
+# ----------------------------------------
+# Propagate any exception stored on the task that may have been
+# swallowed inside `Task.run_async`, so that the upper-level
+# exception-handling logic works as expected.
+⋮----
+exc = getattr(task_i, attr, None)
+⋮----
+# Fallback: treat a KILL-status result as an error
+⋮----
+"""
+    Run copies of `task` async/concurrently one per item in `items` list.
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+    Args:
+        task (Task): task to run
+        items (list[T]): list of items to process
+        input_map (Callable[[T], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], U]): function to map result
+            to final result
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None, after `output_map`) result. Processing continues past
+            None-mapped results; exceptions propagate, since this function
+            always uses the default `RAISE` exception handling. Once a non-None
+            result appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        batch_size (Optional[int]): The number of tasks to run at a time,
+            if None, unbatched
+        turns (int): number of turns to run, -1 for infinite
+        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
+        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
+
+    Returns:
+        list[Optional[U]]: list of final results. Always list[U] if
+        `stop_on_first_result` is disabled
+    """
+message = f"[bold green]Running {len(items)} copies of {task.name}..."
+⋮----
+"""
+    Run the `method` on copies of `agent`, async/concurrently one per
+    item in `items` list.
+    ASSUMPTION: The `method` is an async method and has signature:
+        method(self, input: str|ChatDocument|None) -> ChatDocument|None
+    So this would typically be used for the agent's "responder" methods,
+    e.g. `llm_response_async` or `agent_responder_async`.
+
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+
+    Args:
+        agent (Agent): agent whose method to run
+        method (str): Async method to run on copies of `agent`.
+            The method is assumed to have signature:
+            `method(self, input: str|ChatDocument|None) -> ChatDocument|None`
+        input_map (Callable[[Any], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], Any]): function to map result
+            to final result
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        batch_size (Optional[int]): The number of items to process in each batch.
+            If None, process all items at once.
+    Returns:
+        List[Any]: list of final results
+    """
+# Check if the method is async
+method_name = method.__name__
+⋮----
+# tool_policy hook shared by reference so its state stays global
+agent_cfg = deepcopy_config_sharing_policy(agent.config)
+⋮----
+agent_cls = type(agent)
+agent_name = agent_cfg.name
+⋮----
+async def _do_task(input: str | ChatDocument, i: int) -> Any
+⋮----
+agent_i = agent_cls(agent_cfg)
+method_i = getattr(agent_i, method_name, None)
+⋮----
+result = await method_i(input)
+⋮----
+async def _do_task(item: T) -> U
+⋮----
+async def _do_all(items: Iterable[T]) -> List[U]
+⋮----
+result = await _do_task(item)
+⋮----
+results: List[U] = []
+⋮----
+results = asyncio.run(_do_all(items))
+⋮----
+batches = batched(items, batch_size)
 </file>
 
 <file path="langroid/agent/openai_assistant.py">
@@ -64626,103 +65620,6 @@ def _mutual_loop(base: Path) -> None
     """
 </file>
 
-<file path="tests/main/test_split_inline_reasoning.py">
-"""
-Tests for OpenAIGPT._split_inline_reasoning, which separates inline
-thought-delimiter tags (e.g. <think>...</think>) from text content
-during streaming.
-"""
-⋮----
-split = OpenAIGPT._split_inline_reasoning
-DELIMS = ("<think>", "</think>")
-⋮----
-class TestSplitInlineReasoning
-⋮----
-"""Unit tests for the streaming inline-reasoning splitter."""
-⋮----
-# --- no-op cases: nothing to parse ---
-⋮----
-def test_empty_text(self)
-⋮----
-"""Empty event_text should pass through unchanged."""
-⋮----
-def test_plain_text_no_delimiters(self)
-⋮----
-"""Text without any delimiters should pass through as-is."""
-⋮----
-def test_already_has_reasoning_field(self)
-⋮----
-"""When the API already provides separate reasoning, skip parsing."""
-⋮----
-# --- single chunk contains full <think>...</think> ---
-⋮----
-def test_full_think_block_in_one_chunk(self)
-⋮----
-"""Complete <think>reasoning</think> in a single chunk."""
-⋮----
-def test_text_before_and_after_think(self)
-⋮----
-"""Text surrounding a complete think block."""
-⋮----
-def test_text_before_think_only(self)
-⋮----
-"""Text before think block, nothing after."""
-⋮----
-def test_text_after_think_only(self)
-⋮----
-"""Think block followed by text, no prefix."""
-⋮----
-# --- multi-chunk: start delimiter in one chunk, end in another ---
-⋮----
-def test_start_delimiter_only(self)
-⋮----
-"""Chunk has <think> but no </think> — enters reasoning state."""
-⋮----
-def test_continuation_mid_reasoning(self)
-⋮----
-"""Chunk arrives while already in reasoning (no delimiters)."""
-⋮----
-def test_end_delimiter_while_in_reasoning(self)
-⋮----
-"""Chunk has </think> while in reasoning state."""
-⋮----
-def test_end_delimiter_no_trailing_text(self)
-⋮----
-"""End delimiter with nothing after it."""
-⋮----
-# --- multi-chunk sequence simulating a real stream ---
-⋮----
-def test_three_chunk_sequence(self)
-⋮----
-"""Simulate: chunk1 opens thinking, chunk2 continues, chunk3 closes."""
-# chunk 1: start of thinking
-⋮----
-# chunk 2: still thinking
-⋮----
-# chunk 3: done thinking, answer follows
-⋮----
-# --- custom delimiters ---
-⋮----
-def test_custom_delimiters(self)
-⋮----
-"""Works with non-default delimiters like <thinking>...</thinking>."""
-custom = ("<thinking>", "</thinking>")
-⋮----
-# --- edge cases ---
-⋮----
-def test_empty_think_block(self)
-⋮----
-"""<think></think> with nothing inside."""
-⋮----
-def test_only_start_delimiter(self)
-⋮----
-"""Chunk is exactly the start delimiter, nothing else."""
-⋮----
-def test_only_end_delimiter_while_reasoning(self)
-⋮----
-"""Chunk is exactly the end delimiter."""
-</file>
-
 <file path="tests/main/test_web_search_tools.py">
 """
 NOTE: running this test requires setting the GOOGLE_API_KEY and GOOGLE_CSE_ID
@@ -66228,6 +67125,966 @@ sender_role = Role.ASSISTANT
 tool_id=tool_id,  # for OpenAI Assistant
 </file>
 
+<file path="langroid/language_models/base.py">
+logger = logging.getLogger(__name__)
+⋮----
+def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
+⋮----
+async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
+⋮----
+FunctionCallTypes = Literal["none", "auto"]
+ToolChoiceTypes = Literal["none", "auto", "required"]
+ToolTypes = Literal["function"]
+⋮----
+DEFAULT_CONTEXT_LENGTH = 16_000
+⋮----
+class StreamEventType(Enum)
+⋮----
+TEXT = 1
+FUNC_NAME = 2
+FUNC_ARGS = 3
+TOOL_NAME = 4
+TOOL_ARGS = 5
+REASONING = 6
+⋮----
+class RetryParams(BaseSettings)
+⋮----
+max_retries: int = 5
+initial_delay: float = 1.0
+exponential_base: float = 1.3
+jitter: bool = True
+⋮----
+class LLMConfig(BaseSettings)
+⋮----
+"""
+    Common configuration for all language models.
+    """
+⋮----
+type: str = "openai"
+streamer: Optional[Callable[[Any], None]] = noop_fn
+streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
+api_base: str | None = None
+formatter: None | str = None
+# specify None if you want to use the full max output tokens of the model
+max_output_tokens: int | None = 8192
+timeout: int = 20  # timeout for API requests
+chat_model: str = ""
+completion_model: str = ""
+temperature: float = 0.0
+chat_context_length: int | None = None
+async_stream_quiet: bool = False  # suppress streaming output in async mode?
+completion_context_length: int | None = None
+# if input length + max_output_tokens > context length of model,
+# we will try shortening requested output
+min_output_tokens: int = 64
+use_completion_for_chat: bool = False  # use completion model for chat?
+# use chat model for completion? For OpenAI models, this MUST be set to True!
+use_chat_for_completion: bool = True
+stream: bool = True  # stream output from API?
+# TODO: we could have a `stream_reasoning` flag here to control whether to show
+# reasoning output from reasoning models
+cache_config: None | CacheDBConfig = RedisCacheConfig()
+thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
+retry_params: RetryParams = RetryParams()
+⋮----
+@property
+    def model_max_output_tokens(self) -> int
+⋮----
+# Build fallback names by progressively stripping provider prefixes
+# (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
+# succeeds even before OpenAIGPT.__init__ strips the prefix.
+parts = self.chat_model.split("/")
+fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
+⋮----
+class LLMFunctionCall(BaseModel)
+⋮----
+"""
+    Structure of LLM response indicating it "wants" to call a function.
+    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
+    """
+⋮----
+name: str  # name of function to call
+arguments: Optional[Dict[str, Any]] = None
+⋮----
+@staticmethod
+    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall"
+⋮----
+"""
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+fun_call = LLMFunctionCall(name=message["name"])
+fun_args_str = message["arguments"]
+# sometimes may be malformed with invalid indents,
+# so we try to be safe by removing newlines.
+⋮----
+fun_args_str = fun_args_str.replace("\n", "").strip()
+dict_or_list = parse_imperfect_json(fun_args_str)
+⋮----
+fun_args = dict_or_list
+⋮----
+fun_args = None
+⋮----
+def __str__(self) -> str
+⋮----
+class LLMFunctionSpec(BaseModel)
+⋮----
+"""
+    Description of a function available for the LLM to use.
+    To be used when calling the LLM `chat()` method with the `functions` parameter.
+    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
+    """
+⋮----
+name: str
+description: str
+parameters: Dict[str, Any]
+⋮----
+class OpenAIToolCall(BaseModel)
+⋮----
+"""
+    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
+    See https://platform.openai.com/docs/api-reference/chat/create
+
+    Attributes:
+        id: The id of the tool call.
+        type: The type of the tool call;
+            only "function" is currently possible (7/26/24).
+        function: The function call.
+    """
+⋮----
+id: str | None = None
+type: ToolTypes = "function"
+function: LLMFunctionCall | None = None
+extra_content: Dict[str, Any] | None = None
+⋮----
+@staticmethod
+    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall"
+⋮----
+id = message["id"]
+type = message["type"]
+function = LLMFunctionCall.from_dict(message["function"])
+extra_content = message.get("extra_content")
+⋮----
+class OpenAIToolSpec(BaseModel)
+⋮----
+type: ToolTypes
+strict: Optional[bool] = None
+function: LLMFunctionSpec
+⋮----
+class OpenAIJsonSchemaSpec(BaseModel)
+⋮----
+def to_dict(self) -> Dict[str, Any]
+⋮----
+json_schema: Dict[str, Any] = {
+⋮----
+class LLMTokenUsage(BaseModel)
+⋮----
+"""
+    Usage of tokens by an LLM.
+    """
+⋮----
+prompt_tokens: int = 0
+cached_tokens: int = 0
+completion_tokens: int = 0
+cost: float = 0.0
+calls: int = 0  # how many API calls - not used as of 2025-04-04
+⋮----
+def reset(self) -> None
+⋮----
+@property
+    def total_tokens(self) -> int
+⋮----
+class Role(str, Enum)
+⋮----
+"""
+    Possible roles for a message in a chat.
+    """
+⋮----
+USER = "user"
+SYSTEM = "system"
+ASSISTANT = "assistant"
+FUNCTION = "function"
+TOOL = "tool"
+⋮----
+class LLMMessage(BaseModel)
+⋮----
+"""
+    Class representing an entry in the msg-history sent to the LLM API.
+    It could be one of these:
+    - a user message
+    - an LLM ("Assistant") response
+    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
+    - a result or results from executing a fn or tool-call(s)
+    """
+⋮----
+role: Role
+name: Optional[str] = None
+tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
+tool_id: str = ""  # used by OpenAIAssistant
+# None means "no content" (the model returned only a tool/function call).
+# This is distinct from "" and is dropped from the API payload by api_dict;
+# see api_dict for how a fully-empty message is handled per-API.
+content: Optional[str] = None
+files: List[FileAttachment] = []
+function_call: Optional[LLMFunctionCall] = None
+tool_calls: Optional[List[OpenAIToolCall]] = None
+timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+# link to corresponding chat document, for provenance/rewind purposes
+chat_document_id: str = ""
+⋮----
+def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]
+⋮----
+"""
+        Convert to dictionary for API request, keeping ONLY
+        the fields that are expected in an API call!
+        E.g., DROP the tool_id, since it is only for use in the Assistant API,
+            not the completion API.
+
+        Args:
+            has_system_role: whether the message has a system role (if not,
+                set to "user" role)
+        Returns:
+            dict: dictionary representation of LLM message
+        """
+d = self.model_dump()
+files: List[FileAttachment] = d.pop("files")
+⋮----
+# In there are files, then content is an array of
+# different content-parts
+⋮----
+# if there is a key k = "role" with value "system", change to "user"
+# in case has_system_role is False
+⋮----
+# drop None values since API doesn't accept them (this omits `content`
+# entirely when it is None, i.e. "no content")
+dict_no_none = {k: v for k, v in d.items() if v is not None}
+⋮----
+# OpenAI API does not like empty name
+⋮----
+# arguments must be a string
+⋮----
+# convert tool calls to API format
+⋮----
+# An empty tool-call list is not a call and conveys no useful API
+# information. Omitting it also lets the empty-message fallback
+# below produce a valid message.
+⋮----
+# A message with empty content (None was dropped above, or "") AND no
+# tool/function call would be an entirely empty message, which some APIs
+# (e.g. Gemini) reject; fall back to a single space in that case only.
+# When there IS a tool/function call, empty content is fine (and Gemini
+# 3.x in fact REQUIRES it — it rejects an assistant turn that carries
+# both a call and non-empty text content).
+has_call = bool(dict_no_none.get("tool_calls")) or (
+⋮----
+# IMPORTANT! drop fields that are not expected in API call
+⋮----
+content = "FUNC: " + json.dumps(self.function_call)
+⋮----
+content = self.content or ""
+name_str = f" ({self.name})" if self.name else ""
+⋮----
+class LLMResponse(BaseModel)
+⋮----
+"""
+    Class representing response from LLM.
+    """
+⋮----
+# None means the model returned NO content (e.g. only a tool/function
+# call), which is distinct from an empty string "". Preserving this
+# distinction lets the message be faithfully reproduced downstream
+# (see ChatDocument.content_is_none and LLMMessage.content).
+message: Optional[str] = None
+reasoning: str = ""  # optional reasoning text from reasoning models
+# Original message text including inline thought signatures (e.g.
+# <thinking>...</thinking>). Only set when reasoning was extracted
+# from the message text via get_reasoning_final(); NOT set when
+# reasoning comes from a separate API field (e.g. reasoning_content),
+# since in that case the message text never contained thought tags.
+message_with_reasoning: Optional[str] = None
+# TODO tool_id needs to generalize to multi-tool calls
+⋮----
+oai_tool_calls: Optional[List[OpenAIToolCall]] = None
+⋮----
+usage: Optional[LLMTokenUsage] = None
+cached: bool = False
+⋮----
+def tools_content(self) -> str
+⋮----
+def to_LLMMessage(self) -> LLMMessage
+⋮----
+"""Convert LLM response to an LLMMessage, to be included in the
+        message-list sent to the API.
+        This is currently NOT used in any significant way in the library, and is only
+        provided as a utility to construct a message list for the API when directly
+        working with an LLM object.
+
+        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
+        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
+        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
+        """
+⋮----
+"""
+        If `message` or `function_call` of an LLM response contains an explicit
+        recipient name, return this recipient name and `message` stripped
+        of the recipient name if specified.
+
+        Two cases:
+        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
+        (b) `message` is empty and function_call/tool_call with explicit `recipient`
+
+        Args:
+            recognize_recipient_in_content (bool): When True (default), parses
+                message text for ``TO[<recipient>]:<content>`` patterns and
+                top-level JSON ``{"recipient": "..."}`` fields. When False,
+                only function_call/tool_call ``recipient`` fields are checked.
+
+        Returns:
+            (str): name of recipient, which may be empty string if no recipient
+            (str): content of message
+
+        """
+⋮----
+# in this case we ignore message, since all information is in function_call
+msg = ""
+args = self.function_call.arguments
+recipient = ""
+⋮----
+recipient = args.get("recipient", "")
+⋮----
+msg = self.message or ""
+⋮----
+# get the first tool that has a recipient field, if any
+⋮----
+recipient = tc.function.arguments.get(
+⋮----
+)  # type: ignore
+⋮----
+# It's not a function or tool call, so continue looking to see
+# if a recipient is specified in the message.
+⋮----
+# First check if message contains "TO: <recipient> <content>"
+⋮----
+# check if there is a top level json that specifies 'recipient',
+# and retain the entire message as content.
+⋮----
+recipient_name = top_level_json_field(msg, "recipient") if msg else ""
+content = msg
+⋮----
+# Define an abstract base class for language models
+class LanguageModel(ABC)
+⋮----
+"""
+    Abstract base class for language models.
+    """
+⋮----
+# usage cost by model, accumulates here
+usage_cost_dict: Dict[str, LLMTokenUsage] = {}
+⋮----
+def __init__(self, config: LLMConfig = LLMConfig())
+⋮----
+@staticmethod
+    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]
+⋮----
+"""
+        Create a language model.
+        Args:
+            config: configuration for language model
+        Returns: instance of language model
+        """
+⋮----
+openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
+⋮----
+openai = AzureGPT
+⋮----
+openai = OpenAIGPT
+cls = dict(
+return cls(config)  # type: ignore
+⋮----
+@staticmethod
+    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]
+⋮----
+"""
+        Given an even-length sequence of strings, split into a sequence of pairs
+
+        Args:
+            lst (List[str]): sequence of strings
+
+        Returns:
+            List[Tuple[str,str]]: sequence of pairs of strings
+        """
+evens = lst[::2]
+odds = lst[1::2]
+⋮----
+"""
+        From the chat history, extract system prompt, user-assistant turns, and
+        final user msg.
+
+        Args:
+            messages (List[LLMMessage]): List of messages in the chat history
+
+        Returns:
+            Tuple[str, List[Tuple[str,str]], str]:
+                system prompt, user-assistant turns, final user msg
+
+        """
+# Handle various degenerate cases
+messages = [m for m in messages]  # copy
+DUMMY_SYS_PROMPT = "You are a helpful assistant."
+DUMMY_USER_PROMPT = "Follow the instructions above."
+⋮----
+system_prompt = messages[0].content or ""
+⋮----
+# now we have messages = [Sys,...]
+⋮----
+# now we have messages = [Sys, msg, ...]
+⋮----
+# now we have messages = [Sys, user, ...]
+⋮----
+# now we have messages = [Sys, user, ..., user]
+# so we omit the first and last elements and make pairs of user-asst messages
+conversation = [m.content or "" for m in messages[1:-1]]
+user_prompt = messages[-1].content or ""
+pairs = LanguageModel.user_assistant_pairs(conversation)
+⋮----
+@abstractmethod
+    def set_stream(self, stream: bool) -> bool
+⋮----
+"""Enable or disable streaming output from API.
+        Return previous value of stream."""
+⋮----
+@abstractmethod
+    def get_stream(self) -> bool
+⋮----
+"""Get streaming status"""
+⋮----
+@abstractmethod
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+@abstractmethod
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+"""
+        Get chat-completion response from LLM.
+
+        Args:
+            messages: message-history to send to the LLM
+            max_tokens: max tokens to generate
+            tools: tools available for the LLM to use in its response
+            tool_choice: tool call mode, one of "none", "auto", "required",
+                or a dict specifying a specific tool.
+            functions: functions available for LLM to call (deprecated)
+            function_call: function calling mode, "auto", "none", or a specific fn
+                    (deprecated)
+        """
+⋮----
+"""Async version of `chat`. See `chat` for details."""
+⋮----
+def __call__(self, prompt: str, max_tokens: int) -> LLMResponse
+⋮----
+@staticmethod
+    def _fallback_model_names(model: str) -> List[str]
+⋮----
+parts = model.split("/")
+fallbacks = []
+⋮----
+def info(self) -> ModelInfo
+⋮----
+"""Info of relevant chat model"""
+orig_model = (
+⋮----
+def completion_info(self) -> ModelInfo
+⋮----
+"""Info of relevant completion model"""
+⋮----
+def supports_functions_or_tools(self) -> bool
+⋮----
+"""
+        Does this Model's API support "native" tool-calling, i.e.
+        can we call the API with arguments that contain a list of available tools,
+        and their schemas?
+        Note that, given the plethora of LLM provider APIs this determination is
+        imperfect at best, and leans towards returning True.
+        When the API calls fails with an error indicating tools are not supported,
+        then users are encouraged to use the Langroid-based prompt-based
+        ToolMessage mechanism, which works with ANY LLM. To enable this,
+        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
+        """
+⋮----
+def chat_context_length(self) -> int
+⋮----
+def completion_context_length(self) -> int
+⋮----
+def chat_cost(self) -> Tuple[float, float, float]
+⋮----
+"""
+        Return the cost per 1000 tokens for chat completions.
+
+        Returns:
+            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
+                per 1000 tokens
+        """
+⋮----
+def reset_usage_cost(self) -> None
+⋮----
+counter = self.usage_cost_dict[mdl]
+⋮----
+"""
+        Update usage cost for this LLM.
+        Args:
+            chat (bool): whether to update for chat or completion model
+            prompts (int): number of tokens used for prompts
+            completions (int): number of tokens used for completions
+            cost (float): total token cost in USD
+        """
+mdl = self.config.chat_model if chat else self.config.completion_model
+⋮----
+@classmethod
+    def usage_cost_summary(cls) -> str
+⋮----
+s = ""
+⋮----
+@classmethod
+    def tot_tokens_cost(cls) -> Tuple[int, float]
+⋮----
+"""
+        Return total tokens used and total cost across all models.
+        """
+total_tokens = 0
+total_cost = 0.0
+⋮----
+def get_reasoning_final(self, message: str) -> Tuple[str, str]
+⋮----
+"""Extract "reasoning" and "final answer" from an LLM response, if the
+        reasoning is found within configured delimiters, like <think>, </think>.
+        E.g.,
+        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
+
+        Args:
+            message (str): message from LLM
+
+        Returns:
+            Tuple[str, str]: reasoning, final answer
+        """
+⋮----
+parts = message.split(start)
+⋮----
+"""
+        Given a chat history and a question, convert it to a standalone question.
+        Args:
+            chat_history: list of tuples of (question, answer)
+            query: follow-up question
+
+        Returns: standalone version of the question
+        """
+history = collate_chat_history(chat_history)
+⋮----
+prompt = f"""
+⋮----
+follow_up_question = f"""
+⋮----
+standalone = (
+standalone = standalone.strip()
+⋮----
+class StreamingIfAllowed
+⋮----
+"""Context to temporarily enable or disable streaming, if allowed globally via
+    `settings.stream`"""
+⋮----
+def __init__(self, llm: LanguageModel, stream: bool = True)
+⋮----
+def __enter__(self) -> None
+⋮----
+def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
+</file>
+
+<file path="langroid/language_models/client_cache.py">
+"""
+Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
+"""
+⋮----
+# Cache for client instances, keyed by hashed configuration parameters.
+# Value is a tuple of (client instance, last_used_monotonic_seconds).
+_client_cache: Dict[str, Tuple[Any, float]] = {}
+_client_cache_lock = threading.RLock()
+⋮----
+# Keep track of clients for cleanup
+_all_clients: weakref.WeakSet[Any] = weakref.WeakSet()
+⋮----
+def _get_cache_key(client_type: str, **kwargs: Any) -> str
+⋮----
+"""
+    Generate a cache key from client type and configuration parameters.
+    Uses the same approach as OpenAIGPT._cache_lookup for consistency.
+
+    Args:
+        client_type: Type of client (e.g., "openai", "groq", "cerebras")
+        **kwargs: Configuration parameters (api_key, base_url, timeout, etc.)
+
+    Returns:
+        SHA256 hash of the configuration as a hex string
+    """
+# Convert kwargs to sorted string representation
+sorted_kwargs_str = str(sorted(kwargs.items()))
+⋮----
+# Create raw key combining client type and sorted kwargs
+raw_key = f"{client_type}:{sorted_kwargs_str}"
+⋮----
+# Hash the key for consistent length and to handle complex objects
+hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
+⋮----
+"""
+    Wrap a sync API-key provider for use with ``AsyncOpenAI``.
+
+    ``AsyncOpenAI`` awaits its ``api_key`` callable, so a plain sync
+    provider must be wrapped in an async function. The sync provider is run
+    in a worker thread, so a blocking token refresh cannot stall the event
+    loop. Providers must therefore be thread-safe -- the sync client may
+    call them from arbitrary threads anyway.
+
+    Args:
+        provider: Callable returning a (possibly short-lived) API key.
+
+    Returns:
+        Async callable returning the same key.
+    """
+⋮----
+async def _provider() -> str
+⋮----
+def _api_key_cache_component(api_key: Union[str, Callable[[], str]]) -> Any
+⋮----
+"""
+    Cache-key component for an API key that may be a rotating-key provider.
+
+    A callable provider is keyed on its identity rather than any token value,
+    so rotating tokens never create new cache entries and tokens are never
+    retained in cache keys. The id() cannot be recycled while the entry
+    lives, because the cached client holds a strong reference to the
+    provider (directly for sync clients, via the async wrapper's closure
+    for async clients).
+    """
+⋮----
+def _get_cached_client(cache_key: str) -> Optional[Any]
+⋮----
+"""Get cached client and refresh its last-used timestamp.
+
+    Must be called while holding ``_client_cache_lock``.
+    """
+entry = _client_cache.get(cache_key)
+⋮----
+def _store_client(cache_key: str, client: Any) -> None
+⋮----
+"""Store a client in the cache with the current timestamp.
+
+    Must be called while holding ``_client_cache_lock``.
+    """
+⋮----
+"""
+    Get or create a singleton OpenAI client with the given configuration.
+
+    Args:
+        api_key: OpenAI API key, or a callable returning a fresh key
+            (for short-lived rotating credentials); a callable is resolved
+            per-request by the OpenAI client and is excluded from the
+            cache key (the cache is keyed on the provider's identity)
+        base_url: Optional base URL for API
+        organization: Optional organization ID
+        timeout: Request timeout
+        default_headers: Optional default headers
+        http_client: Optional httpx.Client instance
+        http_client_config: Optional config dict for creating httpx.Client
+
+    Returns:
+        OpenAI client instance
+    """
+⋮----
+timeout = Timeout(timeout)
+⋮----
+# If http_client is provided directly, don't cache (complex object)
+⋮----
+client = OpenAI(
+⋮----
+cache_key = _get_cache_key(
+⋮----
+http_client_config=http_client_config,  # Include config in cache key
+⋮----
+cached_client = _get_cached_client(cache_key)
+⋮----
+created_http_client = None
+⋮----
+created_http_client = Client(**http_client_config)
+⋮----
+http_client=created_http_client,  # Use the client created from config
+⋮----
+"""
+    Get or create a singleton AsyncOpenAI client with the given configuration.
+
+    Args:
+        api_key: OpenAI API key, or a callable returning a fresh key
+            (for short-lived rotating credentials); a callable is resolved
+            per-request by the OpenAI client and is excluded from the
+            cache key (the cache is keyed on the provider's identity)
+        base_url: Optional base URL for API
+        organization: Optional organization ID
+        timeout: Request timeout
+        default_headers: Optional default headers
+        http_client: Optional httpx.AsyncClient instance
+        http_client_config: Optional config dict for creating httpx.AsyncClient
+
+    Returns:
+        AsyncOpenAI client instance
+    """
+⋮----
+api_key_arg: Union[str, Callable[[], Awaitable[str]]]
+⋮----
+# AsyncOpenAI awaits its api_key callable, so wrap the sync provider
+api_key_arg = wrap_api_key_provider_async(api_key)
+⋮----
+api_key_arg = api_key
+⋮----
+client = AsyncOpenAI(
+⋮----
+created_http_client = AsyncClient(**http_client_config)
+⋮----
+def get_groq_client(api_key: str) -> Groq
+⋮----
+"""
+    Get or create a singleton Groq client with the given configuration.
+
+    Args:
+        api_key: Groq API key
+
+    Returns:
+        Groq client instance
+    """
+cache_key = _get_cache_key("groq", api_key=api_key)
+⋮----
+client = Groq(api_key=api_key)
+⋮----
+def get_async_groq_client(api_key: str) -> AsyncGroq
+⋮----
+"""
+    Get or create a singleton AsyncGroq client with the given configuration.
+
+    Args:
+        api_key: Groq API key
+
+    Returns:
+        AsyncGroq client instance
+    """
+cache_key = _get_cache_key("async_groq", api_key=api_key)
+⋮----
+client = AsyncGroq(api_key=api_key)
+⋮----
+def get_cerebras_client(api_key: str) -> Cerebras
+⋮----
+"""
+    Get or create a singleton Cerebras client with the given configuration.
+
+    Args:
+        api_key: Cerebras API key
+
+    Returns:
+        Cerebras client instance
+    """
+cache_key = _get_cache_key("cerebras", api_key=api_key)
+⋮----
+client = Cerebras(api_key=api_key)
+⋮----
+def get_async_cerebras_client(api_key: str) -> AsyncCerebras
+⋮----
+"""
+    Get or create a singleton AsyncCerebras client with the given configuration.
+
+    Args:
+        api_key: Cerebras API key
+
+    Returns:
+        AsyncCerebras client instance
+    """
+cache_key = _get_cache_key("async_cerebras", api_key=api_key)
+⋮----
+client = AsyncCerebras(api_key=api_key)
+⋮----
+def prune_cache(max_age_seconds: float) -> int
+⋮----
+"""
+    Remove cache entries whose last-used time exceeds *max_age_seconds*.
+
+    Evicted clients are **not** closed here because they may still be serving
+    in-flight requests.  Cleanup is handled by the ``atexit`` handler and the
+    garbage collector.
+
+    Args:
+        max_age_seconds: Maximum age (in seconds) for cache entries to keep.
+            Entries older than this value are removed.
+
+    Returns:
+        Number of cache entries removed.
+    """
+⋮----
+now = time.monotonic()
+⋮----
+stale_keys = [
+⋮----
+# Don't close evicted clients here — they may still be serving in-flight
+# requests. The atexit handler and GC will clean them up.
+⋮----
+def _cleanup_clients() -> None
+⋮----
+"""
+    Cleanup function to close all cached clients on exit.
+    Called automatically via atexit.
+    """
+⋮----
+# Check if close is a coroutine function (async)
+⋮----
+# For async clients, we can't await in atexit
+# They will be cleaned up by the OS
+⋮----
+# Sync clients can be closed directly
+⋮----
+pass  # Ignore errors during cleanup
+⋮----
+# Register cleanup function to run on exit
+⋮----
+# For testing purposes
+def _clear_cache() -> None
+⋮----
+"""Clear the client cache. Only for testing."""
+</file>
+
+<file path="SECURITY.md">
+# Security Policy
+
+## Threat model — please read this before reporting
+
+Langroid is a framework for building applications in which an LLM generates
+code and queries that are then executed. Several **optional** agents exist for
+exactly that purpose:
+
+- `TableChatAgent`, `LanceDocChatAgent`, and `VectorStore.compute_from_docs`
+  evaluate LLM-generated **pandas expressions** with `eval()`.
+- `SQLChatAgent` executes LLM-generated **SQL** against a database you supply.
+- `Neo4jChatAgent`, `ArangoChatAgent`, and `CSVGraphAgent` execute
+  LLM-generated **Cypher / AQL** against a graph database you supply.
+
+Executing model-generated code against your own data *is the feature*. An LLM
+is not a trust boundary: if any untrusted text reaches the model's context, you
+must assume the model can be induced to emit any query or expression the
+grammar allows. Langroid cannot prevent this, and does not claim to.
+
+### What is, and is not, a security boundary
+
+The following are **best-effort hardening, not security boundaries**:
+
+- `sanitize_command()` / `CommandValidator` / `safe_eval_globals()` in
+  `langroid/utils/pandas_utils.py`
+- `_DANGEROUS_SQL_PATTERNS` and the `sqlglot` AST checks in `SQLChatAgent`
+- `validate_cypher_query()` / `validate_aql_query()` in the graph agents
+
+They exist to stop an *unlucky* LLM, not a *determined attacker*. The pandas
+path uses explicit allowlists for AST nodes, methods, operators, variables, and
+builtins. The SQL, Cypher, and AQL paths use denylists over full query grammars
+that span multiple dialects, quoting and escaping forms, and function families.
+Such denylists cannot be made complete. We patch clear gaps opportunistically,
+but we do not treat a newly found way around them as a vulnerability in
+Langroid.
+
+The **actual** security boundaries for a Langroid deployment are:
+
+- the privileges of the database credential you hand the agent;
+- the OS user, container, or VM the process runs in;
+- filesystem permissions and network egress rules.
+
+### Deploying these agents safely
+
+If you expose any of the code- or query-executing agents to untrusted input:
+
+- **Give the agent a least-privilege database role.** For `SQLChatAgent`, a
+  read-only, non-superuser role with `GRANT SELECT` on only the intended
+  tables. In PostgreSQL, server-side file reads and writes normally require a
+  superuser, membership in `pg_read_server_files` or
+  `pg_write_server_files`, or a direct grant on a privileged function.
+  `COPY ... PROGRAM` instead requires superuser access or membership in the
+  distinct `pg_execute_server_program` role. Server-side `lo_import` and
+  `lo_export` default to superuser-only use, but an administrator can grant
+  access to those functions directly. Ordinary password-authenticated
+  `dblink` connections do not require any of those roles. Do not install
+  unneeded extensions, and revoke access to dangerous extensions and
+  functions, including `dblink`, in addition to granting only the intended
+  table privileges. Review any site-specific functions and grants as well.
+- **Run the process in a container or VM** with no credentials, secrets, or
+  data you are unwilling to expose to the LLM.
+- **Treat `allow_dangerous_operations=True` and `full_eval=True` as
+  "I am providing my own sandbox."** The first permits dangerous database
+  operations. The second disables pandas AST validation while retaining the
+  restricted globals from `safe_eval_globals()`. Both are documented as
+  trusted-environment-only.
+
+## Reporting a vulnerability
+
+Report privately — **not** via GitHub Issues, Discussions, or any other public
+forum:
+
+1. Go to
+   **[Security Advisories](https://github.com/langroid/langroid/security/advisories)**.
+2. Click **"Report a vulnerability"**.
+3. Include a proof of concept that works against a **default configuration**.
+
+We aim to acknowledge in-scope reports within 7 days.
+
+### In scope
+
+- Vulnerabilities in core framework code: tool dispatch and the agent/tool
+  trust boundary, message routing, sender verification.
+- Parsing and deserialization flaws (XXE, unsafe deserialization, decompression
+  bombs) in the document and message parsers.
+- Path traversal in the file tools (`ReadFileTool`, `WriteFileTool`,
+  `ListDirTool`) and in repository / folder ingestion.
+- Credential or secret leakage in a default configuration that does not depend
+  on any of the specific exclusions below. The out-of-scope rules take
+  precedence over this category.
+- **A code path that skips a documented safety gate entirely** — that is, a
+  *missing call* to a validator, not a *bypass* of one.
+- **A statement the `allowed_statement_types` allowlist misclassifies.** The
+  allowlist is a different kind of control from the denylists above: it decides
+  what a statement *does* over a closed set of statement kinds, so a query that
+  performs a write the allowlist did not authorize — for example by nesting it
+  where the classifier does not look — is a bounded, fixable defect and is in
+  scope.
+- Vulnerable dependencies with a demonstrated impact on Langroid.
+
+### Out of scope
+
+The following will be closed without a fix, an advisory, or a CVE request:
+
+- New bypasses of the SQL, Cypher, or AQL denylists: previously unlisted
+  functions, alternate quoting or escaping forms (backticks, Unicode escapes,
+  schema qualification), or dialect-specific syntax. See "What is, and is not,
+  a security boundary" above.
+- Sandbox escapes from the pandas `eval()` path when `full_eval=True`,
+  including object-graph traversal via dunder attributes. `full_eval=True`
+  disables the AST validator by design.
+- Anything requiring `allow_dangerous_operations=True`.
+- "The LLM can be prompt-injected into generating a harmful query." This is the
+  documented threat model, not a defect.
+- Reports that assume the agent was given a superuser or otherwise
+  over-privileged database credential.
+- Theoretical reports with no working proof of concept against a default
+  configuration.
+
+Reports that chain off a previous advisory as an "incomplete fix" are judged
+against this same scope: if the original issue was a missing gate we will fix
+it, and if it was a denylist gap it is out of scope.
+
+## Supported versions
+
+Security fixes ship in the latest release. Please upgrade to the current
+version of `langroid` rather than requesting backports.
+</file>
+
 <file path="langroid/agent/task.py">
 logger = logging.getLogger(__name__)
 ⋮----
@@ -66461,7 +68318,9 @@ agent = ChatAgent()
 # copy the agent's config, so that we don't modify the original agent's config,
 # which may be shared by other agents.
 ⋮----
-config_copy = copy.deepcopy(agent.config)
+# the tool_policy hook is shared by reference (never deep-copied),
+# so its state (budgets, approvals) stays global across copies
+config_copy = deepcopy_config_sharing_policy(agent.config)
 ⋮----
 agent = cast(ChatAgent, agent)
 ⋮----
@@ -67478,2100 +69337,6 @@ responder = current_responder
 matched = False
 ⋮----
 matched = True
-</file>
-
-<file path="langroid/language_models/client_cache.py">
-"""
-Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
-"""
-⋮----
-# Cache for client instances, keyed by hashed configuration parameters.
-# Value is a tuple of (client instance, last_used_monotonic_seconds).
-_client_cache: Dict[str, Tuple[Any, float]] = {}
-_client_cache_lock = threading.RLock()
-⋮----
-# Keep track of clients for cleanup
-_all_clients: weakref.WeakSet[Any] = weakref.WeakSet()
-⋮----
-def _get_cache_key(client_type: str, **kwargs: Any) -> str
-⋮----
-"""
-    Generate a cache key from client type and configuration parameters.
-    Uses the same approach as OpenAIGPT._cache_lookup for consistency.
-
-    Args:
-        client_type: Type of client (e.g., "openai", "groq", "cerebras")
-        **kwargs: Configuration parameters (api_key, base_url, timeout, etc.)
-
-    Returns:
-        SHA256 hash of the configuration as a hex string
-    """
-# Convert kwargs to sorted string representation
-sorted_kwargs_str = str(sorted(kwargs.items()))
-⋮----
-# Create raw key combining client type and sorted kwargs
-raw_key = f"{client_type}:{sorted_kwargs_str}"
-⋮----
-# Hash the key for consistent length and to handle complex objects
-hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
-⋮----
-"""
-    Wrap a sync API-key provider for use with ``AsyncOpenAI``.
-
-    ``AsyncOpenAI`` awaits its ``api_key`` callable, so a plain sync
-    provider must be wrapped in an async function. The sync provider is run
-    in a worker thread, so a blocking token refresh cannot stall the event
-    loop. Providers must therefore be thread-safe -- the sync client may
-    call them from arbitrary threads anyway.
-
-    Args:
-        provider: Callable returning a (possibly short-lived) API key.
-
-    Returns:
-        Async callable returning the same key.
-    """
-⋮----
-async def _provider() -> str
-⋮----
-def _api_key_cache_component(api_key: Union[str, Callable[[], str]]) -> Any
-⋮----
-"""
-    Cache-key component for an API key that may be a rotating-key provider.
-
-    A callable provider is keyed on its identity rather than any token value,
-    so rotating tokens never create new cache entries and tokens are never
-    retained in cache keys. The id() cannot be recycled while the entry
-    lives, because the cached client holds a strong reference to the
-    provider (directly for sync clients, via the async wrapper's closure
-    for async clients).
-    """
-⋮----
-def _get_cached_client(cache_key: str) -> Optional[Any]
-⋮----
-"""Get cached client and refresh its last-used timestamp.
-
-    Must be called while holding ``_client_cache_lock``.
-    """
-entry = _client_cache.get(cache_key)
-⋮----
-def _store_client(cache_key: str, client: Any) -> None
-⋮----
-"""Store a client in the cache with the current timestamp.
-
-    Must be called while holding ``_client_cache_lock``.
-    """
-⋮----
-"""
-    Get or create a singleton OpenAI client with the given configuration.
-
-    Args:
-        api_key: OpenAI API key, or a callable returning a fresh key
-            (for short-lived rotating credentials); a callable is resolved
-            per-request by the OpenAI client and is excluded from the
-            cache key (the cache is keyed on the provider's identity)
-        base_url: Optional base URL for API
-        organization: Optional organization ID
-        timeout: Request timeout
-        default_headers: Optional default headers
-        http_client: Optional httpx.Client instance
-        http_client_config: Optional config dict for creating httpx.Client
-
-    Returns:
-        OpenAI client instance
-    """
-⋮----
-timeout = Timeout(timeout)
-⋮----
-# If http_client is provided directly, don't cache (complex object)
-⋮----
-client = OpenAI(
-⋮----
-cache_key = _get_cache_key(
-⋮----
-http_client_config=http_client_config,  # Include config in cache key
-⋮----
-cached_client = _get_cached_client(cache_key)
-⋮----
-created_http_client = None
-⋮----
-created_http_client = Client(**http_client_config)
-⋮----
-http_client=created_http_client,  # Use the client created from config
-⋮----
-"""
-    Get or create a singleton AsyncOpenAI client with the given configuration.
-
-    Args:
-        api_key: OpenAI API key, or a callable returning a fresh key
-            (for short-lived rotating credentials); a callable is resolved
-            per-request by the OpenAI client and is excluded from the
-            cache key (the cache is keyed on the provider's identity)
-        base_url: Optional base URL for API
-        organization: Optional organization ID
-        timeout: Request timeout
-        default_headers: Optional default headers
-        http_client: Optional httpx.AsyncClient instance
-        http_client_config: Optional config dict for creating httpx.AsyncClient
-
-    Returns:
-        AsyncOpenAI client instance
-    """
-⋮----
-api_key_arg: Union[str, Callable[[], Awaitable[str]]]
-⋮----
-# AsyncOpenAI awaits its api_key callable, so wrap the sync provider
-api_key_arg = wrap_api_key_provider_async(api_key)
-⋮----
-api_key_arg = api_key
-⋮----
-client = AsyncOpenAI(
-⋮----
-created_http_client = AsyncClient(**http_client_config)
-⋮----
-def get_groq_client(api_key: str) -> Groq
-⋮----
-"""
-    Get or create a singleton Groq client with the given configuration.
-
-    Args:
-        api_key: Groq API key
-
-    Returns:
-        Groq client instance
-    """
-cache_key = _get_cache_key("groq", api_key=api_key)
-⋮----
-client = Groq(api_key=api_key)
-⋮----
-def get_async_groq_client(api_key: str) -> AsyncGroq
-⋮----
-"""
-    Get or create a singleton AsyncGroq client with the given configuration.
-
-    Args:
-        api_key: Groq API key
-
-    Returns:
-        AsyncGroq client instance
-    """
-cache_key = _get_cache_key("async_groq", api_key=api_key)
-⋮----
-client = AsyncGroq(api_key=api_key)
-⋮----
-def get_cerebras_client(api_key: str) -> Cerebras
-⋮----
-"""
-    Get or create a singleton Cerebras client with the given configuration.
-
-    Args:
-        api_key: Cerebras API key
-
-    Returns:
-        Cerebras client instance
-    """
-cache_key = _get_cache_key("cerebras", api_key=api_key)
-⋮----
-client = Cerebras(api_key=api_key)
-⋮----
-def get_async_cerebras_client(api_key: str) -> AsyncCerebras
-⋮----
-"""
-    Get or create a singleton AsyncCerebras client with the given configuration.
-
-    Args:
-        api_key: Cerebras API key
-
-    Returns:
-        AsyncCerebras client instance
-    """
-cache_key = _get_cache_key("async_cerebras", api_key=api_key)
-⋮----
-client = AsyncCerebras(api_key=api_key)
-⋮----
-def prune_cache(max_age_seconds: float) -> int
-⋮----
-"""
-    Remove cache entries whose last-used time exceeds *max_age_seconds*.
-
-    Evicted clients are **not** closed here because they may still be serving
-    in-flight requests.  Cleanup is handled by the ``atexit`` handler and the
-    garbage collector.
-
-    Args:
-        max_age_seconds: Maximum age (in seconds) for cache entries to keep.
-            Entries older than this value are removed.
-
-    Returns:
-        Number of cache entries removed.
-    """
-⋮----
-now = time.monotonic()
-⋮----
-stale_keys = [
-⋮----
-# Don't close evicted clients here — they may still be serving in-flight
-# requests. The atexit handler and GC will clean them up.
-⋮----
-def _cleanup_clients() -> None
-⋮----
-"""
-    Cleanup function to close all cached clients on exit.
-    Called automatically via atexit.
-    """
-⋮----
-# Check if close is a coroutine function (async)
-⋮----
-# For async clients, we can't await in atexit
-# They will be cleaned up by the OS
-⋮----
-# Sync clients can be closed directly
-⋮----
-pass  # Ignore errors during cleanup
-⋮----
-# Register cleanup function to run on exit
-⋮----
-# For testing purposes
-def _clear_cache() -> None
-⋮----
-"""Clear the client cache. Only for testing."""
-</file>
-
-<file path="SECURITY.md">
-# Security Policy
-
-## Threat model — please read this before reporting
-
-Langroid is a framework for building applications in which an LLM generates
-code and queries that are then executed. Several **optional** agents exist for
-exactly that purpose:
-
-- `TableChatAgent`, `LanceDocChatAgent`, and `VectorStore.compute_from_docs`
-  evaluate LLM-generated **pandas expressions** with `eval()`.
-- `SQLChatAgent` executes LLM-generated **SQL** against a database you supply.
-- `Neo4jChatAgent`, `ArangoChatAgent`, and `CSVGraphAgent` execute
-  LLM-generated **Cypher / AQL** against a graph database you supply.
-
-Executing model-generated code against your own data *is the feature*. An LLM
-is not a trust boundary: if any untrusted text reaches the model's context, you
-must assume the model can be induced to emit any query or expression the
-grammar allows. Langroid cannot prevent this, and does not claim to.
-
-### What is, and is not, a security boundary
-
-The following are **best-effort hardening, not security boundaries**:
-
-- `sanitize_command()` / `CommandValidator` / `safe_eval_globals()` in
-  `langroid/utils/pandas_utils.py`
-- `_DANGEROUS_SQL_PATTERNS` and the `sqlglot` AST checks in `SQLChatAgent`
-- `validate_cypher_query()` / `validate_aql_query()` in the graph agents
-
-They exist to stop an *unlucky* LLM, not a *determined attacker*. The pandas
-path uses explicit allowlists for AST nodes, methods, operators, variables, and
-builtins. The SQL, Cypher, and AQL paths use denylists over full query grammars
-that span multiple dialects, quoting and escaping forms, and function families.
-Such denylists cannot be made complete. We patch clear gaps opportunistically,
-but we do not treat a newly found way around them as a vulnerability in
-Langroid.
-
-The **actual** security boundaries for a Langroid deployment are:
-
-- the privileges of the database credential you hand the agent;
-- the OS user, container, or VM the process runs in;
-- filesystem permissions and network egress rules.
-
-### Deploying these agents safely
-
-If you expose any of the code- or query-executing agents to untrusted input:
-
-- **Give the agent a least-privilege database role.** For `SQLChatAgent`, a
-  read-only, non-superuser role with `GRANT SELECT` on only the intended
-  tables. In PostgreSQL, server-side file reads and writes normally require a
-  superuser, membership in `pg_read_server_files` or
-  `pg_write_server_files`, or a direct grant on a privileged function.
-  `COPY ... PROGRAM` instead requires superuser access or membership in the
-  distinct `pg_execute_server_program` role. Server-side `lo_import` and
-  `lo_export` default to superuser-only use, but an administrator can grant
-  access to those functions directly. Ordinary password-authenticated
-  `dblink` connections do not require any of those roles. Do not install
-  unneeded extensions, and revoke access to dangerous extensions and
-  functions, including `dblink`, in addition to granting only the intended
-  table privileges. Review any site-specific functions and grants as well.
-- **Run the process in a container or VM** with no credentials, secrets, or
-  data you are unwilling to expose to the LLM.
-- **Treat `allow_dangerous_operations=True` and `full_eval=True` as
-  "I am providing my own sandbox."** The first permits dangerous database
-  operations. The second disables pandas AST validation while retaining the
-  restricted globals from `safe_eval_globals()`. Both are documented as
-  trusted-environment-only.
-
-## Reporting a vulnerability
-
-Report privately — **not** via GitHub Issues, Discussions, or any other public
-forum:
-
-1. Go to
-   **[Security Advisories](https://github.com/langroid/langroid/security/advisories)**.
-2. Click **"Report a vulnerability"**.
-3. Include a proof of concept that works against a **default configuration**.
-
-We aim to acknowledge in-scope reports within 7 days.
-
-### In scope
-
-- Vulnerabilities in core framework code: tool dispatch and the agent/tool
-  trust boundary, message routing, sender verification.
-- Parsing and deserialization flaws (XXE, unsafe deserialization, decompression
-  bombs) in the document and message parsers.
-- Path traversal in the file tools (`ReadFileTool`, `WriteFileTool`,
-  `ListDirTool`) and in repository / folder ingestion.
-- Credential or secret leakage in a default configuration that does not depend
-  on any of the specific exclusions below. The out-of-scope rules take
-  precedence over this category.
-- **A code path that skips a documented safety gate entirely** — that is, a
-  *missing call* to a validator, not a *bypass* of one.
-- **A statement the `allowed_statement_types` allowlist misclassifies.** The
-  allowlist is a different kind of control from the denylists above: it decides
-  what a statement *does* over a closed set of statement kinds, so a query that
-  performs a write the allowlist did not authorize — for example by nesting it
-  where the classifier does not look — is a bounded, fixable defect and is in
-  scope.
-- Vulnerable dependencies with a demonstrated impact on Langroid.
-
-### Out of scope
-
-The following will be closed without a fix, an advisory, or a CVE request:
-
-- New bypasses of the SQL, Cypher, or AQL denylists: previously unlisted
-  functions, alternate quoting or escaping forms (backticks, Unicode escapes,
-  schema qualification), or dialect-specific syntax. See "What is, and is not,
-  a security boundary" above.
-- Sandbox escapes from the pandas `eval()` path when `full_eval=True`,
-  including object-graph traversal via dunder attributes. `full_eval=True`
-  disables the AST validator by design.
-- Anything requiring `allow_dangerous_operations=True`.
-- "The LLM can be prompt-injected into generating a harmful query." This is the
-  documented threat model, not a defect.
-- Reports that assume the agent was given a superuser or otherwise
-  over-privileged database credential.
-- Theoretical reports with no working proof of concept against a default
-  configuration.
-
-Reports that chain off a previous advisory as an "incomplete fix" are judged
-against this same scope: if the original issue was a missing gate we will fix
-it, and if it was a denylist gap it is out of scope.
-
-## Supported versions
-
-Security fixes ship in the latest release. Please upgrade to the current
-version of `langroid` rather than requesting backports.
-</file>
-
-<file path="langroid/agent/chat_agent.py">
-console = Console()
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-def _is_identified_result(message: LLMMessage) -> bool
-⋮----
-"""Whether a TOOL/FUNCTION result has its identifier and no call payload.
-
-    Such results must survive even with empty content so their calls can be
-    marked complete (issue #1063).
-    """
-has_identifier = (
-⋮----
-def _llm_message_has_payload(message: LLMMessage) -> bool
-⋮----
-"""Whether a message has the fields required for a valid history entry."""
-⋮----
-class ChatAgentConfig(AgentConfig)
-⋮----
-"""
-    Configuration for ChatAgent
-
-    Attributes:
-        system_message: system message to include in message sequence
-             (typically defines role and task of agent).
-             Used only if `task` is not specified in the constructor.
-        user_message: user message to include in message sequence.
-             Used only if `task` is not specified in the constructor.
-        use_tools: whether to use our own ToolMessages mechanism
-        handle_llm_no_tool (Any): desired agent_response when
-            LLM generates non-tool msg.
-        use_functions_api: whether to use functions/tools native to the LLM API
-                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
-        use_tools_api: When `use_functions_api` is True, if this is also True,
-            the OpenAI tool-call API is used, rather than the older/deprecated
-            function-call API. However the tool-call API has some tricky aspects,
-            hence we set this to False by default.
-        strict_recovery: whether to enable strict schema recovery when there
-            is a tool-generation error.
-        enable_orchestration_tool_handling: whether to enable handling of orchestration
-            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
-        output_format: When supported by the LLM (certain OpenAI LLMs
-            and local LLMs served by providers such as vLLM), ensures
-            that the output is a JSON matching the corresponding
-            schema via grammar-based decoding
-        handle_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for handling".
-        use_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for use" (by LLM) and
-            instructions on using T are added to the system message.
-        instructions_output_format: Controls whether we generate instructions for
-            `output_format` in the system message.
-        use_tools_on_output_format: Controls whether to automatically switch
-            to the Langroid-native tools mechanism when `output_format` is set.
-            Note that LLMs may generate tool calls which do not belong to
-            `output_format` even when strict JSON mode is enabled, so this should be
-            enabled when such tool calls are not desired.
-        output_format_include_defaults: Whether to include fields with default arguments
-            in the output schema
-        full_citations: Whether to show source reference citation + content for each
-            citation, or just the main reference citation.
-        search_for_tools_everywhere: Whether to search for tools everywhere,
-            or only in specific LLM response elements based on use_tools /
-            use_functions_api / use_tools_api config settings.
-        recognize_recipient_in_content: Whether to parse LLM response text content
-            for recipient routing patterns, specifically:
-            - ``TO[<recipient>]:<content>`` addressing format, and
-            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
-            When False, only structured routing via function_call/tool_call
-            ``recipient`` fields is recognized. Default is True.
-            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
-            which controls Task-level signals like DONE, PASS, and SEND_TO.
-            To fully disable all text-based routing, set both to False.
-        context_overflow_strategy: Strategy for handling context overflow when
-            message history exceeds model context length. Options:
-            - "truncate": Truncate content of early messages (preserves all messages
-              but with shortened content). This maintains the message sequence.
-            - "drop_turns": Drop complete conversation turns (USER + all responses
-              until next USER). More aggressive but cleaner for voice agents.
-            Default is "truncate" for backward compatibility.
-    """
-⋮----
-system_message: str = "You are a helpful assistant."
-user_message: Optional[str] = None
-handle_llm_no_tool: Any = None
-use_tools: bool = True
-use_functions_api: bool = False
-use_tools_api: bool = True
-strict_recovery: bool = True
-enable_orchestration_tool_handling: bool = True
-output_format: Optional[type] = None
-handle_output_format: bool = True
-use_output_format: bool = True
-instructions_output_format: bool = True
-output_format_include_defaults: bool = True
-use_tools_on_output_format: bool = True
-full_citations: bool = True  # show source + content for each citation?
-search_for_tools_everywhere: bool = True
-recognize_recipient_in_content: bool = True
-context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
-⋮----
-def _set_fn_or_tools(self) -> None
-⋮----
-"""
-        Enable Langroid Tool or OpenAI-like fn-calling,
-        depending on config settings.
-        """
-⋮----
-class ChatAgent(Agent)
-⋮----
-"""
-    Chat Agent interacting with external env
-    (could be human, or external tools).
-    The agent (the LLM actually) is provided with an optional "Task Spec",
-    which is a sequence of `LLMMessage`s. These are used to initialize
-    the `task_messages` of the agent.
-    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
-    The `Agent` class mainly exists to hold various common methods and attributes.
-    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
-    `llm_response` method uses "chat mode" API (i.e. one that takes a
-    message sequence rather than a single message),
-    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
-    that takes a single message).
-    """
-⋮----
-"""
-        Chat-mode agent initialized with task spec as the initial message sequence
-        Args:
-            config: settings for the agent
-
-        """
-⋮----
-# An agent's "task" is defined by a system msg and an optional user msg;
-# These are "priming" messages that kick off the agent's conversation.
-⋮----
-# if task contains a system msg, we override the config system msg
-⋮----
-# if task contains a user msg, we override the config user msg
-⋮----
-# system-level instructions for using tools/functions:
-# We maintain these as tools/functions are enabled/disabled,
-# and whenever an LLM response is sought, these are used to
-# recreate the system message (via `_create_system_and_tools_message`)
-# each time, so it reflects the current set of enabled tools/functions.
-# (a) these are general instructions on using certain tools/functions,
-#   if they are specified in a ToolMessage class as a classmethod `instructions`
-⋮----
-# (b) these are only for the builtin in Langroid TOOLS mechanism:
-⋮----
-# This variable is not None and equals a `ToolMessage` T, if and only if:
-# (a) T has been set as the output_format of this agent, AND
-# (b) T has been "enabled for use" ONLY for enforcing this output format, AND
-# (c) T has NOT been explicitly "enabled for use" by this Agent.
-⋮----
-# As above but deals with "enabled for handling" instead of "enabled for use".
-⋮----
-# instructions specifically related to enforcing `output_format`
-⋮----
-# controls whether to disable strict schemas for this agent if
-# strict mode causes exception
-⋮----
-# Tracks whether any strict tool is enabled; used to determine whether to set
-# `self.disable_strict` on an exception
-⋮----
-# Tracks the set of tools on which we force-disable strict decoding
-⋮----
-# search for tools according to the agent configuration
-⋮----
-# Only enable HANDLING by `agent_response`, NOT LLM generation of these.
-# This is useful where tool-handlers or agent_response generate these
-# tools, and need to be handled.
-# We don't want enable orch tool GENERATION by default, since that
-# might clutter-up the LLM system message unnecessarily.
-⋮----
-def init_state(self) -> None
-⋮----
-"""
-        Initialize the state of the agent. Just conversation state here,
-        but subclasses can override this to initialize other state.
-        """
-⋮----
-@staticmethod
-    def from_id(id: str) -> "ChatAgent"
-⋮----
-"""
-        Get an agent from its ID
-        Args:
-            agent_id (str): ID of the agent
-        Returns:
-            ChatAgent: The agent with the given ID
-        """
-⋮----
-def clone(self, i: int = 0) -> "ChatAgent"
-⋮----
-"""Create i'th clone of this agent, ensuring tool use/handling is cloned.
-        Important: We assume all member variables are in the __init__ method here
-        and in the Agent class.
-        TODO: We are attempting to clone an agent after its state has been
-        changed in possibly many ways. Below is an imperfect solution. Caution advised.
-        Revisit later.
-        """
-agent_cls = type(self)
-# Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
-# instead of deepcopy which loses subclass information
-config_copy = self.config.model_copy(deep=True)
-⋮----
-new_agent = agent_cls(config_copy)
-⋮----
-# Ensure each clone gets its own vecdb client when supported.
-⋮----
-def _clone_extra_state(self, new_agent: "ChatAgent") -> None
-⋮----
-"""Hook for subclasses to copy additional state into clones."""
-⋮----
-def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool
-⋮----
-"""Should we enable strict mode for a given tool?"""
-⋮----
-tool_class = self.llm_tools_map[tool]
-⋮----
-tool_class = tool
-name = tool_class.default_value("request")
-⋮----
-strict: Optional[bool] = tool_class.default_value("strict")
-⋮----
-strict = self._strict_tools_available()
-⋮----
-def _fn_call_available(self) -> bool
-⋮----
-"""Does this agent's LLM support function calling?"""
-⋮----
-def _strict_tools_available(self) -> bool
-⋮----
-"""Does this agent's LLM support strict tools?"""
-⋮----
-def _json_schema_available(self) -> bool
-⋮----
-"""Does this agent's LLM support strict JSON schema output format?"""
-⋮----
-def set_system_message(self, msg: str) -> None
-⋮----
-# if there is message history, update the system message in it
-⋮----
-def set_user_message(self, msg: str) -> None
-⋮----
-@property
-    def task_messages(self) -> List[LLMMessage]
-⋮----
-"""
-        The task messages are the initial messages that define the task
-        of the agent. There will be at least a system message plus possibly a user msg.
-        Returns:
-            List[LLMMessage]: the task messages
-        """
-msgs = [self._create_system_and_tools_message()]
-⋮----
-def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None
-⋮----
-id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
-⋮----
-# dropping tool result, so ADD the corresponding tool-call back
-# to the list of pending calls!
-id = msg.tool_call_id
-⋮----
-# dropping a msg with tool-calls, so DROP these from pending list
-# as well as from id -> call map
-⋮----
-def clear_history(self, start: int = -2, end: int = -1) -> None
-⋮----
-"""
-        Clear the message history, deleting  messages from index `start`,
-        up to index `end`.
-
-        Args:
-            start (int): index of first message to delete; default = -2
-                    (i.e. delete last 2 messages, typically these
-                    are the last user and assistant messages)
-            end (int): index of last message to delete; Default = -1
-                    (i.e. delete all messages up to the last one)
-        """
-n = len(self.message_history)
-⋮----
-start = max(0, n + start)
-end_ = n if end == -1 else end + 1
-dropped = self.message_history[start:end_]
-# consider the dropped msgs in REVERSE order, so we are
-# carefully updating self.oai_tool_calls
-⋮----
-# clear out the chat document from the ObjectRegistry
-⋮----
-def update_history(self, message: str, response: str) -> None
-⋮----
-"""
-        Update the message history with the latest user message and LLM response.
-        Args:
-            message (str): user message
-            response: (str): LLM response
-        """
-⋮----
-def tool_format_rules(self) -> str
-⋮----
-"""
-        Specification of tool formatting rules
-        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
-        based on the currently enabled usable `ToolMessage`s
-
-        Returns:
-            str: formatting rules
-        """
-# ONLY Usable tools (i.e. LLM-generation allowed),
-usable_tool_classes: List[Type[ToolMessage]] = [
-⋮----
-format_instructions = "\n\n".join(
-# if any of the enabled classes has json_group_instructions, then use that,
-# else fall back to ToolMessage.json_group_instructions
-⋮----
-def tool_instructions(self) -> str
-⋮----
-"""
-        Instructions for tools or function-calls, for enabled and usable Tools.
-        These are inserted into system prompt regardless of whether we are using
-        our own ToolMessage mechanism or the LLM's function-call mechanism.
-
-        Returns:
-            str: concatenation of instructions for all usable tools
-        """
-enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
-⋮----
-instructions = []
-⋮----
-class_instructions = ""
-⋮----
-class_instructions = msg_cls.instructions()
-⋮----
-# example will be shown in tool_format_rules() when using TOOLs,
-# so we don't need to show it here.
-example = "" if self.config.use_tools else (msg_cls.usage_examples())
-⋮----
-example = "EXAMPLES:\n" + example
-guidance = (
-⋮----
-instructions_str = "\n\n".join(instructions)
-⋮----
-def augment_system_message(self, message: str) -> None
-⋮----
-"""
-        Augment the system message with the given message.
-        Args:
-            message (str): system message
-        """
-⋮----
-def last_message_with_role(self, role: Role) -> LLMMessage | None
-⋮----
-"""from `message_history`, return the last message with role `role`"""
-n_role_msgs = len([m for m in self.message_history if m.role == role])
-⋮----
-idx = self.nth_message_idx_with_role(role, n_role_msgs)
-⋮----
-def last_message_idx_with_role(self, role: Role) -> int
-⋮----
-"""Index of last message in message_history, with specified role.
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-indices_with_role = [
-⋮----
-def nth_message_idx_with_role(self, role: Role, n: int) -> int
-⋮----
-"""Index of `n`th message in message_history, with specified role.
-        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-⋮----
-def update_last_message(self, message: str, role: str = Role.USER) -> None
-⋮----
-"""
-        Update the last message that has role `role` in the message history.
-        Useful when we want to replace a long user prompt, that may contain context
-        documents plus a question, with just the question.
-        Args:
-            message (str): new message to replace with
-            role (str): role of message to replace
-        """
-⋮----
-# find last message in self.message_history with role `role`
-⋮----
-def delete_last_message(self, role: str = Role.USER) -> None
-⋮----
-"""
-        Delete the last message that has role `role` from the message history.
-        Args:
-            role (str): role of message to delete
-        """
-⋮----
-def _create_system_and_tools_message(self) -> LLMMessage
-⋮----
-"""
-        (Re-)Create the system message for the LLM of the agent,
-        taking into account any tool instructions that have been added
-        after the agent was initialized.
-
-        The system message will consist of:
-        (a) the system message from the `task` arg in constructor, if any,
-            otherwise the default system message from the config
-        (b) the system tool instructions, if any
-        (c) the system json tool instructions, if any
-
-        Returns:
-            LLMMessage object
-        """
-content = self.system_message
-⋮----
-# remove leading and trailing newlines and other whitespace
-⋮----
-def handle_message_fallback(self, msg: str | ChatDocument) -> Any
-⋮----
-"""
-        Fallback method for the "no-tools" scenario, i.e., the current `msg`
-        (presumably emitted by the LLM) does not have any tool that the agent
-        can handle.
-        NOTE: The `msg` may contain tools but either (a) the agent is not
-        enabled to handle them, or (b) there's an explicit `recipient` field
-        in the tool that doesn't match the agent's name.
-
-        Uses the self.config.non_tool_routing to determine the action to take.
-
-        This method can be overridden by subclasses, e.g.,
-        to create a "reminder" message when a tool is expected but the LLM "forgot"
-        to generate one.
-
-        Args:
-            msg (str | ChatDocument): The input msg to handle
-        Returns:
-            Any: The result of the handler method
-        """
-⋮----
-# we ONLY use the `handle_llm_no_tool` config option when
-# the msg is from LLM and does not contain ANY tools at all.
-⋮----
-no_tool_option = self.config.handle_llm_no_tool
-⋮----
-# in case the `no_tool_option` is one of the special NonToolAction vals
-⋮----
-# Otherwise just return `no_tool_option` as is:
-# This can be any string, such as a specific nudge/reminder to the LLM,
-# or even something like ResultTool etc.
-⋮----
-def unhandled_tools(self) -> set[str]
-⋮----
-"""The set of tools that are known but not handled.
-        Useful in task flow: an agent can refuse to accept an incoming msg
-        when it only has unhandled tools.
-        """
-⋮----
-"""
-        Add the tool (message class) to the agent, and enable either
-        - tool USE (i.e. the LLM can generate JSON to use this tool),
-        - tool HANDLING (i.e. the agent can handle JSON from this tool),
-
-        Args:
-            message_class: The ToolMessage class OR List of such classes to enable,
-                for USE, or HANDLING, or both.
-                If this is a list of ToolMessage classes, then the remain args are
-                applied to all classes.
-                Optional; if None, then apply the enabling to all tools in the
-                agent's toolset that have been enabled so far.
-            use: IF True, allow the agent (LLM) to use this tool (or all tools),
-                else disallow
-            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
-                tool (or all tools)
-            force: whether to FORCE the agent (LLM) to USE the specific
-                 tool represented by `message_class`.
-                 `force` is ignored if `message_class` is None.
-            require_recipient: whether to require that recipient be specified
-                when using the tool message (only applies if `use` is True).
-            include_defaults: whether to include fields that have default values,
-                in the "properties" section of the JSON format instructions.
-                (Normally the OpenAI completion API ignores these fields,
-                but the Assistant fn-calling seems to pay attn to these,
-                and if we don't want this, we should set this to False.)
-        """
-⋮----
-# Validate that use/handle are booleans, not accidentally passed tool classes
-⋮----
-param = "use" if isclass(use) else "handle"
-⋮----
-message_class = message_class.require_recipient()
-⋮----
-# XMLToolMessage is not compatible with OpenAI's Tools/functions API,
-# so we disable use of functions API, enable langroid-native Tools,
-# which are prompt-based.
-⋮----
-super().enable_message_handling(message_class)  # enables handling only
-tools = self._get_tool_list(message_class)
-⋮----
-request = message_class.default_value("request")
-⋮----
-llm_function = message_class.llm_function_schema(defaults=include_defaults)
-⋮----
-# `t` was designated as "enabled for handling" ONLY for
-# output_format enforcement, but we are explicitly ]
-# enabling it for handling here, so we set the variable to None.
-⋮----
-tool_class = self.llm_tools_map[t]
-allow_llm_use = tool_class._allow_llm_use
-⋮----
-allow_llm_use = allow_llm_use.default
-⋮----
-# `t` was designated as "enabled for use" ONLY for output_format
-# enforcement, but we are explicitly enabling it for use here,
-# so we set the variable to None.
-⋮----
-def _update_tool_instructions(self) -> None
-⋮----
-# Set tool instructions and JSON format instructions,
-# in case Tools have been enabled/disabled.
-⋮----
-def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]
-⋮----
-"""
-        Returns the current set of enabled requests for inference and tools configs.
-        Used for restoring setings overriden by `set_output_format`.
-        """
-⋮----
-@property
-    def all_llm_tools_known(self) -> set[str]
-⋮----
-"""All known tools; we include `output_format` if it is a `ToolMessage`."""
-known = self.llm_tools_known
-⋮----
-"""
-        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
-        switches to the native Langroid tools mechanism to ensure that no tool
-        calls not of `output_type` are generated. By default, `force_tools`
-        follows the `use_tools_on_output_format` parameter in the config.
-
-        If `output_type` is None, restores to the state prior to setting
-        `output_format`.
-
-        If `use`, we enable use of `output_type` when it is a subclass
-        of `ToolMesage`. Note that this primarily controls instruction
-        generation: the model will always generate `output_type` regardless
-        of whether `use` is set. Defaults to the `use_output_format`
-        parameter in the config. Similarly, handling of `output_type` is
-        controlled by `handle`, which defaults to the
-        `handle_output_format` parameter in the config.
-
-        `instructions` controls whether we generate instructions specifying
-        the output format schema. Defaults to the `instructions_output_format`
-        parameter in the config.
-
-        `is_copy` is set when called via `__getitem__`. In that case, we must
-        copy certain fields to ensure that we do not overwrite the main agent's
-        setings.
-        """
-# Disable usage of an output format which was not specifically enabled
-# by `enable_message`
-⋮----
-# Disable handling of an output format which did not specifically have
-# handling enabled via `enable_message`
-⋮----
-# Reset any previous instructions
-⋮----
-force_tools = self.config.use_tools_on_output_format
-⋮----
-output_type = get_pydantic_wrapper(output_type)
-⋮----
-name = output_type.default_value("request")
-⋮----
-use = self.config.use_output_format
-⋮----
-handle = self.config.handle_output_format
-⋮----
-is_usable = name in self.llm_tools_usable.union(
-is_handled = name in self.llm_tools_handled.union(
-⋮----
-# We must copy `llm_tools_usable` so the base agent
-# is unmodified
-⋮----
-# If handling the tool, do the same for `llm_tools_handled`
-⋮----
-# Enable `output_type`
-⋮----
-# Do not override existing settings
-⋮----
-# If the `output_type` ToilMessage was not already enabled for
-# use, this means we are ONLY enabling it for use specifically
-# for enforcing this output format, so we set the
-# `enabled_use_output_forma  to this output_type, to
-# record that it should be disabled when `output_format` is changed
-⋮----
-# (same reasoning as for use-enabling)
-⋮----
-generated_tool_instructions = name in self.llm_tools_usable.union(
-⋮----
-generated_tool_instructions = False
-⋮----
-instructions = self.config.instructions_output_format
-⋮----
-# Already generated tool instructions as part of "enabling for use",
-# so only need to generate a reminder to use this tool.
-name = cast(ToolMessage, output_type).default_value("request")
-⋮----
-output_format_schema = output_type.llm_function_schema(
-⋮----
-output_format_schema = output_type.model_json_schema()
-⋮----
-def __getitem__(self, output_type: type) -> Self
-⋮----
-"""
-        Returns a (shallow) copy of `self` with a forced output type.
-        """
-clone = copy.copy(self)
-⋮----
-"""
-        Disable this agent from RESPONDING to a `message_class` (Tool). If
-            `message_class` is None, then disable this agent from responding to ALL.
-        Args:
-            message_class: The ToolMessage class to disable; Optional.
-        """
-⋮----
-"""
-        Disable this agent from USING a message class (Tool).
-        If `message_class` is None, then disable this agent from USING ALL tools.
-        Args:
-            message_class: The ToolMessage class to disable.
-                If None, disable all.
-        """
-⋮----
-def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None
-⋮----
-"""
-        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
-        Args:
-            message_class: The only ToolMessage class to allow
-        """
-request = message_class.model_fields["request"].default
-to_remove = [r for r in self.llm_tools_usable if r != request]
-⋮----
-def _load_output_format(self, message: ChatDocument) -> None
-⋮----
-"""
-        If set, attempts to parse a value of type `self.output_format` from the message
-        contents or any tool/function call and assigns it to `content_any`.
-        """
-⋮----
-any_succeeded = False
-attempts: list[str | LLMFunctionCall] = [
-⋮----
-content = json.loads(attempt)
-⋮----
-content = attempt.arguments
-⋮----
-content_any = self.output_format.model_validate(content)
-⋮----
-message.content_any = content_any.value  # type: ignore
-⋮----
-any_succeeded = True
-⋮----
-"""
-        Extracts messages and tracks whether any errors occurred. If strict mode
-        was enabled, disables it for the tool, else triggers strict recovery.
-        """
-⋮----
-most_recent_sent_by_llm = (
-was_llm = most_recent_sent_by_llm or (
-⋮----
-tools = super().get_tool_messages(msg, all_tools)
-⋮----
-# Check if tool class was attached to the exception
-⋮----
-tool_class = ve.tool_class  # type: ignore
-⋮----
-was_strict = (
-# If the result of strict output for a tool using the
-# OpenAI tools API fails to parse, we infer that the
-# schema edits necessary for compatibility prevented
-# adherence to the underlying `ToolMessage` schema and
-# disable strict output for the tool
-⋮----
-# We will trigger the strict recovery mechanism to force
-# the LLM to correct its output, allowing us to parse
-⋮----
-def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None
-⋮----
-"""
-        Returns a `ToolMessage` which wraps all enabled tools, excluding those
-        where strict recovery is disabled. Used in strict recovery.
-        """
-possible_tools = tuple(
-⋮----
-any_tool_type = Union.__getitem__(possible_tools)  # type ignore
-⋮----
-maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
-⋮----
-class AnyTool(ToolMessage)
-⋮----
-purpose: str = "To call a tool/function."
-request: str = "tool_or_function"
-tool: maybe_optional_type  # type: ignore
-⋮----
-def response(self, agent: ChatAgent) -> None | str | ChatDocument
-⋮----
-# One-time use
-⋮----
-# As the ToolMessage schema accepts invalid
-# `tool.request` values, reparse with the
-# corresponding tool
-request = self.tool.request
-⋮----
-tool = agent.llm_tools_map[request].model_validate_json(
-⋮----
-"""Returns instructions for strict recovery."""
-optional_instructions = (
-response_prefix = "If you intended to make such a call, r" if optional else "R"
-instruction_prefix = "If you do so, b" if optional else "B"
-⋮----
-schema_instructions = (
-⋮----
-"""
-        Truncate message at idx in msg history to `tokens` tokens.
-
-        If inplace is True, the message is truncated in place, else
-        it LEAVES the original message INTACT and returns a new message
-        """
-⋮----
-llm_msg = self.message_history[idx]
-⋮----
-llm_msg = copy.deepcopy(self.message_history[idx])
-⋮----
-orig_content = llm_msg.content
-new_content = (
-⋮----
-else orig_content[: tokens * 4]  # approx truncation
-⋮----
-def _reduce_raw_tool_results(self, message: ChatDocument) -> None
-⋮----
-"""
-        If message is the result of a ToolMessage that had
-        a `_max_retained_tokens` set to a non-None value, then we replace contents
-        with a placeholder message.
-        """
-parent_message: ChatDocument | None = message.parent
-tools = [] if parent_message is None else parent_message.tool_messages
-truncate_tools = []
-⋮----
-max_retained_tokens = t._max_retained_tokens
-⋮----
-max_retained_tokens = max_retained_tokens.default
-⋮----
-limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
-⋮----
-max_retained_tokens = limiting_tool._max_retained_tokens
-⋮----
-tool_name = limiting_tool.default_value("request")
-max_tokens: int = max_retained_tokens
-truncation_warning = f"""
-⋮----
-"""
-        Respond to a single user message, appended to the message history,
-        in "chat" mode
-        Args:
-            message (str|ChatDocument): message or ChatDocument object to respond to.
-                If None, use the self.task_messages
-        Returns:
-            LLM response as a ChatDocument object
-        """
-⋮----
-# If enabled and a tool error occurred, we recover by generating the tool in
-# strict json mode
-⋮----
-AnyTool = self._get_any_tool_message()
-⋮----
-recovery_message = self._strict_recovery_instructions(AnyTool)
-augmented_message = message
-⋮----
-augmented_message = recovery_message
-⋮----
-augmented_message = augmented_message + recovery_message
-⋮----
-# only use the augmented message for this one response...
-result = self.llm_response(augmented_message)
-# ... restore the original user message so that the AnyTool recover
-# instructions don't persist in the message history
-# (this can cause the LLM to use the AnyTool directly as a tool)
-⋮----
-msg = message if isinstance(message, str) else message.content
-⋮----
-tool_choice = (
-⋮----
-response = self.llm_response_messages(hist, output_len, tool_choice)
-⋮----
-# Preserve trail of tool_ids for OpenAI Assistant fn-calls
-⋮----
-"""
-        Async version of `llm_response`. See there for details.
-        """
-⋮----
-response = await self.llm_response_messages_async(
-⋮----
-def init_message_history(self) -> None
-⋮----
-"""
-        Initialize the message history with the system message and user message
-        """
-⋮----
-"""
-        Prepare messages to be sent to self.llm_response_messages,
-            which is the main method that calls the LLM API to get a response.
-            If desired output tokens + message history exceeds the model context length,
-            then first the max output tokens is reduced to fit, and if that is not
-            possible, older messages may be truncated to accommodate at least
-            self.config.llm.min_output_tokens of output.
-
-        Returns:
-            Tuple[List[LLMMessage], int]: (messages, output_len)
-                messages = Full list of messages to send
-                output_len = max expected number of tokens in response
-        """
-⋮----
-# this means agent has been used to get LLM response already,
-# and so the last message is an "assistant" response.
-# We delete this last assistant response and re-generate it.
-⋮----
-# initial messages have not yet been loaded, so load them
-⋮----
-# for debugging, show the initial message history
-⋮----
-# update the system message with the latest tool instructions
-⋮----
-# either the message is a str, or it is a fresh ChatDocument
-# different from the last message in the history
-llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
-llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
-# Canonicalize retained whitespace-only results before token counting.
-⋮----
-# process tools if any
-done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
-⋮----
-hist = self.message_history
-output_len = self.config.llm.model_max_output_tokens
-⋮----
-CHAT_HISTORY_BUFFER = 300
-# chat + output > max context length,
-# so first try to shorten requested output len to fit;
-# use an extra margin of CHAT_HISTORY_BUFFER tokens
-# in case our calcs are off (and to allow for some extra tokens)
-output_len = (
-⋮----
-# unacceptably small output len, so compress early parts of
-# conversation history based on the configured strategy
-strategy = self.config.context_overflow_strategy
-⋮----
-# Truncate content of individual messages while preserving
-# the message sequence (important for LLM APIs that require
-# alternating USER/ASSISTANT messages)
-msg_idx_to_compress = 1  # don't touch system msg
-# we will try compressing msg indices up to but not including
-# last user msg
-last_msg_idx_to_compress = (
-n_truncated = 0
-⋮----
-# We want to preserve the first message (typically
-# system msg) and last message (user msg).
-⋮----
-# compress the msg at idx `msg_idx_to_compress`
-⋮----
-output_len = min(
-⋮----
-# we MUST have truncated at least one msg
-msg_tokens = self.chat_num_tokens()
-⋮----
-else:  # strategy == "drop_turns"
-# Drop complete conversation turns. A complete turn is defined
-# as a USER message followed by all messages until the next
-# USER message. This is more aggressive but cleaner for voice
-# agents with limited context.
-n_dropped_turns = 0
-⋮----
-# Find the last USER message index
-last_user_idx = self.last_message_idx_with_role(role=Role.USER)
-⋮----
-# Find the first complete turn to drop (skip system message)
-first_user_idx = -1
-⋮----
-first_user_idx = i
-⋮----
-# Find the end of this turn: last message before next USER
-next_user_idx = -1
-⋮----
-next_user_idx = i
-⋮----
-# Drop the turn
-⋮----
-# we MUST have dropped at least one turn
-⋮----
-# record the position of the corresponding LLMMessage in
-# the message_history
-⋮----
-"""
-        Get function/tool spec/output format arguments for
-        OpenAI-compatible LLM API call
-        """
-functions: Optional[List[LLMFunctionSpec]] = None
-fun_call: str | Dict[str, str] = "none"
-tools: Optional[List[OpenAIToolSpec]] = None
-force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
-⋮----
-functions = [
-fun_call = (
-⋮----
-def to_maybe_strict_spec(function: str) -> OpenAIToolSpec
-⋮----
-spec = self.llm_functions_map[function]
-strict = self._strict_mode_for_tool(function)
-⋮----
-strict_spec = copy.deepcopy(spec)
-⋮----
-strict_spec = spec
-⋮----
-tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
-force_tool = (
-output_format = None
-⋮----
-spec = self.output_format.llm_function_schema(
-⋮----
-output_format = OpenAIJsonSchemaSpec(
-⋮----
-# We always require that outputs strictly match the schema
-⋮----
-param_spec = self.output_format.model_json_schema()
-⋮----
-"""
-        Respond to a series of messages, e.g. with OpenAI ChatCompletion
-        Args:
-            messages: seq of messages (with role, content fields) sent to LLM
-            output_len: max number of tokens expected in response.
-                    If None, use the LLM's default model_max_output_tokens.
-        Returns:
-            Document (i.e. with fields "content", "metadata")
-        """
-⋮----
-output_len = output_len or self.config.llm.model_max_output_tokens
-streamer = noop_fn
-⋮----
-streamer = self.callbacks.start_llm_stream()
-⋮----
-with ExitStack() as stack:  # for conditionally using rich spinner
-⋮----
-# show rich spinner only if not streaming!
-# (Why? b/c the intent of showing a spinner is to "show progress",
-# and we don't need to do that when streaming, since
-# streaming output already shows progress.)
-cm = status(
-⋮----
-response = self.llm.chat(
-⋮----
-# Create temp ChatDocument for tool check, then clean up to avoid
-# polluting ObjectRegistry (see PR #939 discussion)
-temp_doc = ChatDocument.from_LLMResponse(
-⋮----
-response,  # .usage attrib is updated!
-⋮----
-chat_doc = ChatDocument.from_LLMResponse(
-⋮----
-# If using strict output format, parse the output JSON
-⋮----
-"""
-        Async version of `llm_response_messages`. See there for details.
-        """
-⋮----
-streamer_async = async_noop_fn
-⋮----
-streamer_async = await self.callbacks.start_llm_stream_async()
-⋮----
-response = await self.llm.achat(
-⋮----
-"""
-        Call a callback method, only passing 'reasoning' if it accepts it.
-
-        This provides backward compatibility for custom callbacks that don't
-        have the 'reasoning' parameter in their signature.
-
-        Args:
-            callback_name: Name of the callback method (e.g., 'show_llm_response')
-            reasoning: The reasoning content to pass if supported
-            **kwargs: Other arguments to pass to the callback
-        """
-callback = getattr(self.callbacks, callback_name, None)
-⋮----
-# Check if callback accepts 'reasoning' param or **kwargs
-⋮----
-sig = inspect.signature(callback)
-params = sig.parameters
-accepts_reasoning = "reasoning" in params or any(
-⋮----
-# If we can't inspect the signature, assume it doesn't accept reasoning
-accepts_reasoning = False
-⋮----
-is_cached = (
-⋮----
-# We would have already displayed the msg "live" ONLY if
-# streaming was enabled, AND we did not find a cached response.
-# If we are here, it means the response has not yet been displayed.
-cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
-# Track whether we created a temp ChatDocument for cleanup
-is_temp_doc = isinstance(response, LLMResponse)
-chat_doc = (
-# TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
-⋮----
-content = response.message or ""
-tools_content = response.tools_content()
-⋮----
-content = response.content
-tools_content = ""
-reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
-⋮----
-# Clean up temp ChatDocument to avoid polluting ObjectRegistry
-⋮----
-# we are in the context immediately after an LLM responded,
-# we won't have citations yet, so we're done
-⋮----
-citation = (
-⋮----
-reasoning="",  # Citations don't have reasoning
-⋮----
-def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument
-⋮----
-"""
-        Get LLM response to `prompt` (which presumably includes the `message`
-        somewhere, along with possible large "context" passages),
-        but only include `message` as the USER message, and not the
-        full `prompt`, in the message history.
-        Args:
-            message: the original, relatively short, user request or query
-            prompt: the full prompt potentially containing `message` plus context
-
-        Returns:
-            Document object containing the response.
-        """
-# we explicitly call THIS class's respond method,
-# not a derived class's (or else there would be infinite recursion!)
-with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
-⋮----
-"""
-        Async version of `_llm_response_temp_context`. See there for details.
-        """
-⋮----
-answer_doc = cast(
-⋮----
-"""
-        LLM Response to single message, and restore message_history.
-        In effect a "one-off" message & response that leaves agent
-        message history state intact.
-
-        Args:
-            message (str|ChatDocument): message to respond to.
-
-        Returns:
-            A Document object with the response.
-
-        """
-# explicitly call THIS class's respond method,
-⋮----
-n_msgs = len(self.message_history)
-⋮----
-response = cast(ChatDocument, ChatAgent.llm_response(self, message))
-# If there is a response, then we will have two additional
-# messages in the message history, i.e. the user message and the
-# assistant response. We want to (carefully) remove these two messages.
-⋮----
-msg = self.message_history.pop()
-⋮----
-"""
-        Async version of `llm_response_forget`. See there for details.
-        """
-⋮----
-response = cast(
-⋮----
-def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int
-⋮----
-"""
-        Total number of tokens in the message history so far.
-
-        Args:
-            messages: if provided, compute the number of tokens in this list of
-                messages, rather than the current message history.
-        Returns:
-            int: number of tokens in message history
-        """
-⋮----
-hist = messages if messages is not None else self.message_history
-⋮----
-def _message_num_tokens(self, message: LLMMessage) -> int
-⋮----
-"""Count tokens for a message, including serialized user attachments."""
-⋮----
-def _attachment_num_tokens(self, message: LLMMessage) -> int
-⋮----
-"""
-        Estimate attachment contribution using the serialized payload
-        that is sent in the API request for user messages.
-        """
-⋮----
-model = self._chat_model_name_for_attachments()
-⋮----
-def _chat_model_name_for_attachments(self) -> str
-⋮----
-"""Return the model name used for attachment serialization."""
-⋮----
-def message_history_str(self, i: Optional[int] = None) -> str
-⋮----
-"""
-        Return a string representation of the message history
-        Args:
-            i: if provided, return only the i-th message when i is postive,
-                or last k messages when i = -k.
-        Returns:
-        """
-⋮----
-def __del__(self) -> None
-⋮----
-"""
-        Cleanup method called when the ChatAgent is garbage collected.
-        Note: We don't close LLM clients here because they may be shared
-        across multiple agents when client caching is enabled.
-        The clients are managed centrally and cleaned up via atexit hooks.
-        """
-# Previously we closed clients here, but this caused issues when
-# multiple agents shared the same cached client instance.
-# Clients are now managed centrally in langroid.language_models.client_cache
-</file>
-
-<file path="langroid/language_models/base.py">
-logger = logging.getLogger(__name__)
-⋮----
-def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
-⋮----
-async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
-⋮----
-FunctionCallTypes = Literal["none", "auto"]
-ToolChoiceTypes = Literal["none", "auto", "required"]
-ToolTypes = Literal["function"]
-⋮----
-DEFAULT_CONTEXT_LENGTH = 16_000
-⋮----
-class StreamEventType(Enum)
-⋮----
-TEXT = 1
-FUNC_NAME = 2
-FUNC_ARGS = 3
-TOOL_NAME = 4
-TOOL_ARGS = 5
-REASONING = 6
-⋮----
-class RetryParams(BaseSettings)
-⋮----
-max_retries: int = 5
-initial_delay: float = 1.0
-exponential_base: float = 1.3
-jitter: bool = True
-⋮----
-class LLMConfig(BaseSettings)
-⋮----
-"""
-    Common configuration for all language models.
-    """
-⋮----
-type: str = "openai"
-streamer: Optional[Callable[[Any], None]] = noop_fn
-streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
-api_base: str | None = None
-formatter: None | str = None
-# specify None if you want to use the full max output tokens of the model
-max_output_tokens: int | None = 8192
-timeout: int = 20  # timeout for API requests
-chat_model: str = ""
-completion_model: str = ""
-temperature: float = 0.0
-chat_context_length: int | None = None
-async_stream_quiet: bool = False  # suppress streaming output in async mode?
-completion_context_length: int | None = None
-# if input length + max_output_tokens > context length of model,
-# we will try shortening requested output
-min_output_tokens: int = 64
-use_completion_for_chat: bool = False  # use completion model for chat?
-# use chat model for completion? For OpenAI models, this MUST be set to True!
-use_chat_for_completion: bool = True
-stream: bool = True  # stream output from API?
-# TODO: we could have a `stream_reasoning` flag here to control whether to show
-# reasoning output from reasoning models
-cache_config: None | CacheDBConfig = RedisCacheConfig()
-thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
-retry_params: RetryParams = RetryParams()
-⋮----
-@property
-    def model_max_output_tokens(self) -> int
-⋮----
-# Build fallback names by progressively stripping provider prefixes
-# (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
-# succeeds even before OpenAIGPT.__init__ strips the prefix.
-parts = self.chat_model.split("/")
-fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
-⋮----
-class LLMFunctionCall(BaseModel)
-⋮----
-"""
-    Structure of LLM response indicating it "wants" to call a function.
-    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
-    """
-⋮----
-name: str  # name of function to call
-arguments: Optional[Dict[str, Any]] = None
-⋮----
-@staticmethod
-    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall"
-⋮----
-"""
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-fun_call = LLMFunctionCall(name=message["name"])
-fun_args_str = message["arguments"]
-# sometimes may be malformed with invalid indents,
-# so we try to be safe by removing newlines.
-⋮----
-fun_args_str = fun_args_str.replace("\n", "").strip()
-dict_or_list = parse_imperfect_json(fun_args_str)
-⋮----
-fun_args = dict_or_list
-⋮----
-fun_args = None
-⋮----
-def __str__(self) -> str
-⋮----
-class LLMFunctionSpec(BaseModel)
-⋮----
-"""
-    Description of a function available for the LLM to use.
-    To be used when calling the LLM `chat()` method with the `functions` parameter.
-    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
-    """
-⋮----
-name: str
-description: str
-parameters: Dict[str, Any]
-⋮----
-class OpenAIToolCall(BaseModel)
-⋮----
-"""
-    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
-    See https://platform.openai.com/docs/api-reference/chat/create
-
-    Attributes:
-        id: The id of the tool call.
-        type: The type of the tool call;
-            only "function" is currently possible (7/26/24).
-        function: The function call.
-    """
-⋮----
-id: str | None = None
-type: ToolTypes = "function"
-function: LLMFunctionCall | None = None
-extra_content: Dict[str, Any] | None = None
-⋮----
-@staticmethod
-    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall"
-⋮----
-id = message["id"]
-type = message["type"]
-function = LLMFunctionCall.from_dict(message["function"])
-extra_content = message.get("extra_content")
-⋮----
-class OpenAIToolSpec(BaseModel)
-⋮----
-type: ToolTypes
-strict: Optional[bool] = None
-function: LLMFunctionSpec
-⋮----
-class OpenAIJsonSchemaSpec(BaseModel)
-⋮----
-def to_dict(self) -> Dict[str, Any]
-⋮----
-json_schema: Dict[str, Any] = {
-⋮----
-class LLMTokenUsage(BaseModel)
-⋮----
-"""
-    Usage of tokens by an LLM.
-    """
-⋮----
-prompt_tokens: int = 0
-cached_tokens: int = 0
-completion_tokens: int = 0
-cost: float = 0.0
-calls: int = 0  # how many API calls - not used as of 2025-04-04
-⋮----
-def reset(self) -> None
-⋮----
-@property
-    def total_tokens(self) -> int
-⋮----
-class Role(str, Enum)
-⋮----
-"""
-    Possible roles for a message in a chat.
-    """
-⋮----
-USER = "user"
-SYSTEM = "system"
-ASSISTANT = "assistant"
-FUNCTION = "function"
-TOOL = "tool"
-⋮----
-class LLMMessage(BaseModel)
-⋮----
-"""
-    Class representing an entry in the msg-history sent to the LLM API.
-    It could be one of these:
-    - a user message
-    - an LLM ("Assistant") response
-    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
-    - a result or results from executing a fn or tool-call(s)
-    """
-⋮----
-role: Role
-name: Optional[str] = None
-tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
-tool_id: str = ""  # used by OpenAIAssistant
-# None means "no content" (the model returned only a tool/function call).
-# This is distinct from "" and is dropped from the API payload by api_dict;
-# see api_dict for how a fully-empty message is handled per-API.
-content: Optional[str] = None
-files: List[FileAttachment] = []
-function_call: Optional[LLMFunctionCall] = None
-tool_calls: Optional[List[OpenAIToolCall]] = None
-timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-# link to corresponding chat document, for provenance/rewind purposes
-chat_document_id: str = ""
-⋮----
-def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]
-⋮----
-"""
-        Convert to dictionary for API request, keeping ONLY
-        the fields that are expected in an API call!
-        E.g., DROP the tool_id, since it is only for use in the Assistant API,
-            not the completion API.
-
-        Args:
-            has_system_role: whether the message has a system role (if not,
-                set to "user" role)
-        Returns:
-            dict: dictionary representation of LLM message
-        """
-d = self.model_dump()
-files: List[FileAttachment] = d.pop("files")
-⋮----
-# In there are files, then content is an array of
-# different content-parts
-⋮----
-# if there is a key k = "role" with value "system", change to "user"
-# in case has_system_role is False
-⋮----
-# drop None values since API doesn't accept them (this omits `content`
-# entirely when it is None, i.e. "no content")
-dict_no_none = {k: v for k, v in d.items() if v is not None}
-⋮----
-# OpenAI API does not like empty name
-⋮----
-# arguments must be a string
-⋮----
-# convert tool calls to API format
-⋮----
-# An empty tool-call list is not a call and conveys no useful API
-# information. Omitting it also lets the empty-message fallback
-# below produce a valid message.
-⋮----
-# A message with empty content (None was dropped above, or "") AND no
-# tool/function call would be an entirely empty message, which some APIs
-# (e.g. Gemini) reject; fall back to a single space in that case only.
-# When there IS a tool/function call, empty content is fine (and Gemini
-# 3.x in fact REQUIRES it — it rejects an assistant turn that carries
-# both a call and non-empty text content).
-has_call = bool(dict_no_none.get("tool_calls")) or (
-⋮----
-# IMPORTANT! drop fields that are not expected in API call
-⋮----
-content = "FUNC: " + json.dumps(self.function_call)
-⋮----
-content = self.content or ""
-name_str = f" ({self.name})" if self.name else ""
-⋮----
-class LLMResponse(BaseModel)
-⋮----
-"""
-    Class representing response from LLM.
-    """
-⋮----
-# None means the model returned NO content (e.g. only a tool/function
-# call), which is distinct from an empty string "". Preserving this
-# distinction lets the message be faithfully reproduced downstream
-# (see ChatDocument.content_is_none and LLMMessage.content).
-message: Optional[str] = None
-reasoning: str = ""  # optional reasoning text from reasoning models
-# Original message text including inline thought signatures (e.g.
-# <thinking>...</thinking>). Only set when reasoning was extracted
-# from the message text via get_reasoning_final(); NOT set when
-# reasoning comes from a separate API field (e.g. reasoning_content),
-# since in that case the message text never contained thought tags.
-message_with_reasoning: Optional[str] = None
-# TODO tool_id needs to generalize to multi-tool calls
-⋮----
-oai_tool_calls: Optional[List[OpenAIToolCall]] = None
-⋮----
-usage: Optional[LLMTokenUsage] = None
-cached: bool = False
-⋮----
-def tools_content(self) -> str
-⋮----
-def to_LLMMessage(self) -> LLMMessage
-⋮----
-"""Convert LLM response to an LLMMessage, to be included in the
-        message-list sent to the API.
-        This is currently NOT used in any significant way in the library, and is only
-        provided as a utility to construct a message list for the API when directly
-        working with an LLM object.
-
-        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
-        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
-        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
-        """
-⋮----
-"""
-        If `message` or `function_call` of an LLM response contains an explicit
-        recipient name, return this recipient name and `message` stripped
-        of the recipient name if specified.
-
-        Two cases:
-        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
-        (b) `message` is empty and function_call/tool_call with explicit `recipient`
-
-        Args:
-            recognize_recipient_in_content (bool): When True (default), parses
-                message text for ``TO[<recipient>]:<content>`` patterns and
-                top-level JSON ``{"recipient": "..."}`` fields. When False,
-                only function_call/tool_call ``recipient`` fields are checked.
-
-        Returns:
-            (str): name of recipient, which may be empty string if no recipient
-            (str): content of message
-
-        """
-⋮----
-# in this case we ignore message, since all information is in function_call
-msg = ""
-args = self.function_call.arguments
-recipient = ""
-⋮----
-recipient = args.get("recipient", "")
-⋮----
-msg = self.message or ""
-⋮----
-# get the first tool that has a recipient field, if any
-⋮----
-recipient = tc.function.arguments.get(
-⋮----
-)  # type: ignore
-⋮----
-# It's not a function or tool call, so continue looking to see
-# if a recipient is specified in the message.
-⋮----
-# First check if message contains "TO: <recipient> <content>"
-⋮----
-# check if there is a top level json that specifies 'recipient',
-# and retain the entire message as content.
-⋮----
-recipient_name = top_level_json_field(msg, "recipient") if msg else ""
-content = msg
-⋮----
-# Define an abstract base class for language models
-class LanguageModel(ABC)
-⋮----
-"""
-    Abstract base class for language models.
-    """
-⋮----
-# usage cost by model, accumulates here
-usage_cost_dict: Dict[str, LLMTokenUsage] = {}
-⋮----
-def __init__(self, config: LLMConfig = LLMConfig())
-⋮----
-@staticmethod
-    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]
-⋮----
-"""
-        Create a language model.
-        Args:
-            config: configuration for language model
-        Returns: instance of language model
-        """
-⋮----
-openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
-⋮----
-openai = AzureGPT
-⋮----
-openai = OpenAIGPT
-cls = dict(
-return cls(config)  # type: ignore
-⋮----
-@staticmethod
-    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]
-⋮----
-"""
-        Given an even-length sequence of strings, split into a sequence of pairs
-
-        Args:
-            lst (List[str]): sequence of strings
-
-        Returns:
-            List[Tuple[str,str]]: sequence of pairs of strings
-        """
-evens = lst[::2]
-odds = lst[1::2]
-⋮----
-"""
-        From the chat history, extract system prompt, user-assistant turns, and
-        final user msg.
-
-        Args:
-            messages (List[LLMMessage]): List of messages in the chat history
-
-        Returns:
-            Tuple[str, List[Tuple[str,str]], str]:
-                system prompt, user-assistant turns, final user msg
-
-        """
-# Handle various degenerate cases
-messages = [m for m in messages]  # copy
-DUMMY_SYS_PROMPT = "You are a helpful assistant."
-DUMMY_USER_PROMPT = "Follow the instructions above."
-⋮----
-system_prompt = messages[0].content or ""
-⋮----
-# now we have messages = [Sys,...]
-⋮----
-# now we have messages = [Sys, msg, ...]
-⋮----
-# now we have messages = [Sys, user, ...]
-⋮----
-# now we have messages = [Sys, user, ..., user]
-# so we omit the first and last elements and make pairs of user-asst messages
-conversation = [m.content or "" for m in messages[1:-1]]
-user_prompt = messages[-1].content or ""
-pairs = LanguageModel.user_assistant_pairs(conversation)
-⋮----
-@abstractmethod
-    def set_stream(self, stream: bool) -> bool
-⋮----
-"""Enable or disable streaming output from API.
-        Return previous value of stream."""
-⋮----
-@abstractmethod
-    def get_stream(self) -> bool
-⋮----
-"""Get streaming status"""
-⋮----
-@abstractmethod
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-@abstractmethod
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-"""
-        Get chat-completion response from LLM.
-
-        Args:
-            messages: message-history to send to the LLM
-            max_tokens: max tokens to generate
-            tools: tools available for the LLM to use in its response
-            tool_choice: tool call mode, one of "none", "auto", "required",
-                or a dict specifying a specific tool.
-            functions: functions available for LLM to call (deprecated)
-            function_call: function calling mode, "auto", "none", or a specific fn
-                    (deprecated)
-        """
-⋮----
-"""Async version of `chat`. See `chat` for details."""
-⋮----
-def __call__(self, prompt: str, max_tokens: int) -> LLMResponse
-⋮----
-@staticmethod
-    def _fallback_model_names(model: str) -> List[str]
-⋮----
-parts = model.split("/")
-fallbacks = []
-⋮----
-def info(self) -> ModelInfo
-⋮----
-"""Info of relevant chat model"""
-orig_model = (
-⋮----
-def completion_info(self) -> ModelInfo
-⋮----
-"""Info of relevant completion model"""
-⋮----
-def supports_functions_or_tools(self) -> bool
-⋮----
-"""
-        Does this Model's API support "native" tool-calling, i.e.
-        can we call the API with arguments that contain a list of available tools,
-        and their schemas?
-        Note that, given the plethora of LLM provider APIs this determination is
-        imperfect at best, and leans towards returning True.
-        When the API calls fails with an error indicating tools are not supported,
-        then users are encouraged to use the Langroid-based prompt-based
-        ToolMessage mechanism, which works with ANY LLM. To enable this,
-        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
-        """
-⋮----
-def chat_context_length(self) -> int
-⋮----
-def completion_context_length(self) -> int
-⋮----
-def chat_cost(self) -> Tuple[float, float, float]
-⋮----
-"""
-        Return the cost per 1000 tokens for chat completions.
-
-        Returns:
-            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
-                per 1000 tokens
-        """
-⋮----
-def reset_usage_cost(self) -> None
-⋮----
-counter = self.usage_cost_dict[mdl]
-⋮----
-"""
-        Update usage cost for this LLM.
-        Args:
-            chat (bool): whether to update for chat or completion model
-            prompts (int): number of tokens used for prompts
-            completions (int): number of tokens used for completions
-            cost (float): total token cost in USD
-        """
-mdl = self.config.chat_model if chat else self.config.completion_model
-⋮----
-@classmethod
-    def usage_cost_summary(cls) -> str
-⋮----
-s = ""
-⋮----
-@classmethod
-    def tot_tokens_cost(cls) -> Tuple[int, float]
-⋮----
-"""
-        Return total tokens used and total cost across all models.
-        """
-total_tokens = 0
-total_cost = 0.0
-⋮----
-def get_reasoning_final(self, message: str) -> Tuple[str, str]
-⋮----
-"""Extract "reasoning" and "final answer" from an LLM response, if the
-        reasoning is found within configured delimiters, like <think>, </think>.
-        E.g.,
-        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
-
-        Args:
-            message (str): message from LLM
-
-        Returns:
-            Tuple[str, str]: reasoning, final answer
-        """
-⋮----
-parts = message.split(start)
-⋮----
-"""
-        Given a chat history and a question, convert it to a standalone question.
-        Args:
-            chat_history: list of tuples of (question, answer)
-            query: follow-up question
-
-        Returns: standalone version of the question
-        """
-history = collate_chat_history(chat_history)
-⋮----
-prompt = f"""
-⋮----
-follow_up_question = f"""
-⋮----
-standalone = (
-standalone = standalone.strip()
-⋮----
-class StreamingIfAllowed
-⋮----
-"""Context to temporarily enable or disable streaming, if allowed globally via
-    `settings.stream`"""
-⋮----
-def __init__(self, llm: LanguageModel, stream: bool = True)
-⋮----
-def __enter__(self) -> None
-⋮----
-def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
 </file>
 
 <file path="tests/main/sql_chat/test_sql_chat_security.py">
@@ -70621,6 +70386,1355 @@ instruc_msg = f"""
 # user response_forget to avoid accumulating the chat history
 </file>
 
+<file path="langroid/agent/chat_agent.py">
+console = Console()
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+def _is_identified_result(message: LLMMessage) -> bool
+⋮----
+"""Whether a TOOL/FUNCTION result has its identifier and no call payload.
+
+    Such results must survive even with empty content so their calls can be
+    marked complete (issue #1063).
+    """
+has_identifier = (
+⋮----
+def _llm_message_has_payload(message: LLMMessage) -> bool
+⋮----
+"""Whether a message has the fields required for a valid history entry."""
+⋮----
+class ChatAgentConfig(AgentConfig)
+⋮----
+"""
+    Configuration for ChatAgent
+
+    Attributes:
+        system_message: system message to include in message sequence
+             (typically defines role and task of agent).
+             Used only if `task` is not specified in the constructor.
+        user_message: user message to include in message sequence.
+             Used only if `task` is not specified in the constructor.
+        use_tools: whether to use our own ToolMessages mechanism
+        handle_llm_no_tool (Any): desired agent_response when
+            LLM generates non-tool msg.
+        use_functions_api: whether to use functions/tools native to the LLM API
+                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
+        use_tools_api: When `use_functions_api` is True, if this is also True,
+            the OpenAI tool-call API is used, rather than the older/deprecated
+            function-call API. However the tool-call API has some tricky aspects,
+            hence we set this to False by default.
+        strict_recovery: whether to enable strict schema recovery when there
+            is a tool-generation error.
+        enable_orchestration_tool_handling: whether to enable handling of orchestration
+            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
+        output_format: When supported by the LLM (certain OpenAI LLMs
+            and local LLMs served by providers such as vLLM), ensures
+            that the output is a JSON matching the corresponding
+            schema via grammar-based decoding
+        handle_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for handling".
+        use_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for use" (by LLM) and
+            instructions on using T are added to the system message.
+        instructions_output_format: Controls whether we generate instructions for
+            `output_format` in the system message.
+        use_tools_on_output_format: Controls whether to automatically switch
+            to the Langroid-native tools mechanism when `output_format` is set.
+            Note that LLMs may generate tool calls which do not belong to
+            `output_format` even when strict JSON mode is enabled, so this should be
+            enabled when such tool calls are not desired.
+        output_format_include_defaults: Whether to include fields with default arguments
+            in the output schema
+        full_citations: Whether to show source reference citation + content for each
+            citation, or just the main reference citation.
+        search_for_tools_everywhere: Whether to search for tools everywhere,
+            or only in specific LLM response elements based on use_tools /
+            use_functions_api / use_tools_api config settings.
+        recognize_recipient_in_content: Whether to parse LLM response text content
+            for recipient routing patterns, specifically:
+            - ``TO[<recipient>]:<content>`` addressing format, and
+            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
+            When False, only structured routing via function_call/tool_call
+            ``recipient`` fields is recognized. Default is True.
+            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
+            which controls Task-level signals like DONE, PASS, and SEND_TO.
+            To fully disable all text-based routing, set both to False.
+        context_overflow_strategy: Strategy for handling context overflow when
+            message history exceeds model context length. Options:
+            - "truncate": Truncate content of early messages (preserves all messages
+              but with shortened content). This maintains the message sequence.
+            - "drop_turns": Drop complete conversation turns (USER + all responses
+              until next USER). More aggressive but cleaner for voice agents.
+            Default is "truncate" for backward compatibility.
+    """
+⋮----
+system_message: str = "You are a helpful assistant."
+user_message: Optional[str] = None
+handle_llm_no_tool: Any = None
+use_tools: bool = True
+use_functions_api: bool = False
+use_tools_api: bool = True
+strict_recovery: bool = True
+enable_orchestration_tool_handling: bool = True
+output_format: Optional[type] = None
+handle_output_format: bool = True
+use_output_format: bool = True
+instructions_output_format: bool = True
+output_format_include_defaults: bool = True
+use_tools_on_output_format: bool = True
+full_citations: bool = True  # show source + content for each citation?
+search_for_tools_everywhere: bool = True
+recognize_recipient_in_content: bool = True
+context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
+⋮----
+def _set_fn_or_tools(self) -> None
+⋮----
+"""
+        Enable Langroid Tool or OpenAI-like fn-calling,
+        depending on config settings.
+        """
+⋮----
+class ChatAgent(Agent)
+⋮----
+"""
+    Chat Agent interacting with external env
+    (could be human, or external tools).
+    The agent (the LLM actually) is provided with an optional "Task Spec",
+    which is a sequence of `LLMMessage`s. These are used to initialize
+    the `task_messages` of the agent.
+    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
+    The `Agent` class mainly exists to hold various common methods and attributes.
+    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
+    `llm_response` method uses "chat mode" API (i.e. one that takes a
+    message sequence rather than a single message),
+    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
+    that takes a single message).
+    """
+⋮----
+"""
+        Chat-mode agent initialized with task spec as the initial message sequence
+        Args:
+            config: settings for the agent
+
+        """
+⋮----
+# An agent's "task" is defined by a system msg and an optional user msg;
+# These are "priming" messages that kick off the agent's conversation.
+⋮----
+# if task contains a system msg, we override the config system msg
+⋮----
+# if task contains a user msg, we override the config user msg
+⋮----
+# system-level instructions for using tools/functions:
+# We maintain these as tools/functions are enabled/disabled,
+# and whenever an LLM response is sought, these are used to
+# recreate the system message (via `_create_system_and_tools_message`)
+# each time, so it reflects the current set of enabled tools/functions.
+# (a) these are general instructions on using certain tools/functions,
+#   if they are specified in a ToolMessage class as a classmethod `instructions`
+⋮----
+# (b) these are only for the builtin in Langroid TOOLS mechanism:
+⋮----
+# This variable is not None and equals a `ToolMessage` T, if and only if:
+# (a) T has been set as the output_format of this agent, AND
+# (b) T has been "enabled for use" ONLY for enforcing this output format, AND
+# (c) T has NOT been explicitly "enabled for use" by this Agent.
+⋮----
+# As above but deals with "enabled for handling" instead of "enabled for use".
+⋮----
+# instructions specifically related to enforcing `output_format`
+⋮----
+# controls whether to disable strict schemas for this agent if
+# strict mode causes exception
+⋮----
+# Tracks whether any strict tool is enabled; used to determine whether to set
+# `self.disable_strict` on an exception
+⋮----
+# Tracks the set of tools on which we force-disable strict decoding
+⋮----
+# search for tools according to the agent configuration
+⋮----
+# Only enable HANDLING by `agent_response`, NOT LLM generation of these.
+# This is useful where tool-handlers or agent_response generate these
+# tools, and need to be handled.
+# We don't want enable orch tool GENERATION by default, since that
+# might clutter-up the LLM system message unnecessarily.
+⋮----
+def init_state(self) -> None
+⋮----
+"""
+        Initialize the state of the agent. Just conversation state here,
+        but subclasses can override this to initialize other state.
+        """
+⋮----
+@staticmethod
+    def from_id(id: str) -> "ChatAgent"
+⋮----
+"""
+        Get an agent from its ID
+        Args:
+            agent_id (str): ID of the agent
+        Returns:
+            ChatAgent: The agent with the given ID
+        """
+⋮----
+def clone(self, i: int = 0) -> "ChatAgent"
+⋮----
+"""Create i'th clone of this agent, ensuring tool use/handling is cloned.
+        Important: We assume all member variables are in the __init__ method here
+        and in the Agent class.
+        TODO: We are attempting to clone an agent after its state has been
+        changed in possibly many ways. Below is an imperfect solution. Caution advised.
+        Revisit later.
+        """
+⋮----
+agent_cls = type(self)
+# Deep-copy the config WITHOUT mutating it, sharing the tool_policy
+# hook by REFERENCE (memo-seeded deepcopy): copying the policy would
+# fork any state it holds (budgets, approval lists) and can fail
+# outright on unpicklable callables (e.g. objects holding locks).
+config_copy = deepcopy_config_sharing_policy(self.config)
+⋮----
+new_agent = agent_cls(config_copy)
+⋮----
+# Ensure each clone gets its own vecdb client when supported.
+⋮----
+def _clone_extra_state(self, new_agent: "ChatAgent") -> None
+⋮----
+"""Hook for subclasses to copy additional state into clones."""
+⋮----
+def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool
+⋮----
+"""Should we enable strict mode for a given tool?"""
+⋮----
+tool_class = self.llm_tools_map[tool]
+⋮----
+tool_class = tool
+name = tool_class.default_value("request")
+⋮----
+strict: Optional[bool] = tool_class.default_value("strict")
+⋮----
+strict = self._strict_tools_available()
+⋮----
+def _fn_call_available(self) -> bool
+⋮----
+"""Does this agent's LLM support function calling?"""
+⋮----
+def _strict_tools_available(self) -> bool
+⋮----
+"""Does this agent's LLM support strict tools?"""
+⋮----
+def _json_schema_available(self) -> bool
+⋮----
+"""Does this agent's LLM support strict JSON schema output format?"""
+⋮----
+def set_system_message(self, msg: str) -> None
+⋮----
+# if there is message history, update the system message in it
+⋮----
+def set_user_message(self, msg: str) -> None
+⋮----
+@property
+    def task_messages(self) -> List[LLMMessage]
+⋮----
+"""
+        The task messages are the initial messages that define the task
+        of the agent. There will be at least a system message plus possibly a user msg.
+        Returns:
+            List[LLMMessage]: the task messages
+        """
+msgs = [self._create_system_and_tools_message()]
+⋮----
+def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None
+⋮----
+id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
+⋮----
+# dropping tool result, so ADD the corresponding tool-call back
+# to the list of pending calls!
+id = msg.tool_call_id
+⋮----
+# dropping a msg with tool-calls, so DROP these from pending list
+# as well as from id -> call map
+⋮----
+def clear_history(self, start: int = -2, end: int = -1) -> None
+⋮----
+"""
+        Clear the message history, deleting  messages from index `start`,
+        up to index `end`.
+
+        Args:
+            start (int): index of first message to delete; default = -2
+                    (i.e. delete last 2 messages, typically these
+                    are the last user and assistant messages)
+            end (int): index of last message to delete; Default = -1
+                    (i.e. delete all messages up to the last one)
+        """
+n = len(self.message_history)
+⋮----
+start = max(0, n + start)
+end_ = n if end == -1 else end + 1
+dropped = self.message_history[start:end_]
+# consider the dropped msgs in REVERSE order, so we are
+# carefully updating self.oai_tool_calls
+⋮----
+# clear out the chat document from the ObjectRegistry
+⋮----
+def update_history(self, message: str, response: str) -> None
+⋮----
+"""
+        Update the message history with the latest user message and LLM response.
+        Args:
+            message (str): user message
+            response: (str): LLM response
+        """
+⋮----
+def tool_format_rules(self) -> str
+⋮----
+"""
+        Specification of tool formatting rules
+        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
+        based on the currently enabled usable `ToolMessage`s
+
+        Returns:
+            str: formatting rules
+        """
+# ONLY Usable tools (i.e. LLM-generation allowed),
+usable_tool_classes: List[Type[ToolMessage]] = [
+⋮----
+format_instructions = "\n\n".join(
+# if any of the enabled classes has json_group_instructions, then use that,
+# else fall back to ToolMessage.json_group_instructions
+⋮----
+def tool_instructions(self) -> str
+⋮----
+"""
+        Instructions for tools or function-calls, for enabled and usable Tools.
+        These are inserted into system prompt regardless of whether we are using
+        our own ToolMessage mechanism or the LLM's function-call mechanism.
+
+        Returns:
+            str: concatenation of instructions for all usable tools
+        """
+enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
+⋮----
+instructions = []
+⋮----
+class_instructions = ""
+⋮----
+class_instructions = msg_cls.instructions()
+⋮----
+# example will be shown in tool_format_rules() when using TOOLs,
+# so we don't need to show it here.
+example = "" if self.config.use_tools else (msg_cls.usage_examples())
+⋮----
+example = "EXAMPLES:\n" + example
+guidance = (
+⋮----
+instructions_str = "\n\n".join(instructions)
+⋮----
+def augment_system_message(self, message: str) -> None
+⋮----
+"""
+        Augment the system message with the given message.
+        Args:
+            message (str): system message
+        """
+⋮----
+def last_message_with_role(self, role: Role) -> LLMMessage | None
+⋮----
+"""from `message_history`, return the last message with role `role`"""
+n_role_msgs = len([m for m in self.message_history if m.role == role])
+⋮----
+idx = self.nth_message_idx_with_role(role, n_role_msgs)
+⋮----
+def last_message_idx_with_role(self, role: Role) -> int
+⋮----
+"""Index of last message in message_history, with specified role.
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+indices_with_role = [
+⋮----
+def nth_message_idx_with_role(self, role: Role, n: int) -> int
+⋮----
+"""Index of `n`th message in message_history, with specified role.
+        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+⋮----
+def update_last_message(self, message: str, role: str = Role.USER) -> None
+⋮----
+"""
+        Update the last message that has role `role` in the message history.
+        Useful when we want to replace a long user prompt, that may contain context
+        documents plus a question, with just the question.
+        Args:
+            message (str): new message to replace with
+            role (str): role of message to replace
+        """
+⋮----
+# find last message in self.message_history with role `role`
+⋮----
+def delete_last_message(self, role: str = Role.USER) -> None
+⋮----
+"""
+        Delete the last message that has role `role` from the message history.
+        Args:
+            role (str): role of message to delete
+        """
+⋮----
+def _create_system_and_tools_message(self) -> LLMMessage
+⋮----
+"""
+        (Re-)Create the system message for the LLM of the agent,
+        taking into account any tool instructions that have been added
+        after the agent was initialized.
+
+        The system message will consist of:
+        (a) the system message from the `task` arg in constructor, if any,
+            otherwise the default system message from the config
+        (b) the system tool instructions, if any
+        (c) the system json tool instructions, if any
+
+        Returns:
+            LLMMessage object
+        """
+content = self.system_message
+⋮----
+# remove leading and trailing newlines and other whitespace
+⋮----
+def handle_message_fallback(self, msg: str | ChatDocument) -> Any
+⋮----
+"""
+        Fallback method for the "no-tools" scenario, i.e., the current `msg`
+        (presumably emitted by the LLM) does not have any tool that the agent
+        can handle.
+        NOTE: The `msg` may contain tools but either (a) the agent is not
+        enabled to handle them, or (b) there's an explicit `recipient` field
+        in the tool that doesn't match the agent's name.
+
+        Uses the self.config.non_tool_routing to determine the action to take.
+
+        This method can be overridden by subclasses, e.g.,
+        to create a "reminder" message when a tool is expected but the LLM "forgot"
+        to generate one.
+
+        Args:
+            msg (str | ChatDocument): The input msg to handle
+        Returns:
+            Any: The result of the handler method
+        """
+⋮----
+# we ONLY use the `handle_llm_no_tool` config option when
+# the msg is from LLM and does not contain ANY tools at all.
+⋮----
+no_tool_option = self.config.handle_llm_no_tool
+⋮----
+# in case the `no_tool_option` is one of the special NonToolAction vals
+⋮----
+# Otherwise just return `no_tool_option` as is:
+# This can be any string, such as a specific nudge/reminder to the LLM,
+# or even something like ResultTool etc.
+⋮----
+def unhandled_tools(self) -> set[str]
+⋮----
+"""The set of tools that are known but not handled.
+        Useful in task flow: an agent can refuse to accept an incoming msg
+        when it only has unhandled tools.
+        """
+⋮----
+"""
+        Add the tool (message class) to the agent, and enable either
+        - tool USE (i.e. the LLM can generate JSON to use this tool),
+        - tool HANDLING (i.e. the agent can handle JSON from this tool),
+
+        Args:
+            message_class: The ToolMessage class OR List of such classes to enable,
+                for USE, or HANDLING, or both.
+                If this is a list of ToolMessage classes, then the remain args are
+                applied to all classes.
+                Optional; if None, then apply the enabling to all tools in the
+                agent's toolset that have been enabled so far.
+            use: IF True, allow the agent (LLM) to use this tool (or all tools),
+                else disallow
+            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
+                tool (or all tools)
+            force: whether to FORCE the agent (LLM) to USE the specific
+                 tool represented by `message_class`.
+                 `force` is ignored if `message_class` is None.
+            require_recipient: whether to require that recipient be specified
+                when using the tool message (only applies if `use` is True).
+            include_defaults: whether to include fields that have default values,
+                in the "properties" section of the JSON format instructions.
+                (Normally the OpenAI completion API ignores these fields,
+                but the Assistant fn-calling seems to pay attn to these,
+                and if we don't want this, we should set this to False.)
+        """
+⋮----
+# Validate that use/handle are booleans, not accidentally passed tool classes
+⋮----
+param = "use" if isclass(use) else "handle"
+⋮----
+message_class = message_class.require_recipient()
+⋮----
+# XMLToolMessage is not compatible with OpenAI's Tools/functions API,
+# so we disable use of functions API, enable langroid-native Tools,
+# which are prompt-based.
+⋮----
+super().enable_message_handling(message_class)  # enables handling only
+tools = self._get_tool_list(message_class)
+⋮----
+request = message_class.default_value("request")
+⋮----
+llm_function = message_class.llm_function_schema(defaults=include_defaults)
+⋮----
+# `t` was designated as "enabled for handling" ONLY for
+# output_format enforcement, but we are explicitly ]
+# enabling it for handling here, so we set the variable to None.
+⋮----
+tool_class = self.llm_tools_map[t]
+allow_llm_use = tool_class._allow_llm_use
+⋮----
+allow_llm_use = allow_llm_use.default
+⋮----
+# `t` was designated as "enabled for use" ONLY for output_format
+# enforcement, but we are explicitly enabling it for use here,
+# so we set the variable to None.
+⋮----
+def _update_tool_instructions(self) -> None
+⋮----
+# Set tool instructions and JSON format instructions,
+# in case Tools have been enabled/disabled.
+⋮----
+def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]
+⋮----
+"""
+        Returns the current set of enabled requests for inference and tools configs.
+        Used for restoring setings overriden by `set_output_format`.
+        """
+⋮----
+@property
+    def all_llm_tools_known(self) -> set[str]
+⋮----
+"""All known tools; we include `output_format` if it is a `ToolMessage`."""
+known = self.llm_tools_known
+⋮----
+"""
+        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
+        switches to the native Langroid tools mechanism to ensure that no tool
+        calls not of `output_type` are generated. By default, `force_tools`
+        follows the `use_tools_on_output_format` parameter in the config.
+
+        If `output_type` is None, restores to the state prior to setting
+        `output_format`.
+
+        If `use`, we enable use of `output_type` when it is a subclass
+        of `ToolMesage`. Note that this primarily controls instruction
+        generation: the model will always generate `output_type` regardless
+        of whether `use` is set. Defaults to the `use_output_format`
+        parameter in the config. Similarly, handling of `output_type` is
+        controlled by `handle`, which defaults to the
+        `handle_output_format` parameter in the config.
+
+        `instructions` controls whether we generate instructions specifying
+        the output format schema. Defaults to the `instructions_output_format`
+        parameter in the config.
+
+        `is_copy` is set when called via `__getitem__`. In that case, we must
+        copy certain fields to ensure that we do not overwrite the main agent's
+        setings.
+        """
+# Disable usage of an output format which was not specifically enabled
+# by `enable_message`
+⋮----
+# Disable handling of an output format which did not specifically have
+# handling enabled via `enable_message`
+⋮----
+# Reset any previous instructions
+⋮----
+force_tools = self.config.use_tools_on_output_format
+⋮----
+output_type = get_pydantic_wrapper(output_type)
+⋮----
+name = output_type.default_value("request")
+⋮----
+use = self.config.use_output_format
+⋮----
+handle = self.config.handle_output_format
+⋮----
+is_usable = name in self.llm_tools_usable.union(
+is_handled = name in self.llm_tools_handled.union(
+⋮----
+# We must copy `llm_tools_usable` so the base agent
+# is unmodified
+⋮----
+# If handling the tool, do the same for `llm_tools_handled`
+⋮----
+# Enable `output_type`
+⋮----
+# Do not override existing settings
+⋮----
+# If the `output_type` ToilMessage was not already enabled for
+# use, this means we are ONLY enabling it for use specifically
+# for enforcing this output format, so we set the
+# `enabled_use_output_forma  to this output_type, to
+# record that it should be disabled when `output_format` is changed
+⋮----
+# (same reasoning as for use-enabling)
+⋮----
+generated_tool_instructions = name in self.llm_tools_usable.union(
+⋮----
+generated_tool_instructions = False
+⋮----
+instructions = self.config.instructions_output_format
+⋮----
+# Already generated tool instructions as part of "enabling for use",
+# so only need to generate a reminder to use this tool.
+name = cast(ToolMessage, output_type).default_value("request")
+⋮----
+output_format_schema = output_type.llm_function_schema(
+⋮----
+output_format_schema = output_type.model_json_schema()
+⋮----
+def __getitem__(self, output_type: type) -> Self
+⋮----
+"""
+        Returns a (shallow) copy of `self` with a forced output type.
+        """
+clone = copy.copy(self)
+⋮----
+"""
+        Disable this agent from RESPONDING to a `message_class` (Tool). If
+            `message_class` is None, then disable this agent from responding to ALL.
+        Args:
+            message_class: The ToolMessage class to disable; Optional.
+        """
+⋮----
+"""
+        Disable this agent from USING a message class (Tool).
+        If `message_class` is None, then disable this agent from USING ALL tools.
+        Args:
+            message_class: The ToolMessage class to disable.
+                If None, disable all.
+        """
+⋮----
+def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None
+⋮----
+"""
+        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
+        Args:
+            message_class: The only ToolMessage class to allow
+        """
+request = message_class.model_fields["request"].default
+to_remove = [r for r in self.llm_tools_usable if r != request]
+⋮----
+def _load_output_format(self, message: ChatDocument) -> None
+⋮----
+"""
+        If set, attempts to parse a value of type `self.output_format` from the message
+        contents or any tool/function call and assigns it to `content_any`.
+        """
+⋮----
+any_succeeded = False
+attempts: list[str | LLMFunctionCall] = [
+⋮----
+content = json.loads(attempt)
+⋮----
+content = attempt.arguments
+⋮----
+content_any = self.output_format.model_validate(content)
+⋮----
+message.content_any = content_any.value  # type: ignore
+⋮----
+any_succeeded = True
+⋮----
+"""
+        Extracts messages and tracks whether any errors occurred. If strict mode
+        was enabled, disables it for the tool, else triggers strict recovery.
+        """
+⋮----
+most_recent_sent_by_llm = (
+was_llm = most_recent_sent_by_llm or (
+⋮----
+tools = super().get_tool_messages(msg, all_tools)
+⋮----
+# Check if tool class was attached to the exception
+⋮----
+tool_class = ve.tool_class  # type: ignore
+⋮----
+was_strict = (
+# If the result of strict output for a tool using the
+# OpenAI tools API fails to parse, we infer that the
+# schema edits necessary for compatibility prevented
+# adherence to the underlying `ToolMessage` schema and
+# disable strict output for the tool
+⋮----
+# We will trigger the strict recovery mechanism to force
+# the LLM to correct its output, allowing us to parse
+⋮----
+def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None
+⋮----
+"""
+        Returns a `ToolMessage` which wraps all enabled tools, excluding those
+        where strict recovery is disabled. Used in strict recovery.
+        """
+possible_tools = tuple(
+⋮----
+any_tool_type = Union.__getitem__(possible_tools)  # type ignore
+⋮----
+maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
+⋮----
+class AnyTool(ToolMessage)
+⋮----
+purpose: str = "To call a tool/function."
+request: str = "tool_or_function"
+tool: maybe_optional_type  # type: ignore
+⋮----
+# One-time use
+⋮----
+# As the ToolMessage schema accepts invalid
+# `tool.request` values, reparse with the
+# corresponding tool
+request = self.tool.request
+⋮----
+tool = agent.llm_tools_map[request].model_validate_json(
+⋮----
+# pass the chat_doc through, so the recovered tool's policy
+# check sees the same message context a normal dispatch would
+⋮----
+# This wrapper is a parsing shim for strict recovery, NOT a tool
+# execution, so it is exempt from the `tool_policy` hook -- which
+# also guarantees `set_output_format(None)` above always runs. The
+# re-parsed ACTUAL tool is dispatched through the policy-checked
+# path, so the policy is consulted exactly once per logical call.
+AnyTool._tool_policy_exempt = True  # type: ignore[attr-defined]
+⋮----
+"""Returns instructions for strict recovery."""
+optional_instructions = (
+response_prefix = "If you intended to make such a call, r" if optional else "R"
+instruction_prefix = "If you do so, b" if optional else "B"
+⋮----
+schema_instructions = (
+⋮----
+"""
+        Truncate message at idx in msg history to `tokens` tokens.
+
+        If inplace is True, the message is truncated in place, else
+        it LEAVES the original message INTACT and returns a new message
+        """
+⋮----
+llm_msg = self.message_history[idx]
+⋮----
+llm_msg = copy.deepcopy(self.message_history[idx])
+⋮----
+orig_content = llm_msg.content
+new_content = (
+⋮----
+else orig_content[: tokens * 4]  # approx truncation
+⋮----
+def _reduce_raw_tool_results(self, message: ChatDocument) -> None
+⋮----
+"""
+        If message is the result of a ToolMessage that had
+        a `_max_retained_tokens` set to a non-None value, then we replace contents
+        with a placeholder message.
+        """
+parent_message: ChatDocument | None = message.parent
+tools = [] if parent_message is None else parent_message.tool_messages
+truncate_tools = []
+⋮----
+max_retained_tokens = t._max_retained_tokens
+⋮----
+max_retained_tokens = max_retained_tokens.default
+⋮----
+limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
+⋮----
+max_retained_tokens = limiting_tool._max_retained_tokens
+⋮----
+tool_name = limiting_tool.default_value("request")
+max_tokens: int = max_retained_tokens
+truncation_warning = f"""
+⋮----
+"""
+        Respond to a single user message, appended to the message history,
+        in "chat" mode
+        Args:
+            message (str|ChatDocument): message or ChatDocument object to respond to.
+                If None, use the self.task_messages
+        Returns:
+            LLM response as a ChatDocument object
+        """
+⋮----
+# If enabled and a tool error occurred, we recover by generating the tool in
+# strict json mode
+⋮----
+AnyTool = self._get_any_tool_message()
+⋮----
+recovery_message = self._strict_recovery_instructions(AnyTool)
+augmented_message = message
+⋮----
+augmented_message = recovery_message
+⋮----
+augmented_message = augmented_message + recovery_message
+⋮----
+# only use the augmented message for this one response...
+result = self.llm_response(augmented_message)
+# ... restore the original user message so that the AnyTool recover
+# instructions don't persist in the message history
+# (this can cause the LLM to use the AnyTool directly as a tool)
+⋮----
+msg = message if isinstance(message, str) else message.content
+⋮----
+tool_choice = (
+⋮----
+response = self.llm_response_messages(hist, output_len, tool_choice)
+⋮----
+# Preserve trail of tool_ids for OpenAI Assistant fn-calls
+⋮----
+"""
+        Async version of `llm_response`. See there for details.
+        """
+⋮----
+response = await self.llm_response_messages_async(
+⋮----
+def init_message_history(self) -> None
+⋮----
+"""
+        Initialize the message history with the system message and user message
+        """
+⋮----
+"""
+        Prepare messages to be sent to self.llm_response_messages,
+            which is the main method that calls the LLM API to get a response.
+            If desired output tokens + message history exceeds the model context length,
+            then first the max output tokens is reduced to fit, and if that is not
+            possible, older messages may be truncated to accommodate at least
+            self.config.llm.min_output_tokens of output.
+
+        Returns:
+            Tuple[List[LLMMessage], int]: (messages, output_len)
+                messages = Full list of messages to send
+                output_len = max expected number of tokens in response
+        """
+⋮----
+# this means agent has been used to get LLM response already,
+# and so the last message is an "assistant" response.
+# We delete this last assistant response and re-generate it.
+⋮----
+# initial messages have not yet been loaded, so load them
+⋮----
+# for debugging, show the initial message history
+⋮----
+# update the system message with the latest tool instructions
+⋮----
+# either the message is a str, or it is a fresh ChatDocument
+# different from the last message in the history
+llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
+llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
+# Canonicalize retained whitespace-only results before token counting.
+⋮----
+# process tools if any
+done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
+⋮----
+hist = self.message_history
+output_len = self.config.llm.model_max_output_tokens
+⋮----
+CHAT_HISTORY_BUFFER = 300
+# chat + output > max context length,
+# so first try to shorten requested output len to fit;
+# use an extra margin of CHAT_HISTORY_BUFFER tokens
+# in case our calcs are off (and to allow for some extra tokens)
+output_len = (
+⋮----
+# unacceptably small output len, so compress early parts of
+# conversation history based on the configured strategy
+strategy = self.config.context_overflow_strategy
+⋮----
+# Truncate content of individual messages while preserving
+# the message sequence (important for LLM APIs that require
+# alternating USER/ASSISTANT messages)
+msg_idx_to_compress = 1  # don't touch system msg
+# we will try compressing msg indices up to but not including
+# last user msg
+last_msg_idx_to_compress = (
+n_truncated = 0
+⋮----
+# We want to preserve the first message (typically
+# system msg) and last message (user msg).
+⋮----
+# compress the msg at idx `msg_idx_to_compress`
+⋮----
+output_len = min(
+⋮----
+# we MUST have truncated at least one msg
+msg_tokens = self.chat_num_tokens()
+⋮----
+else:  # strategy == "drop_turns"
+# Drop complete conversation turns. A complete turn is defined
+# as a USER message followed by all messages until the next
+# USER message. This is more aggressive but cleaner for voice
+# agents with limited context.
+n_dropped_turns = 0
+⋮----
+# Find the last USER message index
+last_user_idx = self.last_message_idx_with_role(role=Role.USER)
+⋮----
+# Find the first complete turn to drop (skip system message)
+first_user_idx = -1
+⋮----
+first_user_idx = i
+⋮----
+# Find the end of this turn: last message before next USER
+next_user_idx = -1
+⋮----
+next_user_idx = i
+⋮----
+# Drop the turn
+⋮----
+# we MUST have dropped at least one turn
+⋮----
+# record the position of the corresponding LLMMessage in
+# the message_history
+⋮----
+"""
+        Get function/tool spec/output format arguments for
+        OpenAI-compatible LLM API call
+        """
+functions: Optional[List[LLMFunctionSpec]] = None
+fun_call: str | Dict[str, str] = "none"
+tools: Optional[List[OpenAIToolSpec]] = None
+force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
+⋮----
+functions = [
+fun_call = (
+⋮----
+def to_maybe_strict_spec(function: str) -> OpenAIToolSpec
+⋮----
+spec = self.llm_functions_map[function]
+strict = self._strict_mode_for_tool(function)
+⋮----
+strict_spec = copy.deepcopy(spec)
+⋮----
+strict_spec = spec
+⋮----
+tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
+force_tool = (
+output_format = None
+⋮----
+spec = self.output_format.llm_function_schema(
+⋮----
+output_format = OpenAIJsonSchemaSpec(
+⋮----
+# We always require that outputs strictly match the schema
+⋮----
+param_spec = self.output_format.model_json_schema()
+⋮----
+"""
+        Respond to a series of messages, e.g. with OpenAI ChatCompletion
+        Args:
+            messages: seq of messages (with role, content fields) sent to LLM
+            output_len: max number of tokens expected in response.
+                    If None, use the LLM's default model_max_output_tokens.
+        Returns:
+            Document (i.e. with fields "content", "metadata")
+        """
+⋮----
+output_len = output_len or self.config.llm.model_max_output_tokens
+streamer = noop_fn
+⋮----
+streamer = self.callbacks.start_llm_stream()
+⋮----
+with ExitStack() as stack:  # for conditionally using rich spinner
+⋮----
+# show rich spinner only if not streaming!
+# (Why? b/c the intent of showing a spinner is to "show progress",
+# and we don't need to do that when streaming, since
+# streaming output already shows progress.)
+cm = status(
+⋮----
+response = self.llm.chat(
+⋮----
+# Create temp ChatDocument for tool check, then clean up to avoid
+# polluting ObjectRegistry (see PR #939 discussion)
+temp_doc = ChatDocument.from_LLMResponse(
+⋮----
+response,  # .usage attrib is updated!
+⋮----
+chat_doc = ChatDocument.from_LLMResponse(
+⋮----
+# If using strict output format, parse the output JSON
+⋮----
+"""
+        Async version of `llm_response_messages`. See there for details.
+        """
+⋮----
+streamer_async = async_noop_fn
+⋮----
+streamer_async = await self.callbacks.start_llm_stream_async()
+⋮----
+response = await self.llm.achat(
+⋮----
+"""
+        Call a callback method, only passing 'reasoning' if it accepts it.
+
+        This provides backward compatibility for custom callbacks that don't
+        have the 'reasoning' parameter in their signature.
+
+        Args:
+            callback_name: Name of the callback method (e.g., 'show_llm_response')
+            reasoning: The reasoning content to pass if supported
+            **kwargs: Other arguments to pass to the callback
+        """
+callback = getattr(self.callbacks, callback_name, None)
+⋮----
+# Check if callback accepts 'reasoning' param or **kwargs
+⋮----
+sig = inspect.signature(callback)
+params = sig.parameters
+accepts_reasoning = "reasoning" in params or any(
+⋮----
+# If we can't inspect the signature, assume it doesn't accept reasoning
+accepts_reasoning = False
+⋮----
+is_cached = (
+⋮----
+# We would have already displayed the msg "live" ONLY if
+# streaming was enabled, AND we did not find a cached response.
+# If we are here, it means the response has not yet been displayed.
+cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
+# Track whether we created a temp ChatDocument for cleanup
+is_temp_doc = isinstance(response, LLMResponse)
+chat_doc = (
+# TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
+⋮----
+content = response.message or ""
+tools_content = response.tools_content()
+⋮----
+content = response.content
+tools_content = ""
+reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
+⋮----
+# Clean up temp ChatDocument to avoid polluting ObjectRegistry
+⋮----
+# we are in the context immediately after an LLM responded,
+# we won't have citations yet, so we're done
+⋮----
+citation = (
+⋮----
+reasoning="",  # Citations don't have reasoning
+⋮----
+def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument
+⋮----
+"""
+        Get LLM response to `prompt` (which presumably includes the `message`
+        somewhere, along with possible large "context" passages),
+        but only include `message` as the USER message, and not the
+        full `prompt`, in the message history.
+        Args:
+            message: the original, relatively short, user request or query
+            prompt: the full prompt potentially containing `message` plus context
+
+        Returns:
+            Document object containing the response.
+        """
+# we explicitly call THIS class's respond method,
+# not a derived class's (or else there would be infinite recursion!)
+with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
+⋮----
+"""
+        Async version of `_llm_response_temp_context`. See there for details.
+        """
+⋮----
+answer_doc = cast(
+⋮----
+"""
+        LLM Response to single message, and restore message_history.
+        In effect a "one-off" message & response that leaves agent
+        message history state intact.
+
+        Args:
+            message (str|ChatDocument): message to respond to.
+
+        Returns:
+            A Document object with the response.
+
+        """
+# explicitly call THIS class's respond method,
+⋮----
+n_msgs = len(self.message_history)
+⋮----
+response = cast(ChatDocument, ChatAgent.llm_response(self, message))
+# If there is a response, then we will have two additional
+# messages in the message history, i.e. the user message and the
+# assistant response. We want to (carefully) remove these two messages.
+⋮----
+msg = self.message_history.pop()
+⋮----
+"""
+        Async version of `llm_response_forget`. See there for details.
+        """
+⋮----
+response = cast(
+⋮----
+def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int
+⋮----
+"""
+        Total number of tokens in the message history so far.
+
+        Args:
+            messages: if provided, compute the number of tokens in this list of
+                messages, rather than the current message history.
+        Returns:
+            int: number of tokens in message history
+        """
+⋮----
+hist = messages if messages is not None else self.message_history
+⋮----
+def _message_num_tokens(self, message: LLMMessage) -> int
+⋮----
+"""Count tokens for a message, including serialized user attachments."""
+⋮----
+def _attachment_num_tokens(self, message: LLMMessage) -> int
+⋮----
+"""
+        Estimate attachment contribution using the serialized payload
+        that is sent in the API request for user messages.
+        """
+⋮----
+model = self._chat_model_name_for_attachments()
+⋮----
+def _chat_model_name_for_attachments(self) -> str
+⋮----
+"""Return the model name used for attachment serialization."""
+⋮----
+def message_history_str(self, i: Optional[int] = None) -> str
+⋮----
+"""
+        Return a string representation of the message history
+        Args:
+            i: if provided, return only the i-th message when i is postive,
+                or last k messages when i = -k.
+        Returns:
+        """
+⋮----
+def __del__(self) -> None
+⋮----
+"""
+        Cleanup method called when the ChatAgent is garbage collected.
+        Note: We don't close LLM clients here because they may be shared
+        across multiple agents when client caching is enabled.
+        The clients are managed centrally and cleaned up via atexit hooks.
+        """
+# Previously we closed clients here, but this caused issues when
+# multiple agents shared the same cached client instance.
+# Clients are now managed centrally in langroid.language_models.client_cache
+</file>
+
+<file path="langroid/language_models/model_info.py">
+logger = logging.getLogger(__name__)
+⋮----
+class ModelProvider(str, Enum)
+⋮----
+"""Enum for model providers"""
+⋮----
+OPENAI = "openai"
+ANTHROPIC = "anthropic"
+DEEPSEEK = "deepseek"
+GOOGLE = "google"
+MINIMAX = "minimax"
+UNKNOWN = "unknown"
+⋮----
+class ModelName(str, Enum)
+⋮----
+"""Parent class for all model name enums"""
+⋮----
+class OpenAIChatModel(ModelName)
+⋮----
+"""Enum for OpenAI Chat models"""
+⋮----
+GPT3_5_TURBO = "gpt-3.5-turbo"
+GPT4 = "gpt-4o"  # avoid deprecated gpt-4
+GPT4_TURBO = "gpt-4-turbo"
+GPT4o = "gpt-4o"
+GPT4o_MINI = "gpt-4o-mini"
+O1 = "o1"
+O1_MINI = "o1-mini"
+O3_MINI = "o3-mini"
+O3 = "o3"
+O4_MINI = "o4-mini"
+GPT4_1 = "gpt-4.1"
+GPT4_1_MINI = "gpt-4.1-mini"
+GPT4_1_NANO = "gpt-4.1-nano"
+GPT5 = "gpt-5"
+GPT5_MINI = "gpt-5-mini"
+GPT5_NANO = "gpt-5-nano"
+GPT5_PRO = "gpt-5-pro"
+GPT5_1 = "gpt-5.1"
+GPT5_1_CODEX = "gpt-5.1-codex"
+GPT5_1_CODEX_MINI = "gpt-5.1-codex-mini"
+GPT5_1_CHAT = "gpt-5.1-chat"
+GPT5_2 = "gpt-5.2"
+GPT5_2_PRO = "gpt-5.2-pro"
+GPT5_2_CHAT = "gpt-5.2-chat"
+GPT_OSS_120b = "gpt-oss-120b"
+GPT_OSS_20b = "gpt-oss-20b"
+⋮----
+class OpenAICompletionModel(str, Enum)
+⋮----
+"""Enum for OpenAI Completion models"""
+⋮----
+DAVINCI = "davinci-002"
+BABBAGE = "babbage-002"
+⋮----
+class AnthropicModel(ModelName)
+⋮----
+"""Enum for Anthropic models"""
+⋮----
+CLAUDE_3_OPUS = "claude-3-opus-latest"
+CLAUDE_3_SONNET = "claude-3-sonnet-latest"
+CLAUDE_3_HAIKU = "claude-3-haiku-latest"
+CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest"
+CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest"
+CLAUDE_4_OPUS = "claude-opus-4"
+CLAUDE_4_SONNET = "claude-sonnet-4"
+CLAUDE_4_HAIKU = "claude-haiku-4"
+CLAUDE_4_5_OPUS = "claude-opus-4-5"
+CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
+CLAUDE_4_5_HAIKU = "claude-haiku-4-5"
+⋮----
+class DeepSeekModel(ModelName)
+⋮----
+"""Enum for DeepSeek models direct from DeepSeek API"""
+⋮----
+DEEPSEEK = "deepseek/deepseek-chat"
+DEEPSEEK_R1 = "deepseek/deepseek-reasoner"
+OPENROUTER_DEEPSEEK_R1 = "openrouter/deepseek/deepseek-r1"
+⋮----
+class GeminiModel(ModelName)
+⋮----
+"""Enum for Gemini models"""
+⋮----
+GEMINI_1_5_FLASH = "gemini-1.5-flash"
+GEMINI_1_5_FLASH_8B = "gemini-1.5-flash-8b"
+GEMINI_1_5_PRO = "gemini-1.5-pro"
+GEMINI_2_FLASH = "gemini-2.0-flash"
+GEMINI_2_FLASH_LITE = "gemini-2.0-flash-lite"
+GEMINI_2_FLASH_THINKING = "gemini-2.0-flash-thinking-exp"
+GEMINI_2_PRO = "gemini-2.0-pro-exp-02-05"
+GEMINI_2_5_FLASH = "gemini-2.5-flash"
+GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
+GEMINI_2_5_PRO = "gemini-2.5-pro"
+GEMINI_3_FLASH = "gemini-3-flash"
+GEMINI_3_PRO = "gemini-3-pro"
+⋮----
+class MiniMaxModel(ModelName)
+⋮----
+"""Enum for MiniMax models"""
+⋮----
+MINIMAX_M2_7 = "MiniMax-M2.7"
+MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
+MINIMAX_M2_5 = "MiniMax-M2.5"
+MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
+MINIMAX_M2_1 = "MiniMax-M2.1"
+MINIMAX_M2_1_HIGHSPEED = "MiniMax-M2.1-highspeed"
+MINIMAX_M2 = "MiniMax-M2"
+⋮----
+class OpenAI_API_ParamInfo(BaseModel)
+⋮----
+"""
+    Parameters exclusive to some models, when using OpenAI API
+    """
+⋮----
+# model-specific params at top level
+params: Dict[str, List[str]] = dict(
+# model-specific params in extra_body
+extra_parameters: Dict[str, List[str]] = dict(
+⋮----
+class ModelInfo(BaseModel)
+⋮----
+"""
+    Consolidated information about LLM, related to capacity, cost and API
+    idiosyncrasies. Reasonable defaults for all params in case there's no
+    specific info available.
+    """
+⋮----
+name: str = "unknown"
+provider: ModelProvider = ModelProvider.UNKNOWN
+context_length: int = 16_000
+max_cot_tokens: int = 0  # max chain of thought (thinking) tokens where applicable
+max_output_tokens: int = 8192  # Maximum number of output tokens - model dependent
+input_cost_per_million: float = 0.0  # Cost in USD per million input tokens
+cached_cost_per_million: float = 0.0  # Cost in USD per million cached tokens
+output_cost_per_million: float = 0.0  # Cost in USD per million output tokens
+allows_streaming: bool = True  # Whether model supports streaming output
+allows_system_message: bool = True  # Whether model supports system messages
+rename_params: Dict[str, str] = {}  # Rename parameters for OpenAI API
+unsupported_params: List[str] = []
+has_structured_output: bool = False  # Does model API support structured output?
+has_tools: bool = True  # Does model API support tools/function-calling?
+needs_first_user_message: bool = False  # Does API need first msg to be from user?
+description: Optional[str] = None
+⋮----
+GEMINI_CANONICAL_MODEL_NAMES = {model.value for model in GeminiModel}
+DEFAULT_MODEL_INFO = ModelInfo()
+WARNED_UNKNOWN_MODELS: set[tuple[str, ...]] = set()
+⋮----
+# Model information registry
+MODEL_INFO: Dict[str, ModelInfo] = {
+⋮----
+# OpenAI Models
+⋮----
+# Anthropic Models
+⋮----
+# DeepSeek Models
+⋮----
+# Gemini Models
+⋮----
+# Gemini 2.5 Models
+⋮----
+# Gemini 3 Models
+⋮----
+# MiniMax Models
+⋮----
+"""Get model information by name or enum value"""
+# Sequence of models to try, starting with the primary model
+models_to_try = [model] + fallback_models
+⋮----
+# Find the first model in the sequence that has info defined using next()
+# on a generator expression that filters out None results from _get_model_info
+found_info = next(
+⋮----
+None,  # Default value if the iterator is exhausted (no valid info found)
+⋮----
+normalized_models = _normalize_model_names(models_to_try)
+⋮----
+def _get_model_info(model: str | ModelName) -> ModelInfo | None
+⋮----
+def _normalize_model_names(models: List[str | ModelName]) -> List[str]
+⋮----
+normalized_models: List[str] = []
+seen: set[str] = set()
+⋮----
+normalized_model = _normalize_gemini_model_name(_model_name(model))
+⋮----
+def _normalize_gemini_model_name(model: str) -> str | None
+⋮----
+base_model = model.rsplit("/", 1)[-1]
+⋮----
+# Try stripping known suffixes to find a canonical name.
+# Use split (not endswith) for "-preview" so dated variants like
+# "gemini-2.5-flash-lite-preview-06-17" are handled correctly.
+⋮----
+stripped = base_model.split(suffix, maxsplit=1)[0]
+⋮----
+def _warn_unknown_model(models: List[str | ModelName]) -> None
+⋮----
+model_names = tuple(_model_name(model) for model in models)
+⋮----
+def _model_name(model: str | ModelName) -> str
+</file>
+
 <file path="langroid/agent/base.py">
 ORCHESTRATION_STRINGS = [DONE, PASS, PASS_TO, SEND_TO]
 console = Console(quiet=settings.quiet)
@@ -70654,6 +71768,17 @@ add_to_registry: bool = True  # register agent in ObjectRegistry?
 respond_tools_only: bool = False  # respond only to tool messages (not plain text)?
 # allow multiple tool messages in a single response?
 allow_multiple_tools: bool = True
+# Optional pre-execution tool policy hook, called with the final parsed
+# ToolMessage just BEFORE its selected handler runs, as
+# ``tool_policy(tool, agent)`` -- or ``tool_policy(tool, agent, chat_doc=...)``
+# when the callable has a ``chat_doc`` parameter. May be sync or async.
+# Return True or None to ALLOW (the handler runs exactly once); return
+# False or a str reason to REJECT (the handler is NOT run, and the LLM
+# sees a rejection naming the tool and the reason). The hook cannot modify
+# the tool. If the hook itself raises, the tool is blocked (fail-closed)
+# and the rejection deliberately excludes the exception message and tool
+# arguments. See docs/notes/tool-policy-hook.md.
+tool_policy: Optional[Callable[..., Any]] = None
 human_prompt: str = (
 ⋮----
 @field_validator("name")
@@ -71497,8 +72622,6 @@ results: List[str | ChatDocument | None] = []
 ⋮----
 results = ["ERROR: Use ONE tool at a time!"] * len(tools)
 ⋮----
-results = [self.handle_tool_message(t, chat_doc=chat_doc) for t in tools]
-⋮----
 @property
     def all_llm_tools_known(self) -> set[str]
 ⋮----
@@ -71607,7 +72730,7 @@ result_tool_name = msg.default_value("request")
 #     msg in chat_doc.tool_messages):
 #    chat_doc.tool_messages.remove(msg)
 # if we can handle it, do so
-result = self.handle_tool_message(msg, chat_doc=chat_doc)
+result = self._handle_tool_message_with_policy(msg, chat_doc=chat_doc)
 ⋮----
 # else wrap it in an agent response and return it so
 # orchestrator can find a respondent
@@ -71661,6 +72784,48 @@ else result[: max_tokens * 4]  # approx truncate
 ⋮----
 else result.content[: max_tokens * 4]  # approx truncate
 ⋮----
+"""Framework entry point for sync tool dispatch, enforcing `tool_policy`.
+
+        Consults the `tool_policy` hook (see `AgentConfig.tool_policy`) and,
+        if the tool is allowed, delegates to `handle_tool_message` -- which a
+        subclass may override -- exactly as before, so the policy gates tool
+        execution even through such overrides.
+
+        When dispatch is NOT overridden and the tool has no handler, the
+        policy is not consulted (nothing can execute). When dispatch IS
+        overridden, the base cannot know what the override will do, so the
+        policy is consulted regardless, even though the override may end up
+        returning None.
+
+        Args:
+            tool: ToolMessage object representing the tool request.
+            chat_doc: Optional ChatDocument object containing the tool request.
+
+        Returns:
+            The dispatch result, or the policy's LLM-visible rejection.
+        """
+⋮----
+# base dispatch would execute nothing; don't consult the policy
+⋮----
+rejection = check_tool_policy(self.config.tool_policy, tool, self, chat_doc)
+⋮----
+"""Async version of `_handle_tool_message_with_policy`.
+
+        The policy is awaited on the CALLER's event loop (so it can use
+        loop-bound resources), then dispatch proceeds via
+        `handle_tool_message_async` -- which a subclass may override --
+        exactly as before.
+
+        Args:
+            tool: ToolMessage object representing the tool request.
+            chat_doc: Optional ChatDocument object containing the tool request.
+
+        Returns:
+            The dispatch result, or the policy's LLM-visible rejection.
+        """
+⋮----
+rejection = await check_tool_policy_async(
+⋮----
 """
         Asynch version of `handle_tool_message`. See there for details.
         """
@@ -71684,6 +72849,12 @@ result = self.to_ChatDocument(maybe_result, tool_name, chat_doc)
 ⋮----
 """
         Respond to a tool request from the LLM, in the form of an ToolMessage object.
+
+        NOTE: framework dispatch reaches this method through
+        `_handle_tool_message_with_policy`, which enforces the optional
+        `tool_policy` hook BEFORE delegating here; direct calls to this
+        method by user code are the caller's own seam and are not gated.
+
         Args:
             tool: ToolMessage object representing the tool request.
             chat_doc: Optional ChatDocument object containing the tool request.
@@ -71784,403 +72955,6 @@ agent_type = type(agent).__name__
 user_response = Prompt.ask(
 ⋮----
 answer = agent.llm_response(request)
-</file>
-
-<file path="langroid/language_models/model_info.py">
-logger = logging.getLogger(__name__)
-⋮----
-class ModelProvider(str, Enum)
-⋮----
-"""Enum for model providers"""
-⋮----
-OPENAI = "openai"
-ANTHROPIC = "anthropic"
-DEEPSEEK = "deepseek"
-GOOGLE = "google"
-MINIMAX = "minimax"
-UNKNOWN = "unknown"
-⋮----
-class ModelName(str, Enum)
-⋮----
-"""Parent class for all model name enums"""
-⋮----
-class OpenAIChatModel(ModelName)
-⋮----
-"""Enum for OpenAI Chat models"""
-⋮----
-GPT3_5_TURBO = "gpt-3.5-turbo"
-GPT4 = "gpt-4o"  # avoid deprecated gpt-4
-GPT4_TURBO = "gpt-4-turbo"
-GPT4o = "gpt-4o"
-GPT4o_MINI = "gpt-4o-mini"
-O1 = "o1"
-O1_MINI = "o1-mini"
-O3_MINI = "o3-mini"
-O3 = "o3"
-O4_MINI = "o4-mini"
-GPT4_1 = "gpt-4.1"
-GPT4_1_MINI = "gpt-4.1-mini"
-GPT4_1_NANO = "gpt-4.1-nano"
-GPT5 = "gpt-5"
-GPT5_MINI = "gpt-5-mini"
-GPT5_NANO = "gpt-5-nano"
-GPT5_PRO = "gpt-5-pro"
-GPT5_1 = "gpt-5.1"
-GPT5_1_CODEX = "gpt-5.1-codex"
-GPT5_1_CODEX_MINI = "gpt-5.1-codex-mini"
-GPT5_1_CHAT = "gpt-5.1-chat"
-GPT5_2 = "gpt-5.2"
-GPT5_2_PRO = "gpt-5.2-pro"
-GPT5_2_CHAT = "gpt-5.2-chat"
-GPT_OSS_120b = "gpt-oss-120b"
-GPT_OSS_20b = "gpt-oss-20b"
-⋮----
-class OpenAICompletionModel(str, Enum)
-⋮----
-"""Enum for OpenAI Completion models"""
-⋮----
-DAVINCI = "davinci-002"
-BABBAGE = "babbage-002"
-⋮----
-class AnthropicModel(ModelName)
-⋮----
-"""Enum for Anthropic models"""
-⋮----
-CLAUDE_3_OPUS = "claude-3-opus-latest"
-CLAUDE_3_SONNET = "claude-3-sonnet-latest"
-CLAUDE_3_HAIKU = "claude-3-haiku-latest"
-CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest"
-CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest"
-CLAUDE_4_OPUS = "claude-opus-4"
-CLAUDE_4_SONNET = "claude-sonnet-4"
-CLAUDE_4_HAIKU = "claude-haiku-4"
-CLAUDE_4_5_OPUS = "claude-opus-4-5"
-CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
-CLAUDE_4_5_HAIKU = "claude-haiku-4-5"
-⋮----
-class DeepSeekModel(ModelName)
-⋮----
-"""Enum for DeepSeek models direct from DeepSeek API"""
-⋮----
-DEEPSEEK = "deepseek/deepseek-chat"
-DEEPSEEK_R1 = "deepseek/deepseek-reasoner"
-OPENROUTER_DEEPSEEK_R1 = "openrouter/deepseek/deepseek-r1"
-⋮----
-class GeminiModel(ModelName)
-⋮----
-"""Enum for Gemini models"""
-⋮----
-GEMINI_1_5_FLASH = "gemini-1.5-flash"
-GEMINI_1_5_FLASH_8B = "gemini-1.5-flash-8b"
-GEMINI_1_5_PRO = "gemini-1.5-pro"
-GEMINI_2_FLASH = "gemini-2.0-flash"
-GEMINI_2_FLASH_LITE = "gemini-2.0-flash-lite"
-GEMINI_2_FLASH_THINKING = "gemini-2.0-flash-thinking-exp"
-GEMINI_2_PRO = "gemini-2.0-pro-exp-02-05"
-GEMINI_2_5_FLASH = "gemini-2.5-flash"
-GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
-GEMINI_2_5_PRO = "gemini-2.5-pro"
-GEMINI_3_FLASH = "gemini-3-flash"
-GEMINI_3_PRO = "gemini-3-pro"
-⋮----
-class MiniMaxModel(ModelName)
-⋮----
-"""Enum for MiniMax models"""
-⋮----
-MINIMAX_M2_7 = "MiniMax-M2.7"
-MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
-MINIMAX_M2_5 = "MiniMax-M2.5"
-MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
-MINIMAX_M2_1 = "MiniMax-M2.1"
-MINIMAX_M2_1_HIGHSPEED = "MiniMax-M2.1-highspeed"
-MINIMAX_M2 = "MiniMax-M2"
-⋮----
-class OpenAI_API_ParamInfo(BaseModel)
-⋮----
-"""
-    Parameters exclusive to some models, when using OpenAI API
-    """
-⋮----
-# model-specific params at top level
-params: Dict[str, List[str]] = dict(
-# model-specific params in extra_body
-extra_parameters: Dict[str, List[str]] = dict(
-⋮----
-class ModelInfo(BaseModel)
-⋮----
-"""
-    Consolidated information about LLM, related to capacity, cost and API
-    idiosyncrasies. Reasonable defaults for all params in case there's no
-    specific info available.
-    """
-⋮----
-name: str = "unknown"
-provider: ModelProvider = ModelProvider.UNKNOWN
-context_length: int = 16_000
-max_cot_tokens: int = 0  # max chain of thought (thinking) tokens where applicable
-max_output_tokens: int = 8192  # Maximum number of output tokens - model dependent
-input_cost_per_million: float = 0.0  # Cost in USD per million input tokens
-cached_cost_per_million: float = 0.0  # Cost in USD per million cached tokens
-output_cost_per_million: float = 0.0  # Cost in USD per million output tokens
-allows_streaming: bool = True  # Whether model supports streaming output
-allows_system_message: bool = True  # Whether model supports system messages
-rename_params: Dict[str, str] = {}  # Rename parameters for OpenAI API
-unsupported_params: List[str] = []
-has_structured_output: bool = False  # Does model API support structured output?
-has_tools: bool = True  # Does model API support tools/function-calling?
-needs_first_user_message: bool = False  # Does API need first msg to be from user?
-description: Optional[str] = None
-⋮----
-GEMINI_CANONICAL_MODEL_NAMES = {model.value for model in GeminiModel}
-DEFAULT_MODEL_INFO = ModelInfo()
-WARNED_UNKNOWN_MODELS: set[tuple[str, ...]] = set()
-⋮----
-# Model information registry
-MODEL_INFO: Dict[str, ModelInfo] = {
-⋮----
-# OpenAI Models
-⋮----
-# Anthropic Models
-⋮----
-# DeepSeek Models
-⋮----
-# Gemini Models
-⋮----
-# Gemini 2.5 Models
-⋮----
-# Gemini 3 Models
-⋮----
-# MiniMax Models
-⋮----
-"""Get model information by name or enum value"""
-# Sequence of models to try, starting with the primary model
-models_to_try = [model] + fallback_models
-⋮----
-# Find the first model in the sequence that has info defined using next()
-# on a generator expression that filters out None results from _get_model_info
-found_info = next(
-⋮----
-None,  # Default value if the iterator is exhausted (no valid info found)
-⋮----
-normalized_models = _normalize_model_names(models_to_try)
-⋮----
-def _get_model_info(model: str | ModelName) -> ModelInfo | None
-⋮----
-def _normalize_model_names(models: List[str | ModelName]) -> List[str]
-⋮----
-normalized_models: List[str] = []
-seen: set[str] = set()
-⋮----
-normalized_model = _normalize_gemini_model_name(_model_name(model))
-⋮----
-def _normalize_gemini_model_name(model: str) -> str | None
-⋮----
-base_model = model.rsplit("/", 1)[-1]
-⋮----
-# Try stripping known suffixes to find a canonical name.
-# Use split (not endswith) for "-preview" so dated variants like
-# "gemini-2.5-flash-lite-preview-06-17" are handled correctly.
-⋮----
-stripped = base_model.split(suffix, maxsplit=1)[0]
-⋮----
-def _warn_unknown_model(models: List[str | ModelName]) -> None
-⋮----
-model_names = tuple(_model_name(model) for model in models)
-⋮----
-def _model_name(model: str | ModelName) -> str
-</file>
-
-<file path="mkdocs.yml">
-site_name: "langroid"
-repo_name: langroid/langroid
-site_description: "Langroid LLM App Development Framework"
-repo_url: https://github.com/langroid/langroid
-site_url: https://langroid.github.io/langroid
-
-edit_uri: ""
-extra_css:
-  - stylesheets/extra.css
-
-theme:
-  logo: assets/orange-logo-lambda-563.png
-  favicon: assets/orange-logo-lambda-563.png
-  features:
-    - navigation.tabs
-#    - navigation.tracking
-#    - navigation.sections
-#    - navigation.indexes
-    - toc
-    - content.code.copy
-    - content.code.select
-    - content.code.annotate
-  icon:
-      repo: fontawesome/brands/github
-  name: material
-  custom_dir: docs/overrides
-  palette:
-    # Palette toggle for light mode
-    - scheme: default
-      primary: indigo
-      accent: indigo
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
-
-    # Palette toggle for dark mode
-    - scheme: slate
-      primary: indigo
-      accent: indigo
-      toggle:
-        icon: material/brightness-4
-        name: Switch to light mode
-
-plugins:
-  - blog:
-      archive: false
-      blog_toc: true
-      categories: false
-      blog_dir: blog
-
-  - rss:
-      enabled: true
-      match_path: blog/posts/.*
-      image: https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Feed-icon.svg/128px-Feed-icon.svg.png
-      date_from_meta:
-        as_creation: date
-      categories:
-        - categories
-        - tags
-  - search
-  - autorefs
-  #- awesome-pages
-  - gen-files:
-      scripts:
-      - docs/auto_docstring.py
-      #- docs/gen_ref_pages.py
-  - literate-nav:
-      nav_file: SUMMARY.md
-  - mkdocstrings:
-      default_handler: python
-      handlers:
-        python:
-          paths: [.]
-          options:
-            members_order: source
-            separate_signature: false
-            filters: ["!^_"]
-            docstring_options:
-              ignore_init_summary: true
-            merge_init_into_class: true
-  - section-index
-
-watch:
-  - langroid
-
-nav:
-  - Home: index.md
-  - Blog: blog/index.md
-  - Getting Started:
-    - quick-start/index.md
-    - Setup: quick-start/setup.md
-    - LLM interaction: quick-start/llm-interaction.md
-    - Simple Chat Agent: quick-start/chat-agent.md
-    - Task Delegation: quick-start/multi-agent-task-delegation.md
-    - Two Agent Chat: quick-start/two-agent-chat-num.md
-    - Three Agent Chat: quick-start/three-agent-chat-num.md
-    - Agent with Tools/Functions: quick-start/chat-agent-tool.md
-    - Three Agents, with Routing: quick-start/three-agent-chat-num-router.md
-    - Agent with Retrieval: quick-start/chat-agent-docs.md
-  # defer to gen-files + literate-nav
-  - FAQ: FAQ.md
-  - Notes-Updates:
-      - Overview: notes/overview.md
-      - XML-based Tools: notes/xml-tools.md
-      - Async Streaming: notes/async-streaming.md
-      - Knowledge Graphs: notes/knowledge-graphs.md
-      - Gemini LLMs, Embeddings, Vertex AI: notes/gemini.md
-      - LLM-based Pdf Parsing: notes/llm-pdf-parser.md
-      - Large Tool Results: notes/large-tool-results.md
-      - GLHF.chat Support: notes/glhf-chat.md
-      - Structured Output: notes/structured-output.md
-      - Tool Handlers: notes/tool-message-handler.md
-      - Task Termination: notes/task-termination.md
-      - Message Routing: notes/message-routing.md
-      - Llama.cpp Embeddings: notes/llama-cpp-embeddings.md
-      - Azure OpenAI models: notes/azure-openai-models.md
-      - Custom Azure OpenAI client: notes/custom-azure-client.md
-      - Enriching Chunks for Retrieval: notes/enriching-for-retrieval.md
-      - Reasoning Content: notes/reasoning-content.md
-      - None Content in LLM Messages: notes/llm-none-content.md
-      - Weaviate: notes/weaviate.md
-      - Handling LLM Non-Tool Messages: notes/handle-llm-no-tool.md
-      - PGVector: notes/pgvector.md
-      - Pinecone: notes/pinecone.md
-      - Tavily Search Tool: notes/tavily_search.md
-      - Seltz Search Tool: notes/seltz_search.md
-      - Twitter Search via Xquik MCP: notes/twitter-search.md
-      - Marker Pdf Parser: notes/marker-pdf.md
-      - URLLoader : notes/url_loader.md
-      - Crawl4AI Crawler: notes/crawl4ai.md
-      - LangDB AI Gateway: notes/langdb.md
-      - Portkey AI Gateway: notes/portkey.md
-      - Markitdown Parsers: notes/markitdown.md
-      - LiteLLM Proxy: notes/litellm-proxy.md
-      - Chunking: notes/chunking.md
-      - Image, PDF Input: notes/file-input.md
-      - MCP Tools: notes/mcp-tools.md
-      - Code-Injection Protection: notes/code-injection-protection.md
-      - TaskTool: notes/task-tool.md
-      - Local Qdrant VectorDB Cleanup: notes/qdrant-resource-cleanup.md
-      - OpenAI HTTP Client Configuration: notes/openai-http-client.md
-      - OpenAI Client Caching: notes/openai-client-caching.md
-      - Rotating API Keys: notes/rotating-api-keys.md
-      - Cross-Encoder Reranking: notes/cross-encoder.md
-      - Task Logs: notes/html-logger.md
-      - Pydantic v2 Migration: notes/pydantic-v2-migration.md
-      - Batch Processing: notes/batch-processing.md
-
-  - Examples:
-    - Guide: examples/guide.md
-    - Hierarchical Agent Computation: examples/agent-tree.md
-    - Demos:
-      - Audience Targeting: demos/targeting/audience-targeting.md
-  - Tutorials:
-    - Langroid Tour: tutorials/langroid-tour.md
-    - Supported LLMs: tutorials/supported-models.md
-    - Local LLM Setup: tutorials/local-llm-setup.md
-    - Non-OpenAI LLMs: tutorials/non-openai-llms.md
-    - SQLChatAgent: tutorials/postgresql-agent.md
-    - LLM Usage Options: tutorials/llm-usage-options.md
-  - Code/API Docs: reference/
-#  - API Documentation:
-#    - language_models: api/language_models_base.md
-
-
-markdown_extensions:
-  - footnotes
-  - toc:
-      permalink: true
-  - attr_list
-  - md_in_html
-  - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
-  - admonition
-  - pymdownx.details
-  - pymdownx.superfences
-  - pymdownx.highlight:
-      anchor_linenums: true
-      line_spans: __span
-      pygments_lang_class: true
-      use_pygments: true
-  - pymdownx.inlinehilite
-  - pymdownx.snippets
-  - pymdownx.arithmatex:
-      generic: true
-  - markdown.extensions.attr_list:
-extra_javascript:
-  - javascripts/mathjax.js
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 </file>
 
 <file path="tests/main/test_prep_llm_message.py">
@@ -72541,9 +73315,203 @@ pending_calls = list(agent.oai_tool_calls)
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.16.0
+  rev: v0.16.4
   hooks:
     - id: ruff
+</file>
+
+<file path="mkdocs.yml">
+site_name: "langroid"
+repo_name: langroid/langroid
+site_description: "Langroid LLM App Development Framework"
+repo_url: https://github.com/langroid/langroid
+site_url: https://langroid.github.io/langroid
+
+edit_uri: ""
+extra_css:
+  - stylesheets/extra.css
+
+theme:
+  logo: assets/orange-logo-lambda-563.png
+  favicon: assets/orange-logo-lambda-563.png
+  features:
+    - navigation.tabs
+#    - navigation.tracking
+#    - navigation.sections
+#    - navigation.indexes
+    - toc
+    - content.code.copy
+    - content.code.select
+    - content.code.annotate
+  icon:
+      repo: fontawesome/brands/github
+  name: material
+  custom_dir: docs/overrides
+  palette:
+    # Palette toggle for light mode
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+plugins:
+  - blog:
+      archive: false
+      blog_toc: true
+      categories: false
+      blog_dir: blog
+
+  - rss:
+      enabled: true
+      match_path: blog/posts/.*
+      image: https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Feed-icon.svg/128px-Feed-icon.svg.png
+      date_from_meta:
+        as_creation: date
+      categories:
+        - categories
+        - tags
+  - search
+  - autorefs
+  #- awesome-pages
+  - gen-files:
+      scripts:
+      - docs/auto_docstring.py
+      #- docs/gen_ref_pages.py
+  - literate-nav:
+      nav_file: SUMMARY.md
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [.]
+          options:
+            members_order: source
+            separate_signature: false
+            filters: ["!^_"]
+            docstring_options:
+              ignore_init_summary: true
+            merge_init_into_class: true
+  - section-index
+
+watch:
+  - langroid
+
+nav:
+  - Home: index.md
+  - Blog: blog/index.md
+  - Getting Started:
+    - quick-start/index.md
+    - Setup: quick-start/setup.md
+    - LLM interaction: quick-start/llm-interaction.md
+    - Simple Chat Agent: quick-start/chat-agent.md
+    - Task Delegation: quick-start/multi-agent-task-delegation.md
+    - Two Agent Chat: quick-start/two-agent-chat-num.md
+    - Three Agent Chat: quick-start/three-agent-chat-num.md
+    - Agent with Tools/Functions: quick-start/chat-agent-tool.md
+    - Three Agents, with Routing: quick-start/three-agent-chat-num-router.md
+    - Agent with Retrieval: quick-start/chat-agent-docs.md
+  # defer to gen-files + literate-nav
+  - FAQ: FAQ.md
+  - Notes-Updates:
+      - Overview: notes/overview.md
+      - XML-based Tools: notes/xml-tools.md
+      - Async Streaming: notes/async-streaming.md
+      - Knowledge Graphs: notes/knowledge-graphs.md
+      - Gemini LLMs, Embeddings, Vertex AI: notes/gemini.md
+      - LLM-based Pdf Parsing: notes/llm-pdf-parser.md
+      - Large Tool Results: notes/large-tool-results.md
+      - GLHF.chat Support: notes/glhf-chat.md
+      - Structured Output: notes/structured-output.md
+      - Tool Handlers: notes/tool-message-handler.md
+      - Task Termination: notes/task-termination.md
+      - Message Routing: notes/message-routing.md
+      - Llama.cpp Embeddings: notes/llama-cpp-embeddings.md
+      - Azure OpenAI models: notes/azure-openai-models.md
+      - Custom Azure OpenAI client: notes/custom-azure-client.md
+      - Enriching Chunks for Retrieval: notes/enriching-for-retrieval.md
+      - Reasoning Content: notes/reasoning-content.md
+      - None Content in LLM Messages: notes/llm-none-content.md
+      - Weaviate: notes/weaviate.md
+      - Handling LLM Non-Tool Messages: notes/handle-llm-no-tool.md
+      - Tool Policy Hook: notes/tool-policy-hook.md
+      - PGVector: notes/pgvector.md
+      - Pinecone: notes/pinecone.md
+      - Tavily Search Tool: notes/tavily_search.md
+      - Seltz Search Tool: notes/seltz_search.md
+      - Twitter Search via Xquik MCP: notes/twitter-search.md
+      - Marker Pdf Parser: notes/marker-pdf.md
+      - URLLoader : notes/url_loader.md
+      - Crawl4AI Crawler: notes/crawl4ai.md
+      - LangDB AI Gateway: notes/langdb.md
+      - Portkey AI Gateway: notes/portkey.md
+      - Markitdown Parsers: notes/markitdown.md
+      - LiteLLM Proxy: notes/litellm-proxy.md
+      - Chunking: notes/chunking.md
+      - Image, PDF Input: notes/file-input.md
+      - MCP Tools: notes/mcp-tools.md
+      - Code-Injection Protection: notes/code-injection-protection.md
+      - TaskTool: notes/task-tool.md
+      - Local Qdrant VectorDB Cleanup: notes/qdrant-resource-cleanup.md
+      - OpenAI HTTP Client Configuration: notes/openai-http-client.md
+      - OpenAI Client Caching: notes/openai-client-caching.md
+      - Rotating API Keys: notes/rotating-api-keys.md
+      - Cross-Encoder Reranking: notes/cross-encoder.md
+      - Task Logs: notes/html-logger.md
+      - Pydantic v2 Migration: notes/pydantic-v2-migration.md
+      - Batch Processing: notes/batch-processing.md
+
+  - Examples:
+    - Guide: examples/guide.md
+    - Hierarchical Agent Computation: examples/agent-tree.md
+    - Demos:
+      - Audience Targeting: demos/targeting/audience-targeting.md
+  - Tutorials:
+    - Langroid Tour: tutorials/langroid-tour.md
+    - Supported LLMs: tutorials/supported-models.md
+    - Local LLM Setup: tutorials/local-llm-setup.md
+    - Non-OpenAI LLMs: tutorials/non-openai-llms.md
+    - SQLChatAgent: tutorials/postgresql-agent.md
+    - LLM Usage Options: tutorials/llm-usage-options.md
+  - Code/API Docs: reference/
+#  - API Documentation:
+#    - language_models: api/language_models_base.md
+
+
+markdown_extensions:
+  - footnotes
+  - toc:
+      permalink: true
+  - attr_list
+  - md_in_html
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+      use_pygments: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.arithmatex:
+      generic: true
+  - markdown.extensions.attr_list:
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 </file>
 
 <file path="langroid/language_models/openai_gpt.py">

--- a/llms-no-tests-compressed.txt
+++ b/llms-no-tests-compressed.txt
@@ -149,6 +149,7 @@ docs/
     task-tool.md
     tavily_search.md
     tool-message-handler.md
+    tool-policy-hook.md
     twitter-search.md
     url_loader.md
     weaviate.md
@@ -254,6 +255,7 @@ examples/
     text-to-structured.py
     tool-custom-handler.py
     tool-extract-short-example.py
+    tool-policy-hook.py
     xml_tool.py
   chainlit/
     non-callback/
@@ -520,6 +522,7 @@ langroid/
     openai_assistant.py
     task.py
     tool_message.py
+    tool_policy.py
     xml_tool_message.py
   cachedb/
     __init__.py
@@ -41695,6 +41698,159 @@ python3 examples/basic/chat-search-seltz.py
 ---
 </file>
 
+<file path="docs/notes/tool-policy-hook.md">
+# Pre-execution Tool Policy Hook
+
+When Langroid agents are embedded in larger systems, operators often need a
+central place to decide whether a tool call the LLM just made should actually
+run: authorization checks, human-approval gates, DLP scanning, command
+policies, budget limits, and so on. The `AgentConfig.tool_policy` hook
+provides the smallest possible interception point for this: a single optional
+callback, consulted immediately before the selected tool handler executes.
+No policy engine, rules, or registries live in Langroid itself — you plug in
+whatever external engine you like.
+
+## API
+
+```python
+import langroid as lr
+
+class RunCommandTool(lr.ToolMessage):
+    request: str = "run_command"
+    purpose: str = "To run a shell <command>"
+    command: str
+
+def my_policy(tool: lr.ToolMessage, agent: lr.Agent) -> bool | str | None:
+    if isinstance(tool, RunCommandTool) and "rm" in tool.command:
+        return "destructive commands are not allowed"
+    return True  # allow
+
+config = lr.ChatAgentConfig(
+    # ... other params ...
+    tool_policy=my_policy,
+)
+```
+
+The callback is invoked as `tool_policy(tool, agent)` — or as
+`tool_policy(tool, agent, chat_doc=...)` if the callable's signature has a
+`chat_doc` parameter (mirroring the convention for tool handlers). It
+receives:
+
+- `tool`: the final parsed `ToolMessage` instance about to be handled — its
+  `request` field is the tool name, and its other fields are the fully
+  validated arguments
+- `agent`: the agent that is about to run the handler
+- `chat_doc` (optional): the `ChatDocument` containing the tool call, when
+  available
+
+The return value decides what happens:
+
+- `True` or `None` — allow: the selected handler runs exactly once, as usual
+- `False` — reject: the handler is NOT run; the LLM receives a rejection
+  message naming the tool
+- a `str` — reject, with that string included as the reason in the
+  LLM-visible rejection message
+
+The hook cannot modify the tool: argument transformation is deliberately out
+of scope, and the hook receives deep copies of both the `ToolMessage` and
+the `chat_doc`, so any mutation it makes has no effect on what the handler
+sees. It only decides allow vs. reject. It is consulted only when a real
+handler has been selected: a tool with no handler returns `None` as before,
+without the policy being called.
+
+The policy is enforced at the framework's dispatch call sites, ABOVE
+`Agent.handle_tool_message` / `handle_tool_message_async` — so it gates
+tool execution even when a subclass overrides those methods. Three
+consequences of that placement:
+
+- when dispatch IS overridden, the framework cannot know whether the
+  override will execute anything, so the policy is consulted even if the
+  override ends up returning `None` (the no-handler shortcut applies only
+  to un-overridden dispatch)
+- direct calls that YOUR code makes to `agent.handle_tool_message(...)`
+  are your own seam and are not gated by the hook
+- the strict-recovery `AnyTool` wrapper is a parsing shim, not a tool
+  execution, so it is exempt from the hook; the recovered actual tool is
+  policy-checked exactly once when dispatched
+
+## Failure semantics: fail-closed
+
+If the policy callback itself raises an exception, the tool is treated as
+rejected — the handler does not run. This is deliberate: a broken policy
+must never silently become a bypassed policy.
+
+The rejection message sent back to the LLM includes only the tool name and
+the exception's class name — never the exception message or the tool's
+arguments, since either could leak payload contents into the conversation.
+The full exception is logged (via the `langroid.agent.tool_policy` logger)
+for the operator. Similarly, a decision value of an unrecognized type (anything other
+than `True`, `False`, `None`, or `str`) is treated as a rejection rather
+than an allow.
+
+## Sync and async
+
+The hook works on both dispatch paths, with both kinds of callables:
+
+- a sync callback works with both `handle_message` (sync dispatch) and
+  `handle_message_async` (async dispatch)
+- an async callback is awaited on the caller's event loop everywhere on the
+  async path — including when the tool only has a sync handler — so it may
+  safely use loop-bound resources (locks, clients, futures). On the sync
+  path it is run to completion via `asyncio.run()` — or, when an event loop
+  is already running in the calling thread (e.g. sync dispatch invoked from
+  inside async code), on a fresh event loop in a helper thread. Any failure
+  while doing so is handled fail-closed like any other hook error.
+
+On each dispatch, the policy is consulted exactly once per tool call,
+including when async dispatch falls back to a tool's sync handler.
+
+## What the hook does NOT change
+
+- With no `tool_policy` configured (the default), behavior is exactly as
+  before — the hook adds negligible overhead (a None check per dispatch)
+  and no semantic change.
+- The USER-origin tool security filter (see
+  [Code-Injection Protection](code-injection-protection.md) and
+  GHSA-gjgq-w2m6-wr5q) runs first and is unaffected: tools vetoed by that
+  filter are never even shown to the policy, and an allow-everything policy
+  cannot resurrect them.
+- Rejections flow back into the conversation like any other tool-handling
+  result (e.g. validation errors), so the LLM sees why the call was refused
+  and can adjust.
+
+## Caveats
+
+The policy callback is trusted operator code, not a sandbox:
+
+- The deep copies guard against mutation through the `tool` and `chat_doc`
+  arguments; a policy determined to tamper could still reach live state via
+  `agent`. Don't do that — the hook's contract is allow/reject only.
+- Everywhere the framework deep-copies an agent config —
+  `ChatAgent.clone()`, `Task` construction, and batch processing — the
+  policy callable is shared by REFERENCE (exempted from the copy via a
+  pre-seeded deepcopy memo; the live config is never mutated). A stateful
+  policy (a budget counter, an approval list) is therefore consulted
+  globally across the original and all copies, and a policy holding
+  unpicklable resources (e.g. a lock) does not break copying. If you copy
+  a config through some other route (`copy.deepcopy` yourself), that copy
+  is not exempted.
+- An async policy evaluated from purely-sync dispatch that is itself
+  running inside an event loop (a rare nested case) runs on a fresh event
+  loop in a helper thread; loop-bound awaitables can fail there, which
+  blocks the tool (fail-closed) rather than bypassing it.
+- A tool payload carrying a non-copyable value (a lock, a client object)
+  prevents the pre-policy deep copy and causes a fail-closed rejection
+  even under an allow-all policy, with a distinct operator-log diagnostic
+  ("tool payload could not be copied for policy evaluation"). The remedy
+  is keeping tool fields to plain data.
+
+## Example
+
+A runnable example is in `examples/basic/tool-policy-hook.py`, showing a
+policy that blocks payments above a limit, with the LLM reacting to the
+rejection.
+</file>
+
 <file path="docs/notes/twitter-search.md">
 # Twitter Search via Xquik MCP
 
@@ -42448,6 +42604,53 @@ task = lr.Task(agent, interactive=False)
 ⋮----
 # local models do not like the first message to be empty
 user_message = "Can you help me with some questions?"
+</file>
+
+<file path="examples/basic/tool-policy-hook.py">
+"""
+Example of the pre-execution tool policy hook (`AgentConfig.tool_policy`).
+
+A single agent has a `payment` tool. A policy callback (standing in for an
+external authorization/policy engine) rejects any payment above $100; the
+handler is then NOT run, and the LLM sees a rejection naming the tool and
+the reason, so it can react (here, by telling the user).
+
+See docs/notes/tool-policy-hook.md for the full semantics (allow / reject /
+fail-closed on policy errors, sync + async support).
+
+Run like this, optionally specifying an LLM:
+
+python3 examples/basic/tool-policy-hook.py
+
+or
+
+python3 examples/basic/tool-policy-hook.py -m ollama/mistral:7b-instruct-v0.2-q8_0
+"""
+⋮----
+class PaymentTool(lr.agent.ToolMessage)
+⋮----
+request: str = "payment"
+purpose: str = "To pay <amount> dollars to <payee>."
+amount: float
+payee: str
+⋮----
+def handle(self) -> str
+⋮----
+# In real life this would call a payment API
+⋮----
+def payment_policy(tool: lr.ToolMessage, agent: lr.Agent) -> bool | str
+⋮----
+"""Reject payments above $100; allow everything else."""
+⋮----
+def main(model: str = "") -> None
+⋮----
+agent = lr.ChatAgent(
+⋮----
+handle_llm_no_tool="user",  # fwd to user when LLM sends non-tool msg
+⋮----
+task = lr.Task(agent, interactive=True)
+# Try asking: "pay $50 to Alice" (allowed),
+# then: "pay $500 to Bob" (blocked by policy; LLM sees the reason)
 </file>
 
 <file path="examples/mcp/xquik-twitter-search.py">
@@ -45176,271 +45379,6 @@ results_str = "\n\n".join(str(result) for result in search_results)
     def examples(cls) -> List["ToolMessage" | Tuple[str, "ToolMessage"]]
 </file>
 
-<file path="langroid/agent/batch.py">
-T = TypeVar("T")
-U = TypeVar("U")
-⋮----
-class ExceptionHandling(str, Enum)
-⋮----
-"""Enum for exception handling options."""
-⋮----
-RAISE = "raise"
-RETURN_NONE = "return_none"
-RETURN_EXCEPTION = "return_exception"
-⋮----
-"""Convert legacy boolean handle_exceptions to ExceptionHandling enum."""
-⋮----
-"""
-    Unified batch processing logic for both agent methods and tasks.
-
-    Args:
-        inputs: Iterable of inputs to process
-        do_task: Task execution function that takes (input, index) and returns result
-        start_idx: Starting index for the batch
-        stop_on_first_result: Whether to stop after first valid result
-        sequential: Whether to process sequentially
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        output_map: Function to map results to final output format
-    """
-exception_handling = _convert_exception_handling(handle_exceptions)
-⋮----
-def handle_error(e: BaseException) -> Any
-⋮----
-"""Handle exceptions based on exception_handling."""
-⋮----
-results: List[Optional[ChatDocument] | BaseException] = []
-pending: set[asyncio.Task[Any]] = set()
-# Create task-to-index mapping
-task_indices: dict[asyncio.Task[Any], int] = {}
-⋮----
-tasks = [
-task_indices = {task: i for i, task in enumerate(tasks)}
-results = [None] * len(tasks)
-⋮----
-pending = set(tasks)
-⋮----
-# Process completed tasks
-⋮----
-index = task_indices[task]
-⋮----
-result = await task
-⋮----
-results = []
-⋮----
-result = await do_task(input, i + start_idx)
-⋮----
-# Parallel execution
-⋮----
-return_exceptions = exception_handling != ExceptionHandling.RAISE
-⋮----
-results_with_exceptions = cast(
-⋮----
-results = [
-else:  # ExceptionHandling.RETURN_EXCEPTION
-results = results_with_exceptions
-⋮----
-results = [handle_error(e) for _ in inputs]
-⋮----
-"""
-    Common batch processing logic for both agent methods and tasks.
-
-    Args:
-        inputs: List of inputs to process
-        do_task: Task execution function
-        batch_size: Size of batches, if None process all at once
-        stop_on_first_result: Whether to stop after first valid result
-        sequential: Whether to process sequentially
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        output_map: Function to map results
-        message_template: Template for status message
-        message: Optional override for status message
-    """
-⋮----
-"""Extra wrap to run asyncio.run one single time and not once per loop
-
-        Args:
-            inputs (List[str  |  ChatDocument]): inputs to process
-            batch_size (int | None): batch size
-
-        Returns:
-            List[Any]: results
-        """
-results: List[Any] = []
-⋮----
-msg = message or message_template.format(total=len(inputs))
-⋮----
-results = await _process_batch_async(
-⋮----
-batches = batched(inputs, batch_size)
-⋮----
-start_idx = len(results)
-complete_str = f", {start_idx} complete" if start_idx > 0 else ""
-msg = (
-⋮----
-output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
-⋮----
-"""
-    Generate and run copies of a task async/concurrently one per item in `items` list.
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-    Args:
-        gen_task (Callable[[int], Task]): generates the tasks to run
-        items (list[T]): list of items to process
-        input_map (Callable[[T], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], U]): function to map result
-            to final result. If stop_on_first_result is enabled, then
-            map any invalid output to None. We continue until some non-None
-            result is obtained.
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None) result. Successful results are evaluated after
-            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
-            exception object is itself non-None and also stops the batch.
-            Processing continues past None results; once a non-None result
-            appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        batch_size (Optional[int]): The number of tasks to run at a time,
-            if None, unbatched
-        turns (int): number of turns to run, -1 for infinite
-        message (Optional[str]): optionally overrides the console status messages
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
-        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
-
-
-    Returns:
-        list[Optional[U]]: list of final results. Always list[U] if
-        `stop_on_first_result` is disabled
-    """
-inputs = [input_map(item) for item in items]
-⋮----
-task_i = gen_task(i)
-⋮----
-result = await task_i.run_async(
-⋮----
-# exception will be handled by the caller
-⋮----
-# ----------------------------------------
-# Propagate any exception stored on the task that may have been
-# swallowed inside `Task.run_async`, so that the upper-level
-# exception-handling logic works as expected.
-⋮----
-exc = getattr(task_i, attr, None)
-⋮----
-# Fallback: treat a KILL-status result as an error
-⋮----
-"""
-    Run copies of `task` async/concurrently one per item in `items` list.
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-    Args:
-        task (Task): task to run
-        items (list[T]): list of items to process
-        input_map (Callable[[T], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], U]): function to map result
-            to final result
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None, after `output_map`) result. Processing continues past
-            None-mapped results; exceptions propagate, since this function
-            always uses the default `RAISE` exception handling. Once a non-None
-            result appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        batch_size (Optional[int]): The number of tasks to run at a time,
-            if None, unbatched
-        turns (int): number of turns to run, -1 for infinite
-        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
-        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
-
-    Returns:
-        list[Optional[U]]: list of final results. Always list[U] if
-        `stop_on_first_result` is disabled
-    """
-message = f"[bold green]Running {len(items)} copies of {task.name}..."
-⋮----
-"""
-    Run the `method` on copies of `agent`, async/concurrently one per
-    item in `items` list.
-    ASSUMPTION: The `method` is an async method and has signature:
-        method(self, input: str|ChatDocument|None) -> ChatDocument|None
-    So this would typically be used for the agent's "responder" methods,
-    e.g. `llm_response_async` or `agent_responder_async`.
-
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-
-    Args:
-        agent (Agent): agent whose method to run
-        method (str): Async method to run on copies of `agent`.
-            The method is assumed to have signature:
-            `method(self, input: str|ChatDocument|None) -> ChatDocument|None`
-        input_map (Callable[[Any], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], Any]): function to map result
-            to final result
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None) result. Successful results are evaluated after
-            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
-            exception object is itself non-None and also stops the batch.
-            Processing continues past None results; once a non-None result
-            appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        batch_size (Optional[int]): The number of items to process in each batch.
-            If None, process all items at once.
-    Returns:
-        List[Any]: list of final results
-    """
-# Check if the method is async
-method_name = method.__name__
-⋮----
-agent_cfg = copy.deepcopy(agent.config)
-⋮----
-agent_cls = type(agent)
-agent_name = agent_cfg.name
-⋮----
-async def _do_task(input: str | ChatDocument, i: int) -> Any
-⋮----
-agent_i = agent_cls(agent_cfg)
-method_i = getattr(agent_i, method_name, None)
-⋮----
-result = await method_i(input)
-⋮----
-async def _do_task(item: T) -> U
-⋮----
-async def _do_all(items: Iterable[T]) -> List[U]
-⋮----
-result = await _do_task(item)
-⋮----
-results: List[U] = []
-⋮----
-results = asyncio.run(_do_all(items))
-⋮----
-batches = batched(items, batch_size)
-</file>
-
 <file path="langroid/agent/tool_message.py">
 """
 Structured messages to an agent, typically from an LLM, to be handled by
@@ -45695,6 +45633,249 @@ excludes = excludes.union({"request"})
             Dict[str, Any]: simplified schema
         """
 schema = generate_simple_schema(
+</file>
+
+<file path="langroid/agent/tool_policy.py">
+"""Machinery for the pre-execution tool policy hook.
+
+The public surface is the ``tool_policy`` field on
+:class:`langroid.agent.base.AgentConfig`: an optional callable consulted
+just before a parsed ``ToolMessage``'s selected handler runs, deciding
+whether the handler executes (allow) or an LLM-visible rejection is
+returned instead (reject). The functions here evaluate that hook; see
+``docs/notes/tool-policy-hook.md`` for the full semantics.
+"""
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+C = TypeVar("C", bound="AgentConfig")
+⋮----
+class _PolicyCopyError(Exception)
+⋮----
+"""Internal marker: the tool/chat_doc could not be copied for the policy.
+
+    Distinguishes a payload-copy failure (e.g. a tool field holding a lock
+    or client object) from an exception raised by the policy itself, so the
+    operator log can say precisely which happened. Both fail closed.
+    """
+⋮----
+def dispatch_overridden(agent: "Agent", use_async: bool) -> bool
+⋮----
+"""Whether the agent's tool-dispatch method is overridden by a subclass.
+
+    Async dispatch falls back into `handle_tool_message` when a tool has no
+    async handler, so for the async path an override of EITHER method counts.
+
+    Args:
+        agent: The agent whose dispatch is being examined.
+        use_async: True for the async dispatch path.
+
+    Returns:
+        True if a subclass overrides the relevant dispatch method(s).
+    """
+⋮----
+def handler_exists(agent: "Agent", tool: "ToolMessage", use_async: bool) -> bool
+⋮----
+"""Whether base dispatch would find a handler for this tool.
+
+    Args:
+        agent: The agent that would dispatch the tool.
+        tool: The parsed ToolMessage.
+        use_async: True for the async dispatch path, which looks for an
+            `<name>_async` handler first and falls back to the sync one.
+
+    Returns:
+        True if a handler method exists on the agent.
+    """
+tool_name = tool.default_value("request")
+⋮----
+handler_name = getattr(tool, "_handler", tool_name)
+⋮----
+handler_name = tool_name
+⋮----
+def policy_exempt(tool: "ToolMessage") -> bool
+⋮----
+"""Whether this tool is structurally exempt from the `tool_policy` hook.
+
+    Framework-internal parsing shims declare ``_tool_policy_exempt = True``
+    on their class (e.g. the strict-recovery ``AnyTool`` wrapper): such a
+    shim is not a tool execution itself -- the actual tool it carries is
+    re-parsed and dispatched through the policy-checked path, so the policy
+    is consulted exactly once per logical tool call.
+
+    Args:
+        tool: The parsed ToolMessage about to be dispatched.
+
+    Returns:
+        True if the tool's class carries the exemption marker.
+    """
+# SECURITY: resolve the marker on the CLASS only, never the instance.
+# ToolMessage has ``extra="allow"``, so LLM-controlled tool JSON such
+# as ``{"_tool_policy_exempt": true, ...}`` lands on the INSTANCE as an
+# extra field; trusting instance attributes would let the LLM spoof the
+# exemption and bypass the policy.
+⋮----
+def deepcopy_config_sharing_policy(config: C) -> C
+⋮----
+"""Deep-copy an AgentConfig, sharing `tool_policy` by REFERENCE.
+
+    A `tool_policy` hook may be stateful (budgets, approval lists) or hold
+    unpicklable resources (locks, clients), so wherever the framework
+    deep-copies an agent config (agent cloning, Task construction, batch
+    processing) the policy must be exempted from the copy: the copy and the
+    original consult the SAME policy object. The live `config` is never
+    mutated (the exemption is done by pre-seeding the deepcopy memo).
+
+    Args:
+        config: The config to copy.
+
+    Returns:
+        A deep copy of `config` whose `tool_policy` is the same object as
+        `config.tool_policy`.
+    """
+memo: dict[int, Any] = {}
+policy = config.tool_policy
+⋮----
+config_copy: C = copy.deepcopy(config, memo)
+⋮----
+"""Call the `tool_policy` hook with (tool, agent[, chat_doc]).
+
+    The `chat_doc` is passed only if the callable's signature has a
+    `chat_doc` parameter, mirroring the tool-handler convention. The hook
+    decides allow/reject only, so it receives deep COPIES of the tool and
+    the chat_doc: mutating them cannot change what the handler executes.
+
+    Args:
+        policy: The configured `tool_policy` callable.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        The policy's decision, possibly an awaitable if the policy
+        is async.
+    """
+⋮----
+has_chat_doc_param = "chat_doc" in inspect.signature(policy).parameters
+⋮----
+has_chat_doc_param = False
+⋮----
+tool = tool.model_copy(deep=True)
+⋮----
+chat_doc = copy.deepcopy(chat_doc)
+⋮----
+def run_awaitable_sync(awaitable: Any) -> Any
+⋮----
+"""Run an awaitable to completion from sync code.
+
+    Uses `asyncio.run()` when no event loop is running in this thread;
+    otherwise runs it on a fresh event loop in a helper thread, so sync
+    dispatch nested inside async code (e.g. a sync tool handler invoked
+    from async code calling back into sync dispatch) still works.
+
+    Args:
+        awaitable: The awaitable to run.
+
+    Returns:
+        The awaitable's result.
+    """
+⋮----
+async def _await() -> Any
+⋮----
+def _decision_msg(tool_name: str, decision: Any) -> Optional[str]
+⋮----
+"""Convert a `tool_policy` decision into an optional rejection message.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        decision: The value returned by the `tool_policy` hook.
+
+    Returns:
+        None if the tool is allowed (decision is True or None), else an
+        LLM-visible rejection message naming the tool and the reason.
+        Any decision of an unrecognized type is treated as a rejection
+        (fail-closed).
+    """
+⋮----
+reason = "(no reason given)"
+⋮----
+reason = decision
+⋮----
+reason = (
+⋮----
+def _copy_failure_msg(tool_name: str, e: BaseException | None) -> str
+⋮----
+"""Fail-closed rejection for a payload that could not be copied.
+
+    A tool field carrying a non-copyable object (a lock, a client, ...)
+    prevents the pre-policy deep copy; the tool is blocked (fail-closed),
+    with an operator-log diagnostic distinct from "the policy raised". The
+    LLM-visible message still names only the tool and the exception class.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        e: The underlying copy exception, if known.
+
+    Returns:
+        An LLM-visible rejection message.
+    """
+exc_name = type(e).__name__ if e is not None else "Exception"
+⋮----
+def _failure_msg(tool_name: str, e: Exception) -> str
+⋮----
+"""Fail-closed rejection message for a `tool_policy` hook that raised.
+
+    The exception message is deliberately NOT included, since it may
+    embed raw tool arguments; only the exception class name is exposed.
+    The full exception is logged for the operator.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        e: The exception raised by the hook.
+
+    Returns:
+        An LLM-visible rejection message.
+    """
+⋮----
+"""Evaluate the `tool_policy` hook on the sync dispatch path.
+
+    An async policy is run to completion via `run_awaitable_sync` (which
+    works whether or not an event loop is already running in this thread);
+    any failure while doing so is treated like any other hook failure:
+    the tool is blocked (fail-closed).
+
+    Args:
+        policy: The configured `tool_policy` callable, or None.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        None if no policy is configured or the policy allows the tool,
+        else an LLM-visible rejection message.
+    """
+⋮----
+decision = _invoke_policy(policy, tool, agent, chat_doc)
+⋮----
+decision = run_awaitable_sync(decision)
+⋮----
+"""Async version of `check_tool_policy`.
+
+    An async policy is awaited on the CALLING event loop, so it may safely
+    use loop-bound resources (locks, clients, futures).
+
+    Args:
+        policy: The configured `tool_policy` callable, or None.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        None if no policy is configured or the policy allows the tool,
+        else an LLM-visible rejection message.
+    """
+⋮----
+decision = await decision
 </file>
 
 <file path="langroid/language_models/__init__.py">
@@ -49167,6 +49348,272 @@ results = self._convert_tool_result(tool_name, result)
     """
 </file>
 
+<file path="langroid/agent/batch.py">
+T = TypeVar("T")
+U = TypeVar("U")
+⋮----
+class ExceptionHandling(str, Enum)
+⋮----
+"""Enum for exception handling options."""
+⋮----
+RAISE = "raise"
+RETURN_NONE = "return_none"
+RETURN_EXCEPTION = "return_exception"
+⋮----
+"""Convert legacy boolean handle_exceptions to ExceptionHandling enum."""
+⋮----
+"""
+    Unified batch processing logic for both agent methods and tasks.
+
+    Args:
+        inputs: Iterable of inputs to process
+        do_task: Task execution function that takes (input, index) and returns result
+        start_idx: Starting index for the batch
+        stop_on_first_result: Whether to stop after first valid result
+        sequential: Whether to process sequentially
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        output_map: Function to map results to final output format
+    """
+exception_handling = _convert_exception_handling(handle_exceptions)
+⋮----
+def handle_error(e: BaseException) -> Any
+⋮----
+"""Handle exceptions based on exception_handling."""
+⋮----
+results: List[Optional[ChatDocument] | BaseException] = []
+pending: set[asyncio.Task[Any]] = set()
+# Create task-to-index mapping
+task_indices: dict[asyncio.Task[Any], int] = {}
+⋮----
+tasks = [
+task_indices = {task: i for i, task in enumerate(tasks)}
+results = [None] * len(tasks)
+⋮----
+pending = set(tasks)
+⋮----
+# Process completed tasks
+⋮----
+index = task_indices[task]
+⋮----
+result = await task
+⋮----
+results = []
+⋮----
+result = await do_task(input, i + start_idx)
+⋮----
+# Parallel execution
+⋮----
+return_exceptions = exception_handling != ExceptionHandling.RAISE
+⋮----
+results_with_exceptions = cast(
+⋮----
+results = [
+else:  # ExceptionHandling.RETURN_EXCEPTION
+results = results_with_exceptions
+⋮----
+results = [handle_error(e) for _ in inputs]
+⋮----
+"""
+    Common batch processing logic for both agent methods and tasks.
+
+    Args:
+        inputs: List of inputs to process
+        do_task: Task execution function
+        batch_size: Size of batches, if None process all at once
+        stop_on_first_result: Whether to stop after first valid result
+        sequential: Whether to process sequentially
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        output_map: Function to map results
+        message_template: Template for status message
+        message: Optional override for status message
+    """
+⋮----
+"""Extra wrap to run asyncio.run one single time and not once per loop
+
+        Args:
+            inputs (List[str  |  ChatDocument]): inputs to process
+            batch_size (int | None): batch size
+
+        Returns:
+            List[Any]: results
+        """
+results: List[Any] = []
+⋮----
+msg = message or message_template.format(total=len(inputs))
+⋮----
+results = await _process_batch_async(
+⋮----
+batches = batched(inputs, batch_size)
+⋮----
+start_idx = len(results)
+complete_str = f", {start_idx} complete" if start_idx > 0 else ""
+msg = (
+⋮----
+output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
+⋮----
+"""
+    Generate and run copies of a task async/concurrently one per item in `items` list.
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+    Args:
+        gen_task (Callable[[int], Task]): generates the tasks to run
+        items (list[T]): list of items to process
+        input_map (Callable[[T], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], U]): function to map result
+            to final result. If stop_on_first_result is enabled, then
+            map any invalid output to None. We continue until some non-None
+            result is obtained.
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        batch_size (Optional[int]): The number of tasks to run at a time,
+            if None, unbatched
+        turns (int): number of turns to run, -1 for infinite
+        message (Optional[str]): optionally overrides the console status messages
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
+        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
+
+
+    Returns:
+        list[Optional[U]]: list of final results. Always list[U] if
+        `stop_on_first_result` is disabled
+    """
+inputs = [input_map(item) for item in items]
+⋮----
+task_i = gen_task(i)
+⋮----
+result = await task_i.run_async(
+⋮----
+# exception will be handled by the caller
+⋮----
+# ----------------------------------------
+# Propagate any exception stored on the task that may have been
+# swallowed inside `Task.run_async`, so that the upper-level
+# exception-handling logic works as expected.
+⋮----
+exc = getattr(task_i, attr, None)
+⋮----
+# Fallback: treat a KILL-status result as an error
+⋮----
+"""
+    Run copies of `task` async/concurrently one per item in `items` list.
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+    Args:
+        task (Task): task to run
+        items (list[T]): list of items to process
+        input_map (Callable[[T], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], U]): function to map result
+            to final result
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None, after `output_map`) result. Processing continues past
+            None-mapped results; exceptions propagate, since this function
+            always uses the default `RAISE` exception handling. Once a non-None
+            result appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        batch_size (Optional[int]): The number of tasks to run at a time,
+            if None, unbatched
+        turns (int): number of turns to run, -1 for infinite
+        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
+        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
+
+    Returns:
+        list[Optional[U]]: list of final results. Always list[U] if
+        `stop_on_first_result` is disabled
+    """
+message = f"[bold green]Running {len(items)} copies of {task.name}..."
+⋮----
+"""
+    Run the `method` on copies of `agent`, async/concurrently one per
+    item in `items` list.
+    ASSUMPTION: The `method` is an async method and has signature:
+        method(self, input: str|ChatDocument|None) -> ChatDocument|None
+    So this would typically be used for the agent's "responder" methods,
+    e.g. `llm_response_async` or `agent_responder_async`.
+
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+
+    Args:
+        agent (Agent): agent whose method to run
+        method (str): Async method to run on copies of `agent`.
+            The method is assumed to have signature:
+            `method(self, input: str|ChatDocument|None) -> ChatDocument|None`
+        input_map (Callable[[Any], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], Any]): function to map result
+            to final result
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        batch_size (Optional[int]): The number of items to process in each batch.
+            If None, process all items at once.
+    Returns:
+        List[Any]: list of final results
+    """
+# Check if the method is async
+method_name = method.__name__
+⋮----
+# tool_policy hook shared by reference so its state stays global
+agent_cfg = deepcopy_config_sharing_policy(agent.config)
+⋮----
+agent_cls = type(agent)
+agent_name = agent_cfg.name
+⋮----
+async def _do_task(input: str | ChatDocument, i: int) -> Any
+⋮----
+agent_i = agent_cls(agent_cfg)
+method_i = getattr(agent_i, method_name, None)
+⋮----
+result = await method_i(input)
+⋮----
+async def _do_task(item: T) -> U
+⋮----
+async def _do_all(items: Iterable[T]) -> List[U]
+⋮----
+result = await _do_task(item)
+⋮----
+results: List[U] = []
+⋮----
+results = asyncio.run(_do_all(items))
+⋮----
+batches = batched(items, batch_size)
+</file>
+
 <file path="langroid/agent/openai_assistant.py">
 # setup logger
 ⋮----
@@ -52440,6 +52887,966 @@ sender_role = Role.ASSISTANT
 tool_id=tool_id,  # for OpenAI Assistant
 </file>
 
+<file path="langroid/language_models/base.py">
+logger = logging.getLogger(__name__)
+⋮----
+def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
+⋮----
+async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
+⋮----
+FunctionCallTypes = Literal["none", "auto"]
+ToolChoiceTypes = Literal["none", "auto", "required"]
+ToolTypes = Literal["function"]
+⋮----
+DEFAULT_CONTEXT_LENGTH = 16_000
+⋮----
+class StreamEventType(Enum)
+⋮----
+TEXT = 1
+FUNC_NAME = 2
+FUNC_ARGS = 3
+TOOL_NAME = 4
+TOOL_ARGS = 5
+REASONING = 6
+⋮----
+class RetryParams(BaseSettings)
+⋮----
+max_retries: int = 5
+initial_delay: float = 1.0
+exponential_base: float = 1.3
+jitter: bool = True
+⋮----
+class LLMConfig(BaseSettings)
+⋮----
+"""
+    Common configuration for all language models.
+    """
+⋮----
+type: str = "openai"
+streamer: Optional[Callable[[Any], None]] = noop_fn
+streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
+api_base: str | None = None
+formatter: None | str = None
+# specify None if you want to use the full max output tokens of the model
+max_output_tokens: int | None = 8192
+timeout: int = 20  # timeout for API requests
+chat_model: str = ""
+completion_model: str = ""
+temperature: float = 0.0
+chat_context_length: int | None = None
+async_stream_quiet: bool = False  # suppress streaming output in async mode?
+completion_context_length: int | None = None
+# if input length + max_output_tokens > context length of model,
+# we will try shortening requested output
+min_output_tokens: int = 64
+use_completion_for_chat: bool = False  # use completion model for chat?
+# use chat model for completion? For OpenAI models, this MUST be set to True!
+use_chat_for_completion: bool = True
+stream: bool = True  # stream output from API?
+# TODO: we could have a `stream_reasoning` flag here to control whether to show
+# reasoning output from reasoning models
+cache_config: None | CacheDBConfig = RedisCacheConfig()
+thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
+retry_params: RetryParams = RetryParams()
+⋮----
+@property
+    def model_max_output_tokens(self) -> int
+⋮----
+# Build fallback names by progressively stripping provider prefixes
+# (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
+# succeeds even before OpenAIGPT.__init__ strips the prefix.
+parts = self.chat_model.split("/")
+fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
+⋮----
+class LLMFunctionCall(BaseModel)
+⋮----
+"""
+    Structure of LLM response indicating it "wants" to call a function.
+    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
+    """
+⋮----
+name: str  # name of function to call
+arguments: Optional[Dict[str, Any]] = None
+⋮----
+@staticmethod
+    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall"
+⋮----
+"""
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+fun_call = LLMFunctionCall(name=message["name"])
+fun_args_str = message["arguments"]
+# sometimes may be malformed with invalid indents,
+# so we try to be safe by removing newlines.
+⋮----
+fun_args_str = fun_args_str.replace("\n", "").strip()
+dict_or_list = parse_imperfect_json(fun_args_str)
+⋮----
+fun_args = dict_or_list
+⋮----
+fun_args = None
+⋮----
+def __str__(self) -> str
+⋮----
+class LLMFunctionSpec(BaseModel)
+⋮----
+"""
+    Description of a function available for the LLM to use.
+    To be used when calling the LLM `chat()` method with the `functions` parameter.
+    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
+    """
+⋮----
+name: str
+description: str
+parameters: Dict[str, Any]
+⋮----
+class OpenAIToolCall(BaseModel)
+⋮----
+"""
+    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
+    See https://platform.openai.com/docs/api-reference/chat/create
+
+    Attributes:
+        id: The id of the tool call.
+        type: The type of the tool call;
+            only "function" is currently possible (7/26/24).
+        function: The function call.
+    """
+⋮----
+id: str | None = None
+type: ToolTypes = "function"
+function: LLMFunctionCall | None = None
+extra_content: Dict[str, Any] | None = None
+⋮----
+@staticmethod
+    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall"
+⋮----
+id = message["id"]
+type = message["type"]
+function = LLMFunctionCall.from_dict(message["function"])
+extra_content = message.get("extra_content")
+⋮----
+class OpenAIToolSpec(BaseModel)
+⋮----
+type: ToolTypes
+strict: Optional[bool] = None
+function: LLMFunctionSpec
+⋮----
+class OpenAIJsonSchemaSpec(BaseModel)
+⋮----
+def to_dict(self) -> Dict[str, Any]
+⋮----
+json_schema: Dict[str, Any] = {
+⋮----
+class LLMTokenUsage(BaseModel)
+⋮----
+"""
+    Usage of tokens by an LLM.
+    """
+⋮----
+prompt_tokens: int = 0
+cached_tokens: int = 0
+completion_tokens: int = 0
+cost: float = 0.0
+calls: int = 0  # how many API calls - not used as of 2025-04-04
+⋮----
+def reset(self) -> None
+⋮----
+@property
+    def total_tokens(self) -> int
+⋮----
+class Role(str, Enum)
+⋮----
+"""
+    Possible roles for a message in a chat.
+    """
+⋮----
+USER = "user"
+SYSTEM = "system"
+ASSISTANT = "assistant"
+FUNCTION = "function"
+TOOL = "tool"
+⋮----
+class LLMMessage(BaseModel)
+⋮----
+"""
+    Class representing an entry in the msg-history sent to the LLM API.
+    It could be one of these:
+    - a user message
+    - an LLM ("Assistant") response
+    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
+    - a result or results from executing a fn or tool-call(s)
+    """
+⋮----
+role: Role
+name: Optional[str] = None
+tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
+tool_id: str = ""  # used by OpenAIAssistant
+# None means "no content" (the model returned only a tool/function call).
+# This is distinct from "" and is dropped from the API payload by api_dict;
+# see api_dict for how a fully-empty message is handled per-API.
+content: Optional[str] = None
+files: List[FileAttachment] = []
+function_call: Optional[LLMFunctionCall] = None
+tool_calls: Optional[List[OpenAIToolCall]] = None
+timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+# link to corresponding chat document, for provenance/rewind purposes
+chat_document_id: str = ""
+⋮----
+def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]
+⋮----
+"""
+        Convert to dictionary for API request, keeping ONLY
+        the fields that are expected in an API call!
+        E.g., DROP the tool_id, since it is only for use in the Assistant API,
+            not the completion API.
+
+        Args:
+            has_system_role: whether the message has a system role (if not,
+                set to "user" role)
+        Returns:
+            dict: dictionary representation of LLM message
+        """
+d = self.model_dump()
+files: List[FileAttachment] = d.pop("files")
+⋮----
+# In there are files, then content is an array of
+# different content-parts
+⋮----
+# if there is a key k = "role" with value "system", change to "user"
+# in case has_system_role is False
+⋮----
+# drop None values since API doesn't accept them (this omits `content`
+# entirely when it is None, i.e. "no content")
+dict_no_none = {k: v for k, v in d.items() if v is not None}
+⋮----
+# OpenAI API does not like empty name
+⋮----
+# arguments must be a string
+⋮----
+# convert tool calls to API format
+⋮----
+# An empty tool-call list is not a call and conveys no useful API
+# information. Omitting it also lets the empty-message fallback
+# below produce a valid message.
+⋮----
+# A message with empty content (None was dropped above, or "") AND no
+# tool/function call would be an entirely empty message, which some APIs
+# (e.g. Gemini) reject; fall back to a single space in that case only.
+# When there IS a tool/function call, empty content is fine (and Gemini
+# 3.x in fact REQUIRES it — it rejects an assistant turn that carries
+# both a call and non-empty text content).
+has_call = bool(dict_no_none.get("tool_calls")) or (
+⋮----
+# IMPORTANT! drop fields that are not expected in API call
+⋮----
+content = "FUNC: " + json.dumps(self.function_call)
+⋮----
+content = self.content or ""
+name_str = f" ({self.name})" if self.name else ""
+⋮----
+class LLMResponse(BaseModel)
+⋮----
+"""
+    Class representing response from LLM.
+    """
+⋮----
+# None means the model returned NO content (e.g. only a tool/function
+# call), which is distinct from an empty string "". Preserving this
+# distinction lets the message be faithfully reproduced downstream
+# (see ChatDocument.content_is_none and LLMMessage.content).
+message: Optional[str] = None
+reasoning: str = ""  # optional reasoning text from reasoning models
+# Original message text including inline thought signatures (e.g.
+# <thinking>...</thinking>). Only set when reasoning was extracted
+# from the message text via get_reasoning_final(); NOT set when
+# reasoning comes from a separate API field (e.g. reasoning_content),
+# since in that case the message text never contained thought tags.
+message_with_reasoning: Optional[str] = None
+# TODO tool_id needs to generalize to multi-tool calls
+⋮----
+oai_tool_calls: Optional[List[OpenAIToolCall]] = None
+⋮----
+usage: Optional[LLMTokenUsage] = None
+cached: bool = False
+⋮----
+def tools_content(self) -> str
+⋮----
+def to_LLMMessage(self) -> LLMMessage
+⋮----
+"""Convert LLM response to an LLMMessage, to be included in the
+        message-list sent to the API.
+        This is currently NOT used in any significant way in the library, and is only
+        provided as a utility to construct a message list for the API when directly
+        working with an LLM object.
+
+        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
+        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
+        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
+        """
+⋮----
+"""
+        If `message` or `function_call` of an LLM response contains an explicit
+        recipient name, return this recipient name and `message` stripped
+        of the recipient name if specified.
+
+        Two cases:
+        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
+        (b) `message` is empty and function_call/tool_call with explicit `recipient`
+
+        Args:
+            recognize_recipient_in_content (bool): When True (default), parses
+                message text for ``TO[<recipient>]:<content>`` patterns and
+                top-level JSON ``{"recipient": "..."}`` fields. When False,
+                only function_call/tool_call ``recipient`` fields are checked.
+
+        Returns:
+            (str): name of recipient, which may be empty string if no recipient
+            (str): content of message
+
+        """
+⋮----
+# in this case we ignore message, since all information is in function_call
+msg = ""
+args = self.function_call.arguments
+recipient = ""
+⋮----
+recipient = args.get("recipient", "")
+⋮----
+msg = self.message or ""
+⋮----
+# get the first tool that has a recipient field, if any
+⋮----
+recipient = tc.function.arguments.get(
+⋮----
+)  # type: ignore
+⋮----
+# It's not a function or tool call, so continue looking to see
+# if a recipient is specified in the message.
+⋮----
+# First check if message contains "TO: <recipient> <content>"
+⋮----
+# check if there is a top level json that specifies 'recipient',
+# and retain the entire message as content.
+⋮----
+recipient_name = top_level_json_field(msg, "recipient") if msg else ""
+content = msg
+⋮----
+# Define an abstract base class for language models
+class LanguageModel(ABC)
+⋮----
+"""
+    Abstract base class for language models.
+    """
+⋮----
+# usage cost by model, accumulates here
+usage_cost_dict: Dict[str, LLMTokenUsage] = {}
+⋮----
+def __init__(self, config: LLMConfig = LLMConfig())
+⋮----
+@staticmethod
+    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]
+⋮----
+"""
+        Create a language model.
+        Args:
+            config: configuration for language model
+        Returns: instance of language model
+        """
+⋮----
+openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
+⋮----
+openai = AzureGPT
+⋮----
+openai = OpenAIGPT
+cls = dict(
+return cls(config)  # type: ignore
+⋮----
+@staticmethod
+    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]
+⋮----
+"""
+        Given an even-length sequence of strings, split into a sequence of pairs
+
+        Args:
+            lst (List[str]): sequence of strings
+
+        Returns:
+            List[Tuple[str,str]]: sequence of pairs of strings
+        """
+evens = lst[::2]
+odds = lst[1::2]
+⋮----
+"""
+        From the chat history, extract system prompt, user-assistant turns, and
+        final user msg.
+
+        Args:
+            messages (List[LLMMessage]): List of messages in the chat history
+
+        Returns:
+            Tuple[str, List[Tuple[str,str]], str]:
+                system prompt, user-assistant turns, final user msg
+
+        """
+# Handle various degenerate cases
+messages = [m for m in messages]  # copy
+DUMMY_SYS_PROMPT = "You are a helpful assistant."
+DUMMY_USER_PROMPT = "Follow the instructions above."
+⋮----
+system_prompt = messages[0].content or ""
+⋮----
+# now we have messages = [Sys,...]
+⋮----
+# now we have messages = [Sys, msg, ...]
+⋮----
+# now we have messages = [Sys, user, ...]
+⋮----
+# now we have messages = [Sys, user, ..., user]
+# so we omit the first and last elements and make pairs of user-asst messages
+conversation = [m.content or "" for m in messages[1:-1]]
+user_prompt = messages[-1].content or ""
+pairs = LanguageModel.user_assistant_pairs(conversation)
+⋮----
+@abstractmethod
+    def set_stream(self, stream: bool) -> bool
+⋮----
+"""Enable or disable streaming output from API.
+        Return previous value of stream."""
+⋮----
+@abstractmethod
+    def get_stream(self) -> bool
+⋮----
+"""Get streaming status"""
+⋮----
+@abstractmethod
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+@abstractmethod
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+"""
+        Get chat-completion response from LLM.
+
+        Args:
+            messages: message-history to send to the LLM
+            max_tokens: max tokens to generate
+            tools: tools available for the LLM to use in its response
+            tool_choice: tool call mode, one of "none", "auto", "required",
+                or a dict specifying a specific tool.
+            functions: functions available for LLM to call (deprecated)
+            function_call: function calling mode, "auto", "none", or a specific fn
+                    (deprecated)
+        """
+⋮----
+"""Async version of `chat`. See `chat` for details."""
+⋮----
+def __call__(self, prompt: str, max_tokens: int) -> LLMResponse
+⋮----
+@staticmethod
+    def _fallback_model_names(model: str) -> List[str]
+⋮----
+parts = model.split("/")
+fallbacks = []
+⋮----
+def info(self) -> ModelInfo
+⋮----
+"""Info of relevant chat model"""
+orig_model = (
+⋮----
+def completion_info(self) -> ModelInfo
+⋮----
+"""Info of relevant completion model"""
+⋮----
+def supports_functions_or_tools(self) -> bool
+⋮----
+"""
+        Does this Model's API support "native" tool-calling, i.e.
+        can we call the API with arguments that contain a list of available tools,
+        and their schemas?
+        Note that, given the plethora of LLM provider APIs this determination is
+        imperfect at best, and leans towards returning True.
+        When the API calls fails with an error indicating tools are not supported,
+        then users are encouraged to use the Langroid-based prompt-based
+        ToolMessage mechanism, which works with ANY LLM. To enable this,
+        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
+        """
+⋮----
+def chat_context_length(self) -> int
+⋮----
+def completion_context_length(self) -> int
+⋮----
+def chat_cost(self) -> Tuple[float, float, float]
+⋮----
+"""
+        Return the cost per 1000 tokens for chat completions.
+
+        Returns:
+            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
+                per 1000 tokens
+        """
+⋮----
+def reset_usage_cost(self) -> None
+⋮----
+counter = self.usage_cost_dict[mdl]
+⋮----
+"""
+        Update usage cost for this LLM.
+        Args:
+            chat (bool): whether to update for chat or completion model
+            prompts (int): number of tokens used for prompts
+            completions (int): number of tokens used for completions
+            cost (float): total token cost in USD
+        """
+mdl = self.config.chat_model if chat else self.config.completion_model
+⋮----
+@classmethod
+    def usage_cost_summary(cls) -> str
+⋮----
+s = ""
+⋮----
+@classmethod
+    def tot_tokens_cost(cls) -> Tuple[int, float]
+⋮----
+"""
+        Return total tokens used and total cost across all models.
+        """
+total_tokens = 0
+total_cost = 0.0
+⋮----
+def get_reasoning_final(self, message: str) -> Tuple[str, str]
+⋮----
+"""Extract "reasoning" and "final answer" from an LLM response, if the
+        reasoning is found within configured delimiters, like <think>, </think>.
+        E.g.,
+        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
+
+        Args:
+            message (str): message from LLM
+
+        Returns:
+            Tuple[str, str]: reasoning, final answer
+        """
+⋮----
+parts = message.split(start)
+⋮----
+"""
+        Given a chat history and a question, convert it to a standalone question.
+        Args:
+            chat_history: list of tuples of (question, answer)
+            query: follow-up question
+
+        Returns: standalone version of the question
+        """
+history = collate_chat_history(chat_history)
+⋮----
+prompt = f"""
+⋮----
+follow_up_question = f"""
+⋮----
+standalone = (
+standalone = standalone.strip()
+⋮----
+class StreamingIfAllowed
+⋮----
+"""Context to temporarily enable or disable streaming, if allowed globally via
+    `settings.stream`"""
+⋮----
+def __init__(self, llm: LanguageModel, stream: bool = True)
+⋮----
+def __enter__(self) -> None
+⋮----
+def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
+</file>
+
+<file path="langroid/language_models/client_cache.py">
+"""
+Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
+"""
+⋮----
+# Cache for client instances, keyed by hashed configuration parameters.
+# Value is a tuple of (client instance, last_used_monotonic_seconds).
+_client_cache: Dict[str, Tuple[Any, float]] = {}
+_client_cache_lock = threading.RLock()
+⋮----
+# Keep track of clients for cleanup
+_all_clients: weakref.WeakSet[Any] = weakref.WeakSet()
+⋮----
+def _get_cache_key(client_type: str, **kwargs: Any) -> str
+⋮----
+"""
+    Generate a cache key from client type and configuration parameters.
+    Uses the same approach as OpenAIGPT._cache_lookup for consistency.
+
+    Args:
+        client_type: Type of client (e.g., "openai", "groq", "cerebras")
+        **kwargs: Configuration parameters (api_key, base_url, timeout, etc.)
+
+    Returns:
+        SHA256 hash of the configuration as a hex string
+    """
+# Convert kwargs to sorted string representation
+sorted_kwargs_str = str(sorted(kwargs.items()))
+⋮----
+# Create raw key combining client type and sorted kwargs
+raw_key = f"{client_type}:{sorted_kwargs_str}"
+⋮----
+# Hash the key for consistent length and to handle complex objects
+hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
+⋮----
+"""
+    Wrap a sync API-key provider for use with ``AsyncOpenAI``.
+
+    ``AsyncOpenAI`` awaits its ``api_key`` callable, so a plain sync
+    provider must be wrapped in an async function. The sync provider is run
+    in a worker thread, so a blocking token refresh cannot stall the event
+    loop. Providers must therefore be thread-safe -- the sync client may
+    call them from arbitrary threads anyway.
+
+    Args:
+        provider: Callable returning a (possibly short-lived) API key.
+
+    Returns:
+        Async callable returning the same key.
+    """
+⋮----
+async def _provider() -> str
+⋮----
+def _api_key_cache_component(api_key: Union[str, Callable[[], str]]) -> Any
+⋮----
+"""
+    Cache-key component for an API key that may be a rotating-key provider.
+
+    A callable provider is keyed on its identity rather than any token value,
+    so rotating tokens never create new cache entries and tokens are never
+    retained in cache keys. The id() cannot be recycled while the entry
+    lives, because the cached client holds a strong reference to the
+    provider (directly for sync clients, via the async wrapper's closure
+    for async clients).
+    """
+⋮----
+def _get_cached_client(cache_key: str) -> Optional[Any]
+⋮----
+"""Get cached client and refresh its last-used timestamp.
+
+    Must be called while holding ``_client_cache_lock``.
+    """
+entry = _client_cache.get(cache_key)
+⋮----
+def _store_client(cache_key: str, client: Any) -> None
+⋮----
+"""Store a client in the cache with the current timestamp.
+
+    Must be called while holding ``_client_cache_lock``.
+    """
+⋮----
+"""
+    Get or create a singleton OpenAI client with the given configuration.
+
+    Args:
+        api_key: OpenAI API key, or a callable returning a fresh key
+            (for short-lived rotating credentials); a callable is resolved
+            per-request by the OpenAI client and is excluded from the
+            cache key (the cache is keyed on the provider's identity)
+        base_url: Optional base URL for API
+        organization: Optional organization ID
+        timeout: Request timeout
+        default_headers: Optional default headers
+        http_client: Optional httpx.Client instance
+        http_client_config: Optional config dict for creating httpx.Client
+
+    Returns:
+        OpenAI client instance
+    """
+⋮----
+timeout = Timeout(timeout)
+⋮----
+# If http_client is provided directly, don't cache (complex object)
+⋮----
+client = OpenAI(
+⋮----
+cache_key = _get_cache_key(
+⋮----
+http_client_config=http_client_config,  # Include config in cache key
+⋮----
+cached_client = _get_cached_client(cache_key)
+⋮----
+created_http_client = None
+⋮----
+created_http_client = Client(**http_client_config)
+⋮----
+http_client=created_http_client,  # Use the client created from config
+⋮----
+"""
+    Get or create a singleton AsyncOpenAI client with the given configuration.
+
+    Args:
+        api_key: OpenAI API key, or a callable returning a fresh key
+            (for short-lived rotating credentials); a callable is resolved
+            per-request by the OpenAI client and is excluded from the
+            cache key (the cache is keyed on the provider's identity)
+        base_url: Optional base URL for API
+        organization: Optional organization ID
+        timeout: Request timeout
+        default_headers: Optional default headers
+        http_client: Optional httpx.AsyncClient instance
+        http_client_config: Optional config dict for creating httpx.AsyncClient
+
+    Returns:
+        AsyncOpenAI client instance
+    """
+⋮----
+api_key_arg: Union[str, Callable[[], Awaitable[str]]]
+⋮----
+# AsyncOpenAI awaits its api_key callable, so wrap the sync provider
+api_key_arg = wrap_api_key_provider_async(api_key)
+⋮----
+api_key_arg = api_key
+⋮----
+client = AsyncOpenAI(
+⋮----
+created_http_client = AsyncClient(**http_client_config)
+⋮----
+def get_groq_client(api_key: str) -> Groq
+⋮----
+"""
+    Get or create a singleton Groq client with the given configuration.
+
+    Args:
+        api_key: Groq API key
+
+    Returns:
+        Groq client instance
+    """
+cache_key = _get_cache_key("groq", api_key=api_key)
+⋮----
+client = Groq(api_key=api_key)
+⋮----
+def get_async_groq_client(api_key: str) -> AsyncGroq
+⋮----
+"""
+    Get or create a singleton AsyncGroq client with the given configuration.
+
+    Args:
+        api_key: Groq API key
+
+    Returns:
+        AsyncGroq client instance
+    """
+cache_key = _get_cache_key("async_groq", api_key=api_key)
+⋮----
+client = AsyncGroq(api_key=api_key)
+⋮----
+def get_cerebras_client(api_key: str) -> Cerebras
+⋮----
+"""
+    Get or create a singleton Cerebras client with the given configuration.
+
+    Args:
+        api_key: Cerebras API key
+
+    Returns:
+        Cerebras client instance
+    """
+cache_key = _get_cache_key("cerebras", api_key=api_key)
+⋮----
+client = Cerebras(api_key=api_key)
+⋮----
+def get_async_cerebras_client(api_key: str) -> AsyncCerebras
+⋮----
+"""
+    Get or create a singleton AsyncCerebras client with the given configuration.
+
+    Args:
+        api_key: Cerebras API key
+
+    Returns:
+        AsyncCerebras client instance
+    """
+cache_key = _get_cache_key("async_cerebras", api_key=api_key)
+⋮----
+client = AsyncCerebras(api_key=api_key)
+⋮----
+def prune_cache(max_age_seconds: float) -> int
+⋮----
+"""
+    Remove cache entries whose last-used time exceeds *max_age_seconds*.
+
+    Evicted clients are **not** closed here because they may still be serving
+    in-flight requests.  Cleanup is handled by the ``atexit`` handler and the
+    garbage collector.
+
+    Args:
+        max_age_seconds: Maximum age (in seconds) for cache entries to keep.
+            Entries older than this value are removed.
+
+    Returns:
+        Number of cache entries removed.
+    """
+⋮----
+now = time.monotonic()
+⋮----
+stale_keys = [
+⋮----
+# Don't close evicted clients here — they may still be serving in-flight
+# requests. The atexit handler and GC will clean them up.
+⋮----
+def _cleanup_clients() -> None
+⋮----
+"""
+    Cleanup function to close all cached clients on exit.
+    Called automatically via atexit.
+    """
+⋮----
+# Check if close is a coroutine function (async)
+⋮----
+# For async clients, we can't await in atexit
+# They will be cleaned up by the OS
+⋮----
+# Sync clients can be closed directly
+⋮----
+pass  # Ignore errors during cleanup
+⋮----
+# Register cleanup function to run on exit
+⋮----
+# For testing purposes
+def _clear_cache() -> None
+⋮----
+"""Clear the client cache. Only for testing."""
+</file>
+
+<file path="SECURITY.md">
+# Security Policy
+
+## Threat model — please read this before reporting
+
+Langroid is a framework for building applications in which an LLM generates
+code and queries that are then executed. Several **optional** agents exist for
+exactly that purpose:
+
+- `TableChatAgent`, `LanceDocChatAgent`, and `VectorStore.compute_from_docs`
+  evaluate LLM-generated **pandas expressions** with `eval()`.
+- `SQLChatAgent` executes LLM-generated **SQL** against a database you supply.
+- `Neo4jChatAgent`, `ArangoChatAgent`, and `CSVGraphAgent` execute
+  LLM-generated **Cypher / AQL** against a graph database you supply.
+
+Executing model-generated code against your own data *is the feature*. An LLM
+is not a trust boundary: if any untrusted text reaches the model's context, you
+must assume the model can be induced to emit any query or expression the
+grammar allows. Langroid cannot prevent this, and does not claim to.
+
+### What is, and is not, a security boundary
+
+The following are **best-effort hardening, not security boundaries**:
+
+- `sanitize_command()` / `CommandValidator` / `safe_eval_globals()` in
+  `langroid/utils/pandas_utils.py`
+- `_DANGEROUS_SQL_PATTERNS` and the `sqlglot` AST checks in `SQLChatAgent`
+- `validate_cypher_query()` / `validate_aql_query()` in the graph agents
+
+They exist to stop an *unlucky* LLM, not a *determined attacker*. The pandas
+path uses explicit allowlists for AST nodes, methods, operators, variables, and
+builtins. The SQL, Cypher, and AQL paths use denylists over full query grammars
+that span multiple dialects, quoting and escaping forms, and function families.
+Such denylists cannot be made complete. We patch clear gaps opportunistically,
+but we do not treat a newly found way around them as a vulnerability in
+Langroid.
+
+The **actual** security boundaries for a Langroid deployment are:
+
+- the privileges of the database credential you hand the agent;
+- the OS user, container, or VM the process runs in;
+- filesystem permissions and network egress rules.
+
+### Deploying these agents safely
+
+If you expose any of the code- or query-executing agents to untrusted input:
+
+- **Give the agent a least-privilege database role.** For `SQLChatAgent`, a
+  read-only, non-superuser role with `GRANT SELECT` on only the intended
+  tables. In PostgreSQL, server-side file reads and writes normally require a
+  superuser, membership in `pg_read_server_files` or
+  `pg_write_server_files`, or a direct grant on a privileged function.
+  `COPY ... PROGRAM` instead requires superuser access or membership in the
+  distinct `pg_execute_server_program` role. Server-side `lo_import` and
+  `lo_export` default to superuser-only use, but an administrator can grant
+  access to those functions directly. Ordinary password-authenticated
+  `dblink` connections do not require any of those roles. Do not install
+  unneeded extensions, and revoke access to dangerous extensions and
+  functions, including `dblink`, in addition to granting only the intended
+  table privileges. Review any site-specific functions and grants as well.
+- **Run the process in a container or VM** with no credentials, secrets, or
+  data you are unwilling to expose to the LLM.
+- **Treat `allow_dangerous_operations=True` and `full_eval=True` as
+  "I am providing my own sandbox."** The first permits dangerous database
+  operations. The second disables pandas AST validation while retaining the
+  restricted globals from `safe_eval_globals()`. Both are documented as
+  trusted-environment-only.
+
+## Reporting a vulnerability
+
+Report privately — **not** via GitHub Issues, Discussions, or any other public
+forum:
+
+1. Go to
+   **[Security Advisories](https://github.com/langroid/langroid/security/advisories)**.
+2. Click **"Report a vulnerability"**.
+3. Include a proof of concept that works against a **default configuration**.
+
+We aim to acknowledge in-scope reports within 7 days.
+
+### In scope
+
+- Vulnerabilities in core framework code: tool dispatch and the agent/tool
+  trust boundary, message routing, sender verification.
+- Parsing and deserialization flaws (XXE, unsafe deserialization, decompression
+  bombs) in the document and message parsers.
+- Path traversal in the file tools (`ReadFileTool`, `WriteFileTool`,
+  `ListDirTool`) and in repository / folder ingestion.
+- Credential or secret leakage in a default configuration that does not depend
+  on any of the specific exclusions below. The out-of-scope rules take
+  precedence over this category.
+- **A code path that skips a documented safety gate entirely** — that is, a
+  *missing call* to a validator, not a *bypass* of one.
+- **A statement the `allowed_statement_types` allowlist misclassifies.** The
+  allowlist is a different kind of control from the denylists above: it decides
+  what a statement *does* over a closed set of statement kinds, so a query that
+  performs a write the allowlist did not authorize — for example by nesting it
+  where the classifier does not look — is a bounded, fixable defect and is in
+  scope.
+- Vulnerable dependencies with a demonstrated impact on Langroid.
+
+### Out of scope
+
+The following will be closed without a fix, an advisory, or a CVE request:
+
+- New bypasses of the SQL, Cypher, or AQL denylists: previously unlisted
+  functions, alternate quoting or escaping forms (backticks, Unicode escapes,
+  schema qualification), or dialect-specific syntax. See "What is, and is not,
+  a security boundary" above.
+- Sandbox escapes from the pandas `eval()` path when `full_eval=True`,
+  including object-graph traversal via dunder attributes. `full_eval=True`
+  disables the AST validator by design.
+- Anything requiring `allow_dangerous_operations=True`.
+- "The LLM can be prompt-injected into generating a harmful query." This is the
+  documented threat model, not a defect.
+- Reports that assume the agent was given a superuser or otherwise
+  over-privileged database credential.
+- Theoretical reports with no working proof of concept against a default
+  configuration.
+
+Reports that chain off a previous advisory as an "incomplete fix" are judged
+against this same scope: if the original issue was a missing gate we will fix
+it, and if it was a denylist gap it is out of scope.
+
+## Supported versions
+
+Security fixes ship in the latest release. Please upgrade to the current
+version of `langroid` rather than requesting backports.
+</file>
+
 <file path="langroid/agent/task.py">
 logger = logging.getLogger(__name__)
 ⋮----
@@ -52673,7 +54080,9 @@ agent = ChatAgent()
 # copy the agent's config, so that we don't modify the original agent's config,
 # which may be shared by other agents.
 ⋮----
-config_copy = copy.deepcopy(agent.config)
+# the tool_policy hook is shared by reference (never deep-copied),
+# so its state (budgets, approvals) stays global across copies
+config_copy = deepcopy_config_sharing_policy(agent.config)
 ⋮----
 agent = cast(ChatAgent, agent)
 ⋮----
@@ -53692,2100 +55101,6 @@ matched = False
 matched = True
 </file>
 
-<file path="langroid/language_models/client_cache.py">
-"""
-Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
-"""
-⋮----
-# Cache for client instances, keyed by hashed configuration parameters.
-# Value is a tuple of (client instance, last_used_monotonic_seconds).
-_client_cache: Dict[str, Tuple[Any, float]] = {}
-_client_cache_lock = threading.RLock()
-⋮----
-# Keep track of clients for cleanup
-_all_clients: weakref.WeakSet[Any] = weakref.WeakSet()
-⋮----
-def _get_cache_key(client_type: str, **kwargs: Any) -> str
-⋮----
-"""
-    Generate a cache key from client type and configuration parameters.
-    Uses the same approach as OpenAIGPT._cache_lookup for consistency.
-
-    Args:
-        client_type: Type of client (e.g., "openai", "groq", "cerebras")
-        **kwargs: Configuration parameters (api_key, base_url, timeout, etc.)
-
-    Returns:
-        SHA256 hash of the configuration as a hex string
-    """
-# Convert kwargs to sorted string representation
-sorted_kwargs_str = str(sorted(kwargs.items()))
-⋮----
-# Create raw key combining client type and sorted kwargs
-raw_key = f"{client_type}:{sorted_kwargs_str}"
-⋮----
-# Hash the key for consistent length and to handle complex objects
-hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
-⋮----
-"""
-    Wrap a sync API-key provider for use with ``AsyncOpenAI``.
-
-    ``AsyncOpenAI`` awaits its ``api_key`` callable, so a plain sync
-    provider must be wrapped in an async function. The sync provider is run
-    in a worker thread, so a blocking token refresh cannot stall the event
-    loop. Providers must therefore be thread-safe -- the sync client may
-    call them from arbitrary threads anyway.
-
-    Args:
-        provider: Callable returning a (possibly short-lived) API key.
-
-    Returns:
-        Async callable returning the same key.
-    """
-⋮----
-async def _provider() -> str
-⋮----
-def _api_key_cache_component(api_key: Union[str, Callable[[], str]]) -> Any
-⋮----
-"""
-    Cache-key component for an API key that may be a rotating-key provider.
-
-    A callable provider is keyed on its identity rather than any token value,
-    so rotating tokens never create new cache entries and tokens are never
-    retained in cache keys. The id() cannot be recycled while the entry
-    lives, because the cached client holds a strong reference to the
-    provider (directly for sync clients, via the async wrapper's closure
-    for async clients).
-    """
-⋮----
-def _get_cached_client(cache_key: str) -> Optional[Any]
-⋮----
-"""Get cached client and refresh its last-used timestamp.
-
-    Must be called while holding ``_client_cache_lock``.
-    """
-entry = _client_cache.get(cache_key)
-⋮----
-def _store_client(cache_key: str, client: Any) -> None
-⋮----
-"""Store a client in the cache with the current timestamp.
-
-    Must be called while holding ``_client_cache_lock``.
-    """
-⋮----
-"""
-    Get or create a singleton OpenAI client with the given configuration.
-
-    Args:
-        api_key: OpenAI API key, or a callable returning a fresh key
-            (for short-lived rotating credentials); a callable is resolved
-            per-request by the OpenAI client and is excluded from the
-            cache key (the cache is keyed on the provider's identity)
-        base_url: Optional base URL for API
-        organization: Optional organization ID
-        timeout: Request timeout
-        default_headers: Optional default headers
-        http_client: Optional httpx.Client instance
-        http_client_config: Optional config dict for creating httpx.Client
-
-    Returns:
-        OpenAI client instance
-    """
-⋮----
-timeout = Timeout(timeout)
-⋮----
-# If http_client is provided directly, don't cache (complex object)
-⋮----
-client = OpenAI(
-⋮----
-cache_key = _get_cache_key(
-⋮----
-http_client_config=http_client_config,  # Include config in cache key
-⋮----
-cached_client = _get_cached_client(cache_key)
-⋮----
-created_http_client = None
-⋮----
-created_http_client = Client(**http_client_config)
-⋮----
-http_client=created_http_client,  # Use the client created from config
-⋮----
-"""
-    Get or create a singleton AsyncOpenAI client with the given configuration.
-
-    Args:
-        api_key: OpenAI API key, or a callable returning a fresh key
-            (for short-lived rotating credentials); a callable is resolved
-            per-request by the OpenAI client and is excluded from the
-            cache key (the cache is keyed on the provider's identity)
-        base_url: Optional base URL for API
-        organization: Optional organization ID
-        timeout: Request timeout
-        default_headers: Optional default headers
-        http_client: Optional httpx.AsyncClient instance
-        http_client_config: Optional config dict for creating httpx.AsyncClient
-
-    Returns:
-        AsyncOpenAI client instance
-    """
-⋮----
-api_key_arg: Union[str, Callable[[], Awaitable[str]]]
-⋮----
-# AsyncOpenAI awaits its api_key callable, so wrap the sync provider
-api_key_arg = wrap_api_key_provider_async(api_key)
-⋮----
-api_key_arg = api_key
-⋮----
-client = AsyncOpenAI(
-⋮----
-created_http_client = AsyncClient(**http_client_config)
-⋮----
-def get_groq_client(api_key: str) -> Groq
-⋮----
-"""
-    Get or create a singleton Groq client with the given configuration.
-
-    Args:
-        api_key: Groq API key
-
-    Returns:
-        Groq client instance
-    """
-cache_key = _get_cache_key("groq", api_key=api_key)
-⋮----
-client = Groq(api_key=api_key)
-⋮----
-def get_async_groq_client(api_key: str) -> AsyncGroq
-⋮----
-"""
-    Get or create a singleton AsyncGroq client with the given configuration.
-
-    Args:
-        api_key: Groq API key
-
-    Returns:
-        AsyncGroq client instance
-    """
-cache_key = _get_cache_key("async_groq", api_key=api_key)
-⋮----
-client = AsyncGroq(api_key=api_key)
-⋮----
-def get_cerebras_client(api_key: str) -> Cerebras
-⋮----
-"""
-    Get or create a singleton Cerebras client with the given configuration.
-
-    Args:
-        api_key: Cerebras API key
-
-    Returns:
-        Cerebras client instance
-    """
-cache_key = _get_cache_key("cerebras", api_key=api_key)
-⋮----
-client = Cerebras(api_key=api_key)
-⋮----
-def get_async_cerebras_client(api_key: str) -> AsyncCerebras
-⋮----
-"""
-    Get or create a singleton AsyncCerebras client with the given configuration.
-
-    Args:
-        api_key: Cerebras API key
-
-    Returns:
-        AsyncCerebras client instance
-    """
-cache_key = _get_cache_key("async_cerebras", api_key=api_key)
-⋮----
-client = AsyncCerebras(api_key=api_key)
-⋮----
-def prune_cache(max_age_seconds: float) -> int
-⋮----
-"""
-    Remove cache entries whose last-used time exceeds *max_age_seconds*.
-
-    Evicted clients are **not** closed here because they may still be serving
-    in-flight requests.  Cleanup is handled by the ``atexit`` handler and the
-    garbage collector.
-
-    Args:
-        max_age_seconds: Maximum age (in seconds) for cache entries to keep.
-            Entries older than this value are removed.
-
-    Returns:
-        Number of cache entries removed.
-    """
-⋮----
-now = time.monotonic()
-⋮----
-stale_keys = [
-⋮----
-# Don't close evicted clients here — they may still be serving in-flight
-# requests. The atexit handler and GC will clean them up.
-⋮----
-def _cleanup_clients() -> None
-⋮----
-"""
-    Cleanup function to close all cached clients on exit.
-    Called automatically via atexit.
-    """
-⋮----
-# Check if close is a coroutine function (async)
-⋮----
-# For async clients, we can't await in atexit
-# They will be cleaned up by the OS
-⋮----
-# Sync clients can be closed directly
-⋮----
-pass  # Ignore errors during cleanup
-⋮----
-# Register cleanup function to run on exit
-⋮----
-# For testing purposes
-def _clear_cache() -> None
-⋮----
-"""Clear the client cache. Only for testing."""
-</file>
-
-<file path="SECURITY.md">
-# Security Policy
-
-## Threat model — please read this before reporting
-
-Langroid is a framework for building applications in which an LLM generates
-code and queries that are then executed. Several **optional** agents exist for
-exactly that purpose:
-
-- `TableChatAgent`, `LanceDocChatAgent`, and `VectorStore.compute_from_docs`
-  evaluate LLM-generated **pandas expressions** with `eval()`.
-- `SQLChatAgent` executes LLM-generated **SQL** against a database you supply.
-- `Neo4jChatAgent`, `ArangoChatAgent`, and `CSVGraphAgent` execute
-  LLM-generated **Cypher / AQL** against a graph database you supply.
-
-Executing model-generated code against your own data *is the feature*. An LLM
-is not a trust boundary: if any untrusted text reaches the model's context, you
-must assume the model can be induced to emit any query or expression the
-grammar allows. Langroid cannot prevent this, and does not claim to.
-
-### What is, and is not, a security boundary
-
-The following are **best-effort hardening, not security boundaries**:
-
-- `sanitize_command()` / `CommandValidator` / `safe_eval_globals()` in
-  `langroid/utils/pandas_utils.py`
-- `_DANGEROUS_SQL_PATTERNS` and the `sqlglot` AST checks in `SQLChatAgent`
-- `validate_cypher_query()` / `validate_aql_query()` in the graph agents
-
-They exist to stop an *unlucky* LLM, not a *determined attacker*. The pandas
-path uses explicit allowlists for AST nodes, methods, operators, variables, and
-builtins. The SQL, Cypher, and AQL paths use denylists over full query grammars
-that span multiple dialects, quoting and escaping forms, and function families.
-Such denylists cannot be made complete. We patch clear gaps opportunistically,
-but we do not treat a newly found way around them as a vulnerability in
-Langroid.
-
-The **actual** security boundaries for a Langroid deployment are:
-
-- the privileges of the database credential you hand the agent;
-- the OS user, container, or VM the process runs in;
-- filesystem permissions and network egress rules.
-
-### Deploying these agents safely
-
-If you expose any of the code- or query-executing agents to untrusted input:
-
-- **Give the agent a least-privilege database role.** For `SQLChatAgent`, a
-  read-only, non-superuser role with `GRANT SELECT` on only the intended
-  tables. In PostgreSQL, server-side file reads and writes normally require a
-  superuser, membership in `pg_read_server_files` or
-  `pg_write_server_files`, or a direct grant on a privileged function.
-  `COPY ... PROGRAM` instead requires superuser access or membership in the
-  distinct `pg_execute_server_program` role. Server-side `lo_import` and
-  `lo_export` default to superuser-only use, but an administrator can grant
-  access to those functions directly. Ordinary password-authenticated
-  `dblink` connections do not require any of those roles. Do not install
-  unneeded extensions, and revoke access to dangerous extensions and
-  functions, including `dblink`, in addition to granting only the intended
-  table privileges. Review any site-specific functions and grants as well.
-- **Run the process in a container or VM** with no credentials, secrets, or
-  data you are unwilling to expose to the LLM.
-- **Treat `allow_dangerous_operations=True` and `full_eval=True` as
-  "I am providing my own sandbox."** The first permits dangerous database
-  operations. The second disables pandas AST validation while retaining the
-  restricted globals from `safe_eval_globals()`. Both are documented as
-  trusted-environment-only.
-
-## Reporting a vulnerability
-
-Report privately — **not** via GitHub Issues, Discussions, or any other public
-forum:
-
-1. Go to
-   **[Security Advisories](https://github.com/langroid/langroid/security/advisories)**.
-2. Click **"Report a vulnerability"**.
-3. Include a proof of concept that works against a **default configuration**.
-
-We aim to acknowledge in-scope reports within 7 days.
-
-### In scope
-
-- Vulnerabilities in core framework code: tool dispatch and the agent/tool
-  trust boundary, message routing, sender verification.
-- Parsing and deserialization flaws (XXE, unsafe deserialization, decompression
-  bombs) in the document and message parsers.
-- Path traversal in the file tools (`ReadFileTool`, `WriteFileTool`,
-  `ListDirTool`) and in repository / folder ingestion.
-- Credential or secret leakage in a default configuration that does not depend
-  on any of the specific exclusions below. The out-of-scope rules take
-  precedence over this category.
-- **A code path that skips a documented safety gate entirely** — that is, a
-  *missing call* to a validator, not a *bypass* of one.
-- **A statement the `allowed_statement_types` allowlist misclassifies.** The
-  allowlist is a different kind of control from the denylists above: it decides
-  what a statement *does* over a closed set of statement kinds, so a query that
-  performs a write the allowlist did not authorize — for example by nesting it
-  where the classifier does not look — is a bounded, fixable defect and is in
-  scope.
-- Vulnerable dependencies with a demonstrated impact on Langroid.
-
-### Out of scope
-
-The following will be closed without a fix, an advisory, or a CVE request:
-
-- New bypasses of the SQL, Cypher, or AQL denylists: previously unlisted
-  functions, alternate quoting or escaping forms (backticks, Unicode escapes,
-  schema qualification), or dialect-specific syntax. See "What is, and is not,
-  a security boundary" above.
-- Sandbox escapes from the pandas `eval()` path when `full_eval=True`,
-  including object-graph traversal via dunder attributes. `full_eval=True`
-  disables the AST validator by design.
-- Anything requiring `allow_dangerous_operations=True`.
-- "The LLM can be prompt-injected into generating a harmful query." This is the
-  documented threat model, not a defect.
-- Reports that assume the agent was given a superuser or otherwise
-  over-privileged database credential.
-- Theoretical reports with no working proof of concept against a default
-  configuration.
-
-Reports that chain off a previous advisory as an "incomplete fix" are judged
-against this same scope: if the original issue was a missing gate we will fix
-it, and if it was a denylist gap it is out of scope.
-
-## Supported versions
-
-Security fixes ship in the latest release. Please upgrade to the current
-version of `langroid` rather than requesting backports.
-</file>
-
-<file path="langroid/agent/chat_agent.py">
-console = Console()
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-def _is_identified_result(message: LLMMessage) -> bool
-⋮----
-"""Whether a TOOL/FUNCTION result has its identifier and no call payload.
-
-    Such results must survive even with empty content so their calls can be
-    marked complete (issue #1063).
-    """
-has_identifier = (
-⋮----
-def _llm_message_has_payload(message: LLMMessage) -> bool
-⋮----
-"""Whether a message has the fields required for a valid history entry."""
-⋮----
-class ChatAgentConfig(AgentConfig)
-⋮----
-"""
-    Configuration for ChatAgent
-
-    Attributes:
-        system_message: system message to include in message sequence
-             (typically defines role and task of agent).
-             Used only if `task` is not specified in the constructor.
-        user_message: user message to include in message sequence.
-             Used only if `task` is not specified in the constructor.
-        use_tools: whether to use our own ToolMessages mechanism
-        handle_llm_no_tool (Any): desired agent_response when
-            LLM generates non-tool msg.
-        use_functions_api: whether to use functions/tools native to the LLM API
-                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
-        use_tools_api: When `use_functions_api` is True, if this is also True,
-            the OpenAI tool-call API is used, rather than the older/deprecated
-            function-call API. However the tool-call API has some tricky aspects,
-            hence we set this to False by default.
-        strict_recovery: whether to enable strict schema recovery when there
-            is a tool-generation error.
-        enable_orchestration_tool_handling: whether to enable handling of orchestration
-            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
-        output_format: When supported by the LLM (certain OpenAI LLMs
-            and local LLMs served by providers such as vLLM), ensures
-            that the output is a JSON matching the corresponding
-            schema via grammar-based decoding
-        handle_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for handling".
-        use_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for use" (by LLM) and
-            instructions on using T are added to the system message.
-        instructions_output_format: Controls whether we generate instructions for
-            `output_format` in the system message.
-        use_tools_on_output_format: Controls whether to automatically switch
-            to the Langroid-native tools mechanism when `output_format` is set.
-            Note that LLMs may generate tool calls which do not belong to
-            `output_format` even when strict JSON mode is enabled, so this should be
-            enabled when such tool calls are not desired.
-        output_format_include_defaults: Whether to include fields with default arguments
-            in the output schema
-        full_citations: Whether to show source reference citation + content for each
-            citation, or just the main reference citation.
-        search_for_tools_everywhere: Whether to search for tools everywhere,
-            or only in specific LLM response elements based on use_tools /
-            use_functions_api / use_tools_api config settings.
-        recognize_recipient_in_content: Whether to parse LLM response text content
-            for recipient routing patterns, specifically:
-            - ``TO[<recipient>]:<content>`` addressing format, and
-            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
-            When False, only structured routing via function_call/tool_call
-            ``recipient`` fields is recognized. Default is True.
-            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
-            which controls Task-level signals like DONE, PASS, and SEND_TO.
-            To fully disable all text-based routing, set both to False.
-        context_overflow_strategy: Strategy for handling context overflow when
-            message history exceeds model context length. Options:
-            - "truncate": Truncate content of early messages (preserves all messages
-              but with shortened content). This maintains the message sequence.
-            - "drop_turns": Drop complete conversation turns (USER + all responses
-              until next USER). More aggressive but cleaner for voice agents.
-            Default is "truncate" for backward compatibility.
-    """
-⋮----
-system_message: str = "You are a helpful assistant."
-user_message: Optional[str] = None
-handle_llm_no_tool: Any = None
-use_tools: bool = True
-use_functions_api: bool = False
-use_tools_api: bool = True
-strict_recovery: bool = True
-enable_orchestration_tool_handling: bool = True
-output_format: Optional[type] = None
-handle_output_format: bool = True
-use_output_format: bool = True
-instructions_output_format: bool = True
-output_format_include_defaults: bool = True
-use_tools_on_output_format: bool = True
-full_citations: bool = True  # show source + content for each citation?
-search_for_tools_everywhere: bool = True
-recognize_recipient_in_content: bool = True
-context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
-⋮----
-def _set_fn_or_tools(self) -> None
-⋮----
-"""
-        Enable Langroid Tool or OpenAI-like fn-calling,
-        depending on config settings.
-        """
-⋮----
-class ChatAgent(Agent)
-⋮----
-"""
-    Chat Agent interacting with external env
-    (could be human, or external tools).
-    The agent (the LLM actually) is provided with an optional "Task Spec",
-    which is a sequence of `LLMMessage`s. These are used to initialize
-    the `task_messages` of the agent.
-    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
-    The `Agent` class mainly exists to hold various common methods and attributes.
-    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
-    `llm_response` method uses "chat mode" API (i.e. one that takes a
-    message sequence rather than a single message),
-    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
-    that takes a single message).
-    """
-⋮----
-"""
-        Chat-mode agent initialized with task spec as the initial message sequence
-        Args:
-            config: settings for the agent
-
-        """
-⋮----
-# An agent's "task" is defined by a system msg and an optional user msg;
-# These are "priming" messages that kick off the agent's conversation.
-⋮----
-# if task contains a system msg, we override the config system msg
-⋮----
-# if task contains a user msg, we override the config user msg
-⋮----
-# system-level instructions for using tools/functions:
-# We maintain these as tools/functions are enabled/disabled,
-# and whenever an LLM response is sought, these are used to
-# recreate the system message (via `_create_system_and_tools_message`)
-# each time, so it reflects the current set of enabled tools/functions.
-# (a) these are general instructions on using certain tools/functions,
-#   if they are specified in a ToolMessage class as a classmethod `instructions`
-⋮----
-# (b) these are only for the builtin in Langroid TOOLS mechanism:
-⋮----
-# This variable is not None and equals a `ToolMessage` T, if and only if:
-# (a) T has been set as the output_format of this agent, AND
-# (b) T has been "enabled for use" ONLY for enforcing this output format, AND
-# (c) T has NOT been explicitly "enabled for use" by this Agent.
-⋮----
-# As above but deals with "enabled for handling" instead of "enabled for use".
-⋮----
-# instructions specifically related to enforcing `output_format`
-⋮----
-# controls whether to disable strict schemas for this agent if
-# strict mode causes exception
-⋮----
-# Tracks whether any strict tool is enabled; used to determine whether to set
-# `self.disable_strict` on an exception
-⋮----
-# Tracks the set of tools on which we force-disable strict decoding
-⋮----
-# search for tools according to the agent configuration
-⋮----
-# Only enable HANDLING by `agent_response`, NOT LLM generation of these.
-# This is useful where tool-handlers or agent_response generate these
-# tools, and need to be handled.
-# We don't want enable orch tool GENERATION by default, since that
-# might clutter-up the LLM system message unnecessarily.
-⋮----
-def init_state(self) -> None
-⋮----
-"""
-        Initialize the state of the agent. Just conversation state here,
-        but subclasses can override this to initialize other state.
-        """
-⋮----
-@staticmethod
-    def from_id(id: str) -> "ChatAgent"
-⋮----
-"""
-        Get an agent from its ID
-        Args:
-            agent_id (str): ID of the agent
-        Returns:
-            ChatAgent: The agent with the given ID
-        """
-⋮----
-def clone(self, i: int = 0) -> "ChatAgent"
-⋮----
-"""Create i'th clone of this agent, ensuring tool use/handling is cloned.
-        Important: We assume all member variables are in the __init__ method here
-        and in the Agent class.
-        TODO: We are attempting to clone an agent after its state has been
-        changed in possibly many ways. Below is an imperfect solution. Caution advised.
-        Revisit later.
-        """
-agent_cls = type(self)
-# Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
-# instead of deepcopy which loses subclass information
-config_copy = self.config.model_copy(deep=True)
-⋮----
-new_agent = agent_cls(config_copy)
-⋮----
-# Ensure each clone gets its own vecdb client when supported.
-⋮----
-def _clone_extra_state(self, new_agent: "ChatAgent") -> None
-⋮----
-"""Hook for subclasses to copy additional state into clones."""
-⋮----
-def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool
-⋮----
-"""Should we enable strict mode for a given tool?"""
-⋮----
-tool_class = self.llm_tools_map[tool]
-⋮----
-tool_class = tool
-name = tool_class.default_value("request")
-⋮----
-strict: Optional[bool] = tool_class.default_value("strict")
-⋮----
-strict = self._strict_tools_available()
-⋮----
-def _fn_call_available(self) -> bool
-⋮----
-"""Does this agent's LLM support function calling?"""
-⋮----
-def _strict_tools_available(self) -> bool
-⋮----
-"""Does this agent's LLM support strict tools?"""
-⋮----
-def _json_schema_available(self) -> bool
-⋮----
-"""Does this agent's LLM support strict JSON schema output format?"""
-⋮----
-def set_system_message(self, msg: str) -> None
-⋮----
-# if there is message history, update the system message in it
-⋮----
-def set_user_message(self, msg: str) -> None
-⋮----
-@property
-    def task_messages(self) -> List[LLMMessage]
-⋮----
-"""
-        The task messages are the initial messages that define the task
-        of the agent. There will be at least a system message plus possibly a user msg.
-        Returns:
-            List[LLMMessage]: the task messages
-        """
-msgs = [self._create_system_and_tools_message()]
-⋮----
-def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None
-⋮----
-id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
-⋮----
-# dropping tool result, so ADD the corresponding tool-call back
-# to the list of pending calls!
-id = msg.tool_call_id
-⋮----
-# dropping a msg with tool-calls, so DROP these from pending list
-# as well as from id -> call map
-⋮----
-def clear_history(self, start: int = -2, end: int = -1) -> None
-⋮----
-"""
-        Clear the message history, deleting  messages from index `start`,
-        up to index `end`.
-
-        Args:
-            start (int): index of first message to delete; default = -2
-                    (i.e. delete last 2 messages, typically these
-                    are the last user and assistant messages)
-            end (int): index of last message to delete; Default = -1
-                    (i.e. delete all messages up to the last one)
-        """
-n = len(self.message_history)
-⋮----
-start = max(0, n + start)
-end_ = n if end == -1 else end + 1
-dropped = self.message_history[start:end_]
-# consider the dropped msgs in REVERSE order, so we are
-# carefully updating self.oai_tool_calls
-⋮----
-# clear out the chat document from the ObjectRegistry
-⋮----
-def update_history(self, message: str, response: str) -> None
-⋮----
-"""
-        Update the message history with the latest user message and LLM response.
-        Args:
-            message (str): user message
-            response: (str): LLM response
-        """
-⋮----
-def tool_format_rules(self) -> str
-⋮----
-"""
-        Specification of tool formatting rules
-        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
-        based on the currently enabled usable `ToolMessage`s
-
-        Returns:
-            str: formatting rules
-        """
-# ONLY Usable tools (i.e. LLM-generation allowed),
-usable_tool_classes: List[Type[ToolMessage]] = [
-⋮----
-format_instructions = "\n\n".join(
-# if any of the enabled classes has json_group_instructions, then use that,
-# else fall back to ToolMessage.json_group_instructions
-⋮----
-def tool_instructions(self) -> str
-⋮----
-"""
-        Instructions for tools or function-calls, for enabled and usable Tools.
-        These are inserted into system prompt regardless of whether we are using
-        our own ToolMessage mechanism or the LLM's function-call mechanism.
-
-        Returns:
-            str: concatenation of instructions for all usable tools
-        """
-enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
-⋮----
-instructions = []
-⋮----
-class_instructions = ""
-⋮----
-class_instructions = msg_cls.instructions()
-⋮----
-# example will be shown in tool_format_rules() when using TOOLs,
-# so we don't need to show it here.
-example = "" if self.config.use_tools else (msg_cls.usage_examples())
-⋮----
-example = "EXAMPLES:\n" + example
-guidance = (
-⋮----
-instructions_str = "\n\n".join(instructions)
-⋮----
-def augment_system_message(self, message: str) -> None
-⋮----
-"""
-        Augment the system message with the given message.
-        Args:
-            message (str): system message
-        """
-⋮----
-def last_message_with_role(self, role: Role) -> LLMMessage | None
-⋮----
-"""from `message_history`, return the last message with role `role`"""
-n_role_msgs = len([m for m in self.message_history if m.role == role])
-⋮----
-idx = self.nth_message_idx_with_role(role, n_role_msgs)
-⋮----
-def last_message_idx_with_role(self, role: Role) -> int
-⋮----
-"""Index of last message in message_history, with specified role.
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-indices_with_role = [
-⋮----
-def nth_message_idx_with_role(self, role: Role, n: int) -> int
-⋮----
-"""Index of `n`th message in message_history, with specified role.
-        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-⋮----
-def update_last_message(self, message: str, role: str = Role.USER) -> None
-⋮----
-"""
-        Update the last message that has role `role` in the message history.
-        Useful when we want to replace a long user prompt, that may contain context
-        documents plus a question, with just the question.
-        Args:
-            message (str): new message to replace with
-            role (str): role of message to replace
-        """
-⋮----
-# find last message in self.message_history with role `role`
-⋮----
-def delete_last_message(self, role: str = Role.USER) -> None
-⋮----
-"""
-        Delete the last message that has role `role` from the message history.
-        Args:
-            role (str): role of message to delete
-        """
-⋮----
-def _create_system_and_tools_message(self) -> LLMMessage
-⋮----
-"""
-        (Re-)Create the system message for the LLM of the agent,
-        taking into account any tool instructions that have been added
-        after the agent was initialized.
-
-        The system message will consist of:
-        (a) the system message from the `task` arg in constructor, if any,
-            otherwise the default system message from the config
-        (b) the system tool instructions, if any
-        (c) the system json tool instructions, if any
-
-        Returns:
-            LLMMessage object
-        """
-content = self.system_message
-⋮----
-# remove leading and trailing newlines and other whitespace
-⋮----
-def handle_message_fallback(self, msg: str | ChatDocument) -> Any
-⋮----
-"""
-        Fallback method for the "no-tools" scenario, i.e., the current `msg`
-        (presumably emitted by the LLM) does not have any tool that the agent
-        can handle.
-        NOTE: The `msg` may contain tools but either (a) the agent is not
-        enabled to handle them, or (b) there's an explicit `recipient` field
-        in the tool that doesn't match the agent's name.
-
-        Uses the self.config.non_tool_routing to determine the action to take.
-
-        This method can be overridden by subclasses, e.g.,
-        to create a "reminder" message when a tool is expected but the LLM "forgot"
-        to generate one.
-
-        Args:
-            msg (str | ChatDocument): The input msg to handle
-        Returns:
-            Any: The result of the handler method
-        """
-⋮----
-# we ONLY use the `handle_llm_no_tool` config option when
-# the msg is from LLM and does not contain ANY tools at all.
-⋮----
-no_tool_option = self.config.handle_llm_no_tool
-⋮----
-# in case the `no_tool_option` is one of the special NonToolAction vals
-⋮----
-# Otherwise just return `no_tool_option` as is:
-# This can be any string, such as a specific nudge/reminder to the LLM,
-# or even something like ResultTool etc.
-⋮----
-def unhandled_tools(self) -> set[str]
-⋮----
-"""The set of tools that are known but not handled.
-        Useful in task flow: an agent can refuse to accept an incoming msg
-        when it only has unhandled tools.
-        """
-⋮----
-"""
-        Add the tool (message class) to the agent, and enable either
-        - tool USE (i.e. the LLM can generate JSON to use this tool),
-        - tool HANDLING (i.e. the agent can handle JSON from this tool),
-
-        Args:
-            message_class: The ToolMessage class OR List of such classes to enable,
-                for USE, or HANDLING, or both.
-                If this is a list of ToolMessage classes, then the remain args are
-                applied to all classes.
-                Optional; if None, then apply the enabling to all tools in the
-                agent's toolset that have been enabled so far.
-            use: IF True, allow the agent (LLM) to use this tool (or all tools),
-                else disallow
-            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
-                tool (or all tools)
-            force: whether to FORCE the agent (LLM) to USE the specific
-                 tool represented by `message_class`.
-                 `force` is ignored if `message_class` is None.
-            require_recipient: whether to require that recipient be specified
-                when using the tool message (only applies if `use` is True).
-            include_defaults: whether to include fields that have default values,
-                in the "properties" section of the JSON format instructions.
-                (Normally the OpenAI completion API ignores these fields,
-                but the Assistant fn-calling seems to pay attn to these,
-                and if we don't want this, we should set this to False.)
-        """
-⋮----
-# Validate that use/handle are booleans, not accidentally passed tool classes
-⋮----
-param = "use" if isclass(use) else "handle"
-⋮----
-message_class = message_class.require_recipient()
-⋮----
-# XMLToolMessage is not compatible with OpenAI's Tools/functions API,
-# so we disable use of functions API, enable langroid-native Tools,
-# which are prompt-based.
-⋮----
-super().enable_message_handling(message_class)  # enables handling only
-tools = self._get_tool_list(message_class)
-⋮----
-request = message_class.default_value("request")
-⋮----
-llm_function = message_class.llm_function_schema(defaults=include_defaults)
-⋮----
-# `t` was designated as "enabled for handling" ONLY for
-# output_format enforcement, but we are explicitly ]
-# enabling it for handling here, so we set the variable to None.
-⋮----
-tool_class = self.llm_tools_map[t]
-allow_llm_use = tool_class._allow_llm_use
-⋮----
-allow_llm_use = allow_llm_use.default
-⋮----
-# `t` was designated as "enabled for use" ONLY for output_format
-# enforcement, but we are explicitly enabling it for use here,
-# so we set the variable to None.
-⋮----
-def _update_tool_instructions(self) -> None
-⋮----
-# Set tool instructions and JSON format instructions,
-# in case Tools have been enabled/disabled.
-⋮----
-def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]
-⋮----
-"""
-        Returns the current set of enabled requests for inference and tools configs.
-        Used for restoring setings overriden by `set_output_format`.
-        """
-⋮----
-@property
-    def all_llm_tools_known(self) -> set[str]
-⋮----
-"""All known tools; we include `output_format` if it is a `ToolMessage`."""
-known = self.llm_tools_known
-⋮----
-"""
-        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
-        switches to the native Langroid tools mechanism to ensure that no tool
-        calls not of `output_type` are generated. By default, `force_tools`
-        follows the `use_tools_on_output_format` parameter in the config.
-
-        If `output_type` is None, restores to the state prior to setting
-        `output_format`.
-
-        If `use`, we enable use of `output_type` when it is a subclass
-        of `ToolMesage`. Note that this primarily controls instruction
-        generation: the model will always generate `output_type` regardless
-        of whether `use` is set. Defaults to the `use_output_format`
-        parameter in the config. Similarly, handling of `output_type` is
-        controlled by `handle`, which defaults to the
-        `handle_output_format` parameter in the config.
-
-        `instructions` controls whether we generate instructions specifying
-        the output format schema. Defaults to the `instructions_output_format`
-        parameter in the config.
-
-        `is_copy` is set when called via `__getitem__`. In that case, we must
-        copy certain fields to ensure that we do not overwrite the main agent's
-        setings.
-        """
-# Disable usage of an output format which was not specifically enabled
-# by `enable_message`
-⋮----
-# Disable handling of an output format which did not specifically have
-# handling enabled via `enable_message`
-⋮----
-# Reset any previous instructions
-⋮----
-force_tools = self.config.use_tools_on_output_format
-⋮----
-output_type = get_pydantic_wrapper(output_type)
-⋮----
-name = output_type.default_value("request")
-⋮----
-use = self.config.use_output_format
-⋮----
-handle = self.config.handle_output_format
-⋮----
-is_usable = name in self.llm_tools_usable.union(
-is_handled = name in self.llm_tools_handled.union(
-⋮----
-# We must copy `llm_tools_usable` so the base agent
-# is unmodified
-⋮----
-# If handling the tool, do the same for `llm_tools_handled`
-⋮----
-# Enable `output_type`
-⋮----
-# Do not override existing settings
-⋮----
-# If the `output_type` ToilMessage was not already enabled for
-# use, this means we are ONLY enabling it for use specifically
-# for enforcing this output format, so we set the
-# `enabled_use_output_forma  to this output_type, to
-# record that it should be disabled when `output_format` is changed
-⋮----
-# (same reasoning as for use-enabling)
-⋮----
-generated_tool_instructions = name in self.llm_tools_usable.union(
-⋮----
-generated_tool_instructions = False
-⋮----
-instructions = self.config.instructions_output_format
-⋮----
-# Already generated tool instructions as part of "enabling for use",
-# so only need to generate a reminder to use this tool.
-name = cast(ToolMessage, output_type).default_value("request")
-⋮----
-output_format_schema = output_type.llm_function_schema(
-⋮----
-output_format_schema = output_type.model_json_schema()
-⋮----
-def __getitem__(self, output_type: type) -> Self
-⋮----
-"""
-        Returns a (shallow) copy of `self` with a forced output type.
-        """
-clone = copy.copy(self)
-⋮----
-"""
-        Disable this agent from RESPONDING to a `message_class` (Tool). If
-            `message_class` is None, then disable this agent from responding to ALL.
-        Args:
-            message_class: The ToolMessage class to disable; Optional.
-        """
-⋮----
-"""
-        Disable this agent from USING a message class (Tool).
-        If `message_class` is None, then disable this agent from USING ALL tools.
-        Args:
-            message_class: The ToolMessage class to disable.
-                If None, disable all.
-        """
-⋮----
-def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None
-⋮----
-"""
-        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
-        Args:
-            message_class: The only ToolMessage class to allow
-        """
-request = message_class.model_fields["request"].default
-to_remove = [r for r in self.llm_tools_usable if r != request]
-⋮----
-def _load_output_format(self, message: ChatDocument) -> None
-⋮----
-"""
-        If set, attempts to parse a value of type `self.output_format` from the message
-        contents or any tool/function call and assigns it to `content_any`.
-        """
-⋮----
-any_succeeded = False
-attempts: list[str | LLMFunctionCall] = [
-⋮----
-content = json.loads(attempt)
-⋮----
-content = attempt.arguments
-⋮----
-content_any = self.output_format.model_validate(content)
-⋮----
-message.content_any = content_any.value  # type: ignore
-⋮----
-any_succeeded = True
-⋮----
-"""
-        Extracts messages and tracks whether any errors occurred. If strict mode
-        was enabled, disables it for the tool, else triggers strict recovery.
-        """
-⋮----
-most_recent_sent_by_llm = (
-was_llm = most_recent_sent_by_llm or (
-⋮----
-tools = super().get_tool_messages(msg, all_tools)
-⋮----
-# Check if tool class was attached to the exception
-⋮----
-tool_class = ve.tool_class  # type: ignore
-⋮----
-was_strict = (
-# If the result of strict output for a tool using the
-# OpenAI tools API fails to parse, we infer that the
-# schema edits necessary for compatibility prevented
-# adherence to the underlying `ToolMessage` schema and
-# disable strict output for the tool
-⋮----
-# We will trigger the strict recovery mechanism to force
-# the LLM to correct its output, allowing us to parse
-⋮----
-def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None
-⋮----
-"""
-        Returns a `ToolMessage` which wraps all enabled tools, excluding those
-        where strict recovery is disabled. Used in strict recovery.
-        """
-possible_tools = tuple(
-⋮----
-any_tool_type = Union.__getitem__(possible_tools)  # type ignore
-⋮----
-maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
-⋮----
-class AnyTool(ToolMessage)
-⋮----
-purpose: str = "To call a tool/function."
-request: str = "tool_or_function"
-tool: maybe_optional_type  # type: ignore
-⋮----
-def response(self, agent: ChatAgent) -> None | str | ChatDocument
-⋮----
-# One-time use
-⋮----
-# As the ToolMessage schema accepts invalid
-# `tool.request` values, reparse with the
-# corresponding tool
-request = self.tool.request
-⋮----
-tool = agent.llm_tools_map[request].model_validate_json(
-⋮----
-"""Returns instructions for strict recovery."""
-optional_instructions = (
-response_prefix = "If you intended to make such a call, r" if optional else "R"
-instruction_prefix = "If you do so, b" if optional else "B"
-⋮----
-schema_instructions = (
-⋮----
-"""
-        Truncate message at idx in msg history to `tokens` tokens.
-
-        If inplace is True, the message is truncated in place, else
-        it LEAVES the original message INTACT and returns a new message
-        """
-⋮----
-llm_msg = self.message_history[idx]
-⋮----
-llm_msg = copy.deepcopy(self.message_history[idx])
-⋮----
-orig_content = llm_msg.content
-new_content = (
-⋮----
-else orig_content[: tokens * 4]  # approx truncation
-⋮----
-def _reduce_raw_tool_results(self, message: ChatDocument) -> None
-⋮----
-"""
-        If message is the result of a ToolMessage that had
-        a `_max_retained_tokens` set to a non-None value, then we replace contents
-        with a placeholder message.
-        """
-parent_message: ChatDocument | None = message.parent
-tools = [] if parent_message is None else parent_message.tool_messages
-truncate_tools = []
-⋮----
-max_retained_tokens = t._max_retained_tokens
-⋮----
-max_retained_tokens = max_retained_tokens.default
-⋮----
-limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
-⋮----
-max_retained_tokens = limiting_tool._max_retained_tokens
-⋮----
-tool_name = limiting_tool.default_value("request")
-max_tokens: int = max_retained_tokens
-truncation_warning = f"""
-⋮----
-"""
-        Respond to a single user message, appended to the message history,
-        in "chat" mode
-        Args:
-            message (str|ChatDocument): message or ChatDocument object to respond to.
-                If None, use the self.task_messages
-        Returns:
-            LLM response as a ChatDocument object
-        """
-⋮----
-# If enabled and a tool error occurred, we recover by generating the tool in
-# strict json mode
-⋮----
-AnyTool = self._get_any_tool_message()
-⋮----
-recovery_message = self._strict_recovery_instructions(AnyTool)
-augmented_message = message
-⋮----
-augmented_message = recovery_message
-⋮----
-augmented_message = augmented_message + recovery_message
-⋮----
-# only use the augmented message for this one response...
-result = self.llm_response(augmented_message)
-# ... restore the original user message so that the AnyTool recover
-# instructions don't persist in the message history
-# (this can cause the LLM to use the AnyTool directly as a tool)
-⋮----
-msg = message if isinstance(message, str) else message.content
-⋮----
-tool_choice = (
-⋮----
-response = self.llm_response_messages(hist, output_len, tool_choice)
-⋮----
-# Preserve trail of tool_ids for OpenAI Assistant fn-calls
-⋮----
-"""
-        Async version of `llm_response`. See there for details.
-        """
-⋮----
-response = await self.llm_response_messages_async(
-⋮----
-def init_message_history(self) -> None
-⋮----
-"""
-        Initialize the message history with the system message and user message
-        """
-⋮----
-"""
-        Prepare messages to be sent to self.llm_response_messages,
-            which is the main method that calls the LLM API to get a response.
-            If desired output tokens + message history exceeds the model context length,
-            then first the max output tokens is reduced to fit, and if that is not
-            possible, older messages may be truncated to accommodate at least
-            self.config.llm.min_output_tokens of output.
-
-        Returns:
-            Tuple[List[LLMMessage], int]: (messages, output_len)
-                messages = Full list of messages to send
-                output_len = max expected number of tokens in response
-        """
-⋮----
-# this means agent has been used to get LLM response already,
-# and so the last message is an "assistant" response.
-# We delete this last assistant response and re-generate it.
-⋮----
-# initial messages have not yet been loaded, so load them
-⋮----
-# for debugging, show the initial message history
-⋮----
-# update the system message with the latest tool instructions
-⋮----
-# either the message is a str, or it is a fresh ChatDocument
-# different from the last message in the history
-llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
-llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
-# Canonicalize retained whitespace-only results before token counting.
-⋮----
-# process tools if any
-done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
-⋮----
-hist = self.message_history
-output_len = self.config.llm.model_max_output_tokens
-⋮----
-CHAT_HISTORY_BUFFER = 300
-# chat + output > max context length,
-# so first try to shorten requested output len to fit;
-# use an extra margin of CHAT_HISTORY_BUFFER tokens
-# in case our calcs are off (and to allow for some extra tokens)
-output_len = (
-⋮----
-# unacceptably small output len, so compress early parts of
-# conversation history based on the configured strategy
-strategy = self.config.context_overflow_strategy
-⋮----
-# Truncate content of individual messages while preserving
-# the message sequence (important for LLM APIs that require
-# alternating USER/ASSISTANT messages)
-msg_idx_to_compress = 1  # don't touch system msg
-# we will try compressing msg indices up to but not including
-# last user msg
-last_msg_idx_to_compress = (
-n_truncated = 0
-⋮----
-# We want to preserve the first message (typically
-# system msg) and last message (user msg).
-⋮----
-# compress the msg at idx `msg_idx_to_compress`
-⋮----
-output_len = min(
-⋮----
-# we MUST have truncated at least one msg
-msg_tokens = self.chat_num_tokens()
-⋮----
-else:  # strategy == "drop_turns"
-# Drop complete conversation turns. A complete turn is defined
-# as a USER message followed by all messages until the next
-# USER message. This is more aggressive but cleaner for voice
-# agents with limited context.
-n_dropped_turns = 0
-⋮----
-# Find the last USER message index
-last_user_idx = self.last_message_idx_with_role(role=Role.USER)
-⋮----
-# Find the first complete turn to drop (skip system message)
-first_user_idx = -1
-⋮----
-first_user_idx = i
-⋮----
-# Find the end of this turn: last message before next USER
-next_user_idx = -1
-⋮----
-next_user_idx = i
-⋮----
-# Drop the turn
-⋮----
-# we MUST have dropped at least one turn
-⋮----
-# record the position of the corresponding LLMMessage in
-# the message_history
-⋮----
-"""
-        Get function/tool spec/output format arguments for
-        OpenAI-compatible LLM API call
-        """
-functions: Optional[List[LLMFunctionSpec]] = None
-fun_call: str | Dict[str, str] = "none"
-tools: Optional[List[OpenAIToolSpec]] = None
-force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
-⋮----
-functions = [
-fun_call = (
-⋮----
-def to_maybe_strict_spec(function: str) -> OpenAIToolSpec
-⋮----
-spec = self.llm_functions_map[function]
-strict = self._strict_mode_for_tool(function)
-⋮----
-strict_spec = copy.deepcopy(spec)
-⋮----
-strict_spec = spec
-⋮----
-tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
-force_tool = (
-output_format = None
-⋮----
-spec = self.output_format.llm_function_schema(
-⋮----
-output_format = OpenAIJsonSchemaSpec(
-⋮----
-# We always require that outputs strictly match the schema
-⋮----
-param_spec = self.output_format.model_json_schema()
-⋮----
-"""
-        Respond to a series of messages, e.g. with OpenAI ChatCompletion
-        Args:
-            messages: seq of messages (with role, content fields) sent to LLM
-            output_len: max number of tokens expected in response.
-                    If None, use the LLM's default model_max_output_tokens.
-        Returns:
-            Document (i.e. with fields "content", "metadata")
-        """
-⋮----
-output_len = output_len or self.config.llm.model_max_output_tokens
-streamer = noop_fn
-⋮----
-streamer = self.callbacks.start_llm_stream()
-⋮----
-with ExitStack() as stack:  # for conditionally using rich spinner
-⋮----
-# show rich spinner only if not streaming!
-# (Why? b/c the intent of showing a spinner is to "show progress",
-# and we don't need to do that when streaming, since
-# streaming output already shows progress.)
-cm = status(
-⋮----
-response = self.llm.chat(
-⋮----
-# Create temp ChatDocument for tool check, then clean up to avoid
-# polluting ObjectRegistry (see PR #939 discussion)
-temp_doc = ChatDocument.from_LLMResponse(
-⋮----
-response,  # .usage attrib is updated!
-⋮----
-chat_doc = ChatDocument.from_LLMResponse(
-⋮----
-# If using strict output format, parse the output JSON
-⋮----
-"""
-        Async version of `llm_response_messages`. See there for details.
-        """
-⋮----
-streamer_async = async_noop_fn
-⋮----
-streamer_async = await self.callbacks.start_llm_stream_async()
-⋮----
-response = await self.llm.achat(
-⋮----
-"""
-        Call a callback method, only passing 'reasoning' if it accepts it.
-
-        This provides backward compatibility for custom callbacks that don't
-        have the 'reasoning' parameter in their signature.
-
-        Args:
-            callback_name: Name of the callback method (e.g., 'show_llm_response')
-            reasoning: The reasoning content to pass if supported
-            **kwargs: Other arguments to pass to the callback
-        """
-callback = getattr(self.callbacks, callback_name, None)
-⋮----
-# Check if callback accepts 'reasoning' param or **kwargs
-⋮----
-sig = inspect.signature(callback)
-params = sig.parameters
-accepts_reasoning = "reasoning" in params or any(
-⋮----
-# If we can't inspect the signature, assume it doesn't accept reasoning
-accepts_reasoning = False
-⋮----
-is_cached = (
-⋮----
-# We would have already displayed the msg "live" ONLY if
-# streaming was enabled, AND we did not find a cached response.
-# If we are here, it means the response has not yet been displayed.
-cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
-# Track whether we created a temp ChatDocument for cleanup
-is_temp_doc = isinstance(response, LLMResponse)
-chat_doc = (
-# TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
-⋮----
-content = response.message or ""
-tools_content = response.tools_content()
-⋮----
-content = response.content
-tools_content = ""
-reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
-⋮----
-# Clean up temp ChatDocument to avoid polluting ObjectRegistry
-⋮----
-# we are in the context immediately after an LLM responded,
-# we won't have citations yet, so we're done
-⋮----
-citation = (
-⋮----
-reasoning="",  # Citations don't have reasoning
-⋮----
-def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument
-⋮----
-"""
-        Get LLM response to `prompt` (which presumably includes the `message`
-        somewhere, along with possible large "context" passages),
-        but only include `message` as the USER message, and not the
-        full `prompt`, in the message history.
-        Args:
-            message: the original, relatively short, user request or query
-            prompt: the full prompt potentially containing `message` plus context
-
-        Returns:
-            Document object containing the response.
-        """
-# we explicitly call THIS class's respond method,
-# not a derived class's (or else there would be infinite recursion!)
-with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
-⋮----
-"""
-        Async version of `_llm_response_temp_context`. See there for details.
-        """
-⋮----
-answer_doc = cast(
-⋮----
-"""
-        LLM Response to single message, and restore message_history.
-        In effect a "one-off" message & response that leaves agent
-        message history state intact.
-
-        Args:
-            message (str|ChatDocument): message to respond to.
-
-        Returns:
-            A Document object with the response.
-
-        """
-# explicitly call THIS class's respond method,
-⋮----
-n_msgs = len(self.message_history)
-⋮----
-response = cast(ChatDocument, ChatAgent.llm_response(self, message))
-# If there is a response, then we will have two additional
-# messages in the message history, i.e. the user message and the
-# assistant response. We want to (carefully) remove these two messages.
-⋮----
-msg = self.message_history.pop()
-⋮----
-"""
-        Async version of `llm_response_forget`. See there for details.
-        """
-⋮----
-response = cast(
-⋮----
-def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int
-⋮----
-"""
-        Total number of tokens in the message history so far.
-
-        Args:
-            messages: if provided, compute the number of tokens in this list of
-                messages, rather than the current message history.
-        Returns:
-            int: number of tokens in message history
-        """
-⋮----
-hist = messages if messages is not None else self.message_history
-⋮----
-def _message_num_tokens(self, message: LLMMessage) -> int
-⋮----
-"""Count tokens for a message, including serialized user attachments."""
-⋮----
-def _attachment_num_tokens(self, message: LLMMessage) -> int
-⋮----
-"""
-        Estimate attachment contribution using the serialized payload
-        that is sent in the API request for user messages.
-        """
-⋮----
-model = self._chat_model_name_for_attachments()
-⋮----
-def _chat_model_name_for_attachments(self) -> str
-⋮----
-"""Return the model name used for attachment serialization."""
-⋮----
-def message_history_str(self, i: Optional[int] = None) -> str
-⋮----
-"""
-        Return a string representation of the message history
-        Args:
-            i: if provided, return only the i-th message when i is postive,
-                or last k messages when i = -k.
-        Returns:
-        """
-⋮----
-def __del__(self) -> None
-⋮----
-"""
-        Cleanup method called when the ChatAgent is garbage collected.
-        Note: We don't close LLM clients here because they may be shared
-        across multiple agents when client caching is enabled.
-        The clients are managed centrally and cleaned up via atexit hooks.
-        """
-# Previously we closed clients here, but this caused issues when
-# multiple agents shared the same cached client instance.
-# Clients are now managed centrally in langroid.language_models.client_cache
-</file>
-
-<file path="langroid/language_models/base.py">
-logger = logging.getLogger(__name__)
-⋮----
-def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
-⋮----
-async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
-⋮----
-FunctionCallTypes = Literal["none", "auto"]
-ToolChoiceTypes = Literal["none", "auto", "required"]
-ToolTypes = Literal["function"]
-⋮----
-DEFAULT_CONTEXT_LENGTH = 16_000
-⋮----
-class StreamEventType(Enum)
-⋮----
-TEXT = 1
-FUNC_NAME = 2
-FUNC_ARGS = 3
-TOOL_NAME = 4
-TOOL_ARGS = 5
-REASONING = 6
-⋮----
-class RetryParams(BaseSettings)
-⋮----
-max_retries: int = 5
-initial_delay: float = 1.0
-exponential_base: float = 1.3
-jitter: bool = True
-⋮----
-class LLMConfig(BaseSettings)
-⋮----
-"""
-    Common configuration for all language models.
-    """
-⋮----
-type: str = "openai"
-streamer: Optional[Callable[[Any], None]] = noop_fn
-streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
-api_base: str | None = None
-formatter: None | str = None
-# specify None if you want to use the full max output tokens of the model
-max_output_tokens: int | None = 8192
-timeout: int = 20  # timeout for API requests
-chat_model: str = ""
-completion_model: str = ""
-temperature: float = 0.0
-chat_context_length: int | None = None
-async_stream_quiet: bool = False  # suppress streaming output in async mode?
-completion_context_length: int | None = None
-# if input length + max_output_tokens > context length of model,
-# we will try shortening requested output
-min_output_tokens: int = 64
-use_completion_for_chat: bool = False  # use completion model for chat?
-# use chat model for completion? For OpenAI models, this MUST be set to True!
-use_chat_for_completion: bool = True
-stream: bool = True  # stream output from API?
-# TODO: we could have a `stream_reasoning` flag here to control whether to show
-# reasoning output from reasoning models
-cache_config: None | CacheDBConfig = RedisCacheConfig()
-thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
-retry_params: RetryParams = RetryParams()
-⋮----
-@property
-    def model_max_output_tokens(self) -> int
-⋮----
-# Build fallback names by progressively stripping provider prefixes
-# (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
-# succeeds even before OpenAIGPT.__init__ strips the prefix.
-parts = self.chat_model.split("/")
-fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
-⋮----
-class LLMFunctionCall(BaseModel)
-⋮----
-"""
-    Structure of LLM response indicating it "wants" to call a function.
-    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
-    """
-⋮----
-name: str  # name of function to call
-arguments: Optional[Dict[str, Any]] = None
-⋮----
-@staticmethod
-    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall"
-⋮----
-"""
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-fun_call = LLMFunctionCall(name=message["name"])
-fun_args_str = message["arguments"]
-# sometimes may be malformed with invalid indents,
-# so we try to be safe by removing newlines.
-⋮----
-fun_args_str = fun_args_str.replace("\n", "").strip()
-dict_or_list = parse_imperfect_json(fun_args_str)
-⋮----
-fun_args = dict_or_list
-⋮----
-fun_args = None
-⋮----
-def __str__(self) -> str
-⋮----
-class LLMFunctionSpec(BaseModel)
-⋮----
-"""
-    Description of a function available for the LLM to use.
-    To be used when calling the LLM `chat()` method with the `functions` parameter.
-    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
-    """
-⋮----
-name: str
-description: str
-parameters: Dict[str, Any]
-⋮----
-class OpenAIToolCall(BaseModel)
-⋮----
-"""
-    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
-    See https://platform.openai.com/docs/api-reference/chat/create
-
-    Attributes:
-        id: The id of the tool call.
-        type: The type of the tool call;
-            only "function" is currently possible (7/26/24).
-        function: The function call.
-    """
-⋮----
-id: str | None = None
-type: ToolTypes = "function"
-function: LLMFunctionCall | None = None
-extra_content: Dict[str, Any] | None = None
-⋮----
-@staticmethod
-    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall"
-⋮----
-id = message["id"]
-type = message["type"]
-function = LLMFunctionCall.from_dict(message["function"])
-extra_content = message.get("extra_content")
-⋮----
-class OpenAIToolSpec(BaseModel)
-⋮----
-type: ToolTypes
-strict: Optional[bool] = None
-function: LLMFunctionSpec
-⋮----
-class OpenAIJsonSchemaSpec(BaseModel)
-⋮----
-def to_dict(self) -> Dict[str, Any]
-⋮----
-json_schema: Dict[str, Any] = {
-⋮----
-class LLMTokenUsage(BaseModel)
-⋮----
-"""
-    Usage of tokens by an LLM.
-    """
-⋮----
-prompt_tokens: int = 0
-cached_tokens: int = 0
-completion_tokens: int = 0
-cost: float = 0.0
-calls: int = 0  # how many API calls - not used as of 2025-04-04
-⋮----
-def reset(self) -> None
-⋮----
-@property
-    def total_tokens(self) -> int
-⋮----
-class Role(str, Enum)
-⋮----
-"""
-    Possible roles for a message in a chat.
-    """
-⋮----
-USER = "user"
-SYSTEM = "system"
-ASSISTANT = "assistant"
-FUNCTION = "function"
-TOOL = "tool"
-⋮----
-class LLMMessage(BaseModel)
-⋮----
-"""
-    Class representing an entry in the msg-history sent to the LLM API.
-    It could be one of these:
-    - a user message
-    - an LLM ("Assistant") response
-    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
-    - a result or results from executing a fn or tool-call(s)
-    """
-⋮----
-role: Role
-name: Optional[str] = None
-tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
-tool_id: str = ""  # used by OpenAIAssistant
-# None means "no content" (the model returned only a tool/function call).
-# This is distinct from "" and is dropped from the API payload by api_dict;
-# see api_dict for how a fully-empty message is handled per-API.
-content: Optional[str] = None
-files: List[FileAttachment] = []
-function_call: Optional[LLMFunctionCall] = None
-tool_calls: Optional[List[OpenAIToolCall]] = None
-timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-# link to corresponding chat document, for provenance/rewind purposes
-chat_document_id: str = ""
-⋮----
-def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]
-⋮----
-"""
-        Convert to dictionary for API request, keeping ONLY
-        the fields that are expected in an API call!
-        E.g., DROP the tool_id, since it is only for use in the Assistant API,
-            not the completion API.
-
-        Args:
-            has_system_role: whether the message has a system role (if not,
-                set to "user" role)
-        Returns:
-            dict: dictionary representation of LLM message
-        """
-d = self.model_dump()
-files: List[FileAttachment] = d.pop("files")
-⋮----
-# In there are files, then content is an array of
-# different content-parts
-⋮----
-# if there is a key k = "role" with value "system", change to "user"
-# in case has_system_role is False
-⋮----
-# drop None values since API doesn't accept them (this omits `content`
-# entirely when it is None, i.e. "no content")
-dict_no_none = {k: v for k, v in d.items() if v is not None}
-⋮----
-# OpenAI API does not like empty name
-⋮----
-# arguments must be a string
-⋮----
-# convert tool calls to API format
-⋮----
-# An empty tool-call list is not a call and conveys no useful API
-# information. Omitting it also lets the empty-message fallback
-# below produce a valid message.
-⋮----
-# A message with empty content (None was dropped above, or "") AND no
-# tool/function call would be an entirely empty message, which some APIs
-# (e.g. Gemini) reject; fall back to a single space in that case only.
-# When there IS a tool/function call, empty content is fine (and Gemini
-# 3.x in fact REQUIRES it — it rejects an assistant turn that carries
-# both a call and non-empty text content).
-has_call = bool(dict_no_none.get("tool_calls")) or (
-⋮----
-# IMPORTANT! drop fields that are not expected in API call
-⋮----
-content = "FUNC: " + json.dumps(self.function_call)
-⋮----
-content = self.content or ""
-name_str = f" ({self.name})" if self.name else ""
-⋮----
-class LLMResponse(BaseModel)
-⋮----
-"""
-    Class representing response from LLM.
-    """
-⋮----
-# None means the model returned NO content (e.g. only a tool/function
-# call), which is distinct from an empty string "". Preserving this
-# distinction lets the message be faithfully reproduced downstream
-# (see ChatDocument.content_is_none and LLMMessage.content).
-message: Optional[str] = None
-reasoning: str = ""  # optional reasoning text from reasoning models
-# Original message text including inline thought signatures (e.g.
-# <thinking>...</thinking>). Only set when reasoning was extracted
-# from the message text via get_reasoning_final(); NOT set when
-# reasoning comes from a separate API field (e.g. reasoning_content),
-# since in that case the message text never contained thought tags.
-message_with_reasoning: Optional[str] = None
-# TODO tool_id needs to generalize to multi-tool calls
-⋮----
-oai_tool_calls: Optional[List[OpenAIToolCall]] = None
-⋮----
-usage: Optional[LLMTokenUsage] = None
-cached: bool = False
-⋮----
-def tools_content(self) -> str
-⋮----
-def to_LLMMessage(self) -> LLMMessage
-⋮----
-"""Convert LLM response to an LLMMessage, to be included in the
-        message-list sent to the API.
-        This is currently NOT used in any significant way in the library, and is only
-        provided as a utility to construct a message list for the API when directly
-        working with an LLM object.
-
-        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
-        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
-        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
-        """
-⋮----
-"""
-        If `message` or `function_call` of an LLM response contains an explicit
-        recipient name, return this recipient name and `message` stripped
-        of the recipient name if specified.
-
-        Two cases:
-        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
-        (b) `message` is empty and function_call/tool_call with explicit `recipient`
-
-        Args:
-            recognize_recipient_in_content (bool): When True (default), parses
-                message text for ``TO[<recipient>]:<content>`` patterns and
-                top-level JSON ``{"recipient": "..."}`` fields. When False,
-                only function_call/tool_call ``recipient`` fields are checked.
-
-        Returns:
-            (str): name of recipient, which may be empty string if no recipient
-            (str): content of message
-
-        """
-⋮----
-# in this case we ignore message, since all information is in function_call
-msg = ""
-args = self.function_call.arguments
-recipient = ""
-⋮----
-recipient = args.get("recipient", "")
-⋮----
-msg = self.message or ""
-⋮----
-# get the first tool that has a recipient field, if any
-⋮----
-recipient = tc.function.arguments.get(
-⋮----
-)  # type: ignore
-⋮----
-# It's not a function or tool call, so continue looking to see
-# if a recipient is specified in the message.
-⋮----
-# First check if message contains "TO: <recipient> <content>"
-⋮----
-# check if there is a top level json that specifies 'recipient',
-# and retain the entire message as content.
-⋮----
-recipient_name = top_level_json_field(msg, "recipient") if msg else ""
-content = msg
-⋮----
-# Define an abstract base class for language models
-class LanguageModel(ABC)
-⋮----
-"""
-    Abstract base class for language models.
-    """
-⋮----
-# usage cost by model, accumulates here
-usage_cost_dict: Dict[str, LLMTokenUsage] = {}
-⋮----
-def __init__(self, config: LLMConfig = LLMConfig())
-⋮----
-@staticmethod
-    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]
-⋮----
-"""
-        Create a language model.
-        Args:
-            config: configuration for language model
-        Returns: instance of language model
-        """
-⋮----
-openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
-⋮----
-openai = AzureGPT
-⋮----
-openai = OpenAIGPT
-cls = dict(
-return cls(config)  # type: ignore
-⋮----
-@staticmethod
-    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]
-⋮----
-"""
-        Given an even-length sequence of strings, split into a sequence of pairs
-
-        Args:
-            lst (List[str]): sequence of strings
-
-        Returns:
-            List[Tuple[str,str]]: sequence of pairs of strings
-        """
-evens = lst[::2]
-odds = lst[1::2]
-⋮----
-"""
-        From the chat history, extract system prompt, user-assistant turns, and
-        final user msg.
-
-        Args:
-            messages (List[LLMMessage]): List of messages in the chat history
-
-        Returns:
-            Tuple[str, List[Tuple[str,str]], str]:
-                system prompt, user-assistant turns, final user msg
-
-        """
-# Handle various degenerate cases
-messages = [m for m in messages]  # copy
-DUMMY_SYS_PROMPT = "You are a helpful assistant."
-DUMMY_USER_PROMPT = "Follow the instructions above."
-⋮----
-system_prompt = messages[0].content or ""
-⋮----
-# now we have messages = [Sys,...]
-⋮----
-# now we have messages = [Sys, msg, ...]
-⋮----
-# now we have messages = [Sys, user, ...]
-⋮----
-# now we have messages = [Sys, user, ..., user]
-# so we omit the first and last elements and make pairs of user-asst messages
-conversation = [m.content or "" for m in messages[1:-1]]
-user_prompt = messages[-1].content or ""
-pairs = LanguageModel.user_assistant_pairs(conversation)
-⋮----
-@abstractmethod
-    def set_stream(self, stream: bool) -> bool
-⋮----
-"""Enable or disable streaming output from API.
-        Return previous value of stream."""
-⋮----
-@abstractmethod
-    def get_stream(self) -> bool
-⋮----
-"""Get streaming status"""
-⋮----
-@abstractmethod
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-@abstractmethod
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-"""
-        Get chat-completion response from LLM.
-
-        Args:
-            messages: message-history to send to the LLM
-            max_tokens: max tokens to generate
-            tools: tools available for the LLM to use in its response
-            tool_choice: tool call mode, one of "none", "auto", "required",
-                or a dict specifying a specific tool.
-            functions: functions available for LLM to call (deprecated)
-            function_call: function calling mode, "auto", "none", or a specific fn
-                    (deprecated)
-        """
-⋮----
-"""Async version of `chat`. See `chat` for details."""
-⋮----
-def __call__(self, prompt: str, max_tokens: int) -> LLMResponse
-⋮----
-@staticmethod
-    def _fallback_model_names(model: str) -> List[str]
-⋮----
-parts = model.split("/")
-fallbacks = []
-⋮----
-def info(self) -> ModelInfo
-⋮----
-"""Info of relevant chat model"""
-orig_model = (
-⋮----
-def completion_info(self) -> ModelInfo
-⋮----
-"""Info of relevant completion model"""
-⋮----
-def supports_functions_or_tools(self) -> bool
-⋮----
-"""
-        Does this Model's API support "native" tool-calling, i.e.
-        can we call the API with arguments that contain a list of available tools,
-        and their schemas?
-        Note that, given the plethora of LLM provider APIs this determination is
-        imperfect at best, and leans towards returning True.
-        When the API calls fails with an error indicating tools are not supported,
-        then users are encouraged to use the Langroid-based prompt-based
-        ToolMessage mechanism, which works with ANY LLM. To enable this,
-        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
-        """
-⋮----
-def chat_context_length(self) -> int
-⋮----
-def completion_context_length(self) -> int
-⋮----
-def chat_cost(self) -> Tuple[float, float, float]
-⋮----
-"""
-        Return the cost per 1000 tokens for chat completions.
-
-        Returns:
-            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
-                per 1000 tokens
-        """
-⋮----
-def reset_usage_cost(self) -> None
-⋮----
-counter = self.usage_cost_dict[mdl]
-⋮----
-"""
-        Update usage cost for this LLM.
-        Args:
-            chat (bool): whether to update for chat or completion model
-            prompts (int): number of tokens used for prompts
-            completions (int): number of tokens used for completions
-            cost (float): total token cost in USD
-        """
-mdl = self.config.chat_model if chat else self.config.completion_model
-⋮----
-@classmethod
-    def usage_cost_summary(cls) -> str
-⋮----
-s = ""
-⋮----
-@classmethod
-    def tot_tokens_cost(cls) -> Tuple[int, float]
-⋮----
-"""
-        Return total tokens used and total cost across all models.
-        """
-total_tokens = 0
-total_cost = 0.0
-⋮----
-def get_reasoning_final(self, message: str) -> Tuple[str, str]
-⋮----
-"""Extract "reasoning" and "final answer" from an LLM response, if the
-        reasoning is found within configured delimiters, like <think>, </think>.
-        E.g.,
-        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
-
-        Args:
-            message (str): message from LLM
-
-        Returns:
-            Tuple[str, str]: reasoning, final answer
-        """
-⋮----
-parts = message.split(start)
-⋮----
-"""
-        Given a chat history and a question, convert it to a standalone question.
-        Args:
-            chat_history: list of tuples of (question, answer)
-            query: follow-up question
-
-        Returns: standalone version of the question
-        """
-history = collate_chat_history(chat_history)
-⋮----
-prompt = f"""
-⋮----
-follow_up_question = f"""
-⋮----
-standalone = (
-standalone = standalone.strip()
-⋮----
-class StreamingIfAllowed
-⋮----
-"""Context to temporarily enable or disable streaming, if allowed globally via
-    `settings.stream`"""
-⋮----
-def __init__(self, llm: LanguageModel, stream: bool = True)
-⋮----
-def __enter__(self) -> None
-⋮----
-def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
-</file>
-
 <file path="langroid/agent/special/sql/sql_chat_agent.py">
 """
 Agent that allows interaction with an SQL database using SQLAlchemy library.
@@ -56297,6 +55612,1355 @@ instruc_msg = f"""
 # user response_forget to avoid accumulating the chat history
 </file>
 
+<file path="langroid/agent/chat_agent.py">
+console = Console()
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+def _is_identified_result(message: LLMMessage) -> bool
+⋮----
+"""Whether a TOOL/FUNCTION result has its identifier and no call payload.
+
+    Such results must survive even with empty content so their calls can be
+    marked complete (issue #1063).
+    """
+has_identifier = (
+⋮----
+def _llm_message_has_payload(message: LLMMessage) -> bool
+⋮----
+"""Whether a message has the fields required for a valid history entry."""
+⋮----
+class ChatAgentConfig(AgentConfig)
+⋮----
+"""
+    Configuration for ChatAgent
+
+    Attributes:
+        system_message: system message to include in message sequence
+             (typically defines role and task of agent).
+             Used only if `task` is not specified in the constructor.
+        user_message: user message to include in message sequence.
+             Used only if `task` is not specified in the constructor.
+        use_tools: whether to use our own ToolMessages mechanism
+        handle_llm_no_tool (Any): desired agent_response when
+            LLM generates non-tool msg.
+        use_functions_api: whether to use functions/tools native to the LLM API
+                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
+        use_tools_api: When `use_functions_api` is True, if this is also True,
+            the OpenAI tool-call API is used, rather than the older/deprecated
+            function-call API. However the tool-call API has some tricky aspects,
+            hence we set this to False by default.
+        strict_recovery: whether to enable strict schema recovery when there
+            is a tool-generation error.
+        enable_orchestration_tool_handling: whether to enable handling of orchestration
+            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
+        output_format: When supported by the LLM (certain OpenAI LLMs
+            and local LLMs served by providers such as vLLM), ensures
+            that the output is a JSON matching the corresponding
+            schema via grammar-based decoding
+        handle_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for handling".
+        use_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for use" (by LLM) and
+            instructions on using T are added to the system message.
+        instructions_output_format: Controls whether we generate instructions for
+            `output_format` in the system message.
+        use_tools_on_output_format: Controls whether to automatically switch
+            to the Langroid-native tools mechanism when `output_format` is set.
+            Note that LLMs may generate tool calls which do not belong to
+            `output_format` even when strict JSON mode is enabled, so this should be
+            enabled when such tool calls are not desired.
+        output_format_include_defaults: Whether to include fields with default arguments
+            in the output schema
+        full_citations: Whether to show source reference citation + content for each
+            citation, or just the main reference citation.
+        search_for_tools_everywhere: Whether to search for tools everywhere,
+            or only in specific LLM response elements based on use_tools /
+            use_functions_api / use_tools_api config settings.
+        recognize_recipient_in_content: Whether to parse LLM response text content
+            for recipient routing patterns, specifically:
+            - ``TO[<recipient>]:<content>`` addressing format, and
+            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
+            When False, only structured routing via function_call/tool_call
+            ``recipient`` fields is recognized. Default is True.
+            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
+            which controls Task-level signals like DONE, PASS, and SEND_TO.
+            To fully disable all text-based routing, set both to False.
+        context_overflow_strategy: Strategy for handling context overflow when
+            message history exceeds model context length. Options:
+            - "truncate": Truncate content of early messages (preserves all messages
+              but with shortened content). This maintains the message sequence.
+            - "drop_turns": Drop complete conversation turns (USER + all responses
+              until next USER). More aggressive but cleaner for voice agents.
+            Default is "truncate" for backward compatibility.
+    """
+⋮----
+system_message: str = "You are a helpful assistant."
+user_message: Optional[str] = None
+handle_llm_no_tool: Any = None
+use_tools: bool = True
+use_functions_api: bool = False
+use_tools_api: bool = True
+strict_recovery: bool = True
+enable_orchestration_tool_handling: bool = True
+output_format: Optional[type] = None
+handle_output_format: bool = True
+use_output_format: bool = True
+instructions_output_format: bool = True
+output_format_include_defaults: bool = True
+use_tools_on_output_format: bool = True
+full_citations: bool = True  # show source + content for each citation?
+search_for_tools_everywhere: bool = True
+recognize_recipient_in_content: bool = True
+context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
+⋮----
+def _set_fn_or_tools(self) -> None
+⋮----
+"""
+        Enable Langroid Tool or OpenAI-like fn-calling,
+        depending on config settings.
+        """
+⋮----
+class ChatAgent(Agent)
+⋮----
+"""
+    Chat Agent interacting with external env
+    (could be human, or external tools).
+    The agent (the LLM actually) is provided with an optional "Task Spec",
+    which is a sequence of `LLMMessage`s. These are used to initialize
+    the `task_messages` of the agent.
+    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
+    The `Agent` class mainly exists to hold various common methods and attributes.
+    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
+    `llm_response` method uses "chat mode" API (i.e. one that takes a
+    message sequence rather than a single message),
+    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
+    that takes a single message).
+    """
+⋮----
+"""
+        Chat-mode agent initialized with task spec as the initial message sequence
+        Args:
+            config: settings for the agent
+
+        """
+⋮----
+# An agent's "task" is defined by a system msg and an optional user msg;
+# These are "priming" messages that kick off the agent's conversation.
+⋮----
+# if task contains a system msg, we override the config system msg
+⋮----
+# if task contains a user msg, we override the config user msg
+⋮----
+# system-level instructions for using tools/functions:
+# We maintain these as tools/functions are enabled/disabled,
+# and whenever an LLM response is sought, these are used to
+# recreate the system message (via `_create_system_and_tools_message`)
+# each time, so it reflects the current set of enabled tools/functions.
+# (a) these are general instructions on using certain tools/functions,
+#   if they are specified in a ToolMessage class as a classmethod `instructions`
+⋮----
+# (b) these are only for the builtin in Langroid TOOLS mechanism:
+⋮----
+# This variable is not None and equals a `ToolMessage` T, if and only if:
+# (a) T has been set as the output_format of this agent, AND
+# (b) T has been "enabled for use" ONLY for enforcing this output format, AND
+# (c) T has NOT been explicitly "enabled for use" by this Agent.
+⋮----
+# As above but deals with "enabled for handling" instead of "enabled for use".
+⋮----
+# instructions specifically related to enforcing `output_format`
+⋮----
+# controls whether to disable strict schemas for this agent if
+# strict mode causes exception
+⋮----
+# Tracks whether any strict tool is enabled; used to determine whether to set
+# `self.disable_strict` on an exception
+⋮----
+# Tracks the set of tools on which we force-disable strict decoding
+⋮----
+# search for tools according to the agent configuration
+⋮----
+# Only enable HANDLING by `agent_response`, NOT LLM generation of these.
+# This is useful where tool-handlers or agent_response generate these
+# tools, and need to be handled.
+# We don't want enable orch tool GENERATION by default, since that
+# might clutter-up the LLM system message unnecessarily.
+⋮----
+def init_state(self) -> None
+⋮----
+"""
+        Initialize the state of the agent. Just conversation state here,
+        but subclasses can override this to initialize other state.
+        """
+⋮----
+@staticmethod
+    def from_id(id: str) -> "ChatAgent"
+⋮----
+"""
+        Get an agent from its ID
+        Args:
+            agent_id (str): ID of the agent
+        Returns:
+            ChatAgent: The agent with the given ID
+        """
+⋮----
+def clone(self, i: int = 0) -> "ChatAgent"
+⋮----
+"""Create i'th clone of this agent, ensuring tool use/handling is cloned.
+        Important: We assume all member variables are in the __init__ method here
+        and in the Agent class.
+        TODO: We are attempting to clone an agent after its state has been
+        changed in possibly many ways. Below is an imperfect solution. Caution advised.
+        Revisit later.
+        """
+⋮----
+agent_cls = type(self)
+# Deep-copy the config WITHOUT mutating it, sharing the tool_policy
+# hook by REFERENCE (memo-seeded deepcopy): copying the policy would
+# fork any state it holds (budgets, approval lists) and can fail
+# outright on unpicklable callables (e.g. objects holding locks).
+config_copy = deepcopy_config_sharing_policy(self.config)
+⋮----
+new_agent = agent_cls(config_copy)
+⋮----
+# Ensure each clone gets its own vecdb client when supported.
+⋮----
+def _clone_extra_state(self, new_agent: "ChatAgent") -> None
+⋮----
+"""Hook for subclasses to copy additional state into clones."""
+⋮----
+def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool
+⋮----
+"""Should we enable strict mode for a given tool?"""
+⋮----
+tool_class = self.llm_tools_map[tool]
+⋮----
+tool_class = tool
+name = tool_class.default_value("request")
+⋮----
+strict: Optional[bool] = tool_class.default_value("strict")
+⋮----
+strict = self._strict_tools_available()
+⋮----
+def _fn_call_available(self) -> bool
+⋮----
+"""Does this agent's LLM support function calling?"""
+⋮----
+def _strict_tools_available(self) -> bool
+⋮----
+"""Does this agent's LLM support strict tools?"""
+⋮----
+def _json_schema_available(self) -> bool
+⋮----
+"""Does this agent's LLM support strict JSON schema output format?"""
+⋮----
+def set_system_message(self, msg: str) -> None
+⋮----
+# if there is message history, update the system message in it
+⋮----
+def set_user_message(self, msg: str) -> None
+⋮----
+@property
+    def task_messages(self) -> List[LLMMessage]
+⋮----
+"""
+        The task messages are the initial messages that define the task
+        of the agent. There will be at least a system message plus possibly a user msg.
+        Returns:
+            List[LLMMessage]: the task messages
+        """
+msgs = [self._create_system_and_tools_message()]
+⋮----
+def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None
+⋮----
+id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
+⋮----
+# dropping tool result, so ADD the corresponding tool-call back
+# to the list of pending calls!
+id = msg.tool_call_id
+⋮----
+# dropping a msg with tool-calls, so DROP these from pending list
+# as well as from id -> call map
+⋮----
+def clear_history(self, start: int = -2, end: int = -1) -> None
+⋮----
+"""
+        Clear the message history, deleting  messages from index `start`,
+        up to index `end`.
+
+        Args:
+            start (int): index of first message to delete; default = -2
+                    (i.e. delete last 2 messages, typically these
+                    are the last user and assistant messages)
+            end (int): index of last message to delete; Default = -1
+                    (i.e. delete all messages up to the last one)
+        """
+n = len(self.message_history)
+⋮----
+start = max(0, n + start)
+end_ = n if end == -1 else end + 1
+dropped = self.message_history[start:end_]
+# consider the dropped msgs in REVERSE order, so we are
+# carefully updating self.oai_tool_calls
+⋮----
+# clear out the chat document from the ObjectRegistry
+⋮----
+def update_history(self, message: str, response: str) -> None
+⋮----
+"""
+        Update the message history with the latest user message and LLM response.
+        Args:
+            message (str): user message
+            response: (str): LLM response
+        """
+⋮----
+def tool_format_rules(self) -> str
+⋮----
+"""
+        Specification of tool formatting rules
+        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
+        based on the currently enabled usable `ToolMessage`s
+
+        Returns:
+            str: formatting rules
+        """
+# ONLY Usable tools (i.e. LLM-generation allowed),
+usable_tool_classes: List[Type[ToolMessage]] = [
+⋮----
+format_instructions = "\n\n".join(
+# if any of the enabled classes has json_group_instructions, then use that,
+# else fall back to ToolMessage.json_group_instructions
+⋮----
+def tool_instructions(self) -> str
+⋮----
+"""
+        Instructions for tools or function-calls, for enabled and usable Tools.
+        These are inserted into system prompt regardless of whether we are using
+        our own ToolMessage mechanism or the LLM's function-call mechanism.
+
+        Returns:
+            str: concatenation of instructions for all usable tools
+        """
+enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
+⋮----
+instructions = []
+⋮----
+class_instructions = ""
+⋮----
+class_instructions = msg_cls.instructions()
+⋮----
+# example will be shown in tool_format_rules() when using TOOLs,
+# so we don't need to show it here.
+example = "" if self.config.use_tools else (msg_cls.usage_examples())
+⋮----
+example = "EXAMPLES:\n" + example
+guidance = (
+⋮----
+instructions_str = "\n\n".join(instructions)
+⋮----
+def augment_system_message(self, message: str) -> None
+⋮----
+"""
+        Augment the system message with the given message.
+        Args:
+            message (str): system message
+        """
+⋮----
+def last_message_with_role(self, role: Role) -> LLMMessage | None
+⋮----
+"""from `message_history`, return the last message with role `role`"""
+n_role_msgs = len([m for m in self.message_history if m.role == role])
+⋮----
+idx = self.nth_message_idx_with_role(role, n_role_msgs)
+⋮----
+def last_message_idx_with_role(self, role: Role) -> int
+⋮----
+"""Index of last message in message_history, with specified role.
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+indices_with_role = [
+⋮----
+def nth_message_idx_with_role(self, role: Role, n: int) -> int
+⋮----
+"""Index of `n`th message in message_history, with specified role.
+        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+⋮----
+def update_last_message(self, message: str, role: str = Role.USER) -> None
+⋮----
+"""
+        Update the last message that has role `role` in the message history.
+        Useful when we want to replace a long user prompt, that may contain context
+        documents plus a question, with just the question.
+        Args:
+            message (str): new message to replace with
+            role (str): role of message to replace
+        """
+⋮----
+# find last message in self.message_history with role `role`
+⋮----
+def delete_last_message(self, role: str = Role.USER) -> None
+⋮----
+"""
+        Delete the last message that has role `role` from the message history.
+        Args:
+            role (str): role of message to delete
+        """
+⋮----
+def _create_system_and_tools_message(self) -> LLMMessage
+⋮----
+"""
+        (Re-)Create the system message for the LLM of the agent,
+        taking into account any tool instructions that have been added
+        after the agent was initialized.
+
+        The system message will consist of:
+        (a) the system message from the `task` arg in constructor, if any,
+            otherwise the default system message from the config
+        (b) the system tool instructions, if any
+        (c) the system json tool instructions, if any
+
+        Returns:
+            LLMMessage object
+        """
+content = self.system_message
+⋮----
+# remove leading and trailing newlines and other whitespace
+⋮----
+def handle_message_fallback(self, msg: str | ChatDocument) -> Any
+⋮----
+"""
+        Fallback method for the "no-tools" scenario, i.e., the current `msg`
+        (presumably emitted by the LLM) does not have any tool that the agent
+        can handle.
+        NOTE: The `msg` may contain tools but either (a) the agent is not
+        enabled to handle them, or (b) there's an explicit `recipient` field
+        in the tool that doesn't match the agent's name.
+
+        Uses the self.config.non_tool_routing to determine the action to take.
+
+        This method can be overridden by subclasses, e.g.,
+        to create a "reminder" message when a tool is expected but the LLM "forgot"
+        to generate one.
+
+        Args:
+            msg (str | ChatDocument): The input msg to handle
+        Returns:
+            Any: The result of the handler method
+        """
+⋮----
+# we ONLY use the `handle_llm_no_tool` config option when
+# the msg is from LLM and does not contain ANY tools at all.
+⋮----
+no_tool_option = self.config.handle_llm_no_tool
+⋮----
+# in case the `no_tool_option` is one of the special NonToolAction vals
+⋮----
+# Otherwise just return `no_tool_option` as is:
+# This can be any string, such as a specific nudge/reminder to the LLM,
+# or even something like ResultTool etc.
+⋮----
+def unhandled_tools(self) -> set[str]
+⋮----
+"""The set of tools that are known but not handled.
+        Useful in task flow: an agent can refuse to accept an incoming msg
+        when it only has unhandled tools.
+        """
+⋮----
+"""
+        Add the tool (message class) to the agent, and enable either
+        - tool USE (i.e. the LLM can generate JSON to use this tool),
+        - tool HANDLING (i.e. the agent can handle JSON from this tool),
+
+        Args:
+            message_class: The ToolMessage class OR List of such classes to enable,
+                for USE, or HANDLING, or both.
+                If this is a list of ToolMessage classes, then the remain args are
+                applied to all classes.
+                Optional; if None, then apply the enabling to all tools in the
+                agent's toolset that have been enabled so far.
+            use: IF True, allow the agent (LLM) to use this tool (or all tools),
+                else disallow
+            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
+                tool (or all tools)
+            force: whether to FORCE the agent (LLM) to USE the specific
+                 tool represented by `message_class`.
+                 `force` is ignored if `message_class` is None.
+            require_recipient: whether to require that recipient be specified
+                when using the tool message (only applies if `use` is True).
+            include_defaults: whether to include fields that have default values,
+                in the "properties" section of the JSON format instructions.
+                (Normally the OpenAI completion API ignores these fields,
+                but the Assistant fn-calling seems to pay attn to these,
+                and if we don't want this, we should set this to False.)
+        """
+⋮----
+# Validate that use/handle are booleans, not accidentally passed tool classes
+⋮----
+param = "use" if isclass(use) else "handle"
+⋮----
+message_class = message_class.require_recipient()
+⋮----
+# XMLToolMessage is not compatible with OpenAI's Tools/functions API,
+# so we disable use of functions API, enable langroid-native Tools,
+# which are prompt-based.
+⋮----
+super().enable_message_handling(message_class)  # enables handling only
+tools = self._get_tool_list(message_class)
+⋮----
+request = message_class.default_value("request")
+⋮----
+llm_function = message_class.llm_function_schema(defaults=include_defaults)
+⋮----
+# `t` was designated as "enabled for handling" ONLY for
+# output_format enforcement, but we are explicitly ]
+# enabling it for handling here, so we set the variable to None.
+⋮----
+tool_class = self.llm_tools_map[t]
+allow_llm_use = tool_class._allow_llm_use
+⋮----
+allow_llm_use = allow_llm_use.default
+⋮----
+# `t` was designated as "enabled for use" ONLY for output_format
+# enforcement, but we are explicitly enabling it for use here,
+# so we set the variable to None.
+⋮----
+def _update_tool_instructions(self) -> None
+⋮----
+# Set tool instructions and JSON format instructions,
+# in case Tools have been enabled/disabled.
+⋮----
+def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]
+⋮----
+"""
+        Returns the current set of enabled requests for inference and tools configs.
+        Used for restoring setings overriden by `set_output_format`.
+        """
+⋮----
+@property
+    def all_llm_tools_known(self) -> set[str]
+⋮----
+"""All known tools; we include `output_format` if it is a `ToolMessage`."""
+known = self.llm_tools_known
+⋮----
+"""
+        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
+        switches to the native Langroid tools mechanism to ensure that no tool
+        calls not of `output_type` are generated. By default, `force_tools`
+        follows the `use_tools_on_output_format` parameter in the config.
+
+        If `output_type` is None, restores to the state prior to setting
+        `output_format`.
+
+        If `use`, we enable use of `output_type` when it is a subclass
+        of `ToolMesage`. Note that this primarily controls instruction
+        generation: the model will always generate `output_type` regardless
+        of whether `use` is set. Defaults to the `use_output_format`
+        parameter in the config. Similarly, handling of `output_type` is
+        controlled by `handle`, which defaults to the
+        `handle_output_format` parameter in the config.
+
+        `instructions` controls whether we generate instructions specifying
+        the output format schema. Defaults to the `instructions_output_format`
+        parameter in the config.
+
+        `is_copy` is set when called via `__getitem__`. In that case, we must
+        copy certain fields to ensure that we do not overwrite the main agent's
+        setings.
+        """
+# Disable usage of an output format which was not specifically enabled
+# by `enable_message`
+⋮----
+# Disable handling of an output format which did not specifically have
+# handling enabled via `enable_message`
+⋮----
+# Reset any previous instructions
+⋮----
+force_tools = self.config.use_tools_on_output_format
+⋮----
+output_type = get_pydantic_wrapper(output_type)
+⋮----
+name = output_type.default_value("request")
+⋮----
+use = self.config.use_output_format
+⋮----
+handle = self.config.handle_output_format
+⋮----
+is_usable = name in self.llm_tools_usable.union(
+is_handled = name in self.llm_tools_handled.union(
+⋮----
+# We must copy `llm_tools_usable` so the base agent
+# is unmodified
+⋮----
+# If handling the tool, do the same for `llm_tools_handled`
+⋮----
+# Enable `output_type`
+⋮----
+# Do not override existing settings
+⋮----
+# If the `output_type` ToilMessage was not already enabled for
+# use, this means we are ONLY enabling it for use specifically
+# for enforcing this output format, so we set the
+# `enabled_use_output_forma  to this output_type, to
+# record that it should be disabled when `output_format` is changed
+⋮----
+# (same reasoning as for use-enabling)
+⋮----
+generated_tool_instructions = name in self.llm_tools_usable.union(
+⋮----
+generated_tool_instructions = False
+⋮----
+instructions = self.config.instructions_output_format
+⋮----
+# Already generated tool instructions as part of "enabling for use",
+# so only need to generate a reminder to use this tool.
+name = cast(ToolMessage, output_type).default_value("request")
+⋮----
+output_format_schema = output_type.llm_function_schema(
+⋮----
+output_format_schema = output_type.model_json_schema()
+⋮----
+def __getitem__(self, output_type: type) -> Self
+⋮----
+"""
+        Returns a (shallow) copy of `self` with a forced output type.
+        """
+clone = copy.copy(self)
+⋮----
+"""
+        Disable this agent from RESPONDING to a `message_class` (Tool). If
+            `message_class` is None, then disable this agent from responding to ALL.
+        Args:
+            message_class: The ToolMessage class to disable; Optional.
+        """
+⋮----
+"""
+        Disable this agent from USING a message class (Tool).
+        If `message_class` is None, then disable this agent from USING ALL tools.
+        Args:
+            message_class: The ToolMessage class to disable.
+                If None, disable all.
+        """
+⋮----
+def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None
+⋮----
+"""
+        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
+        Args:
+            message_class: The only ToolMessage class to allow
+        """
+request = message_class.model_fields["request"].default
+to_remove = [r for r in self.llm_tools_usable if r != request]
+⋮----
+def _load_output_format(self, message: ChatDocument) -> None
+⋮----
+"""
+        If set, attempts to parse a value of type `self.output_format` from the message
+        contents or any tool/function call and assigns it to `content_any`.
+        """
+⋮----
+any_succeeded = False
+attempts: list[str | LLMFunctionCall] = [
+⋮----
+content = json.loads(attempt)
+⋮----
+content = attempt.arguments
+⋮----
+content_any = self.output_format.model_validate(content)
+⋮----
+message.content_any = content_any.value  # type: ignore
+⋮----
+any_succeeded = True
+⋮----
+"""
+        Extracts messages and tracks whether any errors occurred. If strict mode
+        was enabled, disables it for the tool, else triggers strict recovery.
+        """
+⋮----
+most_recent_sent_by_llm = (
+was_llm = most_recent_sent_by_llm or (
+⋮----
+tools = super().get_tool_messages(msg, all_tools)
+⋮----
+# Check if tool class was attached to the exception
+⋮----
+tool_class = ve.tool_class  # type: ignore
+⋮----
+was_strict = (
+# If the result of strict output for a tool using the
+# OpenAI tools API fails to parse, we infer that the
+# schema edits necessary for compatibility prevented
+# adherence to the underlying `ToolMessage` schema and
+# disable strict output for the tool
+⋮----
+# We will trigger the strict recovery mechanism to force
+# the LLM to correct its output, allowing us to parse
+⋮----
+def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None
+⋮----
+"""
+        Returns a `ToolMessage` which wraps all enabled tools, excluding those
+        where strict recovery is disabled. Used in strict recovery.
+        """
+possible_tools = tuple(
+⋮----
+any_tool_type = Union.__getitem__(possible_tools)  # type ignore
+⋮----
+maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
+⋮----
+class AnyTool(ToolMessage)
+⋮----
+purpose: str = "To call a tool/function."
+request: str = "tool_or_function"
+tool: maybe_optional_type  # type: ignore
+⋮----
+# One-time use
+⋮----
+# As the ToolMessage schema accepts invalid
+# `tool.request` values, reparse with the
+# corresponding tool
+request = self.tool.request
+⋮----
+tool = agent.llm_tools_map[request].model_validate_json(
+⋮----
+# pass the chat_doc through, so the recovered tool's policy
+# check sees the same message context a normal dispatch would
+⋮----
+# This wrapper is a parsing shim for strict recovery, NOT a tool
+# execution, so it is exempt from the `tool_policy` hook -- which
+# also guarantees `set_output_format(None)` above always runs. The
+# re-parsed ACTUAL tool is dispatched through the policy-checked
+# path, so the policy is consulted exactly once per logical call.
+AnyTool._tool_policy_exempt = True  # type: ignore[attr-defined]
+⋮----
+"""Returns instructions for strict recovery."""
+optional_instructions = (
+response_prefix = "If you intended to make such a call, r" if optional else "R"
+instruction_prefix = "If you do so, b" if optional else "B"
+⋮----
+schema_instructions = (
+⋮----
+"""
+        Truncate message at idx in msg history to `tokens` tokens.
+
+        If inplace is True, the message is truncated in place, else
+        it LEAVES the original message INTACT and returns a new message
+        """
+⋮----
+llm_msg = self.message_history[idx]
+⋮----
+llm_msg = copy.deepcopy(self.message_history[idx])
+⋮----
+orig_content = llm_msg.content
+new_content = (
+⋮----
+else orig_content[: tokens * 4]  # approx truncation
+⋮----
+def _reduce_raw_tool_results(self, message: ChatDocument) -> None
+⋮----
+"""
+        If message is the result of a ToolMessage that had
+        a `_max_retained_tokens` set to a non-None value, then we replace contents
+        with a placeholder message.
+        """
+parent_message: ChatDocument | None = message.parent
+tools = [] if parent_message is None else parent_message.tool_messages
+truncate_tools = []
+⋮----
+max_retained_tokens = t._max_retained_tokens
+⋮----
+max_retained_tokens = max_retained_tokens.default
+⋮----
+limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
+⋮----
+max_retained_tokens = limiting_tool._max_retained_tokens
+⋮----
+tool_name = limiting_tool.default_value("request")
+max_tokens: int = max_retained_tokens
+truncation_warning = f"""
+⋮----
+"""
+        Respond to a single user message, appended to the message history,
+        in "chat" mode
+        Args:
+            message (str|ChatDocument): message or ChatDocument object to respond to.
+                If None, use the self.task_messages
+        Returns:
+            LLM response as a ChatDocument object
+        """
+⋮----
+# If enabled and a tool error occurred, we recover by generating the tool in
+# strict json mode
+⋮----
+AnyTool = self._get_any_tool_message()
+⋮----
+recovery_message = self._strict_recovery_instructions(AnyTool)
+augmented_message = message
+⋮----
+augmented_message = recovery_message
+⋮----
+augmented_message = augmented_message + recovery_message
+⋮----
+# only use the augmented message for this one response...
+result = self.llm_response(augmented_message)
+# ... restore the original user message so that the AnyTool recover
+# instructions don't persist in the message history
+# (this can cause the LLM to use the AnyTool directly as a tool)
+⋮----
+msg = message if isinstance(message, str) else message.content
+⋮----
+tool_choice = (
+⋮----
+response = self.llm_response_messages(hist, output_len, tool_choice)
+⋮----
+# Preserve trail of tool_ids for OpenAI Assistant fn-calls
+⋮----
+"""
+        Async version of `llm_response`. See there for details.
+        """
+⋮----
+response = await self.llm_response_messages_async(
+⋮----
+def init_message_history(self) -> None
+⋮----
+"""
+        Initialize the message history with the system message and user message
+        """
+⋮----
+"""
+        Prepare messages to be sent to self.llm_response_messages,
+            which is the main method that calls the LLM API to get a response.
+            If desired output tokens + message history exceeds the model context length,
+            then first the max output tokens is reduced to fit, and if that is not
+            possible, older messages may be truncated to accommodate at least
+            self.config.llm.min_output_tokens of output.
+
+        Returns:
+            Tuple[List[LLMMessage], int]: (messages, output_len)
+                messages = Full list of messages to send
+                output_len = max expected number of tokens in response
+        """
+⋮----
+# this means agent has been used to get LLM response already,
+# and so the last message is an "assistant" response.
+# We delete this last assistant response and re-generate it.
+⋮----
+# initial messages have not yet been loaded, so load them
+⋮----
+# for debugging, show the initial message history
+⋮----
+# update the system message with the latest tool instructions
+⋮----
+# either the message is a str, or it is a fresh ChatDocument
+# different from the last message in the history
+llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
+llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
+# Canonicalize retained whitespace-only results before token counting.
+⋮----
+# process tools if any
+done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
+⋮----
+hist = self.message_history
+output_len = self.config.llm.model_max_output_tokens
+⋮----
+CHAT_HISTORY_BUFFER = 300
+# chat + output > max context length,
+# so first try to shorten requested output len to fit;
+# use an extra margin of CHAT_HISTORY_BUFFER tokens
+# in case our calcs are off (and to allow for some extra tokens)
+output_len = (
+⋮----
+# unacceptably small output len, so compress early parts of
+# conversation history based on the configured strategy
+strategy = self.config.context_overflow_strategy
+⋮----
+# Truncate content of individual messages while preserving
+# the message sequence (important for LLM APIs that require
+# alternating USER/ASSISTANT messages)
+msg_idx_to_compress = 1  # don't touch system msg
+# we will try compressing msg indices up to but not including
+# last user msg
+last_msg_idx_to_compress = (
+n_truncated = 0
+⋮----
+# We want to preserve the first message (typically
+# system msg) and last message (user msg).
+⋮----
+# compress the msg at idx `msg_idx_to_compress`
+⋮----
+output_len = min(
+⋮----
+# we MUST have truncated at least one msg
+msg_tokens = self.chat_num_tokens()
+⋮----
+else:  # strategy == "drop_turns"
+# Drop complete conversation turns. A complete turn is defined
+# as a USER message followed by all messages until the next
+# USER message. This is more aggressive but cleaner for voice
+# agents with limited context.
+n_dropped_turns = 0
+⋮----
+# Find the last USER message index
+last_user_idx = self.last_message_idx_with_role(role=Role.USER)
+⋮----
+# Find the first complete turn to drop (skip system message)
+first_user_idx = -1
+⋮----
+first_user_idx = i
+⋮----
+# Find the end of this turn: last message before next USER
+next_user_idx = -1
+⋮----
+next_user_idx = i
+⋮----
+# Drop the turn
+⋮----
+# we MUST have dropped at least one turn
+⋮----
+# record the position of the corresponding LLMMessage in
+# the message_history
+⋮----
+"""
+        Get function/tool spec/output format arguments for
+        OpenAI-compatible LLM API call
+        """
+functions: Optional[List[LLMFunctionSpec]] = None
+fun_call: str | Dict[str, str] = "none"
+tools: Optional[List[OpenAIToolSpec]] = None
+force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
+⋮----
+functions = [
+fun_call = (
+⋮----
+def to_maybe_strict_spec(function: str) -> OpenAIToolSpec
+⋮----
+spec = self.llm_functions_map[function]
+strict = self._strict_mode_for_tool(function)
+⋮----
+strict_spec = copy.deepcopy(spec)
+⋮----
+strict_spec = spec
+⋮----
+tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
+force_tool = (
+output_format = None
+⋮----
+spec = self.output_format.llm_function_schema(
+⋮----
+output_format = OpenAIJsonSchemaSpec(
+⋮----
+# We always require that outputs strictly match the schema
+⋮----
+param_spec = self.output_format.model_json_schema()
+⋮----
+"""
+        Respond to a series of messages, e.g. with OpenAI ChatCompletion
+        Args:
+            messages: seq of messages (with role, content fields) sent to LLM
+            output_len: max number of tokens expected in response.
+                    If None, use the LLM's default model_max_output_tokens.
+        Returns:
+            Document (i.e. with fields "content", "metadata")
+        """
+⋮----
+output_len = output_len or self.config.llm.model_max_output_tokens
+streamer = noop_fn
+⋮----
+streamer = self.callbacks.start_llm_stream()
+⋮----
+with ExitStack() as stack:  # for conditionally using rich spinner
+⋮----
+# show rich spinner only if not streaming!
+# (Why? b/c the intent of showing a spinner is to "show progress",
+# and we don't need to do that when streaming, since
+# streaming output already shows progress.)
+cm = status(
+⋮----
+response = self.llm.chat(
+⋮----
+# Create temp ChatDocument for tool check, then clean up to avoid
+# polluting ObjectRegistry (see PR #939 discussion)
+temp_doc = ChatDocument.from_LLMResponse(
+⋮----
+response,  # .usage attrib is updated!
+⋮----
+chat_doc = ChatDocument.from_LLMResponse(
+⋮----
+# If using strict output format, parse the output JSON
+⋮----
+"""
+        Async version of `llm_response_messages`. See there for details.
+        """
+⋮----
+streamer_async = async_noop_fn
+⋮----
+streamer_async = await self.callbacks.start_llm_stream_async()
+⋮----
+response = await self.llm.achat(
+⋮----
+"""
+        Call a callback method, only passing 'reasoning' if it accepts it.
+
+        This provides backward compatibility for custom callbacks that don't
+        have the 'reasoning' parameter in their signature.
+
+        Args:
+            callback_name: Name of the callback method (e.g., 'show_llm_response')
+            reasoning: The reasoning content to pass if supported
+            **kwargs: Other arguments to pass to the callback
+        """
+callback = getattr(self.callbacks, callback_name, None)
+⋮----
+# Check if callback accepts 'reasoning' param or **kwargs
+⋮----
+sig = inspect.signature(callback)
+params = sig.parameters
+accepts_reasoning = "reasoning" in params or any(
+⋮----
+# If we can't inspect the signature, assume it doesn't accept reasoning
+accepts_reasoning = False
+⋮----
+is_cached = (
+⋮----
+# We would have already displayed the msg "live" ONLY if
+# streaming was enabled, AND we did not find a cached response.
+# If we are here, it means the response has not yet been displayed.
+cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
+# Track whether we created a temp ChatDocument for cleanup
+is_temp_doc = isinstance(response, LLMResponse)
+chat_doc = (
+# TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
+⋮----
+content = response.message or ""
+tools_content = response.tools_content()
+⋮----
+content = response.content
+tools_content = ""
+reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
+⋮----
+# Clean up temp ChatDocument to avoid polluting ObjectRegistry
+⋮----
+# we are in the context immediately after an LLM responded,
+# we won't have citations yet, so we're done
+⋮----
+citation = (
+⋮----
+reasoning="",  # Citations don't have reasoning
+⋮----
+def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument
+⋮----
+"""
+        Get LLM response to `prompt` (which presumably includes the `message`
+        somewhere, along with possible large "context" passages),
+        but only include `message` as the USER message, and not the
+        full `prompt`, in the message history.
+        Args:
+            message: the original, relatively short, user request or query
+            prompt: the full prompt potentially containing `message` plus context
+
+        Returns:
+            Document object containing the response.
+        """
+# we explicitly call THIS class's respond method,
+# not a derived class's (or else there would be infinite recursion!)
+with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
+⋮----
+"""
+        Async version of `_llm_response_temp_context`. See there for details.
+        """
+⋮----
+answer_doc = cast(
+⋮----
+"""
+        LLM Response to single message, and restore message_history.
+        In effect a "one-off" message & response that leaves agent
+        message history state intact.
+
+        Args:
+            message (str|ChatDocument): message to respond to.
+
+        Returns:
+            A Document object with the response.
+
+        """
+# explicitly call THIS class's respond method,
+⋮----
+n_msgs = len(self.message_history)
+⋮----
+response = cast(ChatDocument, ChatAgent.llm_response(self, message))
+# If there is a response, then we will have two additional
+# messages in the message history, i.e. the user message and the
+# assistant response. We want to (carefully) remove these two messages.
+⋮----
+msg = self.message_history.pop()
+⋮----
+"""
+        Async version of `llm_response_forget`. See there for details.
+        """
+⋮----
+response = cast(
+⋮----
+def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int
+⋮----
+"""
+        Total number of tokens in the message history so far.
+
+        Args:
+            messages: if provided, compute the number of tokens in this list of
+                messages, rather than the current message history.
+        Returns:
+            int: number of tokens in message history
+        """
+⋮----
+hist = messages if messages is not None else self.message_history
+⋮----
+def _message_num_tokens(self, message: LLMMessage) -> int
+⋮----
+"""Count tokens for a message, including serialized user attachments."""
+⋮----
+def _attachment_num_tokens(self, message: LLMMessage) -> int
+⋮----
+"""
+        Estimate attachment contribution using the serialized payload
+        that is sent in the API request for user messages.
+        """
+⋮----
+model = self._chat_model_name_for_attachments()
+⋮----
+def _chat_model_name_for_attachments(self) -> str
+⋮----
+"""Return the model name used for attachment serialization."""
+⋮----
+def message_history_str(self, i: Optional[int] = None) -> str
+⋮----
+"""
+        Return a string representation of the message history
+        Args:
+            i: if provided, return only the i-th message when i is postive,
+                or last k messages when i = -k.
+        Returns:
+        """
+⋮----
+def __del__(self) -> None
+⋮----
+"""
+        Cleanup method called when the ChatAgent is garbage collected.
+        Note: We don't close LLM clients here because they may be shared
+        across multiple agents when client caching is enabled.
+        The clients are managed centrally and cleaned up via atexit hooks.
+        """
+# Previously we closed clients here, but this caused issues when
+# multiple agents shared the same cached client instance.
+# Clients are now managed centrally in langroid.language_models.client_cache
+</file>
+
+<file path="langroid/language_models/model_info.py">
+logger = logging.getLogger(__name__)
+⋮----
+class ModelProvider(str, Enum)
+⋮----
+"""Enum for model providers"""
+⋮----
+OPENAI = "openai"
+ANTHROPIC = "anthropic"
+DEEPSEEK = "deepseek"
+GOOGLE = "google"
+MINIMAX = "minimax"
+UNKNOWN = "unknown"
+⋮----
+class ModelName(str, Enum)
+⋮----
+"""Parent class for all model name enums"""
+⋮----
+class OpenAIChatModel(ModelName)
+⋮----
+"""Enum for OpenAI Chat models"""
+⋮----
+GPT3_5_TURBO = "gpt-3.5-turbo"
+GPT4 = "gpt-4o"  # avoid deprecated gpt-4
+GPT4_TURBO = "gpt-4-turbo"
+GPT4o = "gpt-4o"
+GPT4o_MINI = "gpt-4o-mini"
+O1 = "o1"
+O1_MINI = "o1-mini"
+O3_MINI = "o3-mini"
+O3 = "o3"
+O4_MINI = "o4-mini"
+GPT4_1 = "gpt-4.1"
+GPT4_1_MINI = "gpt-4.1-mini"
+GPT4_1_NANO = "gpt-4.1-nano"
+GPT5 = "gpt-5"
+GPT5_MINI = "gpt-5-mini"
+GPT5_NANO = "gpt-5-nano"
+GPT5_PRO = "gpt-5-pro"
+GPT5_1 = "gpt-5.1"
+GPT5_1_CODEX = "gpt-5.1-codex"
+GPT5_1_CODEX_MINI = "gpt-5.1-codex-mini"
+GPT5_1_CHAT = "gpt-5.1-chat"
+GPT5_2 = "gpt-5.2"
+GPT5_2_PRO = "gpt-5.2-pro"
+GPT5_2_CHAT = "gpt-5.2-chat"
+GPT_OSS_120b = "gpt-oss-120b"
+GPT_OSS_20b = "gpt-oss-20b"
+⋮----
+class OpenAICompletionModel(str, Enum)
+⋮----
+"""Enum for OpenAI Completion models"""
+⋮----
+DAVINCI = "davinci-002"
+BABBAGE = "babbage-002"
+⋮----
+class AnthropicModel(ModelName)
+⋮----
+"""Enum for Anthropic models"""
+⋮----
+CLAUDE_3_OPUS = "claude-3-opus-latest"
+CLAUDE_3_SONNET = "claude-3-sonnet-latest"
+CLAUDE_3_HAIKU = "claude-3-haiku-latest"
+CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest"
+CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest"
+CLAUDE_4_OPUS = "claude-opus-4"
+CLAUDE_4_SONNET = "claude-sonnet-4"
+CLAUDE_4_HAIKU = "claude-haiku-4"
+CLAUDE_4_5_OPUS = "claude-opus-4-5"
+CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
+CLAUDE_4_5_HAIKU = "claude-haiku-4-5"
+⋮----
+class DeepSeekModel(ModelName)
+⋮----
+"""Enum for DeepSeek models direct from DeepSeek API"""
+⋮----
+DEEPSEEK = "deepseek/deepseek-chat"
+DEEPSEEK_R1 = "deepseek/deepseek-reasoner"
+OPENROUTER_DEEPSEEK_R1 = "openrouter/deepseek/deepseek-r1"
+⋮----
+class GeminiModel(ModelName)
+⋮----
+"""Enum for Gemini models"""
+⋮----
+GEMINI_1_5_FLASH = "gemini-1.5-flash"
+GEMINI_1_5_FLASH_8B = "gemini-1.5-flash-8b"
+GEMINI_1_5_PRO = "gemini-1.5-pro"
+GEMINI_2_FLASH = "gemini-2.0-flash"
+GEMINI_2_FLASH_LITE = "gemini-2.0-flash-lite"
+GEMINI_2_FLASH_THINKING = "gemini-2.0-flash-thinking-exp"
+GEMINI_2_PRO = "gemini-2.0-pro-exp-02-05"
+GEMINI_2_5_FLASH = "gemini-2.5-flash"
+GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
+GEMINI_2_5_PRO = "gemini-2.5-pro"
+GEMINI_3_FLASH = "gemini-3-flash"
+GEMINI_3_PRO = "gemini-3-pro"
+⋮----
+class MiniMaxModel(ModelName)
+⋮----
+"""Enum for MiniMax models"""
+⋮----
+MINIMAX_M2_7 = "MiniMax-M2.7"
+MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
+MINIMAX_M2_5 = "MiniMax-M2.5"
+MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
+MINIMAX_M2_1 = "MiniMax-M2.1"
+MINIMAX_M2_1_HIGHSPEED = "MiniMax-M2.1-highspeed"
+MINIMAX_M2 = "MiniMax-M2"
+⋮----
+class OpenAI_API_ParamInfo(BaseModel)
+⋮----
+"""
+    Parameters exclusive to some models, when using OpenAI API
+    """
+⋮----
+# model-specific params at top level
+params: Dict[str, List[str]] = dict(
+# model-specific params in extra_body
+extra_parameters: Dict[str, List[str]] = dict(
+⋮----
+class ModelInfo(BaseModel)
+⋮----
+"""
+    Consolidated information about LLM, related to capacity, cost and API
+    idiosyncrasies. Reasonable defaults for all params in case there's no
+    specific info available.
+    """
+⋮----
+name: str = "unknown"
+provider: ModelProvider = ModelProvider.UNKNOWN
+context_length: int = 16_000
+max_cot_tokens: int = 0  # max chain of thought (thinking) tokens where applicable
+max_output_tokens: int = 8192  # Maximum number of output tokens - model dependent
+input_cost_per_million: float = 0.0  # Cost in USD per million input tokens
+cached_cost_per_million: float = 0.0  # Cost in USD per million cached tokens
+output_cost_per_million: float = 0.0  # Cost in USD per million output tokens
+allows_streaming: bool = True  # Whether model supports streaming output
+allows_system_message: bool = True  # Whether model supports system messages
+rename_params: Dict[str, str] = {}  # Rename parameters for OpenAI API
+unsupported_params: List[str] = []
+has_structured_output: bool = False  # Does model API support structured output?
+has_tools: bool = True  # Does model API support tools/function-calling?
+needs_first_user_message: bool = False  # Does API need first msg to be from user?
+description: Optional[str] = None
+⋮----
+GEMINI_CANONICAL_MODEL_NAMES = {model.value for model in GeminiModel}
+DEFAULT_MODEL_INFO = ModelInfo()
+WARNED_UNKNOWN_MODELS: set[tuple[str, ...]] = set()
+⋮----
+# Model information registry
+MODEL_INFO: Dict[str, ModelInfo] = {
+⋮----
+# OpenAI Models
+⋮----
+# Anthropic Models
+⋮----
+# DeepSeek Models
+⋮----
+# Gemini Models
+⋮----
+# Gemini 2.5 Models
+⋮----
+# Gemini 3 Models
+⋮----
+# MiniMax Models
+⋮----
+"""Get model information by name or enum value"""
+# Sequence of models to try, starting with the primary model
+models_to_try = [model] + fallback_models
+⋮----
+# Find the first model in the sequence that has info defined using next()
+# on a generator expression that filters out None results from _get_model_info
+found_info = next(
+⋮----
+None,  # Default value if the iterator is exhausted (no valid info found)
+⋮----
+normalized_models = _normalize_model_names(models_to_try)
+⋮----
+def _get_model_info(model: str | ModelName) -> ModelInfo | None
+⋮----
+def _normalize_model_names(models: List[str | ModelName]) -> List[str]
+⋮----
+normalized_models: List[str] = []
+seen: set[str] = set()
+⋮----
+normalized_model = _normalize_gemini_model_name(_model_name(model))
+⋮----
+def _normalize_gemini_model_name(model: str) -> str | None
+⋮----
+base_model = model.rsplit("/", 1)[-1]
+⋮----
+# Try stripping known suffixes to find a canonical name.
+# Use split (not endswith) for "-preview" so dated variants like
+# "gemini-2.5-flash-lite-preview-06-17" are handled correctly.
+⋮----
+stripped = base_model.split(suffix, maxsplit=1)[0]
+⋮----
+def _warn_unknown_model(models: List[str | ModelName]) -> None
+⋮----
+model_names = tuple(_model_name(model) for model in models)
+⋮----
+def _model_name(model: str | ModelName) -> str
+</file>
+
 <file path="langroid/agent/base.py">
 ORCHESTRATION_STRINGS = [DONE, PASS, PASS_TO, SEND_TO]
 console = Console(quiet=settings.quiet)
@@ -56330,6 +56994,17 @@ add_to_registry: bool = True  # register agent in ObjectRegistry?
 respond_tools_only: bool = False  # respond only to tool messages (not plain text)?
 # allow multiple tool messages in a single response?
 allow_multiple_tools: bool = True
+# Optional pre-execution tool policy hook, called with the final parsed
+# ToolMessage just BEFORE its selected handler runs, as
+# ``tool_policy(tool, agent)`` -- or ``tool_policy(tool, agent, chat_doc=...)``
+# when the callable has a ``chat_doc`` parameter. May be sync or async.
+# Return True or None to ALLOW (the handler runs exactly once); return
+# False or a str reason to REJECT (the handler is NOT run, and the LLM
+# sees a rejection naming the tool and the reason). The hook cannot modify
+# the tool. If the hook itself raises, the tool is blocked (fail-closed)
+# and the rejection deliberately excludes the exception message and tool
+# arguments. See docs/notes/tool-policy-hook.md.
+tool_policy: Optional[Callable[..., Any]] = None
 human_prompt: str = (
 ⋮----
 @field_validator("name")
@@ -57173,8 +57848,6 @@ results: List[str | ChatDocument | None] = []
 ⋮----
 results = ["ERROR: Use ONE tool at a time!"] * len(tools)
 ⋮----
-results = [self.handle_tool_message(t, chat_doc=chat_doc) for t in tools]
-⋮----
 @property
     def all_llm_tools_known(self) -> set[str]
 ⋮----
@@ -57283,7 +57956,7 @@ result_tool_name = msg.default_value("request")
 #     msg in chat_doc.tool_messages):
 #    chat_doc.tool_messages.remove(msg)
 # if we can handle it, do so
-result = self.handle_tool_message(msg, chat_doc=chat_doc)
+result = self._handle_tool_message_with_policy(msg, chat_doc=chat_doc)
 ⋮----
 # else wrap it in an agent response and return it so
 # orchestrator can find a respondent
@@ -57337,6 +58010,48 @@ else result[: max_tokens * 4]  # approx truncate
 ⋮----
 else result.content[: max_tokens * 4]  # approx truncate
 ⋮----
+"""Framework entry point for sync tool dispatch, enforcing `tool_policy`.
+
+        Consults the `tool_policy` hook (see `AgentConfig.tool_policy`) and,
+        if the tool is allowed, delegates to `handle_tool_message` -- which a
+        subclass may override -- exactly as before, so the policy gates tool
+        execution even through such overrides.
+
+        When dispatch is NOT overridden and the tool has no handler, the
+        policy is not consulted (nothing can execute). When dispatch IS
+        overridden, the base cannot know what the override will do, so the
+        policy is consulted regardless, even though the override may end up
+        returning None.
+
+        Args:
+            tool: ToolMessage object representing the tool request.
+            chat_doc: Optional ChatDocument object containing the tool request.
+
+        Returns:
+            The dispatch result, or the policy's LLM-visible rejection.
+        """
+⋮----
+# base dispatch would execute nothing; don't consult the policy
+⋮----
+rejection = check_tool_policy(self.config.tool_policy, tool, self, chat_doc)
+⋮----
+"""Async version of `_handle_tool_message_with_policy`.
+
+        The policy is awaited on the CALLER's event loop (so it can use
+        loop-bound resources), then dispatch proceeds via
+        `handle_tool_message_async` -- which a subclass may override --
+        exactly as before.
+
+        Args:
+            tool: ToolMessage object representing the tool request.
+            chat_doc: Optional ChatDocument object containing the tool request.
+
+        Returns:
+            The dispatch result, or the policy's LLM-visible rejection.
+        """
+⋮----
+rejection = await check_tool_policy_async(
+⋮----
 """
         Asynch version of `handle_tool_message`. See there for details.
         """
@@ -57360,6 +58075,12 @@ result = self.to_ChatDocument(maybe_result, tool_name, chat_doc)
 ⋮----
 """
         Respond to a tool request from the LLM, in the form of an ToolMessage object.
+
+        NOTE: framework dispatch reaches this method through
+        `_handle_tool_message_with_policy`, which enforces the optional
+        `tool_policy` hook BEFORE delegating here; direct calls to this
+        method by user code are the caller's own seam and are not gated.
+
         Args:
             tool: ToolMessage object representing the tool request.
             chat_doc: Optional ChatDocument object containing the tool request.
@@ -57462,208 +58183,13 @@ user_response = Prompt.ask(
 answer = agent.llm_response(request)
 </file>
 
-<file path="langroid/language_models/model_info.py">
-logger = logging.getLogger(__name__)
-⋮----
-class ModelProvider(str, Enum)
-⋮----
-"""Enum for model providers"""
-⋮----
-OPENAI = "openai"
-ANTHROPIC = "anthropic"
-DEEPSEEK = "deepseek"
-GOOGLE = "google"
-MINIMAX = "minimax"
-UNKNOWN = "unknown"
-⋮----
-class ModelName(str, Enum)
-⋮----
-"""Parent class for all model name enums"""
-⋮----
-class OpenAIChatModel(ModelName)
-⋮----
-"""Enum for OpenAI Chat models"""
-⋮----
-GPT3_5_TURBO = "gpt-3.5-turbo"
-GPT4 = "gpt-4o"  # avoid deprecated gpt-4
-GPT4_TURBO = "gpt-4-turbo"
-GPT4o = "gpt-4o"
-GPT4o_MINI = "gpt-4o-mini"
-O1 = "o1"
-O1_MINI = "o1-mini"
-O3_MINI = "o3-mini"
-O3 = "o3"
-O4_MINI = "o4-mini"
-GPT4_1 = "gpt-4.1"
-GPT4_1_MINI = "gpt-4.1-mini"
-GPT4_1_NANO = "gpt-4.1-nano"
-GPT5 = "gpt-5"
-GPT5_MINI = "gpt-5-mini"
-GPT5_NANO = "gpt-5-nano"
-GPT5_PRO = "gpt-5-pro"
-GPT5_1 = "gpt-5.1"
-GPT5_1_CODEX = "gpt-5.1-codex"
-GPT5_1_CODEX_MINI = "gpt-5.1-codex-mini"
-GPT5_1_CHAT = "gpt-5.1-chat"
-GPT5_2 = "gpt-5.2"
-GPT5_2_PRO = "gpt-5.2-pro"
-GPT5_2_CHAT = "gpt-5.2-chat"
-GPT_OSS_120b = "gpt-oss-120b"
-GPT_OSS_20b = "gpt-oss-20b"
-⋮----
-class OpenAICompletionModel(str, Enum)
-⋮----
-"""Enum for OpenAI Completion models"""
-⋮----
-DAVINCI = "davinci-002"
-BABBAGE = "babbage-002"
-⋮----
-class AnthropicModel(ModelName)
-⋮----
-"""Enum for Anthropic models"""
-⋮----
-CLAUDE_3_OPUS = "claude-3-opus-latest"
-CLAUDE_3_SONNET = "claude-3-sonnet-latest"
-CLAUDE_3_HAIKU = "claude-3-haiku-latest"
-CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest"
-CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest"
-CLAUDE_4_OPUS = "claude-opus-4"
-CLAUDE_4_SONNET = "claude-sonnet-4"
-CLAUDE_4_HAIKU = "claude-haiku-4"
-CLAUDE_4_5_OPUS = "claude-opus-4-5"
-CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
-CLAUDE_4_5_HAIKU = "claude-haiku-4-5"
-⋮----
-class DeepSeekModel(ModelName)
-⋮----
-"""Enum for DeepSeek models direct from DeepSeek API"""
-⋮----
-DEEPSEEK = "deepseek/deepseek-chat"
-DEEPSEEK_R1 = "deepseek/deepseek-reasoner"
-OPENROUTER_DEEPSEEK_R1 = "openrouter/deepseek/deepseek-r1"
-⋮----
-class GeminiModel(ModelName)
-⋮----
-"""Enum for Gemini models"""
-⋮----
-GEMINI_1_5_FLASH = "gemini-1.5-flash"
-GEMINI_1_5_FLASH_8B = "gemini-1.5-flash-8b"
-GEMINI_1_5_PRO = "gemini-1.5-pro"
-GEMINI_2_FLASH = "gemini-2.0-flash"
-GEMINI_2_FLASH_LITE = "gemini-2.0-flash-lite"
-GEMINI_2_FLASH_THINKING = "gemini-2.0-flash-thinking-exp"
-GEMINI_2_PRO = "gemini-2.0-pro-exp-02-05"
-GEMINI_2_5_FLASH = "gemini-2.5-flash"
-GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
-GEMINI_2_5_PRO = "gemini-2.5-pro"
-GEMINI_3_FLASH = "gemini-3-flash"
-GEMINI_3_PRO = "gemini-3-pro"
-⋮----
-class MiniMaxModel(ModelName)
-⋮----
-"""Enum for MiniMax models"""
-⋮----
-MINIMAX_M2_7 = "MiniMax-M2.7"
-MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
-MINIMAX_M2_5 = "MiniMax-M2.5"
-MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
-MINIMAX_M2_1 = "MiniMax-M2.1"
-MINIMAX_M2_1_HIGHSPEED = "MiniMax-M2.1-highspeed"
-MINIMAX_M2 = "MiniMax-M2"
-⋮----
-class OpenAI_API_ParamInfo(BaseModel)
-⋮----
-"""
-    Parameters exclusive to some models, when using OpenAI API
-    """
-⋮----
-# model-specific params at top level
-params: Dict[str, List[str]] = dict(
-# model-specific params in extra_body
-extra_parameters: Dict[str, List[str]] = dict(
-⋮----
-class ModelInfo(BaseModel)
-⋮----
-"""
-    Consolidated information about LLM, related to capacity, cost and API
-    idiosyncrasies. Reasonable defaults for all params in case there's no
-    specific info available.
-    """
-⋮----
-name: str = "unknown"
-provider: ModelProvider = ModelProvider.UNKNOWN
-context_length: int = 16_000
-max_cot_tokens: int = 0  # max chain of thought (thinking) tokens where applicable
-max_output_tokens: int = 8192  # Maximum number of output tokens - model dependent
-input_cost_per_million: float = 0.0  # Cost in USD per million input tokens
-cached_cost_per_million: float = 0.0  # Cost in USD per million cached tokens
-output_cost_per_million: float = 0.0  # Cost in USD per million output tokens
-allows_streaming: bool = True  # Whether model supports streaming output
-allows_system_message: bool = True  # Whether model supports system messages
-rename_params: Dict[str, str] = {}  # Rename parameters for OpenAI API
-unsupported_params: List[str] = []
-has_structured_output: bool = False  # Does model API support structured output?
-has_tools: bool = True  # Does model API support tools/function-calling?
-needs_first_user_message: bool = False  # Does API need first msg to be from user?
-description: Optional[str] = None
-⋮----
-GEMINI_CANONICAL_MODEL_NAMES = {model.value for model in GeminiModel}
-DEFAULT_MODEL_INFO = ModelInfo()
-WARNED_UNKNOWN_MODELS: set[tuple[str, ...]] = set()
-⋮----
-# Model information registry
-MODEL_INFO: Dict[str, ModelInfo] = {
-⋮----
-# OpenAI Models
-⋮----
-# Anthropic Models
-⋮----
-# DeepSeek Models
-⋮----
-# Gemini Models
-⋮----
-# Gemini 2.5 Models
-⋮----
-# Gemini 3 Models
-⋮----
-# MiniMax Models
-⋮----
-"""Get model information by name or enum value"""
-# Sequence of models to try, starting with the primary model
-models_to_try = [model] + fallback_models
-⋮----
-# Find the first model in the sequence that has info defined using next()
-# on a generator expression that filters out None results from _get_model_info
-found_info = next(
-⋮----
-None,  # Default value if the iterator is exhausted (no valid info found)
-⋮----
-normalized_models = _normalize_model_names(models_to_try)
-⋮----
-def _get_model_info(model: str | ModelName) -> ModelInfo | None
-⋮----
-def _normalize_model_names(models: List[str | ModelName]) -> List[str]
-⋮----
-normalized_models: List[str] = []
-seen: set[str] = set()
-⋮----
-normalized_model = _normalize_gemini_model_name(_model_name(model))
-⋮----
-def _normalize_gemini_model_name(model: str) -> str | None
-⋮----
-base_model = model.rsplit("/", 1)[-1]
-⋮----
-# Try stripping known suffixes to find a canonical name.
-# Use split (not endswith) for "-preview" so dated variants like
-# "gemini-2.5-flash-lite-preview-06-17" are handled correctly.
-⋮----
-stripped = base_model.split(suffix, maxsplit=1)[0]
-⋮----
-def _warn_unknown_model(models: List[str | ModelName]) -> None
-⋮----
-model_names = tuple(_model_name(model) for model in models)
-⋮----
-def _model_name(model: str | ModelName) -> str
+<file path=".pre-commit-config.yaml">
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.16.4
+  hooks:
+    - id: ruff
 </file>
 
 <file path="mkdocs.yml">
@@ -57789,6 +58315,7 @@ nav:
       - None Content in LLM Messages: notes/llm-none-content.md
       - Weaviate: notes/weaviate.md
       - Handling LLM Non-Tool Messages: notes/handle-llm-no-tool.md
+      - Tool Policy Hook: notes/tool-policy-hook.md
       - PGVector: notes/pgvector.md
       - Pinecone: notes/pinecone.md
       - Tavily Search Tool: notes/tavily_search.md
@@ -57857,15 +58384,6 @@ markdown_extensions:
 extra_javascript:
   - javascripts/mathjax.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
-</file>
-
-<file path=".pre-commit-config.yaml">
-repos:
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.16.0
-  hooks:
-    - id: ruff
 </file>
 
 <file path="langroid/language_models/openai_gpt.py">

--- a/llms-no-tests-no-examples-compressed.txt
+++ b/llms-no-tests-no-examples-compressed.txt
@@ -149,6 +149,7 @@ docs/
     task-tool.md
     tavily_search.md
     tool-message-handler.md
+    tool-policy-hook.md
     twitter-search.md
     url_loader.md
     weaviate.md
@@ -290,6 +291,7 @@ langroid/
     openai_assistant.py
     task.py
     tool_message.py
+    tool_policy.py
     xml_tool_message.py
   cachedb/
     __init__.py
@@ -25025,6 +25027,159 @@ python3 examples/basic/chat-search-seltz.py
 ---
 </file>
 
+<file path="docs/notes/tool-policy-hook.md">
+# Pre-execution Tool Policy Hook
+
+When Langroid agents are embedded in larger systems, operators often need a
+central place to decide whether a tool call the LLM just made should actually
+run: authorization checks, human-approval gates, DLP scanning, command
+policies, budget limits, and so on. The `AgentConfig.tool_policy` hook
+provides the smallest possible interception point for this: a single optional
+callback, consulted immediately before the selected tool handler executes.
+No policy engine, rules, or registries live in Langroid itself — you plug in
+whatever external engine you like.
+
+## API
+
+```python
+import langroid as lr
+
+class RunCommandTool(lr.ToolMessage):
+    request: str = "run_command"
+    purpose: str = "To run a shell <command>"
+    command: str
+
+def my_policy(tool: lr.ToolMessage, agent: lr.Agent) -> bool | str | None:
+    if isinstance(tool, RunCommandTool) and "rm" in tool.command:
+        return "destructive commands are not allowed"
+    return True  # allow
+
+config = lr.ChatAgentConfig(
+    # ... other params ...
+    tool_policy=my_policy,
+)
+```
+
+The callback is invoked as `tool_policy(tool, agent)` — or as
+`tool_policy(tool, agent, chat_doc=...)` if the callable's signature has a
+`chat_doc` parameter (mirroring the convention for tool handlers). It
+receives:
+
+- `tool`: the final parsed `ToolMessage` instance about to be handled — its
+  `request` field is the tool name, and its other fields are the fully
+  validated arguments
+- `agent`: the agent that is about to run the handler
+- `chat_doc` (optional): the `ChatDocument` containing the tool call, when
+  available
+
+The return value decides what happens:
+
+- `True` or `None` — allow: the selected handler runs exactly once, as usual
+- `False` — reject: the handler is NOT run; the LLM receives a rejection
+  message naming the tool
+- a `str` — reject, with that string included as the reason in the
+  LLM-visible rejection message
+
+The hook cannot modify the tool: argument transformation is deliberately out
+of scope, and the hook receives deep copies of both the `ToolMessage` and
+the `chat_doc`, so any mutation it makes has no effect on what the handler
+sees. It only decides allow vs. reject. It is consulted only when a real
+handler has been selected: a tool with no handler returns `None` as before,
+without the policy being called.
+
+The policy is enforced at the framework's dispatch call sites, ABOVE
+`Agent.handle_tool_message` / `handle_tool_message_async` — so it gates
+tool execution even when a subclass overrides those methods. Three
+consequences of that placement:
+
+- when dispatch IS overridden, the framework cannot know whether the
+  override will execute anything, so the policy is consulted even if the
+  override ends up returning `None` (the no-handler shortcut applies only
+  to un-overridden dispatch)
+- direct calls that YOUR code makes to `agent.handle_tool_message(...)`
+  are your own seam and are not gated by the hook
+- the strict-recovery `AnyTool` wrapper is a parsing shim, not a tool
+  execution, so it is exempt from the hook; the recovered actual tool is
+  policy-checked exactly once when dispatched
+
+## Failure semantics: fail-closed
+
+If the policy callback itself raises an exception, the tool is treated as
+rejected — the handler does not run. This is deliberate: a broken policy
+must never silently become a bypassed policy.
+
+The rejection message sent back to the LLM includes only the tool name and
+the exception's class name — never the exception message or the tool's
+arguments, since either could leak payload contents into the conversation.
+The full exception is logged (via the `langroid.agent.tool_policy` logger)
+for the operator. Similarly, a decision value of an unrecognized type (anything other
+than `True`, `False`, `None`, or `str`) is treated as a rejection rather
+than an allow.
+
+## Sync and async
+
+The hook works on both dispatch paths, with both kinds of callables:
+
+- a sync callback works with both `handle_message` (sync dispatch) and
+  `handle_message_async` (async dispatch)
+- an async callback is awaited on the caller's event loop everywhere on the
+  async path — including when the tool only has a sync handler — so it may
+  safely use loop-bound resources (locks, clients, futures). On the sync
+  path it is run to completion via `asyncio.run()` — or, when an event loop
+  is already running in the calling thread (e.g. sync dispatch invoked from
+  inside async code), on a fresh event loop in a helper thread. Any failure
+  while doing so is handled fail-closed like any other hook error.
+
+On each dispatch, the policy is consulted exactly once per tool call,
+including when async dispatch falls back to a tool's sync handler.
+
+## What the hook does NOT change
+
+- With no `tool_policy` configured (the default), behavior is exactly as
+  before — the hook adds negligible overhead (a None check per dispatch)
+  and no semantic change.
+- The USER-origin tool security filter (see
+  [Code-Injection Protection](code-injection-protection.md) and
+  GHSA-gjgq-w2m6-wr5q) runs first and is unaffected: tools vetoed by that
+  filter are never even shown to the policy, and an allow-everything policy
+  cannot resurrect them.
+- Rejections flow back into the conversation like any other tool-handling
+  result (e.g. validation errors), so the LLM sees why the call was refused
+  and can adjust.
+
+## Caveats
+
+The policy callback is trusted operator code, not a sandbox:
+
+- The deep copies guard against mutation through the `tool` and `chat_doc`
+  arguments; a policy determined to tamper could still reach live state via
+  `agent`. Don't do that — the hook's contract is allow/reject only.
+- Everywhere the framework deep-copies an agent config —
+  `ChatAgent.clone()`, `Task` construction, and batch processing — the
+  policy callable is shared by REFERENCE (exempted from the copy via a
+  pre-seeded deepcopy memo; the live config is never mutated). A stateful
+  policy (a budget counter, an approval list) is therefore consulted
+  globally across the original and all copies, and a policy holding
+  unpicklable resources (e.g. a lock) does not break copying. If you copy
+  a config through some other route (`copy.deepcopy` yourself), that copy
+  is not exempted.
+- An async policy evaluated from purely-sync dispatch that is itself
+  running inside an event loop (a rare nested case) runs on a fresh event
+  loop in a helper thread; loop-bound awaitables can fail there, which
+  blocks the tool (fail-closed) rather than bypassing it.
+- A tool payload carrying a non-copyable value (a lock, a client object)
+  prevents the pre-policy deep copy and causes a fail-closed rejection
+  even under an allow-all policy, with a distinct operator-log diagnostic
+  ("tool payload could not be copied for policy evaluation"). The remedy
+  is keeping tool fields to plain data.
+
+## Example
+
+A runnable example is in `examples/basic/tool-policy-hook.py`, showing a
+policy that blocks payments above a limit, with the LLM reacting to the
+rejection.
+</file>
+
 <file path="docs/notes/twitter-search.md">
 # Twitter Search via Xquik MCP
 
@@ -28363,271 +28518,6 @@ results_str = "\n\n".join(str(result) for result in search_results)
     def examples(cls) -> List["ToolMessage" | Tuple[str, "ToolMessage"]]
 </file>
 
-<file path="langroid/agent/batch.py">
-T = TypeVar("T")
-U = TypeVar("U")
-⋮----
-class ExceptionHandling(str, Enum)
-⋮----
-"""Enum for exception handling options."""
-⋮----
-RAISE = "raise"
-RETURN_NONE = "return_none"
-RETURN_EXCEPTION = "return_exception"
-⋮----
-"""Convert legacy boolean handle_exceptions to ExceptionHandling enum."""
-⋮----
-"""
-    Unified batch processing logic for both agent methods and tasks.
-
-    Args:
-        inputs: Iterable of inputs to process
-        do_task: Task execution function that takes (input, index) and returns result
-        start_idx: Starting index for the batch
-        stop_on_first_result: Whether to stop after first valid result
-        sequential: Whether to process sequentially
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        output_map: Function to map results to final output format
-    """
-exception_handling = _convert_exception_handling(handle_exceptions)
-⋮----
-def handle_error(e: BaseException) -> Any
-⋮----
-"""Handle exceptions based on exception_handling."""
-⋮----
-results: List[Optional[ChatDocument] | BaseException] = []
-pending: set[asyncio.Task[Any]] = set()
-# Create task-to-index mapping
-task_indices: dict[asyncio.Task[Any], int] = {}
-⋮----
-tasks = [
-task_indices = {task: i for i, task in enumerate(tasks)}
-results = [None] * len(tasks)
-⋮----
-pending = set(tasks)
-⋮----
-# Process completed tasks
-⋮----
-index = task_indices[task]
-⋮----
-result = await task
-⋮----
-results = []
-⋮----
-result = await do_task(input, i + start_idx)
-⋮----
-# Parallel execution
-⋮----
-return_exceptions = exception_handling != ExceptionHandling.RAISE
-⋮----
-results_with_exceptions = cast(
-⋮----
-results = [
-else:  # ExceptionHandling.RETURN_EXCEPTION
-results = results_with_exceptions
-⋮----
-results = [handle_error(e) for _ in inputs]
-⋮----
-"""
-    Common batch processing logic for both agent methods and tasks.
-
-    Args:
-        inputs: List of inputs to process
-        do_task: Task execution function
-        batch_size: Size of batches, if None process all at once
-        stop_on_first_result: Whether to stop after first valid result
-        sequential: Whether to process sequentially
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        output_map: Function to map results
-        message_template: Template for status message
-        message: Optional override for status message
-    """
-⋮----
-"""Extra wrap to run asyncio.run one single time and not once per loop
-
-        Args:
-            inputs (List[str  |  ChatDocument]): inputs to process
-            batch_size (int | None): batch size
-
-        Returns:
-            List[Any]: results
-        """
-results: List[Any] = []
-⋮----
-msg = message or message_template.format(total=len(inputs))
-⋮----
-results = await _process_batch_async(
-⋮----
-batches = batched(inputs, batch_size)
-⋮----
-start_idx = len(results)
-complete_str = f", {start_idx} complete" if start_idx > 0 else ""
-msg = (
-⋮----
-output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
-⋮----
-"""
-    Generate and run copies of a task async/concurrently one per item in `items` list.
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-    Args:
-        gen_task (Callable[[int], Task]): generates the tasks to run
-        items (list[T]): list of items to process
-        input_map (Callable[[T], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], U]): function to map result
-            to final result. If stop_on_first_result is enabled, then
-            map any invalid output to None. We continue until some non-None
-            result is obtained.
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None) result. Successful results are evaluated after
-            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
-            exception object is itself non-None and also stops the batch.
-            Processing continues past None results; once a non-None result
-            appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        batch_size (Optional[int]): The number of tasks to run at a time,
-            if None, unbatched
-        turns (int): number of turns to run, -1 for infinite
-        message (Optional[str]): optionally overrides the console status messages
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
-        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
-
-
-    Returns:
-        list[Optional[U]]: list of final results. Always list[U] if
-        `stop_on_first_result` is disabled
-    """
-inputs = [input_map(item) for item in items]
-⋮----
-task_i = gen_task(i)
-⋮----
-result = await task_i.run_async(
-⋮----
-# exception will be handled by the caller
-⋮----
-# ----------------------------------------
-# Propagate any exception stored on the task that may have been
-# swallowed inside `Task.run_async`, so that the upper-level
-# exception-handling logic works as expected.
-⋮----
-exc = getattr(task_i, attr, None)
-⋮----
-# Fallback: treat a KILL-status result as an error
-⋮----
-"""
-    Run copies of `task` async/concurrently one per item in `items` list.
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-    Args:
-        task (Task): task to run
-        items (list[T]): list of items to process
-        input_map (Callable[[T], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], U]): function to map result
-            to final result
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None, after `output_map`) result. Processing continues past
-            None-mapped results; exceptions propagate, since this function
-            always uses the default `RAISE` exception handling. Once a non-None
-            result appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        batch_size (Optional[int]): The number of tasks to run at a time,
-            if None, unbatched
-        turns (int): number of turns to run, -1 for infinite
-        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
-        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
-
-    Returns:
-        list[Optional[U]]: list of final results. Always list[U] if
-        `stop_on_first_result` is disabled
-    """
-message = f"[bold green]Running {len(items)} copies of {task.name}..."
-⋮----
-"""
-    Run the `method` on copies of `agent`, async/concurrently one per
-    item in `items` list.
-    ASSUMPTION: The `method` is an async method and has signature:
-        method(self, input: str|ChatDocument|None) -> ChatDocument|None
-    So this would typically be used for the agent's "responder" methods,
-    e.g. `llm_response_async` or `agent_responder_async`.
-
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-
-    Args:
-        agent (Agent): agent whose method to run
-        method (str): Async method to run on copies of `agent`.
-            The method is assumed to have signature:
-            `method(self, input: str|ChatDocument|None) -> ChatDocument|None`
-        input_map (Callable[[Any], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], Any]): function to map result
-            to final result
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None) result. Successful results are evaluated after
-            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
-            exception object is itself non-None and also stops the batch.
-            Processing continues past None results; once a non-None result
-            appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        batch_size (Optional[int]): The number of items to process in each batch.
-            If None, process all items at once.
-    Returns:
-        List[Any]: list of final results
-    """
-# Check if the method is async
-method_name = method.__name__
-⋮----
-agent_cfg = copy.deepcopy(agent.config)
-⋮----
-agent_cls = type(agent)
-agent_name = agent_cfg.name
-⋮----
-async def _do_task(input: str | ChatDocument, i: int) -> Any
-⋮----
-agent_i = agent_cls(agent_cfg)
-method_i = getattr(agent_i, method_name, None)
-⋮----
-result = await method_i(input)
-⋮----
-async def _do_task(item: T) -> U
-⋮----
-async def _do_all(items: Iterable[T]) -> List[U]
-⋮----
-result = await _do_task(item)
-⋮----
-results: List[U] = []
-⋮----
-results = asyncio.run(_do_all(items))
-⋮----
-batches = batched(items, batch_size)
-</file>
-
 <file path="langroid/agent/tool_message.py">
 """
 Structured messages to an agent, typically from an LLM, to be handled by
@@ -28882,6 +28772,249 @@ excludes = excludes.union({"request"})
             Dict[str, Any]: simplified schema
         """
 schema = generate_simple_schema(
+</file>
+
+<file path="langroid/agent/tool_policy.py">
+"""Machinery for the pre-execution tool policy hook.
+
+The public surface is the ``tool_policy`` field on
+:class:`langroid.agent.base.AgentConfig`: an optional callable consulted
+just before a parsed ``ToolMessage``'s selected handler runs, deciding
+whether the handler executes (allow) or an LLM-visible rejection is
+returned instead (reject). The functions here evaluate that hook; see
+``docs/notes/tool-policy-hook.md`` for the full semantics.
+"""
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+C = TypeVar("C", bound="AgentConfig")
+⋮----
+class _PolicyCopyError(Exception)
+⋮----
+"""Internal marker: the tool/chat_doc could not be copied for the policy.
+
+    Distinguishes a payload-copy failure (e.g. a tool field holding a lock
+    or client object) from an exception raised by the policy itself, so the
+    operator log can say precisely which happened. Both fail closed.
+    """
+⋮----
+def dispatch_overridden(agent: "Agent", use_async: bool) -> bool
+⋮----
+"""Whether the agent's tool-dispatch method is overridden by a subclass.
+
+    Async dispatch falls back into `handle_tool_message` when a tool has no
+    async handler, so for the async path an override of EITHER method counts.
+
+    Args:
+        agent: The agent whose dispatch is being examined.
+        use_async: True for the async dispatch path.
+
+    Returns:
+        True if a subclass overrides the relevant dispatch method(s).
+    """
+⋮----
+def handler_exists(agent: "Agent", tool: "ToolMessage", use_async: bool) -> bool
+⋮----
+"""Whether base dispatch would find a handler for this tool.
+
+    Args:
+        agent: The agent that would dispatch the tool.
+        tool: The parsed ToolMessage.
+        use_async: True for the async dispatch path, which looks for an
+            `<name>_async` handler first and falls back to the sync one.
+
+    Returns:
+        True if a handler method exists on the agent.
+    """
+tool_name = tool.default_value("request")
+⋮----
+handler_name = getattr(tool, "_handler", tool_name)
+⋮----
+handler_name = tool_name
+⋮----
+def policy_exempt(tool: "ToolMessage") -> bool
+⋮----
+"""Whether this tool is structurally exempt from the `tool_policy` hook.
+
+    Framework-internal parsing shims declare ``_tool_policy_exempt = True``
+    on their class (e.g. the strict-recovery ``AnyTool`` wrapper): such a
+    shim is not a tool execution itself -- the actual tool it carries is
+    re-parsed and dispatched through the policy-checked path, so the policy
+    is consulted exactly once per logical tool call.
+
+    Args:
+        tool: The parsed ToolMessage about to be dispatched.
+
+    Returns:
+        True if the tool's class carries the exemption marker.
+    """
+# SECURITY: resolve the marker on the CLASS only, never the instance.
+# ToolMessage has ``extra="allow"``, so LLM-controlled tool JSON such
+# as ``{"_tool_policy_exempt": true, ...}`` lands on the INSTANCE as an
+# extra field; trusting instance attributes would let the LLM spoof the
+# exemption and bypass the policy.
+⋮----
+def deepcopy_config_sharing_policy(config: C) -> C
+⋮----
+"""Deep-copy an AgentConfig, sharing `tool_policy` by REFERENCE.
+
+    A `tool_policy` hook may be stateful (budgets, approval lists) or hold
+    unpicklable resources (locks, clients), so wherever the framework
+    deep-copies an agent config (agent cloning, Task construction, batch
+    processing) the policy must be exempted from the copy: the copy and the
+    original consult the SAME policy object. The live `config` is never
+    mutated (the exemption is done by pre-seeding the deepcopy memo).
+
+    Args:
+        config: The config to copy.
+
+    Returns:
+        A deep copy of `config` whose `tool_policy` is the same object as
+        `config.tool_policy`.
+    """
+memo: dict[int, Any] = {}
+policy = config.tool_policy
+⋮----
+config_copy: C = copy.deepcopy(config, memo)
+⋮----
+"""Call the `tool_policy` hook with (tool, agent[, chat_doc]).
+
+    The `chat_doc` is passed only if the callable's signature has a
+    `chat_doc` parameter, mirroring the tool-handler convention. The hook
+    decides allow/reject only, so it receives deep COPIES of the tool and
+    the chat_doc: mutating them cannot change what the handler executes.
+
+    Args:
+        policy: The configured `tool_policy` callable.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        The policy's decision, possibly an awaitable if the policy
+        is async.
+    """
+⋮----
+has_chat_doc_param = "chat_doc" in inspect.signature(policy).parameters
+⋮----
+has_chat_doc_param = False
+⋮----
+tool = tool.model_copy(deep=True)
+⋮----
+chat_doc = copy.deepcopy(chat_doc)
+⋮----
+def run_awaitable_sync(awaitable: Any) -> Any
+⋮----
+"""Run an awaitable to completion from sync code.
+
+    Uses `asyncio.run()` when no event loop is running in this thread;
+    otherwise runs it on a fresh event loop in a helper thread, so sync
+    dispatch nested inside async code (e.g. a sync tool handler invoked
+    from async code calling back into sync dispatch) still works.
+
+    Args:
+        awaitable: The awaitable to run.
+
+    Returns:
+        The awaitable's result.
+    """
+⋮----
+async def _await() -> Any
+⋮----
+def _decision_msg(tool_name: str, decision: Any) -> Optional[str]
+⋮----
+"""Convert a `tool_policy` decision into an optional rejection message.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        decision: The value returned by the `tool_policy` hook.
+
+    Returns:
+        None if the tool is allowed (decision is True or None), else an
+        LLM-visible rejection message naming the tool and the reason.
+        Any decision of an unrecognized type is treated as a rejection
+        (fail-closed).
+    """
+⋮----
+reason = "(no reason given)"
+⋮----
+reason = decision
+⋮----
+reason = (
+⋮----
+def _copy_failure_msg(tool_name: str, e: BaseException | None) -> str
+⋮----
+"""Fail-closed rejection for a payload that could not be copied.
+
+    A tool field carrying a non-copyable object (a lock, a client, ...)
+    prevents the pre-policy deep copy; the tool is blocked (fail-closed),
+    with an operator-log diagnostic distinct from "the policy raised". The
+    LLM-visible message still names only the tool and the exception class.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        e: The underlying copy exception, if known.
+
+    Returns:
+        An LLM-visible rejection message.
+    """
+exc_name = type(e).__name__ if e is not None else "Exception"
+⋮----
+def _failure_msg(tool_name: str, e: Exception) -> str
+⋮----
+"""Fail-closed rejection message for a `tool_policy` hook that raised.
+
+    The exception message is deliberately NOT included, since it may
+    embed raw tool arguments; only the exception class name is exposed.
+    The full exception is logged for the operator.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        e: The exception raised by the hook.
+
+    Returns:
+        An LLM-visible rejection message.
+    """
+⋮----
+"""Evaluate the `tool_policy` hook on the sync dispatch path.
+
+    An async policy is run to completion via `run_awaitable_sync` (which
+    works whether or not an event loop is already running in this thread);
+    any failure while doing so is treated like any other hook failure:
+    the tool is blocked (fail-closed).
+
+    Args:
+        policy: The configured `tool_policy` callable, or None.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        None if no policy is configured or the policy allows the tool,
+        else an LLM-visible rejection message.
+    """
+⋮----
+decision = _invoke_policy(policy, tool, agent, chat_doc)
+⋮----
+decision = run_awaitable_sync(decision)
+⋮----
+"""Async version of `check_tool_policy`.
+
+    An async policy is awaited on the CALLING event loop, so it may safely
+    use loop-bound resources (locks, clients, futures).
+
+    Args:
+        policy: The configured `tool_policy` callable, or None.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        None if no policy is configured or the policy allows the tool,
+        else an LLM-visible rejection message.
+    """
+⋮----
+decision = await decision
 </file>
 
 <file path="langroid/language_models/__init__.py">
@@ -32313,6 +32446,272 @@ results = self._convert_tool_result(tool_name, result)
     """
 </file>
 
+<file path="langroid/agent/batch.py">
+T = TypeVar("T")
+U = TypeVar("U")
+⋮----
+class ExceptionHandling(str, Enum)
+⋮----
+"""Enum for exception handling options."""
+⋮----
+RAISE = "raise"
+RETURN_NONE = "return_none"
+RETURN_EXCEPTION = "return_exception"
+⋮----
+"""Convert legacy boolean handle_exceptions to ExceptionHandling enum."""
+⋮----
+"""
+    Unified batch processing logic for both agent methods and tasks.
+
+    Args:
+        inputs: Iterable of inputs to process
+        do_task: Task execution function that takes (input, index) and returns result
+        start_idx: Starting index for the batch
+        stop_on_first_result: Whether to stop after first valid result
+        sequential: Whether to process sequentially
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        output_map: Function to map results to final output format
+    """
+exception_handling = _convert_exception_handling(handle_exceptions)
+⋮----
+def handle_error(e: BaseException) -> Any
+⋮----
+"""Handle exceptions based on exception_handling."""
+⋮----
+results: List[Optional[ChatDocument] | BaseException] = []
+pending: set[asyncio.Task[Any]] = set()
+# Create task-to-index mapping
+task_indices: dict[asyncio.Task[Any], int] = {}
+⋮----
+tasks = [
+task_indices = {task: i for i, task in enumerate(tasks)}
+results = [None] * len(tasks)
+⋮----
+pending = set(tasks)
+⋮----
+# Process completed tasks
+⋮----
+index = task_indices[task]
+⋮----
+result = await task
+⋮----
+results = []
+⋮----
+result = await do_task(input, i + start_idx)
+⋮----
+# Parallel execution
+⋮----
+return_exceptions = exception_handling != ExceptionHandling.RAISE
+⋮----
+results_with_exceptions = cast(
+⋮----
+results = [
+else:  # ExceptionHandling.RETURN_EXCEPTION
+results = results_with_exceptions
+⋮----
+results = [handle_error(e) for _ in inputs]
+⋮----
+"""
+    Common batch processing logic for both agent methods and tasks.
+
+    Args:
+        inputs: List of inputs to process
+        do_task: Task execution function
+        batch_size: Size of batches, if None process all at once
+        stop_on_first_result: Whether to stop after first valid result
+        sequential: Whether to process sequentially
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        output_map: Function to map results
+        message_template: Template for status message
+        message: Optional override for status message
+    """
+⋮----
+"""Extra wrap to run asyncio.run one single time and not once per loop
+
+        Args:
+            inputs (List[str  |  ChatDocument]): inputs to process
+            batch_size (int | None): batch size
+
+        Returns:
+            List[Any]: results
+        """
+results: List[Any] = []
+⋮----
+msg = message or message_template.format(total=len(inputs))
+⋮----
+results = await _process_batch_async(
+⋮----
+batches = batched(inputs, batch_size)
+⋮----
+start_idx = len(results)
+complete_str = f", {start_idx} complete" if start_idx > 0 else ""
+msg = (
+⋮----
+output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
+⋮----
+"""
+    Generate and run copies of a task async/concurrently one per item in `items` list.
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+    Args:
+        gen_task (Callable[[int], Task]): generates the tasks to run
+        items (list[T]): list of items to process
+        input_map (Callable[[T], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], U]): function to map result
+            to final result. If stop_on_first_result is enabled, then
+            map any invalid output to None. We continue until some non-None
+            result is obtained.
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        batch_size (Optional[int]): The number of tasks to run at a time,
+            if None, unbatched
+        turns (int): number of turns to run, -1 for infinite
+        message (Optional[str]): optionally overrides the console status messages
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
+        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
+
+
+    Returns:
+        list[Optional[U]]: list of final results. Always list[U] if
+        `stop_on_first_result` is disabled
+    """
+inputs = [input_map(item) for item in items]
+⋮----
+task_i = gen_task(i)
+⋮----
+result = await task_i.run_async(
+⋮----
+# exception will be handled by the caller
+⋮----
+# ----------------------------------------
+# Propagate any exception stored on the task that may have been
+# swallowed inside `Task.run_async`, so that the upper-level
+# exception-handling logic works as expected.
+⋮----
+exc = getattr(task_i, attr, None)
+⋮----
+# Fallback: treat a KILL-status result as an error
+⋮----
+"""
+    Run copies of `task` async/concurrently one per item in `items` list.
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+    Args:
+        task (Task): task to run
+        items (list[T]): list of items to process
+        input_map (Callable[[T], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], U]): function to map result
+            to final result
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None, after `output_map`) result. Processing continues past
+            None-mapped results; exceptions propagate, since this function
+            always uses the default `RAISE` exception handling. Once a non-None
+            result appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        batch_size (Optional[int]): The number of tasks to run at a time,
+            if None, unbatched
+        turns (int): number of turns to run, -1 for infinite
+        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
+        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
+
+    Returns:
+        list[Optional[U]]: list of final results. Always list[U] if
+        `stop_on_first_result` is disabled
+    """
+message = f"[bold green]Running {len(items)} copies of {task.name}..."
+⋮----
+"""
+    Run the `method` on copies of `agent`, async/concurrently one per
+    item in `items` list.
+    ASSUMPTION: The `method` is an async method and has signature:
+        method(self, input: str|ChatDocument|None) -> ChatDocument|None
+    So this would typically be used for the agent's "responder" methods,
+    e.g. `llm_response_async` or `agent_responder_async`.
+
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+
+    Args:
+        agent (Agent): agent whose method to run
+        method (str): Async method to run on copies of `agent`.
+            The method is assumed to have signature:
+            `method(self, input: str|ChatDocument|None) -> ChatDocument|None`
+        input_map (Callable[[Any], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], Any]): function to map result
+            to final result
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        batch_size (Optional[int]): The number of items to process in each batch.
+            If None, process all items at once.
+    Returns:
+        List[Any]: list of final results
+    """
+# Check if the method is async
+method_name = method.__name__
+⋮----
+# tool_policy hook shared by reference so its state stays global
+agent_cfg = deepcopy_config_sharing_policy(agent.config)
+⋮----
+agent_cls = type(agent)
+agent_name = agent_cfg.name
+⋮----
+async def _do_task(input: str | ChatDocument, i: int) -> Any
+⋮----
+agent_i = agent_cls(agent_cfg)
+method_i = getattr(agent_i, method_name, None)
+⋮----
+result = await method_i(input)
+⋮----
+async def _do_task(item: T) -> U
+⋮----
+async def _do_all(items: Iterable[T]) -> List[U]
+⋮----
+result = await _do_task(item)
+⋮----
+results: List[U] = []
+⋮----
+results = asyncio.run(_do_all(items))
+⋮----
+batches = batched(items, batch_size)
+</file>
+
 <file path="langroid/agent/openai_assistant.py">
 # setup logger
 ⋮----
@@ -35586,6 +35985,966 @@ sender_role = Role.ASSISTANT
 tool_id=tool_id,  # for OpenAI Assistant
 </file>
 
+<file path="langroid/language_models/base.py">
+logger = logging.getLogger(__name__)
+⋮----
+def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
+⋮----
+async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
+⋮----
+FunctionCallTypes = Literal["none", "auto"]
+ToolChoiceTypes = Literal["none", "auto", "required"]
+ToolTypes = Literal["function"]
+⋮----
+DEFAULT_CONTEXT_LENGTH = 16_000
+⋮----
+class StreamEventType(Enum)
+⋮----
+TEXT = 1
+FUNC_NAME = 2
+FUNC_ARGS = 3
+TOOL_NAME = 4
+TOOL_ARGS = 5
+REASONING = 6
+⋮----
+class RetryParams(BaseSettings)
+⋮----
+max_retries: int = 5
+initial_delay: float = 1.0
+exponential_base: float = 1.3
+jitter: bool = True
+⋮----
+class LLMConfig(BaseSettings)
+⋮----
+"""
+    Common configuration for all language models.
+    """
+⋮----
+type: str = "openai"
+streamer: Optional[Callable[[Any], None]] = noop_fn
+streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
+api_base: str | None = None
+formatter: None | str = None
+# specify None if you want to use the full max output tokens of the model
+max_output_tokens: int | None = 8192
+timeout: int = 20  # timeout for API requests
+chat_model: str = ""
+completion_model: str = ""
+temperature: float = 0.0
+chat_context_length: int | None = None
+async_stream_quiet: bool = False  # suppress streaming output in async mode?
+completion_context_length: int | None = None
+# if input length + max_output_tokens > context length of model,
+# we will try shortening requested output
+min_output_tokens: int = 64
+use_completion_for_chat: bool = False  # use completion model for chat?
+# use chat model for completion? For OpenAI models, this MUST be set to True!
+use_chat_for_completion: bool = True
+stream: bool = True  # stream output from API?
+# TODO: we could have a `stream_reasoning` flag here to control whether to show
+# reasoning output from reasoning models
+cache_config: None | CacheDBConfig = RedisCacheConfig()
+thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
+retry_params: RetryParams = RetryParams()
+⋮----
+@property
+    def model_max_output_tokens(self) -> int
+⋮----
+# Build fallback names by progressively stripping provider prefixes
+# (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
+# succeeds even before OpenAIGPT.__init__ strips the prefix.
+parts = self.chat_model.split("/")
+fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
+⋮----
+class LLMFunctionCall(BaseModel)
+⋮----
+"""
+    Structure of LLM response indicating it "wants" to call a function.
+    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
+    """
+⋮----
+name: str  # name of function to call
+arguments: Optional[Dict[str, Any]] = None
+⋮----
+@staticmethod
+    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall"
+⋮----
+"""
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+fun_call = LLMFunctionCall(name=message["name"])
+fun_args_str = message["arguments"]
+# sometimes may be malformed with invalid indents,
+# so we try to be safe by removing newlines.
+⋮----
+fun_args_str = fun_args_str.replace("\n", "").strip()
+dict_or_list = parse_imperfect_json(fun_args_str)
+⋮----
+fun_args = dict_or_list
+⋮----
+fun_args = None
+⋮----
+def __str__(self) -> str
+⋮----
+class LLMFunctionSpec(BaseModel)
+⋮----
+"""
+    Description of a function available for the LLM to use.
+    To be used when calling the LLM `chat()` method with the `functions` parameter.
+    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
+    """
+⋮----
+name: str
+description: str
+parameters: Dict[str, Any]
+⋮----
+class OpenAIToolCall(BaseModel)
+⋮----
+"""
+    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
+    See https://platform.openai.com/docs/api-reference/chat/create
+
+    Attributes:
+        id: The id of the tool call.
+        type: The type of the tool call;
+            only "function" is currently possible (7/26/24).
+        function: The function call.
+    """
+⋮----
+id: str | None = None
+type: ToolTypes = "function"
+function: LLMFunctionCall | None = None
+extra_content: Dict[str, Any] | None = None
+⋮----
+@staticmethod
+    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall"
+⋮----
+id = message["id"]
+type = message["type"]
+function = LLMFunctionCall.from_dict(message["function"])
+extra_content = message.get("extra_content")
+⋮----
+class OpenAIToolSpec(BaseModel)
+⋮----
+type: ToolTypes
+strict: Optional[bool] = None
+function: LLMFunctionSpec
+⋮----
+class OpenAIJsonSchemaSpec(BaseModel)
+⋮----
+def to_dict(self) -> Dict[str, Any]
+⋮----
+json_schema: Dict[str, Any] = {
+⋮----
+class LLMTokenUsage(BaseModel)
+⋮----
+"""
+    Usage of tokens by an LLM.
+    """
+⋮----
+prompt_tokens: int = 0
+cached_tokens: int = 0
+completion_tokens: int = 0
+cost: float = 0.0
+calls: int = 0  # how many API calls - not used as of 2025-04-04
+⋮----
+def reset(self) -> None
+⋮----
+@property
+    def total_tokens(self) -> int
+⋮----
+class Role(str, Enum)
+⋮----
+"""
+    Possible roles for a message in a chat.
+    """
+⋮----
+USER = "user"
+SYSTEM = "system"
+ASSISTANT = "assistant"
+FUNCTION = "function"
+TOOL = "tool"
+⋮----
+class LLMMessage(BaseModel)
+⋮----
+"""
+    Class representing an entry in the msg-history sent to the LLM API.
+    It could be one of these:
+    - a user message
+    - an LLM ("Assistant") response
+    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
+    - a result or results from executing a fn or tool-call(s)
+    """
+⋮----
+role: Role
+name: Optional[str] = None
+tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
+tool_id: str = ""  # used by OpenAIAssistant
+# None means "no content" (the model returned only a tool/function call).
+# This is distinct from "" and is dropped from the API payload by api_dict;
+# see api_dict for how a fully-empty message is handled per-API.
+content: Optional[str] = None
+files: List[FileAttachment] = []
+function_call: Optional[LLMFunctionCall] = None
+tool_calls: Optional[List[OpenAIToolCall]] = None
+timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+# link to corresponding chat document, for provenance/rewind purposes
+chat_document_id: str = ""
+⋮----
+def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]
+⋮----
+"""
+        Convert to dictionary for API request, keeping ONLY
+        the fields that are expected in an API call!
+        E.g., DROP the tool_id, since it is only for use in the Assistant API,
+            not the completion API.
+
+        Args:
+            has_system_role: whether the message has a system role (if not,
+                set to "user" role)
+        Returns:
+            dict: dictionary representation of LLM message
+        """
+d = self.model_dump()
+files: List[FileAttachment] = d.pop("files")
+⋮----
+# In there are files, then content is an array of
+# different content-parts
+⋮----
+# if there is a key k = "role" with value "system", change to "user"
+# in case has_system_role is False
+⋮----
+# drop None values since API doesn't accept them (this omits `content`
+# entirely when it is None, i.e. "no content")
+dict_no_none = {k: v for k, v in d.items() if v is not None}
+⋮----
+# OpenAI API does not like empty name
+⋮----
+# arguments must be a string
+⋮----
+# convert tool calls to API format
+⋮----
+# An empty tool-call list is not a call and conveys no useful API
+# information. Omitting it also lets the empty-message fallback
+# below produce a valid message.
+⋮----
+# A message with empty content (None was dropped above, or "") AND no
+# tool/function call would be an entirely empty message, which some APIs
+# (e.g. Gemini) reject; fall back to a single space in that case only.
+# When there IS a tool/function call, empty content is fine (and Gemini
+# 3.x in fact REQUIRES it — it rejects an assistant turn that carries
+# both a call and non-empty text content).
+has_call = bool(dict_no_none.get("tool_calls")) or (
+⋮----
+# IMPORTANT! drop fields that are not expected in API call
+⋮----
+content = "FUNC: " + json.dumps(self.function_call)
+⋮----
+content = self.content or ""
+name_str = f" ({self.name})" if self.name else ""
+⋮----
+class LLMResponse(BaseModel)
+⋮----
+"""
+    Class representing response from LLM.
+    """
+⋮----
+# None means the model returned NO content (e.g. only a tool/function
+# call), which is distinct from an empty string "". Preserving this
+# distinction lets the message be faithfully reproduced downstream
+# (see ChatDocument.content_is_none and LLMMessage.content).
+message: Optional[str] = None
+reasoning: str = ""  # optional reasoning text from reasoning models
+# Original message text including inline thought signatures (e.g.
+# <thinking>...</thinking>). Only set when reasoning was extracted
+# from the message text via get_reasoning_final(); NOT set when
+# reasoning comes from a separate API field (e.g. reasoning_content),
+# since in that case the message text never contained thought tags.
+message_with_reasoning: Optional[str] = None
+# TODO tool_id needs to generalize to multi-tool calls
+⋮----
+oai_tool_calls: Optional[List[OpenAIToolCall]] = None
+⋮----
+usage: Optional[LLMTokenUsage] = None
+cached: bool = False
+⋮----
+def tools_content(self) -> str
+⋮----
+def to_LLMMessage(self) -> LLMMessage
+⋮----
+"""Convert LLM response to an LLMMessage, to be included in the
+        message-list sent to the API.
+        This is currently NOT used in any significant way in the library, and is only
+        provided as a utility to construct a message list for the API when directly
+        working with an LLM object.
+
+        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
+        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
+        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
+        """
+⋮----
+"""
+        If `message` or `function_call` of an LLM response contains an explicit
+        recipient name, return this recipient name and `message` stripped
+        of the recipient name if specified.
+
+        Two cases:
+        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
+        (b) `message` is empty and function_call/tool_call with explicit `recipient`
+
+        Args:
+            recognize_recipient_in_content (bool): When True (default), parses
+                message text for ``TO[<recipient>]:<content>`` patterns and
+                top-level JSON ``{"recipient": "..."}`` fields. When False,
+                only function_call/tool_call ``recipient`` fields are checked.
+
+        Returns:
+            (str): name of recipient, which may be empty string if no recipient
+            (str): content of message
+
+        """
+⋮----
+# in this case we ignore message, since all information is in function_call
+msg = ""
+args = self.function_call.arguments
+recipient = ""
+⋮----
+recipient = args.get("recipient", "")
+⋮----
+msg = self.message or ""
+⋮----
+# get the first tool that has a recipient field, if any
+⋮----
+recipient = tc.function.arguments.get(
+⋮----
+)  # type: ignore
+⋮----
+# It's not a function or tool call, so continue looking to see
+# if a recipient is specified in the message.
+⋮----
+# First check if message contains "TO: <recipient> <content>"
+⋮----
+# check if there is a top level json that specifies 'recipient',
+# and retain the entire message as content.
+⋮----
+recipient_name = top_level_json_field(msg, "recipient") if msg else ""
+content = msg
+⋮----
+# Define an abstract base class for language models
+class LanguageModel(ABC)
+⋮----
+"""
+    Abstract base class for language models.
+    """
+⋮----
+# usage cost by model, accumulates here
+usage_cost_dict: Dict[str, LLMTokenUsage] = {}
+⋮----
+def __init__(self, config: LLMConfig = LLMConfig())
+⋮----
+@staticmethod
+    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]
+⋮----
+"""
+        Create a language model.
+        Args:
+            config: configuration for language model
+        Returns: instance of language model
+        """
+⋮----
+openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
+⋮----
+openai = AzureGPT
+⋮----
+openai = OpenAIGPT
+cls = dict(
+return cls(config)  # type: ignore
+⋮----
+@staticmethod
+    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]
+⋮----
+"""
+        Given an even-length sequence of strings, split into a sequence of pairs
+
+        Args:
+            lst (List[str]): sequence of strings
+
+        Returns:
+            List[Tuple[str,str]]: sequence of pairs of strings
+        """
+evens = lst[::2]
+odds = lst[1::2]
+⋮----
+"""
+        From the chat history, extract system prompt, user-assistant turns, and
+        final user msg.
+
+        Args:
+            messages (List[LLMMessage]): List of messages in the chat history
+
+        Returns:
+            Tuple[str, List[Tuple[str,str]], str]:
+                system prompt, user-assistant turns, final user msg
+
+        """
+# Handle various degenerate cases
+messages = [m for m in messages]  # copy
+DUMMY_SYS_PROMPT = "You are a helpful assistant."
+DUMMY_USER_PROMPT = "Follow the instructions above."
+⋮----
+system_prompt = messages[0].content or ""
+⋮----
+# now we have messages = [Sys,...]
+⋮----
+# now we have messages = [Sys, msg, ...]
+⋮----
+# now we have messages = [Sys, user, ...]
+⋮----
+# now we have messages = [Sys, user, ..., user]
+# so we omit the first and last elements and make pairs of user-asst messages
+conversation = [m.content or "" for m in messages[1:-1]]
+user_prompt = messages[-1].content or ""
+pairs = LanguageModel.user_assistant_pairs(conversation)
+⋮----
+@abstractmethod
+    def set_stream(self, stream: bool) -> bool
+⋮----
+"""Enable or disable streaming output from API.
+        Return previous value of stream."""
+⋮----
+@abstractmethod
+    def get_stream(self) -> bool
+⋮----
+"""Get streaming status"""
+⋮----
+@abstractmethod
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+@abstractmethod
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
+⋮----
+"""
+        Get chat-completion response from LLM.
+
+        Args:
+            messages: message-history to send to the LLM
+            max_tokens: max tokens to generate
+            tools: tools available for the LLM to use in its response
+            tool_choice: tool call mode, one of "none", "auto", "required",
+                or a dict specifying a specific tool.
+            functions: functions available for LLM to call (deprecated)
+            function_call: function calling mode, "auto", "none", or a specific fn
+                    (deprecated)
+        """
+⋮----
+"""Async version of `chat`. See `chat` for details."""
+⋮----
+def __call__(self, prompt: str, max_tokens: int) -> LLMResponse
+⋮----
+@staticmethod
+    def _fallback_model_names(model: str) -> List[str]
+⋮----
+parts = model.split("/")
+fallbacks = []
+⋮----
+def info(self) -> ModelInfo
+⋮----
+"""Info of relevant chat model"""
+orig_model = (
+⋮----
+def completion_info(self) -> ModelInfo
+⋮----
+"""Info of relevant completion model"""
+⋮----
+def supports_functions_or_tools(self) -> bool
+⋮----
+"""
+        Does this Model's API support "native" tool-calling, i.e.
+        can we call the API with arguments that contain a list of available tools,
+        and their schemas?
+        Note that, given the plethora of LLM provider APIs this determination is
+        imperfect at best, and leans towards returning True.
+        When the API calls fails with an error indicating tools are not supported,
+        then users are encouraged to use the Langroid-based prompt-based
+        ToolMessage mechanism, which works with ANY LLM. To enable this,
+        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
+        """
+⋮----
+def chat_context_length(self) -> int
+⋮----
+def completion_context_length(self) -> int
+⋮----
+def chat_cost(self) -> Tuple[float, float, float]
+⋮----
+"""
+        Return the cost per 1000 tokens for chat completions.
+
+        Returns:
+            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
+                per 1000 tokens
+        """
+⋮----
+def reset_usage_cost(self) -> None
+⋮----
+counter = self.usage_cost_dict[mdl]
+⋮----
+"""
+        Update usage cost for this LLM.
+        Args:
+            chat (bool): whether to update for chat or completion model
+            prompts (int): number of tokens used for prompts
+            completions (int): number of tokens used for completions
+            cost (float): total token cost in USD
+        """
+mdl = self.config.chat_model if chat else self.config.completion_model
+⋮----
+@classmethod
+    def usage_cost_summary(cls) -> str
+⋮----
+s = ""
+⋮----
+@classmethod
+    def tot_tokens_cost(cls) -> Tuple[int, float]
+⋮----
+"""
+        Return total tokens used and total cost across all models.
+        """
+total_tokens = 0
+total_cost = 0.0
+⋮----
+def get_reasoning_final(self, message: str) -> Tuple[str, str]
+⋮----
+"""Extract "reasoning" and "final answer" from an LLM response, if the
+        reasoning is found within configured delimiters, like <think>, </think>.
+        E.g.,
+        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
+
+        Args:
+            message (str): message from LLM
+
+        Returns:
+            Tuple[str, str]: reasoning, final answer
+        """
+⋮----
+parts = message.split(start)
+⋮----
+"""
+        Given a chat history and a question, convert it to a standalone question.
+        Args:
+            chat_history: list of tuples of (question, answer)
+            query: follow-up question
+
+        Returns: standalone version of the question
+        """
+history = collate_chat_history(chat_history)
+⋮----
+prompt = f"""
+⋮----
+follow_up_question = f"""
+⋮----
+standalone = (
+standalone = standalone.strip()
+⋮----
+class StreamingIfAllowed
+⋮----
+"""Context to temporarily enable or disable streaming, if allowed globally via
+    `settings.stream`"""
+⋮----
+def __init__(self, llm: LanguageModel, stream: bool = True)
+⋮----
+def __enter__(self) -> None
+⋮----
+def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
+</file>
+
+<file path="langroid/language_models/client_cache.py">
+"""
+Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
+"""
+⋮----
+# Cache for client instances, keyed by hashed configuration parameters.
+# Value is a tuple of (client instance, last_used_monotonic_seconds).
+_client_cache: Dict[str, Tuple[Any, float]] = {}
+_client_cache_lock = threading.RLock()
+⋮----
+# Keep track of clients for cleanup
+_all_clients: weakref.WeakSet[Any] = weakref.WeakSet()
+⋮----
+def _get_cache_key(client_type: str, **kwargs: Any) -> str
+⋮----
+"""
+    Generate a cache key from client type and configuration parameters.
+    Uses the same approach as OpenAIGPT._cache_lookup for consistency.
+
+    Args:
+        client_type: Type of client (e.g., "openai", "groq", "cerebras")
+        **kwargs: Configuration parameters (api_key, base_url, timeout, etc.)
+
+    Returns:
+        SHA256 hash of the configuration as a hex string
+    """
+# Convert kwargs to sorted string representation
+sorted_kwargs_str = str(sorted(kwargs.items()))
+⋮----
+# Create raw key combining client type and sorted kwargs
+raw_key = f"{client_type}:{sorted_kwargs_str}"
+⋮----
+# Hash the key for consistent length and to handle complex objects
+hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
+⋮----
+"""
+    Wrap a sync API-key provider for use with ``AsyncOpenAI``.
+
+    ``AsyncOpenAI`` awaits its ``api_key`` callable, so a plain sync
+    provider must be wrapped in an async function. The sync provider is run
+    in a worker thread, so a blocking token refresh cannot stall the event
+    loop. Providers must therefore be thread-safe -- the sync client may
+    call them from arbitrary threads anyway.
+
+    Args:
+        provider: Callable returning a (possibly short-lived) API key.
+
+    Returns:
+        Async callable returning the same key.
+    """
+⋮----
+async def _provider() -> str
+⋮----
+def _api_key_cache_component(api_key: Union[str, Callable[[], str]]) -> Any
+⋮----
+"""
+    Cache-key component for an API key that may be a rotating-key provider.
+
+    A callable provider is keyed on its identity rather than any token value,
+    so rotating tokens never create new cache entries and tokens are never
+    retained in cache keys. The id() cannot be recycled while the entry
+    lives, because the cached client holds a strong reference to the
+    provider (directly for sync clients, via the async wrapper's closure
+    for async clients).
+    """
+⋮----
+def _get_cached_client(cache_key: str) -> Optional[Any]
+⋮----
+"""Get cached client and refresh its last-used timestamp.
+
+    Must be called while holding ``_client_cache_lock``.
+    """
+entry = _client_cache.get(cache_key)
+⋮----
+def _store_client(cache_key: str, client: Any) -> None
+⋮----
+"""Store a client in the cache with the current timestamp.
+
+    Must be called while holding ``_client_cache_lock``.
+    """
+⋮----
+"""
+    Get or create a singleton OpenAI client with the given configuration.
+
+    Args:
+        api_key: OpenAI API key, or a callable returning a fresh key
+            (for short-lived rotating credentials); a callable is resolved
+            per-request by the OpenAI client and is excluded from the
+            cache key (the cache is keyed on the provider's identity)
+        base_url: Optional base URL for API
+        organization: Optional organization ID
+        timeout: Request timeout
+        default_headers: Optional default headers
+        http_client: Optional httpx.Client instance
+        http_client_config: Optional config dict for creating httpx.Client
+
+    Returns:
+        OpenAI client instance
+    """
+⋮----
+timeout = Timeout(timeout)
+⋮----
+# If http_client is provided directly, don't cache (complex object)
+⋮----
+client = OpenAI(
+⋮----
+cache_key = _get_cache_key(
+⋮----
+http_client_config=http_client_config,  # Include config in cache key
+⋮----
+cached_client = _get_cached_client(cache_key)
+⋮----
+created_http_client = None
+⋮----
+created_http_client = Client(**http_client_config)
+⋮----
+http_client=created_http_client,  # Use the client created from config
+⋮----
+"""
+    Get or create a singleton AsyncOpenAI client with the given configuration.
+
+    Args:
+        api_key: OpenAI API key, or a callable returning a fresh key
+            (for short-lived rotating credentials); a callable is resolved
+            per-request by the OpenAI client and is excluded from the
+            cache key (the cache is keyed on the provider's identity)
+        base_url: Optional base URL for API
+        organization: Optional organization ID
+        timeout: Request timeout
+        default_headers: Optional default headers
+        http_client: Optional httpx.AsyncClient instance
+        http_client_config: Optional config dict for creating httpx.AsyncClient
+
+    Returns:
+        AsyncOpenAI client instance
+    """
+⋮----
+api_key_arg: Union[str, Callable[[], Awaitable[str]]]
+⋮----
+# AsyncOpenAI awaits its api_key callable, so wrap the sync provider
+api_key_arg = wrap_api_key_provider_async(api_key)
+⋮----
+api_key_arg = api_key
+⋮----
+client = AsyncOpenAI(
+⋮----
+created_http_client = AsyncClient(**http_client_config)
+⋮----
+def get_groq_client(api_key: str) -> Groq
+⋮----
+"""
+    Get or create a singleton Groq client with the given configuration.
+
+    Args:
+        api_key: Groq API key
+
+    Returns:
+        Groq client instance
+    """
+cache_key = _get_cache_key("groq", api_key=api_key)
+⋮----
+client = Groq(api_key=api_key)
+⋮----
+def get_async_groq_client(api_key: str) -> AsyncGroq
+⋮----
+"""
+    Get or create a singleton AsyncGroq client with the given configuration.
+
+    Args:
+        api_key: Groq API key
+
+    Returns:
+        AsyncGroq client instance
+    """
+cache_key = _get_cache_key("async_groq", api_key=api_key)
+⋮----
+client = AsyncGroq(api_key=api_key)
+⋮----
+def get_cerebras_client(api_key: str) -> Cerebras
+⋮----
+"""
+    Get or create a singleton Cerebras client with the given configuration.
+
+    Args:
+        api_key: Cerebras API key
+
+    Returns:
+        Cerebras client instance
+    """
+cache_key = _get_cache_key("cerebras", api_key=api_key)
+⋮----
+client = Cerebras(api_key=api_key)
+⋮----
+def get_async_cerebras_client(api_key: str) -> AsyncCerebras
+⋮----
+"""
+    Get or create a singleton AsyncCerebras client with the given configuration.
+
+    Args:
+        api_key: Cerebras API key
+
+    Returns:
+        AsyncCerebras client instance
+    """
+cache_key = _get_cache_key("async_cerebras", api_key=api_key)
+⋮----
+client = AsyncCerebras(api_key=api_key)
+⋮----
+def prune_cache(max_age_seconds: float) -> int
+⋮----
+"""
+    Remove cache entries whose last-used time exceeds *max_age_seconds*.
+
+    Evicted clients are **not** closed here because they may still be serving
+    in-flight requests.  Cleanup is handled by the ``atexit`` handler and the
+    garbage collector.
+
+    Args:
+        max_age_seconds: Maximum age (in seconds) for cache entries to keep.
+            Entries older than this value are removed.
+
+    Returns:
+        Number of cache entries removed.
+    """
+⋮----
+now = time.monotonic()
+⋮----
+stale_keys = [
+⋮----
+# Don't close evicted clients here — they may still be serving in-flight
+# requests. The atexit handler and GC will clean them up.
+⋮----
+def _cleanup_clients() -> None
+⋮----
+"""
+    Cleanup function to close all cached clients on exit.
+    Called automatically via atexit.
+    """
+⋮----
+# Check if close is a coroutine function (async)
+⋮----
+# For async clients, we can't await in atexit
+# They will be cleaned up by the OS
+⋮----
+# Sync clients can be closed directly
+⋮----
+pass  # Ignore errors during cleanup
+⋮----
+# Register cleanup function to run on exit
+⋮----
+# For testing purposes
+def _clear_cache() -> None
+⋮----
+"""Clear the client cache. Only for testing."""
+</file>
+
+<file path="SECURITY.md">
+# Security Policy
+
+## Threat model — please read this before reporting
+
+Langroid is a framework for building applications in which an LLM generates
+code and queries that are then executed. Several **optional** agents exist for
+exactly that purpose:
+
+- `TableChatAgent`, `LanceDocChatAgent`, and `VectorStore.compute_from_docs`
+  evaluate LLM-generated **pandas expressions** with `eval()`.
+- `SQLChatAgent` executes LLM-generated **SQL** against a database you supply.
+- `Neo4jChatAgent`, `ArangoChatAgent`, and `CSVGraphAgent` execute
+  LLM-generated **Cypher / AQL** against a graph database you supply.
+
+Executing model-generated code against your own data *is the feature*. An LLM
+is not a trust boundary: if any untrusted text reaches the model's context, you
+must assume the model can be induced to emit any query or expression the
+grammar allows. Langroid cannot prevent this, and does not claim to.
+
+### What is, and is not, a security boundary
+
+The following are **best-effort hardening, not security boundaries**:
+
+- `sanitize_command()` / `CommandValidator` / `safe_eval_globals()` in
+  `langroid/utils/pandas_utils.py`
+- `_DANGEROUS_SQL_PATTERNS` and the `sqlglot` AST checks in `SQLChatAgent`
+- `validate_cypher_query()` / `validate_aql_query()` in the graph agents
+
+They exist to stop an *unlucky* LLM, not a *determined attacker*. The pandas
+path uses explicit allowlists for AST nodes, methods, operators, variables, and
+builtins. The SQL, Cypher, and AQL paths use denylists over full query grammars
+that span multiple dialects, quoting and escaping forms, and function families.
+Such denylists cannot be made complete. We patch clear gaps opportunistically,
+but we do not treat a newly found way around them as a vulnerability in
+Langroid.
+
+The **actual** security boundaries for a Langroid deployment are:
+
+- the privileges of the database credential you hand the agent;
+- the OS user, container, or VM the process runs in;
+- filesystem permissions and network egress rules.
+
+### Deploying these agents safely
+
+If you expose any of the code- or query-executing agents to untrusted input:
+
+- **Give the agent a least-privilege database role.** For `SQLChatAgent`, a
+  read-only, non-superuser role with `GRANT SELECT` on only the intended
+  tables. In PostgreSQL, server-side file reads and writes normally require a
+  superuser, membership in `pg_read_server_files` or
+  `pg_write_server_files`, or a direct grant on a privileged function.
+  `COPY ... PROGRAM` instead requires superuser access or membership in the
+  distinct `pg_execute_server_program` role. Server-side `lo_import` and
+  `lo_export` default to superuser-only use, but an administrator can grant
+  access to those functions directly. Ordinary password-authenticated
+  `dblink` connections do not require any of those roles. Do not install
+  unneeded extensions, and revoke access to dangerous extensions and
+  functions, including `dblink`, in addition to granting only the intended
+  table privileges. Review any site-specific functions and grants as well.
+- **Run the process in a container or VM** with no credentials, secrets, or
+  data you are unwilling to expose to the LLM.
+- **Treat `allow_dangerous_operations=True` and `full_eval=True` as
+  "I am providing my own sandbox."** The first permits dangerous database
+  operations. The second disables pandas AST validation while retaining the
+  restricted globals from `safe_eval_globals()`. Both are documented as
+  trusted-environment-only.
+
+## Reporting a vulnerability
+
+Report privately — **not** via GitHub Issues, Discussions, or any other public
+forum:
+
+1. Go to
+   **[Security Advisories](https://github.com/langroid/langroid/security/advisories)**.
+2. Click **"Report a vulnerability"**.
+3. Include a proof of concept that works against a **default configuration**.
+
+We aim to acknowledge in-scope reports within 7 days.
+
+### In scope
+
+- Vulnerabilities in core framework code: tool dispatch and the agent/tool
+  trust boundary, message routing, sender verification.
+- Parsing and deserialization flaws (XXE, unsafe deserialization, decompression
+  bombs) in the document and message parsers.
+- Path traversal in the file tools (`ReadFileTool`, `WriteFileTool`,
+  `ListDirTool`) and in repository / folder ingestion.
+- Credential or secret leakage in a default configuration that does not depend
+  on any of the specific exclusions below. The out-of-scope rules take
+  precedence over this category.
+- **A code path that skips a documented safety gate entirely** — that is, a
+  *missing call* to a validator, not a *bypass* of one.
+- **A statement the `allowed_statement_types` allowlist misclassifies.** The
+  allowlist is a different kind of control from the denylists above: it decides
+  what a statement *does* over a closed set of statement kinds, so a query that
+  performs a write the allowlist did not authorize — for example by nesting it
+  where the classifier does not look — is a bounded, fixable defect and is in
+  scope.
+- Vulnerable dependencies with a demonstrated impact on Langroid.
+
+### Out of scope
+
+The following will be closed without a fix, an advisory, or a CVE request:
+
+- New bypasses of the SQL, Cypher, or AQL denylists: previously unlisted
+  functions, alternate quoting or escaping forms (backticks, Unicode escapes,
+  schema qualification), or dialect-specific syntax. See "What is, and is not,
+  a security boundary" above.
+- Sandbox escapes from the pandas `eval()` path when `full_eval=True`,
+  including object-graph traversal via dunder attributes. `full_eval=True`
+  disables the AST validator by design.
+- Anything requiring `allow_dangerous_operations=True`.
+- "The LLM can be prompt-injected into generating a harmful query." This is the
+  documented threat model, not a defect.
+- Reports that assume the agent was given a superuser or otherwise
+  over-privileged database credential.
+- Theoretical reports with no working proof of concept against a default
+  configuration.
+
+Reports that chain off a previous advisory as an "incomplete fix" are judged
+against this same scope: if the original issue was a missing gate we will fix
+it, and if it was a denylist gap it is out of scope.
+
+## Supported versions
+
+Security fixes ship in the latest release. Please upgrade to the current
+version of `langroid` rather than requesting backports.
+</file>
+
 <file path="langroid/agent/task.py">
 logger = logging.getLogger(__name__)
 ⋮----
@@ -35819,7 +37178,9 @@ agent = ChatAgent()
 # copy the agent's config, so that we don't modify the original agent's config,
 # which may be shared by other agents.
 ⋮----
-config_copy = copy.deepcopy(agent.config)
+# the tool_policy hook is shared by reference (never deep-copied),
+# so its state (budgets, approvals) stays global across copies
+config_copy = deepcopy_config_sharing_policy(agent.config)
 ⋮----
 agent = cast(ChatAgent, agent)
 ⋮----
@@ -36838,2100 +38199,6 @@ matched = False
 matched = True
 </file>
 
-<file path="langroid/language_models/client_cache.py">
-"""
-Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
-"""
-⋮----
-# Cache for client instances, keyed by hashed configuration parameters.
-# Value is a tuple of (client instance, last_used_monotonic_seconds).
-_client_cache: Dict[str, Tuple[Any, float]] = {}
-_client_cache_lock = threading.RLock()
-⋮----
-# Keep track of clients for cleanup
-_all_clients: weakref.WeakSet[Any] = weakref.WeakSet()
-⋮----
-def _get_cache_key(client_type: str, **kwargs: Any) -> str
-⋮----
-"""
-    Generate a cache key from client type and configuration parameters.
-    Uses the same approach as OpenAIGPT._cache_lookup for consistency.
-
-    Args:
-        client_type: Type of client (e.g., "openai", "groq", "cerebras")
-        **kwargs: Configuration parameters (api_key, base_url, timeout, etc.)
-
-    Returns:
-        SHA256 hash of the configuration as a hex string
-    """
-# Convert kwargs to sorted string representation
-sorted_kwargs_str = str(sorted(kwargs.items()))
-⋮----
-# Create raw key combining client type and sorted kwargs
-raw_key = f"{client_type}:{sorted_kwargs_str}"
-⋮----
-# Hash the key for consistent length and to handle complex objects
-hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
-⋮----
-"""
-    Wrap a sync API-key provider for use with ``AsyncOpenAI``.
-
-    ``AsyncOpenAI`` awaits its ``api_key`` callable, so a plain sync
-    provider must be wrapped in an async function. The sync provider is run
-    in a worker thread, so a blocking token refresh cannot stall the event
-    loop. Providers must therefore be thread-safe -- the sync client may
-    call them from arbitrary threads anyway.
-
-    Args:
-        provider: Callable returning a (possibly short-lived) API key.
-
-    Returns:
-        Async callable returning the same key.
-    """
-⋮----
-async def _provider() -> str
-⋮----
-def _api_key_cache_component(api_key: Union[str, Callable[[], str]]) -> Any
-⋮----
-"""
-    Cache-key component for an API key that may be a rotating-key provider.
-
-    A callable provider is keyed on its identity rather than any token value,
-    so rotating tokens never create new cache entries and tokens are never
-    retained in cache keys. The id() cannot be recycled while the entry
-    lives, because the cached client holds a strong reference to the
-    provider (directly for sync clients, via the async wrapper's closure
-    for async clients).
-    """
-⋮----
-def _get_cached_client(cache_key: str) -> Optional[Any]
-⋮----
-"""Get cached client and refresh its last-used timestamp.
-
-    Must be called while holding ``_client_cache_lock``.
-    """
-entry = _client_cache.get(cache_key)
-⋮----
-def _store_client(cache_key: str, client: Any) -> None
-⋮----
-"""Store a client in the cache with the current timestamp.
-
-    Must be called while holding ``_client_cache_lock``.
-    """
-⋮----
-"""
-    Get or create a singleton OpenAI client with the given configuration.
-
-    Args:
-        api_key: OpenAI API key, or a callable returning a fresh key
-            (for short-lived rotating credentials); a callable is resolved
-            per-request by the OpenAI client and is excluded from the
-            cache key (the cache is keyed on the provider's identity)
-        base_url: Optional base URL for API
-        organization: Optional organization ID
-        timeout: Request timeout
-        default_headers: Optional default headers
-        http_client: Optional httpx.Client instance
-        http_client_config: Optional config dict for creating httpx.Client
-
-    Returns:
-        OpenAI client instance
-    """
-⋮----
-timeout = Timeout(timeout)
-⋮----
-# If http_client is provided directly, don't cache (complex object)
-⋮----
-client = OpenAI(
-⋮----
-cache_key = _get_cache_key(
-⋮----
-http_client_config=http_client_config,  # Include config in cache key
-⋮----
-cached_client = _get_cached_client(cache_key)
-⋮----
-created_http_client = None
-⋮----
-created_http_client = Client(**http_client_config)
-⋮----
-http_client=created_http_client,  # Use the client created from config
-⋮----
-"""
-    Get or create a singleton AsyncOpenAI client with the given configuration.
-
-    Args:
-        api_key: OpenAI API key, or a callable returning a fresh key
-            (for short-lived rotating credentials); a callable is resolved
-            per-request by the OpenAI client and is excluded from the
-            cache key (the cache is keyed on the provider's identity)
-        base_url: Optional base URL for API
-        organization: Optional organization ID
-        timeout: Request timeout
-        default_headers: Optional default headers
-        http_client: Optional httpx.AsyncClient instance
-        http_client_config: Optional config dict for creating httpx.AsyncClient
-
-    Returns:
-        AsyncOpenAI client instance
-    """
-⋮----
-api_key_arg: Union[str, Callable[[], Awaitable[str]]]
-⋮----
-# AsyncOpenAI awaits its api_key callable, so wrap the sync provider
-api_key_arg = wrap_api_key_provider_async(api_key)
-⋮----
-api_key_arg = api_key
-⋮----
-client = AsyncOpenAI(
-⋮----
-created_http_client = AsyncClient(**http_client_config)
-⋮----
-def get_groq_client(api_key: str) -> Groq
-⋮----
-"""
-    Get or create a singleton Groq client with the given configuration.
-
-    Args:
-        api_key: Groq API key
-
-    Returns:
-        Groq client instance
-    """
-cache_key = _get_cache_key("groq", api_key=api_key)
-⋮----
-client = Groq(api_key=api_key)
-⋮----
-def get_async_groq_client(api_key: str) -> AsyncGroq
-⋮----
-"""
-    Get or create a singleton AsyncGroq client with the given configuration.
-
-    Args:
-        api_key: Groq API key
-
-    Returns:
-        AsyncGroq client instance
-    """
-cache_key = _get_cache_key("async_groq", api_key=api_key)
-⋮----
-client = AsyncGroq(api_key=api_key)
-⋮----
-def get_cerebras_client(api_key: str) -> Cerebras
-⋮----
-"""
-    Get or create a singleton Cerebras client with the given configuration.
-
-    Args:
-        api_key: Cerebras API key
-
-    Returns:
-        Cerebras client instance
-    """
-cache_key = _get_cache_key("cerebras", api_key=api_key)
-⋮----
-client = Cerebras(api_key=api_key)
-⋮----
-def get_async_cerebras_client(api_key: str) -> AsyncCerebras
-⋮----
-"""
-    Get or create a singleton AsyncCerebras client with the given configuration.
-
-    Args:
-        api_key: Cerebras API key
-
-    Returns:
-        AsyncCerebras client instance
-    """
-cache_key = _get_cache_key("async_cerebras", api_key=api_key)
-⋮----
-client = AsyncCerebras(api_key=api_key)
-⋮----
-def prune_cache(max_age_seconds: float) -> int
-⋮----
-"""
-    Remove cache entries whose last-used time exceeds *max_age_seconds*.
-
-    Evicted clients are **not** closed here because they may still be serving
-    in-flight requests.  Cleanup is handled by the ``atexit`` handler and the
-    garbage collector.
-
-    Args:
-        max_age_seconds: Maximum age (in seconds) for cache entries to keep.
-            Entries older than this value are removed.
-
-    Returns:
-        Number of cache entries removed.
-    """
-⋮----
-now = time.monotonic()
-⋮----
-stale_keys = [
-⋮----
-# Don't close evicted clients here — they may still be serving in-flight
-# requests. The atexit handler and GC will clean them up.
-⋮----
-def _cleanup_clients() -> None
-⋮----
-"""
-    Cleanup function to close all cached clients on exit.
-    Called automatically via atexit.
-    """
-⋮----
-# Check if close is a coroutine function (async)
-⋮----
-# For async clients, we can't await in atexit
-# They will be cleaned up by the OS
-⋮----
-# Sync clients can be closed directly
-⋮----
-pass  # Ignore errors during cleanup
-⋮----
-# Register cleanup function to run on exit
-⋮----
-# For testing purposes
-def _clear_cache() -> None
-⋮----
-"""Clear the client cache. Only for testing."""
-</file>
-
-<file path="SECURITY.md">
-# Security Policy
-
-## Threat model — please read this before reporting
-
-Langroid is a framework for building applications in which an LLM generates
-code and queries that are then executed. Several **optional** agents exist for
-exactly that purpose:
-
-- `TableChatAgent`, `LanceDocChatAgent`, and `VectorStore.compute_from_docs`
-  evaluate LLM-generated **pandas expressions** with `eval()`.
-- `SQLChatAgent` executes LLM-generated **SQL** against a database you supply.
-- `Neo4jChatAgent`, `ArangoChatAgent`, and `CSVGraphAgent` execute
-  LLM-generated **Cypher / AQL** against a graph database you supply.
-
-Executing model-generated code against your own data *is the feature*. An LLM
-is not a trust boundary: if any untrusted text reaches the model's context, you
-must assume the model can be induced to emit any query or expression the
-grammar allows. Langroid cannot prevent this, and does not claim to.
-
-### What is, and is not, a security boundary
-
-The following are **best-effort hardening, not security boundaries**:
-
-- `sanitize_command()` / `CommandValidator` / `safe_eval_globals()` in
-  `langroid/utils/pandas_utils.py`
-- `_DANGEROUS_SQL_PATTERNS` and the `sqlglot` AST checks in `SQLChatAgent`
-- `validate_cypher_query()` / `validate_aql_query()` in the graph agents
-
-They exist to stop an *unlucky* LLM, not a *determined attacker*. The pandas
-path uses explicit allowlists for AST nodes, methods, operators, variables, and
-builtins. The SQL, Cypher, and AQL paths use denylists over full query grammars
-that span multiple dialects, quoting and escaping forms, and function families.
-Such denylists cannot be made complete. We patch clear gaps opportunistically,
-but we do not treat a newly found way around them as a vulnerability in
-Langroid.
-
-The **actual** security boundaries for a Langroid deployment are:
-
-- the privileges of the database credential you hand the agent;
-- the OS user, container, or VM the process runs in;
-- filesystem permissions and network egress rules.
-
-### Deploying these agents safely
-
-If you expose any of the code- or query-executing agents to untrusted input:
-
-- **Give the agent a least-privilege database role.** For `SQLChatAgent`, a
-  read-only, non-superuser role with `GRANT SELECT` on only the intended
-  tables. In PostgreSQL, server-side file reads and writes normally require a
-  superuser, membership in `pg_read_server_files` or
-  `pg_write_server_files`, or a direct grant on a privileged function.
-  `COPY ... PROGRAM` instead requires superuser access or membership in the
-  distinct `pg_execute_server_program` role. Server-side `lo_import` and
-  `lo_export` default to superuser-only use, but an administrator can grant
-  access to those functions directly. Ordinary password-authenticated
-  `dblink` connections do not require any of those roles. Do not install
-  unneeded extensions, and revoke access to dangerous extensions and
-  functions, including `dblink`, in addition to granting only the intended
-  table privileges. Review any site-specific functions and grants as well.
-- **Run the process in a container or VM** with no credentials, secrets, or
-  data you are unwilling to expose to the LLM.
-- **Treat `allow_dangerous_operations=True` and `full_eval=True` as
-  "I am providing my own sandbox."** The first permits dangerous database
-  operations. The second disables pandas AST validation while retaining the
-  restricted globals from `safe_eval_globals()`. Both are documented as
-  trusted-environment-only.
-
-## Reporting a vulnerability
-
-Report privately — **not** via GitHub Issues, Discussions, or any other public
-forum:
-
-1. Go to
-   **[Security Advisories](https://github.com/langroid/langroid/security/advisories)**.
-2. Click **"Report a vulnerability"**.
-3. Include a proof of concept that works against a **default configuration**.
-
-We aim to acknowledge in-scope reports within 7 days.
-
-### In scope
-
-- Vulnerabilities in core framework code: tool dispatch and the agent/tool
-  trust boundary, message routing, sender verification.
-- Parsing and deserialization flaws (XXE, unsafe deserialization, decompression
-  bombs) in the document and message parsers.
-- Path traversal in the file tools (`ReadFileTool`, `WriteFileTool`,
-  `ListDirTool`) and in repository / folder ingestion.
-- Credential or secret leakage in a default configuration that does not depend
-  on any of the specific exclusions below. The out-of-scope rules take
-  precedence over this category.
-- **A code path that skips a documented safety gate entirely** — that is, a
-  *missing call* to a validator, not a *bypass* of one.
-- **A statement the `allowed_statement_types` allowlist misclassifies.** The
-  allowlist is a different kind of control from the denylists above: it decides
-  what a statement *does* over a closed set of statement kinds, so a query that
-  performs a write the allowlist did not authorize — for example by nesting it
-  where the classifier does not look — is a bounded, fixable defect and is in
-  scope.
-- Vulnerable dependencies with a demonstrated impact on Langroid.
-
-### Out of scope
-
-The following will be closed without a fix, an advisory, or a CVE request:
-
-- New bypasses of the SQL, Cypher, or AQL denylists: previously unlisted
-  functions, alternate quoting or escaping forms (backticks, Unicode escapes,
-  schema qualification), or dialect-specific syntax. See "What is, and is not,
-  a security boundary" above.
-- Sandbox escapes from the pandas `eval()` path when `full_eval=True`,
-  including object-graph traversal via dunder attributes. `full_eval=True`
-  disables the AST validator by design.
-- Anything requiring `allow_dangerous_operations=True`.
-- "The LLM can be prompt-injected into generating a harmful query." This is the
-  documented threat model, not a defect.
-- Reports that assume the agent was given a superuser or otherwise
-  over-privileged database credential.
-- Theoretical reports with no working proof of concept against a default
-  configuration.
-
-Reports that chain off a previous advisory as an "incomplete fix" are judged
-against this same scope: if the original issue was a missing gate we will fix
-it, and if it was a denylist gap it is out of scope.
-
-## Supported versions
-
-Security fixes ship in the latest release. Please upgrade to the current
-version of `langroid` rather than requesting backports.
-</file>
-
-<file path="langroid/agent/chat_agent.py">
-console = Console()
-⋮----
-logger = logging.getLogger(__name__)
-⋮----
-def _is_identified_result(message: LLMMessage) -> bool
-⋮----
-"""Whether a TOOL/FUNCTION result has its identifier and no call payload.
-
-    Such results must survive even with empty content so their calls can be
-    marked complete (issue #1063).
-    """
-has_identifier = (
-⋮----
-def _llm_message_has_payload(message: LLMMessage) -> bool
-⋮----
-"""Whether a message has the fields required for a valid history entry."""
-⋮----
-class ChatAgentConfig(AgentConfig)
-⋮----
-"""
-    Configuration for ChatAgent
-
-    Attributes:
-        system_message: system message to include in message sequence
-             (typically defines role and task of agent).
-             Used only if `task` is not specified in the constructor.
-        user_message: user message to include in message sequence.
-             Used only if `task` is not specified in the constructor.
-        use_tools: whether to use our own ToolMessages mechanism
-        handle_llm_no_tool (Any): desired agent_response when
-            LLM generates non-tool msg.
-        use_functions_api: whether to use functions/tools native to the LLM API
-                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
-        use_tools_api: When `use_functions_api` is True, if this is also True,
-            the OpenAI tool-call API is used, rather than the older/deprecated
-            function-call API. However the tool-call API has some tricky aspects,
-            hence we set this to False by default.
-        strict_recovery: whether to enable strict schema recovery when there
-            is a tool-generation error.
-        enable_orchestration_tool_handling: whether to enable handling of orchestration
-            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
-        output_format: When supported by the LLM (certain OpenAI LLMs
-            and local LLMs served by providers such as vLLM), ensures
-            that the output is a JSON matching the corresponding
-            schema via grammar-based decoding
-        handle_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for handling".
-        use_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for use" (by LLM) and
-            instructions on using T are added to the system message.
-        instructions_output_format: Controls whether we generate instructions for
-            `output_format` in the system message.
-        use_tools_on_output_format: Controls whether to automatically switch
-            to the Langroid-native tools mechanism when `output_format` is set.
-            Note that LLMs may generate tool calls which do not belong to
-            `output_format` even when strict JSON mode is enabled, so this should be
-            enabled when such tool calls are not desired.
-        output_format_include_defaults: Whether to include fields with default arguments
-            in the output schema
-        full_citations: Whether to show source reference citation + content for each
-            citation, or just the main reference citation.
-        search_for_tools_everywhere: Whether to search for tools everywhere,
-            or only in specific LLM response elements based on use_tools /
-            use_functions_api / use_tools_api config settings.
-        recognize_recipient_in_content: Whether to parse LLM response text content
-            for recipient routing patterns, specifically:
-            - ``TO[<recipient>]:<content>`` addressing format, and
-            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
-            When False, only structured routing via function_call/tool_call
-            ``recipient`` fields is recognized. Default is True.
-            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
-            which controls Task-level signals like DONE, PASS, and SEND_TO.
-            To fully disable all text-based routing, set both to False.
-        context_overflow_strategy: Strategy for handling context overflow when
-            message history exceeds model context length. Options:
-            - "truncate": Truncate content of early messages (preserves all messages
-              but with shortened content). This maintains the message sequence.
-            - "drop_turns": Drop complete conversation turns (USER + all responses
-              until next USER). More aggressive but cleaner for voice agents.
-            Default is "truncate" for backward compatibility.
-    """
-⋮----
-system_message: str = "You are a helpful assistant."
-user_message: Optional[str] = None
-handle_llm_no_tool: Any = None
-use_tools: bool = True
-use_functions_api: bool = False
-use_tools_api: bool = True
-strict_recovery: bool = True
-enable_orchestration_tool_handling: bool = True
-output_format: Optional[type] = None
-handle_output_format: bool = True
-use_output_format: bool = True
-instructions_output_format: bool = True
-output_format_include_defaults: bool = True
-use_tools_on_output_format: bool = True
-full_citations: bool = True  # show source + content for each citation?
-search_for_tools_everywhere: bool = True
-recognize_recipient_in_content: bool = True
-context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
-⋮----
-def _set_fn_or_tools(self) -> None
-⋮----
-"""
-        Enable Langroid Tool or OpenAI-like fn-calling,
-        depending on config settings.
-        """
-⋮----
-class ChatAgent(Agent)
-⋮----
-"""
-    Chat Agent interacting with external env
-    (could be human, or external tools).
-    The agent (the LLM actually) is provided with an optional "Task Spec",
-    which is a sequence of `LLMMessage`s. These are used to initialize
-    the `task_messages` of the agent.
-    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
-    The `Agent` class mainly exists to hold various common methods and attributes.
-    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
-    `llm_response` method uses "chat mode" API (i.e. one that takes a
-    message sequence rather than a single message),
-    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
-    that takes a single message).
-    """
-⋮----
-"""
-        Chat-mode agent initialized with task spec as the initial message sequence
-        Args:
-            config: settings for the agent
-
-        """
-⋮----
-# An agent's "task" is defined by a system msg and an optional user msg;
-# These are "priming" messages that kick off the agent's conversation.
-⋮----
-# if task contains a system msg, we override the config system msg
-⋮----
-# if task contains a user msg, we override the config user msg
-⋮----
-# system-level instructions for using tools/functions:
-# We maintain these as tools/functions are enabled/disabled,
-# and whenever an LLM response is sought, these are used to
-# recreate the system message (via `_create_system_and_tools_message`)
-# each time, so it reflects the current set of enabled tools/functions.
-# (a) these are general instructions on using certain tools/functions,
-#   if they are specified in a ToolMessage class as a classmethod `instructions`
-⋮----
-# (b) these are only for the builtin in Langroid TOOLS mechanism:
-⋮----
-# This variable is not None and equals a `ToolMessage` T, if and only if:
-# (a) T has been set as the output_format of this agent, AND
-# (b) T has been "enabled for use" ONLY for enforcing this output format, AND
-# (c) T has NOT been explicitly "enabled for use" by this Agent.
-⋮----
-# As above but deals with "enabled for handling" instead of "enabled for use".
-⋮----
-# instructions specifically related to enforcing `output_format`
-⋮----
-# controls whether to disable strict schemas for this agent if
-# strict mode causes exception
-⋮----
-# Tracks whether any strict tool is enabled; used to determine whether to set
-# `self.disable_strict` on an exception
-⋮----
-# Tracks the set of tools on which we force-disable strict decoding
-⋮----
-# search for tools according to the agent configuration
-⋮----
-# Only enable HANDLING by `agent_response`, NOT LLM generation of these.
-# This is useful where tool-handlers or agent_response generate these
-# tools, and need to be handled.
-# We don't want enable orch tool GENERATION by default, since that
-# might clutter-up the LLM system message unnecessarily.
-⋮----
-def init_state(self) -> None
-⋮----
-"""
-        Initialize the state of the agent. Just conversation state here,
-        but subclasses can override this to initialize other state.
-        """
-⋮----
-@staticmethod
-    def from_id(id: str) -> "ChatAgent"
-⋮----
-"""
-        Get an agent from its ID
-        Args:
-            agent_id (str): ID of the agent
-        Returns:
-            ChatAgent: The agent with the given ID
-        """
-⋮----
-def clone(self, i: int = 0) -> "ChatAgent"
-⋮----
-"""Create i'th clone of this agent, ensuring tool use/handling is cloned.
-        Important: We assume all member variables are in the __init__ method here
-        and in the Agent class.
-        TODO: We are attempting to clone an agent after its state has been
-        changed in possibly many ways. Below is an imperfect solution. Caution advised.
-        Revisit later.
-        """
-agent_cls = type(self)
-# Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
-# instead of deepcopy which loses subclass information
-config_copy = self.config.model_copy(deep=True)
-⋮----
-new_agent = agent_cls(config_copy)
-⋮----
-# Ensure each clone gets its own vecdb client when supported.
-⋮----
-def _clone_extra_state(self, new_agent: "ChatAgent") -> None
-⋮----
-"""Hook for subclasses to copy additional state into clones."""
-⋮----
-def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool
-⋮----
-"""Should we enable strict mode for a given tool?"""
-⋮----
-tool_class = self.llm_tools_map[tool]
-⋮----
-tool_class = tool
-name = tool_class.default_value("request")
-⋮----
-strict: Optional[bool] = tool_class.default_value("strict")
-⋮----
-strict = self._strict_tools_available()
-⋮----
-def _fn_call_available(self) -> bool
-⋮----
-"""Does this agent's LLM support function calling?"""
-⋮----
-def _strict_tools_available(self) -> bool
-⋮----
-"""Does this agent's LLM support strict tools?"""
-⋮----
-def _json_schema_available(self) -> bool
-⋮----
-"""Does this agent's LLM support strict JSON schema output format?"""
-⋮----
-def set_system_message(self, msg: str) -> None
-⋮----
-# if there is message history, update the system message in it
-⋮----
-def set_user_message(self, msg: str) -> None
-⋮----
-@property
-    def task_messages(self) -> List[LLMMessage]
-⋮----
-"""
-        The task messages are the initial messages that define the task
-        of the agent. There will be at least a system message plus possibly a user msg.
-        Returns:
-            List[LLMMessage]: the task messages
-        """
-msgs = [self._create_system_and_tools_message()]
-⋮----
-def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None
-⋮----
-id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
-⋮----
-# dropping tool result, so ADD the corresponding tool-call back
-# to the list of pending calls!
-id = msg.tool_call_id
-⋮----
-# dropping a msg with tool-calls, so DROP these from pending list
-# as well as from id -> call map
-⋮----
-def clear_history(self, start: int = -2, end: int = -1) -> None
-⋮----
-"""
-        Clear the message history, deleting  messages from index `start`,
-        up to index `end`.
-
-        Args:
-            start (int): index of first message to delete; default = -2
-                    (i.e. delete last 2 messages, typically these
-                    are the last user and assistant messages)
-            end (int): index of last message to delete; Default = -1
-                    (i.e. delete all messages up to the last one)
-        """
-n = len(self.message_history)
-⋮----
-start = max(0, n + start)
-end_ = n if end == -1 else end + 1
-dropped = self.message_history[start:end_]
-# consider the dropped msgs in REVERSE order, so we are
-# carefully updating self.oai_tool_calls
-⋮----
-# clear out the chat document from the ObjectRegistry
-⋮----
-def update_history(self, message: str, response: str) -> None
-⋮----
-"""
-        Update the message history with the latest user message and LLM response.
-        Args:
-            message (str): user message
-            response: (str): LLM response
-        """
-⋮----
-def tool_format_rules(self) -> str
-⋮----
-"""
-        Specification of tool formatting rules
-        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
-        based on the currently enabled usable `ToolMessage`s
-
-        Returns:
-            str: formatting rules
-        """
-# ONLY Usable tools (i.e. LLM-generation allowed),
-usable_tool_classes: List[Type[ToolMessage]] = [
-⋮----
-format_instructions = "\n\n".join(
-# if any of the enabled classes has json_group_instructions, then use that,
-# else fall back to ToolMessage.json_group_instructions
-⋮----
-def tool_instructions(self) -> str
-⋮----
-"""
-        Instructions for tools or function-calls, for enabled and usable Tools.
-        These are inserted into system prompt regardless of whether we are using
-        our own ToolMessage mechanism or the LLM's function-call mechanism.
-
-        Returns:
-            str: concatenation of instructions for all usable tools
-        """
-enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
-⋮----
-instructions = []
-⋮----
-class_instructions = ""
-⋮----
-class_instructions = msg_cls.instructions()
-⋮----
-# example will be shown in tool_format_rules() when using TOOLs,
-# so we don't need to show it here.
-example = "" if self.config.use_tools else (msg_cls.usage_examples())
-⋮----
-example = "EXAMPLES:\n" + example
-guidance = (
-⋮----
-instructions_str = "\n\n".join(instructions)
-⋮----
-def augment_system_message(self, message: str) -> None
-⋮----
-"""
-        Augment the system message with the given message.
-        Args:
-            message (str): system message
-        """
-⋮----
-def last_message_with_role(self, role: Role) -> LLMMessage | None
-⋮----
-"""from `message_history`, return the last message with role `role`"""
-n_role_msgs = len([m for m in self.message_history if m.role == role])
-⋮----
-idx = self.nth_message_idx_with_role(role, n_role_msgs)
-⋮----
-def last_message_idx_with_role(self, role: Role) -> int
-⋮----
-"""Index of last message in message_history, with specified role.
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-indices_with_role = [
-⋮----
-def nth_message_idx_with_role(self, role: Role, n: int) -> int
-⋮----
-"""Index of `n`th message in message_history, with specified role.
-        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-⋮----
-def update_last_message(self, message: str, role: str = Role.USER) -> None
-⋮----
-"""
-        Update the last message that has role `role` in the message history.
-        Useful when we want to replace a long user prompt, that may contain context
-        documents plus a question, with just the question.
-        Args:
-            message (str): new message to replace with
-            role (str): role of message to replace
-        """
-⋮----
-# find last message in self.message_history with role `role`
-⋮----
-def delete_last_message(self, role: str = Role.USER) -> None
-⋮----
-"""
-        Delete the last message that has role `role` from the message history.
-        Args:
-            role (str): role of message to delete
-        """
-⋮----
-def _create_system_and_tools_message(self) -> LLMMessage
-⋮----
-"""
-        (Re-)Create the system message for the LLM of the agent,
-        taking into account any tool instructions that have been added
-        after the agent was initialized.
-
-        The system message will consist of:
-        (a) the system message from the `task` arg in constructor, if any,
-            otherwise the default system message from the config
-        (b) the system tool instructions, if any
-        (c) the system json tool instructions, if any
-
-        Returns:
-            LLMMessage object
-        """
-content = self.system_message
-⋮----
-# remove leading and trailing newlines and other whitespace
-⋮----
-def handle_message_fallback(self, msg: str | ChatDocument) -> Any
-⋮----
-"""
-        Fallback method for the "no-tools" scenario, i.e., the current `msg`
-        (presumably emitted by the LLM) does not have any tool that the agent
-        can handle.
-        NOTE: The `msg` may contain tools but either (a) the agent is not
-        enabled to handle them, or (b) there's an explicit `recipient` field
-        in the tool that doesn't match the agent's name.
-
-        Uses the self.config.non_tool_routing to determine the action to take.
-
-        This method can be overridden by subclasses, e.g.,
-        to create a "reminder" message when a tool is expected but the LLM "forgot"
-        to generate one.
-
-        Args:
-            msg (str | ChatDocument): The input msg to handle
-        Returns:
-            Any: The result of the handler method
-        """
-⋮----
-# we ONLY use the `handle_llm_no_tool` config option when
-# the msg is from LLM and does not contain ANY tools at all.
-⋮----
-no_tool_option = self.config.handle_llm_no_tool
-⋮----
-# in case the `no_tool_option` is one of the special NonToolAction vals
-⋮----
-# Otherwise just return `no_tool_option` as is:
-# This can be any string, such as a specific nudge/reminder to the LLM,
-# or even something like ResultTool etc.
-⋮----
-def unhandled_tools(self) -> set[str]
-⋮----
-"""The set of tools that are known but not handled.
-        Useful in task flow: an agent can refuse to accept an incoming msg
-        when it only has unhandled tools.
-        """
-⋮----
-"""
-        Add the tool (message class) to the agent, and enable either
-        - tool USE (i.e. the LLM can generate JSON to use this tool),
-        - tool HANDLING (i.e. the agent can handle JSON from this tool),
-
-        Args:
-            message_class: The ToolMessage class OR List of such classes to enable,
-                for USE, or HANDLING, or both.
-                If this is a list of ToolMessage classes, then the remain args are
-                applied to all classes.
-                Optional; if None, then apply the enabling to all tools in the
-                agent's toolset that have been enabled so far.
-            use: IF True, allow the agent (LLM) to use this tool (or all tools),
-                else disallow
-            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
-                tool (or all tools)
-            force: whether to FORCE the agent (LLM) to USE the specific
-                 tool represented by `message_class`.
-                 `force` is ignored if `message_class` is None.
-            require_recipient: whether to require that recipient be specified
-                when using the tool message (only applies if `use` is True).
-            include_defaults: whether to include fields that have default values,
-                in the "properties" section of the JSON format instructions.
-                (Normally the OpenAI completion API ignores these fields,
-                but the Assistant fn-calling seems to pay attn to these,
-                and if we don't want this, we should set this to False.)
-        """
-⋮----
-# Validate that use/handle are booleans, not accidentally passed tool classes
-⋮----
-param = "use" if isclass(use) else "handle"
-⋮----
-message_class = message_class.require_recipient()
-⋮----
-# XMLToolMessage is not compatible with OpenAI's Tools/functions API,
-# so we disable use of functions API, enable langroid-native Tools,
-# which are prompt-based.
-⋮----
-super().enable_message_handling(message_class)  # enables handling only
-tools = self._get_tool_list(message_class)
-⋮----
-request = message_class.default_value("request")
-⋮----
-llm_function = message_class.llm_function_schema(defaults=include_defaults)
-⋮----
-# `t` was designated as "enabled for handling" ONLY for
-# output_format enforcement, but we are explicitly ]
-# enabling it for handling here, so we set the variable to None.
-⋮----
-tool_class = self.llm_tools_map[t]
-allow_llm_use = tool_class._allow_llm_use
-⋮----
-allow_llm_use = allow_llm_use.default
-⋮----
-# `t` was designated as "enabled for use" ONLY for output_format
-# enforcement, but we are explicitly enabling it for use here,
-# so we set the variable to None.
-⋮----
-def _update_tool_instructions(self) -> None
-⋮----
-# Set tool instructions and JSON format instructions,
-# in case Tools have been enabled/disabled.
-⋮----
-def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]
-⋮----
-"""
-        Returns the current set of enabled requests for inference and tools configs.
-        Used for restoring setings overriden by `set_output_format`.
-        """
-⋮----
-@property
-    def all_llm_tools_known(self) -> set[str]
-⋮----
-"""All known tools; we include `output_format` if it is a `ToolMessage`."""
-known = self.llm_tools_known
-⋮----
-"""
-        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
-        switches to the native Langroid tools mechanism to ensure that no tool
-        calls not of `output_type` are generated. By default, `force_tools`
-        follows the `use_tools_on_output_format` parameter in the config.
-
-        If `output_type` is None, restores to the state prior to setting
-        `output_format`.
-
-        If `use`, we enable use of `output_type` when it is a subclass
-        of `ToolMesage`. Note that this primarily controls instruction
-        generation: the model will always generate `output_type` regardless
-        of whether `use` is set. Defaults to the `use_output_format`
-        parameter in the config. Similarly, handling of `output_type` is
-        controlled by `handle`, which defaults to the
-        `handle_output_format` parameter in the config.
-
-        `instructions` controls whether we generate instructions specifying
-        the output format schema. Defaults to the `instructions_output_format`
-        parameter in the config.
-
-        `is_copy` is set when called via `__getitem__`. In that case, we must
-        copy certain fields to ensure that we do not overwrite the main agent's
-        setings.
-        """
-# Disable usage of an output format which was not specifically enabled
-# by `enable_message`
-⋮----
-# Disable handling of an output format which did not specifically have
-# handling enabled via `enable_message`
-⋮----
-# Reset any previous instructions
-⋮----
-force_tools = self.config.use_tools_on_output_format
-⋮----
-output_type = get_pydantic_wrapper(output_type)
-⋮----
-name = output_type.default_value("request")
-⋮----
-use = self.config.use_output_format
-⋮----
-handle = self.config.handle_output_format
-⋮----
-is_usable = name in self.llm_tools_usable.union(
-is_handled = name in self.llm_tools_handled.union(
-⋮----
-# We must copy `llm_tools_usable` so the base agent
-# is unmodified
-⋮----
-# If handling the tool, do the same for `llm_tools_handled`
-⋮----
-# Enable `output_type`
-⋮----
-# Do not override existing settings
-⋮----
-# If the `output_type` ToilMessage was not already enabled for
-# use, this means we are ONLY enabling it for use specifically
-# for enforcing this output format, so we set the
-# `enabled_use_output_forma  to this output_type, to
-# record that it should be disabled when `output_format` is changed
-⋮----
-# (same reasoning as for use-enabling)
-⋮----
-generated_tool_instructions = name in self.llm_tools_usable.union(
-⋮----
-generated_tool_instructions = False
-⋮----
-instructions = self.config.instructions_output_format
-⋮----
-# Already generated tool instructions as part of "enabling for use",
-# so only need to generate a reminder to use this tool.
-name = cast(ToolMessage, output_type).default_value("request")
-⋮----
-output_format_schema = output_type.llm_function_schema(
-⋮----
-output_format_schema = output_type.model_json_schema()
-⋮----
-def __getitem__(self, output_type: type) -> Self
-⋮----
-"""
-        Returns a (shallow) copy of `self` with a forced output type.
-        """
-clone = copy.copy(self)
-⋮----
-"""
-        Disable this agent from RESPONDING to a `message_class` (Tool). If
-            `message_class` is None, then disable this agent from responding to ALL.
-        Args:
-            message_class: The ToolMessage class to disable; Optional.
-        """
-⋮----
-"""
-        Disable this agent from USING a message class (Tool).
-        If `message_class` is None, then disable this agent from USING ALL tools.
-        Args:
-            message_class: The ToolMessage class to disable.
-                If None, disable all.
-        """
-⋮----
-def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None
-⋮----
-"""
-        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
-        Args:
-            message_class: The only ToolMessage class to allow
-        """
-request = message_class.model_fields["request"].default
-to_remove = [r for r in self.llm_tools_usable if r != request]
-⋮----
-def _load_output_format(self, message: ChatDocument) -> None
-⋮----
-"""
-        If set, attempts to parse a value of type `self.output_format` from the message
-        contents or any tool/function call and assigns it to `content_any`.
-        """
-⋮----
-any_succeeded = False
-attempts: list[str | LLMFunctionCall] = [
-⋮----
-content = json.loads(attempt)
-⋮----
-content = attempt.arguments
-⋮----
-content_any = self.output_format.model_validate(content)
-⋮----
-message.content_any = content_any.value  # type: ignore
-⋮----
-any_succeeded = True
-⋮----
-"""
-        Extracts messages and tracks whether any errors occurred. If strict mode
-        was enabled, disables it for the tool, else triggers strict recovery.
-        """
-⋮----
-most_recent_sent_by_llm = (
-was_llm = most_recent_sent_by_llm or (
-⋮----
-tools = super().get_tool_messages(msg, all_tools)
-⋮----
-# Check if tool class was attached to the exception
-⋮----
-tool_class = ve.tool_class  # type: ignore
-⋮----
-was_strict = (
-# If the result of strict output for a tool using the
-# OpenAI tools API fails to parse, we infer that the
-# schema edits necessary for compatibility prevented
-# adherence to the underlying `ToolMessage` schema and
-# disable strict output for the tool
-⋮----
-# We will trigger the strict recovery mechanism to force
-# the LLM to correct its output, allowing us to parse
-⋮----
-def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None
-⋮----
-"""
-        Returns a `ToolMessage` which wraps all enabled tools, excluding those
-        where strict recovery is disabled. Used in strict recovery.
-        """
-possible_tools = tuple(
-⋮----
-any_tool_type = Union.__getitem__(possible_tools)  # type ignore
-⋮----
-maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
-⋮----
-class AnyTool(ToolMessage)
-⋮----
-purpose: str = "To call a tool/function."
-request: str = "tool_or_function"
-tool: maybe_optional_type  # type: ignore
-⋮----
-def response(self, agent: ChatAgent) -> None | str | ChatDocument
-⋮----
-# One-time use
-⋮----
-# As the ToolMessage schema accepts invalid
-# `tool.request` values, reparse with the
-# corresponding tool
-request = self.tool.request
-⋮----
-tool = agent.llm_tools_map[request].model_validate_json(
-⋮----
-"""Returns instructions for strict recovery."""
-optional_instructions = (
-response_prefix = "If you intended to make such a call, r" if optional else "R"
-instruction_prefix = "If you do so, b" if optional else "B"
-⋮----
-schema_instructions = (
-⋮----
-"""
-        Truncate message at idx in msg history to `tokens` tokens.
-
-        If inplace is True, the message is truncated in place, else
-        it LEAVES the original message INTACT and returns a new message
-        """
-⋮----
-llm_msg = self.message_history[idx]
-⋮----
-llm_msg = copy.deepcopy(self.message_history[idx])
-⋮----
-orig_content = llm_msg.content
-new_content = (
-⋮----
-else orig_content[: tokens * 4]  # approx truncation
-⋮----
-def _reduce_raw_tool_results(self, message: ChatDocument) -> None
-⋮----
-"""
-        If message is the result of a ToolMessage that had
-        a `_max_retained_tokens` set to a non-None value, then we replace contents
-        with a placeholder message.
-        """
-parent_message: ChatDocument | None = message.parent
-tools = [] if parent_message is None else parent_message.tool_messages
-truncate_tools = []
-⋮----
-max_retained_tokens = t._max_retained_tokens
-⋮----
-max_retained_tokens = max_retained_tokens.default
-⋮----
-limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
-⋮----
-max_retained_tokens = limiting_tool._max_retained_tokens
-⋮----
-tool_name = limiting_tool.default_value("request")
-max_tokens: int = max_retained_tokens
-truncation_warning = f"""
-⋮----
-"""
-        Respond to a single user message, appended to the message history,
-        in "chat" mode
-        Args:
-            message (str|ChatDocument): message or ChatDocument object to respond to.
-                If None, use the self.task_messages
-        Returns:
-            LLM response as a ChatDocument object
-        """
-⋮----
-# If enabled and a tool error occurred, we recover by generating the tool in
-# strict json mode
-⋮----
-AnyTool = self._get_any_tool_message()
-⋮----
-recovery_message = self._strict_recovery_instructions(AnyTool)
-augmented_message = message
-⋮----
-augmented_message = recovery_message
-⋮----
-augmented_message = augmented_message + recovery_message
-⋮----
-# only use the augmented message for this one response...
-result = self.llm_response(augmented_message)
-# ... restore the original user message so that the AnyTool recover
-# instructions don't persist in the message history
-# (this can cause the LLM to use the AnyTool directly as a tool)
-⋮----
-msg = message if isinstance(message, str) else message.content
-⋮----
-tool_choice = (
-⋮----
-response = self.llm_response_messages(hist, output_len, tool_choice)
-⋮----
-# Preserve trail of tool_ids for OpenAI Assistant fn-calls
-⋮----
-"""
-        Async version of `llm_response`. See there for details.
-        """
-⋮----
-response = await self.llm_response_messages_async(
-⋮----
-def init_message_history(self) -> None
-⋮----
-"""
-        Initialize the message history with the system message and user message
-        """
-⋮----
-"""
-        Prepare messages to be sent to self.llm_response_messages,
-            which is the main method that calls the LLM API to get a response.
-            If desired output tokens + message history exceeds the model context length,
-            then first the max output tokens is reduced to fit, and if that is not
-            possible, older messages may be truncated to accommodate at least
-            self.config.llm.min_output_tokens of output.
-
-        Returns:
-            Tuple[List[LLMMessage], int]: (messages, output_len)
-                messages = Full list of messages to send
-                output_len = max expected number of tokens in response
-        """
-⋮----
-# this means agent has been used to get LLM response already,
-# and so the last message is an "assistant" response.
-# We delete this last assistant response and re-generate it.
-⋮----
-# initial messages have not yet been loaded, so load them
-⋮----
-# for debugging, show the initial message history
-⋮----
-# update the system message with the latest tool instructions
-⋮----
-# either the message is a str, or it is a fresh ChatDocument
-# different from the last message in the history
-llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
-llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
-# Canonicalize retained whitespace-only results before token counting.
-⋮----
-# process tools if any
-done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
-⋮----
-hist = self.message_history
-output_len = self.config.llm.model_max_output_tokens
-⋮----
-CHAT_HISTORY_BUFFER = 300
-# chat + output > max context length,
-# so first try to shorten requested output len to fit;
-# use an extra margin of CHAT_HISTORY_BUFFER tokens
-# in case our calcs are off (and to allow for some extra tokens)
-output_len = (
-⋮----
-# unacceptably small output len, so compress early parts of
-# conversation history based on the configured strategy
-strategy = self.config.context_overflow_strategy
-⋮----
-# Truncate content of individual messages while preserving
-# the message sequence (important for LLM APIs that require
-# alternating USER/ASSISTANT messages)
-msg_idx_to_compress = 1  # don't touch system msg
-# we will try compressing msg indices up to but not including
-# last user msg
-last_msg_idx_to_compress = (
-n_truncated = 0
-⋮----
-# We want to preserve the first message (typically
-# system msg) and last message (user msg).
-⋮----
-# compress the msg at idx `msg_idx_to_compress`
-⋮----
-output_len = min(
-⋮----
-# we MUST have truncated at least one msg
-msg_tokens = self.chat_num_tokens()
-⋮----
-else:  # strategy == "drop_turns"
-# Drop complete conversation turns. A complete turn is defined
-# as a USER message followed by all messages until the next
-# USER message. This is more aggressive but cleaner for voice
-# agents with limited context.
-n_dropped_turns = 0
-⋮----
-# Find the last USER message index
-last_user_idx = self.last_message_idx_with_role(role=Role.USER)
-⋮----
-# Find the first complete turn to drop (skip system message)
-first_user_idx = -1
-⋮----
-first_user_idx = i
-⋮----
-# Find the end of this turn: last message before next USER
-next_user_idx = -1
-⋮----
-next_user_idx = i
-⋮----
-# Drop the turn
-⋮----
-# we MUST have dropped at least one turn
-⋮----
-# record the position of the corresponding LLMMessage in
-# the message_history
-⋮----
-"""
-        Get function/tool spec/output format arguments for
-        OpenAI-compatible LLM API call
-        """
-functions: Optional[List[LLMFunctionSpec]] = None
-fun_call: str | Dict[str, str] = "none"
-tools: Optional[List[OpenAIToolSpec]] = None
-force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
-⋮----
-functions = [
-fun_call = (
-⋮----
-def to_maybe_strict_spec(function: str) -> OpenAIToolSpec
-⋮----
-spec = self.llm_functions_map[function]
-strict = self._strict_mode_for_tool(function)
-⋮----
-strict_spec = copy.deepcopy(spec)
-⋮----
-strict_spec = spec
-⋮----
-tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
-force_tool = (
-output_format = None
-⋮----
-spec = self.output_format.llm_function_schema(
-⋮----
-output_format = OpenAIJsonSchemaSpec(
-⋮----
-# We always require that outputs strictly match the schema
-⋮----
-param_spec = self.output_format.model_json_schema()
-⋮----
-"""
-        Respond to a series of messages, e.g. with OpenAI ChatCompletion
-        Args:
-            messages: seq of messages (with role, content fields) sent to LLM
-            output_len: max number of tokens expected in response.
-                    If None, use the LLM's default model_max_output_tokens.
-        Returns:
-            Document (i.e. with fields "content", "metadata")
-        """
-⋮----
-output_len = output_len or self.config.llm.model_max_output_tokens
-streamer = noop_fn
-⋮----
-streamer = self.callbacks.start_llm_stream()
-⋮----
-with ExitStack() as stack:  # for conditionally using rich spinner
-⋮----
-# show rich spinner only if not streaming!
-# (Why? b/c the intent of showing a spinner is to "show progress",
-# and we don't need to do that when streaming, since
-# streaming output already shows progress.)
-cm = status(
-⋮----
-response = self.llm.chat(
-⋮----
-# Create temp ChatDocument for tool check, then clean up to avoid
-# polluting ObjectRegistry (see PR #939 discussion)
-temp_doc = ChatDocument.from_LLMResponse(
-⋮----
-response,  # .usage attrib is updated!
-⋮----
-chat_doc = ChatDocument.from_LLMResponse(
-⋮----
-# If using strict output format, parse the output JSON
-⋮----
-"""
-        Async version of `llm_response_messages`. See there for details.
-        """
-⋮----
-streamer_async = async_noop_fn
-⋮----
-streamer_async = await self.callbacks.start_llm_stream_async()
-⋮----
-response = await self.llm.achat(
-⋮----
-"""
-        Call a callback method, only passing 'reasoning' if it accepts it.
-
-        This provides backward compatibility for custom callbacks that don't
-        have the 'reasoning' parameter in their signature.
-
-        Args:
-            callback_name: Name of the callback method (e.g., 'show_llm_response')
-            reasoning: The reasoning content to pass if supported
-            **kwargs: Other arguments to pass to the callback
-        """
-callback = getattr(self.callbacks, callback_name, None)
-⋮----
-# Check if callback accepts 'reasoning' param or **kwargs
-⋮----
-sig = inspect.signature(callback)
-params = sig.parameters
-accepts_reasoning = "reasoning" in params or any(
-⋮----
-# If we can't inspect the signature, assume it doesn't accept reasoning
-accepts_reasoning = False
-⋮----
-is_cached = (
-⋮----
-# We would have already displayed the msg "live" ONLY if
-# streaming was enabled, AND we did not find a cached response.
-# If we are here, it means the response has not yet been displayed.
-cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
-# Track whether we created a temp ChatDocument for cleanup
-is_temp_doc = isinstance(response, LLMResponse)
-chat_doc = (
-# TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
-⋮----
-content = response.message or ""
-tools_content = response.tools_content()
-⋮----
-content = response.content
-tools_content = ""
-reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
-⋮----
-# Clean up temp ChatDocument to avoid polluting ObjectRegistry
-⋮----
-# we are in the context immediately after an LLM responded,
-# we won't have citations yet, so we're done
-⋮----
-citation = (
-⋮----
-reasoning="",  # Citations don't have reasoning
-⋮----
-def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument
-⋮----
-"""
-        Get LLM response to `prompt` (which presumably includes the `message`
-        somewhere, along with possible large "context" passages),
-        but only include `message` as the USER message, and not the
-        full `prompt`, in the message history.
-        Args:
-            message: the original, relatively short, user request or query
-            prompt: the full prompt potentially containing `message` plus context
-
-        Returns:
-            Document object containing the response.
-        """
-# we explicitly call THIS class's respond method,
-# not a derived class's (or else there would be infinite recursion!)
-with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
-⋮----
-"""
-        Async version of `_llm_response_temp_context`. See there for details.
-        """
-⋮----
-answer_doc = cast(
-⋮----
-"""
-        LLM Response to single message, and restore message_history.
-        In effect a "one-off" message & response that leaves agent
-        message history state intact.
-
-        Args:
-            message (str|ChatDocument): message to respond to.
-
-        Returns:
-            A Document object with the response.
-
-        """
-# explicitly call THIS class's respond method,
-⋮----
-n_msgs = len(self.message_history)
-⋮----
-response = cast(ChatDocument, ChatAgent.llm_response(self, message))
-# If there is a response, then we will have two additional
-# messages in the message history, i.e. the user message and the
-# assistant response. We want to (carefully) remove these two messages.
-⋮----
-msg = self.message_history.pop()
-⋮----
-"""
-        Async version of `llm_response_forget`. See there for details.
-        """
-⋮----
-response = cast(
-⋮----
-def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int
-⋮----
-"""
-        Total number of tokens in the message history so far.
-
-        Args:
-            messages: if provided, compute the number of tokens in this list of
-                messages, rather than the current message history.
-        Returns:
-            int: number of tokens in message history
-        """
-⋮----
-hist = messages if messages is not None else self.message_history
-⋮----
-def _message_num_tokens(self, message: LLMMessage) -> int
-⋮----
-"""Count tokens for a message, including serialized user attachments."""
-⋮----
-def _attachment_num_tokens(self, message: LLMMessage) -> int
-⋮----
-"""
-        Estimate attachment contribution using the serialized payload
-        that is sent in the API request for user messages.
-        """
-⋮----
-model = self._chat_model_name_for_attachments()
-⋮----
-def _chat_model_name_for_attachments(self) -> str
-⋮----
-"""Return the model name used for attachment serialization."""
-⋮----
-def message_history_str(self, i: Optional[int] = None) -> str
-⋮----
-"""
-        Return a string representation of the message history
-        Args:
-            i: if provided, return only the i-th message when i is postive,
-                or last k messages when i = -k.
-        Returns:
-        """
-⋮----
-def __del__(self) -> None
-⋮----
-"""
-        Cleanup method called when the ChatAgent is garbage collected.
-        Note: We don't close LLM clients here because they may be shared
-        across multiple agents when client caching is enabled.
-        The clients are managed centrally and cleaned up via atexit hooks.
-        """
-# Previously we closed clients here, but this caused issues when
-# multiple agents shared the same cached client instance.
-# Clients are now managed centrally in langroid.language_models.client_cache
-</file>
-
-<file path="langroid/language_models/base.py">
-logger = logging.getLogger(__name__)
-⋮----
-def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
-⋮----
-async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None
-⋮----
-FunctionCallTypes = Literal["none", "auto"]
-ToolChoiceTypes = Literal["none", "auto", "required"]
-ToolTypes = Literal["function"]
-⋮----
-DEFAULT_CONTEXT_LENGTH = 16_000
-⋮----
-class StreamEventType(Enum)
-⋮----
-TEXT = 1
-FUNC_NAME = 2
-FUNC_ARGS = 3
-TOOL_NAME = 4
-TOOL_ARGS = 5
-REASONING = 6
-⋮----
-class RetryParams(BaseSettings)
-⋮----
-max_retries: int = 5
-initial_delay: float = 1.0
-exponential_base: float = 1.3
-jitter: bool = True
-⋮----
-class LLMConfig(BaseSettings)
-⋮----
-"""
-    Common configuration for all language models.
-    """
-⋮----
-type: str = "openai"
-streamer: Optional[Callable[[Any], None]] = noop_fn
-streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
-api_base: str | None = None
-formatter: None | str = None
-# specify None if you want to use the full max output tokens of the model
-max_output_tokens: int | None = 8192
-timeout: int = 20  # timeout for API requests
-chat_model: str = ""
-completion_model: str = ""
-temperature: float = 0.0
-chat_context_length: int | None = None
-async_stream_quiet: bool = False  # suppress streaming output in async mode?
-completion_context_length: int | None = None
-# if input length + max_output_tokens > context length of model,
-# we will try shortening requested output
-min_output_tokens: int = 64
-use_completion_for_chat: bool = False  # use completion model for chat?
-# use chat model for completion? For OpenAI models, this MUST be set to True!
-use_chat_for_completion: bool = True
-stream: bool = True  # stream output from API?
-# TODO: we could have a `stream_reasoning` flag here to control whether to show
-# reasoning output from reasoning models
-cache_config: None | CacheDBConfig = RedisCacheConfig()
-thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
-retry_params: RetryParams = RetryParams()
-⋮----
-@property
-    def model_max_output_tokens(self) -> int
-⋮----
-# Build fallback names by progressively stripping provider prefixes
-# (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
-# succeeds even before OpenAIGPT.__init__ strips the prefix.
-parts = self.chat_model.split("/")
-fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
-⋮----
-class LLMFunctionCall(BaseModel)
-⋮----
-"""
-    Structure of LLM response indicating it "wants" to call a function.
-    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
-    """
-⋮----
-name: str  # name of function to call
-arguments: Optional[Dict[str, Any]] = None
-⋮----
-@staticmethod
-    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall"
-⋮----
-"""
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-fun_call = LLMFunctionCall(name=message["name"])
-fun_args_str = message["arguments"]
-# sometimes may be malformed with invalid indents,
-# so we try to be safe by removing newlines.
-⋮----
-fun_args_str = fun_args_str.replace("\n", "").strip()
-dict_or_list = parse_imperfect_json(fun_args_str)
-⋮----
-fun_args = dict_or_list
-⋮----
-fun_args = None
-⋮----
-def __str__(self) -> str
-⋮----
-class LLMFunctionSpec(BaseModel)
-⋮----
-"""
-    Description of a function available for the LLM to use.
-    To be used when calling the LLM `chat()` method with the `functions` parameter.
-    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
-    """
-⋮----
-name: str
-description: str
-parameters: Dict[str, Any]
-⋮----
-class OpenAIToolCall(BaseModel)
-⋮----
-"""
-    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
-    See https://platform.openai.com/docs/api-reference/chat/create
-
-    Attributes:
-        id: The id of the tool call.
-        type: The type of the tool call;
-            only "function" is currently possible (7/26/24).
-        function: The function call.
-    """
-⋮----
-id: str | None = None
-type: ToolTypes = "function"
-function: LLMFunctionCall | None = None
-extra_content: Dict[str, Any] | None = None
-⋮----
-@staticmethod
-    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall"
-⋮----
-id = message["id"]
-type = message["type"]
-function = LLMFunctionCall.from_dict(message["function"])
-extra_content = message.get("extra_content")
-⋮----
-class OpenAIToolSpec(BaseModel)
-⋮----
-type: ToolTypes
-strict: Optional[bool] = None
-function: LLMFunctionSpec
-⋮----
-class OpenAIJsonSchemaSpec(BaseModel)
-⋮----
-def to_dict(self) -> Dict[str, Any]
-⋮----
-json_schema: Dict[str, Any] = {
-⋮----
-class LLMTokenUsage(BaseModel)
-⋮----
-"""
-    Usage of tokens by an LLM.
-    """
-⋮----
-prompt_tokens: int = 0
-cached_tokens: int = 0
-completion_tokens: int = 0
-cost: float = 0.0
-calls: int = 0  # how many API calls - not used as of 2025-04-04
-⋮----
-def reset(self) -> None
-⋮----
-@property
-    def total_tokens(self) -> int
-⋮----
-class Role(str, Enum)
-⋮----
-"""
-    Possible roles for a message in a chat.
-    """
-⋮----
-USER = "user"
-SYSTEM = "system"
-ASSISTANT = "assistant"
-FUNCTION = "function"
-TOOL = "tool"
-⋮----
-class LLMMessage(BaseModel)
-⋮----
-"""
-    Class representing an entry in the msg-history sent to the LLM API.
-    It could be one of these:
-    - a user message
-    - an LLM ("Assistant") response
-    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
-    - a result or results from executing a fn or tool-call(s)
-    """
-⋮----
-role: Role
-name: Optional[str] = None
-tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
-tool_id: str = ""  # used by OpenAIAssistant
-# None means "no content" (the model returned only a tool/function call).
-# This is distinct from "" and is dropped from the API payload by api_dict;
-# see api_dict for how a fully-empty message is handled per-API.
-content: Optional[str] = None
-files: List[FileAttachment] = []
-function_call: Optional[LLMFunctionCall] = None
-tool_calls: Optional[List[OpenAIToolCall]] = None
-timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-# link to corresponding chat document, for provenance/rewind purposes
-chat_document_id: str = ""
-⋮----
-def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]
-⋮----
-"""
-        Convert to dictionary for API request, keeping ONLY
-        the fields that are expected in an API call!
-        E.g., DROP the tool_id, since it is only for use in the Assistant API,
-            not the completion API.
-
-        Args:
-            has_system_role: whether the message has a system role (if not,
-                set to "user" role)
-        Returns:
-            dict: dictionary representation of LLM message
-        """
-d = self.model_dump()
-files: List[FileAttachment] = d.pop("files")
-⋮----
-# In there are files, then content is an array of
-# different content-parts
-⋮----
-# if there is a key k = "role" with value "system", change to "user"
-# in case has_system_role is False
-⋮----
-# drop None values since API doesn't accept them (this omits `content`
-# entirely when it is None, i.e. "no content")
-dict_no_none = {k: v for k, v in d.items() if v is not None}
-⋮----
-# OpenAI API does not like empty name
-⋮----
-# arguments must be a string
-⋮----
-# convert tool calls to API format
-⋮----
-# An empty tool-call list is not a call and conveys no useful API
-# information. Omitting it also lets the empty-message fallback
-# below produce a valid message.
-⋮----
-# A message with empty content (None was dropped above, or "") AND no
-# tool/function call would be an entirely empty message, which some APIs
-# (e.g. Gemini) reject; fall back to a single space in that case only.
-# When there IS a tool/function call, empty content is fine (and Gemini
-# 3.x in fact REQUIRES it — it rejects an assistant turn that carries
-# both a call and non-empty text content).
-has_call = bool(dict_no_none.get("tool_calls")) or (
-⋮----
-# IMPORTANT! drop fields that are not expected in API call
-⋮----
-content = "FUNC: " + json.dumps(self.function_call)
-⋮----
-content = self.content or ""
-name_str = f" ({self.name})" if self.name else ""
-⋮----
-class LLMResponse(BaseModel)
-⋮----
-"""
-    Class representing response from LLM.
-    """
-⋮----
-# None means the model returned NO content (e.g. only a tool/function
-# call), which is distinct from an empty string "". Preserving this
-# distinction lets the message be faithfully reproduced downstream
-# (see ChatDocument.content_is_none and LLMMessage.content).
-message: Optional[str] = None
-reasoning: str = ""  # optional reasoning text from reasoning models
-# Original message text including inline thought signatures (e.g.
-# <thinking>...</thinking>). Only set when reasoning was extracted
-# from the message text via get_reasoning_final(); NOT set when
-# reasoning comes from a separate API field (e.g. reasoning_content),
-# since in that case the message text never contained thought tags.
-message_with_reasoning: Optional[str] = None
-# TODO tool_id needs to generalize to multi-tool calls
-⋮----
-oai_tool_calls: Optional[List[OpenAIToolCall]] = None
-⋮----
-usage: Optional[LLMTokenUsage] = None
-cached: bool = False
-⋮----
-def tools_content(self) -> str
-⋮----
-def to_LLMMessage(self) -> LLMMessage
-⋮----
-"""Convert LLM response to an LLMMessage, to be included in the
-        message-list sent to the API.
-        This is currently NOT used in any significant way in the library, and is only
-        provided as a utility to construct a message list for the API when directly
-        working with an LLM object.
-
-        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
-        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
-        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
-        """
-⋮----
-"""
-        If `message` or `function_call` of an LLM response contains an explicit
-        recipient name, return this recipient name and `message` stripped
-        of the recipient name if specified.
-
-        Two cases:
-        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
-        (b) `message` is empty and function_call/tool_call with explicit `recipient`
-
-        Args:
-            recognize_recipient_in_content (bool): When True (default), parses
-                message text for ``TO[<recipient>]:<content>`` patterns and
-                top-level JSON ``{"recipient": "..."}`` fields. When False,
-                only function_call/tool_call ``recipient`` fields are checked.
-
-        Returns:
-            (str): name of recipient, which may be empty string if no recipient
-            (str): content of message
-
-        """
-⋮----
-# in this case we ignore message, since all information is in function_call
-msg = ""
-args = self.function_call.arguments
-recipient = ""
-⋮----
-recipient = args.get("recipient", "")
-⋮----
-msg = self.message or ""
-⋮----
-# get the first tool that has a recipient field, if any
-⋮----
-recipient = tc.function.arguments.get(
-⋮----
-)  # type: ignore
-⋮----
-# It's not a function or tool call, so continue looking to see
-# if a recipient is specified in the message.
-⋮----
-# First check if message contains "TO: <recipient> <content>"
-⋮----
-# check if there is a top level json that specifies 'recipient',
-# and retain the entire message as content.
-⋮----
-recipient_name = top_level_json_field(msg, "recipient") if msg else ""
-content = msg
-⋮----
-# Define an abstract base class for language models
-class LanguageModel(ABC)
-⋮----
-"""
-    Abstract base class for language models.
-    """
-⋮----
-# usage cost by model, accumulates here
-usage_cost_dict: Dict[str, LLMTokenUsage] = {}
-⋮----
-def __init__(self, config: LLMConfig = LLMConfig())
-⋮----
-@staticmethod
-    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]
-⋮----
-"""
-        Create a language model.
-        Args:
-            config: configuration for language model
-        Returns: instance of language model
-        """
-⋮----
-openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
-⋮----
-openai = AzureGPT
-⋮----
-openai = OpenAIGPT
-cls = dict(
-return cls(config)  # type: ignore
-⋮----
-@staticmethod
-    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]
-⋮----
-"""
-        Given an even-length sequence of strings, split into a sequence of pairs
-
-        Args:
-            lst (List[str]): sequence of strings
-
-        Returns:
-            List[Tuple[str,str]]: sequence of pairs of strings
-        """
-evens = lst[::2]
-odds = lst[1::2]
-⋮----
-"""
-        From the chat history, extract system prompt, user-assistant turns, and
-        final user msg.
-
-        Args:
-            messages (List[LLMMessage]): List of messages in the chat history
-
-        Returns:
-            Tuple[str, List[Tuple[str,str]], str]:
-                system prompt, user-assistant turns, final user msg
-
-        """
-# Handle various degenerate cases
-messages = [m for m in messages]  # copy
-DUMMY_SYS_PROMPT = "You are a helpful assistant."
-DUMMY_USER_PROMPT = "Follow the instructions above."
-⋮----
-system_prompt = messages[0].content or ""
-⋮----
-# now we have messages = [Sys,...]
-⋮----
-# now we have messages = [Sys, msg, ...]
-⋮----
-# now we have messages = [Sys, user, ...]
-⋮----
-# now we have messages = [Sys, user, ..., user]
-# so we omit the first and last elements and make pairs of user-asst messages
-conversation = [m.content or "" for m in messages[1:-1]]
-user_prompt = messages[-1].content or ""
-pairs = LanguageModel.user_assistant_pairs(conversation)
-⋮----
-@abstractmethod
-    def set_stream(self, stream: bool) -> bool
-⋮----
-"""Enable or disable streaming output from API.
-        Return previous value of stream."""
-⋮----
-@abstractmethod
-    def get_stream(self) -> bool
-⋮----
-"""Get streaming status"""
-⋮----
-@abstractmethod
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-@abstractmethod
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse
-⋮----
-"""
-        Get chat-completion response from LLM.
-
-        Args:
-            messages: message-history to send to the LLM
-            max_tokens: max tokens to generate
-            tools: tools available for the LLM to use in its response
-            tool_choice: tool call mode, one of "none", "auto", "required",
-                or a dict specifying a specific tool.
-            functions: functions available for LLM to call (deprecated)
-            function_call: function calling mode, "auto", "none", or a specific fn
-                    (deprecated)
-        """
-⋮----
-"""Async version of `chat`. See `chat` for details."""
-⋮----
-def __call__(self, prompt: str, max_tokens: int) -> LLMResponse
-⋮----
-@staticmethod
-    def _fallback_model_names(model: str) -> List[str]
-⋮----
-parts = model.split("/")
-fallbacks = []
-⋮----
-def info(self) -> ModelInfo
-⋮----
-"""Info of relevant chat model"""
-orig_model = (
-⋮----
-def completion_info(self) -> ModelInfo
-⋮----
-"""Info of relevant completion model"""
-⋮----
-def supports_functions_or_tools(self) -> bool
-⋮----
-"""
-        Does this Model's API support "native" tool-calling, i.e.
-        can we call the API with arguments that contain a list of available tools,
-        and their schemas?
-        Note that, given the plethora of LLM provider APIs this determination is
-        imperfect at best, and leans towards returning True.
-        When the API calls fails with an error indicating tools are not supported,
-        then users are encouraged to use the Langroid-based prompt-based
-        ToolMessage mechanism, which works with ANY LLM. To enable this,
-        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
-        """
-⋮----
-def chat_context_length(self) -> int
-⋮----
-def completion_context_length(self) -> int
-⋮----
-def chat_cost(self) -> Tuple[float, float, float]
-⋮----
-"""
-        Return the cost per 1000 tokens for chat completions.
-
-        Returns:
-            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
-                per 1000 tokens
-        """
-⋮----
-def reset_usage_cost(self) -> None
-⋮----
-counter = self.usage_cost_dict[mdl]
-⋮----
-"""
-        Update usage cost for this LLM.
-        Args:
-            chat (bool): whether to update for chat or completion model
-            prompts (int): number of tokens used for prompts
-            completions (int): number of tokens used for completions
-            cost (float): total token cost in USD
-        """
-mdl = self.config.chat_model if chat else self.config.completion_model
-⋮----
-@classmethod
-    def usage_cost_summary(cls) -> str
-⋮----
-s = ""
-⋮----
-@classmethod
-    def tot_tokens_cost(cls) -> Tuple[int, float]
-⋮----
-"""
-        Return total tokens used and total cost across all models.
-        """
-total_tokens = 0
-total_cost = 0.0
-⋮----
-def get_reasoning_final(self, message: str) -> Tuple[str, str]
-⋮----
-"""Extract "reasoning" and "final answer" from an LLM response, if the
-        reasoning is found within configured delimiters, like <think>, </think>.
-        E.g.,
-        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
-
-        Args:
-            message (str): message from LLM
-
-        Returns:
-            Tuple[str, str]: reasoning, final answer
-        """
-⋮----
-parts = message.split(start)
-⋮----
-"""
-        Given a chat history and a question, convert it to a standalone question.
-        Args:
-            chat_history: list of tuples of (question, answer)
-            query: follow-up question
-
-        Returns: standalone version of the question
-        """
-history = collate_chat_history(chat_history)
-⋮----
-prompt = f"""
-⋮----
-follow_up_question = f"""
-⋮----
-standalone = (
-standalone = standalone.strip()
-⋮----
-class StreamingIfAllowed
-⋮----
-"""Context to temporarily enable or disable streaming, if allowed globally via
-    `settings.stream`"""
-⋮----
-def __init__(self, llm: LanguageModel, stream: bool = True)
-⋮----
-def __enter__(self) -> None
-⋮----
-def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None
-</file>
-
 <file path="langroid/agent/special/sql/sql_chat_agent.py">
 """
 Agent that allows interaction with an SQL database using SQLAlchemy library.
@@ -39443,6 +38710,1355 @@ instruc_msg = f"""
 # user response_forget to avoid accumulating the chat history
 </file>
 
+<file path="langroid/agent/chat_agent.py">
+console = Console()
+⋮----
+logger = logging.getLogger(__name__)
+⋮----
+def _is_identified_result(message: LLMMessage) -> bool
+⋮----
+"""Whether a TOOL/FUNCTION result has its identifier and no call payload.
+
+    Such results must survive even with empty content so their calls can be
+    marked complete (issue #1063).
+    """
+has_identifier = (
+⋮----
+def _llm_message_has_payload(message: LLMMessage) -> bool
+⋮----
+"""Whether a message has the fields required for a valid history entry."""
+⋮----
+class ChatAgentConfig(AgentConfig)
+⋮----
+"""
+    Configuration for ChatAgent
+
+    Attributes:
+        system_message: system message to include in message sequence
+             (typically defines role and task of agent).
+             Used only if `task` is not specified in the constructor.
+        user_message: user message to include in message sequence.
+             Used only if `task` is not specified in the constructor.
+        use_tools: whether to use our own ToolMessages mechanism
+        handle_llm_no_tool (Any): desired agent_response when
+            LLM generates non-tool msg.
+        use_functions_api: whether to use functions/tools native to the LLM API
+                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
+        use_tools_api: When `use_functions_api` is True, if this is also True,
+            the OpenAI tool-call API is used, rather than the older/deprecated
+            function-call API. However the tool-call API has some tricky aspects,
+            hence we set this to False by default.
+        strict_recovery: whether to enable strict schema recovery when there
+            is a tool-generation error.
+        enable_orchestration_tool_handling: whether to enable handling of orchestration
+            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
+        output_format: When supported by the LLM (certain OpenAI LLMs
+            and local LLMs served by providers such as vLLM), ensures
+            that the output is a JSON matching the corresponding
+            schema via grammar-based decoding
+        handle_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for handling".
+        use_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for use" (by LLM) and
+            instructions on using T are added to the system message.
+        instructions_output_format: Controls whether we generate instructions for
+            `output_format` in the system message.
+        use_tools_on_output_format: Controls whether to automatically switch
+            to the Langroid-native tools mechanism when `output_format` is set.
+            Note that LLMs may generate tool calls which do not belong to
+            `output_format` even when strict JSON mode is enabled, so this should be
+            enabled when such tool calls are not desired.
+        output_format_include_defaults: Whether to include fields with default arguments
+            in the output schema
+        full_citations: Whether to show source reference citation + content for each
+            citation, or just the main reference citation.
+        search_for_tools_everywhere: Whether to search for tools everywhere,
+            or only in specific LLM response elements based on use_tools /
+            use_functions_api / use_tools_api config settings.
+        recognize_recipient_in_content: Whether to parse LLM response text content
+            for recipient routing patterns, specifically:
+            - ``TO[<recipient>]:<content>`` addressing format, and
+            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
+            When False, only structured routing via function_call/tool_call
+            ``recipient`` fields is recognized. Default is True.
+            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
+            which controls Task-level signals like DONE, PASS, and SEND_TO.
+            To fully disable all text-based routing, set both to False.
+        context_overflow_strategy: Strategy for handling context overflow when
+            message history exceeds model context length. Options:
+            - "truncate": Truncate content of early messages (preserves all messages
+              but with shortened content). This maintains the message sequence.
+            - "drop_turns": Drop complete conversation turns (USER + all responses
+              until next USER). More aggressive but cleaner for voice agents.
+            Default is "truncate" for backward compatibility.
+    """
+⋮----
+system_message: str = "You are a helpful assistant."
+user_message: Optional[str] = None
+handle_llm_no_tool: Any = None
+use_tools: bool = True
+use_functions_api: bool = False
+use_tools_api: bool = True
+strict_recovery: bool = True
+enable_orchestration_tool_handling: bool = True
+output_format: Optional[type] = None
+handle_output_format: bool = True
+use_output_format: bool = True
+instructions_output_format: bool = True
+output_format_include_defaults: bool = True
+use_tools_on_output_format: bool = True
+full_citations: bool = True  # show source + content for each citation?
+search_for_tools_everywhere: bool = True
+recognize_recipient_in_content: bool = True
+context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
+⋮----
+def _set_fn_or_tools(self) -> None
+⋮----
+"""
+        Enable Langroid Tool or OpenAI-like fn-calling,
+        depending on config settings.
+        """
+⋮----
+class ChatAgent(Agent)
+⋮----
+"""
+    Chat Agent interacting with external env
+    (could be human, or external tools).
+    The agent (the LLM actually) is provided with an optional "Task Spec",
+    which is a sequence of `LLMMessage`s. These are used to initialize
+    the `task_messages` of the agent.
+    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
+    The `Agent` class mainly exists to hold various common methods and attributes.
+    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
+    `llm_response` method uses "chat mode" API (i.e. one that takes a
+    message sequence rather than a single message),
+    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
+    that takes a single message).
+    """
+⋮----
+"""
+        Chat-mode agent initialized with task spec as the initial message sequence
+        Args:
+            config: settings for the agent
+
+        """
+⋮----
+# An agent's "task" is defined by a system msg and an optional user msg;
+# These are "priming" messages that kick off the agent's conversation.
+⋮----
+# if task contains a system msg, we override the config system msg
+⋮----
+# if task contains a user msg, we override the config user msg
+⋮----
+# system-level instructions for using tools/functions:
+# We maintain these as tools/functions are enabled/disabled,
+# and whenever an LLM response is sought, these are used to
+# recreate the system message (via `_create_system_and_tools_message`)
+# each time, so it reflects the current set of enabled tools/functions.
+# (a) these are general instructions on using certain tools/functions,
+#   if they are specified in a ToolMessage class as a classmethod `instructions`
+⋮----
+# (b) these are only for the builtin in Langroid TOOLS mechanism:
+⋮----
+# This variable is not None and equals a `ToolMessage` T, if and only if:
+# (a) T has been set as the output_format of this agent, AND
+# (b) T has been "enabled for use" ONLY for enforcing this output format, AND
+# (c) T has NOT been explicitly "enabled for use" by this Agent.
+⋮----
+# As above but deals with "enabled for handling" instead of "enabled for use".
+⋮----
+# instructions specifically related to enforcing `output_format`
+⋮----
+# controls whether to disable strict schemas for this agent if
+# strict mode causes exception
+⋮----
+# Tracks whether any strict tool is enabled; used to determine whether to set
+# `self.disable_strict` on an exception
+⋮----
+# Tracks the set of tools on which we force-disable strict decoding
+⋮----
+# search for tools according to the agent configuration
+⋮----
+# Only enable HANDLING by `agent_response`, NOT LLM generation of these.
+# This is useful where tool-handlers or agent_response generate these
+# tools, and need to be handled.
+# We don't want enable orch tool GENERATION by default, since that
+# might clutter-up the LLM system message unnecessarily.
+⋮----
+def init_state(self) -> None
+⋮----
+"""
+        Initialize the state of the agent. Just conversation state here,
+        but subclasses can override this to initialize other state.
+        """
+⋮----
+@staticmethod
+    def from_id(id: str) -> "ChatAgent"
+⋮----
+"""
+        Get an agent from its ID
+        Args:
+            agent_id (str): ID of the agent
+        Returns:
+            ChatAgent: The agent with the given ID
+        """
+⋮----
+def clone(self, i: int = 0) -> "ChatAgent"
+⋮----
+"""Create i'th clone of this agent, ensuring tool use/handling is cloned.
+        Important: We assume all member variables are in the __init__ method here
+        and in the Agent class.
+        TODO: We are attempting to clone an agent after its state has been
+        changed in possibly many ways. Below is an imperfect solution. Caution advised.
+        Revisit later.
+        """
+⋮----
+agent_cls = type(self)
+# Deep-copy the config WITHOUT mutating it, sharing the tool_policy
+# hook by REFERENCE (memo-seeded deepcopy): copying the policy would
+# fork any state it holds (budgets, approval lists) and can fail
+# outright on unpicklable callables (e.g. objects holding locks).
+config_copy = deepcopy_config_sharing_policy(self.config)
+⋮----
+new_agent = agent_cls(config_copy)
+⋮----
+# Ensure each clone gets its own vecdb client when supported.
+⋮----
+def _clone_extra_state(self, new_agent: "ChatAgent") -> None
+⋮----
+"""Hook for subclasses to copy additional state into clones."""
+⋮----
+def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool
+⋮----
+"""Should we enable strict mode for a given tool?"""
+⋮----
+tool_class = self.llm_tools_map[tool]
+⋮----
+tool_class = tool
+name = tool_class.default_value("request")
+⋮----
+strict: Optional[bool] = tool_class.default_value("strict")
+⋮----
+strict = self._strict_tools_available()
+⋮----
+def _fn_call_available(self) -> bool
+⋮----
+"""Does this agent's LLM support function calling?"""
+⋮----
+def _strict_tools_available(self) -> bool
+⋮----
+"""Does this agent's LLM support strict tools?"""
+⋮----
+def _json_schema_available(self) -> bool
+⋮----
+"""Does this agent's LLM support strict JSON schema output format?"""
+⋮----
+def set_system_message(self, msg: str) -> None
+⋮----
+# if there is message history, update the system message in it
+⋮----
+def set_user_message(self, msg: str) -> None
+⋮----
+@property
+    def task_messages(self) -> List[LLMMessage]
+⋮----
+"""
+        The task messages are the initial messages that define the task
+        of the agent. There will be at least a system message plus possibly a user msg.
+        Returns:
+            List[LLMMessage]: the task messages
+        """
+msgs = [self._create_system_and_tools_message()]
+⋮----
+def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None
+⋮----
+id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
+⋮----
+# dropping tool result, so ADD the corresponding tool-call back
+# to the list of pending calls!
+id = msg.tool_call_id
+⋮----
+# dropping a msg with tool-calls, so DROP these from pending list
+# as well as from id -> call map
+⋮----
+def clear_history(self, start: int = -2, end: int = -1) -> None
+⋮----
+"""
+        Clear the message history, deleting  messages from index `start`,
+        up to index `end`.
+
+        Args:
+            start (int): index of first message to delete; default = -2
+                    (i.e. delete last 2 messages, typically these
+                    are the last user and assistant messages)
+            end (int): index of last message to delete; Default = -1
+                    (i.e. delete all messages up to the last one)
+        """
+n = len(self.message_history)
+⋮----
+start = max(0, n + start)
+end_ = n if end == -1 else end + 1
+dropped = self.message_history[start:end_]
+# consider the dropped msgs in REVERSE order, so we are
+# carefully updating self.oai_tool_calls
+⋮----
+# clear out the chat document from the ObjectRegistry
+⋮----
+def update_history(self, message: str, response: str) -> None
+⋮----
+"""
+        Update the message history with the latest user message and LLM response.
+        Args:
+            message (str): user message
+            response: (str): LLM response
+        """
+⋮----
+def tool_format_rules(self) -> str
+⋮----
+"""
+        Specification of tool formatting rules
+        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
+        based on the currently enabled usable `ToolMessage`s
+
+        Returns:
+            str: formatting rules
+        """
+# ONLY Usable tools (i.e. LLM-generation allowed),
+usable_tool_classes: List[Type[ToolMessage]] = [
+⋮----
+format_instructions = "\n\n".join(
+# if any of the enabled classes has json_group_instructions, then use that,
+# else fall back to ToolMessage.json_group_instructions
+⋮----
+def tool_instructions(self) -> str
+⋮----
+"""
+        Instructions for tools or function-calls, for enabled and usable Tools.
+        These are inserted into system prompt regardless of whether we are using
+        our own ToolMessage mechanism or the LLM's function-call mechanism.
+
+        Returns:
+            str: concatenation of instructions for all usable tools
+        """
+enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
+⋮----
+instructions = []
+⋮----
+class_instructions = ""
+⋮----
+class_instructions = msg_cls.instructions()
+⋮----
+# example will be shown in tool_format_rules() when using TOOLs,
+# so we don't need to show it here.
+example = "" if self.config.use_tools else (msg_cls.usage_examples())
+⋮----
+example = "EXAMPLES:\n" + example
+guidance = (
+⋮----
+instructions_str = "\n\n".join(instructions)
+⋮----
+def augment_system_message(self, message: str) -> None
+⋮----
+"""
+        Augment the system message with the given message.
+        Args:
+            message (str): system message
+        """
+⋮----
+def last_message_with_role(self, role: Role) -> LLMMessage | None
+⋮----
+"""from `message_history`, return the last message with role `role`"""
+n_role_msgs = len([m for m in self.message_history if m.role == role])
+⋮----
+idx = self.nth_message_idx_with_role(role, n_role_msgs)
+⋮----
+def last_message_idx_with_role(self, role: Role) -> int
+⋮----
+"""Index of last message in message_history, with specified role.
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+indices_with_role = [
+⋮----
+def nth_message_idx_with_role(self, role: Role, n: int) -> int
+⋮----
+"""Index of `n`th message in message_history, with specified role.
+        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+⋮----
+def update_last_message(self, message: str, role: str = Role.USER) -> None
+⋮----
+"""
+        Update the last message that has role `role` in the message history.
+        Useful when we want to replace a long user prompt, that may contain context
+        documents plus a question, with just the question.
+        Args:
+            message (str): new message to replace with
+            role (str): role of message to replace
+        """
+⋮----
+# find last message in self.message_history with role `role`
+⋮----
+def delete_last_message(self, role: str = Role.USER) -> None
+⋮----
+"""
+        Delete the last message that has role `role` from the message history.
+        Args:
+            role (str): role of message to delete
+        """
+⋮----
+def _create_system_and_tools_message(self) -> LLMMessage
+⋮----
+"""
+        (Re-)Create the system message for the LLM of the agent,
+        taking into account any tool instructions that have been added
+        after the agent was initialized.
+
+        The system message will consist of:
+        (a) the system message from the `task` arg in constructor, if any,
+            otherwise the default system message from the config
+        (b) the system tool instructions, if any
+        (c) the system json tool instructions, if any
+
+        Returns:
+            LLMMessage object
+        """
+content = self.system_message
+⋮----
+# remove leading and trailing newlines and other whitespace
+⋮----
+def handle_message_fallback(self, msg: str | ChatDocument) -> Any
+⋮----
+"""
+        Fallback method for the "no-tools" scenario, i.e., the current `msg`
+        (presumably emitted by the LLM) does not have any tool that the agent
+        can handle.
+        NOTE: The `msg` may contain tools but either (a) the agent is not
+        enabled to handle them, or (b) there's an explicit `recipient` field
+        in the tool that doesn't match the agent's name.
+
+        Uses the self.config.non_tool_routing to determine the action to take.
+
+        This method can be overridden by subclasses, e.g.,
+        to create a "reminder" message when a tool is expected but the LLM "forgot"
+        to generate one.
+
+        Args:
+            msg (str | ChatDocument): The input msg to handle
+        Returns:
+            Any: The result of the handler method
+        """
+⋮----
+# we ONLY use the `handle_llm_no_tool` config option when
+# the msg is from LLM and does not contain ANY tools at all.
+⋮----
+no_tool_option = self.config.handle_llm_no_tool
+⋮----
+# in case the `no_tool_option` is one of the special NonToolAction vals
+⋮----
+# Otherwise just return `no_tool_option` as is:
+# This can be any string, such as a specific nudge/reminder to the LLM,
+# or even something like ResultTool etc.
+⋮----
+def unhandled_tools(self) -> set[str]
+⋮----
+"""The set of tools that are known but not handled.
+        Useful in task flow: an agent can refuse to accept an incoming msg
+        when it only has unhandled tools.
+        """
+⋮----
+"""
+        Add the tool (message class) to the agent, and enable either
+        - tool USE (i.e. the LLM can generate JSON to use this tool),
+        - tool HANDLING (i.e. the agent can handle JSON from this tool),
+
+        Args:
+            message_class: The ToolMessage class OR List of such classes to enable,
+                for USE, or HANDLING, or both.
+                If this is a list of ToolMessage classes, then the remain args are
+                applied to all classes.
+                Optional; if None, then apply the enabling to all tools in the
+                agent's toolset that have been enabled so far.
+            use: IF True, allow the agent (LLM) to use this tool (or all tools),
+                else disallow
+            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
+                tool (or all tools)
+            force: whether to FORCE the agent (LLM) to USE the specific
+                 tool represented by `message_class`.
+                 `force` is ignored if `message_class` is None.
+            require_recipient: whether to require that recipient be specified
+                when using the tool message (only applies if `use` is True).
+            include_defaults: whether to include fields that have default values,
+                in the "properties" section of the JSON format instructions.
+                (Normally the OpenAI completion API ignores these fields,
+                but the Assistant fn-calling seems to pay attn to these,
+                and if we don't want this, we should set this to False.)
+        """
+⋮----
+# Validate that use/handle are booleans, not accidentally passed tool classes
+⋮----
+param = "use" if isclass(use) else "handle"
+⋮----
+message_class = message_class.require_recipient()
+⋮----
+# XMLToolMessage is not compatible with OpenAI's Tools/functions API,
+# so we disable use of functions API, enable langroid-native Tools,
+# which are prompt-based.
+⋮----
+super().enable_message_handling(message_class)  # enables handling only
+tools = self._get_tool_list(message_class)
+⋮----
+request = message_class.default_value("request")
+⋮----
+llm_function = message_class.llm_function_schema(defaults=include_defaults)
+⋮----
+# `t` was designated as "enabled for handling" ONLY for
+# output_format enforcement, but we are explicitly ]
+# enabling it for handling here, so we set the variable to None.
+⋮----
+tool_class = self.llm_tools_map[t]
+allow_llm_use = tool_class._allow_llm_use
+⋮----
+allow_llm_use = allow_llm_use.default
+⋮----
+# `t` was designated as "enabled for use" ONLY for output_format
+# enforcement, but we are explicitly enabling it for use here,
+# so we set the variable to None.
+⋮----
+def _update_tool_instructions(self) -> None
+⋮----
+# Set tool instructions and JSON format instructions,
+# in case Tools have been enabled/disabled.
+⋮----
+def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]
+⋮----
+"""
+        Returns the current set of enabled requests for inference and tools configs.
+        Used for restoring setings overriden by `set_output_format`.
+        """
+⋮----
+@property
+    def all_llm_tools_known(self) -> set[str]
+⋮----
+"""All known tools; we include `output_format` if it is a `ToolMessage`."""
+known = self.llm_tools_known
+⋮----
+"""
+        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
+        switches to the native Langroid tools mechanism to ensure that no tool
+        calls not of `output_type` are generated. By default, `force_tools`
+        follows the `use_tools_on_output_format` parameter in the config.
+
+        If `output_type` is None, restores to the state prior to setting
+        `output_format`.
+
+        If `use`, we enable use of `output_type` when it is a subclass
+        of `ToolMesage`. Note that this primarily controls instruction
+        generation: the model will always generate `output_type` regardless
+        of whether `use` is set. Defaults to the `use_output_format`
+        parameter in the config. Similarly, handling of `output_type` is
+        controlled by `handle`, which defaults to the
+        `handle_output_format` parameter in the config.
+
+        `instructions` controls whether we generate instructions specifying
+        the output format schema. Defaults to the `instructions_output_format`
+        parameter in the config.
+
+        `is_copy` is set when called via `__getitem__`. In that case, we must
+        copy certain fields to ensure that we do not overwrite the main agent's
+        setings.
+        """
+# Disable usage of an output format which was not specifically enabled
+# by `enable_message`
+⋮----
+# Disable handling of an output format which did not specifically have
+# handling enabled via `enable_message`
+⋮----
+# Reset any previous instructions
+⋮----
+force_tools = self.config.use_tools_on_output_format
+⋮----
+output_type = get_pydantic_wrapper(output_type)
+⋮----
+name = output_type.default_value("request")
+⋮----
+use = self.config.use_output_format
+⋮----
+handle = self.config.handle_output_format
+⋮----
+is_usable = name in self.llm_tools_usable.union(
+is_handled = name in self.llm_tools_handled.union(
+⋮----
+# We must copy `llm_tools_usable` so the base agent
+# is unmodified
+⋮----
+# If handling the tool, do the same for `llm_tools_handled`
+⋮----
+# Enable `output_type`
+⋮----
+# Do not override existing settings
+⋮----
+# If the `output_type` ToilMessage was not already enabled for
+# use, this means we are ONLY enabling it for use specifically
+# for enforcing this output format, so we set the
+# `enabled_use_output_forma  to this output_type, to
+# record that it should be disabled when `output_format` is changed
+⋮----
+# (same reasoning as for use-enabling)
+⋮----
+generated_tool_instructions = name in self.llm_tools_usable.union(
+⋮----
+generated_tool_instructions = False
+⋮----
+instructions = self.config.instructions_output_format
+⋮----
+# Already generated tool instructions as part of "enabling for use",
+# so only need to generate a reminder to use this tool.
+name = cast(ToolMessage, output_type).default_value("request")
+⋮----
+output_format_schema = output_type.llm_function_schema(
+⋮----
+output_format_schema = output_type.model_json_schema()
+⋮----
+def __getitem__(self, output_type: type) -> Self
+⋮----
+"""
+        Returns a (shallow) copy of `self` with a forced output type.
+        """
+clone = copy.copy(self)
+⋮----
+"""
+        Disable this agent from RESPONDING to a `message_class` (Tool). If
+            `message_class` is None, then disable this agent from responding to ALL.
+        Args:
+            message_class: The ToolMessage class to disable; Optional.
+        """
+⋮----
+"""
+        Disable this agent from USING a message class (Tool).
+        If `message_class` is None, then disable this agent from USING ALL tools.
+        Args:
+            message_class: The ToolMessage class to disable.
+                If None, disable all.
+        """
+⋮----
+def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None
+⋮----
+"""
+        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
+        Args:
+            message_class: The only ToolMessage class to allow
+        """
+request = message_class.model_fields["request"].default
+to_remove = [r for r in self.llm_tools_usable if r != request]
+⋮----
+def _load_output_format(self, message: ChatDocument) -> None
+⋮----
+"""
+        If set, attempts to parse a value of type `self.output_format` from the message
+        contents or any tool/function call and assigns it to `content_any`.
+        """
+⋮----
+any_succeeded = False
+attempts: list[str | LLMFunctionCall] = [
+⋮----
+content = json.loads(attempt)
+⋮----
+content = attempt.arguments
+⋮----
+content_any = self.output_format.model_validate(content)
+⋮----
+message.content_any = content_any.value  # type: ignore
+⋮----
+any_succeeded = True
+⋮----
+"""
+        Extracts messages and tracks whether any errors occurred. If strict mode
+        was enabled, disables it for the tool, else triggers strict recovery.
+        """
+⋮----
+most_recent_sent_by_llm = (
+was_llm = most_recent_sent_by_llm or (
+⋮----
+tools = super().get_tool_messages(msg, all_tools)
+⋮----
+# Check if tool class was attached to the exception
+⋮----
+tool_class = ve.tool_class  # type: ignore
+⋮----
+was_strict = (
+# If the result of strict output for a tool using the
+# OpenAI tools API fails to parse, we infer that the
+# schema edits necessary for compatibility prevented
+# adherence to the underlying `ToolMessage` schema and
+# disable strict output for the tool
+⋮----
+# We will trigger the strict recovery mechanism to force
+# the LLM to correct its output, allowing us to parse
+⋮----
+def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None
+⋮----
+"""
+        Returns a `ToolMessage` which wraps all enabled tools, excluding those
+        where strict recovery is disabled. Used in strict recovery.
+        """
+possible_tools = tuple(
+⋮----
+any_tool_type = Union.__getitem__(possible_tools)  # type ignore
+⋮----
+maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
+⋮----
+class AnyTool(ToolMessage)
+⋮----
+purpose: str = "To call a tool/function."
+request: str = "tool_or_function"
+tool: maybe_optional_type  # type: ignore
+⋮----
+# One-time use
+⋮----
+# As the ToolMessage schema accepts invalid
+# `tool.request` values, reparse with the
+# corresponding tool
+request = self.tool.request
+⋮----
+tool = agent.llm_tools_map[request].model_validate_json(
+⋮----
+# pass the chat_doc through, so the recovered tool's policy
+# check sees the same message context a normal dispatch would
+⋮----
+# This wrapper is a parsing shim for strict recovery, NOT a tool
+# execution, so it is exempt from the `tool_policy` hook -- which
+# also guarantees `set_output_format(None)` above always runs. The
+# re-parsed ACTUAL tool is dispatched through the policy-checked
+# path, so the policy is consulted exactly once per logical call.
+AnyTool._tool_policy_exempt = True  # type: ignore[attr-defined]
+⋮----
+"""Returns instructions for strict recovery."""
+optional_instructions = (
+response_prefix = "If you intended to make such a call, r" if optional else "R"
+instruction_prefix = "If you do so, b" if optional else "B"
+⋮----
+schema_instructions = (
+⋮----
+"""
+        Truncate message at idx in msg history to `tokens` tokens.
+
+        If inplace is True, the message is truncated in place, else
+        it LEAVES the original message INTACT and returns a new message
+        """
+⋮----
+llm_msg = self.message_history[idx]
+⋮----
+llm_msg = copy.deepcopy(self.message_history[idx])
+⋮----
+orig_content = llm_msg.content
+new_content = (
+⋮----
+else orig_content[: tokens * 4]  # approx truncation
+⋮----
+def _reduce_raw_tool_results(self, message: ChatDocument) -> None
+⋮----
+"""
+        If message is the result of a ToolMessage that had
+        a `_max_retained_tokens` set to a non-None value, then we replace contents
+        with a placeholder message.
+        """
+parent_message: ChatDocument | None = message.parent
+tools = [] if parent_message is None else parent_message.tool_messages
+truncate_tools = []
+⋮----
+max_retained_tokens = t._max_retained_tokens
+⋮----
+max_retained_tokens = max_retained_tokens.default
+⋮----
+limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
+⋮----
+max_retained_tokens = limiting_tool._max_retained_tokens
+⋮----
+tool_name = limiting_tool.default_value("request")
+max_tokens: int = max_retained_tokens
+truncation_warning = f"""
+⋮----
+"""
+        Respond to a single user message, appended to the message history,
+        in "chat" mode
+        Args:
+            message (str|ChatDocument): message or ChatDocument object to respond to.
+                If None, use the self.task_messages
+        Returns:
+            LLM response as a ChatDocument object
+        """
+⋮----
+# If enabled and a tool error occurred, we recover by generating the tool in
+# strict json mode
+⋮----
+AnyTool = self._get_any_tool_message()
+⋮----
+recovery_message = self._strict_recovery_instructions(AnyTool)
+augmented_message = message
+⋮----
+augmented_message = recovery_message
+⋮----
+augmented_message = augmented_message + recovery_message
+⋮----
+# only use the augmented message for this one response...
+result = self.llm_response(augmented_message)
+# ... restore the original user message so that the AnyTool recover
+# instructions don't persist in the message history
+# (this can cause the LLM to use the AnyTool directly as a tool)
+⋮----
+msg = message if isinstance(message, str) else message.content
+⋮----
+tool_choice = (
+⋮----
+response = self.llm_response_messages(hist, output_len, tool_choice)
+⋮----
+# Preserve trail of tool_ids for OpenAI Assistant fn-calls
+⋮----
+"""
+        Async version of `llm_response`. See there for details.
+        """
+⋮----
+response = await self.llm_response_messages_async(
+⋮----
+def init_message_history(self) -> None
+⋮----
+"""
+        Initialize the message history with the system message and user message
+        """
+⋮----
+"""
+        Prepare messages to be sent to self.llm_response_messages,
+            which is the main method that calls the LLM API to get a response.
+            If desired output tokens + message history exceeds the model context length,
+            then first the max output tokens is reduced to fit, and if that is not
+            possible, older messages may be truncated to accommodate at least
+            self.config.llm.min_output_tokens of output.
+
+        Returns:
+            Tuple[List[LLMMessage], int]: (messages, output_len)
+                messages = Full list of messages to send
+                output_len = max expected number of tokens in response
+        """
+⋮----
+# this means agent has been used to get LLM response already,
+# and so the last message is an "assistant" response.
+# We delete this last assistant response and re-generate it.
+⋮----
+# initial messages have not yet been loaded, so load them
+⋮----
+# for debugging, show the initial message history
+⋮----
+# update the system message with the latest tool instructions
+⋮----
+# either the message is a str, or it is a fresh ChatDocument
+# different from the last message in the history
+llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
+llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
+# Canonicalize retained whitespace-only results before token counting.
+⋮----
+# process tools if any
+done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
+⋮----
+hist = self.message_history
+output_len = self.config.llm.model_max_output_tokens
+⋮----
+CHAT_HISTORY_BUFFER = 300
+# chat + output > max context length,
+# so first try to shorten requested output len to fit;
+# use an extra margin of CHAT_HISTORY_BUFFER tokens
+# in case our calcs are off (and to allow for some extra tokens)
+output_len = (
+⋮----
+# unacceptably small output len, so compress early parts of
+# conversation history based on the configured strategy
+strategy = self.config.context_overflow_strategy
+⋮----
+# Truncate content of individual messages while preserving
+# the message sequence (important for LLM APIs that require
+# alternating USER/ASSISTANT messages)
+msg_idx_to_compress = 1  # don't touch system msg
+# we will try compressing msg indices up to but not including
+# last user msg
+last_msg_idx_to_compress = (
+n_truncated = 0
+⋮----
+# We want to preserve the first message (typically
+# system msg) and last message (user msg).
+⋮----
+# compress the msg at idx `msg_idx_to_compress`
+⋮----
+output_len = min(
+⋮----
+# we MUST have truncated at least one msg
+msg_tokens = self.chat_num_tokens()
+⋮----
+else:  # strategy == "drop_turns"
+# Drop complete conversation turns. A complete turn is defined
+# as a USER message followed by all messages until the next
+# USER message. This is more aggressive but cleaner for voice
+# agents with limited context.
+n_dropped_turns = 0
+⋮----
+# Find the last USER message index
+last_user_idx = self.last_message_idx_with_role(role=Role.USER)
+⋮----
+# Find the first complete turn to drop (skip system message)
+first_user_idx = -1
+⋮----
+first_user_idx = i
+⋮----
+# Find the end of this turn: last message before next USER
+next_user_idx = -1
+⋮----
+next_user_idx = i
+⋮----
+# Drop the turn
+⋮----
+# we MUST have dropped at least one turn
+⋮----
+# record the position of the corresponding LLMMessage in
+# the message_history
+⋮----
+"""
+        Get function/tool spec/output format arguments for
+        OpenAI-compatible LLM API call
+        """
+functions: Optional[List[LLMFunctionSpec]] = None
+fun_call: str | Dict[str, str] = "none"
+tools: Optional[List[OpenAIToolSpec]] = None
+force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
+⋮----
+functions = [
+fun_call = (
+⋮----
+def to_maybe_strict_spec(function: str) -> OpenAIToolSpec
+⋮----
+spec = self.llm_functions_map[function]
+strict = self._strict_mode_for_tool(function)
+⋮----
+strict_spec = copy.deepcopy(spec)
+⋮----
+strict_spec = spec
+⋮----
+tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
+force_tool = (
+output_format = None
+⋮----
+spec = self.output_format.llm_function_schema(
+⋮----
+output_format = OpenAIJsonSchemaSpec(
+⋮----
+# We always require that outputs strictly match the schema
+⋮----
+param_spec = self.output_format.model_json_schema()
+⋮----
+"""
+        Respond to a series of messages, e.g. with OpenAI ChatCompletion
+        Args:
+            messages: seq of messages (with role, content fields) sent to LLM
+            output_len: max number of tokens expected in response.
+                    If None, use the LLM's default model_max_output_tokens.
+        Returns:
+            Document (i.e. with fields "content", "metadata")
+        """
+⋮----
+output_len = output_len or self.config.llm.model_max_output_tokens
+streamer = noop_fn
+⋮----
+streamer = self.callbacks.start_llm_stream()
+⋮----
+with ExitStack() as stack:  # for conditionally using rich spinner
+⋮----
+# show rich spinner only if not streaming!
+# (Why? b/c the intent of showing a spinner is to "show progress",
+# and we don't need to do that when streaming, since
+# streaming output already shows progress.)
+cm = status(
+⋮----
+response = self.llm.chat(
+⋮----
+# Create temp ChatDocument for tool check, then clean up to avoid
+# polluting ObjectRegistry (see PR #939 discussion)
+temp_doc = ChatDocument.from_LLMResponse(
+⋮----
+response,  # .usage attrib is updated!
+⋮----
+chat_doc = ChatDocument.from_LLMResponse(
+⋮----
+# If using strict output format, parse the output JSON
+⋮----
+"""
+        Async version of `llm_response_messages`. See there for details.
+        """
+⋮----
+streamer_async = async_noop_fn
+⋮----
+streamer_async = await self.callbacks.start_llm_stream_async()
+⋮----
+response = await self.llm.achat(
+⋮----
+"""
+        Call a callback method, only passing 'reasoning' if it accepts it.
+
+        This provides backward compatibility for custom callbacks that don't
+        have the 'reasoning' parameter in their signature.
+
+        Args:
+            callback_name: Name of the callback method (e.g., 'show_llm_response')
+            reasoning: The reasoning content to pass if supported
+            **kwargs: Other arguments to pass to the callback
+        """
+callback = getattr(self.callbacks, callback_name, None)
+⋮----
+# Check if callback accepts 'reasoning' param or **kwargs
+⋮----
+sig = inspect.signature(callback)
+params = sig.parameters
+accepts_reasoning = "reasoning" in params or any(
+⋮----
+# If we can't inspect the signature, assume it doesn't accept reasoning
+accepts_reasoning = False
+⋮----
+is_cached = (
+⋮----
+# We would have already displayed the msg "live" ONLY if
+# streaming was enabled, AND we did not find a cached response.
+# If we are here, it means the response has not yet been displayed.
+cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
+# Track whether we created a temp ChatDocument for cleanup
+is_temp_doc = isinstance(response, LLMResponse)
+chat_doc = (
+# TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
+⋮----
+content = response.message or ""
+tools_content = response.tools_content()
+⋮----
+content = response.content
+tools_content = ""
+reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
+⋮----
+# Clean up temp ChatDocument to avoid polluting ObjectRegistry
+⋮----
+# we are in the context immediately after an LLM responded,
+# we won't have citations yet, so we're done
+⋮----
+citation = (
+⋮----
+reasoning="",  # Citations don't have reasoning
+⋮----
+def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument
+⋮----
+"""
+        Get LLM response to `prompt` (which presumably includes the `message`
+        somewhere, along with possible large "context" passages),
+        but only include `message` as the USER message, and not the
+        full `prompt`, in the message history.
+        Args:
+            message: the original, relatively short, user request or query
+            prompt: the full prompt potentially containing `message` plus context
+
+        Returns:
+            Document object containing the response.
+        """
+# we explicitly call THIS class's respond method,
+# not a derived class's (or else there would be infinite recursion!)
+with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
+⋮----
+"""
+        Async version of `_llm_response_temp_context`. See there for details.
+        """
+⋮----
+answer_doc = cast(
+⋮----
+"""
+        LLM Response to single message, and restore message_history.
+        In effect a "one-off" message & response that leaves agent
+        message history state intact.
+
+        Args:
+            message (str|ChatDocument): message to respond to.
+
+        Returns:
+            A Document object with the response.
+
+        """
+# explicitly call THIS class's respond method,
+⋮----
+n_msgs = len(self.message_history)
+⋮----
+response = cast(ChatDocument, ChatAgent.llm_response(self, message))
+# If there is a response, then we will have two additional
+# messages in the message history, i.e. the user message and the
+# assistant response. We want to (carefully) remove these two messages.
+⋮----
+msg = self.message_history.pop()
+⋮----
+"""
+        Async version of `llm_response_forget`. See there for details.
+        """
+⋮----
+response = cast(
+⋮----
+def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int
+⋮----
+"""
+        Total number of tokens in the message history so far.
+
+        Args:
+            messages: if provided, compute the number of tokens in this list of
+                messages, rather than the current message history.
+        Returns:
+            int: number of tokens in message history
+        """
+⋮----
+hist = messages if messages is not None else self.message_history
+⋮----
+def _message_num_tokens(self, message: LLMMessage) -> int
+⋮----
+"""Count tokens for a message, including serialized user attachments."""
+⋮----
+def _attachment_num_tokens(self, message: LLMMessage) -> int
+⋮----
+"""
+        Estimate attachment contribution using the serialized payload
+        that is sent in the API request for user messages.
+        """
+⋮----
+model = self._chat_model_name_for_attachments()
+⋮----
+def _chat_model_name_for_attachments(self) -> str
+⋮----
+"""Return the model name used for attachment serialization."""
+⋮----
+def message_history_str(self, i: Optional[int] = None) -> str
+⋮----
+"""
+        Return a string representation of the message history
+        Args:
+            i: if provided, return only the i-th message when i is postive,
+                or last k messages when i = -k.
+        Returns:
+        """
+⋮----
+def __del__(self) -> None
+⋮----
+"""
+        Cleanup method called when the ChatAgent is garbage collected.
+        Note: We don't close LLM clients here because they may be shared
+        across multiple agents when client caching is enabled.
+        The clients are managed centrally and cleaned up via atexit hooks.
+        """
+# Previously we closed clients here, but this caused issues when
+# multiple agents shared the same cached client instance.
+# Clients are now managed centrally in langroid.language_models.client_cache
+</file>
+
+<file path="langroid/language_models/model_info.py">
+logger = logging.getLogger(__name__)
+⋮----
+class ModelProvider(str, Enum)
+⋮----
+"""Enum for model providers"""
+⋮----
+OPENAI = "openai"
+ANTHROPIC = "anthropic"
+DEEPSEEK = "deepseek"
+GOOGLE = "google"
+MINIMAX = "minimax"
+UNKNOWN = "unknown"
+⋮----
+class ModelName(str, Enum)
+⋮----
+"""Parent class for all model name enums"""
+⋮----
+class OpenAIChatModel(ModelName)
+⋮----
+"""Enum for OpenAI Chat models"""
+⋮----
+GPT3_5_TURBO = "gpt-3.5-turbo"
+GPT4 = "gpt-4o"  # avoid deprecated gpt-4
+GPT4_TURBO = "gpt-4-turbo"
+GPT4o = "gpt-4o"
+GPT4o_MINI = "gpt-4o-mini"
+O1 = "o1"
+O1_MINI = "o1-mini"
+O3_MINI = "o3-mini"
+O3 = "o3"
+O4_MINI = "o4-mini"
+GPT4_1 = "gpt-4.1"
+GPT4_1_MINI = "gpt-4.1-mini"
+GPT4_1_NANO = "gpt-4.1-nano"
+GPT5 = "gpt-5"
+GPT5_MINI = "gpt-5-mini"
+GPT5_NANO = "gpt-5-nano"
+GPT5_PRO = "gpt-5-pro"
+GPT5_1 = "gpt-5.1"
+GPT5_1_CODEX = "gpt-5.1-codex"
+GPT5_1_CODEX_MINI = "gpt-5.1-codex-mini"
+GPT5_1_CHAT = "gpt-5.1-chat"
+GPT5_2 = "gpt-5.2"
+GPT5_2_PRO = "gpt-5.2-pro"
+GPT5_2_CHAT = "gpt-5.2-chat"
+GPT_OSS_120b = "gpt-oss-120b"
+GPT_OSS_20b = "gpt-oss-20b"
+⋮----
+class OpenAICompletionModel(str, Enum)
+⋮----
+"""Enum for OpenAI Completion models"""
+⋮----
+DAVINCI = "davinci-002"
+BABBAGE = "babbage-002"
+⋮----
+class AnthropicModel(ModelName)
+⋮----
+"""Enum for Anthropic models"""
+⋮----
+CLAUDE_3_OPUS = "claude-3-opus-latest"
+CLAUDE_3_SONNET = "claude-3-sonnet-latest"
+CLAUDE_3_HAIKU = "claude-3-haiku-latest"
+CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest"
+CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest"
+CLAUDE_4_OPUS = "claude-opus-4"
+CLAUDE_4_SONNET = "claude-sonnet-4"
+CLAUDE_4_HAIKU = "claude-haiku-4"
+CLAUDE_4_5_OPUS = "claude-opus-4-5"
+CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
+CLAUDE_4_5_HAIKU = "claude-haiku-4-5"
+⋮----
+class DeepSeekModel(ModelName)
+⋮----
+"""Enum for DeepSeek models direct from DeepSeek API"""
+⋮----
+DEEPSEEK = "deepseek/deepseek-chat"
+DEEPSEEK_R1 = "deepseek/deepseek-reasoner"
+OPENROUTER_DEEPSEEK_R1 = "openrouter/deepseek/deepseek-r1"
+⋮----
+class GeminiModel(ModelName)
+⋮----
+"""Enum for Gemini models"""
+⋮----
+GEMINI_1_5_FLASH = "gemini-1.5-flash"
+GEMINI_1_5_FLASH_8B = "gemini-1.5-flash-8b"
+GEMINI_1_5_PRO = "gemini-1.5-pro"
+GEMINI_2_FLASH = "gemini-2.0-flash"
+GEMINI_2_FLASH_LITE = "gemini-2.0-flash-lite"
+GEMINI_2_FLASH_THINKING = "gemini-2.0-flash-thinking-exp"
+GEMINI_2_PRO = "gemini-2.0-pro-exp-02-05"
+GEMINI_2_5_FLASH = "gemini-2.5-flash"
+GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
+GEMINI_2_5_PRO = "gemini-2.5-pro"
+GEMINI_3_FLASH = "gemini-3-flash"
+GEMINI_3_PRO = "gemini-3-pro"
+⋮----
+class MiniMaxModel(ModelName)
+⋮----
+"""Enum for MiniMax models"""
+⋮----
+MINIMAX_M2_7 = "MiniMax-M2.7"
+MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
+MINIMAX_M2_5 = "MiniMax-M2.5"
+MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
+MINIMAX_M2_1 = "MiniMax-M2.1"
+MINIMAX_M2_1_HIGHSPEED = "MiniMax-M2.1-highspeed"
+MINIMAX_M2 = "MiniMax-M2"
+⋮----
+class OpenAI_API_ParamInfo(BaseModel)
+⋮----
+"""
+    Parameters exclusive to some models, when using OpenAI API
+    """
+⋮----
+# model-specific params at top level
+params: Dict[str, List[str]] = dict(
+# model-specific params in extra_body
+extra_parameters: Dict[str, List[str]] = dict(
+⋮----
+class ModelInfo(BaseModel)
+⋮----
+"""
+    Consolidated information about LLM, related to capacity, cost and API
+    idiosyncrasies. Reasonable defaults for all params in case there's no
+    specific info available.
+    """
+⋮----
+name: str = "unknown"
+provider: ModelProvider = ModelProvider.UNKNOWN
+context_length: int = 16_000
+max_cot_tokens: int = 0  # max chain of thought (thinking) tokens where applicable
+max_output_tokens: int = 8192  # Maximum number of output tokens - model dependent
+input_cost_per_million: float = 0.0  # Cost in USD per million input tokens
+cached_cost_per_million: float = 0.0  # Cost in USD per million cached tokens
+output_cost_per_million: float = 0.0  # Cost in USD per million output tokens
+allows_streaming: bool = True  # Whether model supports streaming output
+allows_system_message: bool = True  # Whether model supports system messages
+rename_params: Dict[str, str] = {}  # Rename parameters for OpenAI API
+unsupported_params: List[str] = []
+has_structured_output: bool = False  # Does model API support structured output?
+has_tools: bool = True  # Does model API support tools/function-calling?
+needs_first_user_message: bool = False  # Does API need first msg to be from user?
+description: Optional[str] = None
+⋮----
+GEMINI_CANONICAL_MODEL_NAMES = {model.value for model in GeminiModel}
+DEFAULT_MODEL_INFO = ModelInfo()
+WARNED_UNKNOWN_MODELS: set[tuple[str, ...]] = set()
+⋮----
+# Model information registry
+MODEL_INFO: Dict[str, ModelInfo] = {
+⋮----
+# OpenAI Models
+⋮----
+# Anthropic Models
+⋮----
+# DeepSeek Models
+⋮----
+# Gemini Models
+⋮----
+# Gemini 2.5 Models
+⋮----
+# Gemini 3 Models
+⋮----
+# MiniMax Models
+⋮----
+"""Get model information by name or enum value"""
+# Sequence of models to try, starting with the primary model
+models_to_try = [model] + fallback_models
+⋮----
+# Find the first model in the sequence that has info defined using next()
+# on a generator expression that filters out None results from _get_model_info
+found_info = next(
+⋮----
+None,  # Default value if the iterator is exhausted (no valid info found)
+⋮----
+normalized_models = _normalize_model_names(models_to_try)
+⋮----
+def _get_model_info(model: str | ModelName) -> ModelInfo | None
+⋮----
+def _normalize_model_names(models: List[str | ModelName]) -> List[str]
+⋮----
+normalized_models: List[str] = []
+seen: set[str] = set()
+⋮----
+normalized_model = _normalize_gemini_model_name(_model_name(model))
+⋮----
+def _normalize_gemini_model_name(model: str) -> str | None
+⋮----
+base_model = model.rsplit("/", 1)[-1]
+⋮----
+# Try stripping known suffixes to find a canonical name.
+# Use split (not endswith) for "-preview" so dated variants like
+# "gemini-2.5-flash-lite-preview-06-17" are handled correctly.
+⋮----
+stripped = base_model.split(suffix, maxsplit=1)[0]
+⋮----
+def _warn_unknown_model(models: List[str | ModelName]) -> None
+⋮----
+model_names = tuple(_model_name(model) for model in models)
+⋮----
+def _model_name(model: str | ModelName) -> str
+</file>
+
 <file path="langroid/agent/base.py">
 ORCHESTRATION_STRINGS = [DONE, PASS, PASS_TO, SEND_TO]
 console = Console(quiet=settings.quiet)
@@ -39476,6 +40092,17 @@ add_to_registry: bool = True  # register agent in ObjectRegistry?
 respond_tools_only: bool = False  # respond only to tool messages (not plain text)?
 # allow multiple tool messages in a single response?
 allow_multiple_tools: bool = True
+# Optional pre-execution tool policy hook, called with the final parsed
+# ToolMessage just BEFORE its selected handler runs, as
+# ``tool_policy(tool, agent)`` -- or ``tool_policy(tool, agent, chat_doc=...)``
+# when the callable has a ``chat_doc`` parameter. May be sync or async.
+# Return True or None to ALLOW (the handler runs exactly once); return
+# False or a str reason to REJECT (the handler is NOT run, and the LLM
+# sees a rejection naming the tool and the reason). The hook cannot modify
+# the tool. If the hook itself raises, the tool is blocked (fail-closed)
+# and the rejection deliberately excludes the exception message and tool
+# arguments. See docs/notes/tool-policy-hook.md.
+tool_policy: Optional[Callable[..., Any]] = None
 human_prompt: str = (
 ⋮----
 @field_validator("name")
@@ -40319,8 +40946,6 @@ results: List[str | ChatDocument | None] = []
 ⋮----
 results = ["ERROR: Use ONE tool at a time!"] * len(tools)
 ⋮----
-results = [self.handle_tool_message(t, chat_doc=chat_doc) for t in tools]
-⋮----
 @property
     def all_llm_tools_known(self) -> set[str]
 ⋮----
@@ -40429,7 +41054,7 @@ result_tool_name = msg.default_value("request")
 #     msg in chat_doc.tool_messages):
 #    chat_doc.tool_messages.remove(msg)
 # if we can handle it, do so
-result = self.handle_tool_message(msg, chat_doc=chat_doc)
+result = self._handle_tool_message_with_policy(msg, chat_doc=chat_doc)
 ⋮----
 # else wrap it in an agent response and return it so
 # orchestrator can find a respondent
@@ -40483,6 +41108,48 @@ else result[: max_tokens * 4]  # approx truncate
 ⋮----
 else result.content[: max_tokens * 4]  # approx truncate
 ⋮----
+"""Framework entry point for sync tool dispatch, enforcing `tool_policy`.
+
+        Consults the `tool_policy` hook (see `AgentConfig.tool_policy`) and,
+        if the tool is allowed, delegates to `handle_tool_message` -- which a
+        subclass may override -- exactly as before, so the policy gates tool
+        execution even through such overrides.
+
+        When dispatch is NOT overridden and the tool has no handler, the
+        policy is not consulted (nothing can execute). When dispatch IS
+        overridden, the base cannot know what the override will do, so the
+        policy is consulted regardless, even though the override may end up
+        returning None.
+
+        Args:
+            tool: ToolMessage object representing the tool request.
+            chat_doc: Optional ChatDocument object containing the tool request.
+
+        Returns:
+            The dispatch result, or the policy's LLM-visible rejection.
+        """
+⋮----
+# base dispatch would execute nothing; don't consult the policy
+⋮----
+rejection = check_tool_policy(self.config.tool_policy, tool, self, chat_doc)
+⋮----
+"""Async version of `_handle_tool_message_with_policy`.
+
+        The policy is awaited on the CALLER's event loop (so it can use
+        loop-bound resources), then dispatch proceeds via
+        `handle_tool_message_async` -- which a subclass may override --
+        exactly as before.
+
+        Args:
+            tool: ToolMessage object representing the tool request.
+            chat_doc: Optional ChatDocument object containing the tool request.
+
+        Returns:
+            The dispatch result, or the policy's LLM-visible rejection.
+        """
+⋮----
+rejection = await check_tool_policy_async(
+⋮----
 """
         Asynch version of `handle_tool_message`. See there for details.
         """
@@ -40506,6 +41173,12 @@ result = self.to_ChatDocument(maybe_result, tool_name, chat_doc)
 ⋮----
 """
         Respond to a tool request from the LLM, in the form of an ToolMessage object.
+
+        NOTE: framework dispatch reaches this method through
+        `_handle_tool_message_with_policy`, which enforces the optional
+        `tool_policy` hook BEFORE delegating here; direct calls to this
+        method by user code are the caller's own seam and are not gated.
+
         Args:
             tool: ToolMessage object representing the tool request.
             chat_doc: Optional ChatDocument object containing the tool request.
@@ -40608,208 +41281,13 @@ user_response = Prompt.ask(
 answer = agent.llm_response(request)
 </file>
 
-<file path="langroid/language_models/model_info.py">
-logger = logging.getLogger(__name__)
-⋮----
-class ModelProvider(str, Enum)
-⋮----
-"""Enum for model providers"""
-⋮----
-OPENAI = "openai"
-ANTHROPIC = "anthropic"
-DEEPSEEK = "deepseek"
-GOOGLE = "google"
-MINIMAX = "minimax"
-UNKNOWN = "unknown"
-⋮----
-class ModelName(str, Enum)
-⋮----
-"""Parent class for all model name enums"""
-⋮----
-class OpenAIChatModel(ModelName)
-⋮----
-"""Enum for OpenAI Chat models"""
-⋮----
-GPT3_5_TURBO = "gpt-3.5-turbo"
-GPT4 = "gpt-4o"  # avoid deprecated gpt-4
-GPT4_TURBO = "gpt-4-turbo"
-GPT4o = "gpt-4o"
-GPT4o_MINI = "gpt-4o-mini"
-O1 = "o1"
-O1_MINI = "o1-mini"
-O3_MINI = "o3-mini"
-O3 = "o3"
-O4_MINI = "o4-mini"
-GPT4_1 = "gpt-4.1"
-GPT4_1_MINI = "gpt-4.1-mini"
-GPT4_1_NANO = "gpt-4.1-nano"
-GPT5 = "gpt-5"
-GPT5_MINI = "gpt-5-mini"
-GPT5_NANO = "gpt-5-nano"
-GPT5_PRO = "gpt-5-pro"
-GPT5_1 = "gpt-5.1"
-GPT5_1_CODEX = "gpt-5.1-codex"
-GPT5_1_CODEX_MINI = "gpt-5.1-codex-mini"
-GPT5_1_CHAT = "gpt-5.1-chat"
-GPT5_2 = "gpt-5.2"
-GPT5_2_PRO = "gpt-5.2-pro"
-GPT5_2_CHAT = "gpt-5.2-chat"
-GPT_OSS_120b = "gpt-oss-120b"
-GPT_OSS_20b = "gpt-oss-20b"
-⋮----
-class OpenAICompletionModel(str, Enum)
-⋮----
-"""Enum for OpenAI Completion models"""
-⋮----
-DAVINCI = "davinci-002"
-BABBAGE = "babbage-002"
-⋮----
-class AnthropicModel(ModelName)
-⋮----
-"""Enum for Anthropic models"""
-⋮----
-CLAUDE_3_OPUS = "claude-3-opus-latest"
-CLAUDE_3_SONNET = "claude-3-sonnet-latest"
-CLAUDE_3_HAIKU = "claude-3-haiku-latest"
-CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest"
-CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest"
-CLAUDE_4_OPUS = "claude-opus-4"
-CLAUDE_4_SONNET = "claude-sonnet-4"
-CLAUDE_4_HAIKU = "claude-haiku-4"
-CLAUDE_4_5_OPUS = "claude-opus-4-5"
-CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
-CLAUDE_4_5_HAIKU = "claude-haiku-4-5"
-⋮----
-class DeepSeekModel(ModelName)
-⋮----
-"""Enum for DeepSeek models direct from DeepSeek API"""
-⋮----
-DEEPSEEK = "deepseek/deepseek-chat"
-DEEPSEEK_R1 = "deepseek/deepseek-reasoner"
-OPENROUTER_DEEPSEEK_R1 = "openrouter/deepseek/deepseek-r1"
-⋮----
-class GeminiModel(ModelName)
-⋮----
-"""Enum for Gemini models"""
-⋮----
-GEMINI_1_5_FLASH = "gemini-1.5-flash"
-GEMINI_1_5_FLASH_8B = "gemini-1.5-flash-8b"
-GEMINI_1_5_PRO = "gemini-1.5-pro"
-GEMINI_2_FLASH = "gemini-2.0-flash"
-GEMINI_2_FLASH_LITE = "gemini-2.0-flash-lite"
-GEMINI_2_FLASH_THINKING = "gemini-2.0-flash-thinking-exp"
-GEMINI_2_PRO = "gemini-2.0-pro-exp-02-05"
-GEMINI_2_5_FLASH = "gemini-2.5-flash"
-GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
-GEMINI_2_5_PRO = "gemini-2.5-pro"
-GEMINI_3_FLASH = "gemini-3-flash"
-GEMINI_3_PRO = "gemini-3-pro"
-⋮----
-class MiniMaxModel(ModelName)
-⋮----
-"""Enum for MiniMax models"""
-⋮----
-MINIMAX_M2_7 = "MiniMax-M2.7"
-MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
-MINIMAX_M2_5 = "MiniMax-M2.5"
-MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
-MINIMAX_M2_1 = "MiniMax-M2.1"
-MINIMAX_M2_1_HIGHSPEED = "MiniMax-M2.1-highspeed"
-MINIMAX_M2 = "MiniMax-M2"
-⋮----
-class OpenAI_API_ParamInfo(BaseModel)
-⋮----
-"""
-    Parameters exclusive to some models, when using OpenAI API
-    """
-⋮----
-# model-specific params at top level
-params: Dict[str, List[str]] = dict(
-# model-specific params in extra_body
-extra_parameters: Dict[str, List[str]] = dict(
-⋮----
-class ModelInfo(BaseModel)
-⋮----
-"""
-    Consolidated information about LLM, related to capacity, cost and API
-    idiosyncrasies. Reasonable defaults for all params in case there's no
-    specific info available.
-    """
-⋮----
-name: str = "unknown"
-provider: ModelProvider = ModelProvider.UNKNOWN
-context_length: int = 16_000
-max_cot_tokens: int = 0  # max chain of thought (thinking) tokens where applicable
-max_output_tokens: int = 8192  # Maximum number of output tokens - model dependent
-input_cost_per_million: float = 0.0  # Cost in USD per million input tokens
-cached_cost_per_million: float = 0.0  # Cost in USD per million cached tokens
-output_cost_per_million: float = 0.0  # Cost in USD per million output tokens
-allows_streaming: bool = True  # Whether model supports streaming output
-allows_system_message: bool = True  # Whether model supports system messages
-rename_params: Dict[str, str] = {}  # Rename parameters for OpenAI API
-unsupported_params: List[str] = []
-has_structured_output: bool = False  # Does model API support structured output?
-has_tools: bool = True  # Does model API support tools/function-calling?
-needs_first_user_message: bool = False  # Does API need first msg to be from user?
-description: Optional[str] = None
-⋮----
-GEMINI_CANONICAL_MODEL_NAMES = {model.value for model in GeminiModel}
-DEFAULT_MODEL_INFO = ModelInfo()
-WARNED_UNKNOWN_MODELS: set[tuple[str, ...]] = set()
-⋮----
-# Model information registry
-MODEL_INFO: Dict[str, ModelInfo] = {
-⋮----
-# OpenAI Models
-⋮----
-# Anthropic Models
-⋮----
-# DeepSeek Models
-⋮----
-# Gemini Models
-⋮----
-# Gemini 2.5 Models
-⋮----
-# Gemini 3 Models
-⋮----
-# MiniMax Models
-⋮----
-"""Get model information by name or enum value"""
-# Sequence of models to try, starting with the primary model
-models_to_try = [model] + fallback_models
-⋮----
-# Find the first model in the sequence that has info defined using next()
-# on a generator expression that filters out None results from _get_model_info
-found_info = next(
-⋮----
-None,  # Default value if the iterator is exhausted (no valid info found)
-⋮----
-normalized_models = _normalize_model_names(models_to_try)
-⋮----
-def _get_model_info(model: str | ModelName) -> ModelInfo | None
-⋮----
-def _normalize_model_names(models: List[str | ModelName]) -> List[str]
-⋮----
-normalized_models: List[str] = []
-seen: set[str] = set()
-⋮----
-normalized_model = _normalize_gemini_model_name(_model_name(model))
-⋮----
-def _normalize_gemini_model_name(model: str) -> str | None
-⋮----
-base_model = model.rsplit("/", 1)[-1]
-⋮----
-# Try stripping known suffixes to find a canonical name.
-# Use split (not endswith) for "-preview" so dated variants like
-# "gemini-2.5-flash-lite-preview-06-17" are handled correctly.
-⋮----
-stripped = base_model.split(suffix, maxsplit=1)[0]
-⋮----
-def _warn_unknown_model(models: List[str | ModelName]) -> None
-⋮----
-model_names = tuple(_model_name(model) for model in models)
-⋮----
-def _model_name(model: str | ModelName) -> str
+<file path=".pre-commit-config.yaml">
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.16.4
+  hooks:
+    - id: ruff
 </file>
 
 <file path="mkdocs.yml">
@@ -40935,6 +41413,7 @@ nav:
       - None Content in LLM Messages: notes/llm-none-content.md
       - Weaviate: notes/weaviate.md
       - Handling LLM Non-Tool Messages: notes/handle-llm-no-tool.md
+      - Tool Policy Hook: notes/tool-policy-hook.md
       - PGVector: notes/pgvector.md
       - Pinecone: notes/pinecone.md
       - Tavily Search Tool: notes/tavily_search.md
@@ -41003,15 +41482,6 @@ markdown_extensions:
 extra_javascript:
   - javascripts/mathjax.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
-</file>
-
-<file path=".pre-commit-config.yaml">
-repos:
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.16.0
-  hooks:
-    - id: ruff
 </file>
 
 <file path="langroid/language_models/openai_gpt.py">

--- a/llms-no-tests-no-examples.txt
+++ b/llms-no-tests-no-examples.txt
@@ -147,6 +147,7 @@ docs/
     task-tool.md
     tavily_search.md
     tool-message-handler.md
+    tool-policy-hook.md
     twitter-search.md
     url_loader.md
     weaviate.md
@@ -288,6 +289,7 @@ langroid/
     openai_assistant.py
     task.py
     tool_message.py
+    tool_policy.py
     xml_tool_message.py
   cachedb/
     __init__.py
@@ -32201,6 +32203,159 @@ python3 examples/basic/chat-search-seltz.py
 ---
 </file>
 
+<file path="docs/notes/tool-policy-hook.md">
+# Pre-execution Tool Policy Hook
+
+When Langroid agents are embedded in larger systems, operators often need a
+central place to decide whether a tool call the LLM just made should actually
+run: authorization checks, human-approval gates, DLP scanning, command
+policies, budget limits, and so on. The `AgentConfig.tool_policy` hook
+provides the smallest possible interception point for this: a single optional
+callback, consulted immediately before the selected tool handler executes.
+No policy engine, rules, or registries live in Langroid itself — you plug in
+whatever external engine you like.
+
+## API
+
+```python
+import langroid as lr
+
+class RunCommandTool(lr.ToolMessage):
+    request: str = "run_command"
+    purpose: str = "To run a shell <command>"
+    command: str
+
+def my_policy(tool: lr.ToolMessage, agent: lr.Agent) -> bool | str | None:
+    if isinstance(tool, RunCommandTool) and "rm" in tool.command:
+        return "destructive commands are not allowed"
+    return True  # allow
+
+config = lr.ChatAgentConfig(
+    # ... other params ...
+    tool_policy=my_policy,
+)
+```
+
+The callback is invoked as `tool_policy(tool, agent)` — or as
+`tool_policy(tool, agent, chat_doc=...)` if the callable's signature has a
+`chat_doc` parameter (mirroring the convention for tool handlers). It
+receives:
+
+- `tool`: the final parsed `ToolMessage` instance about to be handled — its
+  `request` field is the tool name, and its other fields are the fully
+  validated arguments
+- `agent`: the agent that is about to run the handler
+- `chat_doc` (optional): the `ChatDocument` containing the tool call, when
+  available
+
+The return value decides what happens:
+
+- `True` or `None` — allow: the selected handler runs exactly once, as usual
+- `False` — reject: the handler is NOT run; the LLM receives a rejection
+  message naming the tool
+- a `str` — reject, with that string included as the reason in the
+  LLM-visible rejection message
+
+The hook cannot modify the tool: argument transformation is deliberately out
+of scope, and the hook receives deep copies of both the `ToolMessage` and
+the `chat_doc`, so any mutation it makes has no effect on what the handler
+sees. It only decides allow vs. reject. It is consulted only when a real
+handler has been selected: a tool with no handler returns `None` as before,
+without the policy being called.
+
+The policy is enforced at the framework's dispatch call sites, ABOVE
+`Agent.handle_tool_message` / `handle_tool_message_async` — so it gates
+tool execution even when a subclass overrides those methods. Three
+consequences of that placement:
+
+- when dispatch IS overridden, the framework cannot know whether the
+  override will execute anything, so the policy is consulted even if the
+  override ends up returning `None` (the no-handler shortcut applies only
+  to un-overridden dispatch)
+- direct calls that YOUR code makes to `agent.handle_tool_message(...)`
+  are your own seam and are not gated by the hook
+- the strict-recovery `AnyTool` wrapper is a parsing shim, not a tool
+  execution, so it is exempt from the hook; the recovered actual tool is
+  policy-checked exactly once when dispatched
+
+## Failure semantics: fail-closed
+
+If the policy callback itself raises an exception, the tool is treated as
+rejected — the handler does not run. This is deliberate: a broken policy
+must never silently become a bypassed policy.
+
+The rejection message sent back to the LLM includes only the tool name and
+the exception's class name — never the exception message or the tool's
+arguments, since either could leak payload contents into the conversation.
+The full exception is logged (via the `langroid.agent.tool_policy` logger)
+for the operator. Similarly, a decision value of an unrecognized type (anything other
+than `True`, `False`, `None`, or `str`) is treated as a rejection rather
+than an allow.
+
+## Sync and async
+
+The hook works on both dispatch paths, with both kinds of callables:
+
+- a sync callback works with both `handle_message` (sync dispatch) and
+  `handle_message_async` (async dispatch)
+- an async callback is awaited on the caller's event loop everywhere on the
+  async path — including when the tool only has a sync handler — so it may
+  safely use loop-bound resources (locks, clients, futures). On the sync
+  path it is run to completion via `asyncio.run()` — or, when an event loop
+  is already running in the calling thread (e.g. sync dispatch invoked from
+  inside async code), on a fresh event loop in a helper thread. Any failure
+  while doing so is handled fail-closed like any other hook error.
+
+On each dispatch, the policy is consulted exactly once per tool call,
+including when async dispatch falls back to a tool's sync handler.
+
+## What the hook does NOT change
+
+- With no `tool_policy` configured (the default), behavior is exactly as
+  before — the hook adds negligible overhead (a None check per dispatch)
+  and no semantic change.
+- The USER-origin tool security filter (see
+  [Code-Injection Protection](code-injection-protection.md) and
+  GHSA-gjgq-w2m6-wr5q) runs first and is unaffected: tools vetoed by that
+  filter are never even shown to the policy, and an allow-everything policy
+  cannot resurrect them.
+- Rejections flow back into the conversation like any other tool-handling
+  result (e.g. validation errors), so the LLM sees why the call was refused
+  and can adjust.
+
+## Caveats
+
+The policy callback is trusted operator code, not a sandbox:
+
+- The deep copies guard against mutation through the `tool` and `chat_doc`
+  arguments; a policy determined to tamper could still reach live state via
+  `agent`. Don't do that — the hook's contract is allow/reject only.
+- Everywhere the framework deep-copies an agent config —
+  `ChatAgent.clone()`, `Task` construction, and batch processing — the
+  policy callable is shared by REFERENCE (exempted from the copy via a
+  pre-seeded deepcopy memo; the live config is never mutated). A stateful
+  policy (a budget counter, an approval list) is therefore consulted
+  globally across the original and all copies, and a policy holding
+  unpicklable resources (e.g. a lock) does not break copying. If you copy
+  a config through some other route (`copy.deepcopy` yourself), that copy
+  is not exempted.
+- An async policy evaluated from purely-sync dispatch that is itself
+  running inside an event loop (a rare nested case) runs on a fresh event
+  loop in a helper thread; loop-bound awaitables can fail there, which
+  blocks the tool (fail-closed) rather than bypassing it.
+- A tool payload carrying a non-copyable value (a lock, a client object)
+  prevents the pre-policy deep copy and causes a fail-closed rejection
+  even under an allow-all policy, with a distinct operator-log diagnostic
+  ("tool payload could not be copied for policy evaluation"). The remedy
+  is keeping tool fields to plain data.
+
+## Example
+
+A runnable example is in `examples/basic/tool-policy-hook.py`, showing a
+policy that blocks payments above a limit, with the LLM reacting to the
+rejection.
+</file>
+
 <file path="docs/notes/twitter-search.md">
 # Twitter Search via Xquik MCP
 
@@ -38063,596 +38218,6 @@ class SeltzSearchTool(ToolMessage):
         ]
 </file>
 
-<file path="langroid/agent/batch.py">
-import asyncio
-import copy
-import inspect
-import warnings
-from enum import Enum
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    Iterable,
-    List,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-)
-
-from dotenv import load_dotenv
-
-from langroid.agent.base import Agent
-from langroid.agent.chat_document import ChatDocument
-from langroid.agent.task import Task
-from langroid.parsing.utils import batched
-from langroid.utils.configuration import quiet_mode
-from langroid.utils.logging import setup_colored_logging
-from langroid.utils.output import SuppressLoggerWarnings, status
-
-setup_colored_logging()
-
-load_dotenv()
-
-T = TypeVar("T")
-U = TypeVar("U")
-
-
-class ExceptionHandling(str, Enum):
-    """Enum for exception handling options."""
-
-    RAISE = "raise"
-    RETURN_NONE = "return_none"
-    RETURN_EXCEPTION = "return_exception"
-
-
-def _convert_exception_handling(
-    handle_exceptions: Union[bool, ExceptionHandling]
-) -> ExceptionHandling:
-    """Convert legacy boolean handle_exceptions to ExceptionHandling enum."""
-    if isinstance(handle_exceptions, ExceptionHandling):
-        return handle_exceptions
-
-    if isinstance(handle_exceptions, bool):
-        warnings.warn(
-            "Boolean handle_exceptions is deprecated. "
-            "Use ExceptionHandling enum instead: "
-            "RAISE, RETURN_NONE, or RETURN_EXCEPTION.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return (
-            ExceptionHandling.RETURN_NONE
-            if handle_exceptions
-            else ExceptionHandling.RAISE
-        )
-
-    raise TypeError(
-        "handle_exceptions must be bool or ExceptionHandling, "
-        f"not {type(handle_exceptions)}"
-    )
-
-
-async def _process_batch_async(
-    inputs: Iterable[str | ChatDocument],
-    do_task: Callable[[str | ChatDocument, int], Coroutine[Any, Any, Any]],
-    start_idx: int = 0,
-    stop_on_first_result: bool = False,
-    sequential: bool = False,
-    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
-    output_map: Callable[[Any], Any] = lambda x: x,
-) -> List[Optional[ChatDocument] | BaseException]:
-    """
-    Unified batch processing logic for both agent methods and tasks.
-
-    Args:
-        inputs: Iterable of inputs to process
-        do_task: Task execution function that takes (input, index) and returns result
-        start_idx: Starting index for the batch
-        stop_on_first_result: Whether to stop after first valid result
-        sequential: Whether to process sequentially
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        output_map: Function to map results to final output format
-    """
-    exception_handling = _convert_exception_handling(handle_exceptions)
-
-    def handle_error(e: BaseException) -> Any:
-        """Handle exceptions based on exception_handling."""
-        match exception_handling:
-            case ExceptionHandling.RAISE:
-                raise e
-            case ExceptionHandling.RETURN_NONE:
-                return None
-            case ExceptionHandling.RETURN_EXCEPTION:
-                return e
-
-    if stop_on_first_result:
-        results: List[Optional[ChatDocument] | BaseException] = []
-        pending: set[asyncio.Task[Any]] = set()
-        # Create task-to-index mapping
-        task_indices: dict[asyncio.Task[Any], int] = {}
-        try:
-            tasks = [
-                asyncio.create_task(do_task(input, i + start_idx))
-                for i, input in enumerate(inputs)
-            ]
-            task_indices = {task: i for i, task in enumerate(tasks)}
-            results = [None] * len(tasks)
-
-            pending = set(tasks)
-            while pending:
-                done, pending = await asyncio.wait(
-                    pending, return_when=asyncio.FIRST_COMPLETED
-                )
-
-                # Process completed tasks
-                for task in done:
-                    index = task_indices[task]
-                    try:
-                        result = await task
-                        results[index] = output_map(result)
-                    except BaseException as e:
-                        results[index] = handle_error(e)
-
-                if any(r is not None for r in results):
-                    return results
-        finally:
-            for task in pending:
-                task.cancel()
-            try:
-                await asyncio.gather(*pending, return_exceptions=True)
-            except BaseException as e:
-                handle_error(e)
-        return results
-
-    elif sequential:
-        results = []
-        for i, input in enumerate(inputs):
-            try:
-                result = await do_task(input, i + start_idx)
-                results.append(output_map(result))
-            except BaseException as e:
-                results.append(handle_error(e))
-        return results
-
-    # Parallel execution
-    else:
-        try:
-            return_exceptions = exception_handling != ExceptionHandling.RAISE
-            with quiet_mode(), SuppressLoggerWarnings():
-                results_with_exceptions = cast(
-                    list[Optional[ChatDocument | BaseException]],
-                    await asyncio.gather(
-                        *(
-                            do_task(input, i + start_idx)
-                            for i, input in enumerate(inputs)
-                        ),
-                        return_exceptions=return_exceptions,
-                    ),
-                )
-
-                if exception_handling == ExceptionHandling.RETURN_NONE:
-                    results = [
-                        None if isinstance(r, BaseException) else r
-                        for r in results_with_exceptions
-                    ]
-                else:  # ExceptionHandling.RETURN_EXCEPTION
-                    results = results_with_exceptions
-        except BaseException as e:
-            results = [handle_error(e) for _ in inputs]
-
-        return [output_map(r) for r in results]
-
-
-def run_batched_tasks(
-    inputs: List[str | ChatDocument],
-    do_task: Callable[[str | ChatDocument, int], Coroutine[Any, Any, Any]],
-    batch_size: Optional[int],
-    stop_on_first_result: bool,
-    sequential: bool,
-    handle_exceptions: Union[bool, ExceptionHandling],
-    output_map: Callable[[Any], Any],
-    message_template: str,
-    message: Optional[str] = None,
-) -> List[Any]:
-    """
-    Common batch processing logic for both agent methods and tasks.
-
-    Args:
-        inputs: List of inputs to process
-        do_task: Task execution function
-        batch_size: Size of batches, if None process all at once
-        stop_on_first_result: Whether to stop after first valid result
-        sequential: Whether to process sequentially
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        output_map: Function to map results
-        message_template: Template for status message
-        message: Optional override for status message
-    """
-
-    async def run_all_batched_tasks(
-        inputs: List[str | ChatDocument],
-        batch_size: int | None,
-    ) -> List[Any]:
-        """Extra wrap to run asyncio.run one single time and not once per loop
-
-        Args:
-            inputs (List[str  |  ChatDocument]): inputs to process
-            batch_size (int | None): batch size
-
-        Returns:
-            List[Any]: results
-        """
-        results: List[Any] = []
-        if batch_size is None:
-            msg = message or message_template.format(total=len(inputs))
-            with status(msg), SuppressLoggerWarnings():
-                results = await _process_batch_async(
-                    inputs,
-                    do_task,
-                    stop_on_first_result=stop_on_first_result,
-                    sequential=sequential,
-                    handle_exceptions=handle_exceptions,
-                    output_map=output_map,
-                )
-        else:
-            batches = batched(inputs, batch_size)
-            for batch in batches:
-                start_idx = len(results)
-                complete_str = f", {start_idx} complete" if start_idx > 0 else ""
-                msg = (
-                    message or message_template.format(total=len(inputs)) + complete_str
-                )
-
-                if stop_on_first_result and any(r is not None for r in results):
-                    results.extend([None] * len(batch))
-                else:
-                    with status(msg), SuppressLoggerWarnings():
-                        results.extend(
-                            await _process_batch_async(
-                                batch,
-                                do_task,
-                                start_idx=start_idx,
-                                stop_on_first_result=stop_on_first_result,
-                                sequential=sequential,
-                                handle_exceptions=handle_exceptions,
-                                output_map=output_map,
-                            )
-                        )
-        return results
-
-    return asyncio.run(run_all_batched_tasks(inputs, batch_size))
-
-
-def run_batch_task_gen(
-    gen_task: Callable[[int], Task],
-    items: list[T],
-    input_map: Callable[[T], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
-    stop_on_first_result: bool = False,
-    sequential: bool = True,
-    batch_size: Optional[int] = None,
-    turns: int = -1,
-    message: Optional[str] = None,
-    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
-    max_cost: float = 0.0,
-    max_tokens: int = 0,
-) -> list[Optional[U]]:
-    """
-    Generate and run copies of a task async/concurrently one per item in `items` list.
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-    Args:
-        gen_task (Callable[[int], Task]): generates the tasks to run
-        items (list[T]): list of items to process
-        input_map (Callable[[T], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], U]): function to map result
-            to final result. If stop_on_first_result is enabled, then
-            map any invalid output to None. We continue until some non-None
-            result is obtained.
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None) result. Successful results are evaluated after
-            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
-            exception object is itself non-None and also stops the batch.
-            Processing continues past None results; once a non-None result
-            appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        batch_size (Optional[int]): The number of tasks to run at a time,
-            if None, unbatched
-        turns (int): number of turns to run, -1 for infinite
-        message (Optional[str]): optionally overrides the console status messages
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
-        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
-
-
-    Returns:
-        list[Optional[U]]: list of final results. Always list[U] if
-        `stop_on_first_result` is disabled
-    """
-    inputs = [input_map(item) for item in items]
-
-    async def _do_task(
-        input: str | ChatDocument,
-        i: int,
-    ) -> BaseException | Optional[ChatDocument] | tuple[int, Optional[ChatDocument]]:
-        task_i = gen_task(i)
-        if task_i.agent.llm is not None:
-            task_i.agent.llm.set_stream(False)
-        task_i.agent.config.show_stats = False
-
-        try:
-            result = await task_i.run_async(
-                input, turns=turns, max_cost=max_cost, max_tokens=max_tokens
-            )
-        except asyncio.CancelledError as e:
-            task_i.kill()
-            # exception will be handled by the caller
-            raise e
-        # ----------------------------------------
-        # Propagate any exception stored on the task that may have been
-        # swallowed inside `Task.run_async`, so that the upper-level
-        # exception-handling logic works as expected.
-        for attr in ("_exception", "last_exception", "exception"):
-            exc = getattr(task_i, attr, None)
-            if isinstance(exc, BaseException):
-                raise exc
-        # Fallback: treat a KILL-status result as an error
-        if (
-            isinstance(result, ChatDocument)
-            and getattr(result, "status", None) is not None
-            and str(getattr(result, "status")) == "StatusCode.KILL"
-        ):
-            raise RuntimeError(str(result.content))
-        return result
-
-    return run_batched_tasks(
-        inputs=inputs,
-        do_task=_do_task,
-        batch_size=batch_size,
-        stop_on_first_result=stop_on_first_result,
-        sequential=sequential,
-        handle_exceptions=handle_exceptions,
-        output_map=output_map,
-        message_template="[bold green]Running {total} tasks:",
-        message=message,
-    )
-
-
-def run_batch_tasks(
-    task: Task,
-    items: list[T],
-    input_map: Callable[[T], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
-    stop_on_first_result: bool = False,
-    sequential: bool = True,
-    batch_size: Optional[int] = None,
-    turns: int = -1,
-    max_cost: float = 0.0,
-    max_tokens: int = 0,
-) -> List[Optional[U]]:
-    """
-    Run copies of `task` async/concurrently one per item in `items` list.
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-    Args:
-        task (Task): task to run
-        items (list[T]): list of items to process
-        input_map (Callable[[T], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], U]): function to map result
-            to final result
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None, after `output_map`) result. Processing continues past
-            None-mapped results; exceptions propagate, since this function
-            always uses the default `RAISE` exception handling. Once a non-None
-            result appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        batch_size (Optional[int]): The number of tasks to run at a time,
-            if None, unbatched
-        turns (int): number of turns to run, -1 for infinite
-        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
-        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
-
-    Returns:
-        list[Optional[U]]: list of final results. Always list[U] if
-        `stop_on_first_result` is disabled
-    """
-    message = f"[bold green]Running {len(items)} copies of {task.name}..."
-    return run_batch_task_gen(
-        lambda i: task.clone(i),
-        items,
-        input_map,
-        output_map,
-        stop_on_first_result,
-        sequential,
-        batch_size,
-        turns,
-        message,
-        max_cost=max_cost,
-        max_tokens=max_tokens,
-    )
-
-
-def run_batch_agent_method(
-    agent: Agent,
-    method: Callable[
-        [str | ChatDocument | None], Coroutine[Any, Any, ChatDocument | None]
-    ],
-    items: List[Any],
-    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
-    sequential: bool = True,
-    stop_on_first_result: bool = False,
-    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
-    batch_size: Optional[int] = None,
-) -> List[Any]:
-    """
-    Run the `method` on copies of `agent`, async/concurrently one per
-    item in `items` list.
-    ASSUMPTION: The `method` is an async method and has signature:
-        method(self, input: str|ChatDocument|None) -> ChatDocument|None
-    So this would typically be used for the agent's "responder" methods,
-    e.g. `llm_response_async` or `agent_responder_async`.
-
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-
-    Args:
-        agent (Agent): agent whose method to run
-        method (str): Async method to run on copies of `agent`.
-            The method is assumed to have signature:
-            `method(self, input: str|ChatDocument|None) -> ChatDocument|None`
-        input_map (Callable[[Any], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], Any]): function to map result
-            to final result
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None) result. Successful results are evaluated after
-            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
-            exception object is itself non-None and also stops the batch.
-            Processing continues past None results; once a non-None result
-            appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        batch_size (Optional[int]): The number of items to process in each batch.
-            If None, process all items at once.
-    Returns:
-        List[Any]: list of final results
-    """
-    # Check if the method is async
-    method_name = method.__name__
-    if not inspect.iscoroutinefunction(method):
-        raise ValueError(f"The method {method_name} is not async.")
-
-    inputs = [input_map(item) for item in items]
-    agent_cfg = copy.deepcopy(agent.config)
-    assert agent_cfg.llm is not None, "agent must have llm config"
-    agent_cfg.llm.stream = False
-    agent_cfg.show_stats = False
-    agent_cls = type(agent)
-    agent_name = agent_cfg.name
-
-    async def _do_task(input: str | ChatDocument, i: int) -> Any:
-        agent_cfg.name = f"{agent_cfg.name}-{i}"
-        agent_i = agent_cls(agent_cfg)
-        method_i = getattr(agent_i, method_name, None)
-        if method_i is None:
-            raise ValueError(f"Agent {agent_name} has no method {method_name}")
-        result = await method_i(input)
-        return result
-
-    return run_batched_tasks(
-        inputs=inputs,
-        do_task=_do_task,
-        batch_size=batch_size,
-        stop_on_first_result=stop_on_first_result,
-        sequential=sequential,
-        handle_exceptions=handle_exceptions,
-        output_map=output_map,
-        message_template=f"[bold green]Running {{total}} copies of {agent_name}...",
-    )
-
-
-def llm_response_batch(
-    agent: Agent,
-    items: List[Any],
-    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
-    sequential: bool = True,
-    stop_on_first_result: bool = False,
-    batch_size: Optional[int] = None,
-) -> List[Any]:
-    return run_batch_agent_method(
-        agent,
-        agent.llm_response_async,
-        items,
-        input_map=input_map,
-        output_map=output_map,
-        sequential=sequential,
-        stop_on_first_result=stop_on_first_result,
-        batch_size=batch_size,
-    )
-
-
-def agent_response_batch(
-    agent: Agent,
-    items: List[Any],
-    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
-    sequential: bool = True,
-    stop_on_first_result: bool = False,
-    batch_size: Optional[int] = None,
-) -> List[Any]:
-    return run_batch_agent_method(
-        agent,
-        agent.agent_response_async,
-        items,
-        input_map=input_map,
-        output_map=output_map,
-        sequential=sequential,
-        stop_on_first_result=stop_on_first_result,
-        batch_size=batch_size,
-    )
-
-
-def run_batch_function(
-    function: Callable[[T], U],
-    items: list[T],
-    sequential: bool = True,
-    batch_size: Optional[int] = None,
-) -> List[U]:
-    async def _do_task(item: T) -> U:
-        return function(item)
-
-    async def _do_all(items: Iterable[T]) -> List[U]:
-        if sequential:
-            results = []
-            for item in items:
-                result = await _do_task(item)
-                results.append(result)
-            return results
-
-        return await asyncio.gather(*(_do_task(item) for item in items))
-
-    results: List[U] = []
-
-    if batch_size is None:
-        with status(f"[bold green]Running {len(items)} tasks:"):
-            results = asyncio.run(_do_all(items))
-    else:
-        batches = batched(items, batch_size)
-        for batch in batches:
-            with status(f"[bold green]Running batch of {len(batch)} tasks:"):
-                results.extend(asyncio.run(_do_all(batch)))
-
-    return results
-</file>
-
 <file path="langroid/agent/tool_message.py">
 """
 Structured messages to an agent, typically from an LLM, to be handled by
@@ -39067,6 +38632,352 @@ class ToolMessage(ABC, BaseModel):
             exclude=list(cls._get_excluded_fields()),
         )
         return schema
+</file>
+
+<file path="langroid/agent/tool_policy.py">
+"""Machinery for the pre-execution tool policy hook.
+
+The public surface is the ``tool_policy`` field on
+:class:`langroid.agent.base.AgentConfig`: an optional callable consulted
+just before a parsed ``ToolMessage``'s selected handler runs, deciding
+whether the handler executes (allow) or an LLM-visible rejection is
+returned instead (reject). The functions here evaluate that hook; see
+``docs/notes/tool-policy-hook.md`` for the full semantics.
+"""
+
+import asyncio
+import copy
+import inspect
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
+
+if TYPE_CHECKING:
+    from langroid.agent.base import Agent, AgentConfig
+    from langroid.agent.chat_document import ChatDocument
+    from langroid.agent.tool_message import ToolMessage
+
+logger = logging.getLogger(__name__)
+
+C = TypeVar("C", bound="AgentConfig")
+
+
+class _PolicyCopyError(Exception):
+    """Internal marker: the tool/chat_doc could not be copied for the policy.
+
+    Distinguishes a payload-copy failure (e.g. a tool field holding a lock
+    or client object) from an exception raised by the policy itself, so the
+    operator log can say precisely which happened. Both fail closed.
+    """
+
+
+def dispatch_overridden(agent: "Agent", use_async: bool) -> bool:
+    """Whether the agent's tool-dispatch method is overridden by a subclass.
+
+    Async dispatch falls back into `handle_tool_message` when a tool has no
+    async handler, so for the async path an override of EITHER method counts.
+
+    Args:
+        agent: The agent whose dispatch is being examined.
+        use_async: True for the async dispatch path.
+
+    Returns:
+        True if a subclass overrides the relevant dispatch method(s).
+    """
+    from langroid.agent.base import Agent
+
+    if (
+        use_async
+        and type(agent).handle_tool_message_async is not Agent.handle_tool_message_async
+    ):
+        return True
+    return type(agent).handle_tool_message is not Agent.handle_tool_message
+
+
+def handler_exists(agent: "Agent", tool: "ToolMessage", use_async: bool) -> bool:
+    """Whether base dispatch would find a handler for this tool.
+
+    Args:
+        agent: The agent that would dispatch the tool.
+        tool: The parsed ToolMessage.
+        use_async: True for the async dispatch path, which looks for an
+            `<name>_async` handler first and falls back to the sync one.
+
+    Returns:
+        True if a handler method exists on the agent.
+    """
+    tool_name = tool.default_value("request")
+    if hasattr(tool, "_handler"):
+        handler_name = getattr(tool, "_handler", tool_name)
+    else:
+        handler_name = tool_name
+    if use_async and getattr(agent, handler_name + "_async", None) is not None:
+        return True
+    return getattr(agent, handler_name, None) is not None
+
+
+def policy_exempt(tool: "ToolMessage") -> bool:
+    """Whether this tool is structurally exempt from the `tool_policy` hook.
+
+    Framework-internal parsing shims declare ``_tool_policy_exempt = True``
+    on their class (e.g. the strict-recovery ``AnyTool`` wrapper): such a
+    shim is not a tool execution itself -- the actual tool it carries is
+    re-parsed and dispatched through the policy-checked path, so the policy
+    is consulted exactly once per logical tool call.
+
+    Args:
+        tool: The parsed ToolMessage about to be dispatched.
+
+    Returns:
+        True if the tool's class carries the exemption marker.
+    """
+    # SECURITY: resolve the marker on the CLASS only, never the instance.
+    # ToolMessage has ``extra="allow"``, so LLM-controlled tool JSON such
+    # as ``{"_tool_policy_exempt": true, ...}`` lands on the INSTANCE as an
+    # extra field; trusting instance attributes would let the LLM spoof the
+    # exemption and bypass the policy.
+    return getattr(type(tool), "_tool_policy_exempt", False) is True
+
+
+def deepcopy_config_sharing_policy(config: C) -> C:
+    """Deep-copy an AgentConfig, sharing `tool_policy` by REFERENCE.
+
+    A `tool_policy` hook may be stateful (budgets, approval lists) or hold
+    unpicklable resources (locks, clients), so wherever the framework
+    deep-copies an agent config (agent cloning, Task construction, batch
+    processing) the policy must be exempted from the copy: the copy and the
+    original consult the SAME policy object. The live `config` is never
+    mutated (the exemption is done by pre-seeding the deepcopy memo).
+
+    Args:
+        config: The config to copy.
+
+    Returns:
+        A deep copy of `config` whose `tool_policy` is the same object as
+        `config.tool_policy`.
+    """
+    memo: dict[int, Any] = {}
+    policy = config.tool_policy
+    if policy is not None:
+        memo[id(policy)] = policy
+    config_copy: C = copy.deepcopy(config, memo)
+    return config_copy
+
+
+def _invoke_policy(
+    policy: Callable[..., Any],
+    tool: "ToolMessage",
+    agent: "Agent",
+    chat_doc: Optional["ChatDocument"],
+) -> Any:
+    """Call the `tool_policy` hook with (tool, agent[, chat_doc]).
+
+    The `chat_doc` is passed only if the callable's signature has a
+    `chat_doc` parameter, mirroring the tool-handler convention. The hook
+    decides allow/reject only, so it receives deep COPIES of the tool and
+    the chat_doc: mutating them cannot change what the handler executes.
+
+    Args:
+        policy: The configured `tool_policy` callable.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        The policy's decision, possibly an awaitable if the policy
+        is async.
+    """
+    try:
+        has_chat_doc_param = "chat_doc" in inspect.signature(policy).parameters
+    except (ValueError, TypeError):
+        has_chat_doc_param = False
+    try:
+        tool = tool.model_copy(deep=True)
+        if has_chat_doc_param and chat_doc is not None:
+            chat_doc = copy.deepcopy(chat_doc)
+    except Exception as e:
+        raise _PolicyCopyError() from e
+    if has_chat_doc_param:
+        return policy(tool, agent, chat_doc=chat_doc)
+    return policy(tool, agent)
+
+
+def run_awaitable_sync(awaitable: Any) -> Any:
+    """Run an awaitable to completion from sync code.
+
+    Uses `asyncio.run()` when no event loop is running in this thread;
+    otherwise runs it on a fresh event loop in a helper thread, so sync
+    dispatch nested inside async code (e.g. a sync tool handler invoked
+    from async code calling back into sync dispatch) still works.
+
+    Args:
+        awaitable: The awaitable to run.
+
+    Returns:
+        The awaitable's result.
+    """
+
+    async def _await() -> Any:
+        return await awaitable
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(_await())
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(asyncio.run, _await()).result()
+
+
+def _decision_msg(tool_name: str, decision: Any) -> Optional[str]:
+    """Convert a `tool_policy` decision into an optional rejection message.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        decision: The value returned by the `tool_policy` hook.
+
+    Returns:
+        None if the tool is allowed (decision is True or None), else an
+        LLM-visible rejection message naming the tool and the reason.
+        Any decision of an unrecognized type is treated as a rejection
+        (fail-closed).
+    """
+    if decision is None or decision is True:
+        return None
+    if decision is False:
+        reason = "(no reason given)"
+    elif isinstance(decision, str):
+        reason = decision
+    else:
+        reason = (
+            f"policy returned unrecognized decision of type "
+            f"{type(decision).__name__}; failing closed"
+        )
+    return f"Tool `{tool_name}` was NOT executed: blocked by tool policy: {reason}"
+
+
+def _copy_failure_msg(tool_name: str, e: BaseException | None) -> str:
+    """Fail-closed rejection for a payload that could not be copied.
+
+    A tool field carrying a non-copyable object (a lock, a client, ...)
+    prevents the pre-policy deep copy; the tool is blocked (fail-closed),
+    with an operator-log diagnostic distinct from "the policy raised". The
+    LLM-visible message still names only the tool and the exception class.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        e: The underlying copy exception, if known.
+
+    Returns:
+        An LLM-visible rejection message.
+    """
+    exc_name = type(e).__name__ if e is not None else "Exception"
+    logger.error(
+        f"tool payload could not be copied for policy evaluation for tool "
+        f"`{tool_name}`; blocking the tool (fail-closed): "
+        f"{exc_name}: {e}"
+    )
+    return (
+        f"Tool `{tool_name}` was NOT executed: its arguments could not be "
+        f"copied for policy evaluation ({exc_name}); failing closed "
+        f"(tool blocked)."
+    )
+
+
+def _failure_msg(tool_name: str, e: Exception) -> str:
+    """Fail-closed rejection message for a `tool_policy` hook that raised.
+
+    The exception message is deliberately NOT included, since it may
+    embed raw tool arguments; only the exception class name is exposed.
+    The full exception is logged for the operator.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        e: The exception raised by the hook.
+
+    Returns:
+        An LLM-visible rejection message.
+    """
+    logger.error(
+        f"tool_policy hook raised {type(e).__name__} while checking tool "
+        f"`{tool_name}`; blocking the tool (fail-closed): {e}"
+    )
+    return (
+        f"Tool `{tool_name}` was NOT executed: the tool policy hook "
+        f"failed with {type(e).__name__}; failing closed (tool blocked)."
+    )
+
+
+def check_tool_policy(
+    policy: Optional[Callable[..., Any]],
+    tool: "ToolMessage",
+    agent: "Agent",
+    chat_doc: Optional["ChatDocument"],
+) -> Optional[str]:
+    """Evaluate the `tool_policy` hook on the sync dispatch path.
+
+    An async policy is run to completion via `run_awaitable_sync` (which
+    works whether or not an event loop is already running in this thread);
+    any failure while doing so is treated like any other hook failure:
+    the tool is blocked (fail-closed).
+
+    Args:
+        policy: The configured `tool_policy` callable, or None.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        None if no policy is configured or the policy allows the tool,
+        else an LLM-visible rejection message.
+    """
+    if policy is None:
+        return None
+    tool_name = tool.default_value("request")
+    try:
+        decision = _invoke_policy(policy, tool, agent, chat_doc)
+        if inspect.isawaitable(decision):
+            decision = run_awaitable_sync(decision)
+    except _PolicyCopyError as ce:
+        return _copy_failure_msg(tool_name, ce.__cause__)
+    except Exception as e:
+        return _failure_msg(tool_name, e)
+    return _decision_msg(tool_name, decision)
+
+
+async def check_tool_policy_async(
+    policy: Optional[Callable[..., Any]],
+    tool: "ToolMessage",
+    agent: "Agent",
+    chat_doc: Optional["ChatDocument"],
+) -> Optional[str]:
+    """Async version of `check_tool_policy`.
+
+    An async policy is awaited on the CALLING event loop, so it may safely
+    use loop-bound resources (locks, clients, futures).
+
+    Args:
+        policy: The configured `tool_policy` callable, or None.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        None if no policy is configured or the policy allows the tool,
+        else an LLM-visible rejection message.
+    """
+    if policy is None:
+        return None
+    tool_name = tool.default_value("request")
+    try:
+        decision = _invoke_policy(policy, tool, agent, chat_doc)
+        if inspect.isawaitable(decision):
+            decision = await decision
+    except _PolicyCopyError as ce:
+        return _copy_failure_msg(tool_name, ce.__cause__)
+    except Exception as e:
+        return _failure_msg(tool_name, e)
+    return _decision_msg(tool_name, decision)
 </file>
 
 <file path="langroid/language_models/__init__.py">
@@ -44594,6 +44505,598 @@ async def get_mcp_tools_async(
         return await client.client.list_tools()
 </file>
 
+<file path="langroid/agent/batch.py">
+import asyncio
+import inspect
+import warnings
+from enum import Enum
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Iterable,
+    List,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from dotenv import load_dotenv
+
+from langroid.agent.base import Agent
+from langroid.agent.chat_document import ChatDocument
+from langroid.agent.task import Task
+from langroid.parsing.utils import batched
+from langroid.utils.configuration import quiet_mode
+from langroid.utils.logging import setup_colored_logging
+from langroid.utils.output import SuppressLoggerWarnings, status
+
+setup_colored_logging()
+
+load_dotenv()
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+class ExceptionHandling(str, Enum):
+    """Enum for exception handling options."""
+
+    RAISE = "raise"
+    RETURN_NONE = "return_none"
+    RETURN_EXCEPTION = "return_exception"
+
+
+def _convert_exception_handling(
+    handle_exceptions: Union[bool, ExceptionHandling]
+) -> ExceptionHandling:
+    """Convert legacy boolean handle_exceptions to ExceptionHandling enum."""
+    if isinstance(handle_exceptions, ExceptionHandling):
+        return handle_exceptions
+
+    if isinstance(handle_exceptions, bool):
+        warnings.warn(
+            "Boolean handle_exceptions is deprecated. "
+            "Use ExceptionHandling enum instead: "
+            "RAISE, RETURN_NONE, or RETURN_EXCEPTION.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return (
+            ExceptionHandling.RETURN_NONE
+            if handle_exceptions
+            else ExceptionHandling.RAISE
+        )
+
+    raise TypeError(
+        "handle_exceptions must be bool or ExceptionHandling, "
+        f"not {type(handle_exceptions)}"
+    )
+
+
+async def _process_batch_async(
+    inputs: Iterable[str | ChatDocument],
+    do_task: Callable[[str | ChatDocument, int], Coroutine[Any, Any, Any]],
+    start_idx: int = 0,
+    stop_on_first_result: bool = False,
+    sequential: bool = False,
+    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
+    output_map: Callable[[Any], Any] = lambda x: x,
+) -> List[Optional[ChatDocument] | BaseException]:
+    """
+    Unified batch processing logic for both agent methods and tasks.
+
+    Args:
+        inputs: Iterable of inputs to process
+        do_task: Task execution function that takes (input, index) and returns result
+        start_idx: Starting index for the batch
+        stop_on_first_result: Whether to stop after first valid result
+        sequential: Whether to process sequentially
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        output_map: Function to map results to final output format
+    """
+    exception_handling = _convert_exception_handling(handle_exceptions)
+
+    def handle_error(e: BaseException) -> Any:
+        """Handle exceptions based on exception_handling."""
+        match exception_handling:
+            case ExceptionHandling.RAISE:
+                raise e
+            case ExceptionHandling.RETURN_NONE:
+                return None
+            case ExceptionHandling.RETURN_EXCEPTION:
+                return e
+
+    if stop_on_first_result:
+        results: List[Optional[ChatDocument] | BaseException] = []
+        pending: set[asyncio.Task[Any]] = set()
+        # Create task-to-index mapping
+        task_indices: dict[asyncio.Task[Any], int] = {}
+        try:
+            tasks = [
+                asyncio.create_task(do_task(input, i + start_idx))
+                for i, input in enumerate(inputs)
+            ]
+            task_indices = {task: i for i, task in enumerate(tasks)}
+            results = [None] * len(tasks)
+
+            pending = set(tasks)
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED
+                )
+
+                # Process completed tasks
+                for task in done:
+                    index = task_indices[task]
+                    try:
+                        result = await task
+                        results[index] = output_map(result)
+                    except BaseException as e:
+                        results[index] = handle_error(e)
+
+                if any(r is not None for r in results):
+                    return results
+        finally:
+            for task in pending:
+                task.cancel()
+            try:
+                await asyncio.gather(*pending, return_exceptions=True)
+            except BaseException as e:
+                handle_error(e)
+        return results
+
+    elif sequential:
+        results = []
+        for i, input in enumerate(inputs):
+            try:
+                result = await do_task(input, i + start_idx)
+                results.append(output_map(result))
+            except BaseException as e:
+                results.append(handle_error(e))
+        return results
+
+    # Parallel execution
+    else:
+        try:
+            return_exceptions = exception_handling != ExceptionHandling.RAISE
+            with quiet_mode(), SuppressLoggerWarnings():
+                results_with_exceptions = cast(
+                    list[Optional[ChatDocument | BaseException]],
+                    await asyncio.gather(
+                        *(
+                            do_task(input, i + start_idx)
+                            for i, input in enumerate(inputs)
+                        ),
+                        return_exceptions=return_exceptions,
+                    ),
+                )
+
+                if exception_handling == ExceptionHandling.RETURN_NONE:
+                    results = [
+                        None if isinstance(r, BaseException) else r
+                        for r in results_with_exceptions
+                    ]
+                else:  # ExceptionHandling.RETURN_EXCEPTION
+                    results = results_with_exceptions
+        except BaseException as e:
+            results = [handle_error(e) for _ in inputs]
+
+        return [output_map(r) for r in results]
+
+
+def run_batched_tasks(
+    inputs: List[str | ChatDocument],
+    do_task: Callable[[str | ChatDocument, int], Coroutine[Any, Any, Any]],
+    batch_size: Optional[int],
+    stop_on_first_result: bool,
+    sequential: bool,
+    handle_exceptions: Union[bool, ExceptionHandling],
+    output_map: Callable[[Any], Any],
+    message_template: str,
+    message: Optional[str] = None,
+) -> List[Any]:
+    """
+    Common batch processing logic for both agent methods and tasks.
+
+    Args:
+        inputs: List of inputs to process
+        do_task: Task execution function
+        batch_size: Size of batches, if None process all at once
+        stop_on_first_result: Whether to stop after first valid result
+        sequential: Whether to process sequentially
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        output_map: Function to map results
+        message_template: Template for status message
+        message: Optional override for status message
+    """
+
+    async def run_all_batched_tasks(
+        inputs: List[str | ChatDocument],
+        batch_size: int | None,
+    ) -> List[Any]:
+        """Extra wrap to run asyncio.run one single time and not once per loop
+
+        Args:
+            inputs (List[str  |  ChatDocument]): inputs to process
+            batch_size (int | None): batch size
+
+        Returns:
+            List[Any]: results
+        """
+        results: List[Any] = []
+        if batch_size is None:
+            msg = message or message_template.format(total=len(inputs))
+            with status(msg), SuppressLoggerWarnings():
+                results = await _process_batch_async(
+                    inputs,
+                    do_task,
+                    stop_on_first_result=stop_on_first_result,
+                    sequential=sequential,
+                    handle_exceptions=handle_exceptions,
+                    output_map=output_map,
+                )
+        else:
+            batches = batched(inputs, batch_size)
+            for batch in batches:
+                start_idx = len(results)
+                complete_str = f", {start_idx} complete" if start_idx > 0 else ""
+                msg = (
+                    message or message_template.format(total=len(inputs)) + complete_str
+                )
+
+                if stop_on_first_result and any(r is not None for r in results):
+                    results.extend([None] * len(batch))
+                else:
+                    with status(msg), SuppressLoggerWarnings():
+                        results.extend(
+                            await _process_batch_async(
+                                batch,
+                                do_task,
+                                start_idx=start_idx,
+                                stop_on_first_result=stop_on_first_result,
+                                sequential=sequential,
+                                handle_exceptions=handle_exceptions,
+                                output_map=output_map,
+                            )
+                        )
+        return results
+
+    return asyncio.run(run_all_batched_tasks(inputs, batch_size))
+
+
+def run_batch_task_gen(
+    gen_task: Callable[[int], Task],
+    items: list[T],
+    input_map: Callable[[T], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
+    stop_on_first_result: bool = False,
+    sequential: bool = True,
+    batch_size: Optional[int] = None,
+    turns: int = -1,
+    message: Optional[str] = None,
+    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
+    max_cost: float = 0.0,
+    max_tokens: int = 0,
+) -> list[Optional[U]]:
+    """
+    Generate and run copies of a task async/concurrently one per item in `items` list.
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+    Args:
+        gen_task (Callable[[int], Task]): generates the tasks to run
+        items (list[T]): list of items to process
+        input_map (Callable[[T], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], U]): function to map result
+            to final result. If stop_on_first_result is enabled, then
+            map any invalid output to None. We continue until some non-None
+            result is obtained.
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        batch_size (Optional[int]): The number of tasks to run at a time,
+            if None, unbatched
+        turns (int): number of turns to run, -1 for infinite
+        message (Optional[str]): optionally overrides the console status messages
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
+        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
+
+
+    Returns:
+        list[Optional[U]]: list of final results. Always list[U] if
+        `stop_on_first_result` is disabled
+    """
+    inputs = [input_map(item) for item in items]
+
+    async def _do_task(
+        input: str | ChatDocument,
+        i: int,
+    ) -> BaseException | Optional[ChatDocument] | tuple[int, Optional[ChatDocument]]:
+        task_i = gen_task(i)
+        if task_i.agent.llm is not None:
+            task_i.agent.llm.set_stream(False)
+        task_i.agent.config.show_stats = False
+
+        try:
+            result = await task_i.run_async(
+                input, turns=turns, max_cost=max_cost, max_tokens=max_tokens
+            )
+        except asyncio.CancelledError as e:
+            task_i.kill()
+            # exception will be handled by the caller
+            raise e
+        # ----------------------------------------
+        # Propagate any exception stored on the task that may have been
+        # swallowed inside `Task.run_async`, so that the upper-level
+        # exception-handling logic works as expected.
+        for attr in ("_exception", "last_exception", "exception"):
+            exc = getattr(task_i, attr, None)
+            if isinstance(exc, BaseException):
+                raise exc
+        # Fallback: treat a KILL-status result as an error
+        if (
+            isinstance(result, ChatDocument)
+            and getattr(result, "status", None) is not None
+            and str(getattr(result, "status")) == "StatusCode.KILL"
+        ):
+            raise RuntimeError(str(result.content))
+        return result
+
+    return run_batched_tasks(
+        inputs=inputs,
+        do_task=_do_task,
+        batch_size=batch_size,
+        stop_on_first_result=stop_on_first_result,
+        sequential=sequential,
+        handle_exceptions=handle_exceptions,
+        output_map=output_map,
+        message_template="[bold green]Running {total} tasks:",
+        message=message,
+    )
+
+
+def run_batch_tasks(
+    task: Task,
+    items: list[T],
+    input_map: Callable[[T], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
+    stop_on_first_result: bool = False,
+    sequential: bool = True,
+    batch_size: Optional[int] = None,
+    turns: int = -1,
+    max_cost: float = 0.0,
+    max_tokens: int = 0,
+) -> List[Optional[U]]:
+    """
+    Run copies of `task` async/concurrently one per item in `items` list.
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+    Args:
+        task (Task): task to run
+        items (list[T]): list of items to process
+        input_map (Callable[[T], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], U]): function to map result
+            to final result
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None, after `output_map`) result. Processing continues past
+            None-mapped results; exceptions propagate, since this function
+            always uses the default `RAISE` exception handling. Once a non-None
+            result appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        batch_size (Optional[int]): The number of tasks to run at a time,
+            if None, unbatched
+        turns (int): number of turns to run, -1 for infinite
+        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
+        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
+
+    Returns:
+        list[Optional[U]]: list of final results. Always list[U] if
+        `stop_on_first_result` is disabled
+    """
+    message = f"[bold green]Running {len(items)} copies of {task.name}..."
+    return run_batch_task_gen(
+        lambda i: task.clone(i),
+        items,
+        input_map,
+        output_map,
+        stop_on_first_result,
+        sequential,
+        batch_size,
+        turns,
+        message,
+        max_cost=max_cost,
+        max_tokens=max_tokens,
+    )
+
+
+def run_batch_agent_method(
+    agent: Agent,
+    method: Callable[
+        [str | ChatDocument | None], Coroutine[Any, Any, ChatDocument | None]
+    ],
+    items: List[Any],
+    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
+    sequential: bool = True,
+    stop_on_first_result: bool = False,
+    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
+    batch_size: Optional[int] = None,
+) -> List[Any]:
+    """
+    Run the `method` on copies of `agent`, async/concurrently one per
+    item in `items` list.
+    ASSUMPTION: The `method` is an async method and has signature:
+        method(self, input: str|ChatDocument|None) -> ChatDocument|None
+    So this would typically be used for the agent's "responder" methods,
+    e.g. `llm_response_async` or `agent_responder_async`.
+
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+
+    Args:
+        agent (Agent): agent whose method to run
+        method (str): Async method to run on copies of `agent`.
+            The method is assumed to have signature:
+            `method(self, input: str|ChatDocument|None) -> ChatDocument|None`
+        input_map (Callable[[Any], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], Any]): function to map result
+            to final result
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        batch_size (Optional[int]): The number of items to process in each batch.
+            If None, process all items at once.
+    Returns:
+        List[Any]: list of final results
+    """
+    # Check if the method is async
+    method_name = method.__name__
+    if not inspect.iscoroutinefunction(method):
+        raise ValueError(f"The method {method_name} is not async.")
+
+    from langroid.agent.tool_policy import deepcopy_config_sharing_policy
+
+    inputs = [input_map(item) for item in items]
+    # tool_policy hook shared by reference so its state stays global
+    agent_cfg = deepcopy_config_sharing_policy(agent.config)
+    assert agent_cfg.llm is not None, "agent must have llm config"
+    agent_cfg.llm.stream = False
+    agent_cfg.show_stats = False
+    agent_cls = type(agent)
+    agent_name = agent_cfg.name
+
+    async def _do_task(input: str | ChatDocument, i: int) -> Any:
+        agent_cfg.name = f"{agent_cfg.name}-{i}"
+        agent_i = agent_cls(agent_cfg)
+        method_i = getattr(agent_i, method_name, None)
+        if method_i is None:
+            raise ValueError(f"Agent {agent_name} has no method {method_name}")
+        result = await method_i(input)
+        return result
+
+    return run_batched_tasks(
+        inputs=inputs,
+        do_task=_do_task,
+        batch_size=batch_size,
+        stop_on_first_result=stop_on_first_result,
+        sequential=sequential,
+        handle_exceptions=handle_exceptions,
+        output_map=output_map,
+        message_template=f"[bold green]Running {{total}} copies of {agent_name}...",
+    )
+
+
+def llm_response_batch(
+    agent: Agent,
+    items: List[Any],
+    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
+    sequential: bool = True,
+    stop_on_first_result: bool = False,
+    batch_size: Optional[int] = None,
+) -> List[Any]:
+    return run_batch_agent_method(
+        agent,
+        agent.llm_response_async,
+        items,
+        input_map=input_map,
+        output_map=output_map,
+        sequential=sequential,
+        stop_on_first_result=stop_on_first_result,
+        batch_size=batch_size,
+    )
+
+
+def agent_response_batch(
+    agent: Agent,
+    items: List[Any],
+    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
+    sequential: bool = True,
+    stop_on_first_result: bool = False,
+    batch_size: Optional[int] = None,
+) -> List[Any]:
+    return run_batch_agent_method(
+        agent,
+        agent.agent_response_async,
+        items,
+        input_map=input_map,
+        output_map=output_map,
+        sequential=sequential,
+        stop_on_first_result=stop_on_first_result,
+        batch_size=batch_size,
+    )
+
+
+def run_batch_function(
+    function: Callable[[T], U],
+    items: list[T],
+    sequential: bool = True,
+    batch_size: Optional[int] = None,
+) -> List[U]:
+    async def _do_task(item: T) -> U:
+        return function(item)
+
+    async def _do_all(items: Iterable[T]) -> List[U]:
+        if sequential:
+            results = []
+            for item in items:
+                result = await _do_task(item)
+                results.append(result)
+            return results
+
+        return await asyncio.gather(*(_do_task(item) for item in items))
+
+    results: List[U] = []
+
+    if batch_size is None:
+        with status(f"[bold green]Running {len(items)} tasks:"):
+            results = asyncio.run(_do_all(items))
+    else:
+        batches = batched(items, batch_size)
+        for batch in batches:
+            with status(f"[bold green]Running batch of {len(batch)} tasks:"):
+                results.extend(asyncio.run(_do_all(batch)))
+
+    return results
+</file>
+
 <file path="langroid/agent/openai_assistant.py">
 import asyncio
 import json
@@ -49642,6 +50145,1458 @@ LLMMessage.model_rebuild()
 ChatDocMetaData.model_rebuild()
 </file>
 
+<file path="langroid/language_models/base.py">
+import json
+import logging
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from enum import Enum
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
+
+from langroid.cachedb.base import CacheDBConfig
+from langroid.cachedb.redis_cachedb import RedisCacheConfig
+from langroid.language_models.model_info import ModelInfo, get_model_info
+from langroid.parsing.agent_chats import parse_message
+from langroid.parsing.file_attachment import FileAttachment
+from langroid.parsing.parse_json import parse_imperfect_json, top_level_json_field
+from langroid.prompts.dialog import collate_chat_history
+from langroid.utils.configuration import settings
+from langroid.utils.output.printing import show_if_debug
+
+logger = logging.getLogger(__name__)
+
+
+def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+    pass
+
+
+async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+    pass
+
+
+FunctionCallTypes = Literal["none", "auto"]
+ToolChoiceTypes = Literal["none", "auto", "required"]
+ToolTypes = Literal["function"]
+
+DEFAULT_CONTEXT_LENGTH = 16_000
+
+
+class StreamEventType(Enum):
+    TEXT = 1
+    FUNC_NAME = 2
+    FUNC_ARGS = 3
+    TOOL_NAME = 4
+    TOOL_ARGS = 5
+    REASONING = 6
+
+
+class RetryParams(BaseSettings):
+    max_retries: int = 5
+    initial_delay: float = 1.0
+    exponential_base: float = 1.3
+    jitter: bool = True
+
+
+class LLMConfig(BaseSettings):
+    """
+    Common configuration for all language models.
+    """
+
+    type: str = "openai"
+    streamer: Optional[Callable[[Any], None]] = noop_fn
+    streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
+    api_base: str | None = None
+    formatter: None | str = None
+    # specify None if you want to use the full max output tokens of the model
+    max_output_tokens: int | None = 8192
+    timeout: int = 20  # timeout for API requests
+    chat_model: str = ""
+    completion_model: str = ""
+    temperature: float = 0.0
+    chat_context_length: int | None = None
+    async_stream_quiet: bool = False  # suppress streaming output in async mode?
+    completion_context_length: int | None = None
+    # if input length + max_output_tokens > context length of model,
+    # we will try shortening requested output
+    min_output_tokens: int = 64
+    use_completion_for_chat: bool = False  # use completion model for chat?
+    # use chat model for completion? For OpenAI models, this MUST be set to True!
+    use_chat_for_completion: bool = True
+    stream: bool = True  # stream output from API?
+    # TODO: we could have a `stream_reasoning` flag here to control whether to show
+    # reasoning output from reasoning models
+    cache_config: None | CacheDBConfig = RedisCacheConfig()
+    thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
+    retry_params: RetryParams = RetryParams()
+
+    @property
+    def model_max_output_tokens(self) -> int:
+        if self.max_output_tokens:
+            return self.max_output_tokens
+        # Build fallback names by progressively stripping provider prefixes
+        # (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
+        # succeeds even before OpenAIGPT.__init__ strips the prefix.
+        parts = self.chat_model.split("/")
+        fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
+        return get_model_info(self.chat_model, fallbacks).max_output_tokens
+
+
+class LLMFunctionCall(BaseModel):
+    """
+    Structure of LLM response indicating it "wants" to call a function.
+    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
+    """
+
+    name: str  # name of function to call
+    arguments: Optional[Dict[str, Any]] = None
+
+    @staticmethod
+    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall":
+        """
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+        fun_call = LLMFunctionCall(name=message["name"])
+        fun_args_str = message["arguments"]
+        # sometimes may be malformed with invalid indents,
+        # so we try to be safe by removing newlines.
+        if fun_args_str is not None:
+            fun_args_str = fun_args_str.replace("\n", "").strip()
+            dict_or_list = parse_imperfect_json(fun_args_str)
+
+            if not isinstance(dict_or_list, dict):
+                raise ValueError(
+                    f"""
+                        Invalid function args: {fun_args_str}
+                        parsed as {dict_or_list},
+                        which is not a valid dict.
+                        """
+                )
+            fun_args = dict_or_list
+        else:
+            fun_args = None
+        fun_call.arguments = fun_args
+
+        return fun_call
+
+    def __str__(self) -> str:
+        return "FUNC: " + json.dumps(self.model_dump(), indent=2)
+
+
+class LLMFunctionSpec(BaseModel):
+    """
+    Description of a function available for the LLM to use.
+    To be used when calling the LLM `chat()` method with the `functions` parameter.
+    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
+    """
+
+    name: str
+    description: str
+    parameters: Dict[str, Any]
+
+
+class OpenAIToolCall(BaseModel):
+    """
+    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
+    See https://platform.openai.com/docs/api-reference/chat/create
+
+    Attributes:
+        id: The id of the tool call.
+        type: The type of the tool call;
+            only "function" is currently possible (7/26/24).
+        function: The function call.
+    """
+
+    id: str | None = None
+    type: ToolTypes = "function"
+    function: LLMFunctionCall | None = None
+    extra_content: Dict[str, Any] | None = None
+
+    @staticmethod
+    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall":
+        """
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+        id = message["id"]
+        type = message["type"]
+        function = LLMFunctionCall.from_dict(message["function"])
+        extra_content = message.get("extra_content")
+        return OpenAIToolCall(
+            id=id, type=type, function=function, extra_content=extra_content
+        )
+
+    def __str__(self) -> str:
+        if self.function is None:
+            return ""
+        return "OAI-TOOL: " + json.dumps(self.function.model_dump(), indent=2)
+
+
+class OpenAIToolSpec(BaseModel):
+    type: ToolTypes
+    strict: Optional[bool] = None
+    function: LLMFunctionSpec
+
+
+class OpenAIJsonSchemaSpec(BaseModel):
+    strict: Optional[bool] = None
+    function: LLMFunctionSpec
+
+    def to_dict(self) -> Dict[str, Any]:
+        json_schema: Dict[str, Any] = {
+            "name": self.function.name,
+            "description": self.function.description,
+            "schema": self.function.parameters,
+        }
+        if self.strict is not None:
+            json_schema["strict"] = self.strict
+
+        return {
+            "type": "json_schema",
+            "json_schema": json_schema,
+        }
+
+
+class LLMTokenUsage(BaseModel):
+    """
+    Usage of tokens by an LLM.
+    """
+
+    prompt_tokens: int = 0
+    cached_tokens: int = 0
+    completion_tokens: int = 0
+    cost: float = 0.0
+    calls: int = 0  # how many API calls - not used as of 2025-04-04
+
+    def reset(self) -> None:
+        self.prompt_tokens = 0
+        self.cached_tokens = 0
+        self.completion_tokens = 0
+        self.cost = 0.0
+        self.calls = 0
+
+    def __str__(self) -> str:
+        return (
+            f"Tokens = "
+            f"(prompt {self.prompt_tokens}, cached {self.cached_tokens}, "
+            f"completion {self.completion_tokens}), "
+            f"Cost={self.cost}, Calls={self.calls}"
+        )
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+
+class Role(str, Enum):
+    """
+    Possible roles for a message in a chat.
+    """
+
+    USER = "user"
+    SYSTEM = "system"
+    ASSISTANT = "assistant"
+    FUNCTION = "function"
+    TOOL = "tool"
+
+
+class LLMMessage(BaseModel):
+    """
+    Class representing an entry in the msg-history sent to the LLM API.
+    It could be one of these:
+    - a user message
+    - an LLM ("Assistant") response
+    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
+    - a result or results from executing a fn or tool-call(s)
+    """
+
+    role: Role
+    name: Optional[str] = None
+    tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
+    tool_id: str = ""  # used by OpenAIAssistant
+    # None means "no content" (the model returned only a tool/function call).
+    # This is distinct from "" and is dropped from the API payload by api_dict;
+    # see api_dict for how a fully-empty message is handled per-API.
+    content: Optional[str] = None
+    files: List[FileAttachment] = []
+    function_call: Optional[LLMFunctionCall] = None
+    tool_calls: Optional[List[OpenAIToolCall]] = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    # link to corresponding chat document, for provenance/rewind purposes
+    chat_document_id: str = ""
+
+    def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]:
+        """
+        Convert to dictionary for API request, keeping ONLY
+        the fields that are expected in an API call!
+        E.g., DROP the tool_id, since it is only for use in the Assistant API,
+            not the completion API.
+
+        Args:
+            has_system_role: whether the message has a system role (if not,
+                set to "user" role)
+        Returns:
+            dict: dictionary representation of LLM message
+        """
+        d = self.model_dump()
+        files: List[FileAttachment] = d.pop("files")
+        if len(files) > 0 and self.role == Role.USER:
+            # In there are files, then content is an array of
+            # different content-parts
+            d["content"] = [
+                dict(
+                    type="text",
+                    text=self.content or "",
+                )
+            ] + [f.to_dict(model) for f in self.files]
+
+        # if there is a key k = "role" with value "system", change to "user"
+        # in case has_system_role is False
+        if not has_system_role and "role" in d and d["role"] == "system":
+            d["role"] = "user"
+            if d.get("content"):
+                d["content"] = "[ADDITIONAL SYSTEM MESSAGE:]\n\n" + d["content"]
+        # drop None values since API doesn't accept them (this omits `content`
+        # entirely when it is None, i.e. "no content")
+        dict_no_none = {k: v for k, v in d.items() if v is not None}
+        if "name" in dict_no_none and dict_no_none["name"] == "":
+            # OpenAI API does not like empty name
+            del dict_no_none["name"]
+        if "function_call" in dict_no_none:
+            # arguments must be a string
+            if "arguments" in dict_no_none["function_call"]:
+                dict_no_none["function_call"]["arguments"] = json.dumps(
+                    dict_no_none["function_call"]["arguments"]
+                )
+        if dict_no_none.get("tool_calls"):
+            # convert tool calls to API format
+            for tc in dict_no_none["tool_calls"]:
+                if "arguments" in tc["function"]:
+                    # arguments must be a string
+                    if tc["function"]["arguments"] is None:
+                        tc["function"]["arguments"] = "{}"
+                    else:
+                        tc["function"]["arguments"] = json.dumps(
+                            tc["function"]["arguments"]
+                        )
+                if "extra_content" in tc and tc["extra_content"] is None:
+                    del tc["extra_content"]
+        else:
+            # An empty tool-call list is not a call and conveys no useful API
+            # information. Omitting it also lets the empty-message fallback
+            # below produce a valid message.
+            dict_no_none.pop("tool_calls", None)
+        # A message with empty content (None was dropped above, or "") AND no
+        # tool/function call would be an entirely empty message, which some APIs
+        # (e.g. Gemini) reject; fall back to a single space in that case only.
+        # When there IS a tool/function call, empty content is fine (and Gemini
+        # 3.x in fact REQUIRES it — it rejects an assistant turn that carries
+        # both a call and non-empty text content).
+        has_call = bool(dict_no_none.get("tool_calls")) or (
+            dict_no_none.get("function_call") is not None
+        )
+        if not has_call and not dict_no_none.get("content"):
+            dict_no_none["content"] = " "
+        # IMPORTANT! drop fields that are not expected in API call
+        dict_no_none.pop("tool_id", None)
+        dict_no_none.pop("timestamp", None)
+        dict_no_none.pop("chat_document_id", None)
+        return dict_no_none
+
+    def __str__(self) -> str:
+        if self.function_call is not None:
+            content = "FUNC: " + json.dumps(self.function_call)
+        else:
+            content = self.content or ""
+        name_str = f" ({self.name})" if self.name else ""
+        return f"{self.role} {name_str}: {content}"
+
+
+class LLMResponse(BaseModel):
+    """
+    Class representing response from LLM.
+    """
+
+    # None means the model returned NO content (e.g. only a tool/function
+    # call), which is distinct from an empty string "". Preserving this
+    # distinction lets the message be faithfully reproduced downstream
+    # (see ChatDocument.content_is_none and LLMMessage.content).
+    message: Optional[str] = None
+    reasoning: str = ""  # optional reasoning text from reasoning models
+    # Original message text including inline thought signatures (e.g.
+    # <thinking>...</thinking>). Only set when reasoning was extracted
+    # from the message text via get_reasoning_final(); NOT set when
+    # reasoning comes from a separate API field (e.g. reasoning_content),
+    # since in that case the message text never contained thought tags.
+    message_with_reasoning: Optional[str] = None
+    # TODO tool_id needs to generalize to multi-tool calls
+    tool_id: str = ""  # used by OpenAIAssistant
+    oai_tool_calls: Optional[List[OpenAIToolCall]] = None
+    function_call: Optional[LLMFunctionCall] = None
+    usage: Optional[LLMTokenUsage] = None
+    cached: bool = False
+
+    def __str__(self) -> str:
+        if self.function_call is not None:
+            return str(self.function_call)
+        elif self.oai_tool_calls:
+            return "\n".join(str(tc) for tc in self.oai_tool_calls)
+        else:
+            return self.message or ""
+
+    def tools_content(self) -> str:
+        if self.function_call is not None:
+            return str(self.function_call)
+        elif self.oai_tool_calls:
+            return "\n".join(str(tc) for tc in self.oai_tool_calls)
+        else:
+            return ""
+
+    def to_LLMMessage(self) -> LLMMessage:
+        """Convert LLM response to an LLMMessage, to be included in the
+        message-list sent to the API.
+        This is currently NOT used in any significant way in the library, and is only
+        provided as a utility to construct a message list for the API when directly
+        working with an LLM object.
+
+        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
+        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
+        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
+        """
+        return LLMMessage(
+            role=Role.ASSISTANT,
+            content=self.message,
+            name=None if self.function_call is None else self.function_call.name,
+            function_call=self.function_call,
+            tool_calls=self.oai_tool_calls,
+        )
+
+    def get_recipient_and_message(
+        self,
+        recognize_recipient_in_content: bool = True,
+    ) -> Tuple[str, str]:
+        """
+        If `message` or `function_call` of an LLM response contains an explicit
+        recipient name, return this recipient name and `message` stripped
+        of the recipient name if specified.
+
+        Two cases:
+        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
+        (b) `message` is empty and function_call/tool_call with explicit `recipient`
+
+        Args:
+            recognize_recipient_in_content (bool): When True (default), parses
+                message text for ``TO[<recipient>]:<content>`` patterns and
+                top-level JSON ``{"recipient": "..."}`` fields. When False,
+                only function_call/tool_call ``recipient`` fields are checked.
+
+        Returns:
+            (str): name of recipient, which may be empty string if no recipient
+            (str): content of message
+
+        """
+
+        if self.function_call is not None:
+            # in this case we ignore message, since all information is in function_call
+            msg = ""
+            args = self.function_call.arguments
+            recipient = ""
+            if isinstance(args, dict):
+                recipient = args.get("recipient", "")
+            return recipient, msg
+        else:
+            msg = self.message or ""
+            if self.oai_tool_calls is not None:
+                # get the first tool that has a recipient field, if any
+                for tc in self.oai_tool_calls:
+                    if tc.function is not None and tc.function.arguments is not None:
+                        recipient = tc.function.arguments.get(
+                            "recipient"
+                        )  # type: ignore
+                        if recipient is not None and recipient != "":
+                            return recipient, ""
+
+        if not recognize_recipient_in_content:
+            return "", msg
+
+        # It's not a function or tool call, so continue looking to see
+        # if a recipient is specified in the message.
+
+        # First check if message contains "TO: <recipient> <content>"
+        recipient_name, content = parse_message(msg) if msg is not None else ("", "")
+        # check if there is a top level json that specifies 'recipient',
+        # and retain the entire message as content.
+        if recipient_name == "":
+            recipient_name = top_level_json_field(msg, "recipient") if msg else ""
+            content = msg
+        return recipient_name, content
+
+
+# Define an abstract base class for language models
+class LanguageModel(ABC):
+    """
+    Abstract base class for language models.
+    """
+
+    # usage cost by model, accumulates here
+    usage_cost_dict: Dict[str, LLMTokenUsage] = {}
+
+    def __init__(self, config: LLMConfig = LLMConfig()):
+        self.config = config
+        self.chat_model_orig = config.chat_model
+
+    @staticmethod
+    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]:
+        """
+        Create a language model.
+        Args:
+            config: configuration for language model
+        Returns: instance of language model
+        """
+        if type(config) is LLMConfig:
+            raise ValueError(
+                """
+                Cannot create a Language Model object from LLMConfig.
+                Please specify a specific subclass of LLMConfig e.g.,
+                OpenAIGPTConfig. If you are creating a ChatAgent from
+                a ChatAgentConfig, please specify the `llm` field of this config
+                as a specific subclass of LLMConfig, e.g., OpenAIGPTConfig.
+                """
+            )
+        from langroid.language_models.azure_openai import AzureGPT
+        from langroid.language_models.mock_lm import MockLM, MockLMConfig
+        from langroid.language_models.openai_gpt import OpenAIGPT
+
+        if config is None or config.type is None:
+            return None
+
+        if config.type == "mock":
+            return MockLM(cast(MockLMConfig, config))
+
+        openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
+
+        if config.type == "azure":
+            openai = AzureGPT
+        else:
+            openai = OpenAIGPT
+        cls = dict(
+            openai=openai,
+        ).get(config.type, openai)
+        return cls(config)  # type: ignore
+
+    @staticmethod
+    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]:
+        """
+        Given an even-length sequence of strings, split into a sequence of pairs
+
+        Args:
+            lst (List[str]): sequence of strings
+
+        Returns:
+            List[Tuple[str,str]]: sequence of pairs of strings
+        """
+        evens = lst[::2]
+        odds = lst[1::2]
+        return list(zip(evens, odds))
+
+    @staticmethod
+    def get_chat_history_components(
+        messages: List[LLMMessage],
+    ) -> Tuple[str, List[Tuple[str, str]], str]:
+        """
+        From the chat history, extract system prompt, user-assistant turns, and
+        final user msg.
+
+        Args:
+            messages (List[LLMMessage]): List of messages in the chat history
+
+        Returns:
+            Tuple[str, List[Tuple[str,str]], str]:
+                system prompt, user-assistant turns, final user msg
+
+        """
+        # Handle various degenerate cases
+        messages = [m for m in messages]  # copy
+        DUMMY_SYS_PROMPT = "You are a helpful assistant."
+        DUMMY_USER_PROMPT = "Follow the instructions above."
+        if len(messages) == 0 or messages[0].role != Role.SYSTEM:
+            logger.warning("No system msg, creating dummy system prompt")
+            messages.insert(0, LLMMessage(content=DUMMY_SYS_PROMPT, role=Role.SYSTEM))
+        system_prompt = messages[0].content or ""
+
+        # now we have messages = [Sys,...]
+        if len(messages) == 1:
+            logger.warning(
+                "Got only system message in chat history, creating dummy user prompt"
+            )
+            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, msg, ...]
+
+        if messages[1].role != Role.USER:
+            messages.insert(1, LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, user, ...]
+        if messages[-1].role != Role.USER:
+            logger.warning(
+                "Last message in chat history is not a user message,"
+                " creating dummy user prompt"
+            )
+            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, user, ..., user]
+        # so we omit the first and last elements and make pairs of user-asst messages
+        conversation = [m.content or "" for m in messages[1:-1]]
+        user_prompt = messages[-1].content or ""
+        pairs = LanguageModel.user_assistant_pairs(conversation)
+        return system_prompt, pairs, user_prompt
+
+    @abstractmethod
+    def set_stream(self, stream: bool) -> bool:
+        """Enable or disable streaming output from API.
+        Return previous value of stream."""
+        pass
+
+    @abstractmethod
+    def get_stream(self) -> bool:
+        """Get streaming status"""
+        pass
+
+    @abstractmethod
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        pass
+
+    @abstractmethod
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        pass
+
+    @abstractmethod
+    def chat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """
+        Get chat-completion response from LLM.
+
+        Args:
+            messages: message-history to send to the LLM
+            max_tokens: max tokens to generate
+            tools: tools available for the LLM to use in its response
+            tool_choice: tool call mode, one of "none", "auto", "required",
+                or a dict specifying a specific tool.
+            functions: functions available for LLM to call (deprecated)
+            function_call: function calling mode, "auto", "none", or a specific fn
+                    (deprecated)
+        """
+
+        pass
+
+    @abstractmethod
+    async def achat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """Async version of `chat`. See `chat` for details."""
+        pass
+
+    def __call__(self, prompt: str, max_tokens: int) -> LLMResponse:
+        return self.generate(prompt, max_tokens)
+
+    @staticmethod
+    def _fallback_model_names(model: str) -> List[str]:
+        parts = model.split("/")
+        fallbacks = []
+        for i in range(1, len(parts)):
+            fallbacks.append("/".join(parts[i:]))
+        return fallbacks
+
+    def info(self) -> ModelInfo:
+        """Info of relevant chat model"""
+        orig_model = (
+            self.config.completion_model
+            if self.config.use_completion_for_chat
+            else self.chat_model_orig
+        )
+        return get_model_info(orig_model, self._fallback_model_names(orig_model))
+
+    def completion_info(self) -> ModelInfo:
+        """Info of relevant completion model"""
+        orig_model = (
+            self.chat_model_orig
+            if self.config.use_chat_for_completion
+            else self.config.completion_model
+        )
+        return get_model_info(orig_model, self._fallback_model_names(orig_model))
+
+    def supports_functions_or_tools(self) -> bool:
+        """
+        Does this Model's API support "native" tool-calling, i.e.
+        can we call the API with arguments that contain a list of available tools,
+        and their schemas?
+        Note that, given the plethora of LLM provider APIs this determination is
+        imperfect at best, and leans towards returning True.
+        When the API calls fails with an error indicating tools are not supported,
+        then users are encouraged to use the Langroid-based prompt-based
+        ToolMessage mechanism, which works with ANY LLM. To enable this,
+        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
+        """
+        return self.info().has_tools
+
+    def chat_context_length(self) -> int:
+        return self.config.chat_context_length or DEFAULT_CONTEXT_LENGTH
+
+    def completion_context_length(self) -> int:
+        return self.config.completion_context_length or DEFAULT_CONTEXT_LENGTH
+
+    def chat_cost(self) -> Tuple[float, float, float]:
+        """
+        Return the cost per 1000 tokens for chat completions.
+
+        Returns:
+            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
+                per 1000 tokens
+        """
+        return (0.0, 0.0, 0.0)
+
+    def reset_usage_cost(self) -> None:
+        for mdl in [self.config.chat_model, self.config.completion_model]:
+            if mdl is None:
+                return
+            if mdl not in self.usage_cost_dict:
+                self.usage_cost_dict[mdl] = LLMTokenUsage()
+            counter = self.usage_cost_dict[mdl]
+            counter.reset()
+
+    def update_usage_cost(
+        self, chat: bool, prompts: int, completions: int, cost: float
+    ) -> None:
+        """
+        Update usage cost for this LLM.
+        Args:
+            chat (bool): whether to update for chat or completion model
+            prompts (int): number of tokens used for prompts
+            completions (int): number of tokens used for completions
+            cost (float): total token cost in USD
+        """
+        mdl = self.config.chat_model if chat else self.config.completion_model
+        if mdl is None:
+            return
+        if mdl not in self.usage_cost_dict:
+            self.usage_cost_dict[mdl] = LLMTokenUsage()
+        counter = self.usage_cost_dict[mdl]
+        counter.prompt_tokens += prompts
+        counter.completion_tokens += completions
+        counter.cost += cost
+        counter.calls += 1
+
+    @classmethod
+    def usage_cost_summary(cls) -> str:
+        s = ""
+        for model, counter in cls.usage_cost_dict.items():
+            s += f"{model}: {counter}\n"
+        return s
+
+    @classmethod
+    def tot_tokens_cost(cls) -> Tuple[int, float]:
+        """
+        Return total tokens used and total cost across all models.
+        """
+        total_tokens = 0
+        total_cost = 0.0
+        for counter in cls.usage_cost_dict.values():
+            total_tokens += counter.total_tokens
+            total_cost += counter.cost
+        return total_tokens, total_cost
+
+    def get_reasoning_final(self, message: str) -> Tuple[str, str]:
+        """Extract "reasoning" and "final answer" from an LLM response, if the
+        reasoning is found within configured delimiters, like <think>, </think>.
+        E.g.,
+        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
+
+        Args:
+            message (str): message from LLM
+
+        Returns:
+            Tuple[str, str]: reasoning, final answer
+        """
+        start, end = self.config.thought_delimiters
+        if start in message and end in message:
+            parts = message.split(start)
+            if len(parts) > 1:
+                reasoning, final = parts[1].split(end)
+                return reasoning, final
+        return "", message
+
+    def followup_to_standalone(
+        self, chat_history: List[Tuple[str, str]], question: str
+    ) -> str:
+        """
+        Given a chat history and a question, convert it to a standalone question.
+        Args:
+            chat_history: list of tuples of (question, answer)
+            query: follow-up question
+
+        Returns: standalone version of the question
+        """
+        history = collate_chat_history(chat_history)
+
+        prompt = f"""
+        You are an expert at understanding a CHAT HISTORY between an AI Assistant
+        and a User, and you are highly skilled in rephrasing the User's FOLLOW-UP
+        QUESTION/REQUEST as a STANDALONE QUESTION/REQUEST that can be understood
+        WITHOUT the context of the chat history.
+
+        Below is the CHAT HISTORY. When the User asks you to rephrase a
+        FOLLOW-UP QUESTION/REQUEST, your ONLY task is to simply return the
+        question REPHRASED as a STANDALONE QUESTION/REQUEST, without any additional
+        text or context.
+
+        <CHAT_HISTORY>
+        {history}
+        </CHAT_HISTORY>
+        """.strip()
+
+        follow_up_question = f"""
+        Please rephrase this as a stand-alone question or request:
+        <FOLLOW-UP-QUESTION-OR-REQUEST>
+        {question}
+        </FOLLOW-UP-QUESTION-OR-REQUEST>
+        """.strip()
+
+        show_if_debug(prompt, "FOLLOWUP->STANDALONE-PROMPT= ")
+        standalone = (
+            self.chat(
+                messages=[
+                    LLMMessage(role=Role.SYSTEM, content=prompt),
+                    LLMMessage(role=Role.USER, content=follow_up_question),
+                ],
+                max_tokens=1024,
+            ).message
+            or ""
+        )
+        standalone = standalone.strip()
+
+        show_if_debug(prompt, "FOLLOWUP->STANDALONE-RESPONSE= ")
+        return standalone
+
+
+class StreamingIfAllowed:
+    """Context to temporarily enable or disable streaming, if allowed globally via
+    `settings.stream`"""
+
+    def __init__(self, llm: LanguageModel, stream: bool = True):
+        self.llm = llm
+        self.stream = stream
+
+    def __enter__(self) -> None:
+        self.old_stream = self.llm.set_stream(settings.stream and self.stream)
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.llm.set_stream(self.old_stream)
+</file>
+
+<file path="langroid/language_models/client_cache.py">
+"""
+Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
+"""
+
+import asyncio
+import atexit
+import hashlib
+import inspect
+import threading
+import time
+import weakref
+from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, Union, cast
+
+from cerebras.cloud.sdk import AsyncCerebras, Cerebras
+from groq import AsyncGroq, Groq
+from httpx import Timeout
+from openai import AsyncOpenAI, OpenAI
+
+# Cache for client instances, keyed by hashed configuration parameters.
+# Value is a tuple of (client instance, last_used_monotonic_seconds).
+_client_cache: Dict[str, Tuple[Any, float]] = {}
+_client_cache_lock = threading.RLock()
+
+# Keep track of clients for cleanup
+_all_clients: weakref.WeakSet[Any] = weakref.WeakSet()
+
+
+def _get_cache_key(client_type: str, **kwargs: Any) -> str:
+    """
+    Generate a cache key from client type and configuration parameters.
+    Uses the same approach as OpenAIGPT._cache_lookup for consistency.
+
+    Args:
+        client_type: Type of client (e.g., "openai", "groq", "cerebras")
+        **kwargs: Configuration parameters (api_key, base_url, timeout, etc.)
+
+    Returns:
+        SHA256 hash of the configuration as a hex string
+    """
+    # Convert kwargs to sorted string representation
+    sorted_kwargs_str = str(sorted(kwargs.items()))
+
+    # Create raw key combining client type and sorted kwargs
+    raw_key = f"{client_type}:{sorted_kwargs_str}"
+
+    # Hash the key for consistent length and to handle complex objects
+    hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
+
+    return hashed_key
+
+
+def wrap_api_key_provider_async(
+    provider: Callable[[], str],
+) -> Callable[[], Awaitable[str]]:
+    """
+    Wrap a sync API-key provider for use with ``AsyncOpenAI``.
+
+    ``AsyncOpenAI`` awaits its ``api_key`` callable, so a plain sync
+    provider must be wrapped in an async function. The sync provider is run
+    in a worker thread, so a blocking token refresh cannot stall the event
+    loop. Providers must therefore be thread-safe -- the sync client may
+    call them from arbitrary threads anyway.
+
+    Args:
+        provider: Callable returning a (possibly short-lived) API key.
+
+    Returns:
+        Async callable returning the same key.
+    """
+
+    async def _provider() -> str:
+        return await asyncio.to_thread(provider)
+
+    return _provider
+
+
+def _api_key_cache_component(api_key: Union[str, Callable[[], str]]) -> Any:
+    """
+    Cache-key component for an API key that may be a rotating-key provider.
+
+    A callable provider is keyed on its identity rather than any token value,
+    so rotating tokens never create new cache entries and tokens are never
+    retained in cache keys. The id() cannot be recycled while the entry
+    lives, because the cached client holds a strong reference to the
+    provider (directly for sync clients, via the async wrapper's closure
+    for async clients).
+    """
+    if callable(api_key):
+        return ("api_key_provider", id(api_key))
+    return api_key
+
+
+def _get_cached_client(cache_key: str) -> Optional[Any]:
+    """Get cached client and refresh its last-used timestamp.
+
+    Must be called while holding ``_client_cache_lock``.
+    """
+    entry = _client_cache.get(cache_key)
+    if entry is None:
+        return None
+
+    client, _ = entry
+    _client_cache[cache_key] = (client, time.monotonic())
+    return client
+
+
+def _store_client(cache_key: str, client: Any) -> None:
+    """Store a client in the cache with the current timestamp.
+
+    Must be called while holding ``_client_cache_lock``.
+    """
+    _client_cache[cache_key] = (client, time.monotonic())
+    _all_clients.add(client)
+
+
+def get_openai_client(
+    api_key: Union[str, Callable[[], str]],
+    base_url: Optional[str] = None,
+    organization: Optional[str] = None,
+    timeout: Union[float, Timeout] = 120.0,
+    default_headers: Optional[Dict[str, str]] = None,
+    http_client: Optional[Any] = None,
+    http_client_config: Optional[Dict[str, Any]] = None,
+) -> OpenAI:
+    """
+    Get or create a singleton OpenAI client with the given configuration.
+
+    Args:
+        api_key: OpenAI API key, or a callable returning a fresh key
+            (for short-lived rotating credentials); a callable is resolved
+            per-request by the OpenAI client and is excluded from the
+            cache key (the cache is keyed on the provider's identity)
+        base_url: Optional base URL for API
+        organization: Optional organization ID
+        timeout: Request timeout
+        default_headers: Optional default headers
+        http_client: Optional httpx.Client instance
+        http_client_config: Optional config dict for creating httpx.Client
+
+    Returns:
+        OpenAI client instance
+    """
+    if isinstance(timeout, (int, float)):
+        timeout = Timeout(timeout)
+
+    # If http_client is provided directly, don't cache (complex object)
+    if http_client is not None:
+        client = OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            organization=organization,
+            timeout=timeout,
+            default_headers=default_headers,
+            http_client=http_client,
+        )
+        _all_clients.add(client)
+        return client
+
+    cache_key = _get_cache_key(
+        "openai",
+        api_key=_api_key_cache_component(api_key),
+        base_url=base_url,
+        organization=organization,
+        timeout=timeout,
+        default_headers=default_headers,
+        http_client_config=http_client_config,  # Include config in cache key
+    )
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(OpenAI, cached_client)
+
+        created_http_client = None
+        if http_client_config is not None:
+            try:
+                from httpx import Client
+            except ImportError:
+                raise ValueError(
+                    "httpx is required to use http_client_config. "
+                    "Install it with: pip install httpx"
+                )
+            created_http_client = Client(**http_client_config)
+
+        client = OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            organization=organization,
+            timeout=timeout,
+            default_headers=default_headers,
+            http_client=created_http_client,  # Use the client created from config
+        )
+
+        _store_client(cache_key, client)
+    return client
+
+
+def get_async_openai_client(
+    api_key: Union[str, Callable[[], str]],
+    base_url: Optional[str] = None,
+    organization: Optional[str] = None,
+    timeout: Union[float, Timeout] = 120.0,
+    default_headers: Optional[Dict[str, str]] = None,
+    http_client: Optional[Any] = None,
+    http_client_config: Optional[Dict[str, Any]] = None,
+) -> AsyncOpenAI:
+    """
+    Get or create a singleton AsyncOpenAI client with the given configuration.
+
+    Args:
+        api_key: OpenAI API key, or a callable returning a fresh key
+            (for short-lived rotating credentials); a callable is resolved
+            per-request by the OpenAI client and is excluded from the
+            cache key (the cache is keyed on the provider's identity)
+        base_url: Optional base URL for API
+        organization: Optional organization ID
+        timeout: Request timeout
+        default_headers: Optional default headers
+        http_client: Optional httpx.AsyncClient instance
+        http_client_config: Optional config dict for creating httpx.AsyncClient
+
+    Returns:
+        AsyncOpenAI client instance
+    """
+    if isinstance(timeout, (int, float)):
+        timeout = Timeout(timeout)
+
+    api_key_arg: Union[str, Callable[[], Awaitable[str]]]
+    if callable(api_key):
+        # AsyncOpenAI awaits its api_key callable, so wrap the sync provider
+        api_key_arg = wrap_api_key_provider_async(api_key)
+    else:
+        api_key_arg = api_key
+
+    # If http_client is provided directly, don't cache (complex object)
+    if http_client is not None:
+        client = AsyncOpenAI(
+            api_key=api_key_arg,
+            base_url=base_url,
+            organization=organization,
+            timeout=timeout,
+            default_headers=default_headers,
+            http_client=http_client,
+        )
+        _all_clients.add(client)
+        return client
+
+    cache_key = _get_cache_key(
+        "async_openai",
+        api_key=_api_key_cache_component(api_key),
+        base_url=base_url,
+        organization=organization,
+        timeout=timeout,
+        default_headers=default_headers,
+        http_client_config=http_client_config,  # Include config in cache key
+    )
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(AsyncOpenAI, cached_client)
+
+        created_http_client = None
+        if http_client_config is not None:
+            try:
+                from httpx import AsyncClient
+            except ImportError:
+                raise ValueError(
+                    "httpx is required to use http_client_config. "
+                    "Install it with: pip install httpx"
+                )
+            created_http_client = AsyncClient(**http_client_config)
+
+        client = AsyncOpenAI(
+            api_key=api_key_arg,
+            base_url=base_url,
+            organization=organization,
+            timeout=timeout,
+            default_headers=default_headers,
+            http_client=created_http_client,  # Use the client created from config
+        )
+
+        _store_client(cache_key, client)
+    return client
+
+
+def get_groq_client(api_key: str) -> Groq:
+    """
+    Get or create a singleton Groq client with the given configuration.
+
+    Args:
+        api_key: Groq API key
+
+    Returns:
+        Groq client instance
+    """
+    cache_key = _get_cache_key("groq", api_key=api_key)
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(Groq, cached_client)
+
+        client = Groq(api_key=api_key)
+        _store_client(cache_key, client)
+    return client
+
+
+def get_async_groq_client(api_key: str) -> AsyncGroq:
+    """
+    Get or create a singleton AsyncGroq client with the given configuration.
+
+    Args:
+        api_key: Groq API key
+
+    Returns:
+        AsyncGroq client instance
+    """
+    cache_key = _get_cache_key("async_groq", api_key=api_key)
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(AsyncGroq, cached_client)
+
+        client = AsyncGroq(api_key=api_key)
+        _store_client(cache_key, client)
+    return client
+
+
+def get_cerebras_client(api_key: str) -> Cerebras:
+    """
+    Get or create a singleton Cerebras client with the given configuration.
+
+    Args:
+        api_key: Cerebras API key
+
+    Returns:
+        Cerebras client instance
+    """
+    cache_key = _get_cache_key("cerebras", api_key=api_key)
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(Cerebras, cached_client)
+
+        client = Cerebras(api_key=api_key)
+        _store_client(cache_key, client)
+    return client
+
+
+def get_async_cerebras_client(api_key: str) -> AsyncCerebras:
+    """
+    Get or create a singleton AsyncCerebras client with the given configuration.
+
+    Args:
+        api_key: Cerebras API key
+
+    Returns:
+        AsyncCerebras client instance
+    """
+    cache_key = _get_cache_key("async_cerebras", api_key=api_key)
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(AsyncCerebras, cached_client)
+
+        client = AsyncCerebras(api_key=api_key)
+        _store_client(cache_key, client)
+    return client
+
+
+def prune_cache(max_age_seconds: float) -> int:
+    """
+    Remove cache entries whose last-used time exceeds *max_age_seconds*.
+
+    Evicted clients are **not** closed here because they may still be serving
+    in-flight requests.  Cleanup is handled by the ``atexit`` handler and the
+    garbage collector.
+
+    Args:
+        max_age_seconds: Maximum age (in seconds) for cache entries to keep.
+            Entries older than this value are removed.
+
+    Returns:
+        Number of cache entries removed.
+    """
+    if max_age_seconds < 0:
+        raise ValueError("max_age_seconds must be non-negative")
+
+    now = time.monotonic()
+
+    with _client_cache_lock:
+        stale_keys = [
+            key
+            for key, (_, last_used_at) in _client_cache.items()
+            if now - last_used_at > max_age_seconds
+        ]
+
+        for key in stale_keys:
+            _client_cache.pop(key)
+
+    # Don't close evicted clients here — they may still be serving in-flight
+    # requests. The atexit handler and GC will clean them up.
+
+    return len(stale_keys)
+
+
+def _cleanup_clients() -> None:
+    """
+    Cleanup function to close all cached clients on exit.
+    Called automatically via atexit.
+    """
+    for client in list(_all_clients):
+        if hasattr(client, "close") and callable(client.close):
+            try:
+                # Check if close is a coroutine function (async)
+                if inspect.iscoroutinefunction(client.close):
+                    # For async clients, we can't await in atexit
+                    # They will be cleaned up by the OS
+                    pass
+                else:
+                    # Sync clients can be closed directly
+                    client.close()
+            except Exception:
+                pass  # Ignore errors during cleanup
+
+
+# Register cleanup function to run on exit
+atexit.register(_cleanup_clients)
+
+
+# For testing purposes
+def _clear_cache() -> None:
+    """Clear the client cache. Only for testing."""
+    with _client_cache_lock:
+        _client_cache.clear()
+</file>
+
+<file path="SECURITY.md">
+# Security Policy
+
+## Threat model — please read this before reporting
+
+Langroid is a framework for building applications in which an LLM generates
+code and queries that are then executed. Several **optional** agents exist for
+exactly that purpose:
+
+- `TableChatAgent`, `LanceDocChatAgent`, and `VectorStore.compute_from_docs`
+  evaluate LLM-generated **pandas expressions** with `eval()`.
+- `SQLChatAgent` executes LLM-generated **SQL** against a database you supply.
+- `Neo4jChatAgent`, `ArangoChatAgent`, and `CSVGraphAgent` execute
+  LLM-generated **Cypher / AQL** against a graph database you supply.
+
+Executing model-generated code against your own data *is the feature*. An LLM
+is not a trust boundary: if any untrusted text reaches the model's context, you
+must assume the model can be induced to emit any query or expression the
+grammar allows. Langroid cannot prevent this, and does not claim to.
+
+### What is, and is not, a security boundary
+
+The following are **best-effort hardening, not security boundaries**:
+
+- `sanitize_command()` / `CommandValidator` / `safe_eval_globals()` in
+  `langroid/utils/pandas_utils.py`
+- `_DANGEROUS_SQL_PATTERNS` and the `sqlglot` AST checks in `SQLChatAgent`
+- `validate_cypher_query()` / `validate_aql_query()` in the graph agents
+
+They exist to stop an *unlucky* LLM, not a *determined attacker*. The pandas
+path uses explicit allowlists for AST nodes, methods, operators, variables, and
+builtins. The SQL, Cypher, and AQL paths use denylists over full query grammars
+that span multiple dialects, quoting and escaping forms, and function families.
+Such denylists cannot be made complete. We patch clear gaps opportunistically,
+but we do not treat a newly found way around them as a vulnerability in
+Langroid.
+
+The **actual** security boundaries for a Langroid deployment are:
+
+- the privileges of the database credential you hand the agent;
+- the OS user, container, or VM the process runs in;
+- filesystem permissions and network egress rules.
+
+### Deploying these agents safely
+
+If you expose any of the code- or query-executing agents to untrusted input:
+
+- **Give the agent a least-privilege database role.** For `SQLChatAgent`, a
+  read-only, non-superuser role with `GRANT SELECT` on only the intended
+  tables. In PostgreSQL, server-side file reads and writes normally require a
+  superuser, membership in `pg_read_server_files` or
+  `pg_write_server_files`, or a direct grant on a privileged function.
+  `COPY ... PROGRAM` instead requires superuser access or membership in the
+  distinct `pg_execute_server_program` role. Server-side `lo_import` and
+  `lo_export` default to superuser-only use, but an administrator can grant
+  access to those functions directly. Ordinary password-authenticated
+  `dblink` connections do not require any of those roles. Do not install
+  unneeded extensions, and revoke access to dangerous extensions and
+  functions, including `dblink`, in addition to granting only the intended
+  table privileges. Review any site-specific functions and grants as well.
+- **Run the process in a container or VM** with no credentials, secrets, or
+  data you are unwilling to expose to the LLM.
+- **Treat `allow_dangerous_operations=True` and `full_eval=True` as
+  "I am providing my own sandbox."** The first permits dangerous database
+  operations. The second disables pandas AST validation while retaining the
+  restricted globals from `safe_eval_globals()`. Both are documented as
+  trusted-environment-only.
+
+## Reporting a vulnerability
+
+Report privately — **not** via GitHub Issues, Discussions, or any other public
+forum:
+
+1. Go to
+   **[Security Advisories](https://github.com/langroid/langroid/security/advisories)**.
+2. Click **"Report a vulnerability"**.
+3. Include a proof of concept that works against a **default configuration**.
+
+We aim to acknowledge in-scope reports within 7 days.
+
+### In scope
+
+- Vulnerabilities in core framework code: tool dispatch and the agent/tool
+  trust boundary, message routing, sender verification.
+- Parsing and deserialization flaws (XXE, unsafe deserialization, decompression
+  bombs) in the document and message parsers.
+- Path traversal in the file tools (`ReadFileTool`, `WriteFileTool`,
+  `ListDirTool`) and in repository / folder ingestion.
+- Credential or secret leakage in a default configuration that does not depend
+  on any of the specific exclusions below. The out-of-scope rules take
+  precedence over this category.
+- **A code path that skips a documented safety gate entirely** — that is, a
+  *missing call* to a validator, not a *bypass* of one.
+- **A statement the `allowed_statement_types` allowlist misclassifies.** The
+  allowlist is a different kind of control from the denylists above: it decides
+  what a statement *does* over a closed set of statement kinds, so a query that
+  performs a write the allowlist did not authorize — for example by nesting it
+  where the classifier does not look — is a bounded, fixable defect and is in
+  scope.
+- Vulnerable dependencies with a demonstrated impact on Langroid.
+
+### Out of scope
+
+The following will be closed without a fix, an advisory, or a CVE request:
+
+- New bypasses of the SQL, Cypher, or AQL denylists: previously unlisted
+  functions, alternate quoting or escaping forms (backticks, Unicode escapes,
+  schema qualification), or dialect-specific syntax. See "What is, and is not,
+  a security boundary" above.
+- Sandbox escapes from the pandas `eval()` path when `full_eval=True`,
+  including object-graph traversal via dunder attributes. `full_eval=True`
+  disables the AST validator by design.
+- Anything requiring `allow_dangerous_operations=True`.
+- "The LLM can be prompt-injected into generating a harmful query." This is the
+  documented threat model, not a defect.
+- Reports that assume the agent was given a superuser or otherwise
+  over-privileged database credential.
+- Theoretical reports with no working proof of concept against a default
+  configuration.
+
+Reports that chain off a previous advisory as an "incomplete fix" are judged
+against this same scope: if the original issue was a missing gate we will fix
+it, and if it was a denylist gap it is out of scope.
+
+## Supported versions
+
+Security fixes ship in the latest release. Please upgrade to the current
+version of `langroid` rather than requesting backports.
+</file>
+
 <file path="langroid/agent/task.py">
 from __future__ import annotations
 
@@ -49967,7 +51922,11 @@ class Task:
         # copy the agent's config, so that we don't modify the original agent's config,
         # which may be shared by other agents.
         try:
-            config_copy = copy.deepcopy(agent.config)
+            from langroid.agent.tool_policy import deepcopy_config_sharing_policy
+
+            # the tool_policy hook is shared by reference (never deep-copied),
+            # so its state (budgets, approvals) stays global across copies
+            config_copy = deepcopy_config_sharing_policy(agent.config)
             agent.config = config_copy
         except Exception:
             logger.warning(
@@ -52144,576 +54103,1051 @@ class Task:
         return seq_idx < 0
 </file>
 
-<file path="langroid/language_models/client_cache.py">
+<file path="langroid/agent/special/sql/sql_chat_agent.py">
 """
-Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
+Agent that allows interaction with an SQL database using SQLAlchemy library.
+The agent can execute SQL queries in the database and return the result.
+
+Functionality includes:
+- adding table and column context
+- asking a question about a SQL schema
 """
 
-import asyncio
-import atexit
-import hashlib
-import inspect
-import threading
-import time
-import weakref
-from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, Union, cast
+import logging
+import re
+from typing import (
+    Any,
+    Dict,
+    FrozenSet,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
-from cerebras.cloud.sdk import AsyncCerebras, Cerebras
-from groq import AsyncGroq, Groq
-from httpx import Timeout
-from openai import AsyncOpenAI, OpenAI
+from rich.console import Console
 
-# Cache for client instances, keyed by hashed configuration parameters.
-# Value is a tuple of (client instance, last_used_monotonic_seconds).
-_client_cache: Dict[str, Tuple[Any, float]] = {}
-_client_cache_lock = threading.RLock()
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import Entity
+from langroid.utils.constants import SEND_TO
 
-# Keep track of clients for cleanup
-_all_clients: weakref.WeakSet[Any] = weakref.WeakSet()
+try:
+    from sqlalchemy import MetaData, Row, create_engine, inspect, text
+    from sqlalchemy.engine import Engine
+    from sqlalchemy.exc import ResourceClosedError, SQLAlchemyError
+    from sqlalchemy.orm import Session, sessionmaker
+except ImportError as e:
+    raise LangroidImportError(extra="sql", error=str(e))
+
+try:
+    # sqlglot is required for the statement-type allowlist enforced in
+    # `_validate_query`. Importing it at module load ensures the security
+    # guarantee cannot be silently bypassed by a partial/stale install.
+    import sqlglot
+    from sqlglot import expressions as sqlglot_exp
+except ImportError as e:
+    raise LangroidImportError(extra="sql", error=str(e))
+
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.agent.chat_document import ChatDocument
+from langroid.agent.special.sql.utils.description_extractors import (
+    extract_schema_descriptions,
+)
+from langroid.agent.special.sql.utils.populate_metadata import (
+    populate_metadata,
+    populate_metadata_with_schema_tools,
+)
+from langroid.agent.special.sql.utils.system_message import (
+    DEFAULT_SYS_MSG,
+    SCHEMA_TOOLS_SYS_MSG,
+)
+from langroid.agent.special.sql.utils.tools import (
+    GetColumnDescriptionsTool,
+    GetTableNamesTool,
+    GetTableSchemaTool,
+    RunQueryTool,
+)
+from langroid.agent.tools.orchestration import (
+    DonePassTool,
+    DoneTool,
+    ForwardTool,
+    PassTool,
+)
+from langroid.language_models.base import Role
+from langroid.vector_store.base import VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+
+console = Console()
+
+DEFAULT_SQL_CHAT_SYSTEM_MESSAGE = """
+{mode}
+
+You do not need to attempt answering a question with just one query. 
+You could make a sequence of SQL queries to help you write the final query.
+Also if you receive a null or other unexpected result,
+(a) make sure you use the available TOOLs correctly, and 
+(b) see if you have made an assumption in your SQL query, and try another way, 
+   or use `run_query` to explore the database table contents before submitting your 
+   final query. For example when searching for "males" you may have used "gender= 'M'",
+in your query, because you did not know that the possible genders in the table
+are "Male" and "Female". 
+
+Start by asking what I would like to know about the data.
+
+"""
+
+ADDRESSING_INSTRUCTION = """
+IMPORTANT - Whenever you are NOT writing a SQL query, make sure you address the user
+using {prefix}User (NO SPACE between {prefix} and User). 
+You MUST use the EXACT syntax {prefix}User !!!
+
+In other words, you ALWAYS write EITHER:
+ - a SQL query using the `run_query` tool, 
+ - OR address the user using {prefix}User
+"""
+
+DONE_INSTRUCTION = f"""
+When you are SURE you have the CORRECT answer to a user's query or request, 
+use the `{DoneTool.name()}` with `content` set to the answer or result.
+If you DO NOT think you have the answer to the user's query or request,
+you SHOULD NOT use the `{DoneTool.name()}` tool.
+Instead, you must CONTINUE to improve your queries (tools) to get the correct answer,
+and finally use the `{DoneTool.name()}` tool to send the correct answer to the user.
+"""
 
 
-def _get_cache_key(client_type: str, **kwargs: Any) -> str:
-    """
-    Generate a cache key from client type and configuration parameters.
-    Uses the same approach as OpenAIGPT._cache_lookup for consistency.
+SQL_ERROR_MSG = "There was an error in your SQL Query"
+
+
+# Dialect-specific SQL patterns that enable code execution, arbitrary file
+# access, or other escapes from the database engine. Matched against the raw
+# query text (case-insensitive) as a defense-in-depth layer in addition to the
+# sqlglot-based statement-type allowlist.
+_DANGEROUS_SQL_PATTERNS: List["re.Pattern[str]"] = [
+    # PostgreSQL: COPY ... FROM/TO PROGRAM executes shell commands as the DB
+    # server OS user.
+    re.compile(r"\bcopy\b[\s\S]*\bprogram\b", re.IGNORECASE),
+    # PostgreSQL server-side filesystem / log / WAL access. Match the whole
+    # pg_read*, pg_stat*, pg_ls*, pg_current_logfile family rather than naming
+    # individual functions: near-name functions (pg_read_file vs
+    # pg_read_server_file, pg_ls_logdir vs pg_ls_dir, pg_stat_file, ...) all
+    # yield the same file/metadata disclosure primitive.
+    re.compile(r"\bpg_(read|stat|ls|current_logfile)[A-Za-z0-9_]*\s*\(", re.IGNORECASE),
+    re.compile(r"\blo_(import|export)\b", re.IGNORECASE),
+    # MySQL/MariaDB filesystem
+    re.compile(r"\binto\s+(outfile|dumpfile)\b", re.IGNORECASE),
+    re.compile(r"\bload_file\s*\(", re.IGNORECASE),
+    re.compile(r"\bload\s+data\b", re.IGNORECASE),
+    # SQLite: load_extension enables loading arbitrary shared objects;
+    # ATTACH can read/write arbitrary files. The DATABASE keyword is optional
+    # per the SQLite grammar (ATTACH [DATABASE] expr AS schema-name), so match
+    # both forms.
+    re.compile(r"\bload_extension\s*\(", re.IGNORECASE),
+    re.compile(r"\battach\b(\s+database)?\s+['\"\w]", re.IGNORECASE),
+    # SQL Server: command execution, OLE automation, and ad-hoc external data
+    # sources (OPENDATASOURCE is the connection-string counterpart of
+    # OPENROWSET; both can read remote/UNC files).
+    re.compile(r"\bxp_cmdshell\b", re.IGNORECASE),
+    re.compile(r"\bsp_oacreate\b", re.IGNORECASE),
+    re.compile(r"\bsp_oamethod\b", re.IGNORECASE),
+    re.compile(r"\b(openrowset|opendatasource)\b", re.IGNORECASE),
+    re.compile(r"\bbulk\s+insert\b", re.IGNORECASE),
+    # Generic: stored-program creation and procedural language extensions.
+    # LANGUAGE / RULE / EVENT TRIGGER / FOREIGN TABLE are additional PostgreSQL
+    # primitives that can register attacker-controlled code.
+    re.compile(
+        r"\bcreate\s+(or\s+replace\s+)?(function|procedure|trigger|language|rule|event\s+trigger|foreign\s+table)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\bcreate\s+extension\b", re.IGNORECASE),
+]
+
+
+# AST-side blocklist of dangerous SQL function names, applied after sqlglot
+# parses the query. The raw-text regex above can be bypassed by quoted
+# identifiers, inline comments, or schema qualification -- e.g.
+# `"pg_read_file"(...)`, `pg_read_file/**/(...)`,
+# `pg_catalog."pg_read_file"(...)` -- but sqlglot normalizes all those forms
+# to the same function-call node, so a name-based check on the parsed tree
+# catches every variant (GHSA-6xc5-4r68-67fc).
+_DANGEROUS_FUNCTION_NAMES: FrozenSet[str] = frozenset(
+    {
+        "load_file",  # MySQL/MariaDB filesystem read
+        "load_extension",  # SQLite extension loader
+        "sp_oacreate",  # MSSQL OLE automation
+        "sp_oamethod",  # MSSQL OLE automation
+    }
+)
+# Prefix families: any function whose normalized name starts with one of these
+# is considered dangerous. Mirrors the `\bpg_(read|stat|ls|current_logfile)...`
+# and `\blo_(import|export)\b` regex coverage, but on the parsed AST.
+_DANGEROUS_FUNCTION_PREFIXES: Tuple[str, ...] = (
+    "pg_read",
+    "pg_stat",
+    "pg_ls",
+    "pg_current_logfile",
+    "lo_",
+)
+
+
+def _is_dangerous_function_name(name: str) -> bool:
+    """True if `name` (case-folded, unquoted) is a dangerous SQL function."""
+    if name in _DANGEROUS_FUNCTION_NAMES:
+        return True
+    return any(name.startswith(p) for p in _DANGEROUS_FUNCTION_PREFIXES)
+
+
+def _called_function_names(stmt: Any) -> Iterator[str]:
+    """Yield normalized (case-folded, unquoted, schema-stripped) names of
+    every function-call node in `stmt` (a parsed sqlglot expression)."""
+    for node in stmt.find_all(sqlglot_exp.Func):
+        if isinstance(node, sqlglot_exp.Anonymous):
+            this = node.this
+            if isinstance(this, sqlglot_exp.Expression):
+                name = this.name
+            else:
+                name = str(this) if this is not None else ""
+        else:
+            # Typed sqlglot Func subclass: its class key is the SQL keyword.
+            name = getattr(type(node), "key", "") or ""
+        # Strip any schema qualifier that leaked into the name string.
+        name = name.rsplit(".", 1)[-1].strip().lower()
+        if name:
+            yield name
+
+
+def _creates_table(into: Any) -> bool:
+    """Whether a Select's ``into`` arg names a table rather than a variable.
+
+    ``SELECT ... INTO tbl`` creates and populates a table, but MySQL's
+    ``SELECT ... INTO @var`` merely assigns a user variable and writes nothing.
+    sqlglot models the latter as a ``Table`` wrapping a ``Parameter``, so the
+    target's inner node distinguishes them.
 
     Args:
-        client_type: Type of client (e.g., "openai", "groq", "cerebras")
-        **kwargs: Configuration parameters (api_key, base_url, timeout, etc.)
+        into: The ``into`` arg of a sqlglot ``Select``, or None.
 
     Returns:
-        SHA256 hash of the configuration as a hex string
+        True if the target names a table.
     """
-    # Convert kwargs to sorted string representation
-    sorted_kwargs_str = str(sorted(kwargs.items()))
-
-    # Create raw key combining client type and sorted kwargs
-    raw_key = f"{client_type}:{sorted_kwargs_str}"
-
-    # Hash the key for consistent length and to handle complex objects
-    hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
-
-    return hashed_key
+    if into is None:
+        return False
+    target = into.this
+    if target is None:
+        return False
+    return not isinstance(getattr(target, "this", None), sqlglot_exp.Parameter)
 
 
-def wrap_api_key_provider_async(
-    provider: Callable[[], str],
-) -> Callable[[], Awaitable[str]]:
-    """
-    Wrap a sync API-key provider for use with ``AsyncOpenAI``.
+def _nested_write_kinds(stmt: Any, kind_map: Dict[Any, str]) -> Set[str]:
+    """Statement kinds that `stmt` performs *below* its top-level node.
 
-    ``AsyncOpenAI`` awaits its ``api_key`` callable, so a plain sync
-    provider must be wrapped in an async function. The sync provider is run
-    in a worker thread, so a blocking token refresh cannot stall the event
-    loop. Providers must therefore be thread-safe -- the sync client may
-    call them from arbitrary threads anyway.
+    A statement's top-level node does not determine what it writes. Both
+
+    - ``WITH x AS (DELETE FROM t RETURNING *) SELECT * FROM x`` (a
+      data-modifying CTE), and
+    - ``SELECT * INTO new_tbl FROM t`` (which creates and populates a table)
+
+    parse with a ``Select`` top node, so classifying on that node alone reports
+    "SELECT" while the engine still performs the write
+    (GHSA-3gpx-vwr3-xvwx / GHSA-wc83-4cvx-p8xc).
 
     Args:
-        provider: Callable returning a (possibly short-lived) API key.
+        stmt: A parsed sqlglot statement.
+        kind_map: Mapping of sqlglot expression type to statement-kind name.
+
+    Only independently executable nested statements count. A ``MERGE``'s
+    ``WHEN ... THEN UPDATE/INSERT/DELETE`` actions parse as child write nodes
+    but are part of the merge itself, so an operator who allows ``MERGE`` must
+    not also be forced to allow standalone ``UPDATE``/``INSERT``/``DELETE``.
 
     Returns:
-        Async callable returning the same key.
+        The set of kind names written by nested nodes, plus ``"CREATE"`` for
+        the ``SELECT ... INTO`` form. Empty for an ordinary read-only query.
+    """
+    write_types = (
+        sqlglot_exp.Insert,
+        sqlglot_exp.Update,
+        sqlglot_exp.Delete,
+        sqlglot_exp.Merge,
+        sqlglot_exp.Create,
+        sqlglot_exp.Drop,
+        sqlglot_exp.Alter,
+        sqlglot_exp.TruncateTable,
+    )
+
+    # Exempt only the node that *is* a ``WHEN ... THEN`` action, by identity.
+    # Exempting everything beneath a ``When`` would also hide a write nested in
+    # the WHEN *condition* -- e.g.
+    # ``WHEN MATCHED AND EXISTS (WITH x AS (DELETE ...) SELECT * FROM x) THEN
+    # UPDATE ...`` -- or one buried inside the action's own subqueries.
+    merge_actions = {
+        id(when.args["then"])
+        for when in stmt.find_all(sqlglot_exp.When)
+        if when.args.get("then") is not None
+    }
+
+    kinds = {
+        kind_map[type(node)]
+        for node in stmt.find_all(*write_types)
+        if node is not stmt and type(node) in kind_map and id(node) not in merge_actions
+    }
+    # `SELECT ... INTO tbl` carries no nested Create node; it is flagged by the
+    # `into` arg on a Select. Check every Select, not just the top-level one:
+    # under a set operation (`SELECT ... INTO t UNION ALL SELECT ...`) the top
+    # node is a Union and the `into` sits on a branch.
+    selects = list(stmt.find_all(sqlglot_exp.Select))
+    if isinstance(stmt, sqlglot_exp.Select):
+        selects.append(stmt)
+    if any(_creates_table(sel.args.get("into")) for sel in selects):
+        kinds.add("CREATE")
+    return kinds
+
+
+# Default set of SQL statement types the agent is allowed to execute when
+# `allow_dangerous_operations` is False. SELECT-only is safe for Q&A workloads.
+_DEFAULT_ALLOWED_STATEMENTS: List[str] = ["SELECT"]
+
+
+class SQLChatAgentConfig(ChatAgentConfig):
+    system_message: str = DEFAULT_SQL_CHAT_SYSTEM_MESSAGE
+    user_message: None | str = None
+    cache: bool = True  # cache results
+    debug: bool = False
+    use_helper: bool = True
+    is_helper: bool = False
+    stream: bool = True  # allow streaming where needed
+    database_uri: str = ""  # Database URI
+    database_session: None | Session = None  # Database session
+    vecdb: None | VectorStoreConfig = None
+    context_descriptions: Dict[str, Dict[str, Union[str, Dict[str, str]]]] = {}
+    use_schema_tools: bool = False
+    multi_schema: bool = False
+    # whether the agent is used in a continuous chat with user,
+    # as opposed to returning a result from the task.run()
+    chat_mode: bool = False
+    addressing_prefix: str = ""
+    max_result_rows: int | None = None  # limit query results to this
+    max_retained_tokens: int | None = None  # limit history of query results to this
+
+    # --- Security controls (see CVE-2026-25879) ---------------------------
+    # By default, the agent only executes SELECT statements and rejects any
+    # query that matches a known dangerous pattern (e.g. PostgreSQL
+    # `COPY ... FROM PROGRAM`, MySQL `INTO OUTFILE`, SQLite `load_extension`,
+    # MSSQL `xp_cmdshell`). The LLM-generated SQL is influenceable by prompt
+    # injection — including injection via data the LLM reads back from the
+    # database — so executing it without restrictions is unsafe when the DB
+    # role has elevated privileges.
+    #
+    # To enable writes: extend allowed_statement_types, e.g. ["SELECT",
+    # "INSERT", "UPDATE", "DELETE"]. To disable all checks (only do this with
+    # a least-privilege DB role and trusted prompts): set
+    # allow_dangerous_operations=True.
+    allowed_statement_types: List[str] = list(_DEFAULT_ALLOWED_STATEMENTS)
+    allow_dangerous_operations: bool = False
+
+    """
+    Optional, but strongly recommended, context descriptions for tables, columns, 
+    and relationships. It should be a dictionary where each key is a table name 
+    and its value is another dictionary. 
+
+    In this inner dictionary:
+    - The 'description' key corresponds to a string description of the table.
+    - The 'columns' key corresponds to another dictionary where each key is a 
+    column name and its value is a string description of that column.
+    - The 'relationships' key corresponds to another dictionary where each key 
+    is another table name and the value is a description of the relationship to 
+    that table.
+
+    If multi_schema support is enabled, the tables names in the description
+    should be of the form 'schema_name.table_name'.
+
+    For example:
+    {
+        'table1': {
+            'description': 'description of table1',
+            'columns': {
+                'column1': 'description of column1 in table1',
+                'column2': 'description of column2 in table1'
+            }
+        },
+        'table2': {
+            'description': 'description of table2',
+            'columns': {
+                'column3': 'description of column3 in table2',
+                'column4': 'description of column4 in table2'
+            }
+        }
+    }
     """
 
-    async def _provider() -> str:
-        return await asyncio.to_thread(provider)
 
-    return _provider
-
-
-def _api_key_cache_component(api_key: Union[str, Callable[[], str]]) -> Any:
+class SQLChatAgent(ChatAgent):
     """
-    Cache-key component for an API key that may be a rotating-key provider.
-
-    A callable provider is keyed on its identity rather than any token value,
-    so rotating tokens never create new cache entries and tokens are never
-    retained in cache keys. The id() cannot be recycled while the entry
-    lives, because the cached client holds a strong reference to the
-    provider (directly for sync clients, via the async wrapper's closure
-    for async clients).
+    Agent for chatting with a SQL database
     """
-    if callable(api_key):
-        return ("api_key_provider", id(api_key))
-    return api_key
 
+    used_run_query: bool = False
+    llm_responded: bool = False
 
-def _get_cached_client(cache_key: str) -> Optional[Any]:
-    """Get cached client and refresh its last-used timestamp.
+    def __init__(self, config: "SQLChatAgentConfig") -> None:
+        """Initialize the SQLChatAgent.
 
-    Must be called while holding ``_client_cache_lock``.
-    """
-    entry = _client_cache.get(cache_key)
-    if entry is None:
+        Raises:
+            ValueError: If database information is not provided in the config.
+        """
+        self._validate_config(config)
+        self.config: SQLChatAgentConfig = config
+        self._init_database()
+        self._init_metadata()
+        self._init_table_metadata()
+        self.final_instructions = ""
+
+        # Caution - this updates the self.config.system_message!
+        self._init_system_message()
+        super().__init__(config)
+        self._init_tools()
+        if self.config.is_helper:
+            self.system_tool_format_instructions += self.final_instructions
+
+        if self.config.use_helper:
+            # helper_config.system_message is now the fully-populated sys msg of
+            # the main SQLAgent.
+            self.helper_config = self.config.model_copy()
+            self.helper_config.is_helper = True
+            self.helper_config.use_helper = False
+            self.helper_config.chat_mode = False
+            self.helper_agent = SQLHelperAgent(self.helper_config)
+
+    def _validate_config(self, config: "SQLChatAgentConfig") -> None:
+        """Validate the configuration to ensure all necessary fields are present."""
+        if config.database_session is None and config.database_uri is None:
+            raise ValueError("Database information must be provided")
+
+    def _init_database(self) -> None:
+        """Initialize the database engine and session."""
+        if self.config.database_session:
+            self.Session = self.config.database_session
+            self.engine = self.Session.bind
+        else:
+            self.engine = create_engine(self.config.database_uri)
+            self.Session = sessionmaker(bind=self.engine)()
+
+    def _init_metadata(self) -> None:
+        """Initialize the database metadata."""
+        if self.engine is None:
+            raise ValueError("Database engine is None")
+        self.metadata: MetaData | List[MetaData] = []
+
+        if self.config.multi_schema:
+            logger.info(
+                "Initializing SQLChatAgent with database: %s",
+                self.engine,
+            )
+
+            self.metadata = []
+            inspector = inspect(self.engine)
+
+            for schema in inspector.get_schema_names():
+                metadata = MetaData(schema=schema)
+                metadata.reflect(self.engine)
+                self.metadata.append(metadata)
+
+                logger.info(
+                    "Initializing SQLChatAgent with database: %s, schema: %s, "
+                    "and tables: %s",
+                    self.engine,
+                    schema,
+                    metadata.tables,
+                )
+        else:
+            self.metadata = MetaData()
+            self.metadata.reflect(self.engine)
+            logger.info(
+                "SQLChatAgent initialized with database: %s and tables: %s",
+                self.engine,
+                self.metadata.tables,
+            )
+
+    def _init_table_metadata(self) -> None:
+        """Initialize metadata for the tables present in the database."""
+        if not self.config.context_descriptions and isinstance(self.engine, Engine):
+            self.config.context_descriptions = extract_schema_descriptions(
+                self.engine, self.config.multi_schema
+            )
+
+        if self.config.use_schema_tools:
+            self.table_metadata = populate_metadata_with_schema_tools(
+                self.metadata, self.config.context_descriptions
+            )
+        else:
+            self.table_metadata = populate_metadata(
+                self.metadata, self.config.context_descriptions
+            )
+
+    def _init_system_message(self) -> None:
+        """Initialize the system message."""
+        message = self._format_message()
+        self.config.system_message = self.config.system_message.format(mode=message)
+
+        if not self.config.allow_dangerous_operations:
+            allowed = sorted(
+                t.strip().upper() for t in self.config.allowed_statement_types
+            )
+            self.config.system_message += (
+                f"\n\nIMPORTANT - SECURITY POLICY:\n"
+                f"You may ONLY issue SQL queries whose top-level statement "
+                f"type is one of: {allowed}. Any other statement type "
+                f"(e.g. DDL, COPY, EXEC, multi-statement scripts that "
+                f"include a disallowed type) will be REJECTED by the "
+                f"executor and not run.\n"
+            )
+
+        if self.config.chat_mode:
+            self.config.addressing_prefix = self.config.addressing_prefix or SEND_TO
+            self.config.system_message += ADDRESSING_INSTRUCTION.format(
+                prefix=self.config.addressing_prefix
+            )
+        else:
+            self.config.system_message += DONE_INSTRUCTION
+
+    def _init_tools(self) -> None:
+        """Initialize sys msg and tools."""
+        # Create a custom RunQueryTool class with the desired max_retained_tokens
+        if self.config.max_retained_tokens is not None:
+
+            class CustomRunQueryTool(RunQueryTool):
+                _max_retained_tokens = self.config.max_retained_tokens
+
+            self.enable_message([CustomRunQueryTool, ForwardTool])
+        else:
+            self.enable_message([RunQueryTool, ForwardTool])
+
+        if self.config.use_schema_tools:
+            self._enable_schema_tools()
+        if not self.config.chat_mode:
+            self.enable_message(DoneTool)
+            self.enable_message(DonePassTool)
+
+    def _format_message(self) -> str:
+        if self.engine is None:
+            raise ValueError("Database engine is None")
+
+        """Format the system message based on the engine and table metadata."""
+        return (
+            SCHEMA_TOOLS_SYS_MSG.format(dialect=self.engine.dialect.name)
+            if self.config.use_schema_tools
+            else DEFAULT_SYS_MSG.format(
+                dialect=self.engine.dialect.name, schema_dict=self.table_metadata
+            )
+        )
+
+    def _enable_schema_tools(self) -> None:
+        """Enable tools for schema-related functionalities."""
+        self.enable_message(GetTableNamesTool)
+        self.enable_message(GetTableSchemaTool)
+        self.enable_message(GetColumnDescriptionsTool)
+
+    def llm_response(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> Optional[ChatDocument]:
+        self.llm_responded = True
+        self.used_run_query = False
+        return super().llm_response(message)
+
+    def user_response(
+        self,
+        msg: Optional[str | ChatDocument] = None,
+    ) -> Optional[ChatDocument]:
+        self.llm_responded = False
+        self.used_run_query = False
+        return super().user_response(msg)
+
+    def _clarify_answer_instruction(self) -> str:
+        """
+        Prompt to use when asking LLM to clarify intent of
+        an already-generated response
+        """
+        if self.config.chat_mode:
+            return f"""
+                you must use the TOOL `{ForwardTool.name()}` with the `agent` 
+                parameter set to "User"
+                """
+        else:
+            return f"you must use the TOOL `{DonePassTool.name()}`"
+
+    def _clarifying_message(self) -> str:
+        tools_instruction = f"""
+          For example you may want to use the TOOL
+          `{RunQueryTool.name()}` to further explore the database contents
+        """
+        if self.config.use_schema_tools:
+            tools_instruction += """
+            OR you may want to use one of the schema tools to 
+            explore the database schema
+            """
+        return f"""
+            The intent of your response is not clear:
+            - if you intended this to be the FINAL answer to the user's query,
+                {self._clarify_answer_instruction()}
+            - otherwise, use one of the available tools to make progress 
+                to arrive at the final answer.
+                {tools_instruction}
+            """
+
+    def handle_message_fallback(
+        self, message: str | ChatDocument
+    ) -> str | ForwardTool | ChatDocument | None:
+        """
+        We'd end up here if the current msg has no tool.
+        If this is from LLM, we may need to handle the scenario where
+        it may have "forgotten" to generate a tool.
+        """
+        if (
+            not isinstance(message, ChatDocument)
+            or message.metadata.sender != Entity.LLM
+        ):
+            return None
+        if self.config.chat_mode:
+            # send any Non-tool msg to the user
+            return ForwardTool(agent="User")
+        # Agent intent not clear => use the helper agent to
+        # do what this agent should have done, e.g. generate tool, etc.
+        # This is likelier to succeed since this agent has no "baggage" of
+        # prior conversation, other than the system msg, and special
+        # "Intent-interpretation" instructions.
+        if self._json_schema_available() and self.config.strict_recovery:
+            AnyTool = self._get_any_tool_message(optional=False)
+            self.set_output_format(
+                AnyTool,
+                force_tools=True,
+                use=True,
+                handle=True,
+                instructions=True,
+            )
+            recovery_message = self._strict_recovery_instructions(
+                AnyTool, optional=False
+            )
+            result = self.llm_response(recovery_message)
+            # remove the recovery_message (it has User role) from the chat history,
+            # else it may cause the LLM to directly use the AnyTool.
+            self.delete_last_message(role=Role.USER)  # delete last User-role msg
+            return result
+        elif self.config.use_helper:
+            response = self.helper_agent.llm_response(message)
+            tools = self.try_get_tool_messages(response)
+            if tools:
+                return response
+        # fall back on the clarification message
+        return self._clarifying_message()
+
+    def retry_query(self, e: Exception, query: str) -> str:
+        """
+        Generate an error message for a failed SQL query and return it.
+
+        Parameters:
+        e (Exception): The exception raised during the SQL query execution.
+        query (str): The SQL query that failed.
+
+        Returns:
+        str: The error message.
+        """
+        logger.error(f"SQL Query failed: {query}\nException: {e}")
+
+        # Optional part to be included based on `use_schema_tools`
+        optional_schema_description = ""
+        if not self.config.use_schema_tools:
+            optional_schema_description = f"""\
+            This JSON schema maps SQL database structure. It outlines tables, each 
+            with a description and columns. Each table is identified by a key, and holds
+            a description and a dictionary of columns, with column 
+            names as keys and their descriptions as values.
+            
+            ```json
+            {self.config.context_descriptions}
+            ```"""
+
+        # Construct the error message
+        error_message_template = f"""\
+        {SQL_ERROR_MSG}: '{query}'
+        {str(e)}
+        Run a new query, correcting the errors.
+        {optional_schema_description}"""
+
+        return error_message_template
+
+    def _available_tool_names(self) -> str:
+        return ",".join(self.llm_tools_usable)
+
+    def _tool_result_llm_answer_prompt(self) -> str:
+        """
+        Prompt to use at end of tool result,
+        to guide LLM, for the case where it wants to answer the user's query
+        """
+        if self.config.chat_mode:
+            assert self.config.addressing_prefix != ""
+            return """
+                You must EXPLICITLY address the User with 
+                the addressing prefix according to your instructions,
+                to convey your answer to the User.
+                """
+        else:
+            return f"""
+                you must use the `{DoneTool.name()}` with the `content` 
+                set to the answer or result
+                """
+
+    def _sqlglot_dialect(self) -> Optional[str]:
+        """Map the SQLAlchemy dialect name to a sqlglot dialect name."""
+        if self.engine is None:
+            return None
+        name: str = str(self.engine.dialect.name)
+        # sqlglot uses 'postgres', not 'postgresql'; 'tsql' for MSSQL.
+        mapping: Dict[str, str] = {"postgresql": "postgres", "mssql": "tsql"}
+        return mapping.get(name, name)
+
+    def _validate_query(self, query: str) -> Optional[str]:
+        """
+        Check whether `query` is permitted under the agent's security config.
+
+        Returns None if the query may be executed, otherwise an error message
+        explaining why it was rejected (to be relayed to the LLM).
+        """
+        if self.config.allow_dangerous_operations:
+            return None
+
+        for pat in _DANGEROUS_SQL_PATTERNS:
+            if pat.search(query):
+                logger.warning(
+                    "SQLChatAgent rejected query matching dangerous pattern "
+                    f"{pat.pattern!r}: {query!r}"
+                )
+                return (
+                    f"Query REJECTED for safety: it matches a pattern "
+                    f"({pat.pattern!r}) that enables code execution, "
+                    f"filesystem access, or other unsafe operations. "
+                    f"Rewrite the query without using this construct, or ask "
+                    f"the operator to set `allow_dangerous_operations=True` "
+                    f"on the SQLChatAgent config."
+                )
+
+        allowed = {t.strip().upper() for t in self.config.allowed_statement_types}
+        try:
+            statements = sqlglot.parse(query, read=self._sqlglot_dialect())
+        except Exception as e:
+            logger.warning(f"sqlglot failed to parse query {query!r}: {e}")
+            return (
+                f"Query REJECTED for safety: could not be parsed to verify it "
+                f"is a {sorted(allowed)} statement ({e}). Rewrite the query "
+                f"more simply, or ask the operator to set "
+                f"`allow_dangerous_operations=True` on the SQLChatAgent config."
+            )
+
+        kind_map = {
+            sqlglot_exp.Select: "SELECT",
+            sqlglot_exp.Insert: "INSERT",
+            sqlglot_exp.Update: "UPDATE",
+            sqlglot_exp.Delete: "DELETE",
+            sqlglot_exp.Merge: "MERGE",
+            sqlglot_exp.Create: "CREATE",
+            sqlglot_exp.Drop: "DROP",
+            sqlglot_exp.Alter: "ALTER",
+            sqlglot_exp.TruncateTable: "TRUNCATE",
+            sqlglot_exp.Command: "COMMAND",
+        }
+        for stmt in statements:
+            if stmt is None:
+                continue
+            kind = next(
+                (v for k, v in kind_map.items() if isinstance(stmt, k)),
+                type(stmt).__name__.upper(),
+            )
+            if kind not in allowed:
+                logger.warning(
+                    f"SQLChatAgent rejected {kind} statement (allowed: "
+                    f"{sorted(allowed)}): {query!r}"
+                )
+                return (
+                    f"Query REJECTED for safety: statement type {kind!r} is "
+                    f"not in the allowed list {sorted(allowed)}. Rewrite the "
+                    f"query as one of the allowed statement types, or ask "
+                    f"the operator to extend `allowed_statement_types` "
+                    f"(or set `allow_dangerous_operations=True`) on the "
+                    f"SQLChatAgent config."
+                )
+            # The top-level node alone does not determine what a statement
+            # writes. A data-modifying CTE
+            # (``WITH x AS (DELETE ... RETURNING *) SELECT ...``) and
+            # ``SELECT ... INTO tbl`` both parse with a ``Select`` top node, so
+            # the check above classifies them as SELECT while the engine still
+            # performs the write (GHSA-3gpx-vwr3-xvwx / GHSA-wc83-4cvx-p8xc).
+            nested = _nested_write_kinds(stmt, kind_map)
+            disallowed = sorted(nested - allowed)
+            if disallowed:
+                logger.warning(
+                    f"SQLChatAgent rejected {kind} statement embedding "
+                    f"{disallowed} (allowed: {sorted(allowed)}): {query!r}"
+                )
+                return (
+                    f"Query REJECTED for safety: although this parses as a "
+                    f"{kind} statement, it embeds {disallowed}, which is not "
+                    f"in the allowed list {sorted(allowed)} -- the database "
+                    f"would still perform that write. Rewrite the query "
+                    f"without the embedded statement, or ask the operator to "
+                    f"extend `allowed_statement_types` (or set "
+                    f"`allow_dangerous_operations=True`) on the SQLChatAgent "
+                    f"config."
+                )
+            # AST-side dangerous-function check: catches calls that evaded
+            # `_DANGEROUS_SQL_PATTERNS` via quoted identifiers, inline comments,
+            # or schema qualification (GHSA-6xc5-4r68-67fc).
+            for fn_name in _called_function_names(stmt):
+                if _is_dangerous_function_name(fn_name):
+                    logger.warning(
+                        "SQLChatAgent rejected query calling dangerous "
+                        f"function {fn_name!r}: {query!r}"
+                    )
+                    return (
+                        f"Query REJECTED for safety: it calls function "
+                        f"{fn_name!r}, which enables code execution, "
+                        f"filesystem access, or other unsafe operations. "
+                        f"Rewrite the query without using this function, or "
+                        f"ask the operator to set "
+                        f"`allow_dangerous_operations=True` on the "
+                        f"SQLChatAgent config."
+                    )
         return None
 
-    client, _ = entry
-    _client_cache[cache_key] = (client, time.monotonic())
-    return client
+    def run_query(self, msg: RunQueryTool) -> str:
+        """
+        Handle a RunQueryTool message by executing a SQL query and returning the result.
 
+        Args:
+            msg (RunQueryTool): The tool-message to handle.
 
-def _store_client(cache_key: str, client: Any) -> None:
-    """Store a client in the cache with the current timestamp.
+        Returns:
+            str: The result of executing the SQL query.
+        """
+        query = msg.query
+        session = self.Session
+        self.used_run_query = True
 
-    Must be called while holding ``_client_cache_lock``.
-    """
-    _client_cache[cache_key] = (client, time.monotonic())
-    _all_clients.add(client)
+        rejection = self._validate_query(query)
+        if rejection is not None:
+            return f"""
+        Below is the result from your use of the TOOL `{RunQueryTool.name()}`:
+        ==== result ====
+        {rejection}
+        ================
 
+        Try a different query that complies with the policy above.
+        """
 
-def get_openai_client(
-    api_key: Union[str, Callable[[], str]],
-    base_url: Optional[str] = None,
-    organization: Optional[str] = None,
-    timeout: Union[float, Timeout] = 120.0,
-    default_headers: Optional[Dict[str, str]] = None,
-    http_client: Optional[Any] = None,
-    http_client_config: Optional[Dict[str, Any]] = None,
-) -> OpenAI:
-    """
-    Get or create a singleton OpenAI client with the given configuration.
+        try:
+            logger.info(f"Executing SQL query: {query}")
 
-    Args:
-        api_key: OpenAI API key, or a callable returning a fresh key
-            (for short-lived rotating credentials); a callable is resolved
-            per-request by the OpenAI client and is excluded from the
-            cache key (the cache is keyed on the provider's identity)
-        base_url: Optional base URL for API
-        organization: Optional organization ID
-        timeout: Request timeout
-        default_headers: Optional default headers
-        http_client: Optional httpx.Client instance
-        http_client_config: Optional config dict for creating httpx.Client
-
-    Returns:
-        OpenAI client instance
-    """
-    if isinstance(timeout, (int, float)):
-        timeout = Timeout(timeout)
-
-    # If http_client is provided directly, don't cache (complex object)
-    if http_client is not None:
-        client = OpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            organization=organization,
-            timeout=timeout,
-            default_headers=default_headers,
-            http_client=http_client,
-        )
-        _all_clients.add(client)
-        return client
-
-    cache_key = _get_cache_key(
-        "openai",
-        api_key=_api_key_cache_component(api_key),
-        base_url=base_url,
-        organization=organization,
-        timeout=timeout,
-        default_headers=default_headers,
-        http_client_config=http_client_config,  # Include config in cache key
-    )
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(OpenAI, cached_client)
-
-        created_http_client = None
-        if http_client_config is not None:
+            query_result = session.execute(text(query))
+            session.commit()
             try:
-                from httpx import Client
-            except ImportError:
-                raise ValueError(
-                    "httpx is required to use http_client_config. "
-                    "Install it with: pip install httpx"
-                )
-            created_http_client = Client(**http_client_config)
+                # attempt to fetch results: should work for normal SELECT queries
+                rows = query_result.fetchall()
+                n_rows = len(rows)
+                if self.config.max_result_rows and n_rows > self.config.max_result_rows:
+                    rows = rows[: self.config.max_result_rows]
+                    logger.warning(
+                        f"SQL query produced {n_rows} rows, "
+                        f"limiting to {self.config.max_result_rows}"
+                    )
 
-        client = OpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            organization=organization,
-            timeout=timeout,
-            default_headers=default_headers,
-            http_client=created_http_client,  # Use the client created from config
+                response_message = self._format_rows(rows)
+            except ResourceClosedError:
+                # If we get here, it's a non-SELECT query (UPDATE, INSERT, DELETE)
+                affected_rows = query_result.rowcount  # type: ignore
+                response_message = f"""
+                    Non-SELECT query executed successfully. 
+                    Rows affected: {affected_rows}
+                    """
+
+        except SQLAlchemyError as e:
+            session.rollback()
+            logger.error(f"Failed to execute query: {query}\n{e}")
+            response_message = self.retry_query(e, query)
+        finally:
+            session.close()
+
+        final_message = f"""
+        Below is the result from your use of the TOOL `{RunQueryTool.name()}`:
+        ==== result ====
+        {response_message}
+        ================
+        
+        If you are READY to ANSWER the ORIGINAL QUERY:
+        {self._tool_result_llm_answer_prompt()}
+        OTHERWISE:
+             continue using one of your available TOOLs:
+             {",".join(self.llm_tools_usable)}
+        """
+        return final_message
+
+    def _format_rows(self, rows: Sequence[Row[Any]]) -> str:
+        """
+        Format the rows fetched from the query result into a string.
+
+        Args:
+            rows (list): List of rows fetched from the query result.
+
+        Returns:
+            str: Formatted string representation of rows.
+        """
+        # TODO: UPDATE FORMATTING
+        return (
+            ",\n".join(str(row) for row in rows)
+            if rows
+            else "Query executed successfully."
         )
 
-        _store_client(cache_key, client)
-    return client
-
-
-def get_async_openai_client(
-    api_key: Union[str, Callable[[], str]],
-    base_url: Optional[str] = None,
-    organization: Optional[str] = None,
-    timeout: Union[float, Timeout] = 120.0,
-    default_headers: Optional[Dict[str, str]] = None,
-    http_client: Optional[Any] = None,
-    http_client_config: Optional[Dict[str, Any]] = None,
-) -> AsyncOpenAI:
-    """
-    Get or create a singleton AsyncOpenAI client with the given configuration.
-
-    Args:
-        api_key: OpenAI API key, or a callable returning a fresh key
-            (for short-lived rotating credentials); a callable is resolved
-            per-request by the OpenAI client and is excluded from the
-            cache key (the cache is keyed on the provider's identity)
-        base_url: Optional base URL for API
-        organization: Optional organization ID
-        timeout: Request timeout
-        default_headers: Optional default headers
-        http_client: Optional httpx.AsyncClient instance
-        http_client_config: Optional config dict for creating httpx.AsyncClient
-
-    Returns:
-        AsyncOpenAI client instance
-    """
-    if isinstance(timeout, (int, float)):
-        timeout = Timeout(timeout)
-
-    api_key_arg: Union[str, Callable[[], Awaitable[str]]]
-    if callable(api_key):
-        # AsyncOpenAI awaits its api_key callable, so wrap the sync provider
-        api_key_arg = wrap_api_key_provider_async(api_key)
-    else:
-        api_key_arg = api_key
-
-    # If http_client is provided directly, don't cache (complex object)
-    if http_client is not None:
-        client = AsyncOpenAI(
-            api_key=api_key_arg,
-            base_url=base_url,
-            organization=organization,
-            timeout=timeout,
-            default_headers=default_headers,
-            http_client=http_client,
-        )
-        _all_clients.add(client)
-        return client
-
-    cache_key = _get_cache_key(
-        "async_openai",
-        api_key=_api_key_cache_component(api_key),
-        base_url=base_url,
-        organization=organization,
-        timeout=timeout,
-        default_headers=default_headers,
-        http_client_config=http_client_config,  # Include config in cache key
-    )
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(AsyncOpenAI, cached_client)
-
-        created_http_client = None
-        if http_client_config is not None:
-            try:
-                from httpx import AsyncClient
-            except ImportError:
-                raise ValueError(
-                    "httpx is required to use http_client_config. "
-                    "Install it with: pip install httpx"
-                )
-            created_http_client = AsyncClient(**http_client_config)
-
-        client = AsyncOpenAI(
-            api_key=api_key_arg,
-            base_url=base_url,
-            organization=organization,
-            timeout=timeout,
-            default_headers=default_headers,
-            http_client=created_http_client,  # Use the client created from config
-        )
-
-        _store_client(cache_key, client)
-    return client
-
-
-def get_groq_client(api_key: str) -> Groq:
-    """
-    Get or create a singleton Groq client with the given configuration.
-
-    Args:
-        api_key: Groq API key
-
-    Returns:
-        Groq client instance
-    """
-    cache_key = _get_cache_key("groq", api_key=api_key)
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(Groq, cached_client)
-
-        client = Groq(api_key=api_key)
-        _store_client(cache_key, client)
-    return client
-
-
-def get_async_groq_client(api_key: str) -> AsyncGroq:
-    """
-    Get or create a singleton AsyncGroq client with the given configuration.
-
-    Args:
-        api_key: Groq API key
-
-    Returns:
-        AsyncGroq client instance
-    """
-    cache_key = _get_cache_key("async_groq", api_key=api_key)
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(AsyncGroq, cached_client)
-
-        client = AsyncGroq(api_key=api_key)
-        _store_client(cache_key, client)
-    return client
-
-
-def get_cerebras_client(api_key: str) -> Cerebras:
-    """
-    Get or create a singleton Cerebras client with the given configuration.
-
-    Args:
-        api_key: Cerebras API key
-
-    Returns:
-        Cerebras client instance
-    """
-    cache_key = _get_cache_key("cerebras", api_key=api_key)
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(Cerebras, cached_client)
-
-        client = Cerebras(api_key=api_key)
-        _store_client(cache_key, client)
-    return client
-
-
-def get_async_cerebras_client(api_key: str) -> AsyncCerebras:
-    """
-    Get or create a singleton AsyncCerebras client with the given configuration.
-
-    Args:
-        api_key: Cerebras API key
-
-    Returns:
-        AsyncCerebras client instance
-    """
-    cache_key = _get_cache_key("async_cerebras", api_key=api_key)
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(AsyncCerebras, cached_client)
-
-        client = AsyncCerebras(api_key=api_key)
-        _store_client(cache_key, client)
-    return client
-
-
-def prune_cache(max_age_seconds: float) -> int:
-    """
-    Remove cache entries whose last-used time exceeds *max_age_seconds*.
-
-    Evicted clients are **not** closed here because they may still be serving
-    in-flight requests.  Cleanup is handled by the ``atexit`` handler and the
-    garbage collector.
-
-    Args:
-        max_age_seconds: Maximum age (in seconds) for cache entries to keep.
-            Entries older than this value are removed.
-
-    Returns:
-        Number of cache entries removed.
-    """
-    if max_age_seconds < 0:
-        raise ValueError("max_age_seconds must be non-negative")
-
-    now = time.monotonic()
-
-    with _client_cache_lock:
-        stale_keys = [
-            key
-            for key, (_, last_used_at) in _client_cache.items()
-            if now - last_used_at > max_age_seconds
-        ]
-
-        for key in stale_keys:
-            _client_cache.pop(key)
-
-    # Don't close evicted clients here — they may still be serving in-flight
-    # requests. The atexit handler and GC will clean them up.
-
-    return len(stale_keys)
-
-
-def _cleanup_clients() -> None:
-    """
-    Cleanup function to close all cached clients on exit.
-    Called automatically via atexit.
-    """
-    for client in list(_all_clients):
-        if hasattr(client, "close") and callable(client.close):
-            try:
-                # Check if close is a coroutine function (async)
-                if inspect.iscoroutinefunction(client.close):
-                    # For async clients, we can't await in atexit
-                    # They will be cleaned up by the OS
-                    pass
-                else:
-                    # Sync clients can be closed directly
-                    client.close()
-            except Exception:
-                pass  # Ignore errors during cleanup
-
-
-# Register cleanup function to run on exit
-atexit.register(_cleanup_clients)
-
-
-# For testing purposes
-def _clear_cache() -> None:
-    """Clear the client cache. Only for testing."""
-    with _client_cache_lock:
-        _client_cache.clear()
-</file>
-
-<file path="SECURITY.md">
-# Security Policy
-
-## Threat model — please read this before reporting
-
-Langroid is a framework for building applications in which an LLM generates
-code and queries that are then executed. Several **optional** agents exist for
-exactly that purpose:
-
-- `TableChatAgent`, `LanceDocChatAgent`, and `VectorStore.compute_from_docs`
-  evaluate LLM-generated **pandas expressions** with `eval()`.
-- `SQLChatAgent` executes LLM-generated **SQL** against a database you supply.
-- `Neo4jChatAgent`, `ArangoChatAgent`, and `CSVGraphAgent` execute
-  LLM-generated **Cypher / AQL** against a graph database you supply.
-
-Executing model-generated code against your own data *is the feature*. An LLM
-is not a trust boundary: if any untrusted text reaches the model's context, you
-must assume the model can be induced to emit any query or expression the
-grammar allows. Langroid cannot prevent this, and does not claim to.
-
-### What is, and is not, a security boundary
-
-The following are **best-effort hardening, not security boundaries**:
-
-- `sanitize_command()` / `CommandValidator` / `safe_eval_globals()` in
-  `langroid/utils/pandas_utils.py`
-- `_DANGEROUS_SQL_PATTERNS` and the `sqlglot` AST checks in `SQLChatAgent`
-- `validate_cypher_query()` / `validate_aql_query()` in the graph agents
-
-They exist to stop an *unlucky* LLM, not a *determined attacker*. The pandas
-path uses explicit allowlists for AST nodes, methods, operators, variables, and
-builtins. The SQL, Cypher, and AQL paths use denylists over full query grammars
-that span multiple dialects, quoting and escaping forms, and function families.
-Such denylists cannot be made complete. We patch clear gaps opportunistically,
-but we do not treat a newly found way around them as a vulnerability in
-Langroid.
-
-The **actual** security boundaries for a Langroid deployment are:
-
-- the privileges of the database credential you hand the agent;
-- the OS user, container, or VM the process runs in;
-- filesystem permissions and network egress rules.
-
-### Deploying these agents safely
-
-If you expose any of the code- or query-executing agents to untrusted input:
-
-- **Give the agent a least-privilege database role.** For `SQLChatAgent`, a
-  read-only, non-superuser role with `GRANT SELECT` on only the intended
-  tables. In PostgreSQL, server-side file reads and writes normally require a
-  superuser, membership in `pg_read_server_files` or
-  `pg_write_server_files`, or a direct grant on a privileged function.
-  `COPY ... PROGRAM` instead requires superuser access or membership in the
-  distinct `pg_execute_server_program` role. Server-side `lo_import` and
-  `lo_export` default to superuser-only use, but an administrator can grant
-  access to those functions directly. Ordinary password-authenticated
-  `dblink` connections do not require any of those roles. Do not install
-  unneeded extensions, and revoke access to dangerous extensions and
-  functions, including `dblink`, in addition to granting only the intended
-  table privileges. Review any site-specific functions and grants as well.
-- **Run the process in a container or VM** with no credentials, secrets, or
-  data you are unwilling to expose to the LLM.
-- **Treat `allow_dangerous_operations=True` and `full_eval=True` as
-  "I am providing my own sandbox."** The first permits dangerous database
-  operations. The second disables pandas AST validation while retaining the
-  restricted globals from `safe_eval_globals()`. Both are documented as
-  trusted-environment-only.
-
-## Reporting a vulnerability
-
-Report privately — **not** via GitHub Issues, Discussions, or any other public
-forum:
-
-1. Go to
-   **[Security Advisories](https://github.com/langroid/langroid/security/advisories)**.
-2. Click **"Report a vulnerability"**.
-3. Include a proof of concept that works against a **default configuration**.
-
-We aim to acknowledge in-scope reports within 7 days.
-
-### In scope
-
-- Vulnerabilities in core framework code: tool dispatch and the agent/tool
-  trust boundary, message routing, sender verification.
-- Parsing and deserialization flaws (XXE, unsafe deserialization, decompression
-  bombs) in the document and message parsers.
-- Path traversal in the file tools (`ReadFileTool`, `WriteFileTool`,
-  `ListDirTool`) and in repository / folder ingestion.
-- Credential or secret leakage in a default configuration that does not depend
-  on any of the specific exclusions below. The out-of-scope rules take
-  precedence over this category.
-- **A code path that skips a documented safety gate entirely** — that is, a
-  *missing call* to a validator, not a *bypass* of one.
-- **A statement the `allowed_statement_types` allowlist misclassifies.** The
-  allowlist is a different kind of control from the denylists above: it decides
-  what a statement *does* over a closed set of statement kinds, so a query that
-  performs a write the allowlist did not authorize — for example by nesting it
-  where the classifier does not look — is a bounded, fixable defect and is in
-  scope.
-- Vulnerable dependencies with a demonstrated impact on Langroid.
-
-### Out of scope
-
-The following will be closed without a fix, an advisory, or a CVE request:
-
-- New bypasses of the SQL, Cypher, or AQL denylists: previously unlisted
-  functions, alternate quoting or escaping forms (backticks, Unicode escapes,
-  schema qualification), or dialect-specific syntax. See "What is, and is not,
-  a security boundary" above.
-- Sandbox escapes from the pandas `eval()` path when `full_eval=True`,
-  including object-graph traversal via dunder attributes. `full_eval=True`
-  disables the AST validator by design.
-- Anything requiring `allow_dangerous_operations=True`.
-- "The LLM can be prompt-injected into generating a harmful query." This is the
-  documented threat model, not a defect.
-- Reports that assume the agent was given a superuser or otherwise
-  over-privileged database credential.
-- Theoretical reports with no working proof of concept against a default
-  configuration.
-
-Reports that chain off a previous advisory as an "incomplete fix" are judged
-against this same scope: if the original issue was a missing gate we will fix
-it, and if it was a denylist gap it is out of scope.
-
-## Supported versions
-
-Security fixes ship in the latest release. Please upgrade to the current
-version of `langroid` rather than requesting backports.
+    def get_table_names(self, msg: GetTableNamesTool) -> str:
+        """
+        Handle a GetTableNamesTool message by returning the names of all tables in the
+        database.
+
+        Returns:
+            str: The names of all tables in the database.
+        """
+        if isinstance(self.metadata, list):
+            table_names = [", ".join(md.tables.keys()) for md in self.metadata]
+            return ", ".join(table_names)
+
+        return ", ".join(self.metadata.tables.keys())
+
+    def get_table_schema(self, msg: GetTableSchemaTool) -> str:
+        """
+        Handle a GetTableSchemaTool message by returning the schema of all provided
+        tables in the database.
+
+        Returns:
+            str: The schema of all provided tables in the database.
+        """
+        tables = msg.tables
+        result = ""
+        for table_name in tables:
+            table = self.table_metadata.get(table_name)
+            if table is not None:
+                result += f"{table_name}: {table}\n"
+            else:
+                result += f"{table_name} is not a valid table name.\n"
+        return result
+
+    def get_column_descriptions(self, msg: GetColumnDescriptionsTool) -> str:
+        """
+        Handle a GetColumnDescriptionsTool message by returning the descriptions of all
+        provided columns from the database.
+
+        Returns:
+            str: The descriptions of all provided columns from the database.
+        """
+        table = msg.table
+        columns = msg.columns.split(", ")
+        result = f"\nTABLE: {table}"
+        descriptions = self.config.context_descriptions.get(table)
+
+        for col in columns:
+            result += f"\n{col} => {descriptions['columns'][col]}"  # type: ignore
+        return result
+
+
+class SQLHelperAgent(SQLChatAgent):
+
+    def _clarifying_message(self) -> str:
+        tools_instruction = f"""
+          For example the Agent may have forgotten to use the TOOL
+          `{RunQueryTool.name()}` to further explore the database contents
+        """
+        if self.config.use_schema_tools:
+            tools_instruction += """
+            OR the agent may have forgotten to use one of the schema tools to 
+            explore the database schema
+            """
+
+        return f"""
+            The intent of the Agent's response is not clear:
+            - if you think the Agent intended this as ANSWER to the 
+                user's query,
+                {self._clarify_answer_instruction()}
+            - otherwise, the Agent may have forgotten to 
+              use one of the available tools to make progress 
+                to arrive at the final answer.
+                {tools_instruction}
+            """
+
+    def _init_system_message(self) -> None:
+        """Set up helper sys msg"""
+
+        # Note that self.config.system_message is already set to the
+        # parent SQLAgent's system_message
+        self.config.system_message = f"""
+                You role is to help INTERPRET the INTENT of an 
+                AI agent in a conversation. This Agent was supposed to generate
+                a TOOL/Function-call but forgot to do so, and this is where 
+                you can help, by trying to generate the appropriate TOOL
+                based on your best guess of the Agent's INTENT.
+                
+                Below are the instructions that were given to this Agent: 
+                ===== AGENT INSTRUCTIONS =====
+                {self.config.system_message}
+                ===== END OF AGENT INSTRUCTIONS =====
+                """
+
+        # note that the initial msg in chat history will contain:
+        # - system message
+        # - tool instructions
+        # so the final_instructions will be at the end of this initial msg
+
+        self.final_instructions = f"""        
+        You must take note especially of the TOOLs that are
+        available to the Agent. Your reasoning process should be as follows:
+        
+        - If the Agent's message appears to be an ANSWER to the original query,
+          {self._clarify_answer_instruction()}.
+          CAUTION - You must be absolutely sure that the Agent's message is 
+          an ACTUAL ANSWER to the user's query, and not a failed attempt to use 
+          a TOOL without JSON, e.g. something like "run_query" or "done_tool"
+          without any actual JSON formatting.
+           
+        - Else, if you think the Agent intended to use some type of SQL
+          query tool to READ or UPDATE the table(s), 
+          AND it is clear WHICH TOOL is intended as well as the 
+          TOOL PARAMETERS, then you must generate the JSON-Formatted
+          TOOL with the parameters set based on your understanding.
+          Note that the `{RunQueryTool.name()}` is not ONLY for querying the tables,
+          but also for UPDATING the tables.
+           
+        - Else, use the `{PassTool.name()}` to pass the message unchanged.
+            CAUTION - ONLY use `{PassTool.name()}` if you think the Agent's response
+            is NEITHER an ANSWER, nor an intended SQL QUERY.
+        """
+
+    def llm_response(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> Optional[ChatDocument]:
+        if message is None:
+            return None
+        message_str = message if isinstance(message, str) else message.content
+        instruc_msg = f"""
+        Below is the MESSAGE from the SQL Agent. 
+        Remember your instructions on how to respond based on your understanding
+        of the INTENT of this message:        
+        {self.final_instructions}
+        
+        === AGENT MESSAGE =========
+        {message_str}
+        === END OF AGENT MESSAGE ===
+        """
+        # user response_forget to avoid accumulating the chat history
+        return super().llm_response_forget(instruc_msg)
 </file>
 
 <file path="langroid/agent/chat_agent.py">
@@ -53054,10 +55488,14 @@ class ChatAgent(Agent):
         changed in possibly many ways. Below is an imperfect solution. Caution advised.
         Revisit later.
         """
+        from langroid.agent.tool_policy import deepcopy_config_sharing_policy
+
         agent_cls = type(self)
-        # Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
-        # instead of deepcopy which loses subclass information
-        config_copy = self.config.model_copy(deep=True)
+        # Deep-copy the config WITHOUT mutating it, sharing the tool_policy
+        # hook by REFERENCE (memo-seeded deepcopy): copying the policy would
+        # fork any state it holds (budgets, approval lists) and can fail
+        # outright on unpicklable callables (e.g. objects holding locks).
+        config_copy = deepcopy_config_sharing_policy(self.config)
         config_copy.name = f"{config_copy.name}-{i}"
         new_agent = agent_cls(config_copy)
         new_agent.system_tool_instructions = self.system_tool_instructions
@@ -53985,27 +56423,10 @@ class ChatAgent(Agent):
             request: str = "tool_or_function"
             tool: maybe_optional_type  # type: ignore
 
-            def response(self, agent: ChatAgent) -> None | str | ChatDocument:
-                # One-time use
-                agent.set_output_format(None)
-
-                if self.tool is None:
-                    return None
-
-                # As the ToolMessage schema accepts invalid
-                # `tool.request` values, reparse with the
-                # corresponding tool
-                request = self.tool.request
-                if request not in agent.llm_tools_map:
-                    return None
-                tool = agent.llm_tools_map[request].model_validate_json(
-                    self.tool.to_json()
-                )
-
-                return agent.handle_tool_message(tool)
-
-            async def response_async(
-                self, agent: ChatAgent
+            def response(
+                self,
+                agent: ChatAgent,
+                chat_doc: Optional[ChatDocument] = None,
             ) -> None | str | ChatDocument:
                 # One-time use
                 agent.set_output_format(None)
@@ -54023,7 +56444,43 @@ class ChatAgent(Agent):
                     self.tool.to_json()
                 )
 
-                return await agent.handle_tool_message_async(tool)
+                # pass the chat_doc through, so the recovered tool's policy
+                # check sees the same message context a normal dispatch would
+                return agent._handle_tool_message_with_policy(tool, chat_doc=chat_doc)
+
+            async def response_async(
+                self,
+                agent: ChatAgent,
+                chat_doc: Optional[ChatDocument] = None,
+            ) -> None | str | ChatDocument:
+                # One-time use
+                agent.set_output_format(None)
+
+                if self.tool is None:
+                    return None
+
+                # As the ToolMessage schema accepts invalid
+                # `tool.request` values, reparse with the
+                # corresponding tool
+                request = self.tool.request
+                if request not in agent.llm_tools_map:
+                    return None
+                tool = agent.llm_tools_map[request].model_validate_json(
+                    self.tool.to_json()
+                )
+
+                # pass the chat_doc through, so the recovered tool's policy
+                # check sees the same message context a normal dispatch would
+                return await agent._handle_tool_message_with_policy_async(
+                    tool, chat_doc=chat_doc
+                )
+
+        # This wrapper is a parsing shim for strict recovery, NOT a tool
+        # execution, so it is exempt from the `tool_policy` hook -- which
+        # also guarantees `set_output_format(None)` above always runs. The
+        # re-parsed ACTUAL tool is dispatched through the policy-checked
+        # path, so the policy is consulted exactly once per logical call.
+        AnyTool._tool_policy_exempt = True  # type: ignore[attr-defined]
 
         return AnyTool
 
@@ -55152,1931 +57609,865 @@ class ChatAgent(Agent):
         pass
 </file>
 
-<file path="langroid/language_models/base.py">
-import json
+<file path="langroid/language_models/model_info.py">
 import logging
-from abc import ABC, abstractmethod
-from datetime import datetime, timezone
 from enum import Enum
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
-from pydantic_settings import BaseSettings
-
-from langroid.cachedb.base import CacheDBConfig
-from langroid.cachedb.redis_cachedb import RedisCacheConfig
-from langroid.language_models.model_info import ModelInfo, get_model_info
-from langroid.parsing.agent_chats import parse_message
-from langroid.parsing.file_attachment import FileAttachment
-from langroid.parsing.parse_json import parse_imperfect_json, top_level_json_field
-from langroid.prompts.dialog import collate_chat_history
-from langroid.utils.configuration import settings
-from langroid.utils.output.printing import show_if_debug
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
 
-def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+class ModelProvider(str, Enum):
+    """Enum for model providers"""
+
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+    DEEPSEEK = "deepseek"
+    GOOGLE = "google"
+    MINIMAX = "minimax"
+    UNKNOWN = "unknown"
+
+
+class ModelName(str, Enum):
+    """Parent class for all model name enums"""
+
     pass
 
 
-async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
-    pass
+class OpenAIChatModel(ModelName):
+    """Enum for OpenAI Chat models"""
+
+    GPT3_5_TURBO = "gpt-3.5-turbo"
+    GPT4 = "gpt-4o"  # avoid deprecated gpt-4
+    GPT4_TURBO = "gpt-4-turbo"
+    GPT4o = "gpt-4o"
+    GPT4o_MINI = "gpt-4o-mini"
+    O1 = "o1"
+    O1_MINI = "o1-mini"
+    O3_MINI = "o3-mini"
+    O3 = "o3"
+    O4_MINI = "o4-mini"
+    GPT4_1 = "gpt-4.1"
+    GPT4_1_MINI = "gpt-4.1-mini"
+    GPT4_1_NANO = "gpt-4.1-nano"
+    GPT5 = "gpt-5"
+    GPT5_MINI = "gpt-5-mini"
+    GPT5_NANO = "gpt-5-nano"
+    GPT5_PRO = "gpt-5-pro"
+    GPT5_1 = "gpt-5.1"
+    GPT5_1_CODEX = "gpt-5.1-codex"
+    GPT5_1_CODEX_MINI = "gpt-5.1-codex-mini"
+    GPT5_1_CHAT = "gpt-5.1-chat"
+    GPT5_2 = "gpt-5.2"
+    GPT5_2_PRO = "gpt-5.2-pro"
+    GPT5_2_CHAT = "gpt-5.2-chat"
+    GPT_OSS_120b = "gpt-oss-120b"
+    GPT_OSS_20b = "gpt-oss-20b"
 
 
-FunctionCallTypes = Literal["none", "auto"]
-ToolChoiceTypes = Literal["none", "auto", "required"]
-ToolTypes = Literal["function"]
+class OpenAICompletionModel(str, Enum):
+    """Enum for OpenAI Completion models"""
 
-DEFAULT_CONTEXT_LENGTH = 16_000
-
-
-class StreamEventType(Enum):
-    TEXT = 1
-    FUNC_NAME = 2
-    FUNC_ARGS = 3
-    TOOL_NAME = 4
-    TOOL_ARGS = 5
-    REASONING = 6
+    DAVINCI = "davinci-002"
+    BABBAGE = "babbage-002"
 
 
-class RetryParams(BaseSettings):
-    max_retries: int = 5
-    initial_delay: float = 1.0
-    exponential_base: float = 1.3
-    jitter: bool = True
+class AnthropicModel(ModelName):
+    """Enum for Anthropic models"""
+
+    CLAUDE_3_OPUS = "claude-3-opus-latest"
+    CLAUDE_3_SONNET = "claude-3-sonnet-latest"
+    CLAUDE_3_HAIKU = "claude-3-haiku-latest"
+    CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest"
+    CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest"
+    CLAUDE_4_OPUS = "claude-opus-4"
+    CLAUDE_4_SONNET = "claude-sonnet-4"
+    CLAUDE_4_HAIKU = "claude-haiku-4"
+    CLAUDE_4_5_OPUS = "claude-opus-4-5"
+    CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
+    CLAUDE_4_5_HAIKU = "claude-haiku-4-5"
 
 
-class LLMConfig(BaseSettings):
+class DeepSeekModel(ModelName):
+    """Enum for DeepSeek models direct from DeepSeek API"""
+
+    DEEPSEEK = "deepseek/deepseek-chat"
+    DEEPSEEK_R1 = "deepseek/deepseek-reasoner"
+    OPENROUTER_DEEPSEEK_R1 = "openrouter/deepseek/deepseek-r1"
+
+
+class GeminiModel(ModelName):
+    """Enum for Gemini models"""
+
+    GEMINI_1_5_FLASH = "gemini-1.5-flash"
+    GEMINI_1_5_FLASH_8B = "gemini-1.5-flash-8b"
+    GEMINI_1_5_PRO = "gemini-1.5-pro"
+    GEMINI_2_FLASH = "gemini-2.0-flash"
+    GEMINI_2_FLASH_LITE = "gemini-2.0-flash-lite"
+    GEMINI_2_FLASH_THINKING = "gemini-2.0-flash-thinking-exp"
+    GEMINI_2_PRO = "gemini-2.0-pro-exp-02-05"
+    GEMINI_2_5_FLASH = "gemini-2.5-flash"
+    GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
+    GEMINI_2_5_PRO = "gemini-2.5-pro"
+    GEMINI_3_FLASH = "gemini-3-flash"
+    GEMINI_3_PRO = "gemini-3-pro"
+
+
+class MiniMaxModel(ModelName):
+    """Enum for MiniMax models"""
+
+    MINIMAX_M2_7 = "MiniMax-M2.7"
+    MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
+    MINIMAX_M2_5 = "MiniMax-M2.5"
+    MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
+    MINIMAX_M2_1 = "MiniMax-M2.1"
+    MINIMAX_M2_1_HIGHSPEED = "MiniMax-M2.1-highspeed"
+    MINIMAX_M2 = "MiniMax-M2"
+
+
+class OpenAI_API_ParamInfo(BaseModel):
     """
-    Common configuration for all language models.
-    """
-
-    type: str = "openai"
-    streamer: Optional[Callable[[Any], None]] = noop_fn
-    streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
-    api_base: str | None = None
-    formatter: None | str = None
-    # specify None if you want to use the full max output tokens of the model
-    max_output_tokens: int | None = 8192
-    timeout: int = 20  # timeout for API requests
-    chat_model: str = ""
-    completion_model: str = ""
-    temperature: float = 0.0
-    chat_context_length: int | None = None
-    async_stream_quiet: bool = False  # suppress streaming output in async mode?
-    completion_context_length: int | None = None
-    # if input length + max_output_tokens > context length of model,
-    # we will try shortening requested output
-    min_output_tokens: int = 64
-    use_completion_for_chat: bool = False  # use completion model for chat?
-    # use chat model for completion? For OpenAI models, this MUST be set to True!
-    use_chat_for_completion: bool = True
-    stream: bool = True  # stream output from API?
-    # TODO: we could have a `stream_reasoning` flag here to control whether to show
-    # reasoning output from reasoning models
-    cache_config: None | CacheDBConfig = RedisCacheConfig()
-    thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
-    retry_params: RetryParams = RetryParams()
-
-    @property
-    def model_max_output_tokens(self) -> int:
-        if self.max_output_tokens:
-            return self.max_output_tokens
-        # Build fallback names by progressively stripping provider prefixes
-        # (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
-        # succeeds even before OpenAIGPT.__init__ strips the prefix.
-        parts = self.chat_model.split("/")
-        fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
-        return get_model_info(self.chat_model, fallbacks).max_output_tokens
-
-
-class LLMFunctionCall(BaseModel):
-    """
-    Structure of LLM response indicating it "wants" to call a function.
-    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
-    """
-
-    name: str  # name of function to call
-    arguments: Optional[Dict[str, Any]] = None
-
-    @staticmethod
-    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall":
-        """
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-        fun_call = LLMFunctionCall(name=message["name"])
-        fun_args_str = message["arguments"]
-        # sometimes may be malformed with invalid indents,
-        # so we try to be safe by removing newlines.
-        if fun_args_str is not None:
-            fun_args_str = fun_args_str.replace("\n", "").strip()
-            dict_or_list = parse_imperfect_json(fun_args_str)
-
-            if not isinstance(dict_or_list, dict):
-                raise ValueError(
-                    f"""
-                        Invalid function args: {fun_args_str}
-                        parsed as {dict_or_list},
-                        which is not a valid dict.
-                        """
-                )
-            fun_args = dict_or_list
-        else:
-            fun_args = None
-        fun_call.arguments = fun_args
-
-        return fun_call
-
-    def __str__(self) -> str:
-        return "FUNC: " + json.dumps(self.model_dump(), indent=2)
-
-
-class LLMFunctionSpec(BaseModel):
-    """
-    Description of a function available for the LLM to use.
-    To be used when calling the LLM `chat()` method with the `functions` parameter.
-    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
+    Parameters exclusive to some models, when using OpenAI API
     """
 
-    name: str
-    description: str
-    parameters: Dict[str, Any]
-
-
-class OpenAIToolCall(BaseModel):
-    """
-    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
-    See https://platform.openai.com/docs/api-reference/chat/create
-
-    Attributes:
-        id: The id of the tool call.
-        type: The type of the tool call;
-            only "function" is currently possible (7/26/24).
-        function: The function call.
-    """
-
-    id: str | None = None
-    type: ToolTypes = "function"
-    function: LLMFunctionCall | None = None
-    extra_content: Dict[str, Any] | None = None
-
-    @staticmethod
-    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall":
-        """
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-        id = message["id"]
-        type = message["type"]
-        function = LLMFunctionCall.from_dict(message["function"])
-        extra_content = message.get("extra_content")
-        return OpenAIToolCall(
-            id=id, type=type, function=function, extra_content=extra_content
-        )
-
-    def __str__(self) -> str:
-        if self.function is None:
-            return ""
-        return "OAI-TOOL: " + json.dumps(self.function.model_dump(), indent=2)
-
-
-class OpenAIToolSpec(BaseModel):
-    type: ToolTypes
-    strict: Optional[bool] = None
-    function: LLMFunctionSpec
-
-
-class OpenAIJsonSchemaSpec(BaseModel):
-    strict: Optional[bool] = None
-    function: LLMFunctionSpec
-
-    def to_dict(self) -> Dict[str, Any]:
-        json_schema: Dict[str, Any] = {
-            "name": self.function.name,
-            "description": self.function.description,
-            "schema": self.function.parameters,
-        }
-        if self.strict is not None:
-            json_schema["strict"] = self.strict
-
-        return {
-            "type": "json_schema",
-            "json_schema": json_schema,
-        }
-
-
-class LLMTokenUsage(BaseModel):
-    """
-    Usage of tokens by an LLM.
-    """
-
-    prompt_tokens: int = 0
-    cached_tokens: int = 0
-    completion_tokens: int = 0
-    cost: float = 0.0
-    calls: int = 0  # how many API calls - not used as of 2025-04-04
-
-    def reset(self) -> None:
-        self.prompt_tokens = 0
-        self.cached_tokens = 0
-        self.completion_tokens = 0
-        self.cost = 0.0
-        self.calls = 0
-
-    def __str__(self) -> str:
-        return (
-            f"Tokens = "
-            f"(prompt {self.prompt_tokens}, cached {self.cached_tokens}, "
-            f"completion {self.completion_tokens}), "
-            f"Cost={self.cost}, Calls={self.calls}"
-        )
-
-    @property
-    def total_tokens(self) -> int:
-        return self.prompt_tokens + self.completion_tokens
-
-
-class Role(str, Enum):
-    """
-    Possible roles for a message in a chat.
-    """
-
-    USER = "user"
-    SYSTEM = "system"
-    ASSISTANT = "assistant"
-    FUNCTION = "function"
-    TOOL = "tool"
-
-
-class LLMMessage(BaseModel):
-    """
-    Class representing an entry in the msg-history sent to the LLM API.
-    It could be one of these:
-    - a user message
-    - an LLM ("Assistant") response
-    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
-    - a result or results from executing a fn or tool-call(s)
-    """
-
-    role: Role
-    name: Optional[str] = None
-    tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
-    tool_id: str = ""  # used by OpenAIAssistant
-    # None means "no content" (the model returned only a tool/function call).
-    # This is distinct from "" and is dropped from the API payload by api_dict;
-    # see api_dict for how a fully-empty message is handled per-API.
-    content: Optional[str] = None
-    files: List[FileAttachment] = []
-    function_call: Optional[LLMFunctionCall] = None
-    tool_calls: Optional[List[OpenAIToolCall]] = None
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    # link to corresponding chat document, for provenance/rewind purposes
-    chat_document_id: str = ""
-
-    def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]:
-        """
-        Convert to dictionary for API request, keeping ONLY
-        the fields that are expected in an API call!
-        E.g., DROP the tool_id, since it is only for use in the Assistant API,
-            not the completion API.
-
-        Args:
-            has_system_role: whether the message has a system role (if not,
-                set to "user" role)
-        Returns:
-            dict: dictionary representation of LLM message
-        """
-        d = self.model_dump()
-        files: List[FileAttachment] = d.pop("files")
-        if len(files) > 0 and self.role == Role.USER:
-            # In there are files, then content is an array of
-            # different content-parts
-            d["content"] = [
-                dict(
-                    type="text",
-                    text=self.content or "",
-                )
-            ] + [f.to_dict(model) for f in self.files]
-
-        # if there is a key k = "role" with value "system", change to "user"
-        # in case has_system_role is False
-        if not has_system_role and "role" in d and d["role"] == "system":
-            d["role"] = "user"
-            if d.get("content"):
-                d["content"] = "[ADDITIONAL SYSTEM MESSAGE:]\n\n" + d["content"]
-        # drop None values since API doesn't accept them (this omits `content`
-        # entirely when it is None, i.e. "no content")
-        dict_no_none = {k: v for k, v in d.items() if v is not None}
-        if "name" in dict_no_none and dict_no_none["name"] == "":
-            # OpenAI API does not like empty name
-            del dict_no_none["name"]
-        if "function_call" in dict_no_none:
-            # arguments must be a string
-            if "arguments" in dict_no_none["function_call"]:
-                dict_no_none["function_call"]["arguments"] = json.dumps(
-                    dict_no_none["function_call"]["arguments"]
-                )
-        if dict_no_none.get("tool_calls"):
-            # convert tool calls to API format
-            for tc in dict_no_none["tool_calls"]:
-                if "arguments" in tc["function"]:
-                    # arguments must be a string
-                    if tc["function"]["arguments"] is None:
-                        tc["function"]["arguments"] = "{}"
-                    else:
-                        tc["function"]["arguments"] = json.dumps(
-                            tc["function"]["arguments"]
-                        )
-                if "extra_content" in tc and tc["extra_content"] is None:
-                    del tc["extra_content"]
-        else:
-            # An empty tool-call list is not a call and conveys no useful API
-            # information. Omitting it also lets the empty-message fallback
-            # below produce a valid message.
-            dict_no_none.pop("tool_calls", None)
-        # A message with empty content (None was dropped above, or "") AND no
-        # tool/function call would be an entirely empty message, which some APIs
-        # (e.g. Gemini) reject; fall back to a single space in that case only.
-        # When there IS a tool/function call, empty content is fine (and Gemini
-        # 3.x in fact REQUIRES it — it rejects an assistant turn that carries
-        # both a call and non-empty text content).
-        has_call = bool(dict_no_none.get("tool_calls")) or (
-            dict_no_none.get("function_call") is not None
-        )
-        if not has_call and not dict_no_none.get("content"):
-            dict_no_none["content"] = " "
-        # IMPORTANT! drop fields that are not expected in API call
-        dict_no_none.pop("tool_id", None)
-        dict_no_none.pop("timestamp", None)
-        dict_no_none.pop("chat_document_id", None)
-        return dict_no_none
-
-    def __str__(self) -> str:
-        if self.function_call is not None:
-            content = "FUNC: " + json.dumps(self.function_call)
-        else:
-            content = self.content or ""
-        name_str = f" ({self.name})" if self.name else ""
-        return f"{self.role} {name_str}: {content}"
-
-
-class LLMResponse(BaseModel):
-    """
-    Class representing response from LLM.
-    """
-
-    # None means the model returned NO content (e.g. only a tool/function
-    # call), which is distinct from an empty string "". Preserving this
-    # distinction lets the message be faithfully reproduced downstream
-    # (see ChatDocument.content_is_none and LLMMessage.content).
-    message: Optional[str] = None
-    reasoning: str = ""  # optional reasoning text from reasoning models
-    # Original message text including inline thought signatures (e.g.
-    # <thinking>...</thinking>). Only set when reasoning was extracted
-    # from the message text via get_reasoning_final(); NOT set when
-    # reasoning comes from a separate API field (e.g. reasoning_content),
-    # since in that case the message text never contained thought tags.
-    message_with_reasoning: Optional[str] = None
-    # TODO tool_id needs to generalize to multi-tool calls
-    tool_id: str = ""  # used by OpenAIAssistant
-    oai_tool_calls: Optional[List[OpenAIToolCall]] = None
-    function_call: Optional[LLMFunctionCall] = None
-    usage: Optional[LLMTokenUsage] = None
-    cached: bool = False
-
-    def __str__(self) -> str:
-        if self.function_call is not None:
-            return str(self.function_call)
-        elif self.oai_tool_calls:
-            return "\n".join(str(tc) for tc in self.oai_tool_calls)
-        else:
-            return self.message or ""
-
-    def tools_content(self) -> str:
-        if self.function_call is not None:
-            return str(self.function_call)
-        elif self.oai_tool_calls:
-            return "\n".join(str(tc) for tc in self.oai_tool_calls)
-        else:
-            return ""
-
-    def to_LLMMessage(self) -> LLMMessage:
-        """Convert LLM response to an LLMMessage, to be included in the
-        message-list sent to the API.
-        This is currently NOT used in any significant way in the library, and is only
-        provided as a utility to construct a message list for the API when directly
-        working with an LLM object.
-
-        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
-        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
-        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
-        """
-        return LLMMessage(
-            role=Role.ASSISTANT,
-            content=self.message,
-            name=None if self.function_call is None else self.function_call.name,
-            function_call=self.function_call,
-            tool_calls=self.oai_tool_calls,
-        )
-
-    def get_recipient_and_message(
-        self,
-        recognize_recipient_in_content: bool = True,
-    ) -> Tuple[str, str]:
-        """
-        If `message` or `function_call` of an LLM response contains an explicit
-        recipient name, return this recipient name and `message` stripped
-        of the recipient name if specified.
-
-        Two cases:
-        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
-        (b) `message` is empty and function_call/tool_call with explicit `recipient`
-
-        Args:
-            recognize_recipient_in_content (bool): When True (default), parses
-                message text for ``TO[<recipient>]:<content>`` patterns and
-                top-level JSON ``{"recipient": "..."}`` fields. When False,
-                only function_call/tool_call ``recipient`` fields are checked.
-
-        Returns:
-            (str): name of recipient, which may be empty string if no recipient
-            (str): content of message
-
-        """
-
-        if self.function_call is not None:
-            # in this case we ignore message, since all information is in function_call
-            msg = ""
-            args = self.function_call.arguments
-            recipient = ""
-            if isinstance(args, dict):
-                recipient = args.get("recipient", "")
-            return recipient, msg
-        else:
-            msg = self.message or ""
-            if self.oai_tool_calls is not None:
-                # get the first tool that has a recipient field, if any
-                for tc in self.oai_tool_calls:
-                    if tc.function is not None and tc.function.arguments is not None:
-                        recipient = tc.function.arguments.get(
-                            "recipient"
-                        )  # type: ignore
-                        if recipient is not None and recipient != "":
-                            return recipient, ""
-
-        if not recognize_recipient_in_content:
-            return "", msg
-
-        # It's not a function or tool call, so continue looking to see
-        # if a recipient is specified in the message.
-
-        # First check if message contains "TO: <recipient> <content>"
-        recipient_name, content = parse_message(msg) if msg is not None else ("", "")
-        # check if there is a top level json that specifies 'recipient',
-        # and retain the entire message as content.
-        if recipient_name == "":
-            recipient_name = top_level_json_field(msg, "recipient") if msg else ""
-            content = msg
-        return recipient_name, content
-
-
-# Define an abstract base class for language models
-class LanguageModel(ABC):
-    """
-    Abstract base class for language models.
-    """
-
-    # usage cost by model, accumulates here
-    usage_cost_dict: Dict[str, LLMTokenUsage] = {}
-
-    def __init__(self, config: LLMConfig = LLMConfig()):
-        self.config = config
-        self.chat_model_orig = config.chat_model
-
-    @staticmethod
-    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]:
-        """
-        Create a language model.
-        Args:
-            config: configuration for language model
-        Returns: instance of language model
-        """
-        if type(config) is LLMConfig:
-            raise ValueError(
-                """
-                Cannot create a Language Model object from LLMConfig.
-                Please specify a specific subclass of LLMConfig e.g.,
-                OpenAIGPTConfig. If you are creating a ChatAgent from
-                a ChatAgentConfig, please specify the `llm` field of this config
-                as a specific subclass of LLMConfig, e.g., OpenAIGPTConfig.
-                """
-            )
-        from langroid.language_models.azure_openai import AzureGPT
-        from langroid.language_models.mock_lm import MockLM, MockLMConfig
-        from langroid.language_models.openai_gpt import OpenAIGPT
-
-        if config is None or config.type is None:
-            return None
-
-        if config.type == "mock":
-            return MockLM(cast(MockLMConfig, config))
-
-        openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
-
-        if config.type == "azure":
-            openai = AzureGPT
-        else:
-            openai = OpenAIGPT
-        cls = dict(
-            openai=openai,
-        ).get(config.type, openai)
-        return cls(config)  # type: ignore
-
-    @staticmethod
-    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]:
-        """
-        Given an even-length sequence of strings, split into a sequence of pairs
-
-        Args:
-            lst (List[str]): sequence of strings
-
-        Returns:
-            List[Tuple[str,str]]: sequence of pairs of strings
-        """
-        evens = lst[::2]
-        odds = lst[1::2]
-        return list(zip(evens, odds))
-
-    @staticmethod
-    def get_chat_history_components(
-        messages: List[LLMMessage],
-    ) -> Tuple[str, List[Tuple[str, str]], str]:
-        """
-        From the chat history, extract system prompt, user-assistant turns, and
-        final user msg.
-
-        Args:
-            messages (List[LLMMessage]): List of messages in the chat history
-
-        Returns:
-            Tuple[str, List[Tuple[str,str]], str]:
-                system prompt, user-assistant turns, final user msg
-
-        """
-        # Handle various degenerate cases
-        messages = [m for m in messages]  # copy
-        DUMMY_SYS_PROMPT = "You are a helpful assistant."
-        DUMMY_USER_PROMPT = "Follow the instructions above."
-        if len(messages) == 0 or messages[0].role != Role.SYSTEM:
-            logger.warning("No system msg, creating dummy system prompt")
-            messages.insert(0, LLMMessage(content=DUMMY_SYS_PROMPT, role=Role.SYSTEM))
-        system_prompt = messages[0].content or ""
-
-        # now we have messages = [Sys,...]
-        if len(messages) == 1:
-            logger.warning(
-                "Got only system message in chat history, creating dummy user prompt"
-            )
-            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, msg, ...]
-
-        if messages[1].role != Role.USER:
-            messages.insert(1, LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, user, ...]
-        if messages[-1].role != Role.USER:
-            logger.warning(
-                "Last message in chat history is not a user message,"
-                " creating dummy user prompt"
-            )
-            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, user, ..., user]
-        # so we omit the first and last elements and make pairs of user-asst messages
-        conversation = [m.content or "" for m in messages[1:-1]]
-        user_prompt = messages[-1].content or ""
-        pairs = LanguageModel.user_assistant_pairs(conversation)
-        return system_prompt, pairs, user_prompt
-
-    @abstractmethod
-    def set_stream(self, stream: bool) -> bool:
-        """Enable or disable streaming output from API.
-        Return previous value of stream."""
-        pass
-
-    @abstractmethod
-    def get_stream(self) -> bool:
-        """Get streaming status"""
-        pass
-
-    @abstractmethod
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        pass
-
-    @abstractmethod
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        pass
-
-    @abstractmethod
-    def chat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """
-        Get chat-completion response from LLM.
-
-        Args:
-            messages: message-history to send to the LLM
-            max_tokens: max tokens to generate
-            tools: tools available for the LLM to use in its response
-            tool_choice: tool call mode, one of "none", "auto", "required",
-                or a dict specifying a specific tool.
-            functions: functions available for LLM to call (deprecated)
-            function_call: function calling mode, "auto", "none", or a specific fn
-                    (deprecated)
-        """
-
-        pass
-
-    @abstractmethod
-    async def achat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """Async version of `chat`. See `chat` for details."""
-        pass
-
-    def __call__(self, prompt: str, max_tokens: int) -> LLMResponse:
-        return self.generate(prompt, max_tokens)
-
-    @staticmethod
-    def _fallback_model_names(model: str) -> List[str]:
-        parts = model.split("/")
-        fallbacks = []
-        for i in range(1, len(parts)):
-            fallbacks.append("/".join(parts[i:]))
-        return fallbacks
-
-    def info(self) -> ModelInfo:
-        """Info of relevant chat model"""
-        orig_model = (
-            self.config.completion_model
-            if self.config.use_completion_for_chat
-            else self.chat_model_orig
-        )
-        return get_model_info(orig_model, self._fallback_model_names(orig_model))
-
-    def completion_info(self) -> ModelInfo:
-        """Info of relevant completion model"""
-        orig_model = (
-            self.chat_model_orig
-            if self.config.use_chat_for_completion
-            else self.config.completion_model
-        )
-        return get_model_info(orig_model, self._fallback_model_names(orig_model))
-
-    def supports_functions_or_tools(self) -> bool:
-        """
-        Does this Model's API support "native" tool-calling, i.e.
-        can we call the API with arguments that contain a list of available tools,
-        and their schemas?
-        Note that, given the plethora of LLM provider APIs this determination is
-        imperfect at best, and leans towards returning True.
-        When the API calls fails with an error indicating tools are not supported,
-        then users are encouraged to use the Langroid-based prompt-based
-        ToolMessage mechanism, which works with ANY LLM. To enable this,
-        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
-        """
-        return self.info().has_tools
-
-    def chat_context_length(self) -> int:
-        return self.config.chat_context_length or DEFAULT_CONTEXT_LENGTH
-
-    def completion_context_length(self) -> int:
-        return self.config.completion_context_length or DEFAULT_CONTEXT_LENGTH
-
-    def chat_cost(self) -> Tuple[float, float, float]:
-        """
-        Return the cost per 1000 tokens for chat completions.
-
-        Returns:
-            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
-                per 1000 tokens
-        """
-        return (0.0, 0.0, 0.0)
-
-    def reset_usage_cost(self) -> None:
-        for mdl in [self.config.chat_model, self.config.completion_model]:
-            if mdl is None:
-                return
-            if mdl not in self.usage_cost_dict:
-                self.usage_cost_dict[mdl] = LLMTokenUsage()
-            counter = self.usage_cost_dict[mdl]
-            counter.reset()
-
-    def update_usage_cost(
-        self, chat: bool, prompts: int, completions: int, cost: float
-    ) -> None:
-        """
-        Update usage cost for this LLM.
-        Args:
-            chat (bool): whether to update for chat or completion model
-            prompts (int): number of tokens used for prompts
-            completions (int): number of tokens used for completions
-            cost (float): total token cost in USD
-        """
-        mdl = self.config.chat_model if chat else self.config.completion_model
-        if mdl is None:
-            return
-        if mdl not in self.usage_cost_dict:
-            self.usage_cost_dict[mdl] = LLMTokenUsage()
-        counter = self.usage_cost_dict[mdl]
-        counter.prompt_tokens += prompts
-        counter.completion_tokens += completions
-        counter.cost += cost
-        counter.calls += 1
-
-    @classmethod
-    def usage_cost_summary(cls) -> str:
-        s = ""
-        for model, counter in cls.usage_cost_dict.items():
-            s += f"{model}: {counter}\n"
-        return s
-
-    @classmethod
-    def tot_tokens_cost(cls) -> Tuple[int, float]:
-        """
-        Return total tokens used and total cost across all models.
-        """
-        total_tokens = 0
-        total_cost = 0.0
-        for counter in cls.usage_cost_dict.values():
-            total_tokens += counter.total_tokens
-            total_cost += counter.cost
-        return total_tokens, total_cost
-
-    def get_reasoning_final(self, message: str) -> Tuple[str, str]:
-        """Extract "reasoning" and "final answer" from an LLM response, if the
-        reasoning is found within configured delimiters, like <think>, </think>.
-        E.g.,
-        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
-
-        Args:
-            message (str): message from LLM
-
-        Returns:
-            Tuple[str, str]: reasoning, final answer
-        """
-        start, end = self.config.thought_delimiters
-        if start in message and end in message:
-            parts = message.split(start)
-            if len(parts) > 1:
-                reasoning, final = parts[1].split(end)
-                return reasoning, final
-        return "", message
-
-    def followup_to_standalone(
-        self, chat_history: List[Tuple[str, str]], question: str
-    ) -> str:
-        """
-        Given a chat history and a question, convert it to a standalone question.
-        Args:
-            chat_history: list of tuples of (question, answer)
-            query: follow-up question
-
-        Returns: standalone version of the question
-        """
-        history = collate_chat_history(chat_history)
-
-        prompt = f"""
-        You are an expert at understanding a CHAT HISTORY between an AI Assistant
-        and a User, and you are highly skilled in rephrasing the User's FOLLOW-UP
-        QUESTION/REQUEST as a STANDALONE QUESTION/REQUEST that can be understood
-        WITHOUT the context of the chat history.
-
-        Below is the CHAT HISTORY. When the User asks you to rephrase a
-        FOLLOW-UP QUESTION/REQUEST, your ONLY task is to simply return the
-        question REPHRASED as a STANDALONE QUESTION/REQUEST, without any additional
-        text or context.
-
-        <CHAT_HISTORY>
-        {history}
-        </CHAT_HISTORY>
-        """.strip()
-
-        follow_up_question = f"""
-        Please rephrase this as a stand-alone question or request:
-        <FOLLOW-UP-QUESTION-OR-REQUEST>
-        {question}
-        </FOLLOW-UP-QUESTION-OR-REQUEST>
-        """.strip()
-
-        show_if_debug(prompt, "FOLLOWUP->STANDALONE-PROMPT= ")
-        standalone = (
-            self.chat(
-                messages=[
-                    LLMMessage(role=Role.SYSTEM, content=prompt),
-                    LLMMessage(role=Role.USER, content=follow_up_question),
-                ],
-                max_tokens=1024,
-            ).message
-            or ""
-        )
-        standalone = standalone.strip()
-
-        show_if_debug(prompt, "FOLLOWUP->STANDALONE-RESPONSE= ")
-        return standalone
-
-
-class StreamingIfAllowed:
-    """Context to temporarily enable or disable streaming, if allowed globally via
-    `settings.stream`"""
-
-    def __init__(self, llm: LanguageModel, stream: bool = True):
-        self.llm = llm
-        self.stream = stream
-
-    def __enter__(self) -> None:
-        self.old_stream = self.llm.set_stream(settings.stream and self.stream)
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self.llm.set_stream(self.old_stream)
-</file>
-
-<file path="langroid/agent/special/sql/sql_chat_agent.py">
-"""
-Agent that allows interaction with an SQL database using SQLAlchemy library.
-The agent can execute SQL queries in the database and return the result.
-
-Functionality includes:
-- adding table and column context
-- asking a question about a SQL schema
-"""
-
-import logging
-import re
-from typing import (
-    Any,
-    Dict,
-    FrozenSet,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-)
-
-from rich.console import Console
-
-from langroid.exceptions import LangroidImportError
-from langroid.mytypes import Entity
-from langroid.utils.constants import SEND_TO
-
-try:
-    from sqlalchemy import MetaData, Row, create_engine, inspect, text
-    from sqlalchemy.engine import Engine
-    from sqlalchemy.exc import ResourceClosedError, SQLAlchemyError
-    from sqlalchemy.orm import Session, sessionmaker
-except ImportError as e:
-    raise LangroidImportError(extra="sql", error=str(e))
-
-try:
-    # sqlglot is required for the statement-type allowlist enforced in
-    # `_validate_query`. Importing it at module load ensures the security
-    # guarantee cannot be silently bypassed by a partial/stale install.
-    import sqlglot
-    from sqlglot import expressions as sqlglot_exp
-except ImportError as e:
-    raise LangroidImportError(extra="sql", error=str(e))
-
-from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
-from langroid.agent.chat_document import ChatDocument
-from langroid.agent.special.sql.utils.description_extractors import (
-    extract_schema_descriptions,
-)
-from langroid.agent.special.sql.utils.populate_metadata import (
-    populate_metadata,
-    populate_metadata_with_schema_tools,
-)
-from langroid.agent.special.sql.utils.system_message import (
-    DEFAULT_SYS_MSG,
-    SCHEMA_TOOLS_SYS_MSG,
-)
-from langroid.agent.special.sql.utils.tools import (
-    GetColumnDescriptionsTool,
-    GetTableNamesTool,
-    GetTableSchemaTool,
-    RunQueryTool,
-)
-from langroid.agent.tools.orchestration import (
-    DonePassTool,
-    DoneTool,
-    ForwardTool,
-    PassTool,
-)
-from langroid.language_models.base import Role
-from langroid.vector_store.base import VectorStoreConfig
-
-logger = logging.getLogger(__name__)
-
-console = Console()
-
-DEFAULT_SQL_CHAT_SYSTEM_MESSAGE = """
-{mode}
-
-You do not need to attempt answering a question with just one query. 
-You could make a sequence of SQL queries to help you write the final query.
-Also if you receive a null or other unexpected result,
-(a) make sure you use the available TOOLs correctly, and 
-(b) see if you have made an assumption in your SQL query, and try another way, 
-   or use `run_query` to explore the database table contents before submitting your 
-   final query. For example when searching for "males" you may have used "gender= 'M'",
-in your query, because you did not know that the possible genders in the table
-are "Male" and "Female". 
-
-Start by asking what I would like to know about the data.
-
-"""
-
-ADDRESSING_INSTRUCTION = """
-IMPORTANT - Whenever you are NOT writing a SQL query, make sure you address the user
-using {prefix}User (NO SPACE between {prefix} and User). 
-You MUST use the EXACT syntax {prefix}User !!!
-
-In other words, you ALWAYS write EITHER:
- - a SQL query using the `run_query` tool, 
- - OR address the user using {prefix}User
-"""
-
-DONE_INSTRUCTION = f"""
-When you are SURE you have the CORRECT answer to a user's query or request, 
-use the `{DoneTool.name()}` with `content` set to the answer or result.
-If you DO NOT think you have the answer to the user's query or request,
-you SHOULD NOT use the `{DoneTool.name()}` tool.
-Instead, you must CONTINUE to improve your queries (tools) to get the correct answer,
-and finally use the `{DoneTool.name()}` tool to send the correct answer to the user.
-"""
-
-
-SQL_ERROR_MSG = "There was an error in your SQL Query"
-
-
-# Dialect-specific SQL patterns that enable code execution, arbitrary file
-# access, or other escapes from the database engine. Matched against the raw
-# query text (case-insensitive) as a defense-in-depth layer in addition to the
-# sqlglot-based statement-type allowlist.
-_DANGEROUS_SQL_PATTERNS: List["re.Pattern[str]"] = [
-    # PostgreSQL: COPY ... FROM/TO PROGRAM executes shell commands as the DB
-    # server OS user.
-    re.compile(r"\bcopy\b[\s\S]*\bprogram\b", re.IGNORECASE),
-    # PostgreSQL server-side filesystem / log / WAL access. Match the whole
-    # pg_read*, pg_stat*, pg_ls*, pg_current_logfile family rather than naming
-    # individual functions: near-name functions (pg_read_file vs
-    # pg_read_server_file, pg_ls_logdir vs pg_ls_dir, pg_stat_file, ...) all
-    # yield the same file/metadata disclosure primitive.
-    re.compile(r"\bpg_(read|stat|ls|current_logfile)[A-Za-z0-9_]*\s*\(", re.IGNORECASE),
-    re.compile(r"\blo_(import|export)\b", re.IGNORECASE),
-    # MySQL/MariaDB filesystem
-    re.compile(r"\binto\s+(outfile|dumpfile)\b", re.IGNORECASE),
-    re.compile(r"\bload_file\s*\(", re.IGNORECASE),
-    re.compile(r"\bload\s+data\b", re.IGNORECASE),
-    # SQLite: load_extension enables loading arbitrary shared objects;
-    # ATTACH can read/write arbitrary files. The DATABASE keyword is optional
-    # per the SQLite grammar (ATTACH [DATABASE] expr AS schema-name), so match
-    # both forms.
-    re.compile(r"\bload_extension\s*\(", re.IGNORECASE),
-    re.compile(r"\battach\b(\s+database)?\s+['\"\w]", re.IGNORECASE),
-    # SQL Server: command execution, OLE automation, and ad-hoc external data
-    # sources (OPENDATASOURCE is the connection-string counterpart of
-    # OPENROWSET; both can read remote/UNC files).
-    re.compile(r"\bxp_cmdshell\b", re.IGNORECASE),
-    re.compile(r"\bsp_oacreate\b", re.IGNORECASE),
-    re.compile(r"\bsp_oamethod\b", re.IGNORECASE),
-    re.compile(r"\b(openrowset|opendatasource)\b", re.IGNORECASE),
-    re.compile(r"\bbulk\s+insert\b", re.IGNORECASE),
-    # Generic: stored-program creation and procedural language extensions.
-    # LANGUAGE / RULE / EVENT TRIGGER / FOREIGN TABLE are additional PostgreSQL
-    # primitives that can register attacker-controlled code.
-    re.compile(
-        r"\bcreate\s+(or\s+replace\s+)?(function|procedure|trigger|language|rule|event\s+trigger|foreign\s+table)\b",
-        re.IGNORECASE,
-    ),
-    re.compile(r"\bcreate\s+extension\b", re.IGNORECASE),
-]
-
-
-# AST-side blocklist of dangerous SQL function names, applied after sqlglot
-# parses the query. The raw-text regex above can be bypassed by quoted
-# identifiers, inline comments, or schema qualification -- e.g.
-# `"pg_read_file"(...)`, `pg_read_file/**/(...)`,
-# `pg_catalog."pg_read_file"(...)` -- but sqlglot normalizes all those forms
-# to the same function-call node, so a name-based check on the parsed tree
-# catches every variant (GHSA-6xc5-4r68-67fc).
-_DANGEROUS_FUNCTION_NAMES: FrozenSet[str] = frozenset(
-    {
-        "load_file",  # MySQL/MariaDB filesystem read
-        "load_extension",  # SQLite extension loader
-        "sp_oacreate",  # MSSQL OLE automation
-        "sp_oamethod",  # MSSQL OLE automation
-    }
-)
-# Prefix families: any function whose normalized name starts with one of these
-# is considered dangerous. Mirrors the `\bpg_(read|stat|ls|current_logfile)...`
-# and `\blo_(import|export)\b` regex coverage, but on the parsed AST.
-_DANGEROUS_FUNCTION_PREFIXES: Tuple[str, ...] = (
-    "pg_read",
-    "pg_stat",
-    "pg_ls",
-    "pg_current_logfile",
-    "lo_",
-)
-
-
-def _is_dangerous_function_name(name: str) -> bool:
-    """True if `name` (case-folded, unquoted) is a dangerous SQL function."""
-    if name in _DANGEROUS_FUNCTION_NAMES:
-        return True
-    return any(name.startswith(p) for p in _DANGEROUS_FUNCTION_PREFIXES)
-
-
-def _called_function_names(stmt: Any) -> Iterator[str]:
-    """Yield normalized (case-folded, unquoted, schema-stripped) names of
-    every function-call node in `stmt` (a parsed sqlglot expression)."""
-    for node in stmt.find_all(sqlglot_exp.Func):
-        if isinstance(node, sqlglot_exp.Anonymous):
-            this = node.this
-            if isinstance(this, sqlglot_exp.Expression):
-                name = this.name
-            else:
-                name = str(this) if this is not None else ""
-        else:
-            # Typed sqlglot Func subclass: its class key is the SQL keyword.
-            name = getattr(type(node), "key", "") or ""
-        # Strip any schema qualifier that leaked into the name string.
-        name = name.rsplit(".", 1)[-1].strip().lower()
-        if name:
-            yield name
-
-
-def _creates_table(into: Any) -> bool:
-    """Whether a Select's ``into`` arg names a table rather than a variable.
-
-    ``SELECT ... INTO tbl`` creates and populates a table, but MySQL's
-    ``SELECT ... INTO @var`` merely assigns a user variable and writes nothing.
-    sqlglot models the latter as a ``Table`` wrapping a ``Parameter``, so the
-    target's inner node distinguishes them.
-
-    Args:
-        into: The ``into`` arg of a sqlglot ``Select``, or None.
-
-    Returns:
-        True if the target names a table.
-    """
-    if into is None:
-        return False
-    target = into.this
-    if target is None:
-        return False
-    return not isinstance(getattr(target, "this", None), sqlglot_exp.Parameter)
-
-
-def _nested_write_kinds(stmt: Any, kind_map: Dict[Any, str]) -> Set[str]:
-    """Statement kinds that `stmt` performs *below* its top-level node.
-
-    A statement's top-level node does not determine what it writes. Both
-
-    - ``WITH x AS (DELETE FROM t RETURNING *) SELECT * FROM x`` (a
-      data-modifying CTE), and
-    - ``SELECT * INTO new_tbl FROM t`` (which creates and populates a table)
-
-    parse with a ``Select`` top node, so classifying on that node alone reports
-    "SELECT" while the engine still performs the write
-    (GHSA-3gpx-vwr3-xvwx / GHSA-wc83-4cvx-p8xc).
-
-    Args:
-        stmt: A parsed sqlglot statement.
-        kind_map: Mapping of sqlglot expression type to statement-kind name.
-
-    Only independently executable nested statements count. A ``MERGE``'s
-    ``WHEN ... THEN UPDATE/INSERT/DELETE`` actions parse as child write nodes
-    but are part of the merge itself, so an operator who allows ``MERGE`` must
-    not also be forced to allow standalone ``UPDATE``/``INSERT``/``DELETE``.
-
-    Returns:
-        The set of kind names written by nested nodes, plus ``"CREATE"`` for
-        the ``SELECT ... INTO`` form. Empty for an ordinary read-only query.
-    """
-    write_types = (
-        sqlglot_exp.Insert,
-        sqlglot_exp.Update,
-        sqlglot_exp.Delete,
-        sqlglot_exp.Merge,
-        sqlglot_exp.Create,
-        sqlglot_exp.Drop,
-        sqlglot_exp.Alter,
-        sqlglot_exp.TruncateTable,
+    # model-specific params at top level
+    params: Dict[str, List[str]] = dict(
+        reasoning_effort=[
+            OpenAIChatModel.O3_MINI.value,
+            OpenAIChatModel.O3.value,
+            OpenAIChatModel.O4_MINI.value,
+            OpenAIChatModel.GPT5.value,
+            OpenAIChatModel.GPT5_MINI.value,
+            OpenAIChatModel.GPT5_NANO.value,
+            OpenAIChatModel.GPT5_PRO.value,
+            OpenAIChatModel.GPT5_1.value,
+            OpenAIChatModel.GPT5_1_CODEX.value,
+            OpenAIChatModel.GPT5_1_CODEX_MINI.value,
+            OpenAIChatModel.GPT5_2.value,
+            OpenAIChatModel.GPT5_2_PRO.value,
+            OpenAIChatModel.GPT_OSS_120b.value,
+            OpenAIChatModel.GPT_OSS_20b.value,
+            GeminiModel.GEMINI_2_5_PRO.value,
+            GeminiModel.GEMINI_2_5_FLASH.value,
+            GeminiModel.GEMINI_2_5_FLASH_LITE.value,
+        ],
+    )
+    # model-specific params in extra_body
+    extra_parameters: Dict[str, List[str]] = dict(
+        include_reasoning=[
+            DeepSeekModel.OPENROUTER_DEEPSEEK_R1.value,
+        ]
     )
 
-    # Exempt only the node that *is* a ``WHEN ... THEN`` action, by identity.
-    # Exempting everything beneath a ``When`` would also hide a write nested in
-    # the WHEN *condition* -- e.g.
-    # ``WHEN MATCHED AND EXISTS (WITH x AS (DELETE ...) SELECT * FROM x) THEN
-    # UPDATE ...`` -- or one buried inside the action's own subqueries.
-    merge_actions = {
-        id(when.args["then"])
-        for when in stmt.find_all(sqlglot_exp.When)
-        if when.args.get("then") is not None
-    }
 
-    kinds = {
-        kind_map[type(node)]
-        for node in stmt.find_all(*write_types)
-        if node is not stmt and type(node) in kind_map and id(node) not in merge_actions
-    }
-    # `SELECT ... INTO tbl` carries no nested Create node; it is flagged by the
-    # `into` arg on a Select. Check every Select, not just the top-level one:
-    # under a set operation (`SELECT ... INTO t UNION ALL SELECT ...`) the top
-    # node is a Union and the `into` sits on a branch.
-    selects = list(stmt.find_all(sqlglot_exp.Select))
-    if isinstance(stmt, sqlglot_exp.Select):
-        selects.append(stmt)
-    if any(_creates_table(sel.args.get("into")) for sel in selects):
-        kinds.add("CREATE")
-    return kinds
-
-
-# Default set of SQL statement types the agent is allowed to execute when
-# `allow_dangerous_operations` is False. SELECT-only is safe for Q&A workloads.
-_DEFAULT_ALLOWED_STATEMENTS: List[str] = ["SELECT"]
-
-
-class SQLChatAgentConfig(ChatAgentConfig):
-    system_message: str = DEFAULT_SQL_CHAT_SYSTEM_MESSAGE
-    user_message: None | str = None
-    cache: bool = True  # cache results
-    debug: bool = False
-    use_helper: bool = True
-    is_helper: bool = False
-    stream: bool = True  # allow streaming where needed
-    database_uri: str = ""  # Database URI
-    database_session: None | Session = None  # Database session
-    vecdb: None | VectorStoreConfig = None
-    context_descriptions: Dict[str, Dict[str, Union[str, Dict[str, str]]]] = {}
-    use_schema_tools: bool = False
-    multi_schema: bool = False
-    # whether the agent is used in a continuous chat with user,
-    # as opposed to returning a result from the task.run()
-    chat_mode: bool = False
-    addressing_prefix: str = ""
-    max_result_rows: int | None = None  # limit query results to this
-    max_retained_tokens: int | None = None  # limit history of query results to this
-
-    # --- Security controls (see CVE-2026-25879) ---------------------------
-    # By default, the agent only executes SELECT statements and rejects any
-    # query that matches a known dangerous pattern (e.g. PostgreSQL
-    # `COPY ... FROM PROGRAM`, MySQL `INTO OUTFILE`, SQLite `load_extension`,
-    # MSSQL `xp_cmdshell`). The LLM-generated SQL is influenceable by prompt
-    # injection — including injection via data the LLM reads back from the
-    # database — so executing it without restrictions is unsafe when the DB
-    # role has elevated privileges.
-    #
-    # To enable writes: extend allowed_statement_types, e.g. ["SELECT",
-    # "INSERT", "UPDATE", "DELETE"]. To disable all checks (only do this with
-    # a least-privilege DB role and trusted prompts): set
-    # allow_dangerous_operations=True.
-    allowed_statement_types: List[str] = list(_DEFAULT_ALLOWED_STATEMENTS)
-    allow_dangerous_operations: bool = False
-
+class ModelInfo(BaseModel):
     """
-    Optional, but strongly recommended, context descriptions for tables, columns, 
-    and relationships. It should be a dictionary where each key is a table name 
-    and its value is another dictionary. 
-
-    In this inner dictionary:
-    - The 'description' key corresponds to a string description of the table.
-    - The 'columns' key corresponds to another dictionary where each key is a 
-    column name and its value is a string description of that column.
-    - The 'relationships' key corresponds to another dictionary where each key 
-    is another table name and the value is a description of the relationship to 
-    that table.
-
-    If multi_schema support is enabled, the tables names in the description
-    should be of the form 'schema_name.table_name'.
-
-    For example:
-    {
-        'table1': {
-            'description': 'description of table1',
-            'columns': {
-                'column1': 'description of column1 in table1',
-                'column2': 'description of column2 in table1'
-            }
-        },
-        'table2': {
-            'description': 'description of table2',
-            'columns': {
-                'column3': 'description of column3 in table2',
-                'column4': 'description of column4 in table2'
-            }
-        }
-    }
+    Consolidated information about LLM, related to capacity, cost and API
+    idiosyncrasies. Reasonable defaults for all params in case there's no
+    specific info available.
     """
 
+    name: str = "unknown"
+    provider: ModelProvider = ModelProvider.UNKNOWN
+    context_length: int = 16_000
+    max_cot_tokens: int = 0  # max chain of thought (thinking) tokens where applicable
+    max_output_tokens: int = 8192  # Maximum number of output tokens - model dependent
+    input_cost_per_million: float = 0.0  # Cost in USD per million input tokens
+    cached_cost_per_million: float = 0.0  # Cost in USD per million cached tokens
+    output_cost_per_million: float = 0.0  # Cost in USD per million output tokens
+    allows_streaming: bool = True  # Whether model supports streaming output
+    allows_system_message: bool = True  # Whether model supports system messages
+    rename_params: Dict[str, str] = {}  # Rename parameters for OpenAI API
+    unsupported_params: List[str] = []
+    has_structured_output: bool = False  # Does model API support structured output?
+    has_tools: bool = True  # Does model API support tools/function-calling?
+    needs_first_user_message: bool = False  # Does API need first msg to be from user?
+    description: Optional[str] = None
 
-class SQLChatAgent(ChatAgent):
-    """
-    Agent for chatting with a SQL database
-    """
 
-    used_run_query: bool = False
-    llm_responded: bool = False
+GEMINI_CANONICAL_MODEL_NAMES = {model.value for model in GeminiModel}
+DEFAULT_MODEL_INFO = ModelInfo()
+WARNED_UNKNOWN_MODELS: set[tuple[str, ...]] = set()
 
-    def __init__(self, config: "SQLChatAgentConfig") -> None:
-        """Initialize the SQLChatAgent.
 
-        Raises:
-            ValueError: If database information is not provided in the config.
-        """
-        self._validate_config(config)
-        self.config: SQLChatAgentConfig = config
-        self._init_database()
-        self._init_metadata()
-        self._init_table_metadata()
-        self.final_instructions = ""
+# Model information registry
+MODEL_INFO: Dict[str, ModelInfo] = {
+    # OpenAI Models
+    OpenAICompletionModel.DAVINCI.value: ModelInfo(
+        name=OpenAICompletionModel.DAVINCI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=4096,
+        max_output_tokens=4096,
+        input_cost_per_million=2.0,
+        output_cost_per_million=2.0,
+        description="Davinci-002",
+    ),
+    OpenAICompletionModel.BABBAGE.value: ModelInfo(
+        name=OpenAICompletionModel.BABBAGE.value,
+        provider=ModelProvider.OPENAI,
+        context_length=4096,
+        max_output_tokens=4096,
+        input_cost_per_million=0.40,
+        output_cost_per_million=0.40,
+        description="Babbage-002",
+    ),
+    OpenAIChatModel.GPT3_5_TURBO.value: ModelInfo(
+        name=OpenAIChatModel.GPT3_5_TURBO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=16_385,
+        max_output_tokens=4096,
+        input_cost_per_million=0.50,
+        output_cost_per_million=1.50,
+        description="GPT-3.5 Turbo",
+    ),
+    OpenAIChatModel.GPT4.value: ModelInfo(
+        name=OpenAIChatModel.GPT4.value,
+        provider=ModelProvider.OPENAI,
+        context_length=8192,
+        max_output_tokens=8192,
+        input_cost_per_million=30.0,
+        output_cost_per_million=60.0,
+        description="GPT-4 (8K context)",
+    ),
+    OpenAIChatModel.GPT4_TURBO.value: ModelInfo(
+        name=OpenAIChatModel.GPT4_TURBO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=4096,
+        input_cost_per_million=10.0,
+        output_cost_per_million=30.0,
+        description="GPT-4 Turbo",
+    ),
+    OpenAIChatModel.GPT4_1_NANO.value: ModelInfo(
+        name=OpenAIChatModel.GPT4_1_NANO.value,
+        provider=ModelProvider.OPENAI,
+        has_structured_output=True,
+        context_length=1_047_576,
+        max_output_tokens=32_768,
+        input_cost_per_million=0.10,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=0.40,
+        description="GPT-4.1",
+    ),
+    OpenAIChatModel.GPT4_1_MINI.value: ModelInfo(
+        name=OpenAIChatModel.GPT4_1_MINI.value,
+        provider=ModelProvider.OPENAI,
+        has_structured_output=True,
+        context_length=1_047_576,
+        max_output_tokens=32_768,
+        input_cost_per_million=0.40,
+        cached_cost_per_million=0.10,
+        output_cost_per_million=1.60,
+        description="GPT-4.1 Mini",
+    ),
+    OpenAIChatModel.GPT4_1.value: ModelInfo(
+        name=OpenAIChatModel.GPT4_1.value,
+        provider=ModelProvider.OPENAI,
+        has_structured_output=True,
+        context_length=1_047_576,
+        max_output_tokens=32_768,
+        input_cost_per_million=2.00,
+        cached_cost_per_million=0.50,
+        output_cost_per_million=8.00,
+        description="GPT-4.1",
+    ),
+    OpenAIChatModel.GPT4o.value: ModelInfo(
+        name=OpenAIChatModel.GPT4o.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=2.5,
+        cached_cost_per_million=1.25,
+        output_cost_per_million=10.0,
+        has_structured_output=True,
+        description="GPT-4o (128K context)",
+    ),
+    OpenAIChatModel.GPT4o_MINI.value: ModelInfo(
+        name=OpenAIChatModel.GPT4o_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=0.15,
+        cached_cost_per_million=0.075,
+        output_cost_per_million=0.60,
+        has_structured_output=True,
+        description="GPT-4o Mini",
+    ),
+    OpenAIChatModel.O1.value: ModelInfo(
+        name=OpenAIChatModel.O1.value,
+        provider=ModelProvider.OPENAI,
+        context_length=200_000,
+        max_output_tokens=100_000,
+        input_cost_per_million=15.0,
+        cached_cost_per_million=7.50,
+        output_cost_per_million=60.0,
+        allows_streaming=True,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        has_tools=False,
+        description="O1 Reasoning LM",
+    ),
+    OpenAIChatModel.O3.value: ModelInfo(
+        name=OpenAIChatModel.O3.value,
+        provider=ModelProvider.OPENAI,
+        context_length=200_000,
+        max_output_tokens=100_000,
+        input_cost_per_million=2.0,
+        cached_cost_per_million=0.50,
+        output_cost_per_million=8.0,
+        allows_streaming=True,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        has_tools=False,
+        description="O1 Reasoning LM",
+    ),
+    OpenAIChatModel.O1_MINI.value: ModelInfo(
+        name=OpenAIChatModel.O1_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=65_536,
+        input_cost_per_million=1.1,
+        cached_cost_per_million=0.55,
+        output_cost_per_million=4.4,
+        allows_streaming=False,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature", "stream"],
+        has_tools=False,
+        description="O1 Mini Reasoning LM",
+    ),
+    OpenAIChatModel.O3_MINI.value: ModelInfo(
+        name=OpenAIChatModel.O3_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=200_000,
+        max_output_tokens=100_000,
+        input_cost_per_million=1.1,
+        cached_cost_per_million=0.55,
+        output_cost_per_million=4.4,
+        allows_streaming=False,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature", "stream"],
+        has_tools=False,
+        description="O3 Mini Reasoning LM",
+    ),
+    OpenAIChatModel.O4_MINI.value: ModelInfo(
+        name=OpenAIChatModel.O4_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=200_000,
+        max_output_tokens=100_000,
+        input_cost_per_million=1.10,
+        cached_cost_per_million=0.275,
+        output_cost_per_million=4.40,
+        allows_streaming=False,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature", "stream"],
+        has_tools=False,
+        description="O3 Mini Reasoning LM",
+    ),
+    OpenAIChatModel.GPT5.value: ModelInfo(
+        name=OpenAIChatModel.GPT5.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.125,
+        output_cost_per_million=10.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5",
+    ),
+    OpenAIChatModel.GPT5_MINI.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=0.25,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=2.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5 Mini",
+    ),
+    OpenAIChatModel.GPT5_NANO.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_NANO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=0.05,
+        cached_cost_per_million=0.005,
+        output_cost_per_million=0.40,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5 Nano",
+    ),
+    OpenAIChatModel.GPT5_PRO.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_PRO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=272_000,
+        input_cost_per_million=15.00,
+        cached_cost_per_million=7.50,
+        output_cost_per_million=120.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5 Pro",
+    ),
+    OpenAIChatModel.GPT5_1.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_1.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.13,
+        output_cost_per_million=10.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.1",
+    ),
+    OpenAIChatModel.GPT5_1_CODEX.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_1_CODEX.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.125,
+        output_cost_per_million=10.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.1 Codex",
+    ),
+    OpenAIChatModel.GPT5_1_CODEX_MINI.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_1_CODEX_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=0.25,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=2.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.1 Codex Mini",
+    ),
+    OpenAIChatModel.GPT5_1_CHAT.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_1_CHAT.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.125,
+        output_cost_per_million=10.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.1 Chat",
+    ),
+    OpenAIChatModel.GPT5_2.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_2.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=1.75,
+        cached_cost_per_million=0.175,
+        output_cost_per_million=14.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.2",
+    ),
+    OpenAIChatModel.GPT5_2_PRO.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_2_PRO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=272_000,
+        input_cost_per_million=15.00,
+        cached_cost_per_million=7.50,
+        output_cost_per_million=120.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.2 Pro",
+    ),
+    OpenAIChatModel.GPT5_2_CHAT.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_2_CHAT.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=1.75,
+        cached_cost_per_million=0.175,
+        output_cost_per_million=14.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.2 Chat",
+    ),
+    OpenAIChatModel.GPT_OSS_120b.value: ModelInfo(
+        name=OpenAIChatModel.GPT_OSS_120b.value,
+        provider=ModelProvider.OPENAI,
+        context_length=131_072,
+        max_output_tokens=65_535,
+        input_cost_per_million=0.15,
+        cached_cost_per_million=0.075,
+        output_cost_per_million=0.60,
+        has_structured_output=True,
+        description="GPT OSS 120B",
+    ),
+    OpenAIChatModel.GPT_OSS_20b.value: ModelInfo(
+        name=OpenAIChatModel.GPT_OSS_20b.value,
+        provider=ModelProvider.OPENAI,
+        context_length=131_072,
+        max_output_tokens=65_535,
+        input_cost_per_million=0.075,
+        cached_cost_per_million=0.037,
+        output_cost_per_million=0.30,
+        has_structured_output=True,
+        description="GPT OSS 20B",
+    ),
+    # Anthropic Models
+    AnthropicModel.CLAUDE_3_5_SONNET.value: ModelInfo(
+        name=AnthropicModel.CLAUDE_3_5_SONNET.value,
+        provider=ModelProvider.ANTHROPIC,
+        context_length=200_000,
+        max_output_tokens=8192,
+        input_cost_per_million=3.0,
+        cached_cost_per_million=0.30,
+        output_cost_per_million=15.0,
+        description="Claude 3.5 Sonnet",
+    ),
+    AnthropicModel.CLAUDE_3_OPUS.value: ModelInfo(
+        name=AnthropicModel.CLAUDE_3_OPUS.value,
+        provider=ModelProvider.ANTHROPIC,
+        context_length=200_000,
+        max_output_tokens=4096,
+        input_cost_per_million=15.0,
+        cached_cost_per_million=1.50,
+        output_cost_per_million=75.0,
+        description="Claude 3 Opus",
+    ),
+    AnthropicModel.CLAUDE_3_SONNET.value: ModelInfo(
+        name=AnthropicModel.CLAUDE_3_SONNET.value,
+        provider=ModelProvider.ANTHROPIC,
+        context_length=200_000,
+        max_output_tokens=4096,
+        input_cost_per_million=3.0,
+        cached_cost_per_million=0.30,
+        output_cost_per_million=15.0,
+        description="Claude 3 Sonnet",
+    ),
+    AnthropicModel.CLAUDE_3_HAIKU.value: ModelInfo(
+        name=AnthropicModel.CLAUDE_3_HAIKU.value,
+        provider=ModelProvider.ANTHROPIC,
+        context_length=200_000,
+        max_output_tokens=4096,
+        input_cost_per_million=0.25,
+        cached_cost_per_million=0.03,
+        output_cost_per_million=1.25,
+        description="Claude 3 Haiku",
+    ),
+    # DeepSeek Models
+    DeepSeekModel.DEEPSEEK.value: ModelInfo(
+        name=DeepSeekModel.DEEPSEEK.value,
+        provider=ModelProvider.DEEPSEEK,
+        context_length=64_000,
+        max_output_tokens=8_000,
+        input_cost_per_million=0.27,
+        cached_cost_per_million=0.07,
+        output_cost_per_million=1.10,
+        description="DeepSeek Chat",
+    ),
+    DeepSeekModel.DEEPSEEK_R1.value: ModelInfo(
+        name=DeepSeekModel.DEEPSEEK_R1.value,
+        provider=ModelProvider.DEEPSEEK,
+        context_length=64_000,
+        max_output_tokens=8_000,
+        input_cost_per_million=0.55,
+        cached_cost_per_million=0.14,
+        output_cost_per_million=2.19,
+        description="DeepSeek-R1 Reasoning LM",
+    ),
+    # Gemini Models
+    GeminiModel.GEMINI_2_FLASH.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_FLASH.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_056_768,
+        max_output_tokens=8192,
+        input_cost_per_million=0.10,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=0.40,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.0 Flash",
+    ),
+    GeminiModel.GEMINI_2_FLASH_LITE.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_FLASH_LITE.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_056_768,
+        max_output_tokens=8192,
+        input_cost_per_million=0.075,
+        output_cost_per_million=0.30,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.0 Flash Lite",
+    ),
+    GeminiModel.GEMINI_1_5_FLASH.value: ModelInfo(
+        name=GeminiModel.GEMINI_1_5_FLASH.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_056_768,
+        max_output_tokens=8192,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 1.5 Flash",
+    ),
+    GeminiModel.GEMINI_1_5_FLASH_8B.value: ModelInfo(
+        name=GeminiModel.GEMINI_1_5_FLASH_8B.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_000_000,
+        max_output_tokens=8192,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 1.5 Flash 8B",
+    ),
+    GeminiModel.GEMINI_1_5_PRO.value: ModelInfo(
+        name=GeminiModel.GEMINI_1_5_PRO.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=2_000_000,
+        max_output_tokens=8192,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 1.5 Pro",
+    ),
+    GeminiModel.GEMINI_2_PRO.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_PRO.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=2_000_000,
+        max_output_tokens=8192,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2 Pro Exp 02-05",
+    ),
+    GeminiModel.GEMINI_2_FLASH_THINKING.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_FLASH_THINKING.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_000_000,
+        max_output_tokens=64_000,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.0 Flash Thinking",
+    ),
+    # Gemini 2.5 Models
+    GeminiModel.GEMINI_2_5_PRO.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_5_PRO.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_048_576,
+        max_output_tokens=65_536,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.31,
+        output_cost_per_million=10.0,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.5 Pro",
+    ),
+    GeminiModel.GEMINI_2_5_FLASH.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_5_FLASH.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_048_576,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.30,
+        cached_cost_per_million=0.075,
+        output_cost_per_million=2.50,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.5 Flash",
+    ),
+    GeminiModel.GEMINI_2_5_FLASH_LITE.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_5_FLASH_LITE.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=65_536,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.10,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=0.40,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.5 Flash Lite",
+    ),
+    # Gemini 3 Models
+    GeminiModel.GEMINI_3_PRO.value: ModelInfo(
+        name=GeminiModel.GEMINI_3_PRO.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_000_000,
+        max_output_tokens=64_000,
+        input_cost_per_million=2.00,
+        cached_cost_per_million=0.20,
+        output_cost_per_million=12.00,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 3 Pro",
+    ),
+    GeminiModel.GEMINI_3_FLASH.value: ModelInfo(
+        name=GeminiModel.GEMINI_3_FLASH.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_048_576,
+        max_output_tokens=65_535,
+        input_cost_per_million=0.50,
+        cached_cost_per_million=0.05,
+        output_cost_per_million=3.00,
+        description="Gemini 3 Flash",
+    ),
+    # MiniMax Models
+    MiniMaxModel.MINIMAX_M2_7.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_7.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=131_072,
+        input_cost_per_million=0.30,
+        output_cost_per_million=1.20,
+        has_structured_output=True,
+        description="MiniMax M2.7 (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=131_072,
+        input_cost_per_million=0.15,
+        output_cost_per_million=0.60,
+        has_structured_output=True,
+        description="MiniMax M2.7 Highspeed (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_5.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_5.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.30,
+        output_cost_per_million=1.20,
+        has_structured_output=True,
+        description="MiniMax M2.5 (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.15,
+        output_cost_per_million=0.60,
+        has_structured_output=True,
+        description="MiniMax M2.5 Highspeed (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_1.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_1.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.27,
+        output_cost_per_million=0.95,
+        has_structured_output=True,
+        description="MiniMax M2.1 (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.14,
+        output_cost_per_million=0.48,
+        has_structured_output=True,
+        description="MiniMax M2.1 Highspeed (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.27,
+        output_cost_per_million=0.95,
+        has_structured_output=True,
+        description="MiniMax M2 (204K context)",
+    ),
+}
 
-        # Caution - this updates the self.config.system_message!
-        self._init_system_message()
-        super().__init__(config)
-        self._init_tools()
-        if self.config.is_helper:
-            self.system_tool_format_instructions += self.final_instructions
 
-        if self.config.use_helper:
-            # helper_config.system_message is now the fully-populated sys msg of
-            # the main SQLAgent.
-            self.helper_config = self.config.model_copy()
-            self.helper_config.is_helper = True
-            self.helper_config.use_helper = False
-            self.helper_config.chat_mode = False
-            self.helper_agent = SQLHelperAgent(self.helper_config)
+def get_model_info(
+    model: str | ModelName,
+    fallback_models: List[str] = [],
+) -> ModelInfo:
+    """Get model information by name or enum value"""
+    # Sequence of models to try, starting with the primary model
+    models_to_try = [model] + fallback_models
 
-    def _validate_config(self, config: "SQLChatAgentConfig") -> None:
-        """Validate the configuration to ensure all necessary fields are present."""
-        if config.database_session is None and config.database_uri is None:
-            raise ValueError("Database information must be provided")
+    # Find the first model in the sequence that has info defined using next()
+    # on a generator expression that filters out None results from _get_model_info
+    found_info = next(
+        (info for m in models_to_try if (info := _get_model_info(m)) is not None),
+        None,  # Default value if the iterator is exhausted (no valid info found)
+    )
 
-    def _init_database(self) -> None:
-        """Initialize the database engine and session."""
-        if self.config.database_session:
-            self.Session = self.config.database_session
-            self.engine = self.Session.bind
-        else:
-            self.engine = create_engine(self.config.database_uri)
-            self.Session = sessionmaker(bind=self.engine)()
+    if found_info is not None:
+        return found_info
 
-    def _init_metadata(self) -> None:
-        """Initialize the database metadata."""
-        if self.engine is None:
-            raise ValueError("Database engine is None")
-        self.metadata: MetaData | List[MetaData] = []
+    normalized_models = _normalize_model_names(models_to_try)
+    found_info = next(
+        (
+            info
+            for normalized_model in normalized_models
+            if (info := _get_model_info(normalized_model)) is not None
+        ),
+        None,
+    )
+    if found_info is not None:
+        return found_info
 
-        if self.config.multi_schema:
-            logger.info(
-                "Initializing SQLChatAgent with database: %s",
-                self.engine,
-            )
+    _warn_unknown_model(models_to_try)
+    return ModelInfo()
 
-            self.metadata = []
-            inspector = inspect(self.engine)
 
-            for schema in inspector.get_schema_names():
-                metadata = MetaData(schema=schema)
-                metadata.reflect(self.engine)
-                self.metadata.append(metadata)
+def _get_model_info(model: str | ModelName) -> ModelInfo | None:
+    if isinstance(model, str):
+        return MODEL_INFO.get(model)
+    return MODEL_INFO.get(model.value)
 
-                logger.info(
-                    "Initializing SQLChatAgent with database: %s, schema: %s, "
-                    "and tables: %s",
-                    self.engine,
-                    schema,
-                    metadata.tables,
-                )
-        else:
-            self.metadata = MetaData()
-            self.metadata.reflect(self.engine)
-            logger.info(
-                "SQLChatAgent initialized with database: %s and tables: %s",
-                self.engine,
-                self.metadata.tables,
-            )
 
-    def _init_table_metadata(self) -> None:
-        """Initialize metadata for the tables present in the database."""
-        if not self.config.context_descriptions and isinstance(self.engine, Engine):
-            self.config.context_descriptions = extract_schema_descriptions(
-                self.engine, self.config.multi_schema
-            )
+def _normalize_model_names(models: List[str | ModelName]) -> List[str]:
+    normalized_models: List[str] = []
+    seen: set[str] = set()
+    for model in models:
+        normalized_model = _normalize_gemini_model_name(_model_name(model))
+        if normalized_model is None or normalized_model in seen:
+            continue
+        seen.add(normalized_model)
+        normalized_models.append(normalized_model)
+    return normalized_models
 
-        if self.config.use_schema_tools:
-            self.table_metadata = populate_metadata_with_schema_tools(
-                self.metadata, self.config.context_descriptions
-            )
-        else:
-            self.table_metadata = populate_metadata(
-                self.metadata, self.config.context_descriptions
-            )
 
-    def _init_system_message(self) -> None:
-        """Initialize the system message."""
-        message = self._format_message()
-        self.config.system_message = self.config.system_message.format(mode=message)
-
-        if not self.config.allow_dangerous_operations:
-            allowed = sorted(
-                t.strip().upper() for t in self.config.allowed_statement_types
-            )
-            self.config.system_message += (
-                f"\n\nIMPORTANT - SECURITY POLICY:\n"
-                f"You may ONLY issue SQL queries whose top-level statement "
-                f"type is one of: {allowed}. Any other statement type "
-                f"(e.g. DDL, COPY, EXEC, multi-statement scripts that "
-                f"include a disallowed type) will be REJECTED by the "
-                f"executor and not run.\n"
-            )
-
-        if self.config.chat_mode:
-            self.config.addressing_prefix = self.config.addressing_prefix or SEND_TO
-            self.config.system_message += ADDRESSING_INSTRUCTION.format(
-                prefix=self.config.addressing_prefix
-            )
-        else:
-            self.config.system_message += DONE_INSTRUCTION
-
-    def _init_tools(self) -> None:
-        """Initialize sys msg and tools."""
-        # Create a custom RunQueryTool class with the desired max_retained_tokens
-        if self.config.max_retained_tokens is not None:
-
-            class CustomRunQueryTool(RunQueryTool):
-                _max_retained_tokens = self.config.max_retained_tokens
-
-            self.enable_message([CustomRunQueryTool, ForwardTool])
-        else:
-            self.enable_message([RunQueryTool, ForwardTool])
-
-        if self.config.use_schema_tools:
-            self._enable_schema_tools()
-        if not self.config.chat_mode:
-            self.enable_message(DoneTool)
-            self.enable_message(DonePassTool)
-
-    def _format_message(self) -> str:
-        if self.engine is None:
-            raise ValueError("Database engine is None")
-
-        """Format the system message based on the engine and table metadata."""
-        return (
-            SCHEMA_TOOLS_SYS_MSG.format(dialect=self.engine.dialect.name)
-            if self.config.use_schema_tools
-            else DEFAULT_SYS_MSG.format(
-                dialect=self.engine.dialect.name, schema_dict=self.table_metadata
-            )
-        )
-
-    def _enable_schema_tools(self) -> None:
-        """Enable tools for schema-related functionalities."""
-        self.enable_message(GetTableNamesTool)
-        self.enable_message(GetTableSchemaTool)
-        self.enable_message(GetColumnDescriptionsTool)
-
-    def llm_response(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> Optional[ChatDocument]:
-        self.llm_responded = True
-        self.used_run_query = False
-        return super().llm_response(message)
-
-    def user_response(
-        self,
-        msg: Optional[str | ChatDocument] = None,
-    ) -> Optional[ChatDocument]:
-        self.llm_responded = False
-        self.used_run_query = False
-        return super().user_response(msg)
-
-    def _clarify_answer_instruction(self) -> str:
-        """
-        Prompt to use when asking LLM to clarify intent of
-        an already-generated response
-        """
-        if self.config.chat_mode:
-            return f"""
-                you must use the TOOL `{ForwardTool.name()}` with the `agent` 
-                parameter set to "User"
-                """
-        else:
-            return f"you must use the TOOL `{DonePassTool.name()}`"
-
-    def _clarifying_message(self) -> str:
-        tools_instruction = f"""
-          For example you may want to use the TOOL
-          `{RunQueryTool.name()}` to further explore the database contents
-        """
-        if self.config.use_schema_tools:
-            tools_instruction += """
-            OR you may want to use one of the schema tools to 
-            explore the database schema
-            """
-        return f"""
-            The intent of your response is not clear:
-            - if you intended this to be the FINAL answer to the user's query,
-                {self._clarify_answer_instruction()}
-            - otherwise, use one of the available tools to make progress 
-                to arrive at the final answer.
-                {tools_instruction}
-            """
-
-    def handle_message_fallback(
-        self, message: str | ChatDocument
-    ) -> str | ForwardTool | ChatDocument | None:
-        """
-        We'd end up here if the current msg has no tool.
-        If this is from LLM, we may need to handle the scenario where
-        it may have "forgotten" to generate a tool.
-        """
-        if (
-            not isinstance(message, ChatDocument)
-            or message.metadata.sender != Entity.LLM
-        ):
-            return None
-        if self.config.chat_mode:
-            # send any Non-tool msg to the user
-            return ForwardTool(agent="User")
-        # Agent intent not clear => use the helper agent to
-        # do what this agent should have done, e.g. generate tool, etc.
-        # This is likelier to succeed since this agent has no "baggage" of
-        # prior conversation, other than the system msg, and special
-        # "Intent-interpretation" instructions.
-        if self._json_schema_available() and self.config.strict_recovery:
-            AnyTool = self._get_any_tool_message(optional=False)
-            self.set_output_format(
-                AnyTool,
-                force_tools=True,
-                use=True,
-                handle=True,
-                instructions=True,
-            )
-            recovery_message = self._strict_recovery_instructions(
-                AnyTool, optional=False
-            )
-            result = self.llm_response(recovery_message)
-            # remove the recovery_message (it has User role) from the chat history,
-            # else it may cause the LLM to directly use the AnyTool.
-            self.delete_last_message(role=Role.USER)  # delete last User-role msg
-            return result
-        elif self.config.use_helper:
-            response = self.helper_agent.llm_response(message)
-            tools = self.try_get_tool_messages(response)
-            if tools:
-                return response
-        # fall back on the clarification message
-        return self._clarifying_message()
-
-    def retry_query(self, e: Exception, query: str) -> str:
-        """
-        Generate an error message for a failed SQL query and return it.
-
-        Parameters:
-        e (Exception): The exception raised during the SQL query execution.
-        query (str): The SQL query that failed.
-
-        Returns:
-        str: The error message.
-        """
-        logger.error(f"SQL Query failed: {query}\nException: {e}")
-
-        # Optional part to be included based on `use_schema_tools`
-        optional_schema_description = ""
-        if not self.config.use_schema_tools:
-            optional_schema_description = f"""\
-            This JSON schema maps SQL database structure. It outlines tables, each 
-            with a description and columns. Each table is identified by a key, and holds
-            a description and a dictionary of columns, with column 
-            names as keys and their descriptions as values.
-            
-            ```json
-            {self.config.context_descriptions}
-            ```"""
-
-        # Construct the error message
-        error_message_template = f"""\
-        {SQL_ERROR_MSG}: '{query}'
-        {str(e)}
-        Run a new query, correcting the errors.
-        {optional_schema_description}"""
-
-        return error_message_template
-
-    def _available_tool_names(self) -> str:
-        return ",".join(self.llm_tools_usable)
-
-    def _tool_result_llm_answer_prompt(self) -> str:
-        """
-        Prompt to use at end of tool result,
-        to guide LLM, for the case where it wants to answer the user's query
-        """
-        if self.config.chat_mode:
-            assert self.config.addressing_prefix != ""
-            return """
-                You must EXPLICITLY address the User with 
-                the addressing prefix according to your instructions,
-                to convey your answer to the User.
-                """
-        else:
-            return f"""
-                you must use the `{DoneTool.name()}` with the `content` 
-                set to the answer or result
-                """
-
-    def _sqlglot_dialect(self) -> Optional[str]:
-        """Map the SQLAlchemy dialect name to a sqlglot dialect name."""
-        if self.engine is None:
-            return None
-        name: str = str(self.engine.dialect.name)
-        # sqlglot uses 'postgres', not 'postgresql'; 'tsql' for MSSQL.
-        mapping: Dict[str, str] = {"postgresql": "postgres", "mssql": "tsql"}
-        return mapping.get(name, name)
-
-    def _validate_query(self, query: str) -> Optional[str]:
-        """
-        Check whether `query` is permitted under the agent's security config.
-
-        Returns None if the query may be executed, otherwise an error message
-        explaining why it was rejected (to be relayed to the LLM).
-        """
-        if self.config.allow_dangerous_operations:
-            return None
-
-        for pat in _DANGEROUS_SQL_PATTERNS:
-            if pat.search(query):
-                logger.warning(
-                    "SQLChatAgent rejected query matching dangerous pattern "
-                    f"{pat.pattern!r}: {query!r}"
-                )
-                return (
-                    f"Query REJECTED for safety: it matches a pattern "
-                    f"({pat.pattern!r}) that enables code execution, "
-                    f"filesystem access, or other unsafe operations. "
-                    f"Rewrite the query without using this construct, or ask "
-                    f"the operator to set `allow_dangerous_operations=True` "
-                    f"on the SQLChatAgent config."
-                )
-
-        allowed = {t.strip().upper() for t in self.config.allowed_statement_types}
-        try:
-            statements = sqlglot.parse(query, read=self._sqlglot_dialect())
-        except Exception as e:
-            logger.warning(f"sqlglot failed to parse query {query!r}: {e}")
-            return (
-                f"Query REJECTED for safety: could not be parsed to verify it "
-                f"is a {sorted(allowed)} statement ({e}). Rewrite the query "
-                f"more simply, or ask the operator to set "
-                f"`allow_dangerous_operations=True` on the SQLChatAgent config."
-            )
-
-        kind_map = {
-            sqlglot_exp.Select: "SELECT",
-            sqlglot_exp.Insert: "INSERT",
-            sqlglot_exp.Update: "UPDATE",
-            sqlglot_exp.Delete: "DELETE",
-            sqlglot_exp.Merge: "MERGE",
-            sqlglot_exp.Create: "CREATE",
-            sqlglot_exp.Drop: "DROP",
-            sqlglot_exp.Alter: "ALTER",
-            sqlglot_exp.TruncateTable: "TRUNCATE",
-            sqlglot_exp.Command: "COMMAND",
-        }
-        for stmt in statements:
-            if stmt is None:
-                continue
-            kind = next(
-                (v for k, v in kind_map.items() if isinstance(stmt, k)),
-                type(stmt).__name__.upper(),
-            )
-            if kind not in allowed:
-                logger.warning(
-                    f"SQLChatAgent rejected {kind} statement (allowed: "
-                    f"{sorted(allowed)}): {query!r}"
-                )
-                return (
-                    f"Query REJECTED for safety: statement type {kind!r} is "
-                    f"not in the allowed list {sorted(allowed)}. Rewrite the "
-                    f"query as one of the allowed statement types, or ask "
-                    f"the operator to extend `allowed_statement_types` "
-                    f"(or set `allow_dangerous_operations=True`) on the "
-                    f"SQLChatAgent config."
-                )
-            # The top-level node alone does not determine what a statement
-            # writes. A data-modifying CTE
-            # (``WITH x AS (DELETE ... RETURNING *) SELECT ...``) and
-            # ``SELECT ... INTO tbl`` both parse with a ``Select`` top node, so
-            # the check above classifies them as SELECT while the engine still
-            # performs the write (GHSA-3gpx-vwr3-xvwx / GHSA-wc83-4cvx-p8xc).
-            nested = _nested_write_kinds(stmt, kind_map)
-            disallowed = sorted(nested - allowed)
-            if disallowed:
-                logger.warning(
-                    f"SQLChatAgent rejected {kind} statement embedding "
-                    f"{disallowed} (allowed: {sorted(allowed)}): {query!r}"
-                )
-                return (
-                    f"Query REJECTED for safety: although this parses as a "
-                    f"{kind} statement, it embeds {disallowed}, which is not "
-                    f"in the allowed list {sorted(allowed)} -- the database "
-                    f"would still perform that write. Rewrite the query "
-                    f"without the embedded statement, or ask the operator to "
-                    f"extend `allowed_statement_types` (or set "
-                    f"`allow_dangerous_operations=True`) on the SQLChatAgent "
-                    f"config."
-                )
-            # AST-side dangerous-function check: catches calls that evaded
-            # `_DANGEROUS_SQL_PATTERNS` via quoted identifiers, inline comments,
-            # or schema qualification (GHSA-6xc5-4r68-67fc).
-            for fn_name in _called_function_names(stmt):
-                if _is_dangerous_function_name(fn_name):
-                    logger.warning(
-                        "SQLChatAgent rejected query calling dangerous "
-                        f"function {fn_name!r}: {query!r}"
-                    )
-                    return (
-                        f"Query REJECTED for safety: it calls function "
-                        f"{fn_name!r}, which enables code execution, "
-                        f"filesystem access, or other unsafe operations. "
-                        f"Rewrite the query without using this function, or "
-                        f"ask the operator to set "
-                        f"`allow_dangerous_operations=True` on the "
-                        f"SQLChatAgent config."
-                    )
+def _normalize_gemini_model_name(model: str) -> str | None:
+    base_model = model.rsplit("/", 1)[-1]
+    if base_model in GEMINI_CANONICAL_MODEL_NAMES:
+        return base_model
+    if not base_model.startswith("gemini-"):
         return None
 
-    def run_query(self, msg: RunQueryTool) -> str:
-        """
-        Handle a RunQueryTool message by executing a SQL query and returning the result.
-
-        Args:
-            msg (RunQueryTool): The tool-message to handle.
-
-        Returns:
-            str: The result of executing the SQL query.
-        """
-        query = msg.query
-        session = self.Session
-        self.used_run_query = True
-
-        rejection = self._validate_query(query)
-        if rejection is not None:
-            return f"""
-        Below is the result from your use of the TOOL `{RunQueryTool.name()}`:
-        ==== result ====
-        {rejection}
-        ================
-
-        Try a different query that complies with the policy above.
-        """
-
-        try:
-            logger.info(f"Executing SQL query: {query}")
-
-            query_result = session.execute(text(query))
-            session.commit()
-            try:
-                # attempt to fetch results: should work for normal SELECT queries
-                rows = query_result.fetchall()
-                n_rows = len(rows)
-                if self.config.max_result_rows and n_rows > self.config.max_result_rows:
-                    rows = rows[: self.config.max_result_rows]
-                    logger.warning(
-                        f"SQL query produced {n_rows} rows, "
-                        f"limiting to {self.config.max_result_rows}"
-                    )
-
-                response_message = self._format_rows(rows)
-            except ResourceClosedError:
-                # If we get here, it's a non-SELECT query (UPDATE, INSERT, DELETE)
-                affected_rows = query_result.rowcount  # type: ignore
-                response_message = f"""
-                    Non-SELECT query executed successfully. 
-                    Rows affected: {affected_rows}
-                    """
-
-        except SQLAlchemyError as e:
-            session.rollback()
-            logger.error(f"Failed to execute query: {query}\n{e}")
-            response_message = self.retry_query(e, query)
-        finally:
-            session.close()
-
-        final_message = f"""
-        Below is the result from your use of the TOOL `{RunQueryTool.name()}`:
-        ==== result ====
-        {response_message}
-        ================
-        
-        If you are READY to ANSWER the ORIGINAL QUERY:
-        {self._tool_result_llm_answer_prompt()}
-        OTHERWISE:
-             continue using one of your available TOOLs:
-             {",".join(self.llm_tools_usable)}
-        """
-        return final_message
-
-    def _format_rows(self, rows: Sequence[Row[Any]]) -> str:
-        """
-        Format the rows fetched from the query result into a string.
-
-        Args:
-            rows (list): List of rows fetched from the query result.
-
-        Returns:
-            str: Formatted string representation of rows.
-        """
-        # TODO: UPDATE FORMATTING
-        return (
-            ",\n".join(str(row) for row in rows)
-            if rows
-            else "Query executed successfully."
-        )
-
-    def get_table_names(self, msg: GetTableNamesTool) -> str:
-        """
-        Handle a GetTableNamesTool message by returning the names of all tables in the
-        database.
-
-        Returns:
-            str: The names of all tables in the database.
-        """
-        if isinstance(self.metadata, list):
-            table_names = [", ".join(md.tables.keys()) for md in self.metadata]
-            return ", ".join(table_names)
-
-        return ", ".join(self.metadata.tables.keys())
-
-    def get_table_schema(self, msg: GetTableSchemaTool) -> str:
-        """
-        Handle a GetTableSchemaTool message by returning the schema of all provided
-        tables in the database.
-
-        Returns:
-            str: The schema of all provided tables in the database.
-        """
-        tables = msg.tables
-        result = ""
-        for table_name in tables:
-            table = self.table_metadata.get(table_name)
-            if table is not None:
-                result += f"{table_name}: {table}\n"
-            else:
-                result += f"{table_name} is not a valid table name.\n"
-        return result
-
-    def get_column_descriptions(self, msg: GetColumnDescriptionsTool) -> str:
-        """
-        Handle a GetColumnDescriptionsTool message by returning the descriptions of all
-        provided columns from the database.
-
-        Returns:
-            str: The descriptions of all provided columns from the database.
-        """
-        table = msg.table
-        columns = msg.columns.split(", ")
-        result = f"\nTABLE: {table}"
-        descriptions = self.config.context_descriptions.get(table)
-
-        for col in columns:
-            result += f"\n{col} => {descriptions['columns'][col]}"  # type: ignore
-        return result
+    # Try stripping known suffixes to find a canonical name.
+    # Use split (not endswith) for "-preview" so dated variants like
+    # "gemini-2.5-flash-lite-preview-06-17" are handled correctly.
+    for suffix in ("-preview", "-exp", "-experimental", "-latest"):
+        stripped = base_model.split(suffix, maxsplit=1)[0]
+        if stripped != base_model and stripped in GEMINI_CANONICAL_MODEL_NAMES:
+            return stripped
+    return None
 
 
-class SQLHelperAgent(SQLChatAgent):
+def _warn_unknown_model(models: List[str | ModelName]) -> None:
+    model_names = tuple(_model_name(model) for model in models)
+    if model_names in WARNED_UNKNOWN_MODELS:
+        return
 
-    def _clarifying_message(self) -> str:
-        tools_instruction = f"""
-          For example the Agent may have forgotten to use the TOOL
-          `{RunQueryTool.name()}` to further explore the database contents
-        """
-        if self.config.use_schema_tools:
-            tools_instruction += """
-            OR the agent may have forgotten to use one of the schema tools to 
-            explore the database schema
-            """
+    WARNED_UNKNOWN_MODELS.add(model_names)
+    logger.warning(
+        "Unknown model info for %s; using fallback defaults "
+        "(context_length=%s, max_output_tokens=%s). "
+        "Context-length checks may be inaccurate. "
+        "Set `chat_context_length` explicitly if needed.",
+        ", ".join(model_names),
+        DEFAULT_MODEL_INFO.context_length,
+        DEFAULT_MODEL_INFO.max_output_tokens,
+    )
 
-        return f"""
-            The intent of the Agent's response is not clear:
-            - if you think the Agent intended this as ANSWER to the 
-                user's query,
-                {self._clarify_answer_instruction()}
-            - otherwise, the Agent may have forgotten to 
-              use one of the available tools to make progress 
-                to arrive at the final answer.
-                {tools_instruction}
-            """
 
-    def _init_system_message(self) -> None:
-        """Set up helper sys msg"""
-
-        # Note that self.config.system_message is already set to the
-        # parent SQLAgent's system_message
-        self.config.system_message = f"""
-                You role is to help INTERPRET the INTENT of an 
-                AI agent in a conversation. This Agent was supposed to generate
-                a TOOL/Function-call but forgot to do so, and this is where 
-                you can help, by trying to generate the appropriate TOOL
-                based on your best guess of the Agent's INTENT.
-                
-                Below are the instructions that were given to this Agent: 
-                ===== AGENT INSTRUCTIONS =====
-                {self.config.system_message}
-                ===== END OF AGENT INSTRUCTIONS =====
-                """
-
-        # note that the initial msg in chat history will contain:
-        # - system message
-        # - tool instructions
-        # so the final_instructions will be at the end of this initial msg
-
-        self.final_instructions = f"""        
-        You must take note especially of the TOOLs that are
-        available to the Agent. Your reasoning process should be as follows:
-        
-        - If the Agent's message appears to be an ANSWER to the original query,
-          {self._clarify_answer_instruction()}.
-          CAUTION - You must be absolutely sure that the Agent's message is 
-          an ACTUAL ANSWER to the user's query, and not a failed attempt to use 
-          a TOOL without JSON, e.g. something like "run_query" or "done_tool"
-          without any actual JSON formatting.
-           
-        - Else, if you think the Agent intended to use some type of SQL
-          query tool to READ or UPDATE the table(s), 
-          AND it is clear WHICH TOOL is intended as well as the 
-          TOOL PARAMETERS, then you must generate the JSON-Formatted
-          TOOL with the parameters set based on your understanding.
-          Note that the `{RunQueryTool.name()}` is not ONLY for querying the tables,
-          but also for UPDATING the tables.
-           
-        - Else, use the `{PassTool.name()}` to pass the message unchanged.
-            CAUTION - ONLY use `{PassTool.name()}` if you think the Agent's response
-            is NEITHER an ANSWER, nor an intended SQL QUERY.
-        """
-
-    def llm_response(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> Optional[ChatDocument]:
-        if message is None:
-            return None
-        message_str = message if isinstance(message, str) else message.content
-        instruc_msg = f"""
-        Below is the MESSAGE from the SQL Agent. 
-        Remember your instructions on how to respond based on your understanding
-        of the INTENT of this message:        
-        {self.final_instructions}
-        
-        === AGENT MESSAGE =========
-        {message_str}
-        === END OF AGENT MESSAGE ===
-        """
-        # user response_forget to avoid accumulating the chat history
-        return super().llm_response_forget(instruc_msg)
+def _model_name(model: str | ModelName) -> str:
+    if isinstance(model, str):
+        return model
+    return model.value
 </file>
 
 <file path="langroid/agent/base.py">
@@ -57181,6 +58572,17 @@ class AgentConfig(BaseSettings):
     respond_tools_only: bool = False  # respond only to tool messages (not plain text)?
     # allow multiple tool messages in a single response?
     allow_multiple_tools: bool = True
+    # Optional pre-execution tool policy hook, called with the final parsed
+    # ToolMessage just BEFORE its selected handler runs, as
+    # ``tool_policy(tool, agent)`` -- or ``tool_policy(tool, agent, chat_doc=...)``
+    # when the callable has a ``chat_doc`` parameter. May be sync or async.
+    # Return True or None to ALLOW (the handler runs exactly once); return
+    # False or a str reason to REJECT (the handler is NOT run, and the LLM
+    # sees a rejection naming the tool and the reason). The hook cannot modify
+    # the tool. If the hook itself raises, the tool is blocked (fail-closed)
+    # and the rejection deliberately excludes the exception message and tool
+    # arguments. See docs/notes/tool-policy-hook.md.
+    tool_policy: Optional[Callable[..., Any]] = None
     human_prompt: str = (
         "Human (respond or q, x to exit current level, " "or hit enter to continue)"
     )
@@ -58860,7 +60262,7 @@ class Agent(ABC):
         results = self._get_multiple_orch_tool_errs(tools)
         if not results:
             results = [
-                await self.handle_tool_message_async(t, chat_doc=chat_doc)
+                await self._handle_tool_message_with_policy_async(t, chat_doc=chat_doc)
                 for t in tools
             ]
             # if there's a solitary ChatDocument|str result, return it as is
@@ -58928,7 +60330,10 @@ class Agent(ABC):
             results = self._get_multiple_orch_tool_errs(tools)
         if not results:
             chat_doc = msg if isinstance(msg, ChatDocument) else None
-            results = [self.handle_tool_message(t, chat_doc=chat_doc) for t in tools]
+            results = [
+                self._handle_tool_message_with_policy(t, chat_doc=chat_doc)
+                for t in tools
+            ]
             # if there's a solitary ChatDocument|str result, return it as is
             if len(results) == 1 and isinstance(results[0], (str, ChatDocument)):
                 return results[0]
@@ -59106,7 +60511,7 @@ class Agent(ABC):
                 #     msg in chat_doc.tool_messages):
                 #    chat_doc.tool_messages.remove(msg)
                 # if we can handle it, do so
-                result = self.handle_tool_message(msg, chat_doc=chat_doc)
+                result = self._handle_tool_message_with_policy(msg, chat_doc=chat_doc)
                 if result is not None and isinstance(result, ChatDocument):
                     return result
             else:
@@ -59211,6 +60616,88 @@ class Agent(ABC):
             ) + truncate_warning
             return result
 
+    def _handle_tool_message_with_policy(
+        self,
+        tool: ToolMessage,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> None | str | ChatDocument:
+        """Framework entry point for sync tool dispatch, enforcing `tool_policy`.
+
+        Consults the `tool_policy` hook (see `AgentConfig.tool_policy`) and,
+        if the tool is allowed, delegates to `handle_tool_message` -- which a
+        subclass may override -- exactly as before, so the policy gates tool
+        execution even through such overrides.
+
+        When dispatch is NOT overridden and the tool has no handler, the
+        policy is not consulted (nothing can execute). When dispatch IS
+        overridden, the base cannot know what the override will do, so the
+        policy is consulted regardless, even though the override may end up
+        returning None.
+
+        Args:
+            tool: ToolMessage object representing the tool request.
+            chat_doc: Optional ChatDocument object containing the tool request.
+
+        Returns:
+            The dispatch result, or the policy's LLM-visible rejection.
+        """
+        from langroid.agent.tool_policy import (
+            check_tool_policy,
+            dispatch_overridden,
+            handler_exists,
+            policy_exempt,
+        )
+
+        if self.config.tool_policy is not None and not policy_exempt(tool):
+            if not dispatch_overridden(self, use_async=False) and not handler_exists(
+                self, tool, use_async=False
+            ):
+                # base dispatch would execute nothing; don't consult the policy
+                return None
+            rejection = check_tool_policy(self.config.tool_policy, tool, self, chat_doc)
+            if rejection is not None:
+                return rejection
+        return self.handle_tool_message(tool, chat_doc=chat_doc)
+
+    async def _handle_tool_message_with_policy_async(
+        self,
+        tool: ToolMessage,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> None | str | ChatDocument:
+        """Async version of `_handle_tool_message_with_policy`.
+
+        The policy is awaited on the CALLER's event loop (so it can use
+        loop-bound resources), then dispatch proceeds via
+        `handle_tool_message_async` -- which a subclass may override --
+        exactly as before.
+
+        Args:
+            tool: ToolMessage object representing the tool request.
+            chat_doc: Optional ChatDocument object containing the tool request.
+
+        Returns:
+            The dispatch result, or the policy's LLM-visible rejection.
+        """
+        from langroid.agent.tool_policy import (
+            check_tool_policy_async,
+            dispatch_overridden,
+            handler_exists,
+            policy_exempt,
+        )
+
+        if self.config.tool_policy is not None and not policy_exempt(tool):
+            if not dispatch_overridden(self, use_async=True) and not handler_exists(
+                self, tool, use_async=True
+            ):
+                # base dispatch would execute nothing; don't consult the policy
+                return None
+            rejection = await check_tool_policy_async(
+                self.config.tool_policy, tool, self, chat_doc
+            )
+            if rejection is not None:
+                return rejection
+        return await self.handle_tool_message_async(tool, chat_doc=chat_doc)
+
     async def handle_tool_message_async(
         self,
         tool: ToolMessage,
@@ -59253,6 +60740,12 @@ class Agent(ABC):
     ) -> None | str | ChatDocument:
         """
         Respond to a tool request from the LLM, in the form of an ToolMessage object.
+
+        NOTE: framework dispatch reaches this method through
+        `_handle_tool_message_with_policy`, which enforces the optional
+        `tool_policy` hook BEFORE delegating here; direct calls to this
+        method by user code are the caller's own seam and are not gated.
+
         Args:
             tool: ToolMessage object representing the tool request.
             chat_doc: Optional ChatDocument object containing the tool request.
@@ -59453,865 +60946,13 @@ class Agent(ABC):
         return None
 </file>
 
-<file path="langroid/language_models/model_info.py">
-import logging
-from enum import Enum
-from typing import Dict, List, Optional
-
-from pydantic import BaseModel
-
-logger = logging.getLogger(__name__)
-
-
-class ModelProvider(str, Enum):
-    """Enum for model providers"""
-
-    OPENAI = "openai"
-    ANTHROPIC = "anthropic"
-    DEEPSEEK = "deepseek"
-    GOOGLE = "google"
-    MINIMAX = "minimax"
-    UNKNOWN = "unknown"
-
-
-class ModelName(str, Enum):
-    """Parent class for all model name enums"""
-
-    pass
-
-
-class OpenAIChatModel(ModelName):
-    """Enum for OpenAI Chat models"""
-
-    GPT3_5_TURBO = "gpt-3.5-turbo"
-    GPT4 = "gpt-4o"  # avoid deprecated gpt-4
-    GPT4_TURBO = "gpt-4-turbo"
-    GPT4o = "gpt-4o"
-    GPT4o_MINI = "gpt-4o-mini"
-    O1 = "o1"
-    O1_MINI = "o1-mini"
-    O3_MINI = "o3-mini"
-    O3 = "o3"
-    O4_MINI = "o4-mini"
-    GPT4_1 = "gpt-4.1"
-    GPT4_1_MINI = "gpt-4.1-mini"
-    GPT4_1_NANO = "gpt-4.1-nano"
-    GPT5 = "gpt-5"
-    GPT5_MINI = "gpt-5-mini"
-    GPT5_NANO = "gpt-5-nano"
-    GPT5_PRO = "gpt-5-pro"
-    GPT5_1 = "gpt-5.1"
-    GPT5_1_CODEX = "gpt-5.1-codex"
-    GPT5_1_CODEX_MINI = "gpt-5.1-codex-mini"
-    GPT5_1_CHAT = "gpt-5.1-chat"
-    GPT5_2 = "gpt-5.2"
-    GPT5_2_PRO = "gpt-5.2-pro"
-    GPT5_2_CHAT = "gpt-5.2-chat"
-    GPT_OSS_120b = "gpt-oss-120b"
-    GPT_OSS_20b = "gpt-oss-20b"
-
-
-class OpenAICompletionModel(str, Enum):
-    """Enum for OpenAI Completion models"""
-
-    DAVINCI = "davinci-002"
-    BABBAGE = "babbage-002"
-
-
-class AnthropicModel(ModelName):
-    """Enum for Anthropic models"""
-
-    CLAUDE_3_OPUS = "claude-3-opus-latest"
-    CLAUDE_3_SONNET = "claude-3-sonnet-latest"
-    CLAUDE_3_HAIKU = "claude-3-haiku-latest"
-    CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest"
-    CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest"
-    CLAUDE_4_OPUS = "claude-opus-4"
-    CLAUDE_4_SONNET = "claude-sonnet-4"
-    CLAUDE_4_HAIKU = "claude-haiku-4"
-    CLAUDE_4_5_OPUS = "claude-opus-4-5"
-    CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
-    CLAUDE_4_5_HAIKU = "claude-haiku-4-5"
-
-
-class DeepSeekModel(ModelName):
-    """Enum for DeepSeek models direct from DeepSeek API"""
-
-    DEEPSEEK = "deepseek/deepseek-chat"
-    DEEPSEEK_R1 = "deepseek/deepseek-reasoner"
-    OPENROUTER_DEEPSEEK_R1 = "openrouter/deepseek/deepseek-r1"
-
-
-class GeminiModel(ModelName):
-    """Enum for Gemini models"""
-
-    GEMINI_1_5_FLASH = "gemini-1.5-flash"
-    GEMINI_1_5_FLASH_8B = "gemini-1.5-flash-8b"
-    GEMINI_1_5_PRO = "gemini-1.5-pro"
-    GEMINI_2_FLASH = "gemini-2.0-flash"
-    GEMINI_2_FLASH_LITE = "gemini-2.0-flash-lite"
-    GEMINI_2_FLASH_THINKING = "gemini-2.0-flash-thinking-exp"
-    GEMINI_2_PRO = "gemini-2.0-pro-exp-02-05"
-    GEMINI_2_5_FLASH = "gemini-2.5-flash"
-    GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
-    GEMINI_2_5_PRO = "gemini-2.5-pro"
-    GEMINI_3_FLASH = "gemini-3-flash"
-    GEMINI_3_PRO = "gemini-3-pro"
-
-
-class MiniMaxModel(ModelName):
-    """Enum for MiniMax models"""
-
-    MINIMAX_M2_7 = "MiniMax-M2.7"
-    MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
-    MINIMAX_M2_5 = "MiniMax-M2.5"
-    MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
-    MINIMAX_M2_1 = "MiniMax-M2.1"
-    MINIMAX_M2_1_HIGHSPEED = "MiniMax-M2.1-highspeed"
-    MINIMAX_M2 = "MiniMax-M2"
-
-
-class OpenAI_API_ParamInfo(BaseModel):
-    """
-    Parameters exclusive to some models, when using OpenAI API
-    """
-
-    # model-specific params at top level
-    params: Dict[str, List[str]] = dict(
-        reasoning_effort=[
-            OpenAIChatModel.O3_MINI.value,
-            OpenAIChatModel.O3.value,
-            OpenAIChatModel.O4_MINI.value,
-            OpenAIChatModel.GPT5.value,
-            OpenAIChatModel.GPT5_MINI.value,
-            OpenAIChatModel.GPT5_NANO.value,
-            OpenAIChatModel.GPT5_PRO.value,
-            OpenAIChatModel.GPT5_1.value,
-            OpenAIChatModel.GPT5_1_CODEX.value,
-            OpenAIChatModel.GPT5_1_CODEX_MINI.value,
-            OpenAIChatModel.GPT5_2.value,
-            OpenAIChatModel.GPT5_2_PRO.value,
-            OpenAIChatModel.GPT_OSS_120b.value,
-            OpenAIChatModel.GPT_OSS_20b.value,
-            GeminiModel.GEMINI_2_5_PRO.value,
-            GeminiModel.GEMINI_2_5_FLASH.value,
-            GeminiModel.GEMINI_2_5_FLASH_LITE.value,
-        ],
-    )
-    # model-specific params in extra_body
-    extra_parameters: Dict[str, List[str]] = dict(
-        include_reasoning=[
-            DeepSeekModel.OPENROUTER_DEEPSEEK_R1.value,
-        ]
-    )
-
-
-class ModelInfo(BaseModel):
-    """
-    Consolidated information about LLM, related to capacity, cost and API
-    idiosyncrasies. Reasonable defaults for all params in case there's no
-    specific info available.
-    """
-
-    name: str = "unknown"
-    provider: ModelProvider = ModelProvider.UNKNOWN
-    context_length: int = 16_000
-    max_cot_tokens: int = 0  # max chain of thought (thinking) tokens where applicable
-    max_output_tokens: int = 8192  # Maximum number of output tokens - model dependent
-    input_cost_per_million: float = 0.0  # Cost in USD per million input tokens
-    cached_cost_per_million: float = 0.0  # Cost in USD per million cached tokens
-    output_cost_per_million: float = 0.0  # Cost in USD per million output tokens
-    allows_streaming: bool = True  # Whether model supports streaming output
-    allows_system_message: bool = True  # Whether model supports system messages
-    rename_params: Dict[str, str] = {}  # Rename parameters for OpenAI API
-    unsupported_params: List[str] = []
-    has_structured_output: bool = False  # Does model API support structured output?
-    has_tools: bool = True  # Does model API support tools/function-calling?
-    needs_first_user_message: bool = False  # Does API need first msg to be from user?
-    description: Optional[str] = None
-
-
-GEMINI_CANONICAL_MODEL_NAMES = {model.value for model in GeminiModel}
-DEFAULT_MODEL_INFO = ModelInfo()
-WARNED_UNKNOWN_MODELS: set[tuple[str, ...]] = set()
-
-
-# Model information registry
-MODEL_INFO: Dict[str, ModelInfo] = {
-    # OpenAI Models
-    OpenAICompletionModel.DAVINCI.value: ModelInfo(
-        name=OpenAICompletionModel.DAVINCI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=4096,
-        max_output_tokens=4096,
-        input_cost_per_million=2.0,
-        output_cost_per_million=2.0,
-        description="Davinci-002",
-    ),
-    OpenAICompletionModel.BABBAGE.value: ModelInfo(
-        name=OpenAICompletionModel.BABBAGE.value,
-        provider=ModelProvider.OPENAI,
-        context_length=4096,
-        max_output_tokens=4096,
-        input_cost_per_million=0.40,
-        output_cost_per_million=0.40,
-        description="Babbage-002",
-    ),
-    OpenAIChatModel.GPT3_5_TURBO.value: ModelInfo(
-        name=OpenAIChatModel.GPT3_5_TURBO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=16_385,
-        max_output_tokens=4096,
-        input_cost_per_million=0.50,
-        output_cost_per_million=1.50,
-        description="GPT-3.5 Turbo",
-    ),
-    OpenAIChatModel.GPT4.value: ModelInfo(
-        name=OpenAIChatModel.GPT4.value,
-        provider=ModelProvider.OPENAI,
-        context_length=8192,
-        max_output_tokens=8192,
-        input_cost_per_million=30.0,
-        output_cost_per_million=60.0,
-        description="GPT-4 (8K context)",
-    ),
-    OpenAIChatModel.GPT4_TURBO.value: ModelInfo(
-        name=OpenAIChatModel.GPT4_TURBO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=4096,
-        input_cost_per_million=10.0,
-        output_cost_per_million=30.0,
-        description="GPT-4 Turbo",
-    ),
-    OpenAIChatModel.GPT4_1_NANO.value: ModelInfo(
-        name=OpenAIChatModel.GPT4_1_NANO.value,
-        provider=ModelProvider.OPENAI,
-        has_structured_output=True,
-        context_length=1_047_576,
-        max_output_tokens=32_768,
-        input_cost_per_million=0.10,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=0.40,
-        description="GPT-4.1",
-    ),
-    OpenAIChatModel.GPT4_1_MINI.value: ModelInfo(
-        name=OpenAIChatModel.GPT4_1_MINI.value,
-        provider=ModelProvider.OPENAI,
-        has_structured_output=True,
-        context_length=1_047_576,
-        max_output_tokens=32_768,
-        input_cost_per_million=0.40,
-        cached_cost_per_million=0.10,
-        output_cost_per_million=1.60,
-        description="GPT-4.1 Mini",
-    ),
-    OpenAIChatModel.GPT4_1.value: ModelInfo(
-        name=OpenAIChatModel.GPT4_1.value,
-        provider=ModelProvider.OPENAI,
-        has_structured_output=True,
-        context_length=1_047_576,
-        max_output_tokens=32_768,
-        input_cost_per_million=2.00,
-        cached_cost_per_million=0.50,
-        output_cost_per_million=8.00,
-        description="GPT-4.1",
-    ),
-    OpenAIChatModel.GPT4o.value: ModelInfo(
-        name=OpenAIChatModel.GPT4o.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=16_384,
-        input_cost_per_million=2.5,
-        cached_cost_per_million=1.25,
-        output_cost_per_million=10.0,
-        has_structured_output=True,
-        description="GPT-4o (128K context)",
-    ),
-    OpenAIChatModel.GPT4o_MINI.value: ModelInfo(
-        name=OpenAIChatModel.GPT4o_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=16_384,
-        input_cost_per_million=0.15,
-        cached_cost_per_million=0.075,
-        output_cost_per_million=0.60,
-        has_structured_output=True,
-        description="GPT-4o Mini",
-    ),
-    OpenAIChatModel.O1.value: ModelInfo(
-        name=OpenAIChatModel.O1.value,
-        provider=ModelProvider.OPENAI,
-        context_length=200_000,
-        max_output_tokens=100_000,
-        input_cost_per_million=15.0,
-        cached_cost_per_million=7.50,
-        output_cost_per_million=60.0,
-        allows_streaming=True,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        has_tools=False,
-        description="O1 Reasoning LM",
-    ),
-    OpenAIChatModel.O3.value: ModelInfo(
-        name=OpenAIChatModel.O3.value,
-        provider=ModelProvider.OPENAI,
-        context_length=200_000,
-        max_output_tokens=100_000,
-        input_cost_per_million=2.0,
-        cached_cost_per_million=0.50,
-        output_cost_per_million=8.0,
-        allows_streaming=True,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        has_tools=False,
-        description="O1 Reasoning LM",
-    ),
-    OpenAIChatModel.O1_MINI.value: ModelInfo(
-        name=OpenAIChatModel.O1_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=65_536,
-        input_cost_per_million=1.1,
-        cached_cost_per_million=0.55,
-        output_cost_per_million=4.4,
-        allows_streaming=False,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature", "stream"],
-        has_tools=False,
-        description="O1 Mini Reasoning LM",
-    ),
-    OpenAIChatModel.O3_MINI.value: ModelInfo(
-        name=OpenAIChatModel.O3_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=200_000,
-        max_output_tokens=100_000,
-        input_cost_per_million=1.1,
-        cached_cost_per_million=0.55,
-        output_cost_per_million=4.4,
-        allows_streaming=False,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature", "stream"],
-        has_tools=False,
-        description="O3 Mini Reasoning LM",
-    ),
-    OpenAIChatModel.O4_MINI.value: ModelInfo(
-        name=OpenAIChatModel.O4_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=200_000,
-        max_output_tokens=100_000,
-        input_cost_per_million=1.10,
-        cached_cost_per_million=0.275,
-        output_cost_per_million=4.40,
-        allows_streaming=False,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature", "stream"],
-        has_tools=False,
-        description="O3 Mini Reasoning LM",
-    ),
-    OpenAIChatModel.GPT5.value: ModelInfo(
-        name=OpenAIChatModel.GPT5.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.125,
-        output_cost_per_million=10.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5",
-    ),
-    OpenAIChatModel.GPT5_MINI.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=0.25,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=2.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5 Mini",
-    ),
-    OpenAIChatModel.GPT5_NANO.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_NANO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=0.05,
-        cached_cost_per_million=0.005,
-        output_cost_per_million=0.40,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5 Nano",
-    ),
-    OpenAIChatModel.GPT5_PRO.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_PRO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=272_000,
-        input_cost_per_million=15.00,
-        cached_cost_per_million=7.50,
-        output_cost_per_million=120.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5 Pro",
-    ),
-    OpenAIChatModel.GPT5_1.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_1.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.13,
-        output_cost_per_million=10.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.1",
-    ),
-    OpenAIChatModel.GPT5_1_CODEX.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_1_CODEX.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.125,
-        output_cost_per_million=10.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.1 Codex",
-    ),
-    OpenAIChatModel.GPT5_1_CODEX_MINI.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_1_CODEX_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=0.25,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=2.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.1 Codex Mini",
-    ),
-    OpenAIChatModel.GPT5_1_CHAT.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_1_CHAT.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=16_384,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.125,
-        output_cost_per_million=10.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.1 Chat",
-    ),
-    OpenAIChatModel.GPT5_2.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_2.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=1.75,
-        cached_cost_per_million=0.175,
-        output_cost_per_million=14.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.2",
-    ),
-    OpenAIChatModel.GPT5_2_PRO.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_2_PRO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=272_000,
-        input_cost_per_million=15.00,
-        cached_cost_per_million=7.50,
-        output_cost_per_million=120.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.2 Pro",
-    ),
-    OpenAIChatModel.GPT5_2_CHAT.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_2_CHAT.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=16_384,
-        input_cost_per_million=1.75,
-        cached_cost_per_million=0.175,
-        output_cost_per_million=14.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.2 Chat",
-    ),
-    OpenAIChatModel.GPT_OSS_120b.value: ModelInfo(
-        name=OpenAIChatModel.GPT_OSS_120b.value,
-        provider=ModelProvider.OPENAI,
-        context_length=131_072,
-        max_output_tokens=65_535,
-        input_cost_per_million=0.15,
-        cached_cost_per_million=0.075,
-        output_cost_per_million=0.60,
-        has_structured_output=True,
-        description="GPT OSS 120B",
-    ),
-    OpenAIChatModel.GPT_OSS_20b.value: ModelInfo(
-        name=OpenAIChatModel.GPT_OSS_20b.value,
-        provider=ModelProvider.OPENAI,
-        context_length=131_072,
-        max_output_tokens=65_535,
-        input_cost_per_million=0.075,
-        cached_cost_per_million=0.037,
-        output_cost_per_million=0.30,
-        has_structured_output=True,
-        description="GPT OSS 20B",
-    ),
-    # Anthropic Models
-    AnthropicModel.CLAUDE_3_5_SONNET.value: ModelInfo(
-        name=AnthropicModel.CLAUDE_3_5_SONNET.value,
-        provider=ModelProvider.ANTHROPIC,
-        context_length=200_000,
-        max_output_tokens=8192,
-        input_cost_per_million=3.0,
-        cached_cost_per_million=0.30,
-        output_cost_per_million=15.0,
-        description="Claude 3.5 Sonnet",
-    ),
-    AnthropicModel.CLAUDE_3_OPUS.value: ModelInfo(
-        name=AnthropicModel.CLAUDE_3_OPUS.value,
-        provider=ModelProvider.ANTHROPIC,
-        context_length=200_000,
-        max_output_tokens=4096,
-        input_cost_per_million=15.0,
-        cached_cost_per_million=1.50,
-        output_cost_per_million=75.0,
-        description="Claude 3 Opus",
-    ),
-    AnthropicModel.CLAUDE_3_SONNET.value: ModelInfo(
-        name=AnthropicModel.CLAUDE_3_SONNET.value,
-        provider=ModelProvider.ANTHROPIC,
-        context_length=200_000,
-        max_output_tokens=4096,
-        input_cost_per_million=3.0,
-        cached_cost_per_million=0.30,
-        output_cost_per_million=15.0,
-        description="Claude 3 Sonnet",
-    ),
-    AnthropicModel.CLAUDE_3_HAIKU.value: ModelInfo(
-        name=AnthropicModel.CLAUDE_3_HAIKU.value,
-        provider=ModelProvider.ANTHROPIC,
-        context_length=200_000,
-        max_output_tokens=4096,
-        input_cost_per_million=0.25,
-        cached_cost_per_million=0.03,
-        output_cost_per_million=1.25,
-        description="Claude 3 Haiku",
-    ),
-    # DeepSeek Models
-    DeepSeekModel.DEEPSEEK.value: ModelInfo(
-        name=DeepSeekModel.DEEPSEEK.value,
-        provider=ModelProvider.DEEPSEEK,
-        context_length=64_000,
-        max_output_tokens=8_000,
-        input_cost_per_million=0.27,
-        cached_cost_per_million=0.07,
-        output_cost_per_million=1.10,
-        description="DeepSeek Chat",
-    ),
-    DeepSeekModel.DEEPSEEK_R1.value: ModelInfo(
-        name=DeepSeekModel.DEEPSEEK_R1.value,
-        provider=ModelProvider.DEEPSEEK,
-        context_length=64_000,
-        max_output_tokens=8_000,
-        input_cost_per_million=0.55,
-        cached_cost_per_million=0.14,
-        output_cost_per_million=2.19,
-        description="DeepSeek-R1 Reasoning LM",
-    ),
-    # Gemini Models
-    GeminiModel.GEMINI_2_FLASH.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_FLASH.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_056_768,
-        max_output_tokens=8192,
-        input_cost_per_million=0.10,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=0.40,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.0 Flash",
-    ),
-    GeminiModel.GEMINI_2_FLASH_LITE.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_FLASH_LITE.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_056_768,
-        max_output_tokens=8192,
-        input_cost_per_million=0.075,
-        output_cost_per_million=0.30,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.0 Flash Lite",
-    ),
-    GeminiModel.GEMINI_1_5_FLASH.value: ModelInfo(
-        name=GeminiModel.GEMINI_1_5_FLASH.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_056_768,
-        max_output_tokens=8192,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 1.5 Flash",
-    ),
-    GeminiModel.GEMINI_1_5_FLASH_8B.value: ModelInfo(
-        name=GeminiModel.GEMINI_1_5_FLASH_8B.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_000_000,
-        max_output_tokens=8192,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 1.5 Flash 8B",
-    ),
-    GeminiModel.GEMINI_1_5_PRO.value: ModelInfo(
-        name=GeminiModel.GEMINI_1_5_PRO.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=2_000_000,
-        max_output_tokens=8192,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 1.5 Pro",
-    ),
-    GeminiModel.GEMINI_2_PRO.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_PRO.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=2_000_000,
-        max_output_tokens=8192,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2 Pro Exp 02-05",
-    ),
-    GeminiModel.GEMINI_2_FLASH_THINKING.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_FLASH_THINKING.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_000_000,
-        max_output_tokens=64_000,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.0 Flash Thinking",
-    ),
-    # Gemini 2.5 Models
-    GeminiModel.GEMINI_2_5_PRO.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_5_PRO.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_048_576,
-        max_output_tokens=65_536,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.31,
-        output_cost_per_million=10.0,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.5 Pro",
-    ),
-    GeminiModel.GEMINI_2_5_FLASH.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_5_FLASH.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_048_576,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.30,
-        cached_cost_per_million=0.075,
-        output_cost_per_million=2.50,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.5 Flash",
-    ),
-    GeminiModel.GEMINI_2_5_FLASH_LITE.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_5_FLASH_LITE.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=65_536,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.10,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=0.40,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.5 Flash Lite",
-    ),
-    # Gemini 3 Models
-    GeminiModel.GEMINI_3_PRO.value: ModelInfo(
-        name=GeminiModel.GEMINI_3_PRO.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_000_000,
-        max_output_tokens=64_000,
-        input_cost_per_million=2.00,
-        cached_cost_per_million=0.20,
-        output_cost_per_million=12.00,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 3 Pro",
-    ),
-    GeminiModel.GEMINI_3_FLASH.value: ModelInfo(
-        name=GeminiModel.GEMINI_3_FLASH.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_048_576,
-        max_output_tokens=65_535,
-        input_cost_per_million=0.50,
-        cached_cost_per_million=0.05,
-        output_cost_per_million=3.00,
-        description="Gemini 3 Flash",
-    ),
-    # MiniMax Models
-    MiniMaxModel.MINIMAX_M2_7.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_7.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=131_072,
-        input_cost_per_million=0.30,
-        output_cost_per_million=1.20,
-        has_structured_output=True,
-        description="MiniMax M2.7 (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=131_072,
-        input_cost_per_million=0.15,
-        output_cost_per_million=0.60,
-        has_structured_output=True,
-        description="MiniMax M2.7 Highspeed (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_5.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_5.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.30,
-        output_cost_per_million=1.20,
-        has_structured_output=True,
-        description="MiniMax M2.5 (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.15,
-        output_cost_per_million=0.60,
-        has_structured_output=True,
-        description="MiniMax M2.5 Highspeed (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_1.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_1.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.27,
-        output_cost_per_million=0.95,
-        has_structured_output=True,
-        description="MiniMax M2.1 (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.14,
-        output_cost_per_million=0.48,
-        has_structured_output=True,
-        description="MiniMax M2.1 Highspeed (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.27,
-        output_cost_per_million=0.95,
-        has_structured_output=True,
-        description="MiniMax M2 (204K context)",
-    ),
-}
-
-
-def get_model_info(
-    model: str | ModelName,
-    fallback_models: List[str] = [],
-) -> ModelInfo:
-    """Get model information by name or enum value"""
-    # Sequence of models to try, starting with the primary model
-    models_to_try = [model] + fallback_models
-
-    # Find the first model in the sequence that has info defined using next()
-    # on a generator expression that filters out None results from _get_model_info
-    found_info = next(
-        (info for m in models_to_try if (info := _get_model_info(m)) is not None),
-        None,  # Default value if the iterator is exhausted (no valid info found)
-    )
-
-    if found_info is not None:
-        return found_info
-
-    normalized_models = _normalize_model_names(models_to_try)
-    found_info = next(
-        (
-            info
-            for normalized_model in normalized_models
-            if (info := _get_model_info(normalized_model)) is not None
-        ),
-        None,
-    )
-    if found_info is not None:
-        return found_info
-
-    _warn_unknown_model(models_to_try)
-    return ModelInfo()
-
-
-def _get_model_info(model: str | ModelName) -> ModelInfo | None:
-    if isinstance(model, str):
-        return MODEL_INFO.get(model)
-    return MODEL_INFO.get(model.value)
-
-
-def _normalize_model_names(models: List[str | ModelName]) -> List[str]:
-    normalized_models: List[str] = []
-    seen: set[str] = set()
-    for model in models:
-        normalized_model = _normalize_gemini_model_name(_model_name(model))
-        if normalized_model is None or normalized_model in seen:
-            continue
-        seen.add(normalized_model)
-        normalized_models.append(normalized_model)
-    return normalized_models
-
-
-def _normalize_gemini_model_name(model: str) -> str | None:
-    base_model = model.rsplit("/", 1)[-1]
-    if base_model in GEMINI_CANONICAL_MODEL_NAMES:
-        return base_model
-    if not base_model.startswith("gemini-"):
-        return None
-
-    # Try stripping known suffixes to find a canonical name.
-    # Use split (not endswith) for "-preview" so dated variants like
-    # "gemini-2.5-flash-lite-preview-06-17" are handled correctly.
-    for suffix in ("-preview", "-exp", "-experimental", "-latest"):
-        stripped = base_model.split(suffix, maxsplit=1)[0]
-        if stripped != base_model and stripped in GEMINI_CANONICAL_MODEL_NAMES:
-            return stripped
-    return None
-
-
-def _warn_unknown_model(models: List[str | ModelName]) -> None:
-    model_names = tuple(_model_name(model) for model in models)
-    if model_names in WARNED_UNKNOWN_MODELS:
-        return
-
-    WARNED_UNKNOWN_MODELS.add(model_names)
-    logger.warning(
-        "Unknown model info for %s; using fallback defaults "
-        "(context_length=%s, max_output_tokens=%s). "
-        "Context-length checks may be inaccurate. "
-        "Set `chat_context_length` explicitly if needed.",
-        ", ".join(model_names),
-        DEFAULT_MODEL_INFO.context_length,
-        DEFAULT_MODEL_INFO.max_output_tokens,
-    )
-
-
-def _model_name(model: str | ModelName) -> str:
-    if isinstance(model, str):
-        return model
-    return model.value
+<file path=".pre-commit-config.yaml">
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.16.4
+  hooks:
+    - id: ruff
 </file>
 
 <file path="mkdocs.yml">
@@ -60437,6 +61078,7 @@ nav:
       - None Content in LLM Messages: notes/llm-none-content.md
       - Weaviate: notes/weaviate.md
       - Handling LLM Non-Tool Messages: notes/handle-llm-no-tool.md
+      - Tool Policy Hook: notes/tool-policy-hook.md
       - PGVector: notes/pgvector.md
       - Pinecone: notes/pinecone.md
       - Tavily Search Tool: notes/tavily_search.md
@@ -60505,15 +61147,6 @@ markdown_extensions:
 extra_javascript:
   - javascripts/mathjax.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
-</file>
-
-<file path=".pre-commit-config.yaml">
-repos:
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.16.0
-  hooks:
-    - id: ruff
 </file>
 
 <file path="langroid/language_models/openai_gpt.py">

--- a/llms-no-tests.txt
+++ b/llms-no-tests.txt
@@ -147,6 +147,7 @@ docs/
     task-tool.md
     tavily_search.md
     tool-message-handler.md
+    tool-policy-hook.md
     twitter-search.md
     url_loader.md
     weaviate.md
@@ -252,6 +253,7 @@ examples/
     text-to-structured.py
     tool-custom-handler.py
     tool-extract-short-example.py
+    tool-policy-hook.py
     xml_tool.py
   chainlit/
     non-callback/
@@ -518,6 +520,7 @@ langroid/
     openai_assistant.py
     task.py
     tool_message.py
+    tool_policy.py
     xml_tool_message.py
   cachedb/
     __init__.py
@@ -62653,6 +62656,159 @@ python3 examples/basic/chat-search-seltz.py
 ---
 </file>
 
+<file path="docs/notes/tool-policy-hook.md">
+# Pre-execution Tool Policy Hook
+
+When Langroid agents are embedded in larger systems, operators often need a
+central place to decide whether a tool call the LLM just made should actually
+run: authorization checks, human-approval gates, DLP scanning, command
+policies, budget limits, and so on. The `AgentConfig.tool_policy` hook
+provides the smallest possible interception point for this: a single optional
+callback, consulted immediately before the selected tool handler executes.
+No policy engine, rules, or registries live in Langroid itself — you plug in
+whatever external engine you like.
+
+## API
+
+```python
+import langroid as lr
+
+class RunCommandTool(lr.ToolMessage):
+    request: str = "run_command"
+    purpose: str = "To run a shell <command>"
+    command: str
+
+def my_policy(tool: lr.ToolMessage, agent: lr.Agent) -> bool | str | None:
+    if isinstance(tool, RunCommandTool) and "rm" in tool.command:
+        return "destructive commands are not allowed"
+    return True  # allow
+
+config = lr.ChatAgentConfig(
+    # ... other params ...
+    tool_policy=my_policy,
+)
+```
+
+The callback is invoked as `tool_policy(tool, agent)` — or as
+`tool_policy(tool, agent, chat_doc=...)` if the callable's signature has a
+`chat_doc` parameter (mirroring the convention for tool handlers). It
+receives:
+
+- `tool`: the final parsed `ToolMessage` instance about to be handled — its
+  `request` field is the tool name, and its other fields are the fully
+  validated arguments
+- `agent`: the agent that is about to run the handler
+- `chat_doc` (optional): the `ChatDocument` containing the tool call, when
+  available
+
+The return value decides what happens:
+
+- `True` or `None` — allow: the selected handler runs exactly once, as usual
+- `False` — reject: the handler is NOT run; the LLM receives a rejection
+  message naming the tool
+- a `str` — reject, with that string included as the reason in the
+  LLM-visible rejection message
+
+The hook cannot modify the tool: argument transformation is deliberately out
+of scope, and the hook receives deep copies of both the `ToolMessage` and
+the `chat_doc`, so any mutation it makes has no effect on what the handler
+sees. It only decides allow vs. reject. It is consulted only when a real
+handler has been selected: a tool with no handler returns `None` as before,
+without the policy being called.
+
+The policy is enforced at the framework's dispatch call sites, ABOVE
+`Agent.handle_tool_message` / `handle_tool_message_async` — so it gates
+tool execution even when a subclass overrides those methods. Three
+consequences of that placement:
+
+- when dispatch IS overridden, the framework cannot know whether the
+  override will execute anything, so the policy is consulted even if the
+  override ends up returning `None` (the no-handler shortcut applies only
+  to un-overridden dispatch)
+- direct calls that YOUR code makes to `agent.handle_tool_message(...)`
+  are your own seam and are not gated by the hook
+- the strict-recovery `AnyTool` wrapper is a parsing shim, not a tool
+  execution, so it is exempt from the hook; the recovered actual tool is
+  policy-checked exactly once when dispatched
+
+## Failure semantics: fail-closed
+
+If the policy callback itself raises an exception, the tool is treated as
+rejected — the handler does not run. This is deliberate: a broken policy
+must never silently become a bypassed policy.
+
+The rejection message sent back to the LLM includes only the tool name and
+the exception's class name — never the exception message or the tool's
+arguments, since either could leak payload contents into the conversation.
+The full exception is logged (via the `langroid.agent.tool_policy` logger)
+for the operator. Similarly, a decision value of an unrecognized type (anything other
+than `True`, `False`, `None`, or `str`) is treated as a rejection rather
+than an allow.
+
+## Sync and async
+
+The hook works on both dispatch paths, with both kinds of callables:
+
+- a sync callback works with both `handle_message` (sync dispatch) and
+  `handle_message_async` (async dispatch)
+- an async callback is awaited on the caller's event loop everywhere on the
+  async path — including when the tool only has a sync handler — so it may
+  safely use loop-bound resources (locks, clients, futures). On the sync
+  path it is run to completion via `asyncio.run()` — or, when an event loop
+  is already running in the calling thread (e.g. sync dispatch invoked from
+  inside async code), on a fresh event loop in a helper thread. Any failure
+  while doing so is handled fail-closed like any other hook error.
+
+On each dispatch, the policy is consulted exactly once per tool call,
+including when async dispatch falls back to a tool's sync handler.
+
+## What the hook does NOT change
+
+- With no `tool_policy` configured (the default), behavior is exactly as
+  before — the hook adds negligible overhead (a None check per dispatch)
+  and no semantic change.
+- The USER-origin tool security filter (see
+  [Code-Injection Protection](code-injection-protection.md) and
+  GHSA-gjgq-w2m6-wr5q) runs first and is unaffected: tools vetoed by that
+  filter are never even shown to the policy, and an allow-everything policy
+  cannot resurrect them.
+- Rejections flow back into the conversation like any other tool-handling
+  result (e.g. validation errors), so the LLM sees why the call was refused
+  and can adjust.
+
+## Caveats
+
+The policy callback is trusted operator code, not a sandbox:
+
+- The deep copies guard against mutation through the `tool` and `chat_doc`
+  arguments; a policy determined to tamper could still reach live state via
+  `agent`. Don't do that — the hook's contract is allow/reject only.
+- Everywhere the framework deep-copies an agent config —
+  `ChatAgent.clone()`, `Task` construction, and batch processing — the
+  policy callable is shared by REFERENCE (exempted from the copy via a
+  pre-seeded deepcopy memo; the live config is never mutated). A stateful
+  policy (a budget counter, an approval list) is therefore consulted
+  globally across the original and all copies, and a policy holding
+  unpicklable resources (e.g. a lock) does not break copying. If you copy
+  a config through some other route (`copy.deepcopy` yourself), that copy
+  is not exempted.
+- An async policy evaluated from purely-sync dispatch that is itself
+  running inside an event loop (a rare nested case) runs on a fresh event
+  loop in a helper thread; loop-bound awaitables can fail there, which
+  blocks the tool (fail-closed) rather than bypassing it.
+- A tool payload carrying a non-copyable value (a lock, a client object)
+  prevents the pre-policy deep copy and causes a fail-closed rejection
+  even under an allow-all policy, with a distinct operator-log diagnostic
+  ("tool payload could not be copied for policy evaluation"). The remedy
+  is keeping tool fields to plain data.
+
+## Example
+
+A runnable example is in `examples/basic/tool-policy-hook.py`, showing a
+policy that blocks payments above a limit, with the LLM reacting to the
+rejection.
+</file>
+
 <file path="docs/notes/twitter-search.md">
 # Twitter Search via Xquik MCP
 
@@ -63587,6 +63743,76 @@ def main(
 
 if __name__ == "__main__":
     app()
+</file>
+
+<file path="examples/basic/tool-policy-hook.py">
+"""
+Example of the pre-execution tool policy hook (`AgentConfig.tool_policy`).
+
+A single agent has a `payment` tool. A policy callback (standing in for an
+external authorization/policy engine) rejects any payment above $100; the
+handler is then NOT run, and the LLM sees a rejection naming the tool and
+the reason, so it can react (here, by telling the user).
+
+See docs/notes/tool-policy-hook.md for the full semantics (allow / reject /
+fail-closed on policy errors, sync + async support).
+
+Run like this, optionally specifying an LLM:
+
+python3 examples/basic/tool-policy-hook.py
+
+or
+
+python3 examples/basic/tool-policy-hook.py -m ollama/mistral:7b-instruct-v0.2-q8_0
+"""
+
+from fire import Fire
+
+import langroid as lr
+import langroid.language_models as lm
+
+
+class PaymentTool(lr.agent.ToolMessage):
+    request: str = "payment"
+    purpose: str = "To pay <amount> dollars to <payee>."
+    amount: float
+    payee: str
+
+    def handle(self) -> str:
+        # In real life this would call a payment API
+        return f"Paid ${self.amount:.2f} to {self.payee}."
+
+
+def payment_policy(tool: lr.ToolMessage, agent: lr.Agent) -> bool | str:
+    """Reject payments above $100; allow everything else."""
+    if isinstance(tool, PaymentTool) and tool.amount > 100:
+        return "payments above $100 require manager approval"
+    return True
+
+
+def main(model: str = "") -> None:
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            name="Payer",
+            llm=lm.OpenAIGPTConfig(chat_model=model or lm.OpenAIChatModel.GPT4o),
+            system_message="""
+            You help the user make payments, using the `payment` tool.
+            If a payment is blocked by policy, apologize to the user and
+            state the reason; do NOT retry the same payment.
+            """,
+            tool_policy=payment_policy,
+            handle_llm_no_tool="user",  # fwd to user when LLM sends non-tool msg
+        )
+    )
+    agent.enable_message(PaymentTool)
+    task = lr.Task(agent, interactive=True)
+    # Try asking: "pay $50 to Alice" (allowed),
+    # then: "pay $500 to Bob" (blocked by policy; LLM sees the reason)
+    task.run("Ask me what payment I'd like to make.")
+
+
+if __name__ == "__main__":
+    Fire(main)
 </file>
 
 <file path="examples/mcp/xquik-twitter-search.py">
@@ -68894,596 +69120,6 @@ class SeltzSearchTool(ToolMessage):
         ]
 </file>
 
-<file path="langroid/agent/batch.py">
-import asyncio
-import copy
-import inspect
-import warnings
-from enum import Enum
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    Iterable,
-    List,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-)
-
-from dotenv import load_dotenv
-
-from langroid.agent.base import Agent
-from langroid.agent.chat_document import ChatDocument
-from langroid.agent.task import Task
-from langroid.parsing.utils import batched
-from langroid.utils.configuration import quiet_mode
-from langroid.utils.logging import setup_colored_logging
-from langroid.utils.output import SuppressLoggerWarnings, status
-
-setup_colored_logging()
-
-load_dotenv()
-
-T = TypeVar("T")
-U = TypeVar("U")
-
-
-class ExceptionHandling(str, Enum):
-    """Enum for exception handling options."""
-
-    RAISE = "raise"
-    RETURN_NONE = "return_none"
-    RETURN_EXCEPTION = "return_exception"
-
-
-def _convert_exception_handling(
-    handle_exceptions: Union[bool, ExceptionHandling]
-) -> ExceptionHandling:
-    """Convert legacy boolean handle_exceptions to ExceptionHandling enum."""
-    if isinstance(handle_exceptions, ExceptionHandling):
-        return handle_exceptions
-
-    if isinstance(handle_exceptions, bool):
-        warnings.warn(
-            "Boolean handle_exceptions is deprecated. "
-            "Use ExceptionHandling enum instead: "
-            "RAISE, RETURN_NONE, or RETURN_EXCEPTION.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return (
-            ExceptionHandling.RETURN_NONE
-            if handle_exceptions
-            else ExceptionHandling.RAISE
-        )
-
-    raise TypeError(
-        "handle_exceptions must be bool or ExceptionHandling, "
-        f"not {type(handle_exceptions)}"
-    )
-
-
-async def _process_batch_async(
-    inputs: Iterable[str | ChatDocument],
-    do_task: Callable[[str | ChatDocument, int], Coroutine[Any, Any, Any]],
-    start_idx: int = 0,
-    stop_on_first_result: bool = False,
-    sequential: bool = False,
-    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
-    output_map: Callable[[Any], Any] = lambda x: x,
-) -> List[Optional[ChatDocument] | BaseException]:
-    """
-    Unified batch processing logic for both agent methods and tasks.
-
-    Args:
-        inputs: Iterable of inputs to process
-        do_task: Task execution function that takes (input, index) and returns result
-        start_idx: Starting index for the batch
-        stop_on_first_result: Whether to stop after first valid result
-        sequential: Whether to process sequentially
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        output_map: Function to map results to final output format
-    """
-    exception_handling = _convert_exception_handling(handle_exceptions)
-
-    def handle_error(e: BaseException) -> Any:
-        """Handle exceptions based on exception_handling."""
-        match exception_handling:
-            case ExceptionHandling.RAISE:
-                raise e
-            case ExceptionHandling.RETURN_NONE:
-                return None
-            case ExceptionHandling.RETURN_EXCEPTION:
-                return e
-
-    if stop_on_first_result:
-        results: List[Optional[ChatDocument] | BaseException] = []
-        pending: set[asyncio.Task[Any]] = set()
-        # Create task-to-index mapping
-        task_indices: dict[asyncio.Task[Any], int] = {}
-        try:
-            tasks = [
-                asyncio.create_task(do_task(input, i + start_idx))
-                for i, input in enumerate(inputs)
-            ]
-            task_indices = {task: i for i, task in enumerate(tasks)}
-            results = [None] * len(tasks)
-
-            pending = set(tasks)
-            while pending:
-                done, pending = await asyncio.wait(
-                    pending, return_when=asyncio.FIRST_COMPLETED
-                )
-
-                # Process completed tasks
-                for task in done:
-                    index = task_indices[task]
-                    try:
-                        result = await task
-                        results[index] = output_map(result)
-                    except BaseException as e:
-                        results[index] = handle_error(e)
-
-                if any(r is not None for r in results):
-                    return results
-        finally:
-            for task in pending:
-                task.cancel()
-            try:
-                await asyncio.gather(*pending, return_exceptions=True)
-            except BaseException as e:
-                handle_error(e)
-        return results
-
-    elif sequential:
-        results = []
-        for i, input in enumerate(inputs):
-            try:
-                result = await do_task(input, i + start_idx)
-                results.append(output_map(result))
-            except BaseException as e:
-                results.append(handle_error(e))
-        return results
-
-    # Parallel execution
-    else:
-        try:
-            return_exceptions = exception_handling != ExceptionHandling.RAISE
-            with quiet_mode(), SuppressLoggerWarnings():
-                results_with_exceptions = cast(
-                    list[Optional[ChatDocument | BaseException]],
-                    await asyncio.gather(
-                        *(
-                            do_task(input, i + start_idx)
-                            for i, input in enumerate(inputs)
-                        ),
-                        return_exceptions=return_exceptions,
-                    ),
-                )
-
-                if exception_handling == ExceptionHandling.RETURN_NONE:
-                    results = [
-                        None if isinstance(r, BaseException) else r
-                        for r in results_with_exceptions
-                    ]
-                else:  # ExceptionHandling.RETURN_EXCEPTION
-                    results = results_with_exceptions
-        except BaseException as e:
-            results = [handle_error(e) for _ in inputs]
-
-        return [output_map(r) for r in results]
-
-
-def run_batched_tasks(
-    inputs: List[str | ChatDocument],
-    do_task: Callable[[str | ChatDocument, int], Coroutine[Any, Any, Any]],
-    batch_size: Optional[int],
-    stop_on_first_result: bool,
-    sequential: bool,
-    handle_exceptions: Union[bool, ExceptionHandling],
-    output_map: Callable[[Any], Any],
-    message_template: str,
-    message: Optional[str] = None,
-) -> List[Any]:
-    """
-    Common batch processing logic for both agent methods and tasks.
-
-    Args:
-        inputs: List of inputs to process
-        do_task: Task execution function
-        batch_size: Size of batches, if None process all at once
-        stop_on_first_result: Whether to stop after first valid result
-        sequential: Whether to process sequentially
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        output_map: Function to map results
-        message_template: Template for status message
-        message: Optional override for status message
-    """
-
-    async def run_all_batched_tasks(
-        inputs: List[str | ChatDocument],
-        batch_size: int | None,
-    ) -> List[Any]:
-        """Extra wrap to run asyncio.run one single time and not once per loop
-
-        Args:
-            inputs (List[str  |  ChatDocument]): inputs to process
-            batch_size (int | None): batch size
-
-        Returns:
-            List[Any]: results
-        """
-        results: List[Any] = []
-        if batch_size is None:
-            msg = message or message_template.format(total=len(inputs))
-            with status(msg), SuppressLoggerWarnings():
-                results = await _process_batch_async(
-                    inputs,
-                    do_task,
-                    stop_on_first_result=stop_on_first_result,
-                    sequential=sequential,
-                    handle_exceptions=handle_exceptions,
-                    output_map=output_map,
-                )
-        else:
-            batches = batched(inputs, batch_size)
-            for batch in batches:
-                start_idx = len(results)
-                complete_str = f", {start_idx} complete" if start_idx > 0 else ""
-                msg = (
-                    message or message_template.format(total=len(inputs)) + complete_str
-                )
-
-                if stop_on_first_result and any(r is not None for r in results):
-                    results.extend([None] * len(batch))
-                else:
-                    with status(msg), SuppressLoggerWarnings():
-                        results.extend(
-                            await _process_batch_async(
-                                batch,
-                                do_task,
-                                start_idx=start_idx,
-                                stop_on_first_result=stop_on_first_result,
-                                sequential=sequential,
-                                handle_exceptions=handle_exceptions,
-                                output_map=output_map,
-                            )
-                        )
-        return results
-
-    return asyncio.run(run_all_batched_tasks(inputs, batch_size))
-
-
-def run_batch_task_gen(
-    gen_task: Callable[[int], Task],
-    items: list[T],
-    input_map: Callable[[T], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
-    stop_on_first_result: bool = False,
-    sequential: bool = True,
-    batch_size: Optional[int] = None,
-    turns: int = -1,
-    message: Optional[str] = None,
-    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
-    max_cost: float = 0.0,
-    max_tokens: int = 0,
-) -> list[Optional[U]]:
-    """
-    Generate and run copies of a task async/concurrently one per item in `items` list.
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-    Args:
-        gen_task (Callable[[int], Task]): generates the tasks to run
-        items (list[T]): list of items to process
-        input_map (Callable[[T], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], U]): function to map result
-            to final result. If stop_on_first_result is enabled, then
-            map any invalid output to None. We continue until some non-None
-            result is obtained.
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None) result. Successful results are evaluated after
-            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
-            exception object is itself non-None and also stops the batch.
-            Processing continues past None results; once a non-None result
-            appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        batch_size (Optional[int]): The number of tasks to run at a time,
-            if None, unbatched
-        turns (int): number of turns to run, -1 for infinite
-        message (Optional[str]): optionally overrides the console status messages
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
-        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
-
-
-    Returns:
-        list[Optional[U]]: list of final results. Always list[U] if
-        `stop_on_first_result` is disabled
-    """
-    inputs = [input_map(item) for item in items]
-
-    async def _do_task(
-        input: str | ChatDocument,
-        i: int,
-    ) -> BaseException | Optional[ChatDocument] | tuple[int, Optional[ChatDocument]]:
-        task_i = gen_task(i)
-        if task_i.agent.llm is not None:
-            task_i.agent.llm.set_stream(False)
-        task_i.agent.config.show_stats = False
-
-        try:
-            result = await task_i.run_async(
-                input, turns=turns, max_cost=max_cost, max_tokens=max_tokens
-            )
-        except asyncio.CancelledError as e:
-            task_i.kill()
-            # exception will be handled by the caller
-            raise e
-        # ----------------------------------------
-        # Propagate any exception stored on the task that may have been
-        # swallowed inside `Task.run_async`, so that the upper-level
-        # exception-handling logic works as expected.
-        for attr in ("_exception", "last_exception", "exception"):
-            exc = getattr(task_i, attr, None)
-            if isinstance(exc, BaseException):
-                raise exc
-        # Fallback: treat a KILL-status result as an error
-        if (
-            isinstance(result, ChatDocument)
-            and getattr(result, "status", None) is not None
-            and str(getattr(result, "status")) == "StatusCode.KILL"
-        ):
-            raise RuntimeError(str(result.content))
-        return result
-
-    return run_batched_tasks(
-        inputs=inputs,
-        do_task=_do_task,
-        batch_size=batch_size,
-        stop_on_first_result=stop_on_first_result,
-        sequential=sequential,
-        handle_exceptions=handle_exceptions,
-        output_map=output_map,
-        message_template="[bold green]Running {total} tasks:",
-        message=message,
-    )
-
-
-def run_batch_tasks(
-    task: Task,
-    items: list[T],
-    input_map: Callable[[T], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
-    stop_on_first_result: bool = False,
-    sequential: bool = True,
-    batch_size: Optional[int] = None,
-    turns: int = -1,
-    max_cost: float = 0.0,
-    max_tokens: int = 0,
-) -> List[Optional[U]]:
-    """
-    Run copies of `task` async/concurrently one per item in `items` list.
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-    Args:
-        task (Task): task to run
-        items (list[T]): list of items to process
-        input_map (Callable[[T], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], U]): function to map result
-            to final result
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None, after `output_map`) result. Processing continues past
-            None-mapped results; exceptions propagate, since this function
-            always uses the default `RAISE` exception handling. Once a non-None
-            result appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        batch_size (Optional[int]): The number of tasks to run at a time,
-            if None, unbatched
-        turns (int): number of turns to run, -1 for infinite
-        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
-        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
-
-    Returns:
-        list[Optional[U]]: list of final results. Always list[U] if
-        `stop_on_first_result` is disabled
-    """
-    message = f"[bold green]Running {len(items)} copies of {task.name}..."
-    return run_batch_task_gen(
-        lambda i: task.clone(i),
-        items,
-        input_map,
-        output_map,
-        stop_on_first_result,
-        sequential,
-        batch_size,
-        turns,
-        message,
-        max_cost=max_cost,
-        max_tokens=max_tokens,
-    )
-
-
-def run_batch_agent_method(
-    agent: Agent,
-    method: Callable[
-        [str | ChatDocument | None], Coroutine[Any, Any, ChatDocument | None]
-    ],
-    items: List[Any],
-    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
-    sequential: bool = True,
-    stop_on_first_result: bool = False,
-    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
-    batch_size: Optional[int] = None,
-) -> List[Any]:
-    """
-    Run the `method` on copies of `agent`, async/concurrently one per
-    item in `items` list.
-    ASSUMPTION: The `method` is an async method and has signature:
-        method(self, input: str|ChatDocument|None) -> ChatDocument|None
-    So this would typically be used for the agent's "responder" methods,
-    e.g. `llm_response_async` or `agent_responder_async`.
-
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-
-    Args:
-        agent (Agent): agent whose method to run
-        method (str): Async method to run on copies of `agent`.
-            The method is assumed to have signature:
-            `method(self, input: str|ChatDocument|None) -> ChatDocument|None`
-        input_map (Callable[[Any], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], Any]): function to map result
-            to final result
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None) result. Successful results are evaluated after
-            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
-            exception object is itself non-None and also stops the batch.
-            Processing continues past None results; once a non-None result
-            appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        batch_size (Optional[int]): The number of items to process in each batch.
-            If None, process all items at once.
-    Returns:
-        List[Any]: list of final results
-    """
-    # Check if the method is async
-    method_name = method.__name__
-    if not inspect.iscoroutinefunction(method):
-        raise ValueError(f"The method {method_name} is not async.")
-
-    inputs = [input_map(item) for item in items]
-    agent_cfg = copy.deepcopy(agent.config)
-    assert agent_cfg.llm is not None, "agent must have llm config"
-    agent_cfg.llm.stream = False
-    agent_cfg.show_stats = False
-    agent_cls = type(agent)
-    agent_name = agent_cfg.name
-
-    async def _do_task(input: str | ChatDocument, i: int) -> Any:
-        agent_cfg.name = f"{agent_cfg.name}-{i}"
-        agent_i = agent_cls(agent_cfg)
-        method_i = getattr(agent_i, method_name, None)
-        if method_i is None:
-            raise ValueError(f"Agent {agent_name} has no method {method_name}")
-        result = await method_i(input)
-        return result
-
-    return run_batched_tasks(
-        inputs=inputs,
-        do_task=_do_task,
-        batch_size=batch_size,
-        stop_on_first_result=stop_on_first_result,
-        sequential=sequential,
-        handle_exceptions=handle_exceptions,
-        output_map=output_map,
-        message_template=f"[bold green]Running {{total}} copies of {agent_name}...",
-    )
-
-
-def llm_response_batch(
-    agent: Agent,
-    items: List[Any],
-    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
-    sequential: bool = True,
-    stop_on_first_result: bool = False,
-    batch_size: Optional[int] = None,
-) -> List[Any]:
-    return run_batch_agent_method(
-        agent,
-        agent.llm_response_async,
-        items,
-        input_map=input_map,
-        output_map=output_map,
-        sequential=sequential,
-        stop_on_first_result=stop_on_first_result,
-        batch_size=batch_size,
-    )
-
-
-def agent_response_batch(
-    agent: Agent,
-    items: List[Any],
-    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
-    sequential: bool = True,
-    stop_on_first_result: bool = False,
-    batch_size: Optional[int] = None,
-) -> List[Any]:
-    return run_batch_agent_method(
-        agent,
-        agent.agent_response_async,
-        items,
-        input_map=input_map,
-        output_map=output_map,
-        sequential=sequential,
-        stop_on_first_result=stop_on_first_result,
-        batch_size=batch_size,
-    )
-
-
-def run_batch_function(
-    function: Callable[[T], U],
-    items: list[T],
-    sequential: bool = True,
-    batch_size: Optional[int] = None,
-) -> List[U]:
-    async def _do_task(item: T) -> U:
-        return function(item)
-
-    async def _do_all(items: Iterable[T]) -> List[U]:
-        if sequential:
-            results = []
-            for item in items:
-                result = await _do_task(item)
-                results.append(result)
-            return results
-
-        return await asyncio.gather(*(_do_task(item) for item in items))
-
-    results: List[U] = []
-
-    if batch_size is None:
-        with status(f"[bold green]Running {len(items)} tasks:"):
-            results = asyncio.run(_do_all(items))
-    else:
-        batches = batched(items, batch_size)
-        for batch in batches:
-            with status(f"[bold green]Running batch of {len(batch)} tasks:"):
-                results.extend(asyncio.run(_do_all(batch)))
-
-    return results
-</file>
-
 <file path="langroid/agent/tool_message.py">
 """
 Structured messages to an agent, typically from an LLM, to be handled by
@@ -69898,6 +69534,352 @@ class ToolMessage(ABC, BaseModel):
             exclude=list(cls._get_excluded_fields()),
         )
         return schema
+</file>
+
+<file path="langroid/agent/tool_policy.py">
+"""Machinery for the pre-execution tool policy hook.
+
+The public surface is the ``tool_policy`` field on
+:class:`langroid.agent.base.AgentConfig`: an optional callable consulted
+just before a parsed ``ToolMessage``'s selected handler runs, deciding
+whether the handler executes (allow) or an LLM-visible rejection is
+returned instead (reject). The functions here evaluate that hook; see
+``docs/notes/tool-policy-hook.md`` for the full semantics.
+"""
+
+import asyncio
+import copy
+import inspect
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
+
+if TYPE_CHECKING:
+    from langroid.agent.base import Agent, AgentConfig
+    from langroid.agent.chat_document import ChatDocument
+    from langroid.agent.tool_message import ToolMessage
+
+logger = logging.getLogger(__name__)
+
+C = TypeVar("C", bound="AgentConfig")
+
+
+class _PolicyCopyError(Exception):
+    """Internal marker: the tool/chat_doc could not be copied for the policy.
+
+    Distinguishes a payload-copy failure (e.g. a tool field holding a lock
+    or client object) from an exception raised by the policy itself, so the
+    operator log can say precisely which happened. Both fail closed.
+    """
+
+
+def dispatch_overridden(agent: "Agent", use_async: bool) -> bool:
+    """Whether the agent's tool-dispatch method is overridden by a subclass.
+
+    Async dispatch falls back into `handle_tool_message` when a tool has no
+    async handler, so for the async path an override of EITHER method counts.
+
+    Args:
+        agent: The agent whose dispatch is being examined.
+        use_async: True for the async dispatch path.
+
+    Returns:
+        True if a subclass overrides the relevant dispatch method(s).
+    """
+    from langroid.agent.base import Agent
+
+    if (
+        use_async
+        and type(agent).handle_tool_message_async is not Agent.handle_tool_message_async
+    ):
+        return True
+    return type(agent).handle_tool_message is not Agent.handle_tool_message
+
+
+def handler_exists(agent: "Agent", tool: "ToolMessage", use_async: bool) -> bool:
+    """Whether base dispatch would find a handler for this tool.
+
+    Args:
+        agent: The agent that would dispatch the tool.
+        tool: The parsed ToolMessage.
+        use_async: True for the async dispatch path, which looks for an
+            `<name>_async` handler first and falls back to the sync one.
+
+    Returns:
+        True if a handler method exists on the agent.
+    """
+    tool_name = tool.default_value("request")
+    if hasattr(tool, "_handler"):
+        handler_name = getattr(tool, "_handler", tool_name)
+    else:
+        handler_name = tool_name
+    if use_async and getattr(agent, handler_name + "_async", None) is not None:
+        return True
+    return getattr(agent, handler_name, None) is not None
+
+
+def policy_exempt(tool: "ToolMessage") -> bool:
+    """Whether this tool is structurally exempt from the `tool_policy` hook.
+
+    Framework-internal parsing shims declare ``_tool_policy_exempt = True``
+    on their class (e.g. the strict-recovery ``AnyTool`` wrapper): such a
+    shim is not a tool execution itself -- the actual tool it carries is
+    re-parsed and dispatched through the policy-checked path, so the policy
+    is consulted exactly once per logical tool call.
+
+    Args:
+        tool: The parsed ToolMessage about to be dispatched.
+
+    Returns:
+        True if the tool's class carries the exemption marker.
+    """
+    # SECURITY: resolve the marker on the CLASS only, never the instance.
+    # ToolMessage has ``extra="allow"``, so LLM-controlled tool JSON such
+    # as ``{"_tool_policy_exempt": true, ...}`` lands on the INSTANCE as an
+    # extra field; trusting instance attributes would let the LLM spoof the
+    # exemption and bypass the policy.
+    return getattr(type(tool), "_tool_policy_exempt", False) is True
+
+
+def deepcopy_config_sharing_policy(config: C) -> C:
+    """Deep-copy an AgentConfig, sharing `tool_policy` by REFERENCE.
+
+    A `tool_policy` hook may be stateful (budgets, approval lists) or hold
+    unpicklable resources (locks, clients), so wherever the framework
+    deep-copies an agent config (agent cloning, Task construction, batch
+    processing) the policy must be exempted from the copy: the copy and the
+    original consult the SAME policy object. The live `config` is never
+    mutated (the exemption is done by pre-seeding the deepcopy memo).
+
+    Args:
+        config: The config to copy.
+
+    Returns:
+        A deep copy of `config` whose `tool_policy` is the same object as
+        `config.tool_policy`.
+    """
+    memo: dict[int, Any] = {}
+    policy = config.tool_policy
+    if policy is not None:
+        memo[id(policy)] = policy
+    config_copy: C = copy.deepcopy(config, memo)
+    return config_copy
+
+
+def _invoke_policy(
+    policy: Callable[..., Any],
+    tool: "ToolMessage",
+    agent: "Agent",
+    chat_doc: Optional["ChatDocument"],
+) -> Any:
+    """Call the `tool_policy` hook with (tool, agent[, chat_doc]).
+
+    The `chat_doc` is passed only if the callable's signature has a
+    `chat_doc` parameter, mirroring the tool-handler convention. The hook
+    decides allow/reject only, so it receives deep COPIES of the tool and
+    the chat_doc: mutating them cannot change what the handler executes.
+
+    Args:
+        policy: The configured `tool_policy` callable.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        The policy's decision, possibly an awaitable if the policy
+        is async.
+    """
+    try:
+        has_chat_doc_param = "chat_doc" in inspect.signature(policy).parameters
+    except (ValueError, TypeError):
+        has_chat_doc_param = False
+    try:
+        tool = tool.model_copy(deep=True)
+        if has_chat_doc_param and chat_doc is not None:
+            chat_doc = copy.deepcopy(chat_doc)
+    except Exception as e:
+        raise _PolicyCopyError() from e
+    if has_chat_doc_param:
+        return policy(tool, agent, chat_doc=chat_doc)
+    return policy(tool, agent)
+
+
+def run_awaitable_sync(awaitable: Any) -> Any:
+    """Run an awaitable to completion from sync code.
+
+    Uses `asyncio.run()` when no event loop is running in this thread;
+    otherwise runs it on a fresh event loop in a helper thread, so sync
+    dispatch nested inside async code (e.g. a sync tool handler invoked
+    from async code calling back into sync dispatch) still works.
+
+    Args:
+        awaitable: The awaitable to run.
+
+    Returns:
+        The awaitable's result.
+    """
+
+    async def _await() -> Any:
+        return await awaitable
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(_await())
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(asyncio.run, _await()).result()
+
+
+def _decision_msg(tool_name: str, decision: Any) -> Optional[str]:
+    """Convert a `tool_policy` decision into an optional rejection message.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        decision: The value returned by the `tool_policy` hook.
+
+    Returns:
+        None if the tool is allowed (decision is True or None), else an
+        LLM-visible rejection message naming the tool and the reason.
+        Any decision of an unrecognized type is treated as a rejection
+        (fail-closed).
+    """
+    if decision is None or decision is True:
+        return None
+    if decision is False:
+        reason = "(no reason given)"
+    elif isinstance(decision, str):
+        reason = decision
+    else:
+        reason = (
+            f"policy returned unrecognized decision of type "
+            f"{type(decision).__name__}; failing closed"
+        )
+    return f"Tool `{tool_name}` was NOT executed: blocked by tool policy: {reason}"
+
+
+def _copy_failure_msg(tool_name: str, e: BaseException | None) -> str:
+    """Fail-closed rejection for a payload that could not be copied.
+
+    A tool field carrying a non-copyable object (a lock, a client, ...)
+    prevents the pre-policy deep copy; the tool is blocked (fail-closed),
+    with an operator-log diagnostic distinct from "the policy raised". The
+    LLM-visible message still names only the tool and the exception class.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        e: The underlying copy exception, if known.
+
+    Returns:
+        An LLM-visible rejection message.
+    """
+    exc_name = type(e).__name__ if e is not None else "Exception"
+    logger.error(
+        f"tool payload could not be copied for policy evaluation for tool "
+        f"`{tool_name}`; blocking the tool (fail-closed): "
+        f"{exc_name}: {e}"
+    )
+    return (
+        f"Tool `{tool_name}` was NOT executed: its arguments could not be "
+        f"copied for policy evaluation ({exc_name}); failing closed "
+        f"(tool blocked)."
+    )
+
+
+def _failure_msg(tool_name: str, e: Exception) -> str:
+    """Fail-closed rejection message for a `tool_policy` hook that raised.
+
+    The exception message is deliberately NOT included, since it may
+    embed raw tool arguments; only the exception class name is exposed.
+    The full exception is logged for the operator.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        e: The exception raised by the hook.
+
+    Returns:
+        An LLM-visible rejection message.
+    """
+    logger.error(
+        f"tool_policy hook raised {type(e).__name__} while checking tool "
+        f"`{tool_name}`; blocking the tool (fail-closed): {e}"
+    )
+    return (
+        f"Tool `{tool_name}` was NOT executed: the tool policy hook "
+        f"failed with {type(e).__name__}; failing closed (tool blocked)."
+    )
+
+
+def check_tool_policy(
+    policy: Optional[Callable[..., Any]],
+    tool: "ToolMessage",
+    agent: "Agent",
+    chat_doc: Optional["ChatDocument"],
+) -> Optional[str]:
+    """Evaluate the `tool_policy` hook on the sync dispatch path.
+
+    An async policy is run to completion via `run_awaitable_sync` (which
+    works whether or not an event loop is already running in this thread);
+    any failure while doing so is treated like any other hook failure:
+    the tool is blocked (fail-closed).
+
+    Args:
+        policy: The configured `tool_policy` callable, or None.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        None if no policy is configured or the policy allows the tool,
+        else an LLM-visible rejection message.
+    """
+    if policy is None:
+        return None
+    tool_name = tool.default_value("request")
+    try:
+        decision = _invoke_policy(policy, tool, agent, chat_doc)
+        if inspect.isawaitable(decision):
+            decision = run_awaitable_sync(decision)
+    except _PolicyCopyError as ce:
+        return _copy_failure_msg(tool_name, ce.__cause__)
+    except Exception as e:
+        return _failure_msg(tool_name, e)
+    return _decision_msg(tool_name, decision)
+
+
+async def check_tool_policy_async(
+    policy: Optional[Callable[..., Any]],
+    tool: "ToolMessage",
+    agent: "Agent",
+    chat_doc: Optional["ChatDocument"],
+) -> Optional[str]:
+    """Async version of `check_tool_policy`.
+
+    An async policy is awaited on the CALLING event loop, so it may safely
+    use loop-bound resources (locks, clients, futures).
+
+    Args:
+        policy: The configured `tool_policy` callable, or None.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        None if no policy is configured or the policy allows the tool,
+        else an LLM-visible rejection message.
+    """
+    if policy is None:
+        return None
+    tool_name = tool.default_value("request")
+    try:
+        decision = _invoke_policy(policy, tool, agent, chat_doc)
+        if inspect.isawaitable(decision):
+            decision = await decision
+    except _PolicyCopyError as ce:
+        return _copy_failure_msg(tool_name, ce.__cause__)
+    except Exception as e:
+        return _failure_msg(tool_name, e)
+    return _decision_msg(tool_name, decision)
 </file>
 
 <file path="langroid/language_models/__init__.py">
@@ -75515,6 +75497,598 @@ async def get_mcp_tools_async(
         return await client.client.list_tools()
 </file>
 
+<file path="langroid/agent/batch.py">
+import asyncio
+import inspect
+import warnings
+from enum import Enum
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Iterable,
+    List,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from dotenv import load_dotenv
+
+from langroid.agent.base import Agent
+from langroid.agent.chat_document import ChatDocument
+from langroid.agent.task import Task
+from langroid.parsing.utils import batched
+from langroid.utils.configuration import quiet_mode
+from langroid.utils.logging import setup_colored_logging
+from langroid.utils.output import SuppressLoggerWarnings, status
+
+setup_colored_logging()
+
+load_dotenv()
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+class ExceptionHandling(str, Enum):
+    """Enum for exception handling options."""
+
+    RAISE = "raise"
+    RETURN_NONE = "return_none"
+    RETURN_EXCEPTION = "return_exception"
+
+
+def _convert_exception_handling(
+    handle_exceptions: Union[bool, ExceptionHandling]
+) -> ExceptionHandling:
+    """Convert legacy boolean handle_exceptions to ExceptionHandling enum."""
+    if isinstance(handle_exceptions, ExceptionHandling):
+        return handle_exceptions
+
+    if isinstance(handle_exceptions, bool):
+        warnings.warn(
+            "Boolean handle_exceptions is deprecated. "
+            "Use ExceptionHandling enum instead: "
+            "RAISE, RETURN_NONE, or RETURN_EXCEPTION.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return (
+            ExceptionHandling.RETURN_NONE
+            if handle_exceptions
+            else ExceptionHandling.RAISE
+        )
+
+    raise TypeError(
+        "handle_exceptions must be bool or ExceptionHandling, "
+        f"not {type(handle_exceptions)}"
+    )
+
+
+async def _process_batch_async(
+    inputs: Iterable[str | ChatDocument],
+    do_task: Callable[[str | ChatDocument, int], Coroutine[Any, Any, Any]],
+    start_idx: int = 0,
+    stop_on_first_result: bool = False,
+    sequential: bool = False,
+    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
+    output_map: Callable[[Any], Any] = lambda x: x,
+) -> List[Optional[ChatDocument] | BaseException]:
+    """
+    Unified batch processing logic for both agent methods and tasks.
+
+    Args:
+        inputs: Iterable of inputs to process
+        do_task: Task execution function that takes (input, index) and returns result
+        start_idx: Starting index for the batch
+        stop_on_first_result: Whether to stop after first valid result
+        sequential: Whether to process sequentially
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        output_map: Function to map results to final output format
+    """
+    exception_handling = _convert_exception_handling(handle_exceptions)
+
+    def handle_error(e: BaseException) -> Any:
+        """Handle exceptions based on exception_handling."""
+        match exception_handling:
+            case ExceptionHandling.RAISE:
+                raise e
+            case ExceptionHandling.RETURN_NONE:
+                return None
+            case ExceptionHandling.RETURN_EXCEPTION:
+                return e
+
+    if stop_on_first_result:
+        results: List[Optional[ChatDocument] | BaseException] = []
+        pending: set[asyncio.Task[Any]] = set()
+        # Create task-to-index mapping
+        task_indices: dict[asyncio.Task[Any], int] = {}
+        try:
+            tasks = [
+                asyncio.create_task(do_task(input, i + start_idx))
+                for i, input in enumerate(inputs)
+            ]
+            task_indices = {task: i for i, task in enumerate(tasks)}
+            results = [None] * len(tasks)
+
+            pending = set(tasks)
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED
+                )
+
+                # Process completed tasks
+                for task in done:
+                    index = task_indices[task]
+                    try:
+                        result = await task
+                        results[index] = output_map(result)
+                    except BaseException as e:
+                        results[index] = handle_error(e)
+
+                if any(r is not None for r in results):
+                    return results
+        finally:
+            for task in pending:
+                task.cancel()
+            try:
+                await asyncio.gather(*pending, return_exceptions=True)
+            except BaseException as e:
+                handle_error(e)
+        return results
+
+    elif sequential:
+        results = []
+        for i, input in enumerate(inputs):
+            try:
+                result = await do_task(input, i + start_idx)
+                results.append(output_map(result))
+            except BaseException as e:
+                results.append(handle_error(e))
+        return results
+
+    # Parallel execution
+    else:
+        try:
+            return_exceptions = exception_handling != ExceptionHandling.RAISE
+            with quiet_mode(), SuppressLoggerWarnings():
+                results_with_exceptions = cast(
+                    list[Optional[ChatDocument | BaseException]],
+                    await asyncio.gather(
+                        *(
+                            do_task(input, i + start_idx)
+                            for i, input in enumerate(inputs)
+                        ),
+                        return_exceptions=return_exceptions,
+                    ),
+                )
+
+                if exception_handling == ExceptionHandling.RETURN_NONE:
+                    results = [
+                        None if isinstance(r, BaseException) else r
+                        for r in results_with_exceptions
+                    ]
+                else:  # ExceptionHandling.RETURN_EXCEPTION
+                    results = results_with_exceptions
+        except BaseException as e:
+            results = [handle_error(e) for _ in inputs]
+
+        return [output_map(r) for r in results]
+
+
+def run_batched_tasks(
+    inputs: List[str | ChatDocument],
+    do_task: Callable[[str | ChatDocument, int], Coroutine[Any, Any, Any]],
+    batch_size: Optional[int],
+    stop_on_first_result: bool,
+    sequential: bool,
+    handle_exceptions: Union[bool, ExceptionHandling],
+    output_map: Callable[[Any], Any],
+    message_template: str,
+    message: Optional[str] = None,
+) -> List[Any]:
+    """
+    Common batch processing logic for both agent methods and tasks.
+
+    Args:
+        inputs: List of inputs to process
+        do_task: Task execution function
+        batch_size: Size of batches, if None process all at once
+        stop_on_first_result: Whether to stop after first valid result
+        sequential: Whether to process sequentially
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        output_map: Function to map results
+        message_template: Template for status message
+        message: Optional override for status message
+    """
+
+    async def run_all_batched_tasks(
+        inputs: List[str | ChatDocument],
+        batch_size: int | None,
+    ) -> List[Any]:
+        """Extra wrap to run asyncio.run one single time and not once per loop
+
+        Args:
+            inputs (List[str  |  ChatDocument]): inputs to process
+            batch_size (int | None): batch size
+
+        Returns:
+            List[Any]: results
+        """
+        results: List[Any] = []
+        if batch_size is None:
+            msg = message or message_template.format(total=len(inputs))
+            with status(msg), SuppressLoggerWarnings():
+                results = await _process_batch_async(
+                    inputs,
+                    do_task,
+                    stop_on_first_result=stop_on_first_result,
+                    sequential=sequential,
+                    handle_exceptions=handle_exceptions,
+                    output_map=output_map,
+                )
+        else:
+            batches = batched(inputs, batch_size)
+            for batch in batches:
+                start_idx = len(results)
+                complete_str = f", {start_idx} complete" if start_idx > 0 else ""
+                msg = (
+                    message or message_template.format(total=len(inputs)) + complete_str
+                )
+
+                if stop_on_first_result and any(r is not None for r in results):
+                    results.extend([None] * len(batch))
+                else:
+                    with status(msg), SuppressLoggerWarnings():
+                        results.extend(
+                            await _process_batch_async(
+                                batch,
+                                do_task,
+                                start_idx=start_idx,
+                                stop_on_first_result=stop_on_first_result,
+                                sequential=sequential,
+                                handle_exceptions=handle_exceptions,
+                                output_map=output_map,
+                            )
+                        )
+        return results
+
+    return asyncio.run(run_all_batched_tasks(inputs, batch_size))
+
+
+def run_batch_task_gen(
+    gen_task: Callable[[int], Task],
+    items: list[T],
+    input_map: Callable[[T], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
+    stop_on_first_result: bool = False,
+    sequential: bool = True,
+    batch_size: Optional[int] = None,
+    turns: int = -1,
+    message: Optional[str] = None,
+    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
+    max_cost: float = 0.0,
+    max_tokens: int = 0,
+) -> list[Optional[U]]:
+    """
+    Generate and run copies of a task async/concurrently one per item in `items` list.
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+    Args:
+        gen_task (Callable[[int], Task]): generates the tasks to run
+        items (list[T]): list of items to process
+        input_map (Callable[[T], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], U]): function to map result
+            to final result. If stop_on_first_result is enabled, then
+            map any invalid output to None. We continue until some non-None
+            result is obtained.
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        batch_size (Optional[int]): The number of tasks to run at a time,
+            if None, unbatched
+        turns (int): number of turns to run, -1 for infinite
+        message (Optional[str]): optionally overrides the console status messages
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
+        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
+
+
+    Returns:
+        list[Optional[U]]: list of final results. Always list[U] if
+        `stop_on_first_result` is disabled
+    """
+    inputs = [input_map(item) for item in items]
+
+    async def _do_task(
+        input: str | ChatDocument,
+        i: int,
+    ) -> BaseException | Optional[ChatDocument] | tuple[int, Optional[ChatDocument]]:
+        task_i = gen_task(i)
+        if task_i.agent.llm is not None:
+            task_i.agent.llm.set_stream(False)
+        task_i.agent.config.show_stats = False
+
+        try:
+            result = await task_i.run_async(
+                input, turns=turns, max_cost=max_cost, max_tokens=max_tokens
+            )
+        except asyncio.CancelledError as e:
+            task_i.kill()
+            # exception will be handled by the caller
+            raise e
+        # ----------------------------------------
+        # Propagate any exception stored on the task that may have been
+        # swallowed inside `Task.run_async`, so that the upper-level
+        # exception-handling logic works as expected.
+        for attr in ("_exception", "last_exception", "exception"):
+            exc = getattr(task_i, attr, None)
+            if isinstance(exc, BaseException):
+                raise exc
+        # Fallback: treat a KILL-status result as an error
+        if (
+            isinstance(result, ChatDocument)
+            and getattr(result, "status", None) is not None
+            and str(getattr(result, "status")) == "StatusCode.KILL"
+        ):
+            raise RuntimeError(str(result.content))
+        return result
+
+    return run_batched_tasks(
+        inputs=inputs,
+        do_task=_do_task,
+        batch_size=batch_size,
+        stop_on_first_result=stop_on_first_result,
+        sequential=sequential,
+        handle_exceptions=handle_exceptions,
+        output_map=output_map,
+        message_template="[bold green]Running {total} tasks:",
+        message=message,
+    )
+
+
+def run_batch_tasks(
+    task: Task,
+    items: list[T],
+    input_map: Callable[[T], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
+    stop_on_first_result: bool = False,
+    sequential: bool = True,
+    batch_size: Optional[int] = None,
+    turns: int = -1,
+    max_cost: float = 0.0,
+    max_tokens: int = 0,
+) -> List[Optional[U]]:
+    """
+    Run copies of `task` async/concurrently one per item in `items` list.
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+    Args:
+        task (Task): task to run
+        items (list[T]): list of items to process
+        input_map (Callable[[T], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], U]): function to map result
+            to final result
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None, after `output_map`) result. Processing continues past
+            None-mapped results; exceptions propagate, since this function
+            always uses the default `RAISE` exception handling. Once a non-None
+            result appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        batch_size (Optional[int]): The number of tasks to run at a time,
+            if None, unbatched
+        turns (int): number of turns to run, -1 for infinite
+        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
+        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
+
+    Returns:
+        list[Optional[U]]: list of final results. Always list[U] if
+        `stop_on_first_result` is disabled
+    """
+    message = f"[bold green]Running {len(items)} copies of {task.name}..."
+    return run_batch_task_gen(
+        lambda i: task.clone(i),
+        items,
+        input_map,
+        output_map,
+        stop_on_first_result,
+        sequential,
+        batch_size,
+        turns,
+        message,
+        max_cost=max_cost,
+        max_tokens=max_tokens,
+    )
+
+
+def run_batch_agent_method(
+    agent: Agent,
+    method: Callable[
+        [str | ChatDocument | None], Coroutine[Any, Any, ChatDocument | None]
+    ],
+    items: List[Any],
+    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
+    sequential: bool = True,
+    stop_on_first_result: bool = False,
+    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
+    batch_size: Optional[int] = None,
+) -> List[Any]:
+    """
+    Run the `method` on copies of `agent`, async/concurrently one per
+    item in `items` list.
+    ASSUMPTION: The `method` is an async method and has signature:
+        method(self, input: str|ChatDocument|None) -> ChatDocument|None
+    So this would typically be used for the agent's "responder" methods,
+    e.g. `llm_response_async` or `agent_responder_async`.
+
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+
+    Args:
+        agent (Agent): agent whose method to run
+        method (str): Async method to run on copies of `agent`.
+            The method is assumed to have signature:
+            `method(self, input: str|ChatDocument|None) -> ChatDocument|None`
+        input_map (Callable[[Any], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], Any]): function to map result
+            to final result
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        batch_size (Optional[int]): The number of items to process in each batch.
+            If None, process all items at once.
+    Returns:
+        List[Any]: list of final results
+    """
+    # Check if the method is async
+    method_name = method.__name__
+    if not inspect.iscoroutinefunction(method):
+        raise ValueError(f"The method {method_name} is not async.")
+
+    from langroid.agent.tool_policy import deepcopy_config_sharing_policy
+
+    inputs = [input_map(item) for item in items]
+    # tool_policy hook shared by reference so its state stays global
+    agent_cfg = deepcopy_config_sharing_policy(agent.config)
+    assert agent_cfg.llm is not None, "agent must have llm config"
+    agent_cfg.llm.stream = False
+    agent_cfg.show_stats = False
+    agent_cls = type(agent)
+    agent_name = agent_cfg.name
+
+    async def _do_task(input: str | ChatDocument, i: int) -> Any:
+        agent_cfg.name = f"{agent_cfg.name}-{i}"
+        agent_i = agent_cls(agent_cfg)
+        method_i = getattr(agent_i, method_name, None)
+        if method_i is None:
+            raise ValueError(f"Agent {agent_name} has no method {method_name}")
+        result = await method_i(input)
+        return result
+
+    return run_batched_tasks(
+        inputs=inputs,
+        do_task=_do_task,
+        batch_size=batch_size,
+        stop_on_first_result=stop_on_first_result,
+        sequential=sequential,
+        handle_exceptions=handle_exceptions,
+        output_map=output_map,
+        message_template=f"[bold green]Running {{total}} copies of {agent_name}...",
+    )
+
+
+def llm_response_batch(
+    agent: Agent,
+    items: List[Any],
+    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
+    sequential: bool = True,
+    stop_on_first_result: bool = False,
+    batch_size: Optional[int] = None,
+) -> List[Any]:
+    return run_batch_agent_method(
+        agent,
+        agent.llm_response_async,
+        items,
+        input_map=input_map,
+        output_map=output_map,
+        sequential=sequential,
+        stop_on_first_result=stop_on_first_result,
+        batch_size=batch_size,
+    )
+
+
+def agent_response_batch(
+    agent: Agent,
+    items: List[Any],
+    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
+    sequential: bool = True,
+    stop_on_first_result: bool = False,
+    batch_size: Optional[int] = None,
+) -> List[Any]:
+    return run_batch_agent_method(
+        agent,
+        agent.agent_response_async,
+        items,
+        input_map=input_map,
+        output_map=output_map,
+        sequential=sequential,
+        stop_on_first_result=stop_on_first_result,
+        batch_size=batch_size,
+    )
+
+
+def run_batch_function(
+    function: Callable[[T], U],
+    items: list[T],
+    sequential: bool = True,
+    batch_size: Optional[int] = None,
+) -> List[U]:
+    async def _do_task(item: T) -> U:
+        return function(item)
+
+    async def _do_all(items: Iterable[T]) -> List[U]:
+        if sequential:
+            results = []
+            for item in items:
+                result = await _do_task(item)
+                results.append(result)
+            return results
+
+        return await asyncio.gather(*(_do_task(item) for item in items))
+
+    results: List[U] = []
+
+    if batch_size is None:
+        with status(f"[bold green]Running {len(items)} tasks:"):
+            results = asyncio.run(_do_all(items))
+    else:
+        batches = batched(items, batch_size)
+        for batch in batches:
+            with status(f"[bold green]Running batch of {len(batch)} tasks:"):
+                results.extend(asyncio.run(_do_all(batch)))
+
+    return results
+</file>
+
 <file path="langroid/agent/openai_assistant.py">
 import asyncio
 import json
@@ -80563,6 +81137,1458 @@ LLMMessage.model_rebuild()
 ChatDocMetaData.model_rebuild()
 </file>
 
+<file path="langroid/language_models/base.py">
+import json
+import logging
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from enum import Enum
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
+
+from langroid.cachedb.base import CacheDBConfig
+from langroid.cachedb.redis_cachedb import RedisCacheConfig
+from langroid.language_models.model_info import ModelInfo, get_model_info
+from langroid.parsing.agent_chats import parse_message
+from langroid.parsing.file_attachment import FileAttachment
+from langroid.parsing.parse_json import parse_imperfect_json, top_level_json_field
+from langroid.prompts.dialog import collate_chat_history
+from langroid.utils.configuration import settings
+from langroid.utils.output.printing import show_if_debug
+
+logger = logging.getLogger(__name__)
+
+
+def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+    pass
+
+
+async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+    pass
+
+
+FunctionCallTypes = Literal["none", "auto"]
+ToolChoiceTypes = Literal["none", "auto", "required"]
+ToolTypes = Literal["function"]
+
+DEFAULT_CONTEXT_LENGTH = 16_000
+
+
+class StreamEventType(Enum):
+    TEXT = 1
+    FUNC_NAME = 2
+    FUNC_ARGS = 3
+    TOOL_NAME = 4
+    TOOL_ARGS = 5
+    REASONING = 6
+
+
+class RetryParams(BaseSettings):
+    max_retries: int = 5
+    initial_delay: float = 1.0
+    exponential_base: float = 1.3
+    jitter: bool = True
+
+
+class LLMConfig(BaseSettings):
+    """
+    Common configuration for all language models.
+    """
+
+    type: str = "openai"
+    streamer: Optional[Callable[[Any], None]] = noop_fn
+    streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
+    api_base: str | None = None
+    formatter: None | str = None
+    # specify None if you want to use the full max output tokens of the model
+    max_output_tokens: int | None = 8192
+    timeout: int = 20  # timeout for API requests
+    chat_model: str = ""
+    completion_model: str = ""
+    temperature: float = 0.0
+    chat_context_length: int | None = None
+    async_stream_quiet: bool = False  # suppress streaming output in async mode?
+    completion_context_length: int | None = None
+    # if input length + max_output_tokens > context length of model,
+    # we will try shortening requested output
+    min_output_tokens: int = 64
+    use_completion_for_chat: bool = False  # use completion model for chat?
+    # use chat model for completion? For OpenAI models, this MUST be set to True!
+    use_chat_for_completion: bool = True
+    stream: bool = True  # stream output from API?
+    # TODO: we could have a `stream_reasoning` flag here to control whether to show
+    # reasoning output from reasoning models
+    cache_config: None | CacheDBConfig = RedisCacheConfig()
+    thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
+    retry_params: RetryParams = RetryParams()
+
+    @property
+    def model_max_output_tokens(self) -> int:
+        if self.max_output_tokens:
+            return self.max_output_tokens
+        # Build fallback names by progressively stripping provider prefixes
+        # (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
+        # succeeds even before OpenAIGPT.__init__ strips the prefix.
+        parts = self.chat_model.split("/")
+        fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
+        return get_model_info(self.chat_model, fallbacks).max_output_tokens
+
+
+class LLMFunctionCall(BaseModel):
+    """
+    Structure of LLM response indicating it "wants" to call a function.
+    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
+    """
+
+    name: str  # name of function to call
+    arguments: Optional[Dict[str, Any]] = None
+
+    @staticmethod
+    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall":
+        """
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+        fun_call = LLMFunctionCall(name=message["name"])
+        fun_args_str = message["arguments"]
+        # sometimes may be malformed with invalid indents,
+        # so we try to be safe by removing newlines.
+        if fun_args_str is not None:
+            fun_args_str = fun_args_str.replace("\n", "").strip()
+            dict_or_list = parse_imperfect_json(fun_args_str)
+
+            if not isinstance(dict_or_list, dict):
+                raise ValueError(
+                    f"""
+                        Invalid function args: {fun_args_str}
+                        parsed as {dict_or_list},
+                        which is not a valid dict.
+                        """
+                )
+            fun_args = dict_or_list
+        else:
+            fun_args = None
+        fun_call.arguments = fun_args
+
+        return fun_call
+
+    def __str__(self) -> str:
+        return "FUNC: " + json.dumps(self.model_dump(), indent=2)
+
+
+class LLMFunctionSpec(BaseModel):
+    """
+    Description of a function available for the LLM to use.
+    To be used when calling the LLM `chat()` method with the `functions` parameter.
+    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
+    """
+
+    name: str
+    description: str
+    parameters: Dict[str, Any]
+
+
+class OpenAIToolCall(BaseModel):
+    """
+    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
+    See https://platform.openai.com/docs/api-reference/chat/create
+
+    Attributes:
+        id: The id of the tool call.
+        type: The type of the tool call;
+            only "function" is currently possible (7/26/24).
+        function: The function call.
+    """
+
+    id: str | None = None
+    type: ToolTypes = "function"
+    function: LLMFunctionCall | None = None
+    extra_content: Dict[str, Any] | None = None
+
+    @staticmethod
+    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall":
+        """
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+        id = message["id"]
+        type = message["type"]
+        function = LLMFunctionCall.from_dict(message["function"])
+        extra_content = message.get("extra_content")
+        return OpenAIToolCall(
+            id=id, type=type, function=function, extra_content=extra_content
+        )
+
+    def __str__(self) -> str:
+        if self.function is None:
+            return ""
+        return "OAI-TOOL: " + json.dumps(self.function.model_dump(), indent=2)
+
+
+class OpenAIToolSpec(BaseModel):
+    type: ToolTypes
+    strict: Optional[bool] = None
+    function: LLMFunctionSpec
+
+
+class OpenAIJsonSchemaSpec(BaseModel):
+    strict: Optional[bool] = None
+    function: LLMFunctionSpec
+
+    def to_dict(self) -> Dict[str, Any]:
+        json_schema: Dict[str, Any] = {
+            "name": self.function.name,
+            "description": self.function.description,
+            "schema": self.function.parameters,
+        }
+        if self.strict is not None:
+            json_schema["strict"] = self.strict
+
+        return {
+            "type": "json_schema",
+            "json_schema": json_schema,
+        }
+
+
+class LLMTokenUsage(BaseModel):
+    """
+    Usage of tokens by an LLM.
+    """
+
+    prompt_tokens: int = 0
+    cached_tokens: int = 0
+    completion_tokens: int = 0
+    cost: float = 0.0
+    calls: int = 0  # how many API calls - not used as of 2025-04-04
+
+    def reset(self) -> None:
+        self.prompt_tokens = 0
+        self.cached_tokens = 0
+        self.completion_tokens = 0
+        self.cost = 0.0
+        self.calls = 0
+
+    def __str__(self) -> str:
+        return (
+            f"Tokens = "
+            f"(prompt {self.prompt_tokens}, cached {self.cached_tokens}, "
+            f"completion {self.completion_tokens}), "
+            f"Cost={self.cost}, Calls={self.calls}"
+        )
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+
+class Role(str, Enum):
+    """
+    Possible roles for a message in a chat.
+    """
+
+    USER = "user"
+    SYSTEM = "system"
+    ASSISTANT = "assistant"
+    FUNCTION = "function"
+    TOOL = "tool"
+
+
+class LLMMessage(BaseModel):
+    """
+    Class representing an entry in the msg-history sent to the LLM API.
+    It could be one of these:
+    - a user message
+    - an LLM ("Assistant") response
+    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
+    - a result or results from executing a fn or tool-call(s)
+    """
+
+    role: Role
+    name: Optional[str] = None
+    tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
+    tool_id: str = ""  # used by OpenAIAssistant
+    # None means "no content" (the model returned only a tool/function call).
+    # This is distinct from "" and is dropped from the API payload by api_dict;
+    # see api_dict for how a fully-empty message is handled per-API.
+    content: Optional[str] = None
+    files: List[FileAttachment] = []
+    function_call: Optional[LLMFunctionCall] = None
+    tool_calls: Optional[List[OpenAIToolCall]] = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    # link to corresponding chat document, for provenance/rewind purposes
+    chat_document_id: str = ""
+
+    def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]:
+        """
+        Convert to dictionary for API request, keeping ONLY
+        the fields that are expected in an API call!
+        E.g., DROP the tool_id, since it is only for use in the Assistant API,
+            not the completion API.
+
+        Args:
+            has_system_role: whether the message has a system role (if not,
+                set to "user" role)
+        Returns:
+            dict: dictionary representation of LLM message
+        """
+        d = self.model_dump()
+        files: List[FileAttachment] = d.pop("files")
+        if len(files) > 0 and self.role == Role.USER:
+            # In there are files, then content is an array of
+            # different content-parts
+            d["content"] = [
+                dict(
+                    type="text",
+                    text=self.content or "",
+                )
+            ] + [f.to_dict(model) for f in self.files]
+
+        # if there is a key k = "role" with value "system", change to "user"
+        # in case has_system_role is False
+        if not has_system_role and "role" in d and d["role"] == "system":
+            d["role"] = "user"
+            if d.get("content"):
+                d["content"] = "[ADDITIONAL SYSTEM MESSAGE:]\n\n" + d["content"]
+        # drop None values since API doesn't accept them (this omits `content`
+        # entirely when it is None, i.e. "no content")
+        dict_no_none = {k: v for k, v in d.items() if v is not None}
+        if "name" in dict_no_none and dict_no_none["name"] == "":
+            # OpenAI API does not like empty name
+            del dict_no_none["name"]
+        if "function_call" in dict_no_none:
+            # arguments must be a string
+            if "arguments" in dict_no_none["function_call"]:
+                dict_no_none["function_call"]["arguments"] = json.dumps(
+                    dict_no_none["function_call"]["arguments"]
+                )
+        if dict_no_none.get("tool_calls"):
+            # convert tool calls to API format
+            for tc in dict_no_none["tool_calls"]:
+                if "arguments" in tc["function"]:
+                    # arguments must be a string
+                    if tc["function"]["arguments"] is None:
+                        tc["function"]["arguments"] = "{}"
+                    else:
+                        tc["function"]["arguments"] = json.dumps(
+                            tc["function"]["arguments"]
+                        )
+                if "extra_content" in tc and tc["extra_content"] is None:
+                    del tc["extra_content"]
+        else:
+            # An empty tool-call list is not a call and conveys no useful API
+            # information. Omitting it also lets the empty-message fallback
+            # below produce a valid message.
+            dict_no_none.pop("tool_calls", None)
+        # A message with empty content (None was dropped above, or "") AND no
+        # tool/function call would be an entirely empty message, which some APIs
+        # (e.g. Gemini) reject; fall back to a single space in that case only.
+        # When there IS a tool/function call, empty content is fine (and Gemini
+        # 3.x in fact REQUIRES it — it rejects an assistant turn that carries
+        # both a call and non-empty text content).
+        has_call = bool(dict_no_none.get("tool_calls")) or (
+            dict_no_none.get("function_call") is not None
+        )
+        if not has_call and not dict_no_none.get("content"):
+            dict_no_none["content"] = " "
+        # IMPORTANT! drop fields that are not expected in API call
+        dict_no_none.pop("tool_id", None)
+        dict_no_none.pop("timestamp", None)
+        dict_no_none.pop("chat_document_id", None)
+        return dict_no_none
+
+    def __str__(self) -> str:
+        if self.function_call is not None:
+            content = "FUNC: " + json.dumps(self.function_call)
+        else:
+            content = self.content or ""
+        name_str = f" ({self.name})" if self.name else ""
+        return f"{self.role} {name_str}: {content}"
+
+
+class LLMResponse(BaseModel):
+    """
+    Class representing response from LLM.
+    """
+
+    # None means the model returned NO content (e.g. only a tool/function
+    # call), which is distinct from an empty string "". Preserving this
+    # distinction lets the message be faithfully reproduced downstream
+    # (see ChatDocument.content_is_none and LLMMessage.content).
+    message: Optional[str] = None
+    reasoning: str = ""  # optional reasoning text from reasoning models
+    # Original message text including inline thought signatures (e.g.
+    # <thinking>...</thinking>). Only set when reasoning was extracted
+    # from the message text via get_reasoning_final(); NOT set when
+    # reasoning comes from a separate API field (e.g. reasoning_content),
+    # since in that case the message text never contained thought tags.
+    message_with_reasoning: Optional[str] = None
+    # TODO tool_id needs to generalize to multi-tool calls
+    tool_id: str = ""  # used by OpenAIAssistant
+    oai_tool_calls: Optional[List[OpenAIToolCall]] = None
+    function_call: Optional[LLMFunctionCall] = None
+    usage: Optional[LLMTokenUsage] = None
+    cached: bool = False
+
+    def __str__(self) -> str:
+        if self.function_call is not None:
+            return str(self.function_call)
+        elif self.oai_tool_calls:
+            return "\n".join(str(tc) for tc in self.oai_tool_calls)
+        else:
+            return self.message or ""
+
+    def tools_content(self) -> str:
+        if self.function_call is not None:
+            return str(self.function_call)
+        elif self.oai_tool_calls:
+            return "\n".join(str(tc) for tc in self.oai_tool_calls)
+        else:
+            return ""
+
+    def to_LLMMessage(self) -> LLMMessage:
+        """Convert LLM response to an LLMMessage, to be included in the
+        message-list sent to the API.
+        This is currently NOT used in any significant way in the library, and is only
+        provided as a utility to construct a message list for the API when directly
+        working with an LLM object.
+
+        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
+        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
+        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
+        """
+        return LLMMessage(
+            role=Role.ASSISTANT,
+            content=self.message,
+            name=None if self.function_call is None else self.function_call.name,
+            function_call=self.function_call,
+            tool_calls=self.oai_tool_calls,
+        )
+
+    def get_recipient_and_message(
+        self,
+        recognize_recipient_in_content: bool = True,
+    ) -> Tuple[str, str]:
+        """
+        If `message` or `function_call` of an LLM response contains an explicit
+        recipient name, return this recipient name and `message` stripped
+        of the recipient name if specified.
+
+        Two cases:
+        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
+        (b) `message` is empty and function_call/tool_call with explicit `recipient`
+
+        Args:
+            recognize_recipient_in_content (bool): When True (default), parses
+                message text for ``TO[<recipient>]:<content>`` patterns and
+                top-level JSON ``{"recipient": "..."}`` fields. When False,
+                only function_call/tool_call ``recipient`` fields are checked.
+
+        Returns:
+            (str): name of recipient, which may be empty string if no recipient
+            (str): content of message
+
+        """
+
+        if self.function_call is not None:
+            # in this case we ignore message, since all information is in function_call
+            msg = ""
+            args = self.function_call.arguments
+            recipient = ""
+            if isinstance(args, dict):
+                recipient = args.get("recipient", "")
+            return recipient, msg
+        else:
+            msg = self.message or ""
+            if self.oai_tool_calls is not None:
+                # get the first tool that has a recipient field, if any
+                for tc in self.oai_tool_calls:
+                    if tc.function is not None and tc.function.arguments is not None:
+                        recipient = tc.function.arguments.get(
+                            "recipient"
+                        )  # type: ignore
+                        if recipient is not None and recipient != "":
+                            return recipient, ""
+
+        if not recognize_recipient_in_content:
+            return "", msg
+
+        # It's not a function or tool call, so continue looking to see
+        # if a recipient is specified in the message.
+
+        # First check if message contains "TO: <recipient> <content>"
+        recipient_name, content = parse_message(msg) if msg is not None else ("", "")
+        # check if there is a top level json that specifies 'recipient',
+        # and retain the entire message as content.
+        if recipient_name == "":
+            recipient_name = top_level_json_field(msg, "recipient") if msg else ""
+            content = msg
+        return recipient_name, content
+
+
+# Define an abstract base class for language models
+class LanguageModel(ABC):
+    """
+    Abstract base class for language models.
+    """
+
+    # usage cost by model, accumulates here
+    usage_cost_dict: Dict[str, LLMTokenUsage] = {}
+
+    def __init__(self, config: LLMConfig = LLMConfig()):
+        self.config = config
+        self.chat_model_orig = config.chat_model
+
+    @staticmethod
+    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]:
+        """
+        Create a language model.
+        Args:
+            config: configuration for language model
+        Returns: instance of language model
+        """
+        if type(config) is LLMConfig:
+            raise ValueError(
+                """
+                Cannot create a Language Model object from LLMConfig.
+                Please specify a specific subclass of LLMConfig e.g.,
+                OpenAIGPTConfig. If you are creating a ChatAgent from
+                a ChatAgentConfig, please specify the `llm` field of this config
+                as a specific subclass of LLMConfig, e.g., OpenAIGPTConfig.
+                """
+            )
+        from langroid.language_models.azure_openai import AzureGPT
+        from langroid.language_models.mock_lm import MockLM, MockLMConfig
+        from langroid.language_models.openai_gpt import OpenAIGPT
+
+        if config is None or config.type is None:
+            return None
+
+        if config.type == "mock":
+            return MockLM(cast(MockLMConfig, config))
+
+        openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
+
+        if config.type == "azure":
+            openai = AzureGPT
+        else:
+            openai = OpenAIGPT
+        cls = dict(
+            openai=openai,
+        ).get(config.type, openai)
+        return cls(config)  # type: ignore
+
+    @staticmethod
+    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]:
+        """
+        Given an even-length sequence of strings, split into a sequence of pairs
+
+        Args:
+            lst (List[str]): sequence of strings
+
+        Returns:
+            List[Tuple[str,str]]: sequence of pairs of strings
+        """
+        evens = lst[::2]
+        odds = lst[1::2]
+        return list(zip(evens, odds))
+
+    @staticmethod
+    def get_chat_history_components(
+        messages: List[LLMMessage],
+    ) -> Tuple[str, List[Tuple[str, str]], str]:
+        """
+        From the chat history, extract system prompt, user-assistant turns, and
+        final user msg.
+
+        Args:
+            messages (List[LLMMessage]): List of messages in the chat history
+
+        Returns:
+            Tuple[str, List[Tuple[str,str]], str]:
+                system prompt, user-assistant turns, final user msg
+
+        """
+        # Handle various degenerate cases
+        messages = [m for m in messages]  # copy
+        DUMMY_SYS_PROMPT = "You are a helpful assistant."
+        DUMMY_USER_PROMPT = "Follow the instructions above."
+        if len(messages) == 0 or messages[0].role != Role.SYSTEM:
+            logger.warning("No system msg, creating dummy system prompt")
+            messages.insert(0, LLMMessage(content=DUMMY_SYS_PROMPT, role=Role.SYSTEM))
+        system_prompt = messages[0].content or ""
+
+        # now we have messages = [Sys,...]
+        if len(messages) == 1:
+            logger.warning(
+                "Got only system message in chat history, creating dummy user prompt"
+            )
+            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, msg, ...]
+
+        if messages[1].role != Role.USER:
+            messages.insert(1, LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, user, ...]
+        if messages[-1].role != Role.USER:
+            logger.warning(
+                "Last message in chat history is not a user message,"
+                " creating dummy user prompt"
+            )
+            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, user, ..., user]
+        # so we omit the first and last elements and make pairs of user-asst messages
+        conversation = [m.content or "" for m in messages[1:-1]]
+        user_prompt = messages[-1].content or ""
+        pairs = LanguageModel.user_assistant_pairs(conversation)
+        return system_prompt, pairs, user_prompt
+
+    @abstractmethod
+    def set_stream(self, stream: bool) -> bool:
+        """Enable or disable streaming output from API.
+        Return previous value of stream."""
+        pass
+
+    @abstractmethod
+    def get_stream(self) -> bool:
+        """Get streaming status"""
+        pass
+
+    @abstractmethod
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        pass
+
+    @abstractmethod
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        pass
+
+    @abstractmethod
+    def chat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """
+        Get chat-completion response from LLM.
+
+        Args:
+            messages: message-history to send to the LLM
+            max_tokens: max tokens to generate
+            tools: tools available for the LLM to use in its response
+            tool_choice: tool call mode, one of "none", "auto", "required",
+                or a dict specifying a specific tool.
+            functions: functions available for LLM to call (deprecated)
+            function_call: function calling mode, "auto", "none", or a specific fn
+                    (deprecated)
+        """
+
+        pass
+
+    @abstractmethod
+    async def achat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """Async version of `chat`. See `chat` for details."""
+        pass
+
+    def __call__(self, prompt: str, max_tokens: int) -> LLMResponse:
+        return self.generate(prompt, max_tokens)
+
+    @staticmethod
+    def _fallback_model_names(model: str) -> List[str]:
+        parts = model.split("/")
+        fallbacks = []
+        for i in range(1, len(parts)):
+            fallbacks.append("/".join(parts[i:]))
+        return fallbacks
+
+    def info(self) -> ModelInfo:
+        """Info of relevant chat model"""
+        orig_model = (
+            self.config.completion_model
+            if self.config.use_completion_for_chat
+            else self.chat_model_orig
+        )
+        return get_model_info(orig_model, self._fallback_model_names(orig_model))
+
+    def completion_info(self) -> ModelInfo:
+        """Info of relevant completion model"""
+        orig_model = (
+            self.chat_model_orig
+            if self.config.use_chat_for_completion
+            else self.config.completion_model
+        )
+        return get_model_info(orig_model, self._fallback_model_names(orig_model))
+
+    def supports_functions_or_tools(self) -> bool:
+        """
+        Does this Model's API support "native" tool-calling, i.e.
+        can we call the API with arguments that contain a list of available tools,
+        and their schemas?
+        Note that, given the plethora of LLM provider APIs this determination is
+        imperfect at best, and leans towards returning True.
+        When the API calls fails with an error indicating tools are not supported,
+        then users are encouraged to use the Langroid-based prompt-based
+        ToolMessage mechanism, which works with ANY LLM. To enable this,
+        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
+        """
+        return self.info().has_tools
+
+    def chat_context_length(self) -> int:
+        return self.config.chat_context_length or DEFAULT_CONTEXT_LENGTH
+
+    def completion_context_length(self) -> int:
+        return self.config.completion_context_length or DEFAULT_CONTEXT_LENGTH
+
+    def chat_cost(self) -> Tuple[float, float, float]:
+        """
+        Return the cost per 1000 tokens for chat completions.
+
+        Returns:
+            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
+                per 1000 tokens
+        """
+        return (0.0, 0.0, 0.0)
+
+    def reset_usage_cost(self) -> None:
+        for mdl in [self.config.chat_model, self.config.completion_model]:
+            if mdl is None:
+                return
+            if mdl not in self.usage_cost_dict:
+                self.usage_cost_dict[mdl] = LLMTokenUsage()
+            counter = self.usage_cost_dict[mdl]
+            counter.reset()
+
+    def update_usage_cost(
+        self, chat: bool, prompts: int, completions: int, cost: float
+    ) -> None:
+        """
+        Update usage cost for this LLM.
+        Args:
+            chat (bool): whether to update for chat or completion model
+            prompts (int): number of tokens used for prompts
+            completions (int): number of tokens used for completions
+            cost (float): total token cost in USD
+        """
+        mdl = self.config.chat_model if chat else self.config.completion_model
+        if mdl is None:
+            return
+        if mdl not in self.usage_cost_dict:
+            self.usage_cost_dict[mdl] = LLMTokenUsage()
+        counter = self.usage_cost_dict[mdl]
+        counter.prompt_tokens += prompts
+        counter.completion_tokens += completions
+        counter.cost += cost
+        counter.calls += 1
+
+    @classmethod
+    def usage_cost_summary(cls) -> str:
+        s = ""
+        for model, counter in cls.usage_cost_dict.items():
+            s += f"{model}: {counter}\n"
+        return s
+
+    @classmethod
+    def tot_tokens_cost(cls) -> Tuple[int, float]:
+        """
+        Return total tokens used and total cost across all models.
+        """
+        total_tokens = 0
+        total_cost = 0.0
+        for counter in cls.usage_cost_dict.values():
+            total_tokens += counter.total_tokens
+            total_cost += counter.cost
+        return total_tokens, total_cost
+
+    def get_reasoning_final(self, message: str) -> Tuple[str, str]:
+        """Extract "reasoning" and "final answer" from an LLM response, if the
+        reasoning is found within configured delimiters, like <think>, </think>.
+        E.g.,
+        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
+
+        Args:
+            message (str): message from LLM
+
+        Returns:
+            Tuple[str, str]: reasoning, final answer
+        """
+        start, end = self.config.thought_delimiters
+        if start in message and end in message:
+            parts = message.split(start)
+            if len(parts) > 1:
+                reasoning, final = parts[1].split(end)
+                return reasoning, final
+        return "", message
+
+    def followup_to_standalone(
+        self, chat_history: List[Tuple[str, str]], question: str
+    ) -> str:
+        """
+        Given a chat history and a question, convert it to a standalone question.
+        Args:
+            chat_history: list of tuples of (question, answer)
+            query: follow-up question
+
+        Returns: standalone version of the question
+        """
+        history = collate_chat_history(chat_history)
+
+        prompt = f"""
+        You are an expert at understanding a CHAT HISTORY between an AI Assistant
+        and a User, and you are highly skilled in rephrasing the User's FOLLOW-UP
+        QUESTION/REQUEST as a STANDALONE QUESTION/REQUEST that can be understood
+        WITHOUT the context of the chat history.
+
+        Below is the CHAT HISTORY. When the User asks you to rephrase a
+        FOLLOW-UP QUESTION/REQUEST, your ONLY task is to simply return the
+        question REPHRASED as a STANDALONE QUESTION/REQUEST, without any additional
+        text or context.
+
+        <CHAT_HISTORY>
+        {history}
+        </CHAT_HISTORY>
+        """.strip()
+
+        follow_up_question = f"""
+        Please rephrase this as a stand-alone question or request:
+        <FOLLOW-UP-QUESTION-OR-REQUEST>
+        {question}
+        </FOLLOW-UP-QUESTION-OR-REQUEST>
+        """.strip()
+
+        show_if_debug(prompt, "FOLLOWUP->STANDALONE-PROMPT= ")
+        standalone = (
+            self.chat(
+                messages=[
+                    LLMMessage(role=Role.SYSTEM, content=prompt),
+                    LLMMessage(role=Role.USER, content=follow_up_question),
+                ],
+                max_tokens=1024,
+            ).message
+            or ""
+        )
+        standalone = standalone.strip()
+
+        show_if_debug(prompt, "FOLLOWUP->STANDALONE-RESPONSE= ")
+        return standalone
+
+
+class StreamingIfAllowed:
+    """Context to temporarily enable or disable streaming, if allowed globally via
+    `settings.stream`"""
+
+    def __init__(self, llm: LanguageModel, stream: bool = True):
+        self.llm = llm
+        self.stream = stream
+
+    def __enter__(self) -> None:
+        self.old_stream = self.llm.set_stream(settings.stream and self.stream)
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.llm.set_stream(self.old_stream)
+</file>
+
+<file path="langroid/language_models/client_cache.py">
+"""
+Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
+"""
+
+import asyncio
+import atexit
+import hashlib
+import inspect
+import threading
+import time
+import weakref
+from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, Union, cast
+
+from cerebras.cloud.sdk import AsyncCerebras, Cerebras
+from groq import AsyncGroq, Groq
+from httpx import Timeout
+from openai import AsyncOpenAI, OpenAI
+
+# Cache for client instances, keyed by hashed configuration parameters.
+# Value is a tuple of (client instance, last_used_monotonic_seconds).
+_client_cache: Dict[str, Tuple[Any, float]] = {}
+_client_cache_lock = threading.RLock()
+
+# Keep track of clients for cleanup
+_all_clients: weakref.WeakSet[Any] = weakref.WeakSet()
+
+
+def _get_cache_key(client_type: str, **kwargs: Any) -> str:
+    """
+    Generate a cache key from client type and configuration parameters.
+    Uses the same approach as OpenAIGPT._cache_lookup for consistency.
+
+    Args:
+        client_type: Type of client (e.g., "openai", "groq", "cerebras")
+        **kwargs: Configuration parameters (api_key, base_url, timeout, etc.)
+
+    Returns:
+        SHA256 hash of the configuration as a hex string
+    """
+    # Convert kwargs to sorted string representation
+    sorted_kwargs_str = str(sorted(kwargs.items()))
+
+    # Create raw key combining client type and sorted kwargs
+    raw_key = f"{client_type}:{sorted_kwargs_str}"
+
+    # Hash the key for consistent length and to handle complex objects
+    hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
+
+    return hashed_key
+
+
+def wrap_api_key_provider_async(
+    provider: Callable[[], str],
+) -> Callable[[], Awaitable[str]]:
+    """
+    Wrap a sync API-key provider for use with ``AsyncOpenAI``.
+
+    ``AsyncOpenAI`` awaits its ``api_key`` callable, so a plain sync
+    provider must be wrapped in an async function. The sync provider is run
+    in a worker thread, so a blocking token refresh cannot stall the event
+    loop. Providers must therefore be thread-safe -- the sync client may
+    call them from arbitrary threads anyway.
+
+    Args:
+        provider: Callable returning a (possibly short-lived) API key.
+
+    Returns:
+        Async callable returning the same key.
+    """
+
+    async def _provider() -> str:
+        return await asyncio.to_thread(provider)
+
+    return _provider
+
+
+def _api_key_cache_component(api_key: Union[str, Callable[[], str]]) -> Any:
+    """
+    Cache-key component for an API key that may be a rotating-key provider.
+
+    A callable provider is keyed on its identity rather than any token value,
+    so rotating tokens never create new cache entries and tokens are never
+    retained in cache keys. The id() cannot be recycled while the entry
+    lives, because the cached client holds a strong reference to the
+    provider (directly for sync clients, via the async wrapper's closure
+    for async clients).
+    """
+    if callable(api_key):
+        return ("api_key_provider", id(api_key))
+    return api_key
+
+
+def _get_cached_client(cache_key: str) -> Optional[Any]:
+    """Get cached client and refresh its last-used timestamp.
+
+    Must be called while holding ``_client_cache_lock``.
+    """
+    entry = _client_cache.get(cache_key)
+    if entry is None:
+        return None
+
+    client, _ = entry
+    _client_cache[cache_key] = (client, time.monotonic())
+    return client
+
+
+def _store_client(cache_key: str, client: Any) -> None:
+    """Store a client in the cache with the current timestamp.
+
+    Must be called while holding ``_client_cache_lock``.
+    """
+    _client_cache[cache_key] = (client, time.monotonic())
+    _all_clients.add(client)
+
+
+def get_openai_client(
+    api_key: Union[str, Callable[[], str]],
+    base_url: Optional[str] = None,
+    organization: Optional[str] = None,
+    timeout: Union[float, Timeout] = 120.0,
+    default_headers: Optional[Dict[str, str]] = None,
+    http_client: Optional[Any] = None,
+    http_client_config: Optional[Dict[str, Any]] = None,
+) -> OpenAI:
+    """
+    Get or create a singleton OpenAI client with the given configuration.
+
+    Args:
+        api_key: OpenAI API key, or a callable returning a fresh key
+            (for short-lived rotating credentials); a callable is resolved
+            per-request by the OpenAI client and is excluded from the
+            cache key (the cache is keyed on the provider's identity)
+        base_url: Optional base URL for API
+        organization: Optional organization ID
+        timeout: Request timeout
+        default_headers: Optional default headers
+        http_client: Optional httpx.Client instance
+        http_client_config: Optional config dict for creating httpx.Client
+
+    Returns:
+        OpenAI client instance
+    """
+    if isinstance(timeout, (int, float)):
+        timeout = Timeout(timeout)
+
+    # If http_client is provided directly, don't cache (complex object)
+    if http_client is not None:
+        client = OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            organization=organization,
+            timeout=timeout,
+            default_headers=default_headers,
+            http_client=http_client,
+        )
+        _all_clients.add(client)
+        return client
+
+    cache_key = _get_cache_key(
+        "openai",
+        api_key=_api_key_cache_component(api_key),
+        base_url=base_url,
+        organization=organization,
+        timeout=timeout,
+        default_headers=default_headers,
+        http_client_config=http_client_config,  # Include config in cache key
+    )
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(OpenAI, cached_client)
+
+        created_http_client = None
+        if http_client_config is not None:
+            try:
+                from httpx import Client
+            except ImportError:
+                raise ValueError(
+                    "httpx is required to use http_client_config. "
+                    "Install it with: pip install httpx"
+                )
+            created_http_client = Client(**http_client_config)
+
+        client = OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            organization=organization,
+            timeout=timeout,
+            default_headers=default_headers,
+            http_client=created_http_client,  # Use the client created from config
+        )
+
+        _store_client(cache_key, client)
+    return client
+
+
+def get_async_openai_client(
+    api_key: Union[str, Callable[[], str]],
+    base_url: Optional[str] = None,
+    organization: Optional[str] = None,
+    timeout: Union[float, Timeout] = 120.0,
+    default_headers: Optional[Dict[str, str]] = None,
+    http_client: Optional[Any] = None,
+    http_client_config: Optional[Dict[str, Any]] = None,
+) -> AsyncOpenAI:
+    """
+    Get or create a singleton AsyncOpenAI client with the given configuration.
+
+    Args:
+        api_key: OpenAI API key, or a callable returning a fresh key
+            (for short-lived rotating credentials); a callable is resolved
+            per-request by the OpenAI client and is excluded from the
+            cache key (the cache is keyed on the provider's identity)
+        base_url: Optional base URL for API
+        organization: Optional organization ID
+        timeout: Request timeout
+        default_headers: Optional default headers
+        http_client: Optional httpx.AsyncClient instance
+        http_client_config: Optional config dict for creating httpx.AsyncClient
+
+    Returns:
+        AsyncOpenAI client instance
+    """
+    if isinstance(timeout, (int, float)):
+        timeout = Timeout(timeout)
+
+    api_key_arg: Union[str, Callable[[], Awaitable[str]]]
+    if callable(api_key):
+        # AsyncOpenAI awaits its api_key callable, so wrap the sync provider
+        api_key_arg = wrap_api_key_provider_async(api_key)
+    else:
+        api_key_arg = api_key
+
+    # If http_client is provided directly, don't cache (complex object)
+    if http_client is not None:
+        client = AsyncOpenAI(
+            api_key=api_key_arg,
+            base_url=base_url,
+            organization=organization,
+            timeout=timeout,
+            default_headers=default_headers,
+            http_client=http_client,
+        )
+        _all_clients.add(client)
+        return client
+
+    cache_key = _get_cache_key(
+        "async_openai",
+        api_key=_api_key_cache_component(api_key),
+        base_url=base_url,
+        organization=organization,
+        timeout=timeout,
+        default_headers=default_headers,
+        http_client_config=http_client_config,  # Include config in cache key
+    )
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(AsyncOpenAI, cached_client)
+
+        created_http_client = None
+        if http_client_config is not None:
+            try:
+                from httpx import AsyncClient
+            except ImportError:
+                raise ValueError(
+                    "httpx is required to use http_client_config. "
+                    "Install it with: pip install httpx"
+                )
+            created_http_client = AsyncClient(**http_client_config)
+
+        client = AsyncOpenAI(
+            api_key=api_key_arg,
+            base_url=base_url,
+            organization=organization,
+            timeout=timeout,
+            default_headers=default_headers,
+            http_client=created_http_client,  # Use the client created from config
+        )
+
+        _store_client(cache_key, client)
+    return client
+
+
+def get_groq_client(api_key: str) -> Groq:
+    """
+    Get or create a singleton Groq client with the given configuration.
+
+    Args:
+        api_key: Groq API key
+
+    Returns:
+        Groq client instance
+    """
+    cache_key = _get_cache_key("groq", api_key=api_key)
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(Groq, cached_client)
+
+        client = Groq(api_key=api_key)
+        _store_client(cache_key, client)
+    return client
+
+
+def get_async_groq_client(api_key: str) -> AsyncGroq:
+    """
+    Get or create a singleton AsyncGroq client with the given configuration.
+
+    Args:
+        api_key: Groq API key
+
+    Returns:
+        AsyncGroq client instance
+    """
+    cache_key = _get_cache_key("async_groq", api_key=api_key)
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(AsyncGroq, cached_client)
+
+        client = AsyncGroq(api_key=api_key)
+        _store_client(cache_key, client)
+    return client
+
+
+def get_cerebras_client(api_key: str) -> Cerebras:
+    """
+    Get or create a singleton Cerebras client with the given configuration.
+
+    Args:
+        api_key: Cerebras API key
+
+    Returns:
+        Cerebras client instance
+    """
+    cache_key = _get_cache_key("cerebras", api_key=api_key)
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(Cerebras, cached_client)
+
+        client = Cerebras(api_key=api_key)
+        _store_client(cache_key, client)
+    return client
+
+
+def get_async_cerebras_client(api_key: str) -> AsyncCerebras:
+    """
+    Get or create a singleton AsyncCerebras client with the given configuration.
+
+    Args:
+        api_key: Cerebras API key
+
+    Returns:
+        AsyncCerebras client instance
+    """
+    cache_key = _get_cache_key("async_cerebras", api_key=api_key)
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(AsyncCerebras, cached_client)
+
+        client = AsyncCerebras(api_key=api_key)
+        _store_client(cache_key, client)
+    return client
+
+
+def prune_cache(max_age_seconds: float) -> int:
+    """
+    Remove cache entries whose last-used time exceeds *max_age_seconds*.
+
+    Evicted clients are **not** closed here because they may still be serving
+    in-flight requests.  Cleanup is handled by the ``atexit`` handler and the
+    garbage collector.
+
+    Args:
+        max_age_seconds: Maximum age (in seconds) for cache entries to keep.
+            Entries older than this value are removed.
+
+    Returns:
+        Number of cache entries removed.
+    """
+    if max_age_seconds < 0:
+        raise ValueError("max_age_seconds must be non-negative")
+
+    now = time.monotonic()
+
+    with _client_cache_lock:
+        stale_keys = [
+            key
+            for key, (_, last_used_at) in _client_cache.items()
+            if now - last_used_at > max_age_seconds
+        ]
+
+        for key in stale_keys:
+            _client_cache.pop(key)
+
+    # Don't close evicted clients here — they may still be serving in-flight
+    # requests. The atexit handler and GC will clean them up.
+
+    return len(stale_keys)
+
+
+def _cleanup_clients() -> None:
+    """
+    Cleanup function to close all cached clients on exit.
+    Called automatically via atexit.
+    """
+    for client in list(_all_clients):
+        if hasattr(client, "close") and callable(client.close):
+            try:
+                # Check if close is a coroutine function (async)
+                if inspect.iscoroutinefunction(client.close):
+                    # For async clients, we can't await in atexit
+                    # They will be cleaned up by the OS
+                    pass
+                else:
+                    # Sync clients can be closed directly
+                    client.close()
+            except Exception:
+                pass  # Ignore errors during cleanup
+
+
+# Register cleanup function to run on exit
+atexit.register(_cleanup_clients)
+
+
+# For testing purposes
+def _clear_cache() -> None:
+    """Clear the client cache. Only for testing."""
+    with _client_cache_lock:
+        _client_cache.clear()
+</file>
+
+<file path="SECURITY.md">
+# Security Policy
+
+## Threat model — please read this before reporting
+
+Langroid is a framework for building applications in which an LLM generates
+code and queries that are then executed. Several **optional** agents exist for
+exactly that purpose:
+
+- `TableChatAgent`, `LanceDocChatAgent`, and `VectorStore.compute_from_docs`
+  evaluate LLM-generated **pandas expressions** with `eval()`.
+- `SQLChatAgent` executes LLM-generated **SQL** against a database you supply.
+- `Neo4jChatAgent`, `ArangoChatAgent`, and `CSVGraphAgent` execute
+  LLM-generated **Cypher / AQL** against a graph database you supply.
+
+Executing model-generated code against your own data *is the feature*. An LLM
+is not a trust boundary: if any untrusted text reaches the model's context, you
+must assume the model can be induced to emit any query or expression the
+grammar allows. Langroid cannot prevent this, and does not claim to.
+
+### What is, and is not, a security boundary
+
+The following are **best-effort hardening, not security boundaries**:
+
+- `sanitize_command()` / `CommandValidator` / `safe_eval_globals()` in
+  `langroid/utils/pandas_utils.py`
+- `_DANGEROUS_SQL_PATTERNS` and the `sqlglot` AST checks in `SQLChatAgent`
+- `validate_cypher_query()` / `validate_aql_query()` in the graph agents
+
+They exist to stop an *unlucky* LLM, not a *determined attacker*. The pandas
+path uses explicit allowlists for AST nodes, methods, operators, variables, and
+builtins. The SQL, Cypher, and AQL paths use denylists over full query grammars
+that span multiple dialects, quoting and escaping forms, and function families.
+Such denylists cannot be made complete. We patch clear gaps opportunistically,
+but we do not treat a newly found way around them as a vulnerability in
+Langroid.
+
+The **actual** security boundaries for a Langroid deployment are:
+
+- the privileges of the database credential you hand the agent;
+- the OS user, container, or VM the process runs in;
+- filesystem permissions and network egress rules.
+
+### Deploying these agents safely
+
+If you expose any of the code- or query-executing agents to untrusted input:
+
+- **Give the agent a least-privilege database role.** For `SQLChatAgent`, a
+  read-only, non-superuser role with `GRANT SELECT` on only the intended
+  tables. In PostgreSQL, server-side file reads and writes normally require a
+  superuser, membership in `pg_read_server_files` or
+  `pg_write_server_files`, or a direct grant on a privileged function.
+  `COPY ... PROGRAM` instead requires superuser access or membership in the
+  distinct `pg_execute_server_program` role. Server-side `lo_import` and
+  `lo_export` default to superuser-only use, but an administrator can grant
+  access to those functions directly. Ordinary password-authenticated
+  `dblink` connections do not require any of those roles. Do not install
+  unneeded extensions, and revoke access to dangerous extensions and
+  functions, including `dblink`, in addition to granting only the intended
+  table privileges. Review any site-specific functions and grants as well.
+- **Run the process in a container or VM** with no credentials, secrets, or
+  data you are unwilling to expose to the LLM.
+- **Treat `allow_dangerous_operations=True` and `full_eval=True` as
+  "I am providing my own sandbox."** The first permits dangerous database
+  operations. The second disables pandas AST validation while retaining the
+  restricted globals from `safe_eval_globals()`. Both are documented as
+  trusted-environment-only.
+
+## Reporting a vulnerability
+
+Report privately — **not** via GitHub Issues, Discussions, or any other public
+forum:
+
+1. Go to
+   **[Security Advisories](https://github.com/langroid/langroid/security/advisories)**.
+2. Click **"Report a vulnerability"**.
+3. Include a proof of concept that works against a **default configuration**.
+
+We aim to acknowledge in-scope reports within 7 days.
+
+### In scope
+
+- Vulnerabilities in core framework code: tool dispatch and the agent/tool
+  trust boundary, message routing, sender verification.
+- Parsing and deserialization flaws (XXE, unsafe deserialization, decompression
+  bombs) in the document and message parsers.
+- Path traversal in the file tools (`ReadFileTool`, `WriteFileTool`,
+  `ListDirTool`) and in repository / folder ingestion.
+- Credential or secret leakage in a default configuration that does not depend
+  on any of the specific exclusions below. The out-of-scope rules take
+  precedence over this category.
+- **A code path that skips a documented safety gate entirely** — that is, a
+  *missing call* to a validator, not a *bypass* of one.
+- **A statement the `allowed_statement_types` allowlist misclassifies.** The
+  allowlist is a different kind of control from the denylists above: it decides
+  what a statement *does* over a closed set of statement kinds, so a query that
+  performs a write the allowlist did not authorize — for example by nesting it
+  where the classifier does not look — is a bounded, fixable defect and is in
+  scope.
+- Vulnerable dependencies with a demonstrated impact on Langroid.
+
+### Out of scope
+
+The following will be closed without a fix, an advisory, or a CVE request:
+
+- New bypasses of the SQL, Cypher, or AQL denylists: previously unlisted
+  functions, alternate quoting or escaping forms (backticks, Unicode escapes,
+  schema qualification), or dialect-specific syntax. See "What is, and is not,
+  a security boundary" above.
+- Sandbox escapes from the pandas `eval()` path when `full_eval=True`,
+  including object-graph traversal via dunder attributes. `full_eval=True`
+  disables the AST validator by design.
+- Anything requiring `allow_dangerous_operations=True`.
+- "The LLM can be prompt-injected into generating a harmful query." This is the
+  documented threat model, not a defect.
+- Reports that assume the agent was given a superuser or otherwise
+  over-privileged database credential.
+- Theoretical reports with no working proof of concept against a default
+  configuration.
+
+Reports that chain off a previous advisory as an "incomplete fix" are judged
+against this same scope: if the original issue was a missing gate we will fix
+it, and if it was a denylist gap it is out of scope.
+
+## Supported versions
+
+Security fixes ship in the latest release. Please upgrade to the current
+version of `langroid` rather than requesting backports.
+</file>
+
 <file path="langroid/agent/task.py">
 from __future__ import annotations
 
@@ -80888,7 +82914,11 @@ class Task:
         # copy the agent's config, so that we don't modify the original agent's config,
         # which may be shared by other agents.
         try:
-            config_copy = copy.deepcopy(agent.config)
+            from langroid.agent.tool_policy import deepcopy_config_sharing_policy
+
+            # the tool_policy hook is shared by reference (never deep-copied),
+            # so its state (budgets, approvals) stays global across copies
+            config_copy = deepcopy_config_sharing_policy(agent.config)
             agent.config = config_copy
         except Exception:
             logger.warning(
@@ -83065,576 +85095,1051 @@ class Task:
         return seq_idx < 0
 </file>
 
-<file path="langroid/language_models/client_cache.py">
+<file path="langroid/agent/special/sql/sql_chat_agent.py">
 """
-Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
+Agent that allows interaction with an SQL database using SQLAlchemy library.
+The agent can execute SQL queries in the database and return the result.
+
+Functionality includes:
+- adding table and column context
+- asking a question about a SQL schema
 """
 
-import asyncio
-import atexit
-import hashlib
-import inspect
-import threading
-import time
-import weakref
-from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, Union, cast
+import logging
+import re
+from typing import (
+    Any,
+    Dict,
+    FrozenSet,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
-from cerebras.cloud.sdk import AsyncCerebras, Cerebras
-from groq import AsyncGroq, Groq
-from httpx import Timeout
-from openai import AsyncOpenAI, OpenAI
+from rich.console import Console
 
-# Cache for client instances, keyed by hashed configuration parameters.
-# Value is a tuple of (client instance, last_used_monotonic_seconds).
-_client_cache: Dict[str, Tuple[Any, float]] = {}
-_client_cache_lock = threading.RLock()
+from langroid.exceptions import LangroidImportError
+from langroid.mytypes import Entity
+from langroid.utils.constants import SEND_TO
 
-# Keep track of clients for cleanup
-_all_clients: weakref.WeakSet[Any] = weakref.WeakSet()
+try:
+    from sqlalchemy import MetaData, Row, create_engine, inspect, text
+    from sqlalchemy.engine import Engine
+    from sqlalchemy.exc import ResourceClosedError, SQLAlchemyError
+    from sqlalchemy.orm import Session, sessionmaker
+except ImportError as e:
+    raise LangroidImportError(extra="sql", error=str(e))
+
+try:
+    # sqlglot is required for the statement-type allowlist enforced in
+    # `_validate_query`. Importing it at module load ensures the security
+    # guarantee cannot be silently bypassed by a partial/stale install.
+    import sqlglot
+    from sqlglot import expressions as sqlglot_exp
+except ImportError as e:
+    raise LangroidImportError(extra="sql", error=str(e))
+
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.agent.chat_document import ChatDocument
+from langroid.agent.special.sql.utils.description_extractors import (
+    extract_schema_descriptions,
+)
+from langroid.agent.special.sql.utils.populate_metadata import (
+    populate_metadata,
+    populate_metadata_with_schema_tools,
+)
+from langroid.agent.special.sql.utils.system_message import (
+    DEFAULT_SYS_MSG,
+    SCHEMA_TOOLS_SYS_MSG,
+)
+from langroid.agent.special.sql.utils.tools import (
+    GetColumnDescriptionsTool,
+    GetTableNamesTool,
+    GetTableSchemaTool,
+    RunQueryTool,
+)
+from langroid.agent.tools.orchestration import (
+    DonePassTool,
+    DoneTool,
+    ForwardTool,
+    PassTool,
+)
+from langroid.language_models.base import Role
+from langroid.vector_store.base import VectorStoreConfig
+
+logger = logging.getLogger(__name__)
+
+console = Console()
+
+DEFAULT_SQL_CHAT_SYSTEM_MESSAGE = """
+{mode}
+
+You do not need to attempt answering a question with just one query. 
+You could make a sequence of SQL queries to help you write the final query.
+Also if you receive a null or other unexpected result,
+(a) make sure you use the available TOOLs correctly, and 
+(b) see if you have made an assumption in your SQL query, and try another way, 
+   or use `run_query` to explore the database table contents before submitting your 
+   final query. For example when searching for "males" you may have used "gender= 'M'",
+in your query, because you did not know that the possible genders in the table
+are "Male" and "Female". 
+
+Start by asking what I would like to know about the data.
+
+"""
+
+ADDRESSING_INSTRUCTION = """
+IMPORTANT - Whenever you are NOT writing a SQL query, make sure you address the user
+using {prefix}User (NO SPACE between {prefix} and User). 
+You MUST use the EXACT syntax {prefix}User !!!
+
+In other words, you ALWAYS write EITHER:
+ - a SQL query using the `run_query` tool, 
+ - OR address the user using {prefix}User
+"""
+
+DONE_INSTRUCTION = f"""
+When you are SURE you have the CORRECT answer to a user's query or request, 
+use the `{DoneTool.name()}` with `content` set to the answer or result.
+If you DO NOT think you have the answer to the user's query or request,
+you SHOULD NOT use the `{DoneTool.name()}` tool.
+Instead, you must CONTINUE to improve your queries (tools) to get the correct answer,
+and finally use the `{DoneTool.name()}` tool to send the correct answer to the user.
+"""
 
 
-def _get_cache_key(client_type: str, **kwargs: Any) -> str:
-    """
-    Generate a cache key from client type and configuration parameters.
-    Uses the same approach as OpenAIGPT._cache_lookup for consistency.
+SQL_ERROR_MSG = "There was an error in your SQL Query"
+
+
+# Dialect-specific SQL patterns that enable code execution, arbitrary file
+# access, or other escapes from the database engine. Matched against the raw
+# query text (case-insensitive) as a defense-in-depth layer in addition to the
+# sqlglot-based statement-type allowlist.
+_DANGEROUS_SQL_PATTERNS: List["re.Pattern[str]"] = [
+    # PostgreSQL: COPY ... FROM/TO PROGRAM executes shell commands as the DB
+    # server OS user.
+    re.compile(r"\bcopy\b[\s\S]*\bprogram\b", re.IGNORECASE),
+    # PostgreSQL server-side filesystem / log / WAL access. Match the whole
+    # pg_read*, pg_stat*, pg_ls*, pg_current_logfile family rather than naming
+    # individual functions: near-name functions (pg_read_file vs
+    # pg_read_server_file, pg_ls_logdir vs pg_ls_dir, pg_stat_file, ...) all
+    # yield the same file/metadata disclosure primitive.
+    re.compile(r"\bpg_(read|stat|ls|current_logfile)[A-Za-z0-9_]*\s*\(", re.IGNORECASE),
+    re.compile(r"\blo_(import|export)\b", re.IGNORECASE),
+    # MySQL/MariaDB filesystem
+    re.compile(r"\binto\s+(outfile|dumpfile)\b", re.IGNORECASE),
+    re.compile(r"\bload_file\s*\(", re.IGNORECASE),
+    re.compile(r"\bload\s+data\b", re.IGNORECASE),
+    # SQLite: load_extension enables loading arbitrary shared objects;
+    # ATTACH can read/write arbitrary files. The DATABASE keyword is optional
+    # per the SQLite grammar (ATTACH [DATABASE] expr AS schema-name), so match
+    # both forms.
+    re.compile(r"\bload_extension\s*\(", re.IGNORECASE),
+    re.compile(r"\battach\b(\s+database)?\s+['\"\w]", re.IGNORECASE),
+    # SQL Server: command execution, OLE automation, and ad-hoc external data
+    # sources (OPENDATASOURCE is the connection-string counterpart of
+    # OPENROWSET; both can read remote/UNC files).
+    re.compile(r"\bxp_cmdshell\b", re.IGNORECASE),
+    re.compile(r"\bsp_oacreate\b", re.IGNORECASE),
+    re.compile(r"\bsp_oamethod\b", re.IGNORECASE),
+    re.compile(r"\b(openrowset|opendatasource)\b", re.IGNORECASE),
+    re.compile(r"\bbulk\s+insert\b", re.IGNORECASE),
+    # Generic: stored-program creation and procedural language extensions.
+    # LANGUAGE / RULE / EVENT TRIGGER / FOREIGN TABLE are additional PostgreSQL
+    # primitives that can register attacker-controlled code.
+    re.compile(
+        r"\bcreate\s+(or\s+replace\s+)?(function|procedure|trigger|language|rule|event\s+trigger|foreign\s+table)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\bcreate\s+extension\b", re.IGNORECASE),
+]
+
+
+# AST-side blocklist of dangerous SQL function names, applied after sqlglot
+# parses the query. The raw-text regex above can be bypassed by quoted
+# identifiers, inline comments, or schema qualification -- e.g.
+# `"pg_read_file"(...)`, `pg_read_file/**/(...)`,
+# `pg_catalog."pg_read_file"(...)` -- but sqlglot normalizes all those forms
+# to the same function-call node, so a name-based check on the parsed tree
+# catches every variant (GHSA-6xc5-4r68-67fc).
+_DANGEROUS_FUNCTION_NAMES: FrozenSet[str] = frozenset(
+    {
+        "load_file",  # MySQL/MariaDB filesystem read
+        "load_extension",  # SQLite extension loader
+        "sp_oacreate",  # MSSQL OLE automation
+        "sp_oamethod",  # MSSQL OLE automation
+    }
+)
+# Prefix families: any function whose normalized name starts with one of these
+# is considered dangerous. Mirrors the `\bpg_(read|stat|ls|current_logfile)...`
+# and `\blo_(import|export)\b` regex coverage, but on the parsed AST.
+_DANGEROUS_FUNCTION_PREFIXES: Tuple[str, ...] = (
+    "pg_read",
+    "pg_stat",
+    "pg_ls",
+    "pg_current_logfile",
+    "lo_",
+)
+
+
+def _is_dangerous_function_name(name: str) -> bool:
+    """True if `name` (case-folded, unquoted) is a dangerous SQL function."""
+    if name in _DANGEROUS_FUNCTION_NAMES:
+        return True
+    return any(name.startswith(p) for p in _DANGEROUS_FUNCTION_PREFIXES)
+
+
+def _called_function_names(stmt: Any) -> Iterator[str]:
+    """Yield normalized (case-folded, unquoted, schema-stripped) names of
+    every function-call node in `stmt` (a parsed sqlglot expression)."""
+    for node in stmt.find_all(sqlglot_exp.Func):
+        if isinstance(node, sqlglot_exp.Anonymous):
+            this = node.this
+            if isinstance(this, sqlglot_exp.Expression):
+                name = this.name
+            else:
+                name = str(this) if this is not None else ""
+        else:
+            # Typed sqlglot Func subclass: its class key is the SQL keyword.
+            name = getattr(type(node), "key", "") or ""
+        # Strip any schema qualifier that leaked into the name string.
+        name = name.rsplit(".", 1)[-1].strip().lower()
+        if name:
+            yield name
+
+
+def _creates_table(into: Any) -> bool:
+    """Whether a Select's ``into`` arg names a table rather than a variable.
+
+    ``SELECT ... INTO tbl`` creates and populates a table, but MySQL's
+    ``SELECT ... INTO @var`` merely assigns a user variable and writes nothing.
+    sqlglot models the latter as a ``Table`` wrapping a ``Parameter``, so the
+    target's inner node distinguishes them.
 
     Args:
-        client_type: Type of client (e.g., "openai", "groq", "cerebras")
-        **kwargs: Configuration parameters (api_key, base_url, timeout, etc.)
+        into: The ``into`` arg of a sqlglot ``Select``, or None.
 
     Returns:
-        SHA256 hash of the configuration as a hex string
+        True if the target names a table.
     """
-    # Convert kwargs to sorted string representation
-    sorted_kwargs_str = str(sorted(kwargs.items()))
-
-    # Create raw key combining client type and sorted kwargs
-    raw_key = f"{client_type}:{sorted_kwargs_str}"
-
-    # Hash the key for consistent length and to handle complex objects
-    hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
-
-    return hashed_key
+    if into is None:
+        return False
+    target = into.this
+    if target is None:
+        return False
+    return not isinstance(getattr(target, "this", None), sqlglot_exp.Parameter)
 
 
-def wrap_api_key_provider_async(
-    provider: Callable[[], str],
-) -> Callable[[], Awaitable[str]]:
-    """
-    Wrap a sync API-key provider for use with ``AsyncOpenAI``.
+def _nested_write_kinds(stmt: Any, kind_map: Dict[Any, str]) -> Set[str]:
+    """Statement kinds that `stmt` performs *below* its top-level node.
 
-    ``AsyncOpenAI`` awaits its ``api_key`` callable, so a plain sync
-    provider must be wrapped in an async function. The sync provider is run
-    in a worker thread, so a blocking token refresh cannot stall the event
-    loop. Providers must therefore be thread-safe -- the sync client may
-    call them from arbitrary threads anyway.
+    A statement's top-level node does not determine what it writes. Both
+
+    - ``WITH x AS (DELETE FROM t RETURNING *) SELECT * FROM x`` (a
+      data-modifying CTE), and
+    - ``SELECT * INTO new_tbl FROM t`` (which creates and populates a table)
+
+    parse with a ``Select`` top node, so classifying on that node alone reports
+    "SELECT" while the engine still performs the write
+    (GHSA-3gpx-vwr3-xvwx / GHSA-wc83-4cvx-p8xc).
 
     Args:
-        provider: Callable returning a (possibly short-lived) API key.
+        stmt: A parsed sqlglot statement.
+        kind_map: Mapping of sqlglot expression type to statement-kind name.
+
+    Only independently executable nested statements count. A ``MERGE``'s
+    ``WHEN ... THEN UPDATE/INSERT/DELETE`` actions parse as child write nodes
+    but are part of the merge itself, so an operator who allows ``MERGE`` must
+    not also be forced to allow standalone ``UPDATE``/``INSERT``/``DELETE``.
 
     Returns:
-        Async callable returning the same key.
+        The set of kind names written by nested nodes, plus ``"CREATE"`` for
+        the ``SELECT ... INTO`` form. Empty for an ordinary read-only query.
+    """
+    write_types = (
+        sqlglot_exp.Insert,
+        sqlglot_exp.Update,
+        sqlglot_exp.Delete,
+        sqlglot_exp.Merge,
+        sqlglot_exp.Create,
+        sqlglot_exp.Drop,
+        sqlglot_exp.Alter,
+        sqlglot_exp.TruncateTable,
+    )
+
+    # Exempt only the node that *is* a ``WHEN ... THEN`` action, by identity.
+    # Exempting everything beneath a ``When`` would also hide a write nested in
+    # the WHEN *condition* -- e.g.
+    # ``WHEN MATCHED AND EXISTS (WITH x AS (DELETE ...) SELECT * FROM x) THEN
+    # UPDATE ...`` -- or one buried inside the action's own subqueries.
+    merge_actions = {
+        id(when.args["then"])
+        for when in stmt.find_all(sqlglot_exp.When)
+        if when.args.get("then") is not None
+    }
+
+    kinds = {
+        kind_map[type(node)]
+        for node in stmt.find_all(*write_types)
+        if node is not stmt and type(node) in kind_map and id(node) not in merge_actions
+    }
+    # `SELECT ... INTO tbl` carries no nested Create node; it is flagged by the
+    # `into` arg on a Select. Check every Select, not just the top-level one:
+    # under a set operation (`SELECT ... INTO t UNION ALL SELECT ...`) the top
+    # node is a Union and the `into` sits on a branch.
+    selects = list(stmt.find_all(sqlglot_exp.Select))
+    if isinstance(stmt, sqlglot_exp.Select):
+        selects.append(stmt)
+    if any(_creates_table(sel.args.get("into")) for sel in selects):
+        kinds.add("CREATE")
+    return kinds
+
+
+# Default set of SQL statement types the agent is allowed to execute when
+# `allow_dangerous_operations` is False. SELECT-only is safe for Q&A workloads.
+_DEFAULT_ALLOWED_STATEMENTS: List[str] = ["SELECT"]
+
+
+class SQLChatAgentConfig(ChatAgentConfig):
+    system_message: str = DEFAULT_SQL_CHAT_SYSTEM_MESSAGE
+    user_message: None | str = None
+    cache: bool = True  # cache results
+    debug: bool = False
+    use_helper: bool = True
+    is_helper: bool = False
+    stream: bool = True  # allow streaming where needed
+    database_uri: str = ""  # Database URI
+    database_session: None | Session = None  # Database session
+    vecdb: None | VectorStoreConfig = None
+    context_descriptions: Dict[str, Dict[str, Union[str, Dict[str, str]]]] = {}
+    use_schema_tools: bool = False
+    multi_schema: bool = False
+    # whether the agent is used in a continuous chat with user,
+    # as opposed to returning a result from the task.run()
+    chat_mode: bool = False
+    addressing_prefix: str = ""
+    max_result_rows: int | None = None  # limit query results to this
+    max_retained_tokens: int | None = None  # limit history of query results to this
+
+    # --- Security controls (see CVE-2026-25879) ---------------------------
+    # By default, the agent only executes SELECT statements and rejects any
+    # query that matches a known dangerous pattern (e.g. PostgreSQL
+    # `COPY ... FROM PROGRAM`, MySQL `INTO OUTFILE`, SQLite `load_extension`,
+    # MSSQL `xp_cmdshell`). The LLM-generated SQL is influenceable by prompt
+    # injection — including injection via data the LLM reads back from the
+    # database — so executing it without restrictions is unsafe when the DB
+    # role has elevated privileges.
+    #
+    # To enable writes: extend allowed_statement_types, e.g. ["SELECT",
+    # "INSERT", "UPDATE", "DELETE"]. To disable all checks (only do this with
+    # a least-privilege DB role and trusted prompts): set
+    # allow_dangerous_operations=True.
+    allowed_statement_types: List[str] = list(_DEFAULT_ALLOWED_STATEMENTS)
+    allow_dangerous_operations: bool = False
+
+    """
+    Optional, but strongly recommended, context descriptions for tables, columns, 
+    and relationships. It should be a dictionary where each key is a table name 
+    and its value is another dictionary. 
+
+    In this inner dictionary:
+    - The 'description' key corresponds to a string description of the table.
+    - The 'columns' key corresponds to another dictionary where each key is a 
+    column name and its value is a string description of that column.
+    - The 'relationships' key corresponds to another dictionary where each key 
+    is another table name and the value is a description of the relationship to 
+    that table.
+
+    If multi_schema support is enabled, the tables names in the description
+    should be of the form 'schema_name.table_name'.
+
+    For example:
+    {
+        'table1': {
+            'description': 'description of table1',
+            'columns': {
+                'column1': 'description of column1 in table1',
+                'column2': 'description of column2 in table1'
+            }
+        },
+        'table2': {
+            'description': 'description of table2',
+            'columns': {
+                'column3': 'description of column3 in table2',
+                'column4': 'description of column4 in table2'
+            }
+        }
+    }
     """
 
-    async def _provider() -> str:
-        return await asyncio.to_thread(provider)
 
-    return _provider
-
-
-def _api_key_cache_component(api_key: Union[str, Callable[[], str]]) -> Any:
+class SQLChatAgent(ChatAgent):
     """
-    Cache-key component for an API key that may be a rotating-key provider.
-
-    A callable provider is keyed on its identity rather than any token value,
-    so rotating tokens never create new cache entries and tokens are never
-    retained in cache keys. The id() cannot be recycled while the entry
-    lives, because the cached client holds a strong reference to the
-    provider (directly for sync clients, via the async wrapper's closure
-    for async clients).
+    Agent for chatting with a SQL database
     """
-    if callable(api_key):
-        return ("api_key_provider", id(api_key))
-    return api_key
 
+    used_run_query: bool = False
+    llm_responded: bool = False
 
-def _get_cached_client(cache_key: str) -> Optional[Any]:
-    """Get cached client and refresh its last-used timestamp.
+    def __init__(self, config: "SQLChatAgentConfig") -> None:
+        """Initialize the SQLChatAgent.
 
-    Must be called while holding ``_client_cache_lock``.
-    """
-    entry = _client_cache.get(cache_key)
-    if entry is None:
+        Raises:
+            ValueError: If database information is not provided in the config.
+        """
+        self._validate_config(config)
+        self.config: SQLChatAgentConfig = config
+        self._init_database()
+        self._init_metadata()
+        self._init_table_metadata()
+        self.final_instructions = ""
+
+        # Caution - this updates the self.config.system_message!
+        self._init_system_message()
+        super().__init__(config)
+        self._init_tools()
+        if self.config.is_helper:
+            self.system_tool_format_instructions += self.final_instructions
+
+        if self.config.use_helper:
+            # helper_config.system_message is now the fully-populated sys msg of
+            # the main SQLAgent.
+            self.helper_config = self.config.model_copy()
+            self.helper_config.is_helper = True
+            self.helper_config.use_helper = False
+            self.helper_config.chat_mode = False
+            self.helper_agent = SQLHelperAgent(self.helper_config)
+
+    def _validate_config(self, config: "SQLChatAgentConfig") -> None:
+        """Validate the configuration to ensure all necessary fields are present."""
+        if config.database_session is None and config.database_uri is None:
+            raise ValueError("Database information must be provided")
+
+    def _init_database(self) -> None:
+        """Initialize the database engine and session."""
+        if self.config.database_session:
+            self.Session = self.config.database_session
+            self.engine = self.Session.bind
+        else:
+            self.engine = create_engine(self.config.database_uri)
+            self.Session = sessionmaker(bind=self.engine)()
+
+    def _init_metadata(self) -> None:
+        """Initialize the database metadata."""
+        if self.engine is None:
+            raise ValueError("Database engine is None")
+        self.metadata: MetaData | List[MetaData] = []
+
+        if self.config.multi_schema:
+            logger.info(
+                "Initializing SQLChatAgent with database: %s",
+                self.engine,
+            )
+
+            self.metadata = []
+            inspector = inspect(self.engine)
+
+            for schema in inspector.get_schema_names():
+                metadata = MetaData(schema=schema)
+                metadata.reflect(self.engine)
+                self.metadata.append(metadata)
+
+                logger.info(
+                    "Initializing SQLChatAgent with database: %s, schema: %s, "
+                    "and tables: %s",
+                    self.engine,
+                    schema,
+                    metadata.tables,
+                )
+        else:
+            self.metadata = MetaData()
+            self.metadata.reflect(self.engine)
+            logger.info(
+                "SQLChatAgent initialized with database: %s and tables: %s",
+                self.engine,
+                self.metadata.tables,
+            )
+
+    def _init_table_metadata(self) -> None:
+        """Initialize metadata for the tables present in the database."""
+        if not self.config.context_descriptions and isinstance(self.engine, Engine):
+            self.config.context_descriptions = extract_schema_descriptions(
+                self.engine, self.config.multi_schema
+            )
+
+        if self.config.use_schema_tools:
+            self.table_metadata = populate_metadata_with_schema_tools(
+                self.metadata, self.config.context_descriptions
+            )
+        else:
+            self.table_metadata = populate_metadata(
+                self.metadata, self.config.context_descriptions
+            )
+
+    def _init_system_message(self) -> None:
+        """Initialize the system message."""
+        message = self._format_message()
+        self.config.system_message = self.config.system_message.format(mode=message)
+
+        if not self.config.allow_dangerous_operations:
+            allowed = sorted(
+                t.strip().upper() for t in self.config.allowed_statement_types
+            )
+            self.config.system_message += (
+                f"\n\nIMPORTANT - SECURITY POLICY:\n"
+                f"You may ONLY issue SQL queries whose top-level statement "
+                f"type is one of: {allowed}. Any other statement type "
+                f"(e.g. DDL, COPY, EXEC, multi-statement scripts that "
+                f"include a disallowed type) will be REJECTED by the "
+                f"executor and not run.\n"
+            )
+
+        if self.config.chat_mode:
+            self.config.addressing_prefix = self.config.addressing_prefix or SEND_TO
+            self.config.system_message += ADDRESSING_INSTRUCTION.format(
+                prefix=self.config.addressing_prefix
+            )
+        else:
+            self.config.system_message += DONE_INSTRUCTION
+
+    def _init_tools(self) -> None:
+        """Initialize sys msg and tools."""
+        # Create a custom RunQueryTool class with the desired max_retained_tokens
+        if self.config.max_retained_tokens is not None:
+
+            class CustomRunQueryTool(RunQueryTool):
+                _max_retained_tokens = self.config.max_retained_tokens
+
+            self.enable_message([CustomRunQueryTool, ForwardTool])
+        else:
+            self.enable_message([RunQueryTool, ForwardTool])
+
+        if self.config.use_schema_tools:
+            self._enable_schema_tools()
+        if not self.config.chat_mode:
+            self.enable_message(DoneTool)
+            self.enable_message(DonePassTool)
+
+    def _format_message(self) -> str:
+        if self.engine is None:
+            raise ValueError("Database engine is None")
+
+        """Format the system message based on the engine and table metadata."""
+        return (
+            SCHEMA_TOOLS_SYS_MSG.format(dialect=self.engine.dialect.name)
+            if self.config.use_schema_tools
+            else DEFAULT_SYS_MSG.format(
+                dialect=self.engine.dialect.name, schema_dict=self.table_metadata
+            )
+        )
+
+    def _enable_schema_tools(self) -> None:
+        """Enable tools for schema-related functionalities."""
+        self.enable_message(GetTableNamesTool)
+        self.enable_message(GetTableSchemaTool)
+        self.enable_message(GetColumnDescriptionsTool)
+
+    def llm_response(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> Optional[ChatDocument]:
+        self.llm_responded = True
+        self.used_run_query = False
+        return super().llm_response(message)
+
+    def user_response(
+        self,
+        msg: Optional[str | ChatDocument] = None,
+    ) -> Optional[ChatDocument]:
+        self.llm_responded = False
+        self.used_run_query = False
+        return super().user_response(msg)
+
+    def _clarify_answer_instruction(self) -> str:
+        """
+        Prompt to use when asking LLM to clarify intent of
+        an already-generated response
+        """
+        if self.config.chat_mode:
+            return f"""
+                you must use the TOOL `{ForwardTool.name()}` with the `agent` 
+                parameter set to "User"
+                """
+        else:
+            return f"you must use the TOOL `{DonePassTool.name()}`"
+
+    def _clarifying_message(self) -> str:
+        tools_instruction = f"""
+          For example you may want to use the TOOL
+          `{RunQueryTool.name()}` to further explore the database contents
+        """
+        if self.config.use_schema_tools:
+            tools_instruction += """
+            OR you may want to use one of the schema tools to 
+            explore the database schema
+            """
+        return f"""
+            The intent of your response is not clear:
+            - if you intended this to be the FINAL answer to the user's query,
+                {self._clarify_answer_instruction()}
+            - otherwise, use one of the available tools to make progress 
+                to arrive at the final answer.
+                {tools_instruction}
+            """
+
+    def handle_message_fallback(
+        self, message: str | ChatDocument
+    ) -> str | ForwardTool | ChatDocument | None:
+        """
+        We'd end up here if the current msg has no tool.
+        If this is from LLM, we may need to handle the scenario where
+        it may have "forgotten" to generate a tool.
+        """
+        if (
+            not isinstance(message, ChatDocument)
+            or message.metadata.sender != Entity.LLM
+        ):
+            return None
+        if self.config.chat_mode:
+            # send any Non-tool msg to the user
+            return ForwardTool(agent="User")
+        # Agent intent not clear => use the helper agent to
+        # do what this agent should have done, e.g. generate tool, etc.
+        # This is likelier to succeed since this agent has no "baggage" of
+        # prior conversation, other than the system msg, and special
+        # "Intent-interpretation" instructions.
+        if self._json_schema_available() and self.config.strict_recovery:
+            AnyTool = self._get_any_tool_message(optional=False)
+            self.set_output_format(
+                AnyTool,
+                force_tools=True,
+                use=True,
+                handle=True,
+                instructions=True,
+            )
+            recovery_message = self._strict_recovery_instructions(
+                AnyTool, optional=False
+            )
+            result = self.llm_response(recovery_message)
+            # remove the recovery_message (it has User role) from the chat history,
+            # else it may cause the LLM to directly use the AnyTool.
+            self.delete_last_message(role=Role.USER)  # delete last User-role msg
+            return result
+        elif self.config.use_helper:
+            response = self.helper_agent.llm_response(message)
+            tools = self.try_get_tool_messages(response)
+            if tools:
+                return response
+        # fall back on the clarification message
+        return self._clarifying_message()
+
+    def retry_query(self, e: Exception, query: str) -> str:
+        """
+        Generate an error message for a failed SQL query and return it.
+
+        Parameters:
+        e (Exception): The exception raised during the SQL query execution.
+        query (str): The SQL query that failed.
+
+        Returns:
+        str: The error message.
+        """
+        logger.error(f"SQL Query failed: {query}\nException: {e}")
+
+        # Optional part to be included based on `use_schema_tools`
+        optional_schema_description = ""
+        if not self.config.use_schema_tools:
+            optional_schema_description = f"""\
+            This JSON schema maps SQL database structure. It outlines tables, each 
+            with a description and columns. Each table is identified by a key, and holds
+            a description and a dictionary of columns, with column 
+            names as keys and their descriptions as values.
+            
+            ```json
+            {self.config.context_descriptions}
+            ```"""
+
+        # Construct the error message
+        error_message_template = f"""\
+        {SQL_ERROR_MSG}: '{query}'
+        {str(e)}
+        Run a new query, correcting the errors.
+        {optional_schema_description}"""
+
+        return error_message_template
+
+    def _available_tool_names(self) -> str:
+        return ",".join(self.llm_tools_usable)
+
+    def _tool_result_llm_answer_prompt(self) -> str:
+        """
+        Prompt to use at end of tool result,
+        to guide LLM, for the case where it wants to answer the user's query
+        """
+        if self.config.chat_mode:
+            assert self.config.addressing_prefix != ""
+            return """
+                You must EXPLICITLY address the User with 
+                the addressing prefix according to your instructions,
+                to convey your answer to the User.
+                """
+        else:
+            return f"""
+                you must use the `{DoneTool.name()}` with the `content` 
+                set to the answer or result
+                """
+
+    def _sqlglot_dialect(self) -> Optional[str]:
+        """Map the SQLAlchemy dialect name to a sqlglot dialect name."""
+        if self.engine is None:
+            return None
+        name: str = str(self.engine.dialect.name)
+        # sqlglot uses 'postgres', not 'postgresql'; 'tsql' for MSSQL.
+        mapping: Dict[str, str] = {"postgresql": "postgres", "mssql": "tsql"}
+        return mapping.get(name, name)
+
+    def _validate_query(self, query: str) -> Optional[str]:
+        """
+        Check whether `query` is permitted under the agent's security config.
+
+        Returns None if the query may be executed, otherwise an error message
+        explaining why it was rejected (to be relayed to the LLM).
+        """
+        if self.config.allow_dangerous_operations:
+            return None
+
+        for pat in _DANGEROUS_SQL_PATTERNS:
+            if pat.search(query):
+                logger.warning(
+                    "SQLChatAgent rejected query matching dangerous pattern "
+                    f"{pat.pattern!r}: {query!r}"
+                )
+                return (
+                    f"Query REJECTED for safety: it matches a pattern "
+                    f"({pat.pattern!r}) that enables code execution, "
+                    f"filesystem access, or other unsafe operations. "
+                    f"Rewrite the query without using this construct, or ask "
+                    f"the operator to set `allow_dangerous_operations=True` "
+                    f"on the SQLChatAgent config."
+                )
+
+        allowed = {t.strip().upper() for t in self.config.allowed_statement_types}
+        try:
+            statements = sqlglot.parse(query, read=self._sqlglot_dialect())
+        except Exception as e:
+            logger.warning(f"sqlglot failed to parse query {query!r}: {e}")
+            return (
+                f"Query REJECTED for safety: could not be parsed to verify it "
+                f"is a {sorted(allowed)} statement ({e}). Rewrite the query "
+                f"more simply, or ask the operator to set "
+                f"`allow_dangerous_operations=True` on the SQLChatAgent config."
+            )
+
+        kind_map = {
+            sqlglot_exp.Select: "SELECT",
+            sqlglot_exp.Insert: "INSERT",
+            sqlglot_exp.Update: "UPDATE",
+            sqlglot_exp.Delete: "DELETE",
+            sqlglot_exp.Merge: "MERGE",
+            sqlglot_exp.Create: "CREATE",
+            sqlglot_exp.Drop: "DROP",
+            sqlglot_exp.Alter: "ALTER",
+            sqlglot_exp.TruncateTable: "TRUNCATE",
+            sqlglot_exp.Command: "COMMAND",
+        }
+        for stmt in statements:
+            if stmt is None:
+                continue
+            kind = next(
+                (v for k, v in kind_map.items() if isinstance(stmt, k)),
+                type(stmt).__name__.upper(),
+            )
+            if kind not in allowed:
+                logger.warning(
+                    f"SQLChatAgent rejected {kind} statement (allowed: "
+                    f"{sorted(allowed)}): {query!r}"
+                )
+                return (
+                    f"Query REJECTED for safety: statement type {kind!r} is "
+                    f"not in the allowed list {sorted(allowed)}. Rewrite the "
+                    f"query as one of the allowed statement types, or ask "
+                    f"the operator to extend `allowed_statement_types` "
+                    f"(or set `allow_dangerous_operations=True`) on the "
+                    f"SQLChatAgent config."
+                )
+            # The top-level node alone does not determine what a statement
+            # writes. A data-modifying CTE
+            # (``WITH x AS (DELETE ... RETURNING *) SELECT ...``) and
+            # ``SELECT ... INTO tbl`` both parse with a ``Select`` top node, so
+            # the check above classifies them as SELECT while the engine still
+            # performs the write (GHSA-3gpx-vwr3-xvwx / GHSA-wc83-4cvx-p8xc).
+            nested = _nested_write_kinds(stmt, kind_map)
+            disallowed = sorted(nested - allowed)
+            if disallowed:
+                logger.warning(
+                    f"SQLChatAgent rejected {kind} statement embedding "
+                    f"{disallowed} (allowed: {sorted(allowed)}): {query!r}"
+                )
+                return (
+                    f"Query REJECTED for safety: although this parses as a "
+                    f"{kind} statement, it embeds {disallowed}, which is not "
+                    f"in the allowed list {sorted(allowed)} -- the database "
+                    f"would still perform that write. Rewrite the query "
+                    f"without the embedded statement, or ask the operator to "
+                    f"extend `allowed_statement_types` (or set "
+                    f"`allow_dangerous_operations=True`) on the SQLChatAgent "
+                    f"config."
+                )
+            # AST-side dangerous-function check: catches calls that evaded
+            # `_DANGEROUS_SQL_PATTERNS` via quoted identifiers, inline comments,
+            # or schema qualification (GHSA-6xc5-4r68-67fc).
+            for fn_name in _called_function_names(stmt):
+                if _is_dangerous_function_name(fn_name):
+                    logger.warning(
+                        "SQLChatAgent rejected query calling dangerous "
+                        f"function {fn_name!r}: {query!r}"
+                    )
+                    return (
+                        f"Query REJECTED for safety: it calls function "
+                        f"{fn_name!r}, which enables code execution, "
+                        f"filesystem access, or other unsafe operations. "
+                        f"Rewrite the query without using this function, or "
+                        f"ask the operator to set "
+                        f"`allow_dangerous_operations=True` on the "
+                        f"SQLChatAgent config."
+                    )
         return None
 
-    client, _ = entry
-    _client_cache[cache_key] = (client, time.monotonic())
-    return client
+    def run_query(self, msg: RunQueryTool) -> str:
+        """
+        Handle a RunQueryTool message by executing a SQL query and returning the result.
 
+        Args:
+            msg (RunQueryTool): The tool-message to handle.
 
-def _store_client(cache_key: str, client: Any) -> None:
-    """Store a client in the cache with the current timestamp.
+        Returns:
+            str: The result of executing the SQL query.
+        """
+        query = msg.query
+        session = self.Session
+        self.used_run_query = True
 
-    Must be called while holding ``_client_cache_lock``.
-    """
-    _client_cache[cache_key] = (client, time.monotonic())
-    _all_clients.add(client)
+        rejection = self._validate_query(query)
+        if rejection is not None:
+            return f"""
+        Below is the result from your use of the TOOL `{RunQueryTool.name()}`:
+        ==== result ====
+        {rejection}
+        ================
 
+        Try a different query that complies with the policy above.
+        """
 
-def get_openai_client(
-    api_key: Union[str, Callable[[], str]],
-    base_url: Optional[str] = None,
-    organization: Optional[str] = None,
-    timeout: Union[float, Timeout] = 120.0,
-    default_headers: Optional[Dict[str, str]] = None,
-    http_client: Optional[Any] = None,
-    http_client_config: Optional[Dict[str, Any]] = None,
-) -> OpenAI:
-    """
-    Get or create a singleton OpenAI client with the given configuration.
+        try:
+            logger.info(f"Executing SQL query: {query}")
 
-    Args:
-        api_key: OpenAI API key, or a callable returning a fresh key
-            (for short-lived rotating credentials); a callable is resolved
-            per-request by the OpenAI client and is excluded from the
-            cache key (the cache is keyed on the provider's identity)
-        base_url: Optional base URL for API
-        organization: Optional organization ID
-        timeout: Request timeout
-        default_headers: Optional default headers
-        http_client: Optional httpx.Client instance
-        http_client_config: Optional config dict for creating httpx.Client
-
-    Returns:
-        OpenAI client instance
-    """
-    if isinstance(timeout, (int, float)):
-        timeout = Timeout(timeout)
-
-    # If http_client is provided directly, don't cache (complex object)
-    if http_client is not None:
-        client = OpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            organization=organization,
-            timeout=timeout,
-            default_headers=default_headers,
-            http_client=http_client,
-        )
-        _all_clients.add(client)
-        return client
-
-    cache_key = _get_cache_key(
-        "openai",
-        api_key=_api_key_cache_component(api_key),
-        base_url=base_url,
-        organization=organization,
-        timeout=timeout,
-        default_headers=default_headers,
-        http_client_config=http_client_config,  # Include config in cache key
-    )
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(OpenAI, cached_client)
-
-        created_http_client = None
-        if http_client_config is not None:
+            query_result = session.execute(text(query))
+            session.commit()
             try:
-                from httpx import Client
-            except ImportError:
-                raise ValueError(
-                    "httpx is required to use http_client_config. "
-                    "Install it with: pip install httpx"
-                )
-            created_http_client = Client(**http_client_config)
+                # attempt to fetch results: should work for normal SELECT queries
+                rows = query_result.fetchall()
+                n_rows = len(rows)
+                if self.config.max_result_rows and n_rows > self.config.max_result_rows:
+                    rows = rows[: self.config.max_result_rows]
+                    logger.warning(
+                        f"SQL query produced {n_rows} rows, "
+                        f"limiting to {self.config.max_result_rows}"
+                    )
 
-        client = OpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            organization=organization,
-            timeout=timeout,
-            default_headers=default_headers,
-            http_client=created_http_client,  # Use the client created from config
+                response_message = self._format_rows(rows)
+            except ResourceClosedError:
+                # If we get here, it's a non-SELECT query (UPDATE, INSERT, DELETE)
+                affected_rows = query_result.rowcount  # type: ignore
+                response_message = f"""
+                    Non-SELECT query executed successfully. 
+                    Rows affected: {affected_rows}
+                    """
+
+        except SQLAlchemyError as e:
+            session.rollback()
+            logger.error(f"Failed to execute query: {query}\n{e}")
+            response_message = self.retry_query(e, query)
+        finally:
+            session.close()
+
+        final_message = f"""
+        Below is the result from your use of the TOOL `{RunQueryTool.name()}`:
+        ==== result ====
+        {response_message}
+        ================
+        
+        If you are READY to ANSWER the ORIGINAL QUERY:
+        {self._tool_result_llm_answer_prompt()}
+        OTHERWISE:
+             continue using one of your available TOOLs:
+             {",".join(self.llm_tools_usable)}
+        """
+        return final_message
+
+    def _format_rows(self, rows: Sequence[Row[Any]]) -> str:
+        """
+        Format the rows fetched from the query result into a string.
+
+        Args:
+            rows (list): List of rows fetched from the query result.
+
+        Returns:
+            str: Formatted string representation of rows.
+        """
+        # TODO: UPDATE FORMATTING
+        return (
+            ",\n".join(str(row) for row in rows)
+            if rows
+            else "Query executed successfully."
         )
 
-        _store_client(cache_key, client)
-    return client
-
-
-def get_async_openai_client(
-    api_key: Union[str, Callable[[], str]],
-    base_url: Optional[str] = None,
-    organization: Optional[str] = None,
-    timeout: Union[float, Timeout] = 120.0,
-    default_headers: Optional[Dict[str, str]] = None,
-    http_client: Optional[Any] = None,
-    http_client_config: Optional[Dict[str, Any]] = None,
-) -> AsyncOpenAI:
-    """
-    Get or create a singleton AsyncOpenAI client with the given configuration.
-
-    Args:
-        api_key: OpenAI API key, or a callable returning a fresh key
-            (for short-lived rotating credentials); a callable is resolved
-            per-request by the OpenAI client and is excluded from the
-            cache key (the cache is keyed on the provider's identity)
-        base_url: Optional base URL for API
-        organization: Optional organization ID
-        timeout: Request timeout
-        default_headers: Optional default headers
-        http_client: Optional httpx.AsyncClient instance
-        http_client_config: Optional config dict for creating httpx.AsyncClient
-
-    Returns:
-        AsyncOpenAI client instance
-    """
-    if isinstance(timeout, (int, float)):
-        timeout = Timeout(timeout)
-
-    api_key_arg: Union[str, Callable[[], Awaitable[str]]]
-    if callable(api_key):
-        # AsyncOpenAI awaits its api_key callable, so wrap the sync provider
-        api_key_arg = wrap_api_key_provider_async(api_key)
-    else:
-        api_key_arg = api_key
-
-    # If http_client is provided directly, don't cache (complex object)
-    if http_client is not None:
-        client = AsyncOpenAI(
-            api_key=api_key_arg,
-            base_url=base_url,
-            organization=organization,
-            timeout=timeout,
-            default_headers=default_headers,
-            http_client=http_client,
-        )
-        _all_clients.add(client)
-        return client
-
-    cache_key = _get_cache_key(
-        "async_openai",
-        api_key=_api_key_cache_component(api_key),
-        base_url=base_url,
-        organization=organization,
-        timeout=timeout,
-        default_headers=default_headers,
-        http_client_config=http_client_config,  # Include config in cache key
-    )
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(AsyncOpenAI, cached_client)
-
-        created_http_client = None
-        if http_client_config is not None:
-            try:
-                from httpx import AsyncClient
-            except ImportError:
-                raise ValueError(
-                    "httpx is required to use http_client_config. "
-                    "Install it with: pip install httpx"
-                )
-            created_http_client = AsyncClient(**http_client_config)
-
-        client = AsyncOpenAI(
-            api_key=api_key_arg,
-            base_url=base_url,
-            organization=organization,
-            timeout=timeout,
-            default_headers=default_headers,
-            http_client=created_http_client,  # Use the client created from config
-        )
-
-        _store_client(cache_key, client)
-    return client
-
-
-def get_groq_client(api_key: str) -> Groq:
-    """
-    Get or create a singleton Groq client with the given configuration.
-
-    Args:
-        api_key: Groq API key
-
-    Returns:
-        Groq client instance
-    """
-    cache_key = _get_cache_key("groq", api_key=api_key)
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(Groq, cached_client)
-
-        client = Groq(api_key=api_key)
-        _store_client(cache_key, client)
-    return client
-
-
-def get_async_groq_client(api_key: str) -> AsyncGroq:
-    """
-    Get or create a singleton AsyncGroq client with the given configuration.
-
-    Args:
-        api_key: Groq API key
-
-    Returns:
-        AsyncGroq client instance
-    """
-    cache_key = _get_cache_key("async_groq", api_key=api_key)
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(AsyncGroq, cached_client)
-
-        client = AsyncGroq(api_key=api_key)
-        _store_client(cache_key, client)
-    return client
-
-
-def get_cerebras_client(api_key: str) -> Cerebras:
-    """
-    Get or create a singleton Cerebras client with the given configuration.
-
-    Args:
-        api_key: Cerebras API key
-
-    Returns:
-        Cerebras client instance
-    """
-    cache_key = _get_cache_key("cerebras", api_key=api_key)
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(Cerebras, cached_client)
-
-        client = Cerebras(api_key=api_key)
-        _store_client(cache_key, client)
-    return client
-
-
-def get_async_cerebras_client(api_key: str) -> AsyncCerebras:
-    """
-    Get or create a singleton AsyncCerebras client with the given configuration.
-
-    Args:
-        api_key: Cerebras API key
-
-    Returns:
-        AsyncCerebras client instance
-    """
-    cache_key = _get_cache_key("async_cerebras", api_key=api_key)
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(AsyncCerebras, cached_client)
-
-        client = AsyncCerebras(api_key=api_key)
-        _store_client(cache_key, client)
-    return client
-
-
-def prune_cache(max_age_seconds: float) -> int:
-    """
-    Remove cache entries whose last-used time exceeds *max_age_seconds*.
-
-    Evicted clients are **not** closed here because they may still be serving
-    in-flight requests.  Cleanup is handled by the ``atexit`` handler and the
-    garbage collector.
-
-    Args:
-        max_age_seconds: Maximum age (in seconds) for cache entries to keep.
-            Entries older than this value are removed.
-
-    Returns:
-        Number of cache entries removed.
-    """
-    if max_age_seconds < 0:
-        raise ValueError("max_age_seconds must be non-negative")
-
-    now = time.monotonic()
-
-    with _client_cache_lock:
-        stale_keys = [
-            key
-            for key, (_, last_used_at) in _client_cache.items()
-            if now - last_used_at > max_age_seconds
-        ]
-
-        for key in stale_keys:
-            _client_cache.pop(key)
-
-    # Don't close evicted clients here — they may still be serving in-flight
-    # requests. The atexit handler and GC will clean them up.
-
-    return len(stale_keys)
-
-
-def _cleanup_clients() -> None:
-    """
-    Cleanup function to close all cached clients on exit.
-    Called automatically via atexit.
-    """
-    for client in list(_all_clients):
-        if hasattr(client, "close") and callable(client.close):
-            try:
-                # Check if close is a coroutine function (async)
-                if inspect.iscoroutinefunction(client.close):
-                    # For async clients, we can't await in atexit
-                    # They will be cleaned up by the OS
-                    pass
-                else:
-                    # Sync clients can be closed directly
-                    client.close()
-            except Exception:
-                pass  # Ignore errors during cleanup
-
-
-# Register cleanup function to run on exit
-atexit.register(_cleanup_clients)
-
-
-# For testing purposes
-def _clear_cache() -> None:
-    """Clear the client cache. Only for testing."""
-    with _client_cache_lock:
-        _client_cache.clear()
-</file>
-
-<file path="SECURITY.md">
-# Security Policy
-
-## Threat model — please read this before reporting
-
-Langroid is a framework for building applications in which an LLM generates
-code and queries that are then executed. Several **optional** agents exist for
-exactly that purpose:
-
-- `TableChatAgent`, `LanceDocChatAgent`, and `VectorStore.compute_from_docs`
-  evaluate LLM-generated **pandas expressions** with `eval()`.
-- `SQLChatAgent` executes LLM-generated **SQL** against a database you supply.
-- `Neo4jChatAgent`, `ArangoChatAgent`, and `CSVGraphAgent` execute
-  LLM-generated **Cypher / AQL** against a graph database you supply.
-
-Executing model-generated code against your own data *is the feature*. An LLM
-is not a trust boundary: if any untrusted text reaches the model's context, you
-must assume the model can be induced to emit any query or expression the
-grammar allows. Langroid cannot prevent this, and does not claim to.
-
-### What is, and is not, a security boundary
-
-The following are **best-effort hardening, not security boundaries**:
-
-- `sanitize_command()` / `CommandValidator` / `safe_eval_globals()` in
-  `langroid/utils/pandas_utils.py`
-- `_DANGEROUS_SQL_PATTERNS` and the `sqlglot` AST checks in `SQLChatAgent`
-- `validate_cypher_query()` / `validate_aql_query()` in the graph agents
-
-They exist to stop an *unlucky* LLM, not a *determined attacker*. The pandas
-path uses explicit allowlists for AST nodes, methods, operators, variables, and
-builtins. The SQL, Cypher, and AQL paths use denylists over full query grammars
-that span multiple dialects, quoting and escaping forms, and function families.
-Such denylists cannot be made complete. We patch clear gaps opportunistically,
-but we do not treat a newly found way around them as a vulnerability in
-Langroid.
-
-The **actual** security boundaries for a Langroid deployment are:
-
-- the privileges of the database credential you hand the agent;
-- the OS user, container, or VM the process runs in;
-- filesystem permissions and network egress rules.
-
-### Deploying these agents safely
-
-If you expose any of the code- or query-executing agents to untrusted input:
-
-- **Give the agent a least-privilege database role.** For `SQLChatAgent`, a
-  read-only, non-superuser role with `GRANT SELECT` on only the intended
-  tables. In PostgreSQL, server-side file reads and writes normally require a
-  superuser, membership in `pg_read_server_files` or
-  `pg_write_server_files`, or a direct grant on a privileged function.
-  `COPY ... PROGRAM` instead requires superuser access or membership in the
-  distinct `pg_execute_server_program` role. Server-side `lo_import` and
-  `lo_export` default to superuser-only use, but an administrator can grant
-  access to those functions directly. Ordinary password-authenticated
-  `dblink` connections do not require any of those roles. Do not install
-  unneeded extensions, and revoke access to dangerous extensions and
-  functions, including `dblink`, in addition to granting only the intended
-  table privileges. Review any site-specific functions and grants as well.
-- **Run the process in a container or VM** with no credentials, secrets, or
-  data you are unwilling to expose to the LLM.
-- **Treat `allow_dangerous_operations=True` and `full_eval=True` as
-  "I am providing my own sandbox."** The first permits dangerous database
-  operations. The second disables pandas AST validation while retaining the
-  restricted globals from `safe_eval_globals()`. Both are documented as
-  trusted-environment-only.
-
-## Reporting a vulnerability
-
-Report privately — **not** via GitHub Issues, Discussions, or any other public
-forum:
-
-1. Go to
-   **[Security Advisories](https://github.com/langroid/langroid/security/advisories)**.
-2. Click **"Report a vulnerability"**.
-3. Include a proof of concept that works against a **default configuration**.
-
-We aim to acknowledge in-scope reports within 7 days.
-
-### In scope
-
-- Vulnerabilities in core framework code: tool dispatch and the agent/tool
-  trust boundary, message routing, sender verification.
-- Parsing and deserialization flaws (XXE, unsafe deserialization, decompression
-  bombs) in the document and message parsers.
-- Path traversal in the file tools (`ReadFileTool`, `WriteFileTool`,
-  `ListDirTool`) and in repository / folder ingestion.
-- Credential or secret leakage in a default configuration that does not depend
-  on any of the specific exclusions below. The out-of-scope rules take
-  precedence over this category.
-- **A code path that skips a documented safety gate entirely** — that is, a
-  *missing call* to a validator, not a *bypass* of one.
-- **A statement the `allowed_statement_types` allowlist misclassifies.** The
-  allowlist is a different kind of control from the denylists above: it decides
-  what a statement *does* over a closed set of statement kinds, so a query that
-  performs a write the allowlist did not authorize — for example by nesting it
-  where the classifier does not look — is a bounded, fixable defect and is in
-  scope.
-- Vulnerable dependencies with a demonstrated impact on Langroid.
-
-### Out of scope
-
-The following will be closed without a fix, an advisory, or a CVE request:
-
-- New bypasses of the SQL, Cypher, or AQL denylists: previously unlisted
-  functions, alternate quoting or escaping forms (backticks, Unicode escapes,
-  schema qualification), or dialect-specific syntax. See "What is, and is not,
-  a security boundary" above.
-- Sandbox escapes from the pandas `eval()` path when `full_eval=True`,
-  including object-graph traversal via dunder attributes. `full_eval=True`
-  disables the AST validator by design.
-- Anything requiring `allow_dangerous_operations=True`.
-- "The LLM can be prompt-injected into generating a harmful query." This is the
-  documented threat model, not a defect.
-- Reports that assume the agent was given a superuser or otherwise
-  over-privileged database credential.
-- Theoretical reports with no working proof of concept against a default
-  configuration.
-
-Reports that chain off a previous advisory as an "incomplete fix" are judged
-against this same scope: if the original issue was a missing gate we will fix
-it, and if it was a denylist gap it is out of scope.
-
-## Supported versions
-
-Security fixes ship in the latest release. Please upgrade to the current
-version of `langroid` rather than requesting backports.
+    def get_table_names(self, msg: GetTableNamesTool) -> str:
+        """
+        Handle a GetTableNamesTool message by returning the names of all tables in the
+        database.
+
+        Returns:
+            str: The names of all tables in the database.
+        """
+        if isinstance(self.metadata, list):
+            table_names = [", ".join(md.tables.keys()) for md in self.metadata]
+            return ", ".join(table_names)
+
+        return ", ".join(self.metadata.tables.keys())
+
+    def get_table_schema(self, msg: GetTableSchemaTool) -> str:
+        """
+        Handle a GetTableSchemaTool message by returning the schema of all provided
+        tables in the database.
+
+        Returns:
+            str: The schema of all provided tables in the database.
+        """
+        tables = msg.tables
+        result = ""
+        for table_name in tables:
+            table = self.table_metadata.get(table_name)
+            if table is not None:
+                result += f"{table_name}: {table}\n"
+            else:
+                result += f"{table_name} is not a valid table name.\n"
+        return result
+
+    def get_column_descriptions(self, msg: GetColumnDescriptionsTool) -> str:
+        """
+        Handle a GetColumnDescriptionsTool message by returning the descriptions of all
+        provided columns from the database.
+
+        Returns:
+            str: The descriptions of all provided columns from the database.
+        """
+        table = msg.table
+        columns = msg.columns.split(", ")
+        result = f"\nTABLE: {table}"
+        descriptions = self.config.context_descriptions.get(table)
+
+        for col in columns:
+            result += f"\n{col} => {descriptions['columns'][col]}"  # type: ignore
+        return result
+
+
+class SQLHelperAgent(SQLChatAgent):
+
+    def _clarifying_message(self) -> str:
+        tools_instruction = f"""
+          For example the Agent may have forgotten to use the TOOL
+          `{RunQueryTool.name()}` to further explore the database contents
+        """
+        if self.config.use_schema_tools:
+            tools_instruction += """
+            OR the agent may have forgotten to use one of the schema tools to 
+            explore the database schema
+            """
+
+        return f"""
+            The intent of the Agent's response is not clear:
+            - if you think the Agent intended this as ANSWER to the 
+                user's query,
+                {self._clarify_answer_instruction()}
+            - otherwise, the Agent may have forgotten to 
+              use one of the available tools to make progress 
+                to arrive at the final answer.
+                {tools_instruction}
+            """
+
+    def _init_system_message(self) -> None:
+        """Set up helper sys msg"""
+
+        # Note that self.config.system_message is already set to the
+        # parent SQLAgent's system_message
+        self.config.system_message = f"""
+                You role is to help INTERPRET the INTENT of an 
+                AI agent in a conversation. This Agent was supposed to generate
+                a TOOL/Function-call but forgot to do so, and this is where 
+                you can help, by trying to generate the appropriate TOOL
+                based on your best guess of the Agent's INTENT.
+                
+                Below are the instructions that were given to this Agent: 
+                ===== AGENT INSTRUCTIONS =====
+                {self.config.system_message}
+                ===== END OF AGENT INSTRUCTIONS =====
+                """
+
+        # note that the initial msg in chat history will contain:
+        # - system message
+        # - tool instructions
+        # so the final_instructions will be at the end of this initial msg
+
+        self.final_instructions = f"""        
+        You must take note especially of the TOOLs that are
+        available to the Agent. Your reasoning process should be as follows:
+        
+        - If the Agent's message appears to be an ANSWER to the original query,
+          {self._clarify_answer_instruction()}.
+          CAUTION - You must be absolutely sure that the Agent's message is 
+          an ACTUAL ANSWER to the user's query, and not a failed attempt to use 
+          a TOOL without JSON, e.g. something like "run_query" or "done_tool"
+          without any actual JSON formatting.
+           
+        - Else, if you think the Agent intended to use some type of SQL
+          query tool to READ or UPDATE the table(s), 
+          AND it is clear WHICH TOOL is intended as well as the 
+          TOOL PARAMETERS, then you must generate the JSON-Formatted
+          TOOL with the parameters set based on your understanding.
+          Note that the `{RunQueryTool.name()}` is not ONLY for querying the tables,
+          but also for UPDATING the tables.
+           
+        - Else, use the `{PassTool.name()}` to pass the message unchanged.
+            CAUTION - ONLY use `{PassTool.name()}` if you think the Agent's response
+            is NEITHER an ANSWER, nor an intended SQL QUERY.
+        """
+
+    def llm_response(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> Optional[ChatDocument]:
+        if message is None:
+            return None
+        message_str = message if isinstance(message, str) else message.content
+        instruc_msg = f"""
+        Below is the MESSAGE from the SQL Agent. 
+        Remember your instructions on how to respond based on your understanding
+        of the INTENT of this message:        
+        {self.final_instructions}
+        
+        === AGENT MESSAGE =========
+        {message_str}
+        === END OF AGENT MESSAGE ===
+        """
+        # user response_forget to avoid accumulating the chat history
+        return super().llm_response_forget(instruc_msg)
 </file>
 
 <file path="langroid/agent/chat_agent.py">
@@ -83975,10 +86480,14 @@ class ChatAgent(Agent):
         changed in possibly many ways. Below is an imperfect solution. Caution advised.
         Revisit later.
         """
+        from langroid.agent.tool_policy import deepcopy_config_sharing_policy
+
         agent_cls = type(self)
-        # Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
-        # instead of deepcopy which loses subclass information
-        config_copy = self.config.model_copy(deep=True)
+        # Deep-copy the config WITHOUT mutating it, sharing the tool_policy
+        # hook by REFERENCE (memo-seeded deepcopy): copying the policy would
+        # fork any state it holds (budgets, approval lists) and can fail
+        # outright on unpicklable callables (e.g. objects holding locks).
+        config_copy = deepcopy_config_sharing_policy(self.config)
         config_copy.name = f"{config_copy.name}-{i}"
         new_agent = agent_cls(config_copy)
         new_agent.system_tool_instructions = self.system_tool_instructions
@@ -84906,27 +87415,10 @@ class ChatAgent(Agent):
             request: str = "tool_or_function"
             tool: maybe_optional_type  # type: ignore
 
-            def response(self, agent: ChatAgent) -> None | str | ChatDocument:
-                # One-time use
-                agent.set_output_format(None)
-
-                if self.tool is None:
-                    return None
-
-                # As the ToolMessage schema accepts invalid
-                # `tool.request` values, reparse with the
-                # corresponding tool
-                request = self.tool.request
-                if request not in agent.llm_tools_map:
-                    return None
-                tool = agent.llm_tools_map[request].model_validate_json(
-                    self.tool.to_json()
-                )
-
-                return agent.handle_tool_message(tool)
-
-            async def response_async(
-                self, agent: ChatAgent
+            def response(
+                self,
+                agent: ChatAgent,
+                chat_doc: Optional[ChatDocument] = None,
             ) -> None | str | ChatDocument:
                 # One-time use
                 agent.set_output_format(None)
@@ -84944,7 +87436,43 @@ class ChatAgent(Agent):
                     self.tool.to_json()
                 )
 
-                return await agent.handle_tool_message_async(tool)
+                # pass the chat_doc through, so the recovered tool's policy
+                # check sees the same message context a normal dispatch would
+                return agent._handle_tool_message_with_policy(tool, chat_doc=chat_doc)
+
+            async def response_async(
+                self,
+                agent: ChatAgent,
+                chat_doc: Optional[ChatDocument] = None,
+            ) -> None | str | ChatDocument:
+                # One-time use
+                agent.set_output_format(None)
+
+                if self.tool is None:
+                    return None
+
+                # As the ToolMessage schema accepts invalid
+                # `tool.request` values, reparse with the
+                # corresponding tool
+                request = self.tool.request
+                if request not in agent.llm_tools_map:
+                    return None
+                tool = agent.llm_tools_map[request].model_validate_json(
+                    self.tool.to_json()
+                )
+
+                # pass the chat_doc through, so the recovered tool's policy
+                # check sees the same message context a normal dispatch would
+                return await agent._handle_tool_message_with_policy_async(
+                    tool, chat_doc=chat_doc
+                )
+
+        # This wrapper is a parsing shim for strict recovery, NOT a tool
+        # execution, so it is exempt from the `tool_policy` hook -- which
+        # also guarantees `set_output_format(None)` above always runs. The
+        # re-parsed ACTUAL tool is dispatched through the policy-checked
+        # path, so the policy is consulted exactly once per logical call.
+        AnyTool._tool_policy_exempt = True  # type: ignore[attr-defined]
 
         return AnyTool
 
@@ -86073,1931 +88601,865 @@ class ChatAgent(Agent):
         pass
 </file>
 
-<file path="langroid/language_models/base.py">
-import json
+<file path="langroid/language_models/model_info.py">
 import logging
-from abc import ABC, abstractmethod
-from datetime import datetime, timezone
 from enum import Enum
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
-from pydantic_settings import BaseSettings
-
-from langroid.cachedb.base import CacheDBConfig
-from langroid.cachedb.redis_cachedb import RedisCacheConfig
-from langroid.language_models.model_info import ModelInfo, get_model_info
-from langroid.parsing.agent_chats import parse_message
-from langroid.parsing.file_attachment import FileAttachment
-from langroid.parsing.parse_json import parse_imperfect_json, top_level_json_field
-from langroid.prompts.dialog import collate_chat_history
-from langroid.utils.configuration import settings
-from langroid.utils.output.printing import show_if_debug
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
 
-def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+class ModelProvider(str, Enum):
+    """Enum for model providers"""
+
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+    DEEPSEEK = "deepseek"
+    GOOGLE = "google"
+    MINIMAX = "minimax"
+    UNKNOWN = "unknown"
+
+
+class ModelName(str, Enum):
+    """Parent class for all model name enums"""
+
     pass
 
 
-async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
-    pass
+class OpenAIChatModel(ModelName):
+    """Enum for OpenAI Chat models"""
+
+    GPT3_5_TURBO = "gpt-3.5-turbo"
+    GPT4 = "gpt-4o"  # avoid deprecated gpt-4
+    GPT4_TURBO = "gpt-4-turbo"
+    GPT4o = "gpt-4o"
+    GPT4o_MINI = "gpt-4o-mini"
+    O1 = "o1"
+    O1_MINI = "o1-mini"
+    O3_MINI = "o3-mini"
+    O3 = "o3"
+    O4_MINI = "o4-mini"
+    GPT4_1 = "gpt-4.1"
+    GPT4_1_MINI = "gpt-4.1-mini"
+    GPT4_1_NANO = "gpt-4.1-nano"
+    GPT5 = "gpt-5"
+    GPT5_MINI = "gpt-5-mini"
+    GPT5_NANO = "gpt-5-nano"
+    GPT5_PRO = "gpt-5-pro"
+    GPT5_1 = "gpt-5.1"
+    GPT5_1_CODEX = "gpt-5.1-codex"
+    GPT5_1_CODEX_MINI = "gpt-5.1-codex-mini"
+    GPT5_1_CHAT = "gpt-5.1-chat"
+    GPT5_2 = "gpt-5.2"
+    GPT5_2_PRO = "gpt-5.2-pro"
+    GPT5_2_CHAT = "gpt-5.2-chat"
+    GPT_OSS_120b = "gpt-oss-120b"
+    GPT_OSS_20b = "gpt-oss-20b"
 
 
-FunctionCallTypes = Literal["none", "auto"]
-ToolChoiceTypes = Literal["none", "auto", "required"]
-ToolTypes = Literal["function"]
+class OpenAICompletionModel(str, Enum):
+    """Enum for OpenAI Completion models"""
 
-DEFAULT_CONTEXT_LENGTH = 16_000
-
-
-class StreamEventType(Enum):
-    TEXT = 1
-    FUNC_NAME = 2
-    FUNC_ARGS = 3
-    TOOL_NAME = 4
-    TOOL_ARGS = 5
-    REASONING = 6
+    DAVINCI = "davinci-002"
+    BABBAGE = "babbage-002"
 
 
-class RetryParams(BaseSettings):
-    max_retries: int = 5
-    initial_delay: float = 1.0
-    exponential_base: float = 1.3
-    jitter: bool = True
+class AnthropicModel(ModelName):
+    """Enum for Anthropic models"""
+
+    CLAUDE_3_OPUS = "claude-3-opus-latest"
+    CLAUDE_3_SONNET = "claude-3-sonnet-latest"
+    CLAUDE_3_HAIKU = "claude-3-haiku-latest"
+    CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest"
+    CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest"
+    CLAUDE_4_OPUS = "claude-opus-4"
+    CLAUDE_4_SONNET = "claude-sonnet-4"
+    CLAUDE_4_HAIKU = "claude-haiku-4"
+    CLAUDE_4_5_OPUS = "claude-opus-4-5"
+    CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
+    CLAUDE_4_5_HAIKU = "claude-haiku-4-5"
 
 
-class LLMConfig(BaseSettings):
+class DeepSeekModel(ModelName):
+    """Enum for DeepSeek models direct from DeepSeek API"""
+
+    DEEPSEEK = "deepseek/deepseek-chat"
+    DEEPSEEK_R1 = "deepseek/deepseek-reasoner"
+    OPENROUTER_DEEPSEEK_R1 = "openrouter/deepseek/deepseek-r1"
+
+
+class GeminiModel(ModelName):
+    """Enum for Gemini models"""
+
+    GEMINI_1_5_FLASH = "gemini-1.5-flash"
+    GEMINI_1_5_FLASH_8B = "gemini-1.5-flash-8b"
+    GEMINI_1_5_PRO = "gemini-1.5-pro"
+    GEMINI_2_FLASH = "gemini-2.0-flash"
+    GEMINI_2_FLASH_LITE = "gemini-2.0-flash-lite"
+    GEMINI_2_FLASH_THINKING = "gemini-2.0-flash-thinking-exp"
+    GEMINI_2_PRO = "gemini-2.0-pro-exp-02-05"
+    GEMINI_2_5_FLASH = "gemini-2.5-flash"
+    GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
+    GEMINI_2_5_PRO = "gemini-2.5-pro"
+    GEMINI_3_FLASH = "gemini-3-flash"
+    GEMINI_3_PRO = "gemini-3-pro"
+
+
+class MiniMaxModel(ModelName):
+    """Enum for MiniMax models"""
+
+    MINIMAX_M2_7 = "MiniMax-M2.7"
+    MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
+    MINIMAX_M2_5 = "MiniMax-M2.5"
+    MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
+    MINIMAX_M2_1 = "MiniMax-M2.1"
+    MINIMAX_M2_1_HIGHSPEED = "MiniMax-M2.1-highspeed"
+    MINIMAX_M2 = "MiniMax-M2"
+
+
+class OpenAI_API_ParamInfo(BaseModel):
     """
-    Common configuration for all language models.
-    """
-
-    type: str = "openai"
-    streamer: Optional[Callable[[Any], None]] = noop_fn
-    streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
-    api_base: str | None = None
-    formatter: None | str = None
-    # specify None if you want to use the full max output tokens of the model
-    max_output_tokens: int | None = 8192
-    timeout: int = 20  # timeout for API requests
-    chat_model: str = ""
-    completion_model: str = ""
-    temperature: float = 0.0
-    chat_context_length: int | None = None
-    async_stream_quiet: bool = False  # suppress streaming output in async mode?
-    completion_context_length: int | None = None
-    # if input length + max_output_tokens > context length of model,
-    # we will try shortening requested output
-    min_output_tokens: int = 64
-    use_completion_for_chat: bool = False  # use completion model for chat?
-    # use chat model for completion? For OpenAI models, this MUST be set to True!
-    use_chat_for_completion: bool = True
-    stream: bool = True  # stream output from API?
-    # TODO: we could have a `stream_reasoning` flag here to control whether to show
-    # reasoning output from reasoning models
-    cache_config: None | CacheDBConfig = RedisCacheConfig()
-    thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
-    retry_params: RetryParams = RetryParams()
-
-    @property
-    def model_max_output_tokens(self) -> int:
-        if self.max_output_tokens:
-            return self.max_output_tokens
-        # Build fallback names by progressively stripping provider prefixes
-        # (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
-        # succeeds even before OpenAIGPT.__init__ strips the prefix.
-        parts = self.chat_model.split("/")
-        fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
-        return get_model_info(self.chat_model, fallbacks).max_output_tokens
-
-
-class LLMFunctionCall(BaseModel):
-    """
-    Structure of LLM response indicating it "wants" to call a function.
-    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
-    """
-
-    name: str  # name of function to call
-    arguments: Optional[Dict[str, Any]] = None
-
-    @staticmethod
-    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall":
-        """
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-        fun_call = LLMFunctionCall(name=message["name"])
-        fun_args_str = message["arguments"]
-        # sometimes may be malformed with invalid indents,
-        # so we try to be safe by removing newlines.
-        if fun_args_str is not None:
-            fun_args_str = fun_args_str.replace("\n", "").strip()
-            dict_or_list = parse_imperfect_json(fun_args_str)
-
-            if not isinstance(dict_or_list, dict):
-                raise ValueError(
-                    f"""
-                        Invalid function args: {fun_args_str}
-                        parsed as {dict_or_list},
-                        which is not a valid dict.
-                        """
-                )
-            fun_args = dict_or_list
-        else:
-            fun_args = None
-        fun_call.arguments = fun_args
-
-        return fun_call
-
-    def __str__(self) -> str:
-        return "FUNC: " + json.dumps(self.model_dump(), indent=2)
-
-
-class LLMFunctionSpec(BaseModel):
-    """
-    Description of a function available for the LLM to use.
-    To be used when calling the LLM `chat()` method with the `functions` parameter.
-    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
+    Parameters exclusive to some models, when using OpenAI API
     """
 
-    name: str
-    description: str
-    parameters: Dict[str, Any]
-
-
-class OpenAIToolCall(BaseModel):
-    """
-    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
-    See https://platform.openai.com/docs/api-reference/chat/create
-
-    Attributes:
-        id: The id of the tool call.
-        type: The type of the tool call;
-            only "function" is currently possible (7/26/24).
-        function: The function call.
-    """
-
-    id: str | None = None
-    type: ToolTypes = "function"
-    function: LLMFunctionCall | None = None
-    extra_content: Dict[str, Any] | None = None
-
-    @staticmethod
-    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall":
-        """
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-        id = message["id"]
-        type = message["type"]
-        function = LLMFunctionCall.from_dict(message["function"])
-        extra_content = message.get("extra_content")
-        return OpenAIToolCall(
-            id=id, type=type, function=function, extra_content=extra_content
-        )
-
-    def __str__(self) -> str:
-        if self.function is None:
-            return ""
-        return "OAI-TOOL: " + json.dumps(self.function.model_dump(), indent=2)
-
-
-class OpenAIToolSpec(BaseModel):
-    type: ToolTypes
-    strict: Optional[bool] = None
-    function: LLMFunctionSpec
-
-
-class OpenAIJsonSchemaSpec(BaseModel):
-    strict: Optional[bool] = None
-    function: LLMFunctionSpec
-
-    def to_dict(self) -> Dict[str, Any]:
-        json_schema: Dict[str, Any] = {
-            "name": self.function.name,
-            "description": self.function.description,
-            "schema": self.function.parameters,
-        }
-        if self.strict is not None:
-            json_schema["strict"] = self.strict
-
-        return {
-            "type": "json_schema",
-            "json_schema": json_schema,
-        }
-
-
-class LLMTokenUsage(BaseModel):
-    """
-    Usage of tokens by an LLM.
-    """
-
-    prompt_tokens: int = 0
-    cached_tokens: int = 0
-    completion_tokens: int = 0
-    cost: float = 0.0
-    calls: int = 0  # how many API calls - not used as of 2025-04-04
-
-    def reset(self) -> None:
-        self.prompt_tokens = 0
-        self.cached_tokens = 0
-        self.completion_tokens = 0
-        self.cost = 0.0
-        self.calls = 0
-
-    def __str__(self) -> str:
-        return (
-            f"Tokens = "
-            f"(prompt {self.prompt_tokens}, cached {self.cached_tokens}, "
-            f"completion {self.completion_tokens}), "
-            f"Cost={self.cost}, Calls={self.calls}"
-        )
-
-    @property
-    def total_tokens(self) -> int:
-        return self.prompt_tokens + self.completion_tokens
-
-
-class Role(str, Enum):
-    """
-    Possible roles for a message in a chat.
-    """
-
-    USER = "user"
-    SYSTEM = "system"
-    ASSISTANT = "assistant"
-    FUNCTION = "function"
-    TOOL = "tool"
-
-
-class LLMMessage(BaseModel):
-    """
-    Class representing an entry in the msg-history sent to the LLM API.
-    It could be one of these:
-    - a user message
-    - an LLM ("Assistant") response
-    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
-    - a result or results from executing a fn or tool-call(s)
-    """
-
-    role: Role
-    name: Optional[str] = None
-    tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
-    tool_id: str = ""  # used by OpenAIAssistant
-    # None means "no content" (the model returned only a tool/function call).
-    # This is distinct from "" and is dropped from the API payload by api_dict;
-    # see api_dict for how a fully-empty message is handled per-API.
-    content: Optional[str] = None
-    files: List[FileAttachment] = []
-    function_call: Optional[LLMFunctionCall] = None
-    tool_calls: Optional[List[OpenAIToolCall]] = None
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    # link to corresponding chat document, for provenance/rewind purposes
-    chat_document_id: str = ""
-
-    def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]:
-        """
-        Convert to dictionary for API request, keeping ONLY
-        the fields that are expected in an API call!
-        E.g., DROP the tool_id, since it is only for use in the Assistant API,
-            not the completion API.
-
-        Args:
-            has_system_role: whether the message has a system role (if not,
-                set to "user" role)
-        Returns:
-            dict: dictionary representation of LLM message
-        """
-        d = self.model_dump()
-        files: List[FileAttachment] = d.pop("files")
-        if len(files) > 0 and self.role == Role.USER:
-            # In there are files, then content is an array of
-            # different content-parts
-            d["content"] = [
-                dict(
-                    type="text",
-                    text=self.content or "",
-                )
-            ] + [f.to_dict(model) for f in self.files]
-
-        # if there is a key k = "role" with value "system", change to "user"
-        # in case has_system_role is False
-        if not has_system_role and "role" in d and d["role"] == "system":
-            d["role"] = "user"
-            if d.get("content"):
-                d["content"] = "[ADDITIONAL SYSTEM MESSAGE:]\n\n" + d["content"]
-        # drop None values since API doesn't accept them (this omits `content`
-        # entirely when it is None, i.e. "no content")
-        dict_no_none = {k: v for k, v in d.items() if v is not None}
-        if "name" in dict_no_none and dict_no_none["name"] == "":
-            # OpenAI API does not like empty name
-            del dict_no_none["name"]
-        if "function_call" in dict_no_none:
-            # arguments must be a string
-            if "arguments" in dict_no_none["function_call"]:
-                dict_no_none["function_call"]["arguments"] = json.dumps(
-                    dict_no_none["function_call"]["arguments"]
-                )
-        if dict_no_none.get("tool_calls"):
-            # convert tool calls to API format
-            for tc in dict_no_none["tool_calls"]:
-                if "arguments" in tc["function"]:
-                    # arguments must be a string
-                    if tc["function"]["arguments"] is None:
-                        tc["function"]["arguments"] = "{}"
-                    else:
-                        tc["function"]["arguments"] = json.dumps(
-                            tc["function"]["arguments"]
-                        )
-                if "extra_content" in tc and tc["extra_content"] is None:
-                    del tc["extra_content"]
-        else:
-            # An empty tool-call list is not a call and conveys no useful API
-            # information. Omitting it also lets the empty-message fallback
-            # below produce a valid message.
-            dict_no_none.pop("tool_calls", None)
-        # A message with empty content (None was dropped above, or "") AND no
-        # tool/function call would be an entirely empty message, which some APIs
-        # (e.g. Gemini) reject; fall back to a single space in that case only.
-        # When there IS a tool/function call, empty content is fine (and Gemini
-        # 3.x in fact REQUIRES it — it rejects an assistant turn that carries
-        # both a call and non-empty text content).
-        has_call = bool(dict_no_none.get("tool_calls")) or (
-            dict_no_none.get("function_call") is not None
-        )
-        if not has_call and not dict_no_none.get("content"):
-            dict_no_none["content"] = " "
-        # IMPORTANT! drop fields that are not expected in API call
-        dict_no_none.pop("tool_id", None)
-        dict_no_none.pop("timestamp", None)
-        dict_no_none.pop("chat_document_id", None)
-        return dict_no_none
-
-    def __str__(self) -> str:
-        if self.function_call is not None:
-            content = "FUNC: " + json.dumps(self.function_call)
-        else:
-            content = self.content or ""
-        name_str = f" ({self.name})" if self.name else ""
-        return f"{self.role} {name_str}: {content}"
-
-
-class LLMResponse(BaseModel):
-    """
-    Class representing response from LLM.
-    """
-
-    # None means the model returned NO content (e.g. only a tool/function
-    # call), which is distinct from an empty string "". Preserving this
-    # distinction lets the message be faithfully reproduced downstream
-    # (see ChatDocument.content_is_none and LLMMessage.content).
-    message: Optional[str] = None
-    reasoning: str = ""  # optional reasoning text from reasoning models
-    # Original message text including inline thought signatures (e.g.
-    # <thinking>...</thinking>). Only set when reasoning was extracted
-    # from the message text via get_reasoning_final(); NOT set when
-    # reasoning comes from a separate API field (e.g. reasoning_content),
-    # since in that case the message text never contained thought tags.
-    message_with_reasoning: Optional[str] = None
-    # TODO tool_id needs to generalize to multi-tool calls
-    tool_id: str = ""  # used by OpenAIAssistant
-    oai_tool_calls: Optional[List[OpenAIToolCall]] = None
-    function_call: Optional[LLMFunctionCall] = None
-    usage: Optional[LLMTokenUsage] = None
-    cached: bool = False
-
-    def __str__(self) -> str:
-        if self.function_call is not None:
-            return str(self.function_call)
-        elif self.oai_tool_calls:
-            return "\n".join(str(tc) for tc in self.oai_tool_calls)
-        else:
-            return self.message or ""
-
-    def tools_content(self) -> str:
-        if self.function_call is not None:
-            return str(self.function_call)
-        elif self.oai_tool_calls:
-            return "\n".join(str(tc) for tc in self.oai_tool_calls)
-        else:
-            return ""
-
-    def to_LLMMessage(self) -> LLMMessage:
-        """Convert LLM response to an LLMMessage, to be included in the
-        message-list sent to the API.
-        This is currently NOT used in any significant way in the library, and is only
-        provided as a utility to construct a message list for the API when directly
-        working with an LLM object.
-
-        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
-        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
-        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
-        """
-        return LLMMessage(
-            role=Role.ASSISTANT,
-            content=self.message,
-            name=None if self.function_call is None else self.function_call.name,
-            function_call=self.function_call,
-            tool_calls=self.oai_tool_calls,
-        )
-
-    def get_recipient_and_message(
-        self,
-        recognize_recipient_in_content: bool = True,
-    ) -> Tuple[str, str]:
-        """
-        If `message` or `function_call` of an LLM response contains an explicit
-        recipient name, return this recipient name and `message` stripped
-        of the recipient name if specified.
-
-        Two cases:
-        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
-        (b) `message` is empty and function_call/tool_call with explicit `recipient`
-
-        Args:
-            recognize_recipient_in_content (bool): When True (default), parses
-                message text for ``TO[<recipient>]:<content>`` patterns and
-                top-level JSON ``{"recipient": "..."}`` fields. When False,
-                only function_call/tool_call ``recipient`` fields are checked.
-
-        Returns:
-            (str): name of recipient, which may be empty string if no recipient
-            (str): content of message
-
-        """
-
-        if self.function_call is not None:
-            # in this case we ignore message, since all information is in function_call
-            msg = ""
-            args = self.function_call.arguments
-            recipient = ""
-            if isinstance(args, dict):
-                recipient = args.get("recipient", "")
-            return recipient, msg
-        else:
-            msg = self.message or ""
-            if self.oai_tool_calls is not None:
-                # get the first tool that has a recipient field, if any
-                for tc in self.oai_tool_calls:
-                    if tc.function is not None and tc.function.arguments is not None:
-                        recipient = tc.function.arguments.get(
-                            "recipient"
-                        )  # type: ignore
-                        if recipient is not None and recipient != "":
-                            return recipient, ""
-
-        if not recognize_recipient_in_content:
-            return "", msg
-
-        # It's not a function or tool call, so continue looking to see
-        # if a recipient is specified in the message.
-
-        # First check if message contains "TO: <recipient> <content>"
-        recipient_name, content = parse_message(msg) if msg is not None else ("", "")
-        # check if there is a top level json that specifies 'recipient',
-        # and retain the entire message as content.
-        if recipient_name == "":
-            recipient_name = top_level_json_field(msg, "recipient") if msg else ""
-            content = msg
-        return recipient_name, content
-
-
-# Define an abstract base class for language models
-class LanguageModel(ABC):
-    """
-    Abstract base class for language models.
-    """
-
-    # usage cost by model, accumulates here
-    usage_cost_dict: Dict[str, LLMTokenUsage] = {}
-
-    def __init__(self, config: LLMConfig = LLMConfig()):
-        self.config = config
-        self.chat_model_orig = config.chat_model
-
-    @staticmethod
-    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]:
-        """
-        Create a language model.
-        Args:
-            config: configuration for language model
-        Returns: instance of language model
-        """
-        if type(config) is LLMConfig:
-            raise ValueError(
-                """
-                Cannot create a Language Model object from LLMConfig.
-                Please specify a specific subclass of LLMConfig e.g.,
-                OpenAIGPTConfig. If you are creating a ChatAgent from
-                a ChatAgentConfig, please specify the `llm` field of this config
-                as a specific subclass of LLMConfig, e.g., OpenAIGPTConfig.
-                """
-            )
-        from langroid.language_models.azure_openai import AzureGPT
-        from langroid.language_models.mock_lm import MockLM, MockLMConfig
-        from langroid.language_models.openai_gpt import OpenAIGPT
-
-        if config is None or config.type is None:
-            return None
-
-        if config.type == "mock":
-            return MockLM(cast(MockLMConfig, config))
-
-        openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
-
-        if config.type == "azure":
-            openai = AzureGPT
-        else:
-            openai = OpenAIGPT
-        cls = dict(
-            openai=openai,
-        ).get(config.type, openai)
-        return cls(config)  # type: ignore
-
-    @staticmethod
-    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]:
-        """
-        Given an even-length sequence of strings, split into a sequence of pairs
-
-        Args:
-            lst (List[str]): sequence of strings
-
-        Returns:
-            List[Tuple[str,str]]: sequence of pairs of strings
-        """
-        evens = lst[::2]
-        odds = lst[1::2]
-        return list(zip(evens, odds))
-
-    @staticmethod
-    def get_chat_history_components(
-        messages: List[LLMMessage],
-    ) -> Tuple[str, List[Tuple[str, str]], str]:
-        """
-        From the chat history, extract system prompt, user-assistant turns, and
-        final user msg.
-
-        Args:
-            messages (List[LLMMessage]): List of messages in the chat history
-
-        Returns:
-            Tuple[str, List[Tuple[str,str]], str]:
-                system prompt, user-assistant turns, final user msg
-
-        """
-        # Handle various degenerate cases
-        messages = [m for m in messages]  # copy
-        DUMMY_SYS_PROMPT = "You are a helpful assistant."
-        DUMMY_USER_PROMPT = "Follow the instructions above."
-        if len(messages) == 0 or messages[0].role != Role.SYSTEM:
-            logger.warning("No system msg, creating dummy system prompt")
-            messages.insert(0, LLMMessage(content=DUMMY_SYS_PROMPT, role=Role.SYSTEM))
-        system_prompt = messages[0].content or ""
-
-        # now we have messages = [Sys,...]
-        if len(messages) == 1:
-            logger.warning(
-                "Got only system message in chat history, creating dummy user prompt"
-            )
-            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, msg, ...]
-
-        if messages[1].role != Role.USER:
-            messages.insert(1, LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, user, ...]
-        if messages[-1].role != Role.USER:
-            logger.warning(
-                "Last message in chat history is not a user message,"
-                " creating dummy user prompt"
-            )
-            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, user, ..., user]
-        # so we omit the first and last elements and make pairs of user-asst messages
-        conversation = [m.content or "" for m in messages[1:-1]]
-        user_prompt = messages[-1].content or ""
-        pairs = LanguageModel.user_assistant_pairs(conversation)
-        return system_prompt, pairs, user_prompt
-
-    @abstractmethod
-    def set_stream(self, stream: bool) -> bool:
-        """Enable or disable streaming output from API.
-        Return previous value of stream."""
-        pass
-
-    @abstractmethod
-    def get_stream(self) -> bool:
-        """Get streaming status"""
-        pass
-
-    @abstractmethod
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        pass
-
-    @abstractmethod
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        pass
-
-    @abstractmethod
-    def chat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """
-        Get chat-completion response from LLM.
-
-        Args:
-            messages: message-history to send to the LLM
-            max_tokens: max tokens to generate
-            tools: tools available for the LLM to use in its response
-            tool_choice: tool call mode, one of "none", "auto", "required",
-                or a dict specifying a specific tool.
-            functions: functions available for LLM to call (deprecated)
-            function_call: function calling mode, "auto", "none", or a specific fn
-                    (deprecated)
-        """
-
-        pass
-
-    @abstractmethod
-    async def achat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """Async version of `chat`. See `chat` for details."""
-        pass
-
-    def __call__(self, prompt: str, max_tokens: int) -> LLMResponse:
-        return self.generate(prompt, max_tokens)
-
-    @staticmethod
-    def _fallback_model_names(model: str) -> List[str]:
-        parts = model.split("/")
-        fallbacks = []
-        for i in range(1, len(parts)):
-            fallbacks.append("/".join(parts[i:]))
-        return fallbacks
-
-    def info(self) -> ModelInfo:
-        """Info of relevant chat model"""
-        orig_model = (
-            self.config.completion_model
-            if self.config.use_completion_for_chat
-            else self.chat_model_orig
-        )
-        return get_model_info(orig_model, self._fallback_model_names(orig_model))
-
-    def completion_info(self) -> ModelInfo:
-        """Info of relevant completion model"""
-        orig_model = (
-            self.chat_model_orig
-            if self.config.use_chat_for_completion
-            else self.config.completion_model
-        )
-        return get_model_info(orig_model, self._fallback_model_names(orig_model))
-
-    def supports_functions_or_tools(self) -> bool:
-        """
-        Does this Model's API support "native" tool-calling, i.e.
-        can we call the API with arguments that contain a list of available tools,
-        and their schemas?
-        Note that, given the plethora of LLM provider APIs this determination is
-        imperfect at best, and leans towards returning True.
-        When the API calls fails with an error indicating tools are not supported,
-        then users are encouraged to use the Langroid-based prompt-based
-        ToolMessage mechanism, which works with ANY LLM. To enable this,
-        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
-        """
-        return self.info().has_tools
-
-    def chat_context_length(self) -> int:
-        return self.config.chat_context_length or DEFAULT_CONTEXT_LENGTH
-
-    def completion_context_length(self) -> int:
-        return self.config.completion_context_length or DEFAULT_CONTEXT_LENGTH
-
-    def chat_cost(self) -> Tuple[float, float, float]:
-        """
-        Return the cost per 1000 tokens for chat completions.
-
-        Returns:
-            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
-                per 1000 tokens
-        """
-        return (0.0, 0.0, 0.0)
-
-    def reset_usage_cost(self) -> None:
-        for mdl in [self.config.chat_model, self.config.completion_model]:
-            if mdl is None:
-                return
-            if mdl not in self.usage_cost_dict:
-                self.usage_cost_dict[mdl] = LLMTokenUsage()
-            counter = self.usage_cost_dict[mdl]
-            counter.reset()
-
-    def update_usage_cost(
-        self, chat: bool, prompts: int, completions: int, cost: float
-    ) -> None:
-        """
-        Update usage cost for this LLM.
-        Args:
-            chat (bool): whether to update for chat or completion model
-            prompts (int): number of tokens used for prompts
-            completions (int): number of tokens used for completions
-            cost (float): total token cost in USD
-        """
-        mdl = self.config.chat_model if chat else self.config.completion_model
-        if mdl is None:
-            return
-        if mdl not in self.usage_cost_dict:
-            self.usage_cost_dict[mdl] = LLMTokenUsage()
-        counter = self.usage_cost_dict[mdl]
-        counter.prompt_tokens += prompts
-        counter.completion_tokens += completions
-        counter.cost += cost
-        counter.calls += 1
-
-    @classmethod
-    def usage_cost_summary(cls) -> str:
-        s = ""
-        for model, counter in cls.usage_cost_dict.items():
-            s += f"{model}: {counter}\n"
-        return s
-
-    @classmethod
-    def tot_tokens_cost(cls) -> Tuple[int, float]:
-        """
-        Return total tokens used and total cost across all models.
-        """
-        total_tokens = 0
-        total_cost = 0.0
-        for counter in cls.usage_cost_dict.values():
-            total_tokens += counter.total_tokens
-            total_cost += counter.cost
-        return total_tokens, total_cost
-
-    def get_reasoning_final(self, message: str) -> Tuple[str, str]:
-        """Extract "reasoning" and "final answer" from an LLM response, if the
-        reasoning is found within configured delimiters, like <think>, </think>.
-        E.g.,
-        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
-
-        Args:
-            message (str): message from LLM
-
-        Returns:
-            Tuple[str, str]: reasoning, final answer
-        """
-        start, end = self.config.thought_delimiters
-        if start in message and end in message:
-            parts = message.split(start)
-            if len(parts) > 1:
-                reasoning, final = parts[1].split(end)
-                return reasoning, final
-        return "", message
-
-    def followup_to_standalone(
-        self, chat_history: List[Tuple[str, str]], question: str
-    ) -> str:
-        """
-        Given a chat history and a question, convert it to a standalone question.
-        Args:
-            chat_history: list of tuples of (question, answer)
-            query: follow-up question
-
-        Returns: standalone version of the question
-        """
-        history = collate_chat_history(chat_history)
-
-        prompt = f"""
-        You are an expert at understanding a CHAT HISTORY between an AI Assistant
-        and a User, and you are highly skilled in rephrasing the User's FOLLOW-UP
-        QUESTION/REQUEST as a STANDALONE QUESTION/REQUEST that can be understood
-        WITHOUT the context of the chat history.
-
-        Below is the CHAT HISTORY. When the User asks you to rephrase a
-        FOLLOW-UP QUESTION/REQUEST, your ONLY task is to simply return the
-        question REPHRASED as a STANDALONE QUESTION/REQUEST, without any additional
-        text or context.
-
-        <CHAT_HISTORY>
-        {history}
-        </CHAT_HISTORY>
-        """.strip()
-
-        follow_up_question = f"""
-        Please rephrase this as a stand-alone question or request:
-        <FOLLOW-UP-QUESTION-OR-REQUEST>
-        {question}
-        </FOLLOW-UP-QUESTION-OR-REQUEST>
-        """.strip()
-
-        show_if_debug(prompt, "FOLLOWUP->STANDALONE-PROMPT= ")
-        standalone = (
-            self.chat(
-                messages=[
-                    LLMMessage(role=Role.SYSTEM, content=prompt),
-                    LLMMessage(role=Role.USER, content=follow_up_question),
-                ],
-                max_tokens=1024,
-            ).message
-            or ""
-        )
-        standalone = standalone.strip()
-
-        show_if_debug(prompt, "FOLLOWUP->STANDALONE-RESPONSE= ")
-        return standalone
-
-
-class StreamingIfAllowed:
-    """Context to temporarily enable or disable streaming, if allowed globally via
-    `settings.stream`"""
-
-    def __init__(self, llm: LanguageModel, stream: bool = True):
-        self.llm = llm
-        self.stream = stream
-
-    def __enter__(self) -> None:
-        self.old_stream = self.llm.set_stream(settings.stream and self.stream)
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self.llm.set_stream(self.old_stream)
-</file>
-
-<file path="langroid/agent/special/sql/sql_chat_agent.py">
-"""
-Agent that allows interaction with an SQL database using SQLAlchemy library.
-The agent can execute SQL queries in the database and return the result.
-
-Functionality includes:
-- adding table and column context
-- asking a question about a SQL schema
-"""
-
-import logging
-import re
-from typing import (
-    Any,
-    Dict,
-    FrozenSet,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-)
-
-from rich.console import Console
-
-from langroid.exceptions import LangroidImportError
-from langroid.mytypes import Entity
-from langroid.utils.constants import SEND_TO
-
-try:
-    from sqlalchemy import MetaData, Row, create_engine, inspect, text
-    from sqlalchemy.engine import Engine
-    from sqlalchemy.exc import ResourceClosedError, SQLAlchemyError
-    from sqlalchemy.orm import Session, sessionmaker
-except ImportError as e:
-    raise LangroidImportError(extra="sql", error=str(e))
-
-try:
-    # sqlglot is required for the statement-type allowlist enforced in
-    # `_validate_query`. Importing it at module load ensures the security
-    # guarantee cannot be silently bypassed by a partial/stale install.
-    import sqlglot
-    from sqlglot import expressions as sqlglot_exp
-except ImportError as e:
-    raise LangroidImportError(extra="sql", error=str(e))
-
-from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
-from langroid.agent.chat_document import ChatDocument
-from langroid.agent.special.sql.utils.description_extractors import (
-    extract_schema_descriptions,
-)
-from langroid.agent.special.sql.utils.populate_metadata import (
-    populate_metadata,
-    populate_metadata_with_schema_tools,
-)
-from langroid.agent.special.sql.utils.system_message import (
-    DEFAULT_SYS_MSG,
-    SCHEMA_TOOLS_SYS_MSG,
-)
-from langroid.agent.special.sql.utils.tools import (
-    GetColumnDescriptionsTool,
-    GetTableNamesTool,
-    GetTableSchemaTool,
-    RunQueryTool,
-)
-from langroid.agent.tools.orchestration import (
-    DonePassTool,
-    DoneTool,
-    ForwardTool,
-    PassTool,
-)
-from langroid.language_models.base import Role
-from langroid.vector_store.base import VectorStoreConfig
-
-logger = logging.getLogger(__name__)
-
-console = Console()
-
-DEFAULT_SQL_CHAT_SYSTEM_MESSAGE = """
-{mode}
-
-You do not need to attempt answering a question with just one query. 
-You could make a sequence of SQL queries to help you write the final query.
-Also if you receive a null or other unexpected result,
-(a) make sure you use the available TOOLs correctly, and 
-(b) see if you have made an assumption in your SQL query, and try another way, 
-   or use `run_query` to explore the database table contents before submitting your 
-   final query. For example when searching for "males" you may have used "gender= 'M'",
-in your query, because you did not know that the possible genders in the table
-are "Male" and "Female". 
-
-Start by asking what I would like to know about the data.
-
-"""
-
-ADDRESSING_INSTRUCTION = """
-IMPORTANT - Whenever you are NOT writing a SQL query, make sure you address the user
-using {prefix}User (NO SPACE between {prefix} and User). 
-You MUST use the EXACT syntax {prefix}User !!!
-
-In other words, you ALWAYS write EITHER:
- - a SQL query using the `run_query` tool, 
- - OR address the user using {prefix}User
-"""
-
-DONE_INSTRUCTION = f"""
-When you are SURE you have the CORRECT answer to a user's query or request, 
-use the `{DoneTool.name()}` with `content` set to the answer or result.
-If you DO NOT think you have the answer to the user's query or request,
-you SHOULD NOT use the `{DoneTool.name()}` tool.
-Instead, you must CONTINUE to improve your queries (tools) to get the correct answer,
-and finally use the `{DoneTool.name()}` tool to send the correct answer to the user.
-"""
-
-
-SQL_ERROR_MSG = "There was an error in your SQL Query"
-
-
-# Dialect-specific SQL patterns that enable code execution, arbitrary file
-# access, or other escapes from the database engine. Matched against the raw
-# query text (case-insensitive) as a defense-in-depth layer in addition to the
-# sqlglot-based statement-type allowlist.
-_DANGEROUS_SQL_PATTERNS: List["re.Pattern[str]"] = [
-    # PostgreSQL: COPY ... FROM/TO PROGRAM executes shell commands as the DB
-    # server OS user.
-    re.compile(r"\bcopy\b[\s\S]*\bprogram\b", re.IGNORECASE),
-    # PostgreSQL server-side filesystem / log / WAL access. Match the whole
-    # pg_read*, pg_stat*, pg_ls*, pg_current_logfile family rather than naming
-    # individual functions: near-name functions (pg_read_file vs
-    # pg_read_server_file, pg_ls_logdir vs pg_ls_dir, pg_stat_file, ...) all
-    # yield the same file/metadata disclosure primitive.
-    re.compile(r"\bpg_(read|stat|ls|current_logfile)[A-Za-z0-9_]*\s*\(", re.IGNORECASE),
-    re.compile(r"\blo_(import|export)\b", re.IGNORECASE),
-    # MySQL/MariaDB filesystem
-    re.compile(r"\binto\s+(outfile|dumpfile)\b", re.IGNORECASE),
-    re.compile(r"\bload_file\s*\(", re.IGNORECASE),
-    re.compile(r"\bload\s+data\b", re.IGNORECASE),
-    # SQLite: load_extension enables loading arbitrary shared objects;
-    # ATTACH can read/write arbitrary files. The DATABASE keyword is optional
-    # per the SQLite grammar (ATTACH [DATABASE] expr AS schema-name), so match
-    # both forms.
-    re.compile(r"\bload_extension\s*\(", re.IGNORECASE),
-    re.compile(r"\battach\b(\s+database)?\s+['\"\w]", re.IGNORECASE),
-    # SQL Server: command execution, OLE automation, and ad-hoc external data
-    # sources (OPENDATASOURCE is the connection-string counterpart of
-    # OPENROWSET; both can read remote/UNC files).
-    re.compile(r"\bxp_cmdshell\b", re.IGNORECASE),
-    re.compile(r"\bsp_oacreate\b", re.IGNORECASE),
-    re.compile(r"\bsp_oamethod\b", re.IGNORECASE),
-    re.compile(r"\b(openrowset|opendatasource)\b", re.IGNORECASE),
-    re.compile(r"\bbulk\s+insert\b", re.IGNORECASE),
-    # Generic: stored-program creation and procedural language extensions.
-    # LANGUAGE / RULE / EVENT TRIGGER / FOREIGN TABLE are additional PostgreSQL
-    # primitives that can register attacker-controlled code.
-    re.compile(
-        r"\bcreate\s+(or\s+replace\s+)?(function|procedure|trigger|language|rule|event\s+trigger|foreign\s+table)\b",
-        re.IGNORECASE,
-    ),
-    re.compile(r"\bcreate\s+extension\b", re.IGNORECASE),
-]
-
-
-# AST-side blocklist of dangerous SQL function names, applied after sqlglot
-# parses the query. The raw-text regex above can be bypassed by quoted
-# identifiers, inline comments, or schema qualification -- e.g.
-# `"pg_read_file"(...)`, `pg_read_file/**/(...)`,
-# `pg_catalog."pg_read_file"(...)` -- but sqlglot normalizes all those forms
-# to the same function-call node, so a name-based check on the parsed tree
-# catches every variant (GHSA-6xc5-4r68-67fc).
-_DANGEROUS_FUNCTION_NAMES: FrozenSet[str] = frozenset(
-    {
-        "load_file",  # MySQL/MariaDB filesystem read
-        "load_extension",  # SQLite extension loader
-        "sp_oacreate",  # MSSQL OLE automation
-        "sp_oamethod",  # MSSQL OLE automation
-    }
-)
-# Prefix families: any function whose normalized name starts with one of these
-# is considered dangerous. Mirrors the `\bpg_(read|stat|ls|current_logfile)...`
-# and `\blo_(import|export)\b` regex coverage, but on the parsed AST.
-_DANGEROUS_FUNCTION_PREFIXES: Tuple[str, ...] = (
-    "pg_read",
-    "pg_stat",
-    "pg_ls",
-    "pg_current_logfile",
-    "lo_",
-)
-
-
-def _is_dangerous_function_name(name: str) -> bool:
-    """True if `name` (case-folded, unquoted) is a dangerous SQL function."""
-    if name in _DANGEROUS_FUNCTION_NAMES:
-        return True
-    return any(name.startswith(p) for p in _DANGEROUS_FUNCTION_PREFIXES)
-
-
-def _called_function_names(stmt: Any) -> Iterator[str]:
-    """Yield normalized (case-folded, unquoted, schema-stripped) names of
-    every function-call node in `stmt` (a parsed sqlglot expression)."""
-    for node in stmt.find_all(sqlglot_exp.Func):
-        if isinstance(node, sqlglot_exp.Anonymous):
-            this = node.this
-            if isinstance(this, sqlglot_exp.Expression):
-                name = this.name
-            else:
-                name = str(this) if this is not None else ""
-        else:
-            # Typed sqlglot Func subclass: its class key is the SQL keyword.
-            name = getattr(type(node), "key", "") or ""
-        # Strip any schema qualifier that leaked into the name string.
-        name = name.rsplit(".", 1)[-1].strip().lower()
-        if name:
-            yield name
-
-
-def _creates_table(into: Any) -> bool:
-    """Whether a Select's ``into`` arg names a table rather than a variable.
-
-    ``SELECT ... INTO tbl`` creates and populates a table, but MySQL's
-    ``SELECT ... INTO @var`` merely assigns a user variable and writes nothing.
-    sqlglot models the latter as a ``Table`` wrapping a ``Parameter``, so the
-    target's inner node distinguishes them.
-
-    Args:
-        into: The ``into`` arg of a sqlglot ``Select``, or None.
-
-    Returns:
-        True if the target names a table.
-    """
-    if into is None:
-        return False
-    target = into.this
-    if target is None:
-        return False
-    return not isinstance(getattr(target, "this", None), sqlglot_exp.Parameter)
-
-
-def _nested_write_kinds(stmt: Any, kind_map: Dict[Any, str]) -> Set[str]:
-    """Statement kinds that `stmt` performs *below* its top-level node.
-
-    A statement's top-level node does not determine what it writes. Both
-
-    - ``WITH x AS (DELETE FROM t RETURNING *) SELECT * FROM x`` (a
-      data-modifying CTE), and
-    - ``SELECT * INTO new_tbl FROM t`` (which creates and populates a table)
-
-    parse with a ``Select`` top node, so classifying on that node alone reports
-    "SELECT" while the engine still performs the write
-    (GHSA-3gpx-vwr3-xvwx / GHSA-wc83-4cvx-p8xc).
-
-    Args:
-        stmt: A parsed sqlglot statement.
-        kind_map: Mapping of sqlglot expression type to statement-kind name.
-
-    Only independently executable nested statements count. A ``MERGE``'s
-    ``WHEN ... THEN UPDATE/INSERT/DELETE`` actions parse as child write nodes
-    but are part of the merge itself, so an operator who allows ``MERGE`` must
-    not also be forced to allow standalone ``UPDATE``/``INSERT``/``DELETE``.
-
-    Returns:
-        The set of kind names written by nested nodes, plus ``"CREATE"`` for
-        the ``SELECT ... INTO`` form. Empty for an ordinary read-only query.
-    """
-    write_types = (
-        sqlglot_exp.Insert,
-        sqlglot_exp.Update,
-        sqlglot_exp.Delete,
-        sqlglot_exp.Merge,
-        sqlglot_exp.Create,
-        sqlglot_exp.Drop,
-        sqlglot_exp.Alter,
-        sqlglot_exp.TruncateTable,
+    # model-specific params at top level
+    params: Dict[str, List[str]] = dict(
+        reasoning_effort=[
+            OpenAIChatModel.O3_MINI.value,
+            OpenAIChatModel.O3.value,
+            OpenAIChatModel.O4_MINI.value,
+            OpenAIChatModel.GPT5.value,
+            OpenAIChatModel.GPT5_MINI.value,
+            OpenAIChatModel.GPT5_NANO.value,
+            OpenAIChatModel.GPT5_PRO.value,
+            OpenAIChatModel.GPT5_1.value,
+            OpenAIChatModel.GPT5_1_CODEX.value,
+            OpenAIChatModel.GPT5_1_CODEX_MINI.value,
+            OpenAIChatModel.GPT5_2.value,
+            OpenAIChatModel.GPT5_2_PRO.value,
+            OpenAIChatModel.GPT_OSS_120b.value,
+            OpenAIChatModel.GPT_OSS_20b.value,
+            GeminiModel.GEMINI_2_5_PRO.value,
+            GeminiModel.GEMINI_2_5_FLASH.value,
+            GeminiModel.GEMINI_2_5_FLASH_LITE.value,
+        ],
+    )
+    # model-specific params in extra_body
+    extra_parameters: Dict[str, List[str]] = dict(
+        include_reasoning=[
+            DeepSeekModel.OPENROUTER_DEEPSEEK_R1.value,
+        ]
     )
 
-    # Exempt only the node that *is* a ``WHEN ... THEN`` action, by identity.
-    # Exempting everything beneath a ``When`` would also hide a write nested in
-    # the WHEN *condition* -- e.g.
-    # ``WHEN MATCHED AND EXISTS (WITH x AS (DELETE ...) SELECT * FROM x) THEN
-    # UPDATE ...`` -- or one buried inside the action's own subqueries.
-    merge_actions = {
-        id(when.args["then"])
-        for when in stmt.find_all(sqlglot_exp.When)
-        if when.args.get("then") is not None
-    }
 
-    kinds = {
-        kind_map[type(node)]
-        for node in stmt.find_all(*write_types)
-        if node is not stmt and type(node) in kind_map and id(node) not in merge_actions
-    }
-    # `SELECT ... INTO tbl` carries no nested Create node; it is flagged by the
-    # `into` arg on a Select. Check every Select, not just the top-level one:
-    # under a set operation (`SELECT ... INTO t UNION ALL SELECT ...`) the top
-    # node is a Union and the `into` sits on a branch.
-    selects = list(stmt.find_all(sqlglot_exp.Select))
-    if isinstance(stmt, sqlglot_exp.Select):
-        selects.append(stmt)
-    if any(_creates_table(sel.args.get("into")) for sel in selects):
-        kinds.add("CREATE")
-    return kinds
-
-
-# Default set of SQL statement types the agent is allowed to execute when
-# `allow_dangerous_operations` is False. SELECT-only is safe for Q&A workloads.
-_DEFAULT_ALLOWED_STATEMENTS: List[str] = ["SELECT"]
-
-
-class SQLChatAgentConfig(ChatAgentConfig):
-    system_message: str = DEFAULT_SQL_CHAT_SYSTEM_MESSAGE
-    user_message: None | str = None
-    cache: bool = True  # cache results
-    debug: bool = False
-    use_helper: bool = True
-    is_helper: bool = False
-    stream: bool = True  # allow streaming where needed
-    database_uri: str = ""  # Database URI
-    database_session: None | Session = None  # Database session
-    vecdb: None | VectorStoreConfig = None
-    context_descriptions: Dict[str, Dict[str, Union[str, Dict[str, str]]]] = {}
-    use_schema_tools: bool = False
-    multi_schema: bool = False
-    # whether the agent is used in a continuous chat with user,
-    # as opposed to returning a result from the task.run()
-    chat_mode: bool = False
-    addressing_prefix: str = ""
-    max_result_rows: int | None = None  # limit query results to this
-    max_retained_tokens: int | None = None  # limit history of query results to this
-
-    # --- Security controls (see CVE-2026-25879) ---------------------------
-    # By default, the agent only executes SELECT statements and rejects any
-    # query that matches a known dangerous pattern (e.g. PostgreSQL
-    # `COPY ... FROM PROGRAM`, MySQL `INTO OUTFILE`, SQLite `load_extension`,
-    # MSSQL `xp_cmdshell`). The LLM-generated SQL is influenceable by prompt
-    # injection — including injection via data the LLM reads back from the
-    # database — so executing it without restrictions is unsafe when the DB
-    # role has elevated privileges.
-    #
-    # To enable writes: extend allowed_statement_types, e.g. ["SELECT",
-    # "INSERT", "UPDATE", "DELETE"]. To disable all checks (only do this with
-    # a least-privilege DB role and trusted prompts): set
-    # allow_dangerous_operations=True.
-    allowed_statement_types: List[str] = list(_DEFAULT_ALLOWED_STATEMENTS)
-    allow_dangerous_operations: bool = False
-
+class ModelInfo(BaseModel):
     """
-    Optional, but strongly recommended, context descriptions for tables, columns, 
-    and relationships. It should be a dictionary where each key is a table name 
-    and its value is another dictionary. 
-
-    In this inner dictionary:
-    - The 'description' key corresponds to a string description of the table.
-    - The 'columns' key corresponds to another dictionary where each key is a 
-    column name and its value is a string description of that column.
-    - The 'relationships' key corresponds to another dictionary where each key 
-    is another table name and the value is a description of the relationship to 
-    that table.
-
-    If multi_schema support is enabled, the tables names in the description
-    should be of the form 'schema_name.table_name'.
-
-    For example:
-    {
-        'table1': {
-            'description': 'description of table1',
-            'columns': {
-                'column1': 'description of column1 in table1',
-                'column2': 'description of column2 in table1'
-            }
-        },
-        'table2': {
-            'description': 'description of table2',
-            'columns': {
-                'column3': 'description of column3 in table2',
-                'column4': 'description of column4 in table2'
-            }
-        }
-    }
+    Consolidated information about LLM, related to capacity, cost and API
+    idiosyncrasies. Reasonable defaults for all params in case there's no
+    specific info available.
     """
 
+    name: str = "unknown"
+    provider: ModelProvider = ModelProvider.UNKNOWN
+    context_length: int = 16_000
+    max_cot_tokens: int = 0  # max chain of thought (thinking) tokens where applicable
+    max_output_tokens: int = 8192  # Maximum number of output tokens - model dependent
+    input_cost_per_million: float = 0.0  # Cost in USD per million input tokens
+    cached_cost_per_million: float = 0.0  # Cost in USD per million cached tokens
+    output_cost_per_million: float = 0.0  # Cost in USD per million output tokens
+    allows_streaming: bool = True  # Whether model supports streaming output
+    allows_system_message: bool = True  # Whether model supports system messages
+    rename_params: Dict[str, str] = {}  # Rename parameters for OpenAI API
+    unsupported_params: List[str] = []
+    has_structured_output: bool = False  # Does model API support structured output?
+    has_tools: bool = True  # Does model API support tools/function-calling?
+    needs_first_user_message: bool = False  # Does API need first msg to be from user?
+    description: Optional[str] = None
 
-class SQLChatAgent(ChatAgent):
-    """
-    Agent for chatting with a SQL database
-    """
 
-    used_run_query: bool = False
-    llm_responded: bool = False
+GEMINI_CANONICAL_MODEL_NAMES = {model.value for model in GeminiModel}
+DEFAULT_MODEL_INFO = ModelInfo()
+WARNED_UNKNOWN_MODELS: set[tuple[str, ...]] = set()
 
-    def __init__(self, config: "SQLChatAgentConfig") -> None:
-        """Initialize the SQLChatAgent.
 
-        Raises:
-            ValueError: If database information is not provided in the config.
-        """
-        self._validate_config(config)
-        self.config: SQLChatAgentConfig = config
-        self._init_database()
-        self._init_metadata()
-        self._init_table_metadata()
-        self.final_instructions = ""
+# Model information registry
+MODEL_INFO: Dict[str, ModelInfo] = {
+    # OpenAI Models
+    OpenAICompletionModel.DAVINCI.value: ModelInfo(
+        name=OpenAICompletionModel.DAVINCI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=4096,
+        max_output_tokens=4096,
+        input_cost_per_million=2.0,
+        output_cost_per_million=2.0,
+        description="Davinci-002",
+    ),
+    OpenAICompletionModel.BABBAGE.value: ModelInfo(
+        name=OpenAICompletionModel.BABBAGE.value,
+        provider=ModelProvider.OPENAI,
+        context_length=4096,
+        max_output_tokens=4096,
+        input_cost_per_million=0.40,
+        output_cost_per_million=0.40,
+        description="Babbage-002",
+    ),
+    OpenAIChatModel.GPT3_5_TURBO.value: ModelInfo(
+        name=OpenAIChatModel.GPT3_5_TURBO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=16_385,
+        max_output_tokens=4096,
+        input_cost_per_million=0.50,
+        output_cost_per_million=1.50,
+        description="GPT-3.5 Turbo",
+    ),
+    OpenAIChatModel.GPT4.value: ModelInfo(
+        name=OpenAIChatModel.GPT4.value,
+        provider=ModelProvider.OPENAI,
+        context_length=8192,
+        max_output_tokens=8192,
+        input_cost_per_million=30.0,
+        output_cost_per_million=60.0,
+        description="GPT-4 (8K context)",
+    ),
+    OpenAIChatModel.GPT4_TURBO.value: ModelInfo(
+        name=OpenAIChatModel.GPT4_TURBO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=4096,
+        input_cost_per_million=10.0,
+        output_cost_per_million=30.0,
+        description="GPT-4 Turbo",
+    ),
+    OpenAIChatModel.GPT4_1_NANO.value: ModelInfo(
+        name=OpenAIChatModel.GPT4_1_NANO.value,
+        provider=ModelProvider.OPENAI,
+        has_structured_output=True,
+        context_length=1_047_576,
+        max_output_tokens=32_768,
+        input_cost_per_million=0.10,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=0.40,
+        description="GPT-4.1",
+    ),
+    OpenAIChatModel.GPT4_1_MINI.value: ModelInfo(
+        name=OpenAIChatModel.GPT4_1_MINI.value,
+        provider=ModelProvider.OPENAI,
+        has_structured_output=True,
+        context_length=1_047_576,
+        max_output_tokens=32_768,
+        input_cost_per_million=0.40,
+        cached_cost_per_million=0.10,
+        output_cost_per_million=1.60,
+        description="GPT-4.1 Mini",
+    ),
+    OpenAIChatModel.GPT4_1.value: ModelInfo(
+        name=OpenAIChatModel.GPT4_1.value,
+        provider=ModelProvider.OPENAI,
+        has_structured_output=True,
+        context_length=1_047_576,
+        max_output_tokens=32_768,
+        input_cost_per_million=2.00,
+        cached_cost_per_million=0.50,
+        output_cost_per_million=8.00,
+        description="GPT-4.1",
+    ),
+    OpenAIChatModel.GPT4o.value: ModelInfo(
+        name=OpenAIChatModel.GPT4o.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=2.5,
+        cached_cost_per_million=1.25,
+        output_cost_per_million=10.0,
+        has_structured_output=True,
+        description="GPT-4o (128K context)",
+    ),
+    OpenAIChatModel.GPT4o_MINI.value: ModelInfo(
+        name=OpenAIChatModel.GPT4o_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=0.15,
+        cached_cost_per_million=0.075,
+        output_cost_per_million=0.60,
+        has_structured_output=True,
+        description="GPT-4o Mini",
+    ),
+    OpenAIChatModel.O1.value: ModelInfo(
+        name=OpenAIChatModel.O1.value,
+        provider=ModelProvider.OPENAI,
+        context_length=200_000,
+        max_output_tokens=100_000,
+        input_cost_per_million=15.0,
+        cached_cost_per_million=7.50,
+        output_cost_per_million=60.0,
+        allows_streaming=True,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        has_tools=False,
+        description="O1 Reasoning LM",
+    ),
+    OpenAIChatModel.O3.value: ModelInfo(
+        name=OpenAIChatModel.O3.value,
+        provider=ModelProvider.OPENAI,
+        context_length=200_000,
+        max_output_tokens=100_000,
+        input_cost_per_million=2.0,
+        cached_cost_per_million=0.50,
+        output_cost_per_million=8.0,
+        allows_streaming=True,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        has_tools=False,
+        description="O1 Reasoning LM",
+    ),
+    OpenAIChatModel.O1_MINI.value: ModelInfo(
+        name=OpenAIChatModel.O1_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=65_536,
+        input_cost_per_million=1.1,
+        cached_cost_per_million=0.55,
+        output_cost_per_million=4.4,
+        allows_streaming=False,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature", "stream"],
+        has_tools=False,
+        description="O1 Mini Reasoning LM",
+    ),
+    OpenAIChatModel.O3_MINI.value: ModelInfo(
+        name=OpenAIChatModel.O3_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=200_000,
+        max_output_tokens=100_000,
+        input_cost_per_million=1.1,
+        cached_cost_per_million=0.55,
+        output_cost_per_million=4.4,
+        allows_streaming=False,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature", "stream"],
+        has_tools=False,
+        description="O3 Mini Reasoning LM",
+    ),
+    OpenAIChatModel.O4_MINI.value: ModelInfo(
+        name=OpenAIChatModel.O4_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=200_000,
+        max_output_tokens=100_000,
+        input_cost_per_million=1.10,
+        cached_cost_per_million=0.275,
+        output_cost_per_million=4.40,
+        allows_streaming=False,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature", "stream"],
+        has_tools=False,
+        description="O3 Mini Reasoning LM",
+    ),
+    OpenAIChatModel.GPT5.value: ModelInfo(
+        name=OpenAIChatModel.GPT5.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.125,
+        output_cost_per_million=10.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5",
+    ),
+    OpenAIChatModel.GPT5_MINI.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=0.25,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=2.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5 Mini",
+    ),
+    OpenAIChatModel.GPT5_NANO.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_NANO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=0.05,
+        cached_cost_per_million=0.005,
+        output_cost_per_million=0.40,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5 Nano",
+    ),
+    OpenAIChatModel.GPT5_PRO.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_PRO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=272_000,
+        input_cost_per_million=15.00,
+        cached_cost_per_million=7.50,
+        output_cost_per_million=120.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5 Pro",
+    ),
+    OpenAIChatModel.GPT5_1.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_1.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.13,
+        output_cost_per_million=10.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.1",
+    ),
+    OpenAIChatModel.GPT5_1_CODEX.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_1_CODEX.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.125,
+        output_cost_per_million=10.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.1 Codex",
+    ),
+    OpenAIChatModel.GPT5_1_CODEX_MINI.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_1_CODEX_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=0.25,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=2.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.1 Codex Mini",
+    ),
+    OpenAIChatModel.GPT5_1_CHAT.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_1_CHAT.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.125,
+        output_cost_per_million=10.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.1 Chat",
+    ),
+    OpenAIChatModel.GPT5_2.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_2.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=1.75,
+        cached_cost_per_million=0.175,
+        output_cost_per_million=14.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.2",
+    ),
+    OpenAIChatModel.GPT5_2_PRO.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_2_PRO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=272_000,
+        input_cost_per_million=15.00,
+        cached_cost_per_million=7.50,
+        output_cost_per_million=120.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.2 Pro",
+    ),
+    OpenAIChatModel.GPT5_2_CHAT.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_2_CHAT.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=1.75,
+        cached_cost_per_million=0.175,
+        output_cost_per_million=14.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.2 Chat",
+    ),
+    OpenAIChatModel.GPT_OSS_120b.value: ModelInfo(
+        name=OpenAIChatModel.GPT_OSS_120b.value,
+        provider=ModelProvider.OPENAI,
+        context_length=131_072,
+        max_output_tokens=65_535,
+        input_cost_per_million=0.15,
+        cached_cost_per_million=0.075,
+        output_cost_per_million=0.60,
+        has_structured_output=True,
+        description="GPT OSS 120B",
+    ),
+    OpenAIChatModel.GPT_OSS_20b.value: ModelInfo(
+        name=OpenAIChatModel.GPT_OSS_20b.value,
+        provider=ModelProvider.OPENAI,
+        context_length=131_072,
+        max_output_tokens=65_535,
+        input_cost_per_million=0.075,
+        cached_cost_per_million=0.037,
+        output_cost_per_million=0.30,
+        has_structured_output=True,
+        description="GPT OSS 20B",
+    ),
+    # Anthropic Models
+    AnthropicModel.CLAUDE_3_5_SONNET.value: ModelInfo(
+        name=AnthropicModel.CLAUDE_3_5_SONNET.value,
+        provider=ModelProvider.ANTHROPIC,
+        context_length=200_000,
+        max_output_tokens=8192,
+        input_cost_per_million=3.0,
+        cached_cost_per_million=0.30,
+        output_cost_per_million=15.0,
+        description="Claude 3.5 Sonnet",
+    ),
+    AnthropicModel.CLAUDE_3_OPUS.value: ModelInfo(
+        name=AnthropicModel.CLAUDE_3_OPUS.value,
+        provider=ModelProvider.ANTHROPIC,
+        context_length=200_000,
+        max_output_tokens=4096,
+        input_cost_per_million=15.0,
+        cached_cost_per_million=1.50,
+        output_cost_per_million=75.0,
+        description="Claude 3 Opus",
+    ),
+    AnthropicModel.CLAUDE_3_SONNET.value: ModelInfo(
+        name=AnthropicModel.CLAUDE_3_SONNET.value,
+        provider=ModelProvider.ANTHROPIC,
+        context_length=200_000,
+        max_output_tokens=4096,
+        input_cost_per_million=3.0,
+        cached_cost_per_million=0.30,
+        output_cost_per_million=15.0,
+        description="Claude 3 Sonnet",
+    ),
+    AnthropicModel.CLAUDE_3_HAIKU.value: ModelInfo(
+        name=AnthropicModel.CLAUDE_3_HAIKU.value,
+        provider=ModelProvider.ANTHROPIC,
+        context_length=200_000,
+        max_output_tokens=4096,
+        input_cost_per_million=0.25,
+        cached_cost_per_million=0.03,
+        output_cost_per_million=1.25,
+        description="Claude 3 Haiku",
+    ),
+    # DeepSeek Models
+    DeepSeekModel.DEEPSEEK.value: ModelInfo(
+        name=DeepSeekModel.DEEPSEEK.value,
+        provider=ModelProvider.DEEPSEEK,
+        context_length=64_000,
+        max_output_tokens=8_000,
+        input_cost_per_million=0.27,
+        cached_cost_per_million=0.07,
+        output_cost_per_million=1.10,
+        description="DeepSeek Chat",
+    ),
+    DeepSeekModel.DEEPSEEK_R1.value: ModelInfo(
+        name=DeepSeekModel.DEEPSEEK_R1.value,
+        provider=ModelProvider.DEEPSEEK,
+        context_length=64_000,
+        max_output_tokens=8_000,
+        input_cost_per_million=0.55,
+        cached_cost_per_million=0.14,
+        output_cost_per_million=2.19,
+        description="DeepSeek-R1 Reasoning LM",
+    ),
+    # Gemini Models
+    GeminiModel.GEMINI_2_FLASH.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_FLASH.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_056_768,
+        max_output_tokens=8192,
+        input_cost_per_million=0.10,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=0.40,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.0 Flash",
+    ),
+    GeminiModel.GEMINI_2_FLASH_LITE.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_FLASH_LITE.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_056_768,
+        max_output_tokens=8192,
+        input_cost_per_million=0.075,
+        output_cost_per_million=0.30,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.0 Flash Lite",
+    ),
+    GeminiModel.GEMINI_1_5_FLASH.value: ModelInfo(
+        name=GeminiModel.GEMINI_1_5_FLASH.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_056_768,
+        max_output_tokens=8192,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 1.5 Flash",
+    ),
+    GeminiModel.GEMINI_1_5_FLASH_8B.value: ModelInfo(
+        name=GeminiModel.GEMINI_1_5_FLASH_8B.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_000_000,
+        max_output_tokens=8192,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 1.5 Flash 8B",
+    ),
+    GeminiModel.GEMINI_1_5_PRO.value: ModelInfo(
+        name=GeminiModel.GEMINI_1_5_PRO.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=2_000_000,
+        max_output_tokens=8192,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 1.5 Pro",
+    ),
+    GeminiModel.GEMINI_2_PRO.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_PRO.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=2_000_000,
+        max_output_tokens=8192,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2 Pro Exp 02-05",
+    ),
+    GeminiModel.GEMINI_2_FLASH_THINKING.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_FLASH_THINKING.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_000_000,
+        max_output_tokens=64_000,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.0 Flash Thinking",
+    ),
+    # Gemini 2.5 Models
+    GeminiModel.GEMINI_2_5_PRO.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_5_PRO.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_048_576,
+        max_output_tokens=65_536,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.31,
+        output_cost_per_million=10.0,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.5 Pro",
+    ),
+    GeminiModel.GEMINI_2_5_FLASH.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_5_FLASH.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_048_576,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.30,
+        cached_cost_per_million=0.075,
+        output_cost_per_million=2.50,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.5 Flash",
+    ),
+    GeminiModel.GEMINI_2_5_FLASH_LITE.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_5_FLASH_LITE.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=65_536,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.10,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=0.40,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.5 Flash Lite",
+    ),
+    # Gemini 3 Models
+    GeminiModel.GEMINI_3_PRO.value: ModelInfo(
+        name=GeminiModel.GEMINI_3_PRO.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_000_000,
+        max_output_tokens=64_000,
+        input_cost_per_million=2.00,
+        cached_cost_per_million=0.20,
+        output_cost_per_million=12.00,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 3 Pro",
+    ),
+    GeminiModel.GEMINI_3_FLASH.value: ModelInfo(
+        name=GeminiModel.GEMINI_3_FLASH.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_048_576,
+        max_output_tokens=65_535,
+        input_cost_per_million=0.50,
+        cached_cost_per_million=0.05,
+        output_cost_per_million=3.00,
+        description="Gemini 3 Flash",
+    ),
+    # MiniMax Models
+    MiniMaxModel.MINIMAX_M2_7.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_7.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=131_072,
+        input_cost_per_million=0.30,
+        output_cost_per_million=1.20,
+        has_structured_output=True,
+        description="MiniMax M2.7 (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=131_072,
+        input_cost_per_million=0.15,
+        output_cost_per_million=0.60,
+        has_structured_output=True,
+        description="MiniMax M2.7 Highspeed (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_5.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_5.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.30,
+        output_cost_per_million=1.20,
+        has_structured_output=True,
+        description="MiniMax M2.5 (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.15,
+        output_cost_per_million=0.60,
+        has_structured_output=True,
+        description="MiniMax M2.5 Highspeed (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_1.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_1.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.27,
+        output_cost_per_million=0.95,
+        has_structured_output=True,
+        description="MiniMax M2.1 (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.14,
+        output_cost_per_million=0.48,
+        has_structured_output=True,
+        description="MiniMax M2.1 Highspeed (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.27,
+        output_cost_per_million=0.95,
+        has_structured_output=True,
+        description="MiniMax M2 (204K context)",
+    ),
+}
 
-        # Caution - this updates the self.config.system_message!
-        self._init_system_message()
-        super().__init__(config)
-        self._init_tools()
-        if self.config.is_helper:
-            self.system_tool_format_instructions += self.final_instructions
 
-        if self.config.use_helper:
-            # helper_config.system_message is now the fully-populated sys msg of
-            # the main SQLAgent.
-            self.helper_config = self.config.model_copy()
-            self.helper_config.is_helper = True
-            self.helper_config.use_helper = False
-            self.helper_config.chat_mode = False
-            self.helper_agent = SQLHelperAgent(self.helper_config)
+def get_model_info(
+    model: str | ModelName,
+    fallback_models: List[str] = [],
+) -> ModelInfo:
+    """Get model information by name or enum value"""
+    # Sequence of models to try, starting with the primary model
+    models_to_try = [model] + fallback_models
 
-    def _validate_config(self, config: "SQLChatAgentConfig") -> None:
-        """Validate the configuration to ensure all necessary fields are present."""
-        if config.database_session is None and config.database_uri is None:
-            raise ValueError("Database information must be provided")
+    # Find the first model in the sequence that has info defined using next()
+    # on a generator expression that filters out None results from _get_model_info
+    found_info = next(
+        (info for m in models_to_try if (info := _get_model_info(m)) is not None),
+        None,  # Default value if the iterator is exhausted (no valid info found)
+    )
 
-    def _init_database(self) -> None:
-        """Initialize the database engine and session."""
-        if self.config.database_session:
-            self.Session = self.config.database_session
-            self.engine = self.Session.bind
-        else:
-            self.engine = create_engine(self.config.database_uri)
-            self.Session = sessionmaker(bind=self.engine)()
+    if found_info is not None:
+        return found_info
 
-    def _init_metadata(self) -> None:
-        """Initialize the database metadata."""
-        if self.engine is None:
-            raise ValueError("Database engine is None")
-        self.metadata: MetaData | List[MetaData] = []
+    normalized_models = _normalize_model_names(models_to_try)
+    found_info = next(
+        (
+            info
+            for normalized_model in normalized_models
+            if (info := _get_model_info(normalized_model)) is not None
+        ),
+        None,
+    )
+    if found_info is not None:
+        return found_info
 
-        if self.config.multi_schema:
-            logger.info(
-                "Initializing SQLChatAgent with database: %s",
-                self.engine,
-            )
+    _warn_unknown_model(models_to_try)
+    return ModelInfo()
 
-            self.metadata = []
-            inspector = inspect(self.engine)
 
-            for schema in inspector.get_schema_names():
-                metadata = MetaData(schema=schema)
-                metadata.reflect(self.engine)
-                self.metadata.append(metadata)
+def _get_model_info(model: str | ModelName) -> ModelInfo | None:
+    if isinstance(model, str):
+        return MODEL_INFO.get(model)
+    return MODEL_INFO.get(model.value)
 
-                logger.info(
-                    "Initializing SQLChatAgent with database: %s, schema: %s, "
-                    "and tables: %s",
-                    self.engine,
-                    schema,
-                    metadata.tables,
-                )
-        else:
-            self.metadata = MetaData()
-            self.metadata.reflect(self.engine)
-            logger.info(
-                "SQLChatAgent initialized with database: %s and tables: %s",
-                self.engine,
-                self.metadata.tables,
-            )
 
-    def _init_table_metadata(self) -> None:
-        """Initialize metadata for the tables present in the database."""
-        if not self.config.context_descriptions and isinstance(self.engine, Engine):
-            self.config.context_descriptions = extract_schema_descriptions(
-                self.engine, self.config.multi_schema
-            )
+def _normalize_model_names(models: List[str | ModelName]) -> List[str]:
+    normalized_models: List[str] = []
+    seen: set[str] = set()
+    for model in models:
+        normalized_model = _normalize_gemini_model_name(_model_name(model))
+        if normalized_model is None or normalized_model in seen:
+            continue
+        seen.add(normalized_model)
+        normalized_models.append(normalized_model)
+    return normalized_models
 
-        if self.config.use_schema_tools:
-            self.table_metadata = populate_metadata_with_schema_tools(
-                self.metadata, self.config.context_descriptions
-            )
-        else:
-            self.table_metadata = populate_metadata(
-                self.metadata, self.config.context_descriptions
-            )
 
-    def _init_system_message(self) -> None:
-        """Initialize the system message."""
-        message = self._format_message()
-        self.config.system_message = self.config.system_message.format(mode=message)
-
-        if not self.config.allow_dangerous_operations:
-            allowed = sorted(
-                t.strip().upper() for t in self.config.allowed_statement_types
-            )
-            self.config.system_message += (
-                f"\n\nIMPORTANT - SECURITY POLICY:\n"
-                f"You may ONLY issue SQL queries whose top-level statement "
-                f"type is one of: {allowed}. Any other statement type "
-                f"(e.g. DDL, COPY, EXEC, multi-statement scripts that "
-                f"include a disallowed type) will be REJECTED by the "
-                f"executor and not run.\n"
-            )
-
-        if self.config.chat_mode:
-            self.config.addressing_prefix = self.config.addressing_prefix or SEND_TO
-            self.config.system_message += ADDRESSING_INSTRUCTION.format(
-                prefix=self.config.addressing_prefix
-            )
-        else:
-            self.config.system_message += DONE_INSTRUCTION
-
-    def _init_tools(self) -> None:
-        """Initialize sys msg and tools."""
-        # Create a custom RunQueryTool class with the desired max_retained_tokens
-        if self.config.max_retained_tokens is not None:
-
-            class CustomRunQueryTool(RunQueryTool):
-                _max_retained_tokens = self.config.max_retained_tokens
-
-            self.enable_message([CustomRunQueryTool, ForwardTool])
-        else:
-            self.enable_message([RunQueryTool, ForwardTool])
-
-        if self.config.use_schema_tools:
-            self._enable_schema_tools()
-        if not self.config.chat_mode:
-            self.enable_message(DoneTool)
-            self.enable_message(DonePassTool)
-
-    def _format_message(self) -> str:
-        if self.engine is None:
-            raise ValueError("Database engine is None")
-
-        """Format the system message based on the engine and table metadata."""
-        return (
-            SCHEMA_TOOLS_SYS_MSG.format(dialect=self.engine.dialect.name)
-            if self.config.use_schema_tools
-            else DEFAULT_SYS_MSG.format(
-                dialect=self.engine.dialect.name, schema_dict=self.table_metadata
-            )
-        )
-
-    def _enable_schema_tools(self) -> None:
-        """Enable tools for schema-related functionalities."""
-        self.enable_message(GetTableNamesTool)
-        self.enable_message(GetTableSchemaTool)
-        self.enable_message(GetColumnDescriptionsTool)
-
-    def llm_response(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> Optional[ChatDocument]:
-        self.llm_responded = True
-        self.used_run_query = False
-        return super().llm_response(message)
-
-    def user_response(
-        self,
-        msg: Optional[str | ChatDocument] = None,
-    ) -> Optional[ChatDocument]:
-        self.llm_responded = False
-        self.used_run_query = False
-        return super().user_response(msg)
-
-    def _clarify_answer_instruction(self) -> str:
-        """
-        Prompt to use when asking LLM to clarify intent of
-        an already-generated response
-        """
-        if self.config.chat_mode:
-            return f"""
-                you must use the TOOL `{ForwardTool.name()}` with the `agent` 
-                parameter set to "User"
-                """
-        else:
-            return f"you must use the TOOL `{DonePassTool.name()}`"
-
-    def _clarifying_message(self) -> str:
-        tools_instruction = f"""
-          For example you may want to use the TOOL
-          `{RunQueryTool.name()}` to further explore the database contents
-        """
-        if self.config.use_schema_tools:
-            tools_instruction += """
-            OR you may want to use one of the schema tools to 
-            explore the database schema
-            """
-        return f"""
-            The intent of your response is not clear:
-            - if you intended this to be the FINAL answer to the user's query,
-                {self._clarify_answer_instruction()}
-            - otherwise, use one of the available tools to make progress 
-                to arrive at the final answer.
-                {tools_instruction}
-            """
-
-    def handle_message_fallback(
-        self, message: str | ChatDocument
-    ) -> str | ForwardTool | ChatDocument | None:
-        """
-        We'd end up here if the current msg has no tool.
-        If this is from LLM, we may need to handle the scenario where
-        it may have "forgotten" to generate a tool.
-        """
-        if (
-            not isinstance(message, ChatDocument)
-            or message.metadata.sender != Entity.LLM
-        ):
-            return None
-        if self.config.chat_mode:
-            # send any Non-tool msg to the user
-            return ForwardTool(agent="User")
-        # Agent intent not clear => use the helper agent to
-        # do what this agent should have done, e.g. generate tool, etc.
-        # This is likelier to succeed since this agent has no "baggage" of
-        # prior conversation, other than the system msg, and special
-        # "Intent-interpretation" instructions.
-        if self._json_schema_available() and self.config.strict_recovery:
-            AnyTool = self._get_any_tool_message(optional=False)
-            self.set_output_format(
-                AnyTool,
-                force_tools=True,
-                use=True,
-                handle=True,
-                instructions=True,
-            )
-            recovery_message = self._strict_recovery_instructions(
-                AnyTool, optional=False
-            )
-            result = self.llm_response(recovery_message)
-            # remove the recovery_message (it has User role) from the chat history,
-            # else it may cause the LLM to directly use the AnyTool.
-            self.delete_last_message(role=Role.USER)  # delete last User-role msg
-            return result
-        elif self.config.use_helper:
-            response = self.helper_agent.llm_response(message)
-            tools = self.try_get_tool_messages(response)
-            if tools:
-                return response
-        # fall back on the clarification message
-        return self._clarifying_message()
-
-    def retry_query(self, e: Exception, query: str) -> str:
-        """
-        Generate an error message for a failed SQL query and return it.
-
-        Parameters:
-        e (Exception): The exception raised during the SQL query execution.
-        query (str): The SQL query that failed.
-
-        Returns:
-        str: The error message.
-        """
-        logger.error(f"SQL Query failed: {query}\nException: {e}")
-
-        # Optional part to be included based on `use_schema_tools`
-        optional_schema_description = ""
-        if not self.config.use_schema_tools:
-            optional_schema_description = f"""\
-            This JSON schema maps SQL database structure. It outlines tables, each 
-            with a description and columns. Each table is identified by a key, and holds
-            a description and a dictionary of columns, with column 
-            names as keys and their descriptions as values.
-            
-            ```json
-            {self.config.context_descriptions}
-            ```"""
-
-        # Construct the error message
-        error_message_template = f"""\
-        {SQL_ERROR_MSG}: '{query}'
-        {str(e)}
-        Run a new query, correcting the errors.
-        {optional_schema_description}"""
-
-        return error_message_template
-
-    def _available_tool_names(self) -> str:
-        return ",".join(self.llm_tools_usable)
-
-    def _tool_result_llm_answer_prompt(self) -> str:
-        """
-        Prompt to use at end of tool result,
-        to guide LLM, for the case where it wants to answer the user's query
-        """
-        if self.config.chat_mode:
-            assert self.config.addressing_prefix != ""
-            return """
-                You must EXPLICITLY address the User with 
-                the addressing prefix according to your instructions,
-                to convey your answer to the User.
-                """
-        else:
-            return f"""
-                you must use the `{DoneTool.name()}` with the `content` 
-                set to the answer or result
-                """
-
-    def _sqlglot_dialect(self) -> Optional[str]:
-        """Map the SQLAlchemy dialect name to a sqlglot dialect name."""
-        if self.engine is None:
-            return None
-        name: str = str(self.engine.dialect.name)
-        # sqlglot uses 'postgres', not 'postgresql'; 'tsql' for MSSQL.
-        mapping: Dict[str, str] = {"postgresql": "postgres", "mssql": "tsql"}
-        return mapping.get(name, name)
-
-    def _validate_query(self, query: str) -> Optional[str]:
-        """
-        Check whether `query` is permitted under the agent's security config.
-
-        Returns None if the query may be executed, otherwise an error message
-        explaining why it was rejected (to be relayed to the LLM).
-        """
-        if self.config.allow_dangerous_operations:
-            return None
-
-        for pat in _DANGEROUS_SQL_PATTERNS:
-            if pat.search(query):
-                logger.warning(
-                    "SQLChatAgent rejected query matching dangerous pattern "
-                    f"{pat.pattern!r}: {query!r}"
-                )
-                return (
-                    f"Query REJECTED for safety: it matches a pattern "
-                    f"({pat.pattern!r}) that enables code execution, "
-                    f"filesystem access, or other unsafe operations. "
-                    f"Rewrite the query without using this construct, or ask "
-                    f"the operator to set `allow_dangerous_operations=True` "
-                    f"on the SQLChatAgent config."
-                )
-
-        allowed = {t.strip().upper() for t in self.config.allowed_statement_types}
-        try:
-            statements = sqlglot.parse(query, read=self._sqlglot_dialect())
-        except Exception as e:
-            logger.warning(f"sqlglot failed to parse query {query!r}: {e}")
-            return (
-                f"Query REJECTED for safety: could not be parsed to verify it "
-                f"is a {sorted(allowed)} statement ({e}). Rewrite the query "
-                f"more simply, or ask the operator to set "
-                f"`allow_dangerous_operations=True` on the SQLChatAgent config."
-            )
-
-        kind_map = {
-            sqlglot_exp.Select: "SELECT",
-            sqlglot_exp.Insert: "INSERT",
-            sqlglot_exp.Update: "UPDATE",
-            sqlglot_exp.Delete: "DELETE",
-            sqlglot_exp.Merge: "MERGE",
-            sqlglot_exp.Create: "CREATE",
-            sqlglot_exp.Drop: "DROP",
-            sqlglot_exp.Alter: "ALTER",
-            sqlglot_exp.TruncateTable: "TRUNCATE",
-            sqlglot_exp.Command: "COMMAND",
-        }
-        for stmt in statements:
-            if stmt is None:
-                continue
-            kind = next(
-                (v for k, v in kind_map.items() if isinstance(stmt, k)),
-                type(stmt).__name__.upper(),
-            )
-            if kind not in allowed:
-                logger.warning(
-                    f"SQLChatAgent rejected {kind} statement (allowed: "
-                    f"{sorted(allowed)}): {query!r}"
-                )
-                return (
-                    f"Query REJECTED for safety: statement type {kind!r} is "
-                    f"not in the allowed list {sorted(allowed)}. Rewrite the "
-                    f"query as one of the allowed statement types, or ask "
-                    f"the operator to extend `allowed_statement_types` "
-                    f"(or set `allow_dangerous_operations=True`) on the "
-                    f"SQLChatAgent config."
-                )
-            # The top-level node alone does not determine what a statement
-            # writes. A data-modifying CTE
-            # (``WITH x AS (DELETE ... RETURNING *) SELECT ...``) and
-            # ``SELECT ... INTO tbl`` both parse with a ``Select`` top node, so
-            # the check above classifies them as SELECT while the engine still
-            # performs the write (GHSA-3gpx-vwr3-xvwx / GHSA-wc83-4cvx-p8xc).
-            nested = _nested_write_kinds(stmt, kind_map)
-            disallowed = sorted(nested - allowed)
-            if disallowed:
-                logger.warning(
-                    f"SQLChatAgent rejected {kind} statement embedding "
-                    f"{disallowed} (allowed: {sorted(allowed)}): {query!r}"
-                )
-                return (
-                    f"Query REJECTED for safety: although this parses as a "
-                    f"{kind} statement, it embeds {disallowed}, which is not "
-                    f"in the allowed list {sorted(allowed)} -- the database "
-                    f"would still perform that write. Rewrite the query "
-                    f"without the embedded statement, or ask the operator to "
-                    f"extend `allowed_statement_types` (or set "
-                    f"`allow_dangerous_operations=True`) on the SQLChatAgent "
-                    f"config."
-                )
-            # AST-side dangerous-function check: catches calls that evaded
-            # `_DANGEROUS_SQL_PATTERNS` via quoted identifiers, inline comments,
-            # or schema qualification (GHSA-6xc5-4r68-67fc).
-            for fn_name in _called_function_names(stmt):
-                if _is_dangerous_function_name(fn_name):
-                    logger.warning(
-                        "SQLChatAgent rejected query calling dangerous "
-                        f"function {fn_name!r}: {query!r}"
-                    )
-                    return (
-                        f"Query REJECTED for safety: it calls function "
-                        f"{fn_name!r}, which enables code execution, "
-                        f"filesystem access, or other unsafe operations. "
-                        f"Rewrite the query without using this function, or "
-                        f"ask the operator to set "
-                        f"`allow_dangerous_operations=True` on the "
-                        f"SQLChatAgent config."
-                    )
+def _normalize_gemini_model_name(model: str) -> str | None:
+    base_model = model.rsplit("/", 1)[-1]
+    if base_model in GEMINI_CANONICAL_MODEL_NAMES:
+        return base_model
+    if not base_model.startswith("gemini-"):
         return None
 
-    def run_query(self, msg: RunQueryTool) -> str:
-        """
-        Handle a RunQueryTool message by executing a SQL query and returning the result.
-
-        Args:
-            msg (RunQueryTool): The tool-message to handle.
-
-        Returns:
-            str: The result of executing the SQL query.
-        """
-        query = msg.query
-        session = self.Session
-        self.used_run_query = True
-
-        rejection = self._validate_query(query)
-        if rejection is not None:
-            return f"""
-        Below is the result from your use of the TOOL `{RunQueryTool.name()}`:
-        ==== result ====
-        {rejection}
-        ================
-
-        Try a different query that complies with the policy above.
-        """
-
-        try:
-            logger.info(f"Executing SQL query: {query}")
-
-            query_result = session.execute(text(query))
-            session.commit()
-            try:
-                # attempt to fetch results: should work for normal SELECT queries
-                rows = query_result.fetchall()
-                n_rows = len(rows)
-                if self.config.max_result_rows and n_rows > self.config.max_result_rows:
-                    rows = rows[: self.config.max_result_rows]
-                    logger.warning(
-                        f"SQL query produced {n_rows} rows, "
-                        f"limiting to {self.config.max_result_rows}"
-                    )
-
-                response_message = self._format_rows(rows)
-            except ResourceClosedError:
-                # If we get here, it's a non-SELECT query (UPDATE, INSERT, DELETE)
-                affected_rows = query_result.rowcount  # type: ignore
-                response_message = f"""
-                    Non-SELECT query executed successfully. 
-                    Rows affected: {affected_rows}
-                    """
-
-        except SQLAlchemyError as e:
-            session.rollback()
-            logger.error(f"Failed to execute query: {query}\n{e}")
-            response_message = self.retry_query(e, query)
-        finally:
-            session.close()
-
-        final_message = f"""
-        Below is the result from your use of the TOOL `{RunQueryTool.name()}`:
-        ==== result ====
-        {response_message}
-        ================
-        
-        If you are READY to ANSWER the ORIGINAL QUERY:
-        {self._tool_result_llm_answer_prompt()}
-        OTHERWISE:
-             continue using one of your available TOOLs:
-             {",".join(self.llm_tools_usable)}
-        """
-        return final_message
-
-    def _format_rows(self, rows: Sequence[Row[Any]]) -> str:
-        """
-        Format the rows fetched from the query result into a string.
-
-        Args:
-            rows (list): List of rows fetched from the query result.
-
-        Returns:
-            str: Formatted string representation of rows.
-        """
-        # TODO: UPDATE FORMATTING
-        return (
-            ",\n".join(str(row) for row in rows)
-            if rows
-            else "Query executed successfully."
-        )
-
-    def get_table_names(self, msg: GetTableNamesTool) -> str:
-        """
-        Handle a GetTableNamesTool message by returning the names of all tables in the
-        database.
-
-        Returns:
-            str: The names of all tables in the database.
-        """
-        if isinstance(self.metadata, list):
-            table_names = [", ".join(md.tables.keys()) for md in self.metadata]
-            return ", ".join(table_names)
-
-        return ", ".join(self.metadata.tables.keys())
-
-    def get_table_schema(self, msg: GetTableSchemaTool) -> str:
-        """
-        Handle a GetTableSchemaTool message by returning the schema of all provided
-        tables in the database.
-
-        Returns:
-            str: The schema of all provided tables in the database.
-        """
-        tables = msg.tables
-        result = ""
-        for table_name in tables:
-            table = self.table_metadata.get(table_name)
-            if table is not None:
-                result += f"{table_name}: {table}\n"
-            else:
-                result += f"{table_name} is not a valid table name.\n"
-        return result
-
-    def get_column_descriptions(self, msg: GetColumnDescriptionsTool) -> str:
-        """
-        Handle a GetColumnDescriptionsTool message by returning the descriptions of all
-        provided columns from the database.
-
-        Returns:
-            str: The descriptions of all provided columns from the database.
-        """
-        table = msg.table
-        columns = msg.columns.split(", ")
-        result = f"\nTABLE: {table}"
-        descriptions = self.config.context_descriptions.get(table)
-
-        for col in columns:
-            result += f"\n{col} => {descriptions['columns'][col]}"  # type: ignore
-        return result
+    # Try stripping known suffixes to find a canonical name.
+    # Use split (not endswith) for "-preview" so dated variants like
+    # "gemini-2.5-flash-lite-preview-06-17" are handled correctly.
+    for suffix in ("-preview", "-exp", "-experimental", "-latest"):
+        stripped = base_model.split(suffix, maxsplit=1)[0]
+        if stripped != base_model and stripped in GEMINI_CANONICAL_MODEL_NAMES:
+            return stripped
+    return None
 
 
-class SQLHelperAgent(SQLChatAgent):
+def _warn_unknown_model(models: List[str | ModelName]) -> None:
+    model_names = tuple(_model_name(model) for model in models)
+    if model_names in WARNED_UNKNOWN_MODELS:
+        return
 
-    def _clarifying_message(self) -> str:
-        tools_instruction = f"""
-          For example the Agent may have forgotten to use the TOOL
-          `{RunQueryTool.name()}` to further explore the database contents
-        """
-        if self.config.use_schema_tools:
-            tools_instruction += """
-            OR the agent may have forgotten to use one of the schema tools to 
-            explore the database schema
-            """
+    WARNED_UNKNOWN_MODELS.add(model_names)
+    logger.warning(
+        "Unknown model info for %s; using fallback defaults "
+        "(context_length=%s, max_output_tokens=%s). "
+        "Context-length checks may be inaccurate. "
+        "Set `chat_context_length` explicitly if needed.",
+        ", ".join(model_names),
+        DEFAULT_MODEL_INFO.context_length,
+        DEFAULT_MODEL_INFO.max_output_tokens,
+    )
 
-        return f"""
-            The intent of the Agent's response is not clear:
-            - if you think the Agent intended this as ANSWER to the 
-                user's query,
-                {self._clarify_answer_instruction()}
-            - otherwise, the Agent may have forgotten to 
-              use one of the available tools to make progress 
-                to arrive at the final answer.
-                {tools_instruction}
-            """
 
-    def _init_system_message(self) -> None:
-        """Set up helper sys msg"""
-
-        # Note that self.config.system_message is already set to the
-        # parent SQLAgent's system_message
-        self.config.system_message = f"""
-                You role is to help INTERPRET the INTENT of an 
-                AI agent in a conversation. This Agent was supposed to generate
-                a TOOL/Function-call but forgot to do so, and this is where 
-                you can help, by trying to generate the appropriate TOOL
-                based on your best guess of the Agent's INTENT.
-                
-                Below are the instructions that were given to this Agent: 
-                ===== AGENT INSTRUCTIONS =====
-                {self.config.system_message}
-                ===== END OF AGENT INSTRUCTIONS =====
-                """
-
-        # note that the initial msg in chat history will contain:
-        # - system message
-        # - tool instructions
-        # so the final_instructions will be at the end of this initial msg
-
-        self.final_instructions = f"""        
-        You must take note especially of the TOOLs that are
-        available to the Agent. Your reasoning process should be as follows:
-        
-        - If the Agent's message appears to be an ANSWER to the original query,
-          {self._clarify_answer_instruction()}.
-          CAUTION - You must be absolutely sure that the Agent's message is 
-          an ACTUAL ANSWER to the user's query, and not a failed attempt to use 
-          a TOOL without JSON, e.g. something like "run_query" or "done_tool"
-          without any actual JSON formatting.
-           
-        - Else, if you think the Agent intended to use some type of SQL
-          query tool to READ or UPDATE the table(s), 
-          AND it is clear WHICH TOOL is intended as well as the 
-          TOOL PARAMETERS, then you must generate the JSON-Formatted
-          TOOL with the parameters set based on your understanding.
-          Note that the `{RunQueryTool.name()}` is not ONLY for querying the tables,
-          but also for UPDATING the tables.
-           
-        - Else, use the `{PassTool.name()}` to pass the message unchanged.
-            CAUTION - ONLY use `{PassTool.name()}` if you think the Agent's response
-            is NEITHER an ANSWER, nor an intended SQL QUERY.
-        """
-
-    def llm_response(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> Optional[ChatDocument]:
-        if message is None:
-            return None
-        message_str = message if isinstance(message, str) else message.content
-        instruc_msg = f"""
-        Below is the MESSAGE from the SQL Agent. 
-        Remember your instructions on how to respond based on your understanding
-        of the INTENT of this message:        
-        {self.final_instructions}
-        
-        === AGENT MESSAGE =========
-        {message_str}
-        === END OF AGENT MESSAGE ===
-        """
-        # user response_forget to avoid accumulating the chat history
-        return super().llm_response_forget(instruc_msg)
+def _model_name(model: str | ModelName) -> str:
+    if isinstance(model, str):
+        return model
+    return model.value
 </file>
 
 <file path="langroid/agent/base.py">
@@ -88102,6 +89564,17 @@ class AgentConfig(BaseSettings):
     respond_tools_only: bool = False  # respond only to tool messages (not plain text)?
     # allow multiple tool messages in a single response?
     allow_multiple_tools: bool = True
+    # Optional pre-execution tool policy hook, called with the final parsed
+    # ToolMessage just BEFORE its selected handler runs, as
+    # ``tool_policy(tool, agent)`` -- or ``tool_policy(tool, agent, chat_doc=...)``
+    # when the callable has a ``chat_doc`` parameter. May be sync or async.
+    # Return True or None to ALLOW (the handler runs exactly once); return
+    # False or a str reason to REJECT (the handler is NOT run, and the LLM
+    # sees a rejection naming the tool and the reason). The hook cannot modify
+    # the tool. If the hook itself raises, the tool is blocked (fail-closed)
+    # and the rejection deliberately excludes the exception message and tool
+    # arguments. See docs/notes/tool-policy-hook.md.
+    tool_policy: Optional[Callable[..., Any]] = None
     human_prompt: str = (
         "Human (respond or q, x to exit current level, " "or hit enter to continue)"
     )
@@ -89781,7 +91254,7 @@ class Agent(ABC):
         results = self._get_multiple_orch_tool_errs(tools)
         if not results:
             results = [
-                await self.handle_tool_message_async(t, chat_doc=chat_doc)
+                await self._handle_tool_message_with_policy_async(t, chat_doc=chat_doc)
                 for t in tools
             ]
             # if there's a solitary ChatDocument|str result, return it as is
@@ -89849,7 +91322,10 @@ class Agent(ABC):
             results = self._get_multiple_orch_tool_errs(tools)
         if not results:
             chat_doc = msg if isinstance(msg, ChatDocument) else None
-            results = [self.handle_tool_message(t, chat_doc=chat_doc) for t in tools]
+            results = [
+                self._handle_tool_message_with_policy(t, chat_doc=chat_doc)
+                for t in tools
+            ]
             # if there's a solitary ChatDocument|str result, return it as is
             if len(results) == 1 and isinstance(results[0], (str, ChatDocument)):
                 return results[0]
@@ -90027,7 +91503,7 @@ class Agent(ABC):
                 #     msg in chat_doc.tool_messages):
                 #    chat_doc.tool_messages.remove(msg)
                 # if we can handle it, do so
-                result = self.handle_tool_message(msg, chat_doc=chat_doc)
+                result = self._handle_tool_message_with_policy(msg, chat_doc=chat_doc)
                 if result is not None and isinstance(result, ChatDocument):
                     return result
             else:
@@ -90132,6 +91608,88 @@ class Agent(ABC):
             ) + truncate_warning
             return result
 
+    def _handle_tool_message_with_policy(
+        self,
+        tool: ToolMessage,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> None | str | ChatDocument:
+        """Framework entry point for sync tool dispatch, enforcing `tool_policy`.
+
+        Consults the `tool_policy` hook (see `AgentConfig.tool_policy`) and,
+        if the tool is allowed, delegates to `handle_tool_message` -- which a
+        subclass may override -- exactly as before, so the policy gates tool
+        execution even through such overrides.
+
+        When dispatch is NOT overridden and the tool has no handler, the
+        policy is not consulted (nothing can execute). When dispatch IS
+        overridden, the base cannot know what the override will do, so the
+        policy is consulted regardless, even though the override may end up
+        returning None.
+
+        Args:
+            tool: ToolMessage object representing the tool request.
+            chat_doc: Optional ChatDocument object containing the tool request.
+
+        Returns:
+            The dispatch result, or the policy's LLM-visible rejection.
+        """
+        from langroid.agent.tool_policy import (
+            check_tool_policy,
+            dispatch_overridden,
+            handler_exists,
+            policy_exempt,
+        )
+
+        if self.config.tool_policy is not None and not policy_exempt(tool):
+            if not dispatch_overridden(self, use_async=False) and not handler_exists(
+                self, tool, use_async=False
+            ):
+                # base dispatch would execute nothing; don't consult the policy
+                return None
+            rejection = check_tool_policy(self.config.tool_policy, tool, self, chat_doc)
+            if rejection is not None:
+                return rejection
+        return self.handle_tool_message(tool, chat_doc=chat_doc)
+
+    async def _handle_tool_message_with_policy_async(
+        self,
+        tool: ToolMessage,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> None | str | ChatDocument:
+        """Async version of `_handle_tool_message_with_policy`.
+
+        The policy is awaited on the CALLER's event loop (so it can use
+        loop-bound resources), then dispatch proceeds via
+        `handle_tool_message_async` -- which a subclass may override --
+        exactly as before.
+
+        Args:
+            tool: ToolMessage object representing the tool request.
+            chat_doc: Optional ChatDocument object containing the tool request.
+
+        Returns:
+            The dispatch result, or the policy's LLM-visible rejection.
+        """
+        from langroid.agent.tool_policy import (
+            check_tool_policy_async,
+            dispatch_overridden,
+            handler_exists,
+            policy_exempt,
+        )
+
+        if self.config.tool_policy is not None and not policy_exempt(tool):
+            if not dispatch_overridden(self, use_async=True) and not handler_exists(
+                self, tool, use_async=True
+            ):
+                # base dispatch would execute nothing; don't consult the policy
+                return None
+            rejection = await check_tool_policy_async(
+                self.config.tool_policy, tool, self, chat_doc
+            )
+            if rejection is not None:
+                return rejection
+        return await self.handle_tool_message_async(tool, chat_doc=chat_doc)
+
     async def handle_tool_message_async(
         self,
         tool: ToolMessage,
@@ -90174,6 +91732,12 @@ class Agent(ABC):
     ) -> None | str | ChatDocument:
         """
         Respond to a tool request from the LLM, in the form of an ToolMessage object.
+
+        NOTE: framework dispatch reaches this method through
+        `_handle_tool_message_with_policy`, which enforces the optional
+        `tool_policy` hook BEFORE delegating here; direct calls to this
+        method by user code are the caller's own seam and are not gated.
+
         Args:
             tool: ToolMessage object representing the tool request.
             chat_doc: Optional ChatDocument object containing the tool request.
@@ -90374,865 +91938,13 @@ class Agent(ABC):
         return None
 </file>
 
-<file path="langroid/language_models/model_info.py">
-import logging
-from enum import Enum
-from typing import Dict, List, Optional
-
-from pydantic import BaseModel
-
-logger = logging.getLogger(__name__)
-
-
-class ModelProvider(str, Enum):
-    """Enum for model providers"""
-
-    OPENAI = "openai"
-    ANTHROPIC = "anthropic"
-    DEEPSEEK = "deepseek"
-    GOOGLE = "google"
-    MINIMAX = "minimax"
-    UNKNOWN = "unknown"
-
-
-class ModelName(str, Enum):
-    """Parent class for all model name enums"""
-
-    pass
-
-
-class OpenAIChatModel(ModelName):
-    """Enum for OpenAI Chat models"""
-
-    GPT3_5_TURBO = "gpt-3.5-turbo"
-    GPT4 = "gpt-4o"  # avoid deprecated gpt-4
-    GPT4_TURBO = "gpt-4-turbo"
-    GPT4o = "gpt-4o"
-    GPT4o_MINI = "gpt-4o-mini"
-    O1 = "o1"
-    O1_MINI = "o1-mini"
-    O3_MINI = "o3-mini"
-    O3 = "o3"
-    O4_MINI = "o4-mini"
-    GPT4_1 = "gpt-4.1"
-    GPT4_1_MINI = "gpt-4.1-mini"
-    GPT4_1_NANO = "gpt-4.1-nano"
-    GPT5 = "gpt-5"
-    GPT5_MINI = "gpt-5-mini"
-    GPT5_NANO = "gpt-5-nano"
-    GPT5_PRO = "gpt-5-pro"
-    GPT5_1 = "gpt-5.1"
-    GPT5_1_CODEX = "gpt-5.1-codex"
-    GPT5_1_CODEX_MINI = "gpt-5.1-codex-mini"
-    GPT5_1_CHAT = "gpt-5.1-chat"
-    GPT5_2 = "gpt-5.2"
-    GPT5_2_PRO = "gpt-5.2-pro"
-    GPT5_2_CHAT = "gpt-5.2-chat"
-    GPT_OSS_120b = "gpt-oss-120b"
-    GPT_OSS_20b = "gpt-oss-20b"
-
-
-class OpenAICompletionModel(str, Enum):
-    """Enum for OpenAI Completion models"""
-
-    DAVINCI = "davinci-002"
-    BABBAGE = "babbage-002"
-
-
-class AnthropicModel(ModelName):
-    """Enum for Anthropic models"""
-
-    CLAUDE_3_OPUS = "claude-3-opus-latest"
-    CLAUDE_3_SONNET = "claude-3-sonnet-latest"
-    CLAUDE_3_HAIKU = "claude-3-haiku-latest"
-    CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest"
-    CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest"
-    CLAUDE_4_OPUS = "claude-opus-4"
-    CLAUDE_4_SONNET = "claude-sonnet-4"
-    CLAUDE_4_HAIKU = "claude-haiku-4"
-    CLAUDE_4_5_OPUS = "claude-opus-4-5"
-    CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
-    CLAUDE_4_5_HAIKU = "claude-haiku-4-5"
-
-
-class DeepSeekModel(ModelName):
-    """Enum for DeepSeek models direct from DeepSeek API"""
-
-    DEEPSEEK = "deepseek/deepseek-chat"
-    DEEPSEEK_R1 = "deepseek/deepseek-reasoner"
-    OPENROUTER_DEEPSEEK_R1 = "openrouter/deepseek/deepseek-r1"
-
-
-class GeminiModel(ModelName):
-    """Enum for Gemini models"""
-
-    GEMINI_1_5_FLASH = "gemini-1.5-flash"
-    GEMINI_1_5_FLASH_8B = "gemini-1.5-flash-8b"
-    GEMINI_1_5_PRO = "gemini-1.5-pro"
-    GEMINI_2_FLASH = "gemini-2.0-flash"
-    GEMINI_2_FLASH_LITE = "gemini-2.0-flash-lite"
-    GEMINI_2_FLASH_THINKING = "gemini-2.0-flash-thinking-exp"
-    GEMINI_2_PRO = "gemini-2.0-pro-exp-02-05"
-    GEMINI_2_5_FLASH = "gemini-2.5-flash"
-    GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
-    GEMINI_2_5_PRO = "gemini-2.5-pro"
-    GEMINI_3_FLASH = "gemini-3-flash"
-    GEMINI_3_PRO = "gemini-3-pro"
-
-
-class MiniMaxModel(ModelName):
-    """Enum for MiniMax models"""
-
-    MINIMAX_M2_7 = "MiniMax-M2.7"
-    MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
-    MINIMAX_M2_5 = "MiniMax-M2.5"
-    MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
-    MINIMAX_M2_1 = "MiniMax-M2.1"
-    MINIMAX_M2_1_HIGHSPEED = "MiniMax-M2.1-highspeed"
-    MINIMAX_M2 = "MiniMax-M2"
-
-
-class OpenAI_API_ParamInfo(BaseModel):
-    """
-    Parameters exclusive to some models, when using OpenAI API
-    """
-
-    # model-specific params at top level
-    params: Dict[str, List[str]] = dict(
-        reasoning_effort=[
-            OpenAIChatModel.O3_MINI.value,
-            OpenAIChatModel.O3.value,
-            OpenAIChatModel.O4_MINI.value,
-            OpenAIChatModel.GPT5.value,
-            OpenAIChatModel.GPT5_MINI.value,
-            OpenAIChatModel.GPT5_NANO.value,
-            OpenAIChatModel.GPT5_PRO.value,
-            OpenAIChatModel.GPT5_1.value,
-            OpenAIChatModel.GPT5_1_CODEX.value,
-            OpenAIChatModel.GPT5_1_CODEX_MINI.value,
-            OpenAIChatModel.GPT5_2.value,
-            OpenAIChatModel.GPT5_2_PRO.value,
-            OpenAIChatModel.GPT_OSS_120b.value,
-            OpenAIChatModel.GPT_OSS_20b.value,
-            GeminiModel.GEMINI_2_5_PRO.value,
-            GeminiModel.GEMINI_2_5_FLASH.value,
-            GeminiModel.GEMINI_2_5_FLASH_LITE.value,
-        ],
-    )
-    # model-specific params in extra_body
-    extra_parameters: Dict[str, List[str]] = dict(
-        include_reasoning=[
-            DeepSeekModel.OPENROUTER_DEEPSEEK_R1.value,
-        ]
-    )
-
-
-class ModelInfo(BaseModel):
-    """
-    Consolidated information about LLM, related to capacity, cost and API
-    idiosyncrasies. Reasonable defaults for all params in case there's no
-    specific info available.
-    """
-
-    name: str = "unknown"
-    provider: ModelProvider = ModelProvider.UNKNOWN
-    context_length: int = 16_000
-    max_cot_tokens: int = 0  # max chain of thought (thinking) tokens where applicable
-    max_output_tokens: int = 8192  # Maximum number of output tokens - model dependent
-    input_cost_per_million: float = 0.0  # Cost in USD per million input tokens
-    cached_cost_per_million: float = 0.0  # Cost in USD per million cached tokens
-    output_cost_per_million: float = 0.0  # Cost in USD per million output tokens
-    allows_streaming: bool = True  # Whether model supports streaming output
-    allows_system_message: bool = True  # Whether model supports system messages
-    rename_params: Dict[str, str] = {}  # Rename parameters for OpenAI API
-    unsupported_params: List[str] = []
-    has_structured_output: bool = False  # Does model API support structured output?
-    has_tools: bool = True  # Does model API support tools/function-calling?
-    needs_first_user_message: bool = False  # Does API need first msg to be from user?
-    description: Optional[str] = None
-
-
-GEMINI_CANONICAL_MODEL_NAMES = {model.value for model in GeminiModel}
-DEFAULT_MODEL_INFO = ModelInfo()
-WARNED_UNKNOWN_MODELS: set[tuple[str, ...]] = set()
-
-
-# Model information registry
-MODEL_INFO: Dict[str, ModelInfo] = {
-    # OpenAI Models
-    OpenAICompletionModel.DAVINCI.value: ModelInfo(
-        name=OpenAICompletionModel.DAVINCI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=4096,
-        max_output_tokens=4096,
-        input_cost_per_million=2.0,
-        output_cost_per_million=2.0,
-        description="Davinci-002",
-    ),
-    OpenAICompletionModel.BABBAGE.value: ModelInfo(
-        name=OpenAICompletionModel.BABBAGE.value,
-        provider=ModelProvider.OPENAI,
-        context_length=4096,
-        max_output_tokens=4096,
-        input_cost_per_million=0.40,
-        output_cost_per_million=0.40,
-        description="Babbage-002",
-    ),
-    OpenAIChatModel.GPT3_5_TURBO.value: ModelInfo(
-        name=OpenAIChatModel.GPT3_5_TURBO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=16_385,
-        max_output_tokens=4096,
-        input_cost_per_million=0.50,
-        output_cost_per_million=1.50,
-        description="GPT-3.5 Turbo",
-    ),
-    OpenAIChatModel.GPT4.value: ModelInfo(
-        name=OpenAIChatModel.GPT4.value,
-        provider=ModelProvider.OPENAI,
-        context_length=8192,
-        max_output_tokens=8192,
-        input_cost_per_million=30.0,
-        output_cost_per_million=60.0,
-        description="GPT-4 (8K context)",
-    ),
-    OpenAIChatModel.GPT4_TURBO.value: ModelInfo(
-        name=OpenAIChatModel.GPT4_TURBO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=4096,
-        input_cost_per_million=10.0,
-        output_cost_per_million=30.0,
-        description="GPT-4 Turbo",
-    ),
-    OpenAIChatModel.GPT4_1_NANO.value: ModelInfo(
-        name=OpenAIChatModel.GPT4_1_NANO.value,
-        provider=ModelProvider.OPENAI,
-        has_structured_output=True,
-        context_length=1_047_576,
-        max_output_tokens=32_768,
-        input_cost_per_million=0.10,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=0.40,
-        description="GPT-4.1",
-    ),
-    OpenAIChatModel.GPT4_1_MINI.value: ModelInfo(
-        name=OpenAIChatModel.GPT4_1_MINI.value,
-        provider=ModelProvider.OPENAI,
-        has_structured_output=True,
-        context_length=1_047_576,
-        max_output_tokens=32_768,
-        input_cost_per_million=0.40,
-        cached_cost_per_million=0.10,
-        output_cost_per_million=1.60,
-        description="GPT-4.1 Mini",
-    ),
-    OpenAIChatModel.GPT4_1.value: ModelInfo(
-        name=OpenAIChatModel.GPT4_1.value,
-        provider=ModelProvider.OPENAI,
-        has_structured_output=True,
-        context_length=1_047_576,
-        max_output_tokens=32_768,
-        input_cost_per_million=2.00,
-        cached_cost_per_million=0.50,
-        output_cost_per_million=8.00,
-        description="GPT-4.1",
-    ),
-    OpenAIChatModel.GPT4o.value: ModelInfo(
-        name=OpenAIChatModel.GPT4o.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=16_384,
-        input_cost_per_million=2.5,
-        cached_cost_per_million=1.25,
-        output_cost_per_million=10.0,
-        has_structured_output=True,
-        description="GPT-4o (128K context)",
-    ),
-    OpenAIChatModel.GPT4o_MINI.value: ModelInfo(
-        name=OpenAIChatModel.GPT4o_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=16_384,
-        input_cost_per_million=0.15,
-        cached_cost_per_million=0.075,
-        output_cost_per_million=0.60,
-        has_structured_output=True,
-        description="GPT-4o Mini",
-    ),
-    OpenAIChatModel.O1.value: ModelInfo(
-        name=OpenAIChatModel.O1.value,
-        provider=ModelProvider.OPENAI,
-        context_length=200_000,
-        max_output_tokens=100_000,
-        input_cost_per_million=15.0,
-        cached_cost_per_million=7.50,
-        output_cost_per_million=60.0,
-        allows_streaming=True,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        has_tools=False,
-        description="O1 Reasoning LM",
-    ),
-    OpenAIChatModel.O3.value: ModelInfo(
-        name=OpenAIChatModel.O3.value,
-        provider=ModelProvider.OPENAI,
-        context_length=200_000,
-        max_output_tokens=100_000,
-        input_cost_per_million=2.0,
-        cached_cost_per_million=0.50,
-        output_cost_per_million=8.0,
-        allows_streaming=True,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        has_tools=False,
-        description="O1 Reasoning LM",
-    ),
-    OpenAIChatModel.O1_MINI.value: ModelInfo(
-        name=OpenAIChatModel.O1_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=65_536,
-        input_cost_per_million=1.1,
-        cached_cost_per_million=0.55,
-        output_cost_per_million=4.4,
-        allows_streaming=False,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature", "stream"],
-        has_tools=False,
-        description="O1 Mini Reasoning LM",
-    ),
-    OpenAIChatModel.O3_MINI.value: ModelInfo(
-        name=OpenAIChatModel.O3_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=200_000,
-        max_output_tokens=100_000,
-        input_cost_per_million=1.1,
-        cached_cost_per_million=0.55,
-        output_cost_per_million=4.4,
-        allows_streaming=False,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature", "stream"],
-        has_tools=False,
-        description="O3 Mini Reasoning LM",
-    ),
-    OpenAIChatModel.O4_MINI.value: ModelInfo(
-        name=OpenAIChatModel.O4_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=200_000,
-        max_output_tokens=100_000,
-        input_cost_per_million=1.10,
-        cached_cost_per_million=0.275,
-        output_cost_per_million=4.40,
-        allows_streaming=False,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature", "stream"],
-        has_tools=False,
-        description="O3 Mini Reasoning LM",
-    ),
-    OpenAIChatModel.GPT5.value: ModelInfo(
-        name=OpenAIChatModel.GPT5.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.125,
-        output_cost_per_million=10.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5",
-    ),
-    OpenAIChatModel.GPT5_MINI.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=0.25,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=2.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5 Mini",
-    ),
-    OpenAIChatModel.GPT5_NANO.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_NANO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=0.05,
-        cached_cost_per_million=0.005,
-        output_cost_per_million=0.40,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5 Nano",
-    ),
-    OpenAIChatModel.GPT5_PRO.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_PRO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=272_000,
-        input_cost_per_million=15.00,
-        cached_cost_per_million=7.50,
-        output_cost_per_million=120.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5 Pro",
-    ),
-    OpenAIChatModel.GPT5_1.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_1.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.13,
-        output_cost_per_million=10.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.1",
-    ),
-    OpenAIChatModel.GPT5_1_CODEX.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_1_CODEX.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.125,
-        output_cost_per_million=10.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.1 Codex",
-    ),
-    OpenAIChatModel.GPT5_1_CODEX_MINI.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_1_CODEX_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=0.25,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=2.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.1 Codex Mini",
-    ),
-    OpenAIChatModel.GPT5_1_CHAT.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_1_CHAT.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=16_384,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.125,
-        output_cost_per_million=10.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.1 Chat",
-    ),
-    OpenAIChatModel.GPT5_2.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_2.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=1.75,
-        cached_cost_per_million=0.175,
-        output_cost_per_million=14.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.2",
-    ),
-    OpenAIChatModel.GPT5_2_PRO.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_2_PRO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=272_000,
-        input_cost_per_million=15.00,
-        cached_cost_per_million=7.50,
-        output_cost_per_million=120.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.2 Pro",
-    ),
-    OpenAIChatModel.GPT5_2_CHAT.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_2_CHAT.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=16_384,
-        input_cost_per_million=1.75,
-        cached_cost_per_million=0.175,
-        output_cost_per_million=14.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.2 Chat",
-    ),
-    OpenAIChatModel.GPT_OSS_120b.value: ModelInfo(
-        name=OpenAIChatModel.GPT_OSS_120b.value,
-        provider=ModelProvider.OPENAI,
-        context_length=131_072,
-        max_output_tokens=65_535,
-        input_cost_per_million=0.15,
-        cached_cost_per_million=0.075,
-        output_cost_per_million=0.60,
-        has_structured_output=True,
-        description="GPT OSS 120B",
-    ),
-    OpenAIChatModel.GPT_OSS_20b.value: ModelInfo(
-        name=OpenAIChatModel.GPT_OSS_20b.value,
-        provider=ModelProvider.OPENAI,
-        context_length=131_072,
-        max_output_tokens=65_535,
-        input_cost_per_million=0.075,
-        cached_cost_per_million=0.037,
-        output_cost_per_million=0.30,
-        has_structured_output=True,
-        description="GPT OSS 20B",
-    ),
-    # Anthropic Models
-    AnthropicModel.CLAUDE_3_5_SONNET.value: ModelInfo(
-        name=AnthropicModel.CLAUDE_3_5_SONNET.value,
-        provider=ModelProvider.ANTHROPIC,
-        context_length=200_000,
-        max_output_tokens=8192,
-        input_cost_per_million=3.0,
-        cached_cost_per_million=0.30,
-        output_cost_per_million=15.0,
-        description="Claude 3.5 Sonnet",
-    ),
-    AnthropicModel.CLAUDE_3_OPUS.value: ModelInfo(
-        name=AnthropicModel.CLAUDE_3_OPUS.value,
-        provider=ModelProvider.ANTHROPIC,
-        context_length=200_000,
-        max_output_tokens=4096,
-        input_cost_per_million=15.0,
-        cached_cost_per_million=1.50,
-        output_cost_per_million=75.0,
-        description="Claude 3 Opus",
-    ),
-    AnthropicModel.CLAUDE_3_SONNET.value: ModelInfo(
-        name=AnthropicModel.CLAUDE_3_SONNET.value,
-        provider=ModelProvider.ANTHROPIC,
-        context_length=200_000,
-        max_output_tokens=4096,
-        input_cost_per_million=3.0,
-        cached_cost_per_million=0.30,
-        output_cost_per_million=15.0,
-        description="Claude 3 Sonnet",
-    ),
-    AnthropicModel.CLAUDE_3_HAIKU.value: ModelInfo(
-        name=AnthropicModel.CLAUDE_3_HAIKU.value,
-        provider=ModelProvider.ANTHROPIC,
-        context_length=200_000,
-        max_output_tokens=4096,
-        input_cost_per_million=0.25,
-        cached_cost_per_million=0.03,
-        output_cost_per_million=1.25,
-        description="Claude 3 Haiku",
-    ),
-    # DeepSeek Models
-    DeepSeekModel.DEEPSEEK.value: ModelInfo(
-        name=DeepSeekModel.DEEPSEEK.value,
-        provider=ModelProvider.DEEPSEEK,
-        context_length=64_000,
-        max_output_tokens=8_000,
-        input_cost_per_million=0.27,
-        cached_cost_per_million=0.07,
-        output_cost_per_million=1.10,
-        description="DeepSeek Chat",
-    ),
-    DeepSeekModel.DEEPSEEK_R1.value: ModelInfo(
-        name=DeepSeekModel.DEEPSEEK_R1.value,
-        provider=ModelProvider.DEEPSEEK,
-        context_length=64_000,
-        max_output_tokens=8_000,
-        input_cost_per_million=0.55,
-        cached_cost_per_million=0.14,
-        output_cost_per_million=2.19,
-        description="DeepSeek-R1 Reasoning LM",
-    ),
-    # Gemini Models
-    GeminiModel.GEMINI_2_FLASH.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_FLASH.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_056_768,
-        max_output_tokens=8192,
-        input_cost_per_million=0.10,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=0.40,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.0 Flash",
-    ),
-    GeminiModel.GEMINI_2_FLASH_LITE.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_FLASH_LITE.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_056_768,
-        max_output_tokens=8192,
-        input_cost_per_million=0.075,
-        output_cost_per_million=0.30,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.0 Flash Lite",
-    ),
-    GeminiModel.GEMINI_1_5_FLASH.value: ModelInfo(
-        name=GeminiModel.GEMINI_1_5_FLASH.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_056_768,
-        max_output_tokens=8192,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 1.5 Flash",
-    ),
-    GeminiModel.GEMINI_1_5_FLASH_8B.value: ModelInfo(
-        name=GeminiModel.GEMINI_1_5_FLASH_8B.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_000_000,
-        max_output_tokens=8192,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 1.5 Flash 8B",
-    ),
-    GeminiModel.GEMINI_1_5_PRO.value: ModelInfo(
-        name=GeminiModel.GEMINI_1_5_PRO.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=2_000_000,
-        max_output_tokens=8192,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 1.5 Pro",
-    ),
-    GeminiModel.GEMINI_2_PRO.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_PRO.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=2_000_000,
-        max_output_tokens=8192,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2 Pro Exp 02-05",
-    ),
-    GeminiModel.GEMINI_2_FLASH_THINKING.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_FLASH_THINKING.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_000_000,
-        max_output_tokens=64_000,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.0 Flash Thinking",
-    ),
-    # Gemini 2.5 Models
-    GeminiModel.GEMINI_2_5_PRO.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_5_PRO.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_048_576,
-        max_output_tokens=65_536,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.31,
-        output_cost_per_million=10.0,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.5 Pro",
-    ),
-    GeminiModel.GEMINI_2_5_FLASH.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_5_FLASH.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_048_576,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.30,
-        cached_cost_per_million=0.075,
-        output_cost_per_million=2.50,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.5 Flash",
-    ),
-    GeminiModel.GEMINI_2_5_FLASH_LITE.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_5_FLASH_LITE.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=65_536,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.10,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=0.40,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.5 Flash Lite",
-    ),
-    # Gemini 3 Models
-    GeminiModel.GEMINI_3_PRO.value: ModelInfo(
-        name=GeminiModel.GEMINI_3_PRO.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_000_000,
-        max_output_tokens=64_000,
-        input_cost_per_million=2.00,
-        cached_cost_per_million=0.20,
-        output_cost_per_million=12.00,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 3 Pro",
-    ),
-    GeminiModel.GEMINI_3_FLASH.value: ModelInfo(
-        name=GeminiModel.GEMINI_3_FLASH.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_048_576,
-        max_output_tokens=65_535,
-        input_cost_per_million=0.50,
-        cached_cost_per_million=0.05,
-        output_cost_per_million=3.00,
-        description="Gemini 3 Flash",
-    ),
-    # MiniMax Models
-    MiniMaxModel.MINIMAX_M2_7.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_7.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=131_072,
-        input_cost_per_million=0.30,
-        output_cost_per_million=1.20,
-        has_structured_output=True,
-        description="MiniMax M2.7 (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=131_072,
-        input_cost_per_million=0.15,
-        output_cost_per_million=0.60,
-        has_structured_output=True,
-        description="MiniMax M2.7 Highspeed (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_5.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_5.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.30,
-        output_cost_per_million=1.20,
-        has_structured_output=True,
-        description="MiniMax M2.5 (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.15,
-        output_cost_per_million=0.60,
-        has_structured_output=True,
-        description="MiniMax M2.5 Highspeed (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_1.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_1.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.27,
-        output_cost_per_million=0.95,
-        has_structured_output=True,
-        description="MiniMax M2.1 (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.14,
-        output_cost_per_million=0.48,
-        has_structured_output=True,
-        description="MiniMax M2.1 Highspeed (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.27,
-        output_cost_per_million=0.95,
-        has_structured_output=True,
-        description="MiniMax M2 (204K context)",
-    ),
-}
-
-
-def get_model_info(
-    model: str | ModelName,
-    fallback_models: List[str] = [],
-) -> ModelInfo:
-    """Get model information by name or enum value"""
-    # Sequence of models to try, starting with the primary model
-    models_to_try = [model] + fallback_models
-
-    # Find the first model in the sequence that has info defined using next()
-    # on a generator expression that filters out None results from _get_model_info
-    found_info = next(
-        (info for m in models_to_try if (info := _get_model_info(m)) is not None),
-        None,  # Default value if the iterator is exhausted (no valid info found)
-    )
-
-    if found_info is not None:
-        return found_info
-
-    normalized_models = _normalize_model_names(models_to_try)
-    found_info = next(
-        (
-            info
-            for normalized_model in normalized_models
-            if (info := _get_model_info(normalized_model)) is not None
-        ),
-        None,
-    )
-    if found_info is not None:
-        return found_info
-
-    _warn_unknown_model(models_to_try)
-    return ModelInfo()
-
-
-def _get_model_info(model: str | ModelName) -> ModelInfo | None:
-    if isinstance(model, str):
-        return MODEL_INFO.get(model)
-    return MODEL_INFO.get(model.value)
-
-
-def _normalize_model_names(models: List[str | ModelName]) -> List[str]:
-    normalized_models: List[str] = []
-    seen: set[str] = set()
-    for model in models:
-        normalized_model = _normalize_gemini_model_name(_model_name(model))
-        if normalized_model is None or normalized_model in seen:
-            continue
-        seen.add(normalized_model)
-        normalized_models.append(normalized_model)
-    return normalized_models
-
-
-def _normalize_gemini_model_name(model: str) -> str | None:
-    base_model = model.rsplit("/", 1)[-1]
-    if base_model in GEMINI_CANONICAL_MODEL_NAMES:
-        return base_model
-    if not base_model.startswith("gemini-"):
-        return None
-
-    # Try stripping known suffixes to find a canonical name.
-    # Use split (not endswith) for "-preview" so dated variants like
-    # "gemini-2.5-flash-lite-preview-06-17" are handled correctly.
-    for suffix in ("-preview", "-exp", "-experimental", "-latest"):
-        stripped = base_model.split(suffix, maxsplit=1)[0]
-        if stripped != base_model and stripped in GEMINI_CANONICAL_MODEL_NAMES:
-            return stripped
-    return None
-
-
-def _warn_unknown_model(models: List[str | ModelName]) -> None:
-    model_names = tuple(_model_name(model) for model in models)
-    if model_names in WARNED_UNKNOWN_MODELS:
-        return
-
-    WARNED_UNKNOWN_MODELS.add(model_names)
-    logger.warning(
-        "Unknown model info for %s; using fallback defaults "
-        "(context_length=%s, max_output_tokens=%s). "
-        "Context-length checks may be inaccurate. "
-        "Set `chat_context_length` explicitly if needed.",
-        ", ".join(model_names),
-        DEFAULT_MODEL_INFO.context_length,
-        DEFAULT_MODEL_INFO.max_output_tokens,
-    )
-
-
-def _model_name(model: str | ModelName) -> str:
-    if isinstance(model, str):
-        return model
-    return model.value
+<file path=".pre-commit-config.yaml">
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.16.4
+  hooks:
+    - id: ruff
 </file>
 
 <file path="mkdocs.yml">
@@ -91358,6 +92070,7 @@ nav:
       - None Content in LLM Messages: notes/llm-none-content.md
       - Weaviate: notes/weaviate.md
       - Handling LLM Non-Tool Messages: notes/handle-llm-no-tool.md
+      - Tool Policy Hook: notes/tool-policy-hook.md
       - PGVector: notes/pgvector.md
       - Pinecone: notes/pinecone.md
       - Tavily Search Tool: notes/tavily_search.md
@@ -91426,15 +92139,6 @@ markdown_extensions:
 extra_javascript:
   - javascripts/mathjax.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
-</file>
-
-<file path=".pre-commit-config.yaml">
-repos:
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.16.0
-  hooks:
-    - id: ruff
 </file>
 
 <file path="langroid/language_models/openai_gpt.py">

--- a/llms.txt
+++ b/llms.txt
@@ -147,6 +147,7 @@ docs/
     task-tool.md
     tavily_search.md
     tool-message-handler.md
+    tool-policy-hook.md
     twitter-search.md
     url_loader.md
     weaviate.md
@@ -252,6 +253,7 @@ examples/
     text-to-structured.py
     tool-custom-handler.py
     tool-extract-short-example.py
+    tool-policy-hook.py
     xml_tool.py
   chainlit/
     non-callback/
@@ -518,6 +520,7 @@ langroid/
     openai_assistant.py
     task.py
     tool_message.py
+    tool_policy.py
     xml_tool_message.py
   cachedb/
     __init__.py
@@ -770,6 +773,7 @@ tests/
     test_tool_messages.py
     test_tool_orchestration.py
     test_tool_origin_taint.py
+    test_tool_policy_hook.py
     test_tool_taint_laundering.py
     test_url_loader.py
     test_vector_stores.py
@@ -80441,6 +80445,159 @@ python3 examples/basic/chat-search-seltz.py
 ---
 </file>
 
+<file path="docs/notes/tool-policy-hook.md">
+# Pre-execution Tool Policy Hook
+
+When Langroid agents are embedded in larger systems, operators often need a
+central place to decide whether a tool call the LLM just made should actually
+run: authorization checks, human-approval gates, DLP scanning, command
+policies, budget limits, and so on. The `AgentConfig.tool_policy` hook
+provides the smallest possible interception point for this: a single optional
+callback, consulted immediately before the selected tool handler executes.
+No policy engine, rules, or registries live in Langroid itself — you plug in
+whatever external engine you like.
+
+## API
+
+```python
+import langroid as lr
+
+class RunCommandTool(lr.ToolMessage):
+    request: str = "run_command"
+    purpose: str = "To run a shell <command>"
+    command: str
+
+def my_policy(tool: lr.ToolMessage, agent: lr.Agent) -> bool | str | None:
+    if isinstance(tool, RunCommandTool) and "rm" in tool.command:
+        return "destructive commands are not allowed"
+    return True  # allow
+
+config = lr.ChatAgentConfig(
+    # ... other params ...
+    tool_policy=my_policy,
+)
+```
+
+The callback is invoked as `tool_policy(tool, agent)` — or as
+`tool_policy(tool, agent, chat_doc=...)` if the callable's signature has a
+`chat_doc` parameter (mirroring the convention for tool handlers). It
+receives:
+
+- `tool`: the final parsed `ToolMessage` instance about to be handled — its
+  `request` field is the tool name, and its other fields are the fully
+  validated arguments
+- `agent`: the agent that is about to run the handler
+- `chat_doc` (optional): the `ChatDocument` containing the tool call, when
+  available
+
+The return value decides what happens:
+
+- `True` or `None` — allow: the selected handler runs exactly once, as usual
+- `False` — reject: the handler is NOT run; the LLM receives a rejection
+  message naming the tool
+- a `str` — reject, with that string included as the reason in the
+  LLM-visible rejection message
+
+The hook cannot modify the tool: argument transformation is deliberately out
+of scope, and the hook receives deep copies of both the `ToolMessage` and
+the `chat_doc`, so any mutation it makes has no effect on what the handler
+sees. It only decides allow vs. reject. It is consulted only when a real
+handler has been selected: a tool with no handler returns `None` as before,
+without the policy being called.
+
+The policy is enforced at the framework's dispatch call sites, ABOVE
+`Agent.handle_tool_message` / `handle_tool_message_async` — so it gates
+tool execution even when a subclass overrides those methods. Three
+consequences of that placement:
+
+- when dispatch IS overridden, the framework cannot know whether the
+  override will execute anything, so the policy is consulted even if the
+  override ends up returning `None` (the no-handler shortcut applies only
+  to un-overridden dispatch)
+- direct calls that YOUR code makes to `agent.handle_tool_message(...)`
+  are your own seam and are not gated by the hook
+- the strict-recovery `AnyTool` wrapper is a parsing shim, not a tool
+  execution, so it is exempt from the hook; the recovered actual tool is
+  policy-checked exactly once when dispatched
+
+## Failure semantics: fail-closed
+
+If the policy callback itself raises an exception, the tool is treated as
+rejected — the handler does not run. This is deliberate: a broken policy
+must never silently become a bypassed policy.
+
+The rejection message sent back to the LLM includes only the tool name and
+the exception's class name — never the exception message or the tool's
+arguments, since either could leak payload contents into the conversation.
+The full exception is logged (via the `langroid.agent.tool_policy` logger)
+for the operator. Similarly, a decision value of an unrecognized type (anything other
+than `True`, `False`, `None`, or `str`) is treated as a rejection rather
+than an allow.
+
+## Sync and async
+
+The hook works on both dispatch paths, with both kinds of callables:
+
+- a sync callback works with both `handle_message` (sync dispatch) and
+  `handle_message_async` (async dispatch)
+- an async callback is awaited on the caller's event loop everywhere on the
+  async path — including when the tool only has a sync handler — so it may
+  safely use loop-bound resources (locks, clients, futures). On the sync
+  path it is run to completion via `asyncio.run()` — or, when an event loop
+  is already running in the calling thread (e.g. sync dispatch invoked from
+  inside async code), on a fresh event loop in a helper thread. Any failure
+  while doing so is handled fail-closed like any other hook error.
+
+On each dispatch, the policy is consulted exactly once per tool call,
+including when async dispatch falls back to a tool's sync handler.
+
+## What the hook does NOT change
+
+- With no `tool_policy` configured (the default), behavior is exactly as
+  before — the hook adds negligible overhead (a None check per dispatch)
+  and no semantic change.
+- The USER-origin tool security filter (see
+  [Code-Injection Protection](code-injection-protection.md) and
+  GHSA-gjgq-w2m6-wr5q) runs first and is unaffected: tools vetoed by that
+  filter are never even shown to the policy, and an allow-everything policy
+  cannot resurrect them.
+- Rejections flow back into the conversation like any other tool-handling
+  result (e.g. validation errors), so the LLM sees why the call was refused
+  and can adjust.
+
+## Caveats
+
+The policy callback is trusted operator code, not a sandbox:
+
+- The deep copies guard against mutation through the `tool` and `chat_doc`
+  arguments; a policy determined to tamper could still reach live state via
+  `agent`. Don't do that — the hook's contract is allow/reject only.
+- Everywhere the framework deep-copies an agent config —
+  `ChatAgent.clone()`, `Task` construction, and batch processing — the
+  policy callable is shared by REFERENCE (exempted from the copy via a
+  pre-seeded deepcopy memo; the live config is never mutated). A stateful
+  policy (a budget counter, an approval list) is therefore consulted
+  globally across the original and all copies, and a policy holding
+  unpicklable resources (e.g. a lock) does not break copying. If you copy
+  a config through some other route (`copy.deepcopy` yourself), that copy
+  is not exempted.
+- An async policy evaluated from purely-sync dispatch that is itself
+  running inside an event loop (a rare nested case) runs on a fresh event
+  loop in a helper thread; loop-bound awaitables can fail there, which
+  blocks the tool (fail-closed) rather than bypassing it.
+- A tool payload carrying a non-copyable value (a lock, a client object)
+  prevents the pre-policy deep copy and causes a fail-closed rejection
+  even under an allow-all policy, with a distinct operator-log diagnostic
+  ("tool payload could not be copied for policy evaluation"). The remedy
+  is keeping tool fields to plain data.
+
+## Example
+
+A runnable example is in `examples/basic/tool-policy-hook.py`, showing a
+policy that blocks payments above a limit, with the LLM reacting to the
+rejection.
+</file>
+
 <file path="docs/notes/twitter-search.md">
 # Twitter Search via Xquik MCP
 
@@ -81375,6 +81532,76 @@ def main(
 
 if __name__ == "__main__":
     app()
+</file>
+
+<file path="examples/basic/tool-policy-hook.py">
+"""
+Example of the pre-execution tool policy hook (`AgentConfig.tool_policy`).
+
+A single agent has a `payment` tool. A policy callback (standing in for an
+external authorization/policy engine) rejects any payment above $100; the
+handler is then NOT run, and the LLM sees a rejection naming the tool and
+the reason, so it can react (here, by telling the user).
+
+See docs/notes/tool-policy-hook.md for the full semantics (allow / reject /
+fail-closed on policy errors, sync + async support).
+
+Run like this, optionally specifying an LLM:
+
+python3 examples/basic/tool-policy-hook.py
+
+or
+
+python3 examples/basic/tool-policy-hook.py -m ollama/mistral:7b-instruct-v0.2-q8_0
+"""
+
+from fire import Fire
+
+import langroid as lr
+import langroid.language_models as lm
+
+
+class PaymentTool(lr.agent.ToolMessage):
+    request: str = "payment"
+    purpose: str = "To pay <amount> dollars to <payee>."
+    amount: float
+    payee: str
+
+    def handle(self) -> str:
+        # In real life this would call a payment API
+        return f"Paid ${self.amount:.2f} to {self.payee}."
+
+
+def payment_policy(tool: lr.ToolMessage, agent: lr.Agent) -> bool | str:
+    """Reject payments above $100; allow everything else."""
+    if isinstance(tool, PaymentTool) and tool.amount > 100:
+        return "payments above $100 require manager approval"
+    return True
+
+
+def main(model: str = "") -> None:
+    agent = lr.ChatAgent(
+        lr.ChatAgentConfig(
+            name="Payer",
+            llm=lm.OpenAIGPTConfig(chat_model=model or lm.OpenAIChatModel.GPT4o),
+            system_message="""
+            You help the user make payments, using the `payment` tool.
+            If a payment is blocked by policy, apologize to the user and
+            state the reason; do NOT retry the same payment.
+            """,
+            tool_policy=payment_policy,
+            handle_llm_no_tool="user",  # fwd to user when LLM sends non-tool msg
+        )
+    )
+    agent.enable_message(PaymentTool)
+    task = lr.Task(agent, interactive=True)
+    # Try asking: "pay $50 to Alice" (allowed),
+    # then: "pay $500 to Bob" (blocked by policy; LLM sees the reason)
+    task.run("Ask me what payment I'd like to make.")
+
+
+if __name__ == "__main__":
+    Fire(main)
 </file>
 
 <file path="examples/mcp/xquik-twitter-search.py">
@@ -86682,596 +86909,6 @@ class SeltzSearchTool(ToolMessage):
         ]
 </file>
 
-<file path="langroid/agent/batch.py">
-import asyncio
-import copy
-import inspect
-import warnings
-from enum import Enum
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    Iterable,
-    List,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-)
-
-from dotenv import load_dotenv
-
-from langroid.agent.base import Agent
-from langroid.agent.chat_document import ChatDocument
-from langroid.agent.task import Task
-from langroid.parsing.utils import batched
-from langroid.utils.configuration import quiet_mode
-from langroid.utils.logging import setup_colored_logging
-from langroid.utils.output import SuppressLoggerWarnings, status
-
-setup_colored_logging()
-
-load_dotenv()
-
-T = TypeVar("T")
-U = TypeVar("U")
-
-
-class ExceptionHandling(str, Enum):
-    """Enum for exception handling options."""
-
-    RAISE = "raise"
-    RETURN_NONE = "return_none"
-    RETURN_EXCEPTION = "return_exception"
-
-
-def _convert_exception_handling(
-    handle_exceptions: Union[bool, ExceptionHandling]
-) -> ExceptionHandling:
-    """Convert legacy boolean handle_exceptions to ExceptionHandling enum."""
-    if isinstance(handle_exceptions, ExceptionHandling):
-        return handle_exceptions
-
-    if isinstance(handle_exceptions, bool):
-        warnings.warn(
-            "Boolean handle_exceptions is deprecated. "
-            "Use ExceptionHandling enum instead: "
-            "RAISE, RETURN_NONE, or RETURN_EXCEPTION.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return (
-            ExceptionHandling.RETURN_NONE
-            if handle_exceptions
-            else ExceptionHandling.RAISE
-        )
-
-    raise TypeError(
-        "handle_exceptions must be bool or ExceptionHandling, "
-        f"not {type(handle_exceptions)}"
-    )
-
-
-async def _process_batch_async(
-    inputs: Iterable[str | ChatDocument],
-    do_task: Callable[[str | ChatDocument, int], Coroutine[Any, Any, Any]],
-    start_idx: int = 0,
-    stop_on_first_result: bool = False,
-    sequential: bool = False,
-    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
-    output_map: Callable[[Any], Any] = lambda x: x,
-) -> List[Optional[ChatDocument] | BaseException]:
-    """
-    Unified batch processing logic for both agent methods and tasks.
-
-    Args:
-        inputs: Iterable of inputs to process
-        do_task: Task execution function that takes (input, index) and returns result
-        start_idx: Starting index for the batch
-        stop_on_first_result: Whether to stop after first valid result
-        sequential: Whether to process sequentially
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        output_map: Function to map results to final output format
-    """
-    exception_handling = _convert_exception_handling(handle_exceptions)
-
-    def handle_error(e: BaseException) -> Any:
-        """Handle exceptions based on exception_handling."""
-        match exception_handling:
-            case ExceptionHandling.RAISE:
-                raise e
-            case ExceptionHandling.RETURN_NONE:
-                return None
-            case ExceptionHandling.RETURN_EXCEPTION:
-                return e
-
-    if stop_on_first_result:
-        results: List[Optional[ChatDocument] | BaseException] = []
-        pending: set[asyncio.Task[Any]] = set()
-        # Create task-to-index mapping
-        task_indices: dict[asyncio.Task[Any], int] = {}
-        try:
-            tasks = [
-                asyncio.create_task(do_task(input, i + start_idx))
-                for i, input in enumerate(inputs)
-            ]
-            task_indices = {task: i for i, task in enumerate(tasks)}
-            results = [None] * len(tasks)
-
-            pending = set(tasks)
-            while pending:
-                done, pending = await asyncio.wait(
-                    pending, return_when=asyncio.FIRST_COMPLETED
-                )
-
-                # Process completed tasks
-                for task in done:
-                    index = task_indices[task]
-                    try:
-                        result = await task
-                        results[index] = output_map(result)
-                    except BaseException as e:
-                        results[index] = handle_error(e)
-
-                if any(r is not None for r in results):
-                    return results
-        finally:
-            for task in pending:
-                task.cancel()
-            try:
-                await asyncio.gather(*pending, return_exceptions=True)
-            except BaseException as e:
-                handle_error(e)
-        return results
-
-    elif sequential:
-        results = []
-        for i, input in enumerate(inputs):
-            try:
-                result = await do_task(input, i + start_idx)
-                results.append(output_map(result))
-            except BaseException as e:
-                results.append(handle_error(e))
-        return results
-
-    # Parallel execution
-    else:
-        try:
-            return_exceptions = exception_handling != ExceptionHandling.RAISE
-            with quiet_mode(), SuppressLoggerWarnings():
-                results_with_exceptions = cast(
-                    list[Optional[ChatDocument | BaseException]],
-                    await asyncio.gather(
-                        *(
-                            do_task(input, i + start_idx)
-                            for i, input in enumerate(inputs)
-                        ),
-                        return_exceptions=return_exceptions,
-                    ),
-                )
-
-                if exception_handling == ExceptionHandling.RETURN_NONE:
-                    results = [
-                        None if isinstance(r, BaseException) else r
-                        for r in results_with_exceptions
-                    ]
-                else:  # ExceptionHandling.RETURN_EXCEPTION
-                    results = results_with_exceptions
-        except BaseException as e:
-            results = [handle_error(e) for _ in inputs]
-
-        return [output_map(r) for r in results]
-
-
-def run_batched_tasks(
-    inputs: List[str | ChatDocument],
-    do_task: Callable[[str | ChatDocument, int], Coroutine[Any, Any, Any]],
-    batch_size: Optional[int],
-    stop_on_first_result: bool,
-    sequential: bool,
-    handle_exceptions: Union[bool, ExceptionHandling],
-    output_map: Callable[[Any], Any],
-    message_template: str,
-    message: Optional[str] = None,
-) -> List[Any]:
-    """
-    Common batch processing logic for both agent methods and tasks.
-
-    Args:
-        inputs: List of inputs to process
-        do_task: Task execution function
-        batch_size: Size of batches, if None process all at once
-        stop_on_first_result: Whether to stop after first valid result
-        sequential: Whether to process sequentially
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        output_map: Function to map results
-        message_template: Template for status message
-        message: Optional override for status message
-    """
-
-    async def run_all_batched_tasks(
-        inputs: List[str | ChatDocument],
-        batch_size: int | None,
-    ) -> List[Any]:
-        """Extra wrap to run asyncio.run one single time and not once per loop
-
-        Args:
-            inputs (List[str  |  ChatDocument]): inputs to process
-            batch_size (int | None): batch size
-
-        Returns:
-            List[Any]: results
-        """
-        results: List[Any] = []
-        if batch_size is None:
-            msg = message or message_template.format(total=len(inputs))
-            with status(msg), SuppressLoggerWarnings():
-                results = await _process_batch_async(
-                    inputs,
-                    do_task,
-                    stop_on_first_result=stop_on_first_result,
-                    sequential=sequential,
-                    handle_exceptions=handle_exceptions,
-                    output_map=output_map,
-                )
-        else:
-            batches = batched(inputs, batch_size)
-            for batch in batches:
-                start_idx = len(results)
-                complete_str = f", {start_idx} complete" if start_idx > 0 else ""
-                msg = (
-                    message or message_template.format(total=len(inputs)) + complete_str
-                )
-
-                if stop_on_first_result and any(r is not None for r in results):
-                    results.extend([None] * len(batch))
-                else:
-                    with status(msg), SuppressLoggerWarnings():
-                        results.extend(
-                            await _process_batch_async(
-                                batch,
-                                do_task,
-                                start_idx=start_idx,
-                                stop_on_first_result=stop_on_first_result,
-                                sequential=sequential,
-                                handle_exceptions=handle_exceptions,
-                                output_map=output_map,
-                            )
-                        )
-        return results
-
-    return asyncio.run(run_all_batched_tasks(inputs, batch_size))
-
-
-def run_batch_task_gen(
-    gen_task: Callable[[int], Task],
-    items: list[T],
-    input_map: Callable[[T], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
-    stop_on_first_result: bool = False,
-    sequential: bool = True,
-    batch_size: Optional[int] = None,
-    turns: int = -1,
-    message: Optional[str] = None,
-    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
-    max_cost: float = 0.0,
-    max_tokens: int = 0,
-) -> list[Optional[U]]:
-    """
-    Generate and run copies of a task async/concurrently one per item in `items` list.
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-    Args:
-        gen_task (Callable[[int], Task]): generates the tasks to run
-        items (list[T]): list of items to process
-        input_map (Callable[[T], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], U]): function to map result
-            to final result. If stop_on_first_result is enabled, then
-            map any invalid output to None. We continue until some non-None
-            result is obtained.
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None) result. Successful results are evaluated after
-            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
-            exception object is itself non-None and also stops the batch.
-            Processing continues past None results; once a non-None result
-            appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        batch_size (Optional[int]): The number of tasks to run at a time,
-            if None, unbatched
-        turns (int): number of turns to run, -1 for infinite
-        message (Optional[str]): optionally overrides the console status messages
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
-        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
-
-
-    Returns:
-        list[Optional[U]]: list of final results. Always list[U] if
-        `stop_on_first_result` is disabled
-    """
-    inputs = [input_map(item) for item in items]
-
-    async def _do_task(
-        input: str | ChatDocument,
-        i: int,
-    ) -> BaseException | Optional[ChatDocument] | tuple[int, Optional[ChatDocument]]:
-        task_i = gen_task(i)
-        if task_i.agent.llm is not None:
-            task_i.agent.llm.set_stream(False)
-        task_i.agent.config.show_stats = False
-
-        try:
-            result = await task_i.run_async(
-                input, turns=turns, max_cost=max_cost, max_tokens=max_tokens
-            )
-        except asyncio.CancelledError as e:
-            task_i.kill()
-            # exception will be handled by the caller
-            raise e
-        # ----------------------------------------
-        # Propagate any exception stored on the task that may have been
-        # swallowed inside `Task.run_async`, so that the upper-level
-        # exception-handling logic works as expected.
-        for attr in ("_exception", "last_exception", "exception"):
-            exc = getattr(task_i, attr, None)
-            if isinstance(exc, BaseException):
-                raise exc
-        # Fallback: treat a KILL-status result as an error
-        if (
-            isinstance(result, ChatDocument)
-            and getattr(result, "status", None) is not None
-            and str(getattr(result, "status")) == "StatusCode.KILL"
-        ):
-            raise RuntimeError(str(result.content))
-        return result
-
-    return run_batched_tasks(
-        inputs=inputs,
-        do_task=_do_task,
-        batch_size=batch_size,
-        stop_on_first_result=stop_on_first_result,
-        sequential=sequential,
-        handle_exceptions=handle_exceptions,
-        output_map=output_map,
-        message_template="[bold green]Running {total} tasks:",
-        message=message,
-    )
-
-
-def run_batch_tasks(
-    task: Task,
-    items: list[T],
-    input_map: Callable[[T], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
-    stop_on_first_result: bool = False,
-    sequential: bool = True,
-    batch_size: Optional[int] = None,
-    turns: int = -1,
-    max_cost: float = 0.0,
-    max_tokens: int = 0,
-) -> List[Optional[U]]:
-    """
-    Run copies of `task` async/concurrently one per item in `items` list.
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-    Args:
-        task (Task): task to run
-        items (list[T]): list of items to process
-        input_map (Callable[[T], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], U]): function to map result
-            to final result
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None, after `output_map`) result. Processing continues past
-            None-mapped results; exceptions propagate, since this function
-            always uses the default `RAISE` exception handling. Once a non-None
-            result appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        batch_size (Optional[int]): The number of tasks to run at a time,
-            if None, unbatched
-        turns (int): number of turns to run, -1 for infinite
-        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
-        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
-
-    Returns:
-        list[Optional[U]]: list of final results. Always list[U] if
-        `stop_on_first_result` is disabled
-    """
-    message = f"[bold green]Running {len(items)} copies of {task.name}..."
-    return run_batch_task_gen(
-        lambda i: task.clone(i),
-        items,
-        input_map,
-        output_map,
-        stop_on_first_result,
-        sequential,
-        batch_size,
-        turns,
-        message,
-        max_cost=max_cost,
-        max_tokens=max_tokens,
-    )
-
-
-def run_batch_agent_method(
-    agent: Agent,
-    method: Callable[
-        [str | ChatDocument | None], Coroutine[Any, Any, ChatDocument | None]
-    ],
-    items: List[Any],
-    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
-    sequential: bool = True,
-    stop_on_first_result: bool = False,
-    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
-    batch_size: Optional[int] = None,
-) -> List[Any]:
-    """
-    Run the `method` on copies of `agent`, async/concurrently one per
-    item in `items` list.
-    ASSUMPTION: The `method` is an async method and has signature:
-        method(self, input: str|ChatDocument|None) -> ChatDocument|None
-    So this would typically be used for the agent's "responder" methods,
-    e.g. `llm_response_async` or `agent_responder_async`.
-
-    For each item, apply `input_map` to get the initial message to process.
-    For each result, apply `output_map` to get the final result.
-
-    Args:
-        agent (Agent): agent whose method to run
-        method (str): Async method to run on copies of `agent`.
-            The method is assumed to have signature:
-            `method(self, input: str|ChatDocument|None) -> ChatDocument|None`
-        input_map (Callable[[Any], str|ChatDocument]): function to map item to
-            initial message to process
-        output_map (Callable[[ChatDocument|str], Any]): function to map result
-            to final result
-        sequential (bool): whether to run sequentially
-            (e.g. some APIs such as ooba don't support concurrent requests)
-        stop_on_first_result (bool): whether to stop after the first valid
-            (non-None) result. Successful results are evaluated after
-            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
-            exception object is itself non-None and also stops the batch.
-            Processing continues past None results; once a non-None result
-            appears, pending tasks are cancelled and their entries in the
-            returned list are None.
-        handle_exceptions: How to handle exceptions:
-            - RAISE or False: Let exceptions propagate
-            - RETURN_NONE or True: Convert exceptions to None in results
-            - RETURN_EXCEPTION: Include exception objects in results
-            Boolean values are deprecated and will be removed in a future version.
-        batch_size (Optional[int]): The number of items to process in each batch.
-            If None, process all items at once.
-    Returns:
-        List[Any]: list of final results
-    """
-    # Check if the method is async
-    method_name = method.__name__
-    if not inspect.iscoroutinefunction(method):
-        raise ValueError(f"The method {method_name} is not async.")
-
-    inputs = [input_map(item) for item in items]
-    agent_cfg = copy.deepcopy(agent.config)
-    assert agent_cfg.llm is not None, "agent must have llm config"
-    agent_cfg.llm.stream = False
-    agent_cfg.show_stats = False
-    agent_cls = type(agent)
-    agent_name = agent_cfg.name
-
-    async def _do_task(input: str | ChatDocument, i: int) -> Any:
-        agent_cfg.name = f"{agent_cfg.name}-{i}"
-        agent_i = agent_cls(agent_cfg)
-        method_i = getattr(agent_i, method_name, None)
-        if method_i is None:
-            raise ValueError(f"Agent {agent_name} has no method {method_name}")
-        result = await method_i(input)
-        return result
-
-    return run_batched_tasks(
-        inputs=inputs,
-        do_task=_do_task,
-        batch_size=batch_size,
-        stop_on_first_result=stop_on_first_result,
-        sequential=sequential,
-        handle_exceptions=handle_exceptions,
-        output_map=output_map,
-        message_template=f"[bold green]Running {{total}} copies of {agent_name}...",
-    )
-
-
-def llm_response_batch(
-    agent: Agent,
-    items: List[Any],
-    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
-    sequential: bool = True,
-    stop_on_first_result: bool = False,
-    batch_size: Optional[int] = None,
-) -> List[Any]:
-    return run_batch_agent_method(
-        agent,
-        agent.llm_response_async,
-        items,
-        input_map=input_map,
-        output_map=output_map,
-        sequential=sequential,
-        stop_on_first_result=stop_on_first_result,
-        batch_size=batch_size,
-    )
-
-
-def agent_response_batch(
-    agent: Agent,
-    items: List[Any],
-    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
-    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
-    sequential: bool = True,
-    stop_on_first_result: bool = False,
-    batch_size: Optional[int] = None,
-) -> List[Any]:
-    return run_batch_agent_method(
-        agent,
-        agent.agent_response_async,
-        items,
-        input_map=input_map,
-        output_map=output_map,
-        sequential=sequential,
-        stop_on_first_result=stop_on_first_result,
-        batch_size=batch_size,
-    )
-
-
-def run_batch_function(
-    function: Callable[[T], U],
-    items: list[T],
-    sequential: bool = True,
-    batch_size: Optional[int] = None,
-) -> List[U]:
-    async def _do_task(item: T) -> U:
-        return function(item)
-
-    async def _do_all(items: Iterable[T]) -> List[U]:
-        if sequential:
-            results = []
-            for item in items:
-                result = await _do_task(item)
-                results.append(result)
-            return results
-
-        return await asyncio.gather(*(_do_task(item) for item in items))
-
-    results: List[U] = []
-
-    if batch_size is None:
-        with status(f"[bold green]Running {len(items)} tasks:"):
-            results = asyncio.run(_do_all(items))
-    else:
-        batches = batched(items, batch_size)
-        for batch in batches:
-            with status(f"[bold green]Running batch of {len(batch)} tasks:"):
-                results.extend(asyncio.run(_do_all(batch)))
-
-    return results
-</file>
-
 <file path="langroid/agent/tool_message.py">
 """
 Structured messages to an agent, typically from an LLM, to be handled by
@@ -87686,6 +87323,352 @@ class ToolMessage(ABC, BaseModel):
             exclude=list(cls._get_excluded_fields()),
         )
         return schema
+</file>
+
+<file path="langroid/agent/tool_policy.py">
+"""Machinery for the pre-execution tool policy hook.
+
+The public surface is the ``tool_policy`` field on
+:class:`langroid.agent.base.AgentConfig`: an optional callable consulted
+just before a parsed ``ToolMessage``'s selected handler runs, deciding
+whether the handler executes (allow) or an LLM-visible rejection is
+returned instead (reject). The functions here evaluate that hook; see
+``docs/notes/tool-policy-hook.md`` for the full semantics.
+"""
+
+import asyncio
+import copy
+import inspect
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
+
+if TYPE_CHECKING:
+    from langroid.agent.base import Agent, AgentConfig
+    from langroid.agent.chat_document import ChatDocument
+    from langroid.agent.tool_message import ToolMessage
+
+logger = logging.getLogger(__name__)
+
+C = TypeVar("C", bound="AgentConfig")
+
+
+class _PolicyCopyError(Exception):
+    """Internal marker: the tool/chat_doc could not be copied for the policy.
+
+    Distinguishes a payload-copy failure (e.g. a tool field holding a lock
+    or client object) from an exception raised by the policy itself, so the
+    operator log can say precisely which happened. Both fail closed.
+    """
+
+
+def dispatch_overridden(agent: "Agent", use_async: bool) -> bool:
+    """Whether the agent's tool-dispatch method is overridden by a subclass.
+
+    Async dispatch falls back into `handle_tool_message` when a tool has no
+    async handler, so for the async path an override of EITHER method counts.
+
+    Args:
+        agent: The agent whose dispatch is being examined.
+        use_async: True for the async dispatch path.
+
+    Returns:
+        True if a subclass overrides the relevant dispatch method(s).
+    """
+    from langroid.agent.base import Agent
+
+    if (
+        use_async
+        and type(agent).handle_tool_message_async is not Agent.handle_tool_message_async
+    ):
+        return True
+    return type(agent).handle_tool_message is not Agent.handle_tool_message
+
+
+def handler_exists(agent: "Agent", tool: "ToolMessage", use_async: bool) -> bool:
+    """Whether base dispatch would find a handler for this tool.
+
+    Args:
+        agent: The agent that would dispatch the tool.
+        tool: The parsed ToolMessage.
+        use_async: True for the async dispatch path, which looks for an
+            `<name>_async` handler first and falls back to the sync one.
+
+    Returns:
+        True if a handler method exists on the agent.
+    """
+    tool_name = tool.default_value("request")
+    if hasattr(tool, "_handler"):
+        handler_name = getattr(tool, "_handler", tool_name)
+    else:
+        handler_name = tool_name
+    if use_async and getattr(agent, handler_name + "_async", None) is not None:
+        return True
+    return getattr(agent, handler_name, None) is not None
+
+
+def policy_exempt(tool: "ToolMessage") -> bool:
+    """Whether this tool is structurally exempt from the `tool_policy` hook.
+
+    Framework-internal parsing shims declare ``_tool_policy_exempt = True``
+    on their class (e.g. the strict-recovery ``AnyTool`` wrapper): such a
+    shim is not a tool execution itself -- the actual tool it carries is
+    re-parsed and dispatched through the policy-checked path, so the policy
+    is consulted exactly once per logical tool call.
+
+    Args:
+        tool: The parsed ToolMessage about to be dispatched.
+
+    Returns:
+        True if the tool's class carries the exemption marker.
+    """
+    # SECURITY: resolve the marker on the CLASS only, never the instance.
+    # ToolMessage has ``extra="allow"``, so LLM-controlled tool JSON such
+    # as ``{"_tool_policy_exempt": true, ...}`` lands on the INSTANCE as an
+    # extra field; trusting instance attributes would let the LLM spoof the
+    # exemption and bypass the policy.
+    return getattr(type(tool), "_tool_policy_exempt", False) is True
+
+
+def deepcopy_config_sharing_policy(config: C) -> C:
+    """Deep-copy an AgentConfig, sharing `tool_policy` by REFERENCE.
+
+    A `tool_policy` hook may be stateful (budgets, approval lists) or hold
+    unpicklable resources (locks, clients), so wherever the framework
+    deep-copies an agent config (agent cloning, Task construction, batch
+    processing) the policy must be exempted from the copy: the copy and the
+    original consult the SAME policy object. The live `config` is never
+    mutated (the exemption is done by pre-seeding the deepcopy memo).
+
+    Args:
+        config: The config to copy.
+
+    Returns:
+        A deep copy of `config` whose `tool_policy` is the same object as
+        `config.tool_policy`.
+    """
+    memo: dict[int, Any] = {}
+    policy = config.tool_policy
+    if policy is not None:
+        memo[id(policy)] = policy
+    config_copy: C = copy.deepcopy(config, memo)
+    return config_copy
+
+
+def _invoke_policy(
+    policy: Callable[..., Any],
+    tool: "ToolMessage",
+    agent: "Agent",
+    chat_doc: Optional["ChatDocument"],
+) -> Any:
+    """Call the `tool_policy` hook with (tool, agent[, chat_doc]).
+
+    The `chat_doc` is passed only if the callable's signature has a
+    `chat_doc` parameter, mirroring the tool-handler convention. The hook
+    decides allow/reject only, so it receives deep COPIES of the tool and
+    the chat_doc: mutating them cannot change what the handler executes.
+
+    Args:
+        policy: The configured `tool_policy` callable.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        The policy's decision, possibly an awaitable if the policy
+        is async.
+    """
+    try:
+        has_chat_doc_param = "chat_doc" in inspect.signature(policy).parameters
+    except (ValueError, TypeError):
+        has_chat_doc_param = False
+    try:
+        tool = tool.model_copy(deep=True)
+        if has_chat_doc_param and chat_doc is not None:
+            chat_doc = copy.deepcopy(chat_doc)
+    except Exception as e:
+        raise _PolicyCopyError() from e
+    if has_chat_doc_param:
+        return policy(tool, agent, chat_doc=chat_doc)
+    return policy(tool, agent)
+
+
+def run_awaitable_sync(awaitable: Any) -> Any:
+    """Run an awaitable to completion from sync code.
+
+    Uses `asyncio.run()` when no event loop is running in this thread;
+    otherwise runs it on a fresh event loop in a helper thread, so sync
+    dispatch nested inside async code (e.g. a sync tool handler invoked
+    from async code calling back into sync dispatch) still works.
+
+    Args:
+        awaitable: The awaitable to run.
+
+    Returns:
+        The awaitable's result.
+    """
+
+    async def _await() -> Any:
+        return await awaitable
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(_await())
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(asyncio.run, _await()).result()
+
+
+def _decision_msg(tool_name: str, decision: Any) -> Optional[str]:
+    """Convert a `tool_policy` decision into an optional rejection message.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        decision: The value returned by the `tool_policy` hook.
+
+    Returns:
+        None if the tool is allowed (decision is True or None), else an
+        LLM-visible rejection message naming the tool and the reason.
+        Any decision of an unrecognized type is treated as a rejection
+        (fail-closed).
+    """
+    if decision is None or decision is True:
+        return None
+    if decision is False:
+        reason = "(no reason given)"
+    elif isinstance(decision, str):
+        reason = decision
+    else:
+        reason = (
+            f"policy returned unrecognized decision of type "
+            f"{type(decision).__name__}; failing closed"
+        )
+    return f"Tool `{tool_name}` was NOT executed: blocked by tool policy: {reason}"
+
+
+def _copy_failure_msg(tool_name: str, e: BaseException | None) -> str:
+    """Fail-closed rejection for a payload that could not be copied.
+
+    A tool field carrying a non-copyable object (a lock, a client, ...)
+    prevents the pre-policy deep copy; the tool is blocked (fail-closed),
+    with an operator-log diagnostic distinct from "the policy raised". The
+    LLM-visible message still names only the tool and the exception class.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        e: The underlying copy exception, if known.
+
+    Returns:
+        An LLM-visible rejection message.
+    """
+    exc_name = type(e).__name__ if e is not None else "Exception"
+    logger.error(
+        f"tool payload could not be copied for policy evaluation for tool "
+        f"`{tool_name}`; blocking the tool (fail-closed): "
+        f"{exc_name}: {e}"
+    )
+    return (
+        f"Tool `{tool_name}` was NOT executed: its arguments could not be "
+        f"copied for policy evaluation ({exc_name}); failing closed "
+        f"(tool blocked)."
+    )
+
+
+def _failure_msg(tool_name: str, e: Exception) -> str:
+    """Fail-closed rejection message for a `tool_policy` hook that raised.
+
+    The exception message is deliberately NOT included, since it may
+    embed raw tool arguments; only the exception class name is exposed.
+    The full exception is logged for the operator.
+
+    Args:
+        tool_name: Name (`request` value) of the tool being checked.
+        e: The exception raised by the hook.
+
+    Returns:
+        An LLM-visible rejection message.
+    """
+    logger.error(
+        f"tool_policy hook raised {type(e).__name__} while checking tool "
+        f"`{tool_name}`; blocking the tool (fail-closed): {e}"
+    )
+    return (
+        f"Tool `{tool_name}` was NOT executed: the tool policy hook "
+        f"failed with {type(e).__name__}; failing closed (tool blocked)."
+    )
+
+
+def check_tool_policy(
+    policy: Optional[Callable[..., Any]],
+    tool: "ToolMessage",
+    agent: "Agent",
+    chat_doc: Optional["ChatDocument"],
+) -> Optional[str]:
+    """Evaluate the `tool_policy` hook on the sync dispatch path.
+
+    An async policy is run to completion via `run_awaitable_sync` (which
+    works whether or not an event loop is already running in this thread);
+    any failure while doing so is treated like any other hook failure:
+    the tool is blocked (fail-closed).
+
+    Args:
+        policy: The configured `tool_policy` callable, or None.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        None if no policy is configured or the policy allows the tool,
+        else an LLM-visible rejection message.
+    """
+    if policy is None:
+        return None
+    tool_name = tool.default_value("request")
+    try:
+        decision = _invoke_policy(policy, tool, agent, chat_doc)
+        if inspect.isawaitable(decision):
+            decision = run_awaitable_sync(decision)
+    except _PolicyCopyError as ce:
+        return _copy_failure_msg(tool_name, ce.__cause__)
+    except Exception as e:
+        return _failure_msg(tool_name, e)
+    return _decision_msg(tool_name, decision)
+
+
+async def check_tool_policy_async(
+    policy: Optional[Callable[..., Any]],
+    tool: "ToolMessage",
+    agent: "Agent",
+    chat_doc: Optional["ChatDocument"],
+) -> Optional[str]:
+    """Async version of `check_tool_policy`.
+
+    An async policy is awaited on the CALLING event loop, so it may safely
+    use loop-bound resources (locks, clients, futures).
+
+    Args:
+        policy: The configured `tool_policy` callable, or None.
+        tool: The final parsed ToolMessage about to be handled.
+        agent: The agent about to run the handler.
+        chat_doc: The ChatDocument containing the tool call, if available.
+
+    Returns:
+        None if no policy is configured or the policy allows the tool,
+        else an LLM-visible rejection message.
+    """
+    if policy is None:
+        return None
+    tool_name = tool.default_value("request")
+    try:
+        decision = _invoke_policy(policy, tool, agent, chat_doc)
+        if inspect.isawaitable(decision):
+            decision = await decision
+    except _PolicyCopyError as ce:
+        return _copy_failure_msg(tool_name, ce.__cause__)
+    except Exception as e:
+        return _failure_msg(tool_name, e)
+    return _decision_msg(tool_name, decision)
 </file>
 
 <file path="langroid/language_models/__init__.py">
@@ -96962,6 +96945,171 @@ class TestSeltzSearchIntegration:
         assert len(result) > 100
 </file>
 
+<file path="tests/main/test_split_inline_reasoning.py">
+"""
+Tests for OpenAIGPT._split_inline_reasoning, which separates inline
+thought-delimiter tags (e.g. <think>...</think>) from text content
+during streaming.
+"""
+
+from langroid.language_models.openai_gpt import OpenAIGPT
+
+split = OpenAIGPT._split_inline_reasoning
+DELIMS = ("<think>", "</think>")
+
+
+class TestSplitInlineReasoning:
+    """Unit tests for the streaming inline-reasoning splitter."""
+
+    # --- no-op cases: nothing to parse ---
+
+    def test_empty_text(self):
+        """Empty event_text should pass through unchanged."""
+        text, reasoning, in_r = split("", "", False, DELIMS)
+        assert text == ""
+        assert reasoning == ""
+        assert in_r is False
+
+    def test_plain_text_no_delimiters(self):
+        """Text without any delimiters should pass through as-is."""
+        text, reasoning, in_r = split("hello world", "", False, DELIMS)
+        assert text == "hello world"
+        assert reasoning == ""
+        assert in_r is False
+
+    def test_already_has_reasoning_field(self):
+        """When the API already provides separate reasoning, skip parsing."""
+        text, reasoning, in_r = split("some text", "api reasoning", False, DELIMS)
+        assert text == "some text"
+        assert reasoning == "api reasoning"
+        assert in_r is False
+
+    # --- single chunk contains full <think>...</think> ---
+
+    def test_full_think_block_in_one_chunk(self):
+        """Complete <think>reasoning</think> in a single chunk."""
+        text, reasoning, in_r = split("<think>step 1</think>", "", False, DELIMS)
+        assert text == ""
+        assert reasoning == "step 1"
+        assert in_r is False
+
+    def test_text_before_and_after_think(self):
+        """Text surrounding a complete think block."""
+        text, reasoning, in_r = split(
+            "before<think>middle</think>after", "", False, DELIMS
+        )
+        assert text == "beforeafter"
+        assert reasoning == "middle"
+        assert in_r is False
+
+    def test_text_before_think_only(self):
+        """Text before think block, nothing after."""
+        text, reasoning, in_r = split(
+            "prefix<think>reasoning</think>", "", False, DELIMS
+        )
+        assert text == "prefix"
+        assert reasoning == "reasoning"
+        assert in_r is False
+
+    def test_text_after_think_only(self):
+        """Think block followed by text, no prefix."""
+        text, reasoning, in_r = split(
+            "<think>reasoning</think>suffix", "", False, DELIMS
+        )
+        assert text == "suffix"
+        assert reasoning == "reasoning"
+        assert in_r is False
+
+    # --- multi-chunk: start delimiter in one chunk, end in another ---
+
+    def test_start_delimiter_only(self):
+        """Chunk has <think> but no </think> — enters reasoning state."""
+        text, reasoning, in_r = split(
+            "hello<think>partial reasoning", "", False, DELIMS
+        )
+        assert text == "hello"
+        assert reasoning == "partial reasoning"
+        assert in_r is True
+
+    def test_continuation_mid_reasoning(self):
+        """Chunk arrives while already in reasoning (no delimiters)."""
+        text, reasoning, in_r = split("more reasoning stuff", "", True, DELIMS)
+        assert text == ""
+        assert reasoning == "more reasoning stuff"
+        assert in_r is True
+
+    def test_end_delimiter_while_in_reasoning(self):
+        """Chunk has </think> while in reasoning state."""
+        text, reasoning, in_r = split("final bit</think>answer", "", True, DELIMS)
+        assert text == "answer"
+        assert reasoning == "final bit"
+        assert in_r is False
+
+    def test_end_delimiter_no_trailing_text(self):
+        """End delimiter with nothing after it."""
+        text, reasoning, in_r = split("last thought</think>", "", True, DELIMS)
+        assert text == ""
+        assert reasoning == "last thought"
+        assert in_r is False
+
+    # --- multi-chunk sequence simulating a real stream ---
+
+    def test_three_chunk_sequence(self):
+        """Simulate: chunk1 opens thinking, chunk2 continues, chunk3 closes."""
+        # chunk 1: start of thinking
+        text1, reason1, in_r = split("<think>step 1", "", False, DELIMS)
+        assert text1 == ""
+        assert reason1 == "step 1"
+        assert in_r is True
+
+        # chunk 2: still thinking
+        text2, reason2, in_r = split(" step 2", "", in_r, DELIMS)
+        assert text2 == ""
+        assert reason2 == " step 2"
+        assert in_r is True
+
+        # chunk 3: done thinking, answer follows
+        text3, reason3, in_r = split(" step 3</think>The answer", "", in_r, DELIMS)
+        assert text3 == "The answer"
+        assert reason3 == " step 3"
+        assert in_r is False
+
+    # --- custom delimiters ---
+
+    def test_custom_delimiters(self):
+        """Works with non-default delimiters like <thinking>...</thinking>."""
+        custom = ("<thinking>", "</thinking>")
+        text, reasoning, in_r = split(
+            "<thinking>hmm</thinking>result", "", False, custom
+        )
+        assert text == "result"
+        assert reasoning == "hmm"
+        assert in_r is False
+
+    # --- edge cases ---
+
+    def test_empty_think_block(self):
+        """<think></think> with nothing inside."""
+        text, reasoning, in_r = split("<think></think>answer", "", False, DELIMS)
+        assert text == "answer"
+        assert reasoning == ""
+        assert in_r is False
+
+    def test_only_start_delimiter(self):
+        """Chunk is exactly the start delimiter, nothing else."""
+        text, reasoning, in_r = split("<think>", "", False, DELIMS)
+        assert text == ""
+        assert reasoning == ""
+        assert in_r is True
+
+    def test_only_end_delimiter_while_reasoning(self):
+        """Chunk is exactly the end delimiter."""
+        text, reasoning, in_r = split("</think>", "", True, DELIMS)
+        assert text == ""
+        assert reasoning == ""
+        assert in_r is False
+</file>
+
 <file path="tests/main/test_tool_messages.py">
 import itertools
 import json
@@ -99389,6 +99537,867 @@ def test_tainted_handoff_does_not_dispatch_handle_only_tool():
     legit = agent.agent_response(_handoff_doc(tainted=False))
     assert legit is not None
     assert "SECRET:pwned" in legit.content
+</file>
+
+<file path="tests/main/test_tool_policy_hook.py">
+"""
+Tests for the pre-execution tool policy hook (`AgentConfig.tool_policy`),
+issue #1095.
+
+Contract:
+
+1. No hook configured => tool dispatch behaves exactly as before (sync + async).
+2. Hook allows (returns True or None) => the selected handler runs exactly once.
+3. Hook denies (returns False or a str reason) => the handler runs zero times,
+   and an LLM-visible rejection (tool name + reason) is produced.
+4. The hook receives the final parsed ToolMessage (identity + payload) plus
+   bounded context (the agent, and the chat_doc when available), BEFORE
+   execution.
+5. Hook failure (exception) => fail-closed rejection; raw tool arguments do
+   NOT leak into the rejection message.
+6. Composes with (does not weaken) the USER-origin tool security filter.
+
+The hook must work on both sync and async dispatch paths, with both sync and
+async callables. It cannot mutate what the handler executes, it is consulted
+only when a real handler is selected, and it is shared by reference across
+agent clones.
+"""
+
+import asyncio
+import logging
+import threading
+from collections import OrderedDict
+from typing import Any, List, Optional, Tuple, Type, Union
+
+import pytest
+
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.agent.chat_document import ChatDocument
+from langroid.agent.task import Task
+from langroid.agent.tool_message import ToolMessage
+from langroid.language_models.mock_lm import MockLMConfig
+from langroid.mytypes import Entity
+
+HandleResult = Union[None, str, OrderedDict[str, str], ChatDocument]
+
+
+class SquareTool(ToolMessage):
+    request: str = "square"
+    purpose: str = "To compute the square of a number <x>"
+    x: int
+
+
+class NoHandlerTool(ToolMessage):
+    request: str = "orphan_tool"
+    purpose: str = "A tool with no handler anywhere"
+    y: int
+
+
+class CountingAgent(ChatAgent):
+    """Agent with a sync handler for SquareTool that counts invocations."""
+
+    def __init__(self, config: ChatAgentConfig):
+        super().__init__(config)
+        self.calls: int = 0
+
+    def square(self, msg: SquareTool) -> str:
+        self.calls += 1
+        return f"SQUARE_RESULT: {msg.x ** 2}"
+
+
+class CountingAsyncAgent(CountingAgent):
+    """Agent with a genuine async handler for SquareTool."""
+
+    async def square_async(self, msg: SquareTool) -> str:
+        self.calls += 1
+        return f"SQUARE_RESULT: {msg.x ** 2}"
+
+
+def mk_agent(
+    tool_policy: Any = None,
+    agent_cls: Type[CountingAgent] = CountingAgent,
+) -> CountingAgent:
+    agent = agent_cls(
+        ChatAgentConfig(
+            name="TestAgent",
+            llm=MockLMConfig(response_fn=lambda x: x),
+            tool_policy=tool_policy,
+        )
+    )
+    agent.enable_message(SquareTool)
+    return agent
+
+
+def llm_tool_msg(agent: ChatAgent, x: int = 3) -> ChatDocument:
+    """An LLM-origin ChatDocument containing a SquareTool call."""
+    return agent.create_llm_response(SquareTool(x=x).to_json())
+
+
+def result_content(result: HandleResult) -> str:
+    assert result is not None
+    return result.content if isinstance(result, ChatDocument) else str(result)
+
+
+# -------------------- contract 1: no hook => unchanged --------------------
+
+
+def test_no_policy_sync_dispatch_unchanged() -> None:
+    agent = mk_agent()
+    assert agent.config.tool_policy is None
+    result = agent.handle_message(llm_tool_msg(agent))
+    assert "SQUARE_RESULT: 9" in result_content(result)
+    assert agent.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_no_policy_async_dispatch_unchanged() -> None:
+    agent = mk_agent(agent_cls=CountingAsyncAgent)
+    result = await agent.handle_message_async(llm_tool_msg(agent))
+    assert "SQUARE_RESULT: 9" in result_content(result)
+    assert agent.calls == 1
+
+
+# -------------------- contract 2: allow => handler runs once --------------------
+
+
+@pytest.mark.parametrize("decision", [True, None])
+def test_allow_sync(decision: Optional[bool]) -> None:
+    agent = mk_agent(
+        tool_policy=lambda tool, agent: decision,
+    )
+    result = agent.handle_message(llm_tool_msg(agent, x=5))
+    assert "SQUARE_RESULT: 25" in result_content(result)
+    assert agent.calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", [True, None])
+async def test_allow_async(decision: Optional[bool]) -> None:
+    agent = mk_agent(
+        tool_policy=lambda tool, agent: decision,
+        agent_cls=CountingAsyncAgent,
+    )
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=5))
+    assert "SQUARE_RESULT: 25" in result_content(result)
+    assert agent.calls == 1
+
+
+# ---------------- contract 3: deny => zero runs, LLM-visible rejection ----------
+
+
+def test_deny_with_reason_sync() -> None:
+    agent = mk_agent(tool_policy=lambda tool, agent: "budget exceeded")
+    result = agent.handle_message(llm_tool_msg(agent, x=5))
+    content = result_content(result)
+    assert agent.calls == 0
+    assert "square" in content  # tool name
+    assert "budget exceeded" in content  # policy's reason
+    assert "SQUARE_RESULT" not in content
+
+
+def test_deny_with_false_sync() -> None:
+    agent = mk_agent(tool_policy=lambda tool, agent: False)
+    result = agent.handle_message(llm_tool_msg(agent, x=5))
+    content = result_content(result)
+    assert agent.calls == 0
+    assert "square" in content
+
+
+@pytest.mark.asyncio
+async def test_deny_with_reason_async() -> None:
+    agent = mk_agent(
+        tool_policy=lambda tool, agent: "budget exceeded",
+        agent_cls=CountingAsyncAgent,
+    )
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=5))
+    content = result_content(result)
+    assert agent.calls == 0
+    assert "square" in content
+    assert "budget exceeded" in content
+
+
+def test_deny_unrecognized_decision_fails_closed() -> None:
+    """A decision of an unrecognized type must NOT be treated as allow."""
+    agent = mk_agent(tool_policy=lambda tool, agent: 42)
+    result = agent.handle_message(llm_tool_msg(agent, x=5))
+    content = result_content(result)
+    assert agent.calls == 0
+    assert "square" in content
+
+
+# ------------- contract 4: hook sees parsed tool + bounded context -------------
+
+
+def test_policy_receives_parsed_tool_and_context() -> None:
+    seen: List[Tuple[ToolMessage, ChatAgent, Optional[ChatDocument]]] = []
+
+    def policy(
+        tool: ToolMessage,
+        agent: ChatAgent,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> bool:
+        seen.append((tool, agent, chat_doc))
+        return True
+
+    agent = mk_agent(tool_policy=policy)
+    msg = llm_tool_msg(agent, x=7)
+    agent.handle_message(msg)
+    assert len(seen) == 1
+    tool, seen_agent, chat_doc = seen[0]
+    assert isinstance(tool, SquareTool)
+    assert tool.request == "square"
+    assert tool.x == 7  # final parsed payload
+    assert seen_agent is agent
+    assert chat_doc is not None
+    assert chat_doc.content == msg.content
+    assert agent.calls == 1
+
+
+def test_policy_without_chat_doc_param() -> None:
+    """A 2-arg policy (tool, agent) is supported."""
+    seen: List[SquareTool] = []
+
+    def policy(tool: ToolMessage, agent: ChatAgent) -> bool:
+        assert isinstance(tool, SquareTool)
+        seen.append(tool)
+        return True
+
+    agent = mk_agent(tool_policy=policy)
+    agent.handle_message(llm_tool_msg(agent, x=7))
+    assert len(seen) == 1 and seen[0].x == 7
+    assert agent.calls == 1
+
+
+# ---------- contract 5: hook failure => fail-closed, no argument leak ----------
+
+
+SECRET = "31337"
+
+
+def failing_policy(tool: ToolMessage, agent: ChatAgent) -> bool:
+    # a sloppy policy that embeds tool arguments in its exception
+    assert isinstance(tool, SquareTool)
+    raise ValueError(f"policy blew up on x={tool.x}")
+
+
+def test_policy_exception_fails_closed_sync() -> None:
+    agent = mk_agent(tool_policy=failing_policy)
+    result = agent.handle_message(llm_tool_msg(agent, x=int(SECRET)))
+    content = result_content(result)
+    assert agent.calls == 0  # handler never ran
+    assert "square" in content  # tool name present
+    assert SECRET not in content  # raw tool args must not leak
+    assert "policy blew up" not in content  # nor the exception message
+
+
+@pytest.mark.asyncio
+async def test_policy_exception_fails_closed_async() -> None:
+    agent = mk_agent(
+        tool_policy=failing_policy,
+        agent_cls=CountingAsyncAgent,
+    )
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=int(SECRET)))
+    content = result_content(result)
+    assert agent.calls == 0
+    assert "square" in content
+    assert SECRET not in content
+
+
+# -------------------- sync/async callback x dispatch matrix --------------------
+
+
+@pytest.mark.parametrize("decision", [True, "denied by async policy"])
+def test_async_policy_sync_dispatch(decision: Union[bool, str]) -> None:
+    async def policy(tool: ToolMessage, agent: ChatAgent) -> Union[bool, str]:
+        return decision
+
+    agent = mk_agent(tool_policy=policy)
+    result = agent.handle_message(llm_tool_msg(agent, x=4))
+    content = result_content(result)
+    if decision is True:
+        assert "SQUARE_RESULT: 16" in content
+        assert agent.calls == 1
+    else:
+        assert agent.calls == 0
+        assert "denied by async policy" in content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", [True, "denied by async policy"])
+async def test_async_policy_async_dispatch(decision: Union[bool, str]) -> None:
+    async def policy(tool: ToolMessage, agent: ChatAgent) -> Union[bool, str]:
+        return decision
+
+    agent = mk_agent(tool_policy=policy, agent_cls=CountingAsyncAgent)
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=4))
+    content = result_content(result)
+    if decision is True:
+        assert "SQUARE_RESULT: 16" in content
+        assert agent.calls == 1
+    else:
+        assert agent.calls == 0
+        assert "denied by async policy" in content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", [True, "denied by async policy"])
+async def test_async_policy_async_dispatch_sync_handler(
+    decision: Union[bool, str],
+) -> None:
+    """Async policy + async dispatch falling back to a SYNC handler: the
+    policy must be evaluated correctly on this route too."""
+
+    async def policy(tool: ToolMessage, agent: ChatAgent) -> Union[bool, str]:
+        return decision
+
+    agent = mk_agent(tool_policy=policy)  # sync handler only
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=4))
+    content = result_content(result)
+    if decision is True:
+        assert "SQUARE_RESULT: 16" in content
+        assert agent.calls == 1
+    else:
+        assert agent.calls == 0
+        assert "denied by async policy" in content
+
+
+@pytest.mark.asyncio
+async def test_async_policy_loop_bound_state_async_dispatch_sync_handler() -> None:
+    """On the async-dispatch-to-sync-handler route, an async policy must be
+    awaited on the CALLER's event loop: a policy awaiting a Future created
+    on that loop (a loop-bound resource) must evaluate correctly rather
+    than spuriously failing closed."""
+    loop = asyncio.get_running_loop()
+    fut: "asyncio.Future[bool]" = loop.create_future()
+    loop.call_later(0.01, fut.set_result, True)
+
+    async def policy(tool: ToolMessage, agent: ChatAgent) -> bool:
+        return await fut
+
+    agent = mk_agent(tool_policy=policy)  # sync handler only
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=3))
+    assert "SQUARE_RESULT: 9" in result_content(result)
+    assert agent.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_policy_async_dispatch_sync_handler() -> None:
+    """Async dispatch falling back to a sync handler still runs the
+    policy exactly once."""
+    seen: List[ToolMessage] = []
+
+    def policy(tool: ToolMessage, agent: ChatAgent) -> bool:
+        seen.append(tool)
+        return True
+
+    agent = mk_agent(tool_policy=policy)  # sync handler only
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=3))
+    assert "SQUARE_RESULT: 9" in result_content(result)
+    assert agent.calls == 1
+    assert len(seen) == 1  # policy consulted exactly once
+
+
+# ------------------- the hook cannot mutate what executes -------------------
+
+
+def test_policy_cannot_mutate_tool() -> None:
+    """The hook sees copies of the tool AND the chat_doc: mutations through
+    either must not reach the handler (no argument transformation)."""
+
+    def policy(
+        tool: ToolMessage,
+        agent: ChatAgent,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> bool:
+        assert isinstance(tool, SquareTool)
+        tool.x = 999  # tamper via the tool param
+        assert chat_doc is not None
+        for t in chat_doc.tool_messages:  # tamper via the chat_doc route
+            if isinstance(t, SquareTool):
+                t.x = 999
+        return True
+
+    agent = mk_agent(tool_policy=policy)
+    msg = llm_tool_msg(agent, x=3)
+    result = agent.handle_message(msg)
+    assert "SQUARE_RESULT: 9" in result_content(result)  # 3**2, not 999**2
+    assert agent.calls == 1
+    # the real chat_doc's parsed tool is untouched too
+    assert all(t.x == 3 for t in msg.tool_messages if isinstance(t, SquareTool))
+
+
+# ------------- non-copyable payload => distinct fail-closed rejection -------------
+
+
+class LockCarrierTool(ToolMessage):
+    request: str = "lock_carrier"
+    purpose: str = "A tool whose payload holds a non-copyable object"
+    payload: Any = None
+
+
+class LockCarrierAgent(CountingAgent):
+    def lock_carrier(self, msg: LockCarrierTool) -> str:
+        self.calls += 1
+        return "LOCK_HANDLED"
+
+
+def test_non_copyable_payload_fails_closed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A payload the pre-policy deep copy cannot copy (here: a thread lock)
+    fails CLOSED even under an allow-all policy, with an operator-log
+    diagnostic distinct from 'the policy raised', and an LLM message naming
+    only the tool and exception class."""
+    agent = LockCarrierAgent(
+        ChatAgentConfig(
+            name="TestAgent",
+            llm=MockLMConfig(response_fn=lambda x: x),
+            tool_policy=lambda tool, agent: True,  # allow-all
+        )
+    )
+    agent.enable_message(LockCarrierTool)
+    tool = LockCarrierTool(payload=threading.Lock())
+    msg = agent.create_llm_response(content="calling tool", tool_messages=[tool])
+    with caplog.at_level(logging.ERROR, logger="langroid.agent.tool_policy"):
+        result = agent.handle_message(msg)
+    content = result_content(result)
+    assert agent.calls == 0  # handler never ran
+    assert "lock_carrier" in content
+    assert "could not be copied" in content
+    assert "TypeError" in content  # exception class only...
+    assert "_thread.lock" not in content  # ...no payload repr in LLM message
+    assert "could not be copied for policy evaluation" in caplog.text
+    assert "policy hook raised" not in caplog.text  # distinct diagnostic
+
+
+# --------------- policy consulted only when a handler exists ---------------
+
+
+def test_no_handler_policy_not_called_sync() -> None:
+    seen: List[ToolMessage] = []
+
+    def policy(tool: ToolMessage, agent: ChatAgent) -> bool:
+        seen.append(tool)
+        return True
+
+    agent = mk_agent(tool_policy=policy)
+    agent.enable_message(NoHandlerTool)
+    msg = agent.create_llm_response(NoHandlerTool(y=1).to_json())
+    assert agent.handle_message(msg) is None
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_no_handler_policy_not_called_async() -> None:
+    seen: List[ToolMessage] = []
+
+    def policy(tool: ToolMessage, agent: ChatAgent) -> bool:
+        seen.append(tool)
+        return True
+
+    agent = mk_agent(tool_policy=policy)
+    agent.enable_message(NoHandlerTool)
+    msg = agent.create_llm_response(NoHandlerTool(y=1).to_json())
+    assert await agent.handle_message_async(msg) is None
+    assert seen == []
+
+
+# ---------- policy gates dispatch even through subclass overrides ----------
+
+
+class OverridingAgent(CountingAgent):
+    """Subclass with a GENERIC handle_tool_message override, as user code
+    sometimes does (e.g. to log or wrap every tool execution)."""
+
+    def __init__(self, config: ChatAgentConfig):
+        super().__init__(config)
+        self.override_calls: int = 0
+
+    def handle_tool_message(
+        self,
+        tool: ToolMessage,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> Union[None, str, ChatDocument]:
+        self.override_calls += 1
+        if isinstance(tool, SquareTool):
+            return f"OVERRIDE_RESULT: {tool.x + 1}"
+        return super().handle_tool_message(tool, chat_doc=chat_doc)
+
+
+def test_override_gated_by_policy_sync() -> None:
+    agent = mk_agent(
+        tool_policy=lambda tool, agent: "not allowed",
+        agent_cls=OverridingAgent,
+    )
+    assert isinstance(agent, OverridingAgent)
+    result = agent.handle_message(llm_tool_msg(agent, x=3))
+    assert "blocked by tool policy" in result_content(result)
+    assert agent.override_calls == 0  # override never ran
+    assert agent.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_override_gated_by_policy_async() -> None:
+    agent = mk_agent(
+        tool_policy=lambda tool, agent: "not allowed",
+        agent_cls=OverridingAgent,
+    )
+    assert isinstance(agent, OverridingAgent)
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=3))
+    assert "blocked by tool policy" in result_content(result)
+    assert agent.override_calls == 0
+    assert agent.calls == 0
+
+
+def test_override_allowed_by_policy_sync() -> None:
+    agent = mk_agent(
+        tool_policy=lambda tool, agent: True,
+        agent_cls=OverridingAgent,
+    )
+    assert isinstance(agent, OverridingAgent)
+    result = agent.handle_message(llm_tool_msg(agent, x=3))
+    assert "OVERRIDE_RESULT: 4" in result_content(result)  # override honored
+    assert agent.override_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_override_allowed_by_policy_async() -> None:
+    agent = mk_agent(
+        tool_policy=lambda tool, agent: True,
+        agent_cls=OverridingAgent,
+    )
+    assert isinstance(agent, OverridingAgent)
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=3))
+    assert "OVERRIDE_RESULT: 4" in result_content(result)
+    assert agent.override_calls == 1
+
+
+def test_override_no_policy_unchanged_sync() -> None:
+    agent = mk_agent(agent_cls=OverridingAgent)
+    assert isinstance(agent, OverridingAgent)
+    result = agent.handle_message(llm_tool_msg(agent, x=3))
+    assert "OVERRIDE_RESULT: 4" in result_content(result)
+    assert agent.override_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_override_no_policy_unchanged_async() -> None:
+    agent = mk_agent(agent_cls=OverridingAgent)
+    assert isinstance(agent, OverridingAgent)
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=3))
+    assert "OVERRIDE_RESULT: 4" in result_content(result)
+    assert agent.override_calls == 1
+
+
+# ------------------- policy shared by reference across clones -------------------
+
+
+class BudgetPolicy:
+    """Stateful one-use budget: only the first tool call (across ALL agents
+    sharing this policy object) is allowed."""
+
+    def __init__(self) -> None:
+        self.used: int = 0
+
+    def __call__(self, tool: ToolMessage, agent: ChatAgent) -> bool:
+        self.used += 1
+        return self.used <= 1
+
+
+def test_policy_state_shared_across_clones() -> None:
+    budget = BudgetPolicy()
+    agent = mk_agent(tool_policy=budget)
+    clone = agent.clone(1)
+    assert isinstance(clone, CountingAgent)
+    assert clone.config.tool_policy is budget  # shared by reference
+
+    r1 = agent.handle_message(llm_tool_msg(agent, x=2))
+    assert "SQUARE_RESULT: 4" in result_content(r1)
+    assert agent.calls == 1
+
+    # the clone consults the SAME budget, which is now exhausted
+    r2 = clone.handle_message(llm_tool_msg(clone, x=3))
+    assert "blocked by tool policy" in result_content(r2)
+    assert clone.calls == 0
+    assert budget.used == 2
+
+
+def test_policy_shared_across_task_wrapped_clone() -> None:
+    """Task construction deep-copies the agent's config; the policy must
+    stay shared by reference so budget state is enforced globally."""
+    budget = BudgetPolicy()
+    agent = mk_agent(tool_policy=budget)
+    clone = agent.clone(1)
+    assert isinstance(clone, CountingAgent)
+    Task(clone, interactive=False)  # triggers the config copy in Task.__init__
+    assert clone.config.tool_policy is budget  # still shared, not forked
+
+    r1 = agent.handle_message(llm_tool_msg(agent, x=2))
+    assert "SQUARE_RESULT: 4" in result_content(r1)
+    r2 = clone.handle_message(llm_tool_msg(clone, x=3))
+    assert "blocked by tool policy" in result_content(r2)
+    assert clone.calls == 0
+    assert budget.used == 2
+
+
+_POLICY_SETS: List[Any] = []
+
+
+class SetRecordingConfig(ChatAgentConfig):
+    """Records every post-construction assignment to `tool_policy`."""
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "tool_policy":
+            _POLICY_SETS.append(value)
+        super().__setattr__(name, value)
+
+
+def test_clone_never_mutates_live_policy() -> None:
+    """Structural (not timing) check: clone() must never mutate the live
+    config's tool_policy -- in particular never set it to None mid-copy,
+    which a concurrent dispatch could otherwise observe."""
+    budget = BudgetPolicy()
+    cfg = SetRecordingConfig(
+        name="TestAgent",
+        llm=MockLMConfig(response_fn=lambda x: x),
+        tool_policy=budget,
+    )
+    agent = CountingAgent(cfg)
+    agent.enable_message(SquareTool)
+    _POLICY_SETS.clear()
+    before = agent.config.tool_policy
+    clone = agent.clone(1)
+    assert agent.config.tool_policy is before
+    assert before is budget
+    assert _POLICY_SETS == []  # no code path assigned tool_policy on the live cfg
+    assert clone.config.tool_policy is budget
+
+
+class LockingPolicy:
+    """Policy object holding an unpicklable resource (a thread lock)."""
+
+    def __init__(self) -> None:
+        self.lock: threading.Lock = threading.Lock()
+
+    def __call__(self, tool: ToolMessage, agent: ChatAgent) -> bool:
+        with self.lock:
+            return True
+
+    def __deepcopy__(self, memo: Any) -> "LockingPolicy":
+        raise TypeError("cannot deepcopy LockingPolicy (holds a lock)")
+
+
+def test_clone_with_unpicklable_policy() -> None:
+    policy = LockingPolicy()
+    agent = mk_agent(tool_policy=policy)
+    clone = agent.clone(1)  # must not raise
+    assert clone.config.tool_policy is policy
+    result = clone.handle_message(llm_tool_msg(clone, x=2))
+    assert "SQUARE_RESULT: 4" in result_content(result)
+
+
+# --------- strict-recovery AnyTool shim: exempt; inner tool checked once ---------
+
+
+def _strict_recovery_wrapper(agent: CountingAgent, x: int) -> ToolMessage:
+    """Enable strict recovery's AnyTool on `agent` (as the recovery code
+    does) and return a wrapper instance carrying a SquareTool call."""
+    any_tool_class = agent._get_any_tool_message()
+    assert any_tool_class is not None
+    agent.set_output_format(
+        any_tool_class,
+        force_tools=True,
+        use=True,
+        handle=True,
+        instructions=True,
+    )
+    assert agent.output_format is not None  # strict mode is on
+    # the dynamic AnyTool class defaults `request`/`purpose`, which mypy
+    # cannot see through type[ToolMessage]
+    return any_tool_class(tool=SquareTool(x=x))  # type: ignore[call-arg]
+
+
+def test_strict_recovery_policy_consulted_once() -> None:
+    """The AnyTool wrapper is a parsing shim, not a tool execution: a
+    one-use budget must be consumed only by the INNER re-parsed tool."""
+    budget = BudgetPolicy()
+    agent = mk_agent(tool_policy=budget)
+    wrapper = _strict_recovery_wrapper(agent, x=5)
+    result = agent.handle_message(agent.create_llm_response(wrapper.to_json()))
+    assert "SQUARE_RESULT: 25" in result_content(result)
+    assert agent.calls == 1
+    assert budget.used == 1  # consulted exactly once, on the real tool
+    assert agent.output_format is None  # recovery reset strict mode
+
+
+@pytest.mark.asyncio
+async def test_strict_recovery_policy_consulted_once_async() -> None:
+    budget = BudgetPolicy()
+    agent = mk_agent(tool_policy=budget)
+    wrapper = _strict_recovery_wrapper(agent, x=5)
+    result = await agent.handle_message_async(
+        agent.create_llm_response(wrapper.to_json())
+    )
+    assert "SQUARE_RESULT: 25" in result_content(result)
+    assert agent.calls == 1
+    assert budget.used == 1
+    assert agent.output_format is None
+
+
+def test_strict_recovery_denied_inner_tool() -> None:
+    """A deny-all policy blocks the INNER tool (normal rejection), but the
+    shim itself must still run so strict mode is reset."""
+    agent = mk_agent(tool_policy=lambda tool, agent: "no tools allowed")
+    wrapper = _strict_recovery_wrapper(agent, x=5)
+    result = agent.handle_message(agent.create_llm_response(wrapper.to_json()))
+    content = result_content(result)
+    assert agent.calls == 0
+    assert "blocked by tool policy" in content
+    assert "square" in content
+    assert agent.output_format is None  # set_output_format(None) still ran
+
+
+def _chat_doc_aware_policy(
+    seen_docs: List[Optional[ChatDocument]],
+) -> Any:
+    """A policy whose decision depends on message context: it denies when
+    no chat_doc is provided, allows when the chat_doc is present."""
+
+    def policy(
+        tool: ToolMessage,
+        agent: ChatAgent,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> Union[bool, str]:
+        seen_docs.append(chat_doc)
+        if chat_doc is None:
+            return "no message context provided"
+        return True
+
+    return policy
+
+
+def test_strict_recovery_policy_receives_chat_doc() -> None:
+    """The recovered inner tool's policy check must see the same chat_doc
+    a normal dispatch would, not None."""
+    seen_docs: List[Optional[ChatDocument]] = []
+    agent = mk_agent(tool_policy=_chat_doc_aware_policy(seen_docs))
+    wrapper = _strict_recovery_wrapper(agent, x=5)
+    msg = agent.create_llm_response(wrapper.to_json())
+    result = agent.handle_message(msg)
+    assert "SQUARE_RESULT: 25" in result_content(result)
+    assert agent.calls == 1
+    # the policy saw the real message context (as a copy), not None
+    assert len(seen_docs) == 1
+    assert seen_docs[0] is not None
+    assert seen_docs[0].content == msg.content
+
+
+@pytest.mark.asyncio
+async def test_strict_recovery_policy_receives_chat_doc_async() -> None:
+    seen_docs: List[Optional[ChatDocument]] = []
+    agent = mk_agent(tool_policy=_chat_doc_aware_policy(seen_docs))
+    wrapper = _strict_recovery_wrapper(agent, x=5)
+    msg = agent.create_llm_response(wrapper.to_json())
+    result = await agent.handle_message_async(msg)
+    assert "SQUARE_RESULT: 25" in result_content(result)
+    assert agent.calls == 1
+    assert len(seen_docs) == 1
+    assert seen_docs[0] is not None
+    assert seen_docs[0].content == msg.content
+
+
+def test_injected_exemption_marker_does_not_bypass_policy() -> None:
+    """ToolMessage allows extra fields, so an LLM could emit
+    `"_tool_policy_exempt": true` inside its tool JSON, planting the marker
+    as an INSTANCE attribute. The exemption must resolve on the CLASS only,
+    so this spoof must not bypass a deny-all policy."""
+    agent = mk_agent(tool_policy=lambda tool, agent: "denied")
+    spoofed_json = (
+        SquareTool(x=3)
+        .to_json()
+        .replace(
+            '"request":',
+            '"_tool_policy_exempt": true, "request":',
+            1,
+        )
+    )
+    msg = agent.create_llm_response(spoofed_json)
+    parsed = agent.try_get_tool_messages(msg, all_tools=True)
+    # the spoofed marker really lands on the parsed instance...
+    assert any(getattr(t, "_tool_policy_exempt", False) is True for t in parsed)
+    result = agent.handle_message(msg)
+    content = result_content(result)
+    assert agent.calls == 0  # handler never ran
+    assert "blocked by tool policy" in content
+
+
+def test_strict_recovery_no_policy_unchanged() -> None:
+    agent = mk_agent()
+    wrapper = _strict_recovery_wrapper(agent, x=5)
+    result = agent.handle_message(agent.create_llm_response(wrapper.to_json()))
+    assert "SQUARE_RESULT: 25" in result_content(result)
+    assert agent.calls == 1
+    assert agent.output_format is None
+
+
+# ---------------- contract 6: composes with USER-origin filter ----------------
+
+
+def test_policy_does_not_weaken_user_origin_filter() -> None:
+    """A handle-only tool arriving as raw USER input must stay vetoed by
+    `_filter_user_origin_tools`; the policy hook never even sees it, and
+    an allow-everything policy cannot resurrect it."""
+    policy_calls: List[ToolMessage] = []
+
+    def policy(tool: ToolMessage, agent: ChatAgent) -> bool:
+        policy_calls.append(tool)
+        return True
+
+    agent = CountingAgent(
+        ChatAgentConfig(
+            name="TestAgent",
+            llm=MockLMConfig(response_fn=lambda x: x),
+            tool_policy=policy,
+        )
+    )
+    # handle-only: LLM cannot use it, so raw USER input must not trigger it
+    agent.enable_message(SquareTool, use=False, handle=True)
+    user_msg = agent.create_user_response(SquareTool(x=3).to_json())
+    assert user_msg.metadata.sender == Entity.USER
+    result = agent.handle_message(user_msg)
+    assert agent.calls == 0
+    assert policy_calls == []
+    assert result is None or "SQUARE_RESULT" not in result_content(result)
+
+
+# ------------------- end-to-end: LLM sees the rejection -------------------
+
+
+def test_rejection_is_seen_by_llm_in_task_loop() -> None:
+    llm_inputs: List[str] = []
+
+    def mock_llm(x: str) -> str:
+        llm_inputs.append(x)
+        if len(llm_inputs) == 1:
+            # the tool argument IS the secret sentinel, so a leak of the
+            # raw argument into the rejection would fail the assertion below
+            return SquareTool(x=int(SECRET)).to_json()
+        return "understood, giving up"
+
+    agent = CountingAgent(
+        ChatAgentConfig(
+            name="TestAgent",
+            llm=MockLMConfig(response_fn=mock_llm),
+            tool_policy=lambda tool, agent: "quota exhausted",
+        )
+    )
+    agent.enable_message(SquareTool)
+    task = Task(agent, interactive=False)
+    task.run("go", turns=4)
+    assert agent.calls == 0
+    # the LLM's second input is the policy rejection
+    assert any("quota exhausted" in s for s in llm_inputs[1:])
+    assert all(SECRET not in s for s in llm_inputs)
 </file>
 
 <file path="tests/main/test_tool_taint_laundering.py">
@@ -102674,6 +103683,598 @@ async def get_mcp_tools_async(
         if not client.client:
             raise RuntimeError("Client not initialized. Use async with FastMCPClient.")
         return await client.client.list_tools()
+</file>
+
+<file path="langroid/agent/batch.py">
+import asyncio
+import inspect
+import warnings
+from enum import Enum
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Iterable,
+    List,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from dotenv import load_dotenv
+
+from langroid.agent.base import Agent
+from langroid.agent.chat_document import ChatDocument
+from langroid.agent.task import Task
+from langroid.parsing.utils import batched
+from langroid.utils.configuration import quiet_mode
+from langroid.utils.logging import setup_colored_logging
+from langroid.utils.output import SuppressLoggerWarnings, status
+
+setup_colored_logging()
+
+load_dotenv()
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+class ExceptionHandling(str, Enum):
+    """Enum for exception handling options."""
+
+    RAISE = "raise"
+    RETURN_NONE = "return_none"
+    RETURN_EXCEPTION = "return_exception"
+
+
+def _convert_exception_handling(
+    handle_exceptions: Union[bool, ExceptionHandling]
+) -> ExceptionHandling:
+    """Convert legacy boolean handle_exceptions to ExceptionHandling enum."""
+    if isinstance(handle_exceptions, ExceptionHandling):
+        return handle_exceptions
+
+    if isinstance(handle_exceptions, bool):
+        warnings.warn(
+            "Boolean handle_exceptions is deprecated. "
+            "Use ExceptionHandling enum instead: "
+            "RAISE, RETURN_NONE, or RETURN_EXCEPTION.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return (
+            ExceptionHandling.RETURN_NONE
+            if handle_exceptions
+            else ExceptionHandling.RAISE
+        )
+
+    raise TypeError(
+        "handle_exceptions must be bool or ExceptionHandling, "
+        f"not {type(handle_exceptions)}"
+    )
+
+
+async def _process_batch_async(
+    inputs: Iterable[str | ChatDocument],
+    do_task: Callable[[str | ChatDocument, int], Coroutine[Any, Any, Any]],
+    start_idx: int = 0,
+    stop_on_first_result: bool = False,
+    sequential: bool = False,
+    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
+    output_map: Callable[[Any], Any] = lambda x: x,
+) -> List[Optional[ChatDocument] | BaseException]:
+    """
+    Unified batch processing logic for both agent methods and tasks.
+
+    Args:
+        inputs: Iterable of inputs to process
+        do_task: Task execution function that takes (input, index) and returns result
+        start_idx: Starting index for the batch
+        stop_on_first_result: Whether to stop after first valid result
+        sequential: Whether to process sequentially
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        output_map: Function to map results to final output format
+    """
+    exception_handling = _convert_exception_handling(handle_exceptions)
+
+    def handle_error(e: BaseException) -> Any:
+        """Handle exceptions based on exception_handling."""
+        match exception_handling:
+            case ExceptionHandling.RAISE:
+                raise e
+            case ExceptionHandling.RETURN_NONE:
+                return None
+            case ExceptionHandling.RETURN_EXCEPTION:
+                return e
+
+    if stop_on_first_result:
+        results: List[Optional[ChatDocument] | BaseException] = []
+        pending: set[asyncio.Task[Any]] = set()
+        # Create task-to-index mapping
+        task_indices: dict[asyncio.Task[Any], int] = {}
+        try:
+            tasks = [
+                asyncio.create_task(do_task(input, i + start_idx))
+                for i, input in enumerate(inputs)
+            ]
+            task_indices = {task: i for i, task in enumerate(tasks)}
+            results = [None] * len(tasks)
+
+            pending = set(tasks)
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED
+                )
+
+                # Process completed tasks
+                for task in done:
+                    index = task_indices[task]
+                    try:
+                        result = await task
+                        results[index] = output_map(result)
+                    except BaseException as e:
+                        results[index] = handle_error(e)
+
+                if any(r is not None for r in results):
+                    return results
+        finally:
+            for task in pending:
+                task.cancel()
+            try:
+                await asyncio.gather(*pending, return_exceptions=True)
+            except BaseException as e:
+                handle_error(e)
+        return results
+
+    elif sequential:
+        results = []
+        for i, input in enumerate(inputs):
+            try:
+                result = await do_task(input, i + start_idx)
+                results.append(output_map(result))
+            except BaseException as e:
+                results.append(handle_error(e))
+        return results
+
+    # Parallel execution
+    else:
+        try:
+            return_exceptions = exception_handling != ExceptionHandling.RAISE
+            with quiet_mode(), SuppressLoggerWarnings():
+                results_with_exceptions = cast(
+                    list[Optional[ChatDocument | BaseException]],
+                    await asyncio.gather(
+                        *(
+                            do_task(input, i + start_idx)
+                            for i, input in enumerate(inputs)
+                        ),
+                        return_exceptions=return_exceptions,
+                    ),
+                )
+
+                if exception_handling == ExceptionHandling.RETURN_NONE:
+                    results = [
+                        None if isinstance(r, BaseException) else r
+                        for r in results_with_exceptions
+                    ]
+                else:  # ExceptionHandling.RETURN_EXCEPTION
+                    results = results_with_exceptions
+        except BaseException as e:
+            results = [handle_error(e) for _ in inputs]
+
+        return [output_map(r) for r in results]
+
+
+def run_batched_tasks(
+    inputs: List[str | ChatDocument],
+    do_task: Callable[[str | ChatDocument, int], Coroutine[Any, Any, Any]],
+    batch_size: Optional[int],
+    stop_on_first_result: bool,
+    sequential: bool,
+    handle_exceptions: Union[bool, ExceptionHandling],
+    output_map: Callable[[Any], Any],
+    message_template: str,
+    message: Optional[str] = None,
+) -> List[Any]:
+    """
+    Common batch processing logic for both agent methods and tasks.
+
+    Args:
+        inputs: List of inputs to process
+        do_task: Task execution function
+        batch_size: Size of batches, if None process all at once
+        stop_on_first_result: Whether to stop after first valid result
+        sequential: Whether to process sequentially
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        output_map: Function to map results
+        message_template: Template for status message
+        message: Optional override for status message
+    """
+
+    async def run_all_batched_tasks(
+        inputs: List[str | ChatDocument],
+        batch_size: int | None,
+    ) -> List[Any]:
+        """Extra wrap to run asyncio.run one single time and not once per loop
+
+        Args:
+            inputs (List[str  |  ChatDocument]): inputs to process
+            batch_size (int | None): batch size
+
+        Returns:
+            List[Any]: results
+        """
+        results: List[Any] = []
+        if batch_size is None:
+            msg = message or message_template.format(total=len(inputs))
+            with status(msg), SuppressLoggerWarnings():
+                results = await _process_batch_async(
+                    inputs,
+                    do_task,
+                    stop_on_first_result=stop_on_first_result,
+                    sequential=sequential,
+                    handle_exceptions=handle_exceptions,
+                    output_map=output_map,
+                )
+        else:
+            batches = batched(inputs, batch_size)
+            for batch in batches:
+                start_idx = len(results)
+                complete_str = f", {start_idx} complete" if start_idx > 0 else ""
+                msg = (
+                    message or message_template.format(total=len(inputs)) + complete_str
+                )
+
+                if stop_on_first_result and any(r is not None for r in results):
+                    results.extend([None] * len(batch))
+                else:
+                    with status(msg), SuppressLoggerWarnings():
+                        results.extend(
+                            await _process_batch_async(
+                                batch,
+                                do_task,
+                                start_idx=start_idx,
+                                stop_on_first_result=stop_on_first_result,
+                                sequential=sequential,
+                                handle_exceptions=handle_exceptions,
+                                output_map=output_map,
+                            )
+                        )
+        return results
+
+    return asyncio.run(run_all_batched_tasks(inputs, batch_size))
+
+
+def run_batch_task_gen(
+    gen_task: Callable[[int], Task],
+    items: list[T],
+    input_map: Callable[[T], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
+    stop_on_first_result: bool = False,
+    sequential: bool = True,
+    batch_size: Optional[int] = None,
+    turns: int = -1,
+    message: Optional[str] = None,
+    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
+    max_cost: float = 0.0,
+    max_tokens: int = 0,
+) -> list[Optional[U]]:
+    """
+    Generate and run copies of a task async/concurrently one per item in `items` list.
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+    Args:
+        gen_task (Callable[[int], Task]): generates the tasks to run
+        items (list[T]): list of items to process
+        input_map (Callable[[T], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], U]): function to map result
+            to final result. If stop_on_first_result is enabled, then
+            map any invalid output to None. We continue until some non-None
+            result is obtained.
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        batch_size (Optional[int]): The number of tasks to run at a time,
+            if None, unbatched
+        turns (int): number of turns to run, -1 for infinite
+        message (Optional[str]): optionally overrides the console status messages
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
+        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
+
+
+    Returns:
+        list[Optional[U]]: list of final results. Always list[U] if
+        `stop_on_first_result` is disabled
+    """
+    inputs = [input_map(item) for item in items]
+
+    async def _do_task(
+        input: str | ChatDocument,
+        i: int,
+    ) -> BaseException | Optional[ChatDocument] | tuple[int, Optional[ChatDocument]]:
+        task_i = gen_task(i)
+        if task_i.agent.llm is not None:
+            task_i.agent.llm.set_stream(False)
+        task_i.agent.config.show_stats = False
+
+        try:
+            result = await task_i.run_async(
+                input, turns=turns, max_cost=max_cost, max_tokens=max_tokens
+            )
+        except asyncio.CancelledError as e:
+            task_i.kill()
+            # exception will be handled by the caller
+            raise e
+        # ----------------------------------------
+        # Propagate any exception stored on the task that may have been
+        # swallowed inside `Task.run_async`, so that the upper-level
+        # exception-handling logic works as expected.
+        for attr in ("_exception", "last_exception", "exception"):
+            exc = getattr(task_i, attr, None)
+            if isinstance(exc, BaseException):
+                raise exc
+        # Fallback: treat a KILL-status result as an error
+        if (
+            isinstance(result, ChatDocument)
+            and getattr(result, "status", None) is not None
+            and str(getattr(result, "status")) == "StatusCode.KILL"
+        ):
+            raise RuntimeError(str(result.content))
+        return result
+
+    return run_batched_tasks(
+        inputs=inputs,
+        do_task=_do_task,
+        batch_size=batch_size,
+        stop_on_first_result=stop_on_first_result,
+        sequential=sequential,
+        handle_exceptions=handle_exceptions,
+        output_map=output_map,
+        message_template="[bold green]Running {total} tasks:",
+        message=message,
+    )
+
+
+def run_batch_tasks(
+    task: Task,
+    items: list[T],
+    input_map: Callable[[T], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], U] = lambda x: x,  # type: ignore
+    stop_on_first_result: bool = False,
+    sequential: bool = True,
+    batch_size: Optional[int] = None,
+    turns: int = -1,
+    max_cost: float = 0.0,
+    max_tokens: int = 0,
+) -> List[Optional[U]]:
+    """
+    Run copies of `task` async/concurrently one per item in `items` list.
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+    Args:
+        task (Task): task to run
+        items (list[T]): list of items to process
+        input_map (Callable[[T], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], U]): function to map result
+            to final result
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None, after `output_map`) result. Processing continues past
+            None-mapped results; exceptions propagate, since this function
+            always uses the default `RAISE` exception handling. Once a non-None
+            result appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        batch_size (Optional[int]): The number of tasks to run at a time,
+            if None, unbatched
+        turns (int): number of turns to run, -1 for infinite
+        max_cost: float: maximum cost to run the task (default 0.0 for unlimited)
+        max_tokens: int: maximum token usage (in and out) (default 0 for unlimited)
+
+    Returns:
+        list[Optional[U]]: list of final results. Always list[U] if
+        `stop_on_first_result` is disabled
+    """
+    message = f"[bold green]Running {len(items)} copies of {task.name}..."
+    return run_batch_task_gen(
+        lambda i: task.clone(i),
+        items,
+        input_map,
+        output_map,
+        stop_on_first_result,
+        sequential,
+        batch_size,
+        turns,
+        message,
+        max_cost=max_cost,
+        max_tokens=max_tokens,
+    )
+
+
+def run_batch_agent_method(
+    agent: Agent,
+    method: Callable[
+        [str | ChatDocument | None], Coroutine[Any, Any, ChatDocument | None]
+    ],
+    items: List[Any],
+    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
+    sequential: bool = True,
+    stop_on_first_result: bool = False,
+    handle_exceptions: Union[bool, ExceptionHandling] = ExceptionHandling.RAISE,
+    batch_size: Optional[int] = None,
+) -> List[Any]:
+    """
+    Run the `method` on copies of `agent`, async/concurrently one per
+    item in `items` list.
+    ASSUMPTION: The `method` is an async method and has signature:
+        method(self, input: str|ChatDocument|None) -> ChatDocument|None
+    So this would typically be used for the agent's "responder" methods,
+    e.g. `llm_response_async` or `agent_responder_async`.
+
+    For each item, apply `input_map` to get the initial message to process.
+    For each result, apply `output_map` to get the final result.
+
+    Args:
+        agent (Agent): agent whose method to run
+        method (str): Async method to run on copies of `agent`.
+            The method is assumed to have signature:
+            `method(self, input: str|ChatDocument|None) -> ChatDocument|None`
+        input_map (Callable[[Any], str|ChatDocument]): function to map item to
+            initial message to process
+        output_map (Callable[[ChatDocument|str], Any]): function to map result
+            to final result
+        sequential (bool): whether to run sequentially
+            (e.g. some APIs such as ooba don't support concurrent requests)
+        stop_on_first_result (bool): whether to stop after the first valid
+            (non-None) result. Successful results are evaluated after
+            `output_map`; with `ExceptionHandling.RETURN_EXCEPTION` the returned
+            exception object is itself non-None and also stops the batch.
+            Processing continues past None results; once a non-None result
+            appears, pending tasks are cancelled and their entries in the
+            returned list are None.
+        handle_exceptions: How to handle exceptions:
+            - RAISE or False: Let exceptions propagate
+            - RETURN_NONE or True: Convert exceptions to None in results
+            - RETURN_EXCEPTION: Include exception objects in results
+            Boolean values are deprecated and will be removed in a future version.
+        batch_size (Optional[int]): The number of items to process in each batch.
+            If None, process all items at once.
+    Returns:
+        List[Any]: list of final results
+    """
+    # Check if the method is async
+    method_name = method.__name__
+    if not inspect.iscoroutinefunction(method):
+        raise ValueError(f"The method {method_name} is not async.")
+
+    from langroid.agent.tool_policy import deepcopy_config_sharing_policy
+
+    inputs = [input_map(item) for item in items]
+    # tool_policy hook shared by reference so its state stays global
+    agent_cfg = deepcopy_config_sharing_policy(agent.config)
+    assert agent_cfg.llm is not None, "agent must have llm config"
+    agent_cfg.llm.stream = False
+    agent_cfg.show_stats = False
+    agent_cls = type(agent)
+    agent_name = agent_cfg.name
+
+    async def _do_task(input: str | ChatDocument, i: int) -> Any:
+        agent_cfg.name = f"{agent_cfg.name}-{i}"
+        agent_i = agent_cls(agent_cfg)
+        method_i = getattr(agent_i, method_name, None)
+        if method_i is None:
+            raise ValueError(f"Agent {agent_name} has no method {method_name}")
+        result = await method_i(input)
+        return result
+
+    return run_batched_tasks(
+        inputs=inputs,
+        do_task=_do_task,
+        batch_size=batch_size,
+        stop_on_first_result=stop_on_first_result,
+        sequential=sequential,
+        handle_exceptions=handle_exceptions,
+        output_map=output_map,
+        message_template=f"[bold green]Running {{total}} copies of {agent_name}...",
+    )
+
+
+def llm_response_batch(
+    agent: Agent,
+    items: List[Any],
+    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
+    sequential: bool = True,
+    stop_on_first_result: bool = False,
+    batch_size: Optional[int] = None,
+) -> List[Any]:
+    return run_batch_agent_method(
+        agent,
+        agent.llm_response_async,
+        items,
+        input_map=input_map,
+        output_map=output_map,
+        sequential=sequential,
+        stop_on_first_result=stop_on_first_result,
+        batch_size=batch_size,
+    )
+
+
+def agent_response_batch(
+    agent: Agent,
+    items: List[Any],
+    input_map: Callable[[Any], str | ChatDocument] = lambda x: str(x),
+    output_map: Callable[[ChatDocument | None], Any] = lambda x: x,
+    sequential: bool = True,
+    stop_on_first_result: bool = False,
+    batch_size: Optional[int] = None,
+) -> List[Any]:
+    return run_batch_agent_method(
+        agent,
+        agent.agent_response_async,
+        items,
+        input_map=input_map,
+        output_map=output_map,
+        sequential=sequential,
+        stop_on_first_result=stop_on_first_result,
+        batch_size=batch_size,
+    )
+
+
+def run_batch_function(
+    function: Callable[[T], U],
+    items: list[T],
+    sequential: bool = True,
+    batch_size: Optional[int] = None,
+) -> List[U]:
+    async def _do_task(item: T) -> U:
+        return function(item)
+
+    async def _do_all(items: Iterable[T]) -> List[U]:
+        if sequential:
+            results = []
+            for item in items:
+                result = await _do_task(item)
+                results.append(result)
+            return results
+
+        return await asyncio.gather(*(_do_task(item) for item in items))
+
+    results: List[U] = []
+
+    if batch_size is None:
+        with status(f"[bold green]Running {len(items)} tasks:"):
+            results = asyncio.run(_do_all(items))
+    else:
+        batches = batched(items, batch_size)
+        for batch in batches:
+            with status(f"[bold green]Running batch of {len(batch)} tasks:"):
+                results.extend(asyncio.run(_do_all(batch)))
+
+    return results
 </file>
 
 <file path="langroid/agent/openai_assistant.py">
@@ -110519,171 +112120,6 @@ def test_unresolvable_symlinks_are_skipped_without_aborting(
     assert INSIDE in _all_text(loader(base))
 </file>
 
-<file path="tests/main/test_split_inline_reasoning.py">
-"""
-Tests for OpenAIGPT._split_inline_reasoning, which separates inline
-thought-delimiter tags (e.g. <think>...</think>) from text content
-during streaming.
-"""
-
-from langroid.language_models.openai_gpt import OpenAIGPT
-
-split = OpenAIGPT._split_inline_reasoning
-DELIMS = ("<think>", "</think>")
-
-
-class TestSplitInlineReasoning:
-    """Unit tests for the streaming inline-reasoning splitter."""
-
-    # --- no-op cases: nothing to parse ---
-
-    def test_empty_text(self):
-        """Empty event_text should pass through unchanged."""
-        text, reasoning, in_r = split("", "", False, DELIMS)
-        assert text == ""
-        assert reasoning == ""
-        assert in_r is False
-
-    def test_plain_text_no_delimiters(self):
-        """Text without any delimiters should pass through as-is."""
-        text, reasoning, in_r = split("hello world", "", False, DELIMS)
-        assert text == "hello world"
-        assert reasoning == ""
-        assert in_r is False
-
-    def test_already_has_reasoning_field(self):
-        """When the API already provides separate reasoning, skip parsing."""
-        text, reasoning, in_r = split("some text", "api reasoning", False, DELIMS)
-        assert text == "some text"
-        assert reasoning == "api reasoning"
-        assert in_r is False
-
-    # --- single chunk contains full <think>...</think> ---
-
-    def test_full_think_block_in_one_chunk(self):
-        """Complete <think>reasoning</think> in a single chunk."""
-        text, reasoning, in_r = split("<think>step 1</think>", "", False, DELIMS)
-        assert text == ""
-        assert reasoning == "step 1"
-        assert in_r is False
-
-    def test_text_before_and_after_think(self):
-        """Text surrounding a complete think block."""
-        text, reasoning, in_r = split(
-            "before<think>middle</think>after", "", False, DELIMS
-        )
-        assert text == "beforeafter"
-        assert reasoning == "middle"
-        assert in_r is False
-
-    def test_text_before_think_only(self):
-        """Text before think block, nothing after."""
-        text, reasoning, in_r = split(
-            "prefix<think>reasoning</think>", "", False, DELIMS
-        )
-        assert text == "prefix"
-        assert reasoning == "reasoning"
-        assert in_r is False
-
-    def test_text_after_think_only(self):
-        """Think block followed by text, no prefix."""
-        text, reasoning, in_r = split(
-            "<think>reasoning</think>suffix", "", False, DELIMS
-        )
-        assert text == "suffix"
-        assert reasoning == "reasoning"
-        assert in_r is False
-
-    # --- multi-chunk: start delimiter in one chunk, end in another ---
-
-    def test_start_delimiter_only(self):
-        """Chunk has <think> but no </think> — enters reasoning state."""
-        text, reasoning, in_r = split(
-            "hello<think>partial reasoning", "", False, DELIMS
-        )
-        assert text == "hello"
-        assert reasoning == "partial reasoning"
-        assert in_r is True
-
-    def test_continuation_mid_reasoning(self):
-        """Chunk arrives while already in reasoning (no delimiters)."""
-        text, reasoning, in_r = split("more reasoning stuff", "", True, DELIMS)
-        assert text == ""
-        assert reasoning == "more reasoning stuff"
-        assert in_r is True
-
-    def test_end_delimiter_while_in_reasoning(self):
-        """Chunk has </think> while in reasoning state."""
-        text, reasoning, in_r = split("final bit</think>answer", "", True, DELIMS)
-        assert text == "answer"
-        assert reasoning == "final bit"
-        assert in_r is False
-
-    def test_end_delimiter_no_trailing_text(self):
-        """End delimiter with nothing after it."""
-        text, reasoning, in_r = split("last thought</think>", "", True, DELIMS)
-        assert text == ""
-        assert reasoning == "last thought"
-        assert in_r is False
-
-    # --- multi-chunk sequence simulating a real stream ---
-
-    def test_three_chunk_sequence(self):
-        """Simulate: chunk1 opens thinking, chunk2 continues, chunk3 closes."""
-        # chunk 1: start of thinking
-        text1, reason1, in_r = split("<think>step 1", "", False, DELIMS)
-        assert text1 == ""
-        assert reason1 == "step 1"
-        assert in_r is True
-
-        # chunk 2: still thinking
-        text2, reason2, in_r = split(" step 2", "", in_r, DELIMS)
-        assert text2 == ""
-        assert reason2 == " step 2"
-        assert in_r is True
-
-        # chunk 3: done thinking, answer follows
-        text3, reason3, in_r = split(" step 3</think>The answer", "", in_r, DELIMS)
-        assert text3 == "The answer"
-        assert reason3 == " step 3"
-        assert in_r is False
-
-    # --- custom delimiters ---
-
-    def test_custom_delimiters(self):
-        """Works with non-default delimiters like <thinking>...</thinking>."""
-        custom = ("<thinking>", "</thinking>")
-        text, reasoning, in_r = split(
-            "<thinking>hmm</thinking>result", "", False, custom
-        )
-        assert text == "result"
-        assert reasoning == "hmm"
-        assert in_r is False
-
-    # --- edge cases ---
-
-    def test_empty_think_block(self):
-        """<think></think> with nothing inside."""
-        text, reasoning, in_r = split("<think></think>answer", "", False, DELIMS)
-        assert text == "answer"
-        assert reasoning == ""
-        assert in_r is False
-
-    def test_only_start_delimiter(self):
-        """Chunk is exactly the start delimiter, nothing else."""
-        text, reasoning, in_r = split("<think>", "", False, DELIMS)
-        assert text == ""
-        assert reasoning == ""
-        assert in_r is True
-
-    def test_only_end_delimiter_while_reasoning(self):
-        """Chunk is exactly the end delimiter."""
-        text, reasoning, in_r = split("</think>", "", True, DELIMS)
-        assert text == ""
-        assert reasoning == ""
-        assert in_r is False
-</file>
-
 <file path="tests/main/test_web_search_tools.py">
 """
 NOTE: running this test requires setting the GOOGLE_API_KEY and GOOGLE_CSE_ID
@@ -112454,6 +113890,1458 @@ LLMMessage.model_rebuild()
 ChatDocMetaData.model_rebuild()
 </file>
 
+<file path="langroid/language_models/base.py">
+import json
+import logging
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from enum import Enum
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
+
+from langroid.cachedb.base import CacheDBConfig
+from langroid.cachedb.redis_cachedb import RedisCacheConfig
+from langroid.language_models.model_info import ModelInfo, get_model_info
+from langroid.parsing.agent_chats import parse_message
+from langroid.parsing.file_attachment import FileAttachment
+from langroid.parsing.parse_json import parse_imperfect_json, top_level_json_field
+from langroid.prompts.dialog import collate_chat_history
+from langroid.utils.configuration import settings
+from langroid.utils.output.printing import show_if_debug
+
+logger = logging.getLogger(__name__)
+
+
+def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+    pass
+
+
+async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
+    pass
+
+
+FunctionCallTypes = Literal["none", "auto"]
+ToolChoiceTypes = Literal["none", "auto", "required"]
+ToolTypes = Literal["function"]
+
+DEFAULT_CONTEXT_LENGTH = 16_000
+
+
+class StreamEventType(Enum):
+    TEXT = 1
+    FUNC_NAME = 2
+    FUNC_ARGS = 3
+    TOOL_NAME = 4
+    TOOL_ARGS = 5
+    REASONING = 6
+
+
+class RetryParams(BaseSettings):
+    max_retries: int = 5
+    initial_delay: float = 1.0
+    exponential_base: float = 1.3
+    jitter: bool = True
+
+
+class LLMConfig(BaseSettings):
+    """
+    Common configuration for all language models.
+    """
+
+    type: str = "openai"
+    streamer: Optional[Callable[[Any], None]] = noop_fn
+    streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
+    api_base: str | None = None
+    formatter: None | str = None
+    # specify None if you want to use the full max output tokens of the model
+    max_output_tokens: int | None = 8192
+    timeout: int = 20  # timeout for API requests
+    chat_model: str = ""
+    completion_model: str = ""
+    temperature: float = 0.0
+    chat_context_length: int | None = None
+    async_stream_quiet: bool = False  # suppress streaming output in async mode?
+    completion_context_length: int | None = None
+    # if input length + max_output_tokens > context length of model,
+    # we will try shortening requested output
+    min_output_tokens: int = 64
+    use_completion_for_chat: bool = False  # use completion model for chat?
+    # use chat model for completion? For OpenAI models, this MUST be set to True!
+    use_chat_for_completion: bool = True
+    stream: bool = True  # stream output from API?
+    # TODO: we could have a `stream_reasoning` flag here to control whether to show
+    # reasoning output from reasoning models
+    cache_config: None | CacheDBConfig = RedisCacheConfig()
+    thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
+    retry_params: RetryParams = RetryParams()
+
+    @property
+    def model_max_output_tokens(self) -> int:
+        if self.max_output_tokens:
+            return self.max_output_tokens
+        # Build fallback names by progressively stripping provider prefixes
+        # (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
+        # succeeds even before OpenAIGPT.__init__ strips the prefix.
+        parts = self.chat_model.split("/")
+        fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
+        return get_model_info(self.chat_model, fallbacks).max_output_tokens
+
+
+class LLMFunctionCall(BaseModel):
+    """
+    Structure of LLM response indicating it "wants" to call a function.
+    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
+    """
+
+    name: str  # name of function to call
+    arguments: Optional[Dict[str, Any]] = None
+
+    @staticmethod
+    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall":
+        """
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+        fun_call = LLMFunctionCall(name=message["name"])
+        fun_args_str = message["arguments"]
+        # sometimes may be malformed with invalid indents,
+        # so we try to be safe by removing newlines.
+        if fun_args_str is not None:
+            fun_args_str = fun_args_str.replace("\n", "").strip()
+            dict_or_list = parse_imperfect_json(fun_args_str)
+
+            if not isinstance(dict_or_list, dict):
+                raise ValueError(
+                    f"""
+                        Invalid function args: {fun_args_str}
+                        parsed as {dict_or_list},
+                        which is not a valid dict.
+                        """
+                )
+            fun_args = dict_or_list
+        else:
+            fun_args = None
+        fun_call.arguments = fun_args
+
+        return fun_call
+
+    def __str__(self) -> str:
+        return "FUNC: " + json.dumps(self.model_dump(), indent=2)
+
+
+class LLMFunctionSpec(BaseModel):
+    """
+    Description of a function available for the LLM to use.
+    To be used when calling the LLM `chat()` method with the `functions` parameter.
+    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
+    """
+
+    name: str
+    description: str
+    parameters: Dict[str, Any]
+
+
+class OpenAIToolCall(BaseModel):
+    """
+    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
+    See https://platform.openai.com/docs/api-reference/chat/create
+
+    Attributes:
+        id: The id of the tool call.
+        type: The type of the tool call;
+            only "function" is currently possible (7/26/24).
+        function: The function call.
+    """
+
+    id: str | None = None
+    type: ToolTypes = "function"
+    function: LLMFunctionCall | None = None
+    extra_content: Dict[str, Any] | None = None
+
+    @staticmethod
+    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall":
+        """
+        Initialize from dictionary.
+        Args:
+            d: dictionary containing fields to initialize
+        """
+        id = message["id"]
+        type = message["type"]
+        function = LLMFunctionCall.from_dict(message["function"])
+        extra_content = message.get("extra_content")
+        return OpenAIToolCall(
+            id=id, type=type, function=function, extra_content=extra_content
+        )
+
+    def __str__(self) -> str:
+        if self.function is None:
+            return ""
+        return "OAI-TOOL: " + json.dumps(self.function.model_dump(), indent=2)
+
+
+class OpenAIToolSpec(BaseModel):
+    type: ToolTypes
+    strict: Optional[bool] = None
+    function: LLMFunctionSpec
+
+
+class OpenAIJsonSchemaSpec(BaseModel):
+    strict: Optional[bool] = None
+    function: LLMFunctionSpec
+
+    def to_dict(self) -> Dict[str, Any]:
+        json_schema: Dict[str, Any] = {
+            "name": self.function.name,
+            "description": self.function.description,
+            "schema": self.function.parameters,
+        }
+        if self.strict is not None:
+            json_schema["strict"] = self.strict
+
+        return {
+            "type": "json_schema",
+            "json_schema": json_schema,
+        }
+
+
+class LLMTokenUsage(BaseModel):
+    """
+    Usage of tokens by an LLM.
+    """
+
+    prompt_tokens: int = 0
+    cached_tokens: int = 0
+    completion_tokens: int = 0
+    cost: float = 0.0
+    calls: int = 0  # how many API calls - not used as of 2025-04-04
+
+    def reset(self) -> None:
+        self.prompt_tokens = 0
+        self.cached_tokens = 0
+        self.completion_tokens = 0
+        self.cost = 0.0
+        self.calls = 0
+
+    def __str__(self) -> str:
+        return (
+            f"Tokens = "
+            f"(prompt {self.prompt_tokens}, cached {self.cached_tokens}, "
+            f"completion {self.completion_tokens}), "
+            f"Cost={self.cost}, Calls={self.calls}"
+        )
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+
+class Role(str, Enum):
+    """
+    Possible roles for a message in a chat.
+    """
+
+    USER = "user"
+    SYSTEM = "system"
+    ASSISTANT = "assistant"
+    FUNCTION = "function"
+    TOOL = "tool"
+
+
+class LLMMessage(BaseModel):
+    """
+    Class representing an entry in the msg-history sent to the LLM API.
+    It could be one of these:
+    - a user message
+    - an LLM ("Assistant") response
+    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
+    - a result or results from executing a fn or tool-call(s)
+    """
+
+    role: Role
+    name: Optional[str] = None
+    tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
+    tool_id: str = ""  # used by OpenAIAssistant
+    # None means "no content" (the model returned only a tool/function call).
+    # This is distinct from "" and is dropped from the API payload by api_dict;
+    # see api_dict for how a fully-empty message is handled per-API.
+    content: Optional[str] = None
+    files: List[FileAttachment] = []
+    function_call: Optional[LLMFunctionCall] = None
+    tool_calls: Optional[List[OpenAIToolCall]] = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    # link to corresponding chat document, for provenance/rewind purposes
+    chat_document_id: str = ""
+
+    def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]:
+        """
+        Convert to dictionary for API request, keeping ONLY
+        the fields that are expected in an API call!
+        E.g., DROP the tool_id, since it is only for use in the Assistant API,
+            not the completion API.
+
+        Args:
+            has_system_role: whether the message has a system role (if not,
+                set to "user" role)
+        Returns:
+            dict: dictionary representation of LLM message
+        """
+        d = self.model_dump()
+        files: List[FileAttachment] = d.pop("files")
+        if len(files) > 0 and self.role == Role.USER:
+            # In there are files, then content is an array of
+            # different content-parts
+            d["content"] = [
+                dict(
+                    type="text",
+                    text=self.content or "",
+                )
+            ] + [f.to_dict(model) for f in self.files]
+
+        # if there is a key k = "role" with value "system", change to "user"
+        # in case has_system_role is False
+        if not has_system_role and "role" in d and d["role"] == "system":
+            d["role"] = "user"
+            if d.get("content"):
+                d["content"] = "[ADDITIONAL SYSTEM MESSAGE:]\n\n" + d["content"]
+        # drop None values since API doesn't accept them (this omits `content`
+        # entirely when it is None, i.e. "no content")
+        dict_no_none = {k: v for k, v in d.items() if v is not None}
+        if "name" in dict_no_none and dict_no_none["name"] == "":
+            # OpenAI API does not like empty name
+            del dict_no_none["name"]
+        if "function_call" in dict_no_none:
+            # arguments must be a string
+            if "arguments" in dict_no_none["function_call"]:
+                dict_no_none["function_call"]["arguments"] = json.dumps(
+                    dict_no_none["function_call"]["arguments"]
+                )
+        if dict_no_none.get("tool_calls"):
+            # convert tool calls to API format
+            for tc in dict_no_none["tool_calls"]:
+                if "arguments" in tc["function"]:
+                    # arguments must be a string
+                    if tc["function"]["arguments"] is None:
+                        tc["function"]["arguments"] = "{}"
+                    else:
+                        tc["function"]["arguments"] = json.dumps(
+                            tc["function"]["arguments"]
+                        )
+                if "extra_content" in tc and tc["extra_content"] is None:
+                    del tc["extra_content"]
+        else:
+            # An empty tool-call list is not a call and conveys no useful API
+            # information. Omitting it also lets the empty-message fallback
+            # below produce a valid message.
+            dict_no_none.pop("tool_calls", None)
+        # A message with empty content (None was dropped above, or "") AND no
+        # tool/function call would be an entirely empty message, which some APIs
+        # (e.g. Gemini) reject; fall back to a single space in that case only.
+        # When there IS a tool/function call, empty content is fine (and Gemini
+        # 3.x in fact REQUIRES it — it rejects an assistant turn that carries
+        # both a call and non-empty text content).
+        has_call = bool(dict_no_none.get("tool_calls")) or (
+            dict_no_none.get("function_call") is not None
+        )
+        if not has_call and not dict_no_none.get("content"):
+            dict_no_none["content"] = " "
+        # IMPORTANT! drop fields that are not expected in API call
+        dict_no_none.pop("tool_id", None)
+        dict_no_none.pop("timestamp", None)
+        dict_no_none.pop("chat_document_id", None)
+        return dict_no_none
+
+    def __str__(self) -> str:
+        if self.function_call is not None:
+            content = "FUNC: " + json.dumps(self.function_call)
+        else:
+            content = self.content or ""
+        name_str = f" ({self.name})" if self.name else ""
+        return f"{self.role} {name_str}: {content}"
+
+
+class LLMResponse(BaseModel):
+    """
+    Class representing response from LLM.
+    """
+
+    # None means the model returned NO content (e.g. only a tool/function
+    # call), which is distinct from an empty string "". Preserving this
+    # distinction lets the message be faithfully reproduced downstream
+    # (see ChatDocument.content_is_none and LLMMessage.content).
+    message: Optional[str] = None
+    reasoning: str = ""  # optional reasoning text from reasoning models
+    # Original message text including inline thought signatures (e.g.
+    # <thinking>...</thinking>). Only set when reasoning was extracted
+    # from the message text via get_reasoning_final(); NOT set when
+    # reasoning comes from a separate API field (e.g. reasoning_content),
+    # since in that case the message text never contained thought tags.
+    message_with_reasoning: Optional[str] = None
+    # TODO tool_id needs to generalize to multi-tool calls
+    tool_id: str = ""  # used by OpenAIAssistant
+    oai_tool_calls: Optional[List[OpenAIToolCall]] = None
+    function_call: Optional[LLMFunctionCall] = None
+    usage: Optional[LLMTokenUsage] = None
+    cached: bool = False
+
+    def __str__(self) -> str:
+        if self.function_call is not None:
+            return str(self.function_call)
+        elif self.oai_tool_calls:
+            return "\n".join(str(tc) for tc in self.oai_tool_calls)
+        else:
+            return self.message or ""
+
+    def tools_content(self) -> str:
+        if self.function_call is not None:
+            return str(self.function_call)
+        elif self.oai_tool_calls:
+            return "\n".join(str(tc) for tc in self.oai_tool_calls)
+        else:
+            return ""
+
+    def to_LLMMessage(self) -> LLMMessage:
+        """Convert LLM response to an LLMMessage, to be included in the
+        message-list sent to the API.
+        This is currently NOT used in any significant way in the library, and is only
+        provided as a utility to construct a message list for the API when directly
+        working with an LLM object.
+
+        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
+        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
+        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
+        """
+        return LLMMessage(
+            role=Role.ASSISTANT,
+            content=self.message,
+            name=None if self.function_call is None else self.function_call.name,
+            function_call=self.function_call,
+            tool_calls=self.oai_tool_calls,
+        )
+
+    def get_recipient_and_message(
+        self,
+        recognize_recipient_in_content: bool = True,
+    ) -> Tuple[str, str]:
+        """
+        If `message` or `function_call` of an LLM response contains an explicit
+        recipient name, return this recipient name and `message` stripped
+        of the recipient name if specified.
+
+        Two cases:
+        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
+        (b) `message` is empty and function_call/tool_call with explicit `recipient`
+
+        Args:
+            recognize_recipient_in_content (bool): When True (default), parses
+                message text for ``TO[<recipient>]:<content>`` patterns and
+                top-level JSON ``{"recipient": "..."}`` fields. When False,
+                only function_call/tool_call ``recipient`` fields are checked.
+
+        Returns:
+            (str): name of recipient, which may be empty string if no recipient
+            (str): content of message
+
+        """
+
+        if self.function_call is not None:
+            # in this case we ignore message, since all information is in function_call
+            msg = ""
+            args = self.function_call.arguments
+            recipient = ""
+            if isinstance(args, dict):
+                recipient = args.get("recipient", "")
+            return recipient, msg
+        else:
+            msg = self.message or ""
+            if self.oai_tool_calls is not None:
+                # get the first tool that has a recipient field, if any
+                for tc in self.oai_tool_calls:
+                    if tc.function is not None and tc.function.arguments is not None:
+                        recipient = tc.function.arguments.get(
+                            "recipient"
+                        )  # type: ignore
+                        if recipient is not None and recipient != "":
+                            return recipient, ""
+
+        if not recognize_recipient_in_content:
+            return "", msg
+
+        # It's not a function or tool call, so continue looking to see
+        # if a recipient is specified in the message.
+
+        # First check if message contains "TO: <recipient> <content>"
+        recipient_name, content = parse_message(msg) if msg is not None else ("", "")
+        # check if there is a top level json that specifies 'recipient',
+        # and retain the entire message as content.
+        if recipient_name == "":
+            recipient_name = top_level_json_field(msg, "recipient") if msg else ""
+            content = msg
+        return recipient_name, content
+
+
+# Define an abstract base class for language models
+class LanguageModel(ABC):
+    """
+    Abstract base class for language models.
+    """
+
+    # usage cost by model, accumulates here
+    usage_cost_dict: Dict[str, LLMTokenUsage] = {}
+
+    def __init__(self, config: LLMConfig = LLMConfig()):
+        self.config = config
+        self.chat_model_orig = config.chat_model
+
+    @staticmethod
+    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]:
+        """
+        Create a language model.
+        Args:
+            config: configuration for language model
+        Returns: instance of language model
+        """
+        if type(config) is LLMConfig:
+            raise ValueError(
+                """
+                Cannot create a Language Model object from LLMConfig.
+                Please specify a specific subclass of LLMConfig e.g.,
+                OpenAIGPTConfig. If you are creating a ChatAgent from
+                a ChatAgentConfig, please specify the `llm` field of this config
+                as a specific subclass of LLMConfig, e.g., OpenAIGPTConfig.
+                """
+            )
+        from langroid.language_models.azure_openai import AzureGPT
+        from langroid.language_models.mock_lm import MockLM, MockLMConfig
+        from langroid.language_models.openai_gpt import OpenAIGPT
+
+        if config is None or config.type is None:
+            return None
+
+        if config.type == "mock":
+            return MockLM(cast(MockLMConfig, config))
+
+        openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
+
+        if config.type == "azure":
+            openai = AzureGPT
+        else:
+            openai = OpenAIGPT
+        cls = dict(
+            openai=openai,
+        ).get(config.type, openai)
+        return cls(config)  # type: ignore
+
+    @staticmethod
+    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]:
+        """
+        Given an even-length sequence of strings, split into a sequence of pairs
+
+        Args:
+            lst (List[str]): sequence of strings
+
+        Returns:
+            List[Tuple[str,str]]: sequence of pairs of strings
+        """
+        evens = lst[::2]
+        odds = lst[1::2]
+        return list(zip(evens, odds))
+
+    @staticmethod
+    def get_chat_history_components(
+        messages: List[LLMMessage],
+    ) -> Tuple[str, List[Tuple[str, str]], str]:
+        """
+        From the chat history, extract system prompt, user-assistant turns, and
+        final user msg.
+
+        Args:
+            messages (List[LLMMessage]): List of messages in the chat history
+
+        Returns:
+            Tuple[str, List[Tuple[str,str]], str]:
+                system prompt, user-assistant turns, final user msg
+
+        """
+        # Handle various degenerate cases
+        messages = [m for m in messages]  # copy
+        DUMMY_SYS_PROMPT = "You are a helpful assistant."
+        DUMMY_USER_PROMPT = "Follow the instructions above."
+        if len(messages) == 0 or messages[0].role != Role.SYSTEM:
+            logger.warning("No system msg, creating dummy system prompt")
+            messages.insert(0, LLMMessage(content=DUMMY_SYS_PROMPT, role=Role.SYSTEM))
+        system_prompt = messages[0].content or ""
+
+        # now we have messages = [Sys,...]
+        if len(messages) == 1:
+            logger.warning(
+                "Got only system message in chat history, creating dummy user prompt"
+            )
+            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, msg, ...]
+
+        if messages[1].role != Role.USER:
+            messages.insert(1, LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, user, ...]
+        if messages[-1].role != Role.USER:
+            logger.warning(
+                "Last message in chat history is not a user message,"
+                " creating dummy user prompt"
+            )
+            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
+
+        # now we have messages = [Sys, user, ..., user]
+        # so we omit the first and last elements and make pairs of user-asst messages
+        conversation = [m.content or "" for m in messages[1:-1]]
+        user_prompt = messages[-1].content or ""
+        pairs = LanguageModel.user_assistant_pairs(conversation)
+        return system_prompt, pairs, user_prompt
+
+    @abstractmethod
+    def set_stream(self, stream: bool) -> bool:
+        """Enable or disable streaming output from API.
+        Return previous value of stream."""
+        pass
+
+    @abstractmethod
+    def get_stream(self) -> bool:
+        """Get streaming status"""
+        pass
+
+    @abstractmethod
+    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        pass
+
+    @abstractmethod
+    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
+        pass
+
+    @abstractmethod
+    def chat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """
+        Get chat-completion response from LLM.
+
+        Args:
+            messages: message-history to send to the LLM
+            max_tokens: max tokens to generate
+            tools: tools available for the LLM to use in its response
+            tool_choice: tool call mode, one of "none", "auto", "required",
+                or a dict specifying a specific tool.
+            functions: functions available for LLM to call (deprecated)
+            function_call: function calling mode, "auto", "none", or a specific fn
+                    (deprecated)
+        """
+
+        pass
+
+    @abstractmethod
+    async def achat(
+        self,
+        messages: Union[str, List[LLMMessage]],
+        max_tokens: int = 200,
+        tools: Optional[List[OpenAIToolSpec]] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+        functions: Optional[List[LLMFunctionSpec]] = None,
+        function_call: str | Dict[str, str] = "auto",
+        response_format: Optional[OpenAIJsonSchemaSpec] = None,
+    ) -> LLMResponse:
+        """Async version of `chat`. See `chat` for details."""
+        pass
+
+    def __call__(self, prompt: str, max_tokens: int) -> LLMResponse:
+        return self.generate(prompt, max_tokens)
+
+    @staticmethod
+    def _fallback_model_names(model: str) -> List[str]:
+        parts = model.split("/")
+        fallbacks = []
+        for i in range(1, len(parts)):
+            fallbacks.append("/".join(parts[i:]))
+        return fallbacks
+
+    def info(self) -> ModelInfo:
+        """Info of relevant chat model"""
+        orig_model = (
+            self.config.completion_model
+            if self.config.use_completion_for_chat
+            else self.chat_model_orig
+        )
+        return get_model_info(orig_model, self._fallback_model_names(orig_model))
+
+    def completion_info(self) -> ModelInfo:
+        """Info of relevant completion model"""
+        orig_model = (
+            self.chat_model_orig
+            if self.config.use_chat_for_completion
+            else self.config.completion_model
+        )
+        return get_model_info(orig_model, self._fallback_model_names(orig_model))
+
+    def supports_functions_or_tools(self) -> bool:
+        """
+        Does this Model's API support "native" tool-calling, i.e.
+        can we call the API with arguments that contain a list of available tools,
+        and their schemas?
+        Note that, given the plethora of LLM provider APIs this determination is
+        imperfect at best, and leans towards returning True.
+        When the API calls fails with an error indicating tools are not supported,
+        then users are encouraged to use the Langroid-based prompt-based
+        ToolMessage mechanism, which works with ANY LLM. To enable this,
+        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
+        """
+        return self.info().has_tools
+
+    def chat_context_length(self) -> int:
+        return self.config.chat_context_length or DEFAULT_CONTEXT_LENGTH
+
+    def completion_context_length(self) -> int:
+        return self.config.completion_context_length or DEFAULT_CONTEXT_LENGTH
+
+    def chat_cost(self) -> Tuple[float, float, float]:
+        """
+        Return the cost per 1000 tokens for chat completions.
+
+        Returns:
+            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
+                per 1000 tokens
+        """
+        return (0.0, 0.0, 0.0)
+
+    def reset_usage_cost(self) -> None:
+        for mdl in [self.config.chat_model, self.config.completion_model]:
+            if mdl is None:
+                return
+            if mdl not in self.usage_cost_dict:
+                self.usage_cost_dict[mdl] = LLMTokenUsage()
+            counter = self.usage_cost_dict[mdl]
+            counter.reset()
+
+    def update_usage_cost(
+        self, chat: bool, prompts: int, completions: int, cost: float
+    ) -> None:
+        """
+        Update usage cost for this LLM.
+        Args:
+            chat (bool): whether to update for chat or completion model
+            prompts (int): number of tokens used for prompts
+            completions (int): number of tokens used for completions
+            cost (float): total token cost in USD
+        """
+        mdl = self.config.chat_model if chat else self.config.completion_model
+        if mdl is None:
+            return
+        if mdl not in self.usage_cost_dict:
+            self.usage_cost_dict[mdl] = LLMTokenUsage()
+        counter = self.usage_cost_dict[mdl]
+        counter.prompt_tokens += prompts
+        counter.completion_tokens += completions
+        counter.cost += cost
+        counter.calls += 1
+
+    @classmethod
+    def usage_cost_summary(cls) -> str:
+        s = ""
+        for model, counter in cls.usage_cost_dict.items():
+            s += f"{model}: {counter}\n"
+        return s
+
+    @classmethod
+    def tot_tokens_cost(cls) -> Tuple[int, float]:
+        """
+        Return total tokens used and total cost across all models.
+        """
+        total_tokens = 0
+        total_cost = 0.0
+        for counter in cls.usage_cost_dict.values():
+            total_tokens += counter.total_tokens
+            total_cost += counter.cost
+        return total_tokens, total_cost
+
+    def get_reasoning_final(self, message: str) -> Tuple[str, str]:
+        """Extract "reasoning" and "final answer" from an LLM response, if the
+        reasoning is found within configured delimiters, like <think>, </think>.
+        E.g.,
+        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
+
+        Args:
+            message (str): message from LLM
+
+        Returns:
+            Tuple[str, str]: reasoning, final answer
+        """
+        start, end = self.config.thought_delimiters
+        if start in message and end in message:
+            parts = message.split(start)
+            if len(parts) > 1:
+                reasoning, final = parts[1].split(end)
+                return reasoning, final
+        return "", message
+
+    def followup_to_standalone(
+        self, chat_history: List[Tuple[str, str]], question: str
+    ) -> str:
+        """
+        Given a chat history and a question, convert it to a standalone question.
+        Args:
+            chat_history: list of tuples of (question, answer)
+            query: follow-up question
+
+        Returns: standalone version of the question
+        """
+        history = collate_chat_history(chat_history)
+
+        prompt = f"""
+        You are an expert at understanding a CHAT HISTORY between an AI Assistant
+        and a User, and you are highly skilled in rephrasing the User's FOLLOW-UP
+        QUESTION/REQUEST as a STANDALONE QUESTION/REQUEST that can be understood
+        WITHOUT the context of the chat history.
+
+        Below is the CHAT HISTORY. When the User asks you to rephrase a
+        FOLLOW-UP QUESTION/REQUEST, your ONLY task is to simply return the
+        question REPHRASED as a STANDALONE QUESTION/REQUEST, without any additional
+        text or context.
+
+        <CHAT_HISTORY>
+        {history}
+        </CHAT_HISTORY>
+        """.strip()
+
+        follow_up_question = f"""
+        Please rephrase this as a stand-alone question or request:
+        <FOLLOW-UP-QUESTION-OR-REQUEST>
+        {question}
+        </FOLLOW-UP-QUESTION-OR-REQUEST>
+        """.strip()
+
+        show_if_debug(prompt, "FOLLOWUP->STANDALONE-PROMPT= ")
+        standalone = (
+            self.chat(
+                messages=[
+                    LLMMessage(role=Role.SYSTEM, content=prompt),
+                    LLMMessage(role=Role.USER, content=follow_up_question),
+                ],
+                max_tokens=1024,
+            ).message
+            or ""
+        )
+        standalone = standalone.strip()
+
+        show_if_debug(prompt, "FOLLOWUP->STANDALONE-RESPONSE= ")
+        return standalone
+
+
+class StreamingIfAllowed:
+    """Context to temporarily enable or disable streaming, if allowed globally via
+    `settings.stream`"""
+
+    def __init__(self, llm: LanguageModel, stream: bool = True):
+        self.llm = llm
+        self.stream = stream
+
+    def __enter__(self) -> None:
+        self.old_stream = self.llm.set_stream(settings.stream and self.stream)
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.llm.set_stream(self.old_stream)
+</file>
+
+<file path="langroid/language_models/client_cache.py">
+"""
+Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
+"""
+
+import asyncio
+import atexit
+import hashlib
+import inspect
+import threading
+import time
+import weakref
+from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, Union, cast
+
+from cerebras.cloud.sdk import AsyncCerebras, Cerebras
+from groq import AsyncGroq, Groq
+from httpx import Timeout
+from openai import AsyncOpenAI, OpenAI
+
+# Cache for client instances, keyed by hashed configuration parameters.
+# Value is a tuple of (client instance, last_used_monotonic_seconds).
+_client_cache: Dict[str, Tuple[Any, float]] = {}
+_client_cache_lock = threading.RLock()
+
+# Keep track of clients for cleanup
+_all_clients: weakref.WeakSet[Any] = weakref.WeakSet()
+
+
+def _get_cache_key(client_type: str, **kwargs: Any) -> str:
+    """
+    Generate a cache key from client type and configuration parameters.
+    Uses the same approach as OpenAIGPT._cache_lookup for consistency.
+
+    Args:
+        client_type: Type of client (e.g., "openai", "groq", "cerebras")
+        **kwargs: Configuration parameters (api_key, base_url, timeout, etc.)
+
+    Returns:
+        SHA256 hash of the configuration as a hex string
+    """
+    # Convert kwargs to sorted string representation
+    sorted_kwargs_str = str(sorted(kwargs.items()))
+
+    # Create raw key combining client type and sorted kwargs
+    raw_key = f"{client_type}:{sorted_kwargs_str}"
+
+    # Hash the key for consistent length and to handle complex objects
+    hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
+
+    return hashed_key
+
+
+def wrap_api_key_provider_async(
+    provider: Callable[[], str],
+) -> Callable[[], Awaitable[str]]:
+    """
+    Wrap a sync API-key provider for use with ``AsyncOpenAI``.
+
+    ``AsyncOpenAI`` awaits its ``api_key`` callable, so a plain sync
+    provider must be wrapped in an async function. The sync provider is run
+    in a worker thread, so a blocking token refresh cannot stall the event
+    loop. Providers must therefore be thread-safe -- the sync client may
+    call them from arbitrary threads anyway.
+
+    Args:
+        provider: Callable returning a (possibly short-lived) API key.
+
+    Returns:
+        Async callable returning the same key.
+    """
+
+    async def _provider() -> str:
+        return await asyncio.to_thread(provider)
+
+    return _provider
+
+
+def _api_key_cache_component(api_key: Union[str, Callable[[], str]]) -> Any:
+    """
+    Cache-key component for an API key that may be a rotating-key provider.
+
+    A callable provider is keyed on its identity rather than any token value,
+    so rotating tokens never create new cache entries and tokens are never
+    retained in cache keys. The id() cannot be recycled while the entry
+    lives, because the cached client holds a strong reference to the
+    provider (directly for sync clients, via the async wrapper's closure
+    for async clients).
+    """
+    if callable(api_key):
+        return ("api_key_provider", id(api_key))
+    return api_key
+
+
+def _get_cached_client(cache_key: str) -> Optional[Any]:
+    """Get cached client and refresh its last-used timestamp.
+
+    Must be called while holding ``_client_cache_lock``.
+    """
+    entry = _client_cache.get(cache_key)
+    if entry is None:
+        return None
+
+    client, _ = entry
+    _client_cache[cache_key] = (client, time.monotonic())
+    return client
+
+
+def _store_client(cache_key: str, client: Any) -> None:
+    """Store a client in the cache with the current timestamp.
+
+    Must be called while holding ``_client_cache_lock``.
+    """
+    _client_cache[cache_key] = (client, time.monotonic())
+    _all_clients.add(client)
+
+
+def get_openai_client(
+    api_key: Union[str, Callable[[], str]],
+    base_url: Optional[str] = None,
+    organization: Optional[str] = None,
+    timeout: Union[float, Timeout] = 120.0,
+    default_headers: Optional[Dict[str, str]] = None,
+    http_client: Optional[Any] = None,
+    http_client_config: Optional[Dict[str, Any]] = None,
+) -> OpenAI:
+    """
+    Get or create a singleton OpenAI client with the given configuration.
+
+    Args:
+        api_key: OpenAI API key, or a callable returning a fresh key
+            (for short-lived rotating credentials); a callable is resolved
+            per-request by the OpenAI client and is excluded from the
+            cache key (the cache is keyed on the provider's identity)
+        base_url: Optional base URL for API
+        organization: Optional organization ID
+        timeout: Request timeout
+        default_headers: Optional default headers
+        http_client: Optional httpx.Client instance
+        http_client_config: Optional config dict for creating httpx.Client
+
+    Returns:
+        OpenAI client instance
+    """
+    if isinstance(timeout, (int, float)):
+        timeout = Timeout(timeout)
+
+    # If http_client is provided directly, don't cache (complex object)
+    if http_client is not None:
+        client = OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            organization=organization,
+            timeout=timeout,
+            default_headers=default_headers,
+            http_client=http_client,
+        )
+        _all_clients.add(client)
+        return client
+
+    cache_key = _get_cache_key(
+        "openai",
+        api_key=_api_key_cache_component(api_key),
+        base_url=base_url,
+        organization=organization,
+        timeout=timeout,
+        default_headers=default_headers,
+        http_client_config=http_client_config,  # Include config in cache key
+    )
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(OpenAI, cached_client)
+
+        created_http_client = None
+        if http_client_config is not None:
+            try:
+                from httpx import Client
+            except ImportError:
+                raise ValueError(
+                    "httpx is required to use http_client_config. "
+                    "Install it with: pip install httpx"
+                )
+            created_http_client = Client(**http_client_config)
+
+        client = OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            organization=organization,
+            timeout=timeout,
+            default_headers=default_headers,
+            http_client=created_http_client,  # Use the client created from config
+        )
+
+        _store_client(cache_key, client)
+    return client
+
+
+def get_async_openai_client(
+    api_key: Union[str, Callable[[], str]],
+    base_url: Optional[str] = None,
+    organization: Optional[str] = None,
+    timeout: Union[float, Timeout] = 120.0,
+    default_headers: Optional[Dict[str, str]] = None,
+    http_client: Optional[Any] = None,
+    http_client_config: Optional[Dict[str, Any]] = None,
+) -> AsyncOpenAI:
+    """
+    Get or create a singleton AsyncOpenAI client with the given configuration.
+
+    Args:
+        api_key: OpenAI API key, or a callable returning a fresh key
+            (for short-lived rotating credentials); a callable is resolved
+            per-request by the OpenAI client and is excluded from the
+            cache key (the cache is keyed on the provider's identity)
+        base_url: Optional base URL for API
+        organization: Optional organization ID
+        timeout: Request timeout
+        default_headers: Optional default headers
+        http_client: Optional httpx.AsyncClient instance
+        http_client_config: Optional config dict for creating httpx.AsyncClient
+
+    Returns:
+        AsyncOpenAI client instance
+    """
+    if isinstance(timeout, (int, float)):
+        timeout = Timeout(timeout)
+
+    api_key_arg: Union[str, Callable[[], Awaitable[str]]]
+    if callable(api_key):
+        # AsyncOpenAI awaits its api_key callable, so wrap the sync provider
+        api_key_arg = wrap_api_key_provider_async(api_key)
+    else:
+        api_key_arg = api_key
+
+    # If http_client is provided directly, don't cache (complex object)
+    if http_client is not None:
+        client = AsyncOpenAI(
+            api_key=api_key_arg,
+            base_url=base_url,
+            organization=organization,
+            timeout=timeout,
+            default_headers=default_headers,
+            http_client=http_client,
+        )
+        _all_clients.add(client)
+        return client
+
+    cache_key = _get_cache_key(
+        "async_openai",
+        api_key=_api_key_cache_component(api_key),
+        base_url=base_url,
+        organization=organization,
+        timeout=timeout,
+        default_headers=default_headers,
+        http_client_config=http_client_config,  # Include config in cache key
+    )
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(AsyncOpenAI, cached_client)
+
+        created_http_client = None
+        if http_client_config is not None:
+            try:
+                from httpx import AsyncClient
+            except ImportError:
+                raise ValueError(
+                    "httpx is required to use http_client_config. "
+                    "Install it with: pip install httpx"
+                )
+            created_http_client = AsyncClient(**http_client_config)
+
+        client = AsyncOpenAI(
+            api_key=api_key_arg,
+            base_url=base_url,
+            organization=organization,
+            timeout=timeout,
+            default_headers=default_headers,
+            http_client=created_http_client,  # Use the client created from config
+        )
+
+        _store_client(cache_key, client)
+    return client
+
+
+def get_groq_client(api_key: str) -> Groq:
+    """
+    Get or create a singleton Groq client with the given configuration.
+
+    Args:
+        api_key: Groq API key
+
+    Returns:
+        Groq client instance
+    """
+    cache_key = _get_cache_key("groq", api_key=api_key)
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(Groq, cached_client)
+
+        client = Groq(api_key=api_key)
+        _store_client(cache_key, client)
+    return client
+
+
+def get_async_groq_client(api_key: str) -> AsyncGroq:
+    """
+    Get or create a singleton AsyncGroq client with the given configuration.
+
+    Args:
+        api_key: Groq API key
+
+    Returns:
+        AsyncGroq client instance
+    """
+    cache_key = _get_cache_key("async_groq", api_key=api_key)
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(AsyncGroq, cached_client)
+
+        client = AsyncGroq(api_key=api_key)
+        _store_client(cache_key, client)
+    return client
+
+
+def get_cerebras_client(api_key: str) -> Cerebras:
+    """
+    Get or create a singleton Cerebras client with the given configuration.
+
+    Args:
+        api_key: Cerebras API key
+
+    Returns:
+        Cerebras client instance
+    """
+    cache_key = _get_cache_key("cerebras", api_key=api_key)
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(Cerebras, cached_client)
+
+        client = Cerebras(api_key=api_key)
+        _store_client(cache_key, client)
+    return client
+
+
+def get_async_cerebras_client(api_key: str) -> AsyncCerebras:
+    """
+    Get or create a singleton AsyncCerebras client with the given configuration.
+
+    Args:
+        api_key: Cerebras API key
+
+    Returns:
+        AsyncCerebras client instance
+    """
+    cache_key = _get_cache_key("async_cerebras", api_key=api_key)
+
+    with _client_cache_lock:
+        cached_client = _get_cached_client(cache_key)
+        if cached_client is not None:
+            return cast(AsyncCerebras, cached_client)
+
+        client = AsyncCerebras(api_key=api_key)
+        _store_client(cache_key, client)
+    return client
+
+
+def prune_cache(max_age_seconds: float) -> int:
+    """
+    Remove cache entries whose last-used time exceeds *max_age_seconds*.
+
+    Evicted clients are **not** closed here because they may still be serving
+    in-flight requests.  Cleanup is handled by the ``atexit`` handler and the
+    garbage collector.
+
+    Args:
+        max_age_seconds: Maximum age (in seconds) for cache entries to keep.
+            Entries older than this value are removed.
+
+    Returns:
+        Number of cache entries removed.
+    """
+    if max_age_seconds < 0:
+        raise ValueError("max_age_seconds must be non-negative")
+
+    now = time.monotonic()
+
+    with _client_cache_lock:
+        stale_keys = [
+            key
+            for key, (_, last_used_at) in _client_cache.items()
+            if now - last_used_at > max_age_seconds
+        ]
+
+        for key in stale_keys:
+            _client_cache.pop(key)
+
+    # Don't close evicted clients here — they may still be serving in-flight
+    # requests. The atexit handler and GC will clean them up.
+
+    return len(stale_keys)
+
+
+def _cleanup_clients() -> None:
+    """
+    Cleanup function to close all cached clients on exit.
+    Called automatically via atexit.
+    """
+    for client in list(_all_clients):
+        if hasattr(client, "close") and callable(client.close):
+            try:
+                # Check if close is a coroutine function (async)
+                if inspect.iscoroutinefunction(client.close):
+                    # For async clients, we can't await in atexit
+                    # They will be cleaned up by the OS
+                    pass
+                else:
+                    # Sync clients can be closed directly
+                    client.close()
+            except Exception:
+                pass  # Ignore errors during cleanup
+
+
+# Register cleanup function to run on exit
+atexit.register(_cleanup_clients)
+
+
+# For testing purposes
+def _clear_cache() -> None:
+    """Clear the client cache. Only for testing."""
+    with _client_cache_lock:
+        _client_cache.clear()
+</file>
+
+<file path="SECURITY.md">
+# Security Policy
+
+## Threat model — please read this before reporting
+
+Langroid is a framework for building applications in which an LLM generates
+code and queries that are then executed. Several **optional** agents exist for
+exactly that purpose:
+
+- `TableChatAgent`, `LanceDocChatAgent`, and `VectorStore.compute_from_docs`
+  evaluate LLM-generated **pandas expressions** with `eval()`.
+- `SQLChatAgent` executes LLM-generated **SQL** against a database you supply.
+- `Neo4jChatAgent`, `ArangoChatAgent`, and `CSVGraphAgent` execute
+  LLM-generated **Cypher / AQL** against a graph database you supply.
+
+Executing model-generated code against your own data *is the feature*. An LLM
+is not a trust boundary: if any untrusted text reaches the model's context, you
+must assume the model can be induced to emit any query or expression the
+grammar allows. Langroid cannot prevent this, and does not claim to.
+
+### What is, and is not, a security boundary
+
+The following are **best-effort hardening, not security boundaries**:
+
+- `sanitize_command()` / `CommandValidator` / `safe_eval_globals()` in
+  `langroid/utils/pandas_utils.py`
+- `_DANGEROUS_SQL_PATTERNS` and the `sqlglot` AST checks in `SQLChatAgent`
+- `validate_cypher_query()` / `validate_aql_query()` in the graph agents
+
+They exist to stop an *unlucky* LLM, not a *determined attacker*. The pandas
+path uses explicit allowlists for AST nodes, methods, operators, variables, and
+builtins. The SQL, Cypher, and AQL paths use denylists over full query grammars
+that span multiple dialects, quoting and escaping forms, and function families.
+Such denylists cannot be made complete. We patch clear gaps opportunistically,
+but we do not treat a newly found way around them as a vulnerability in
+Langroid.
+
+The **actual** security boundaries for a Langroid deployment are:
+
+- the privileges of the database credential you hand the agent;
+- the OS user, container, or VM the process runs in;
+- filesystem permissions and network egress rules.
+
+### Deploying these agents safely
+
+If you expose any of the code- or query-executing agents to untrusted input:
+
+- **Give the agent a least-privilege database role.** For `SQLChatAgent`, a
+  read-only, non-superuser role with `GRANT SELECT` on only the intended
+  tables. In PostgreSQL, server-side file reads and writes normally require a
+  superuser, membership in `pg_read_server_files` or
+  `pg_write_server_files`, or a direct grant on a privileged function.
+  `COPY ... PROGRAM` instead requires superuser access or membership in the
+  distinct `pg_execute_server_program` role. Server-side `lo_import` and
+  `lo_export` default to superuser-only use, but an administrator can grant
+  access to those functions directly. Ordinary password-authenticated
+  `dblink` connections do not require any of those roles. Do not install
+  unneeded extensions, and revoke access to dangerous extensions and
+  functions, including `dblink`, in addition to granting only the intended
+  table privileges. Review any site-specific functions and grants as well.
+- **Run the process in a container or VM** with no credentials, secrets, or
+  data you are unwilling to expose to the LLM.
+- **Treat `allow_dangerous_operations=True` and `full_eval=True` as
+  "I am providing my own sandbox."** The first permits dangerous database
+  operations. The second disables pandas AST validation while retaining the
+  restricted globals from `safe_eval_globals()`. Both are documented as
+  trusted-environment-only.
+
+## Reporting a vulnerability
+
+Report privately — **not** via GitHub Issues, Discussions, or any other public
+forum:
+
+1. Go to
+   **[Security Advisories](https://github.com/langroid/langroid/security/advisories)**.
+2. Click **"Report a vulnerability"**.
+3. Include a proof of concept that works against a **default configuration**.
+
+We aim to acknowledge in-scope reports within 7 days.
+
+### In scope
+
+- Vulnerabilities in core framework code: tool dispatch and the agent/tool
+  trust boundary, message routing, sender verification.
+- Parsing and deserialization flaws (XXE, unsafe deserialization, decompression
+  bombs) in the document and message parsers.
+- Path traversal in the file tools (`ReadFileTool`, `WriteFileTool`,
+  `ListDirTool`) and in repository / folder ingestion.
+- Credential or secret leakage in a default configuration that does not depend
+  on any of the specific exclusions below. The out-of-scope rules take
+  precedence over this category.
+- **A code path that skips a documented safety gate entirely** — that is, a
+  *missing call* to a validator, not a *bypass* of one.
+- **A statement the `allowed_statement_types` allowlist misclassifies.** The
+  allowlist is a different kind of control from the denylists above: it decides
+  what a statement *does* over a closed set of statement kinds, so a query that
+  performs a write the allowlist did not authorize — for example by nesting it
+  where the classifier does not look — is a bounded, fixable defect and is in
+  scope.
+- Vulnerable dependencies with a demonstrated impact on Langroid.
+
+### Out of scope
+
+The following will be closed without a fix, an advisory, or a CVE request:
+
+- New bypasses of the SQL, Cypher, or AQL denylists: previously unlisted
+  functions, alternate quoting or escaping forms (backticks, Unicode escapes,
+  schema qualification), or dialect-specific syntax. See "What is, and is not,
+  a security boundary" above.
+- Sandbox escapes from the pandas `eval()` path when `full_eval=True`,
+  including object-graph traversal via dunder attributes. `full_eval=True`
+  disables the AST validator by design.
+- Anything requiring `allow_dangerous_operations=True`.
+- "The LLM can be prompt-injected into generating a harmful query." This is the
+  documented threat model, not a defect.
+- Reports that assume the agent was given a superuser or otherwise
+  over-privileged database credential.
+- Theoretical reports with no working proof of concept against a default
+  configuration.
+
+Reports that chain off a previous advisory as an "incomplete fix" are judged
+against this same scope: if the original issue was a missing gate we will fix
+it, and if it was a denylist gap it is out of scope.
+
+## Supported versions
+
+Security fixes ship in the latest release. Please upgrade to the current
+version of `langroid` rather than requesting backports.
+</file>
+
 <file path="langroid/agent/task.py">
 from __future__ import annotations
 
@@ -112779,7 +115667,11 @@ class Task:
         # copy the agent's config, so that we don't modify the original agent's config,
         # which may be shared by other agents.
         try:
-            config_copy = copy.deepcopy(agent.config)
+            from langroid.agent.tool_policy import deepcopy_config_sharing_policy
+
+            # the tool_policy hook is shared by reference (never deep-copied),
+            # so its state (budgets, approvals) stays global across copies
+            config_copy = deepcopy_config_sharing_policy(agent.config)
             agent.config = config_copy
         except Exception:
             logger.warning(
@@ -114954,3894 +117846,6 @@ class Task:
                 seq_idx -= 1
                 msg_idx -= 1
         return seq_idx < 0
-</file>
-
-<file path="langroid/language_models/client_cache.py">
-"""
-Client caching/singleton pattern for LLM clients to prevent connection pool exhaustion.
-"""
-
-import asyncio
-import atexit
-import hashlib
-import inspect
-import threading
-import time
-import weakref
-from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, Union, cast
-
-from cerebras.cloud.sdk import AsyncCerebras, Cerebras
-from groq import AsyncGroq, Groq
-from httpx import Timeout
-from openai import AsyncOpenAI, OpenAI
-
-# Cache for client instances, keyed by hashed configuration parameters.
-# Value is a tuple of (client instance, last_used_monotonic_seconds).
-_client_cache: Dict[str, Tuple[Any, float]] = {}
-_client_cache_lock = threading.RLock()
-
-# Keep track of clients for cleanup
-_all_clients: weakref.WeakSet[Any] = weakref.WeakSet()
-
-
-def _get_cache_key(client_type: str, **kwargs: Any) -> str:
-    """
-    Generate a cache key from client type and configuration parameters.
-    Uses the same approach as OpenAIGPT._cache_lookup for consistency.
-
-    Args:
-        client_type: Type of client (e.g., "openai", "groq", "cerebras")
-        **kwargs: Configuration parameters (api_key, base_url, timeout, etc.)
-
-    Returns:
-        SHA256 hash of the configuration as a hex string
-    """
-    # Convert kwargs to sorted string representation
-    sorted_kwargs_str = str(sorted(kwargs.items()))
-
-    # Create raw key combining client type and sorted kwargs
-    raw_key = f"{client_type}:{sorted_kwargs_str}"
-
-    # Hash the key for consistent length and to handle complex objects
-    hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
-
-    return hashed_key
-
-
-def wrap_api_key_provider_async(
-    provider: Callable[[], str],
-) -> Callable[[], Awaitable[str]]:
-    """
-    Wrap a sync API-key provider for use with ``AsyncOpenAI``.
-
-    ``AsyncOpenAI`` awaits its ``api_key`` callable, so a plain sync
-    provider must be wrapped in an async function. The sync provider is run
-    in a worker thread, so a blocking token refresh cannot stall the event
-    loop. Providers must therefore be thread-safe -- the sync client may
-    call them from arbitrary threads anyway.
-
-    Args:
-        provider: Callable returning a (possibly short-lived) API key.
-
-    Returns:
-        Async callable returning the same key.
-    """
-
-    async def _provider() -> str:
-        return await asyncio.to_thread(provider)
-
-    return _provider
-
-
-def _api_key_cache_component(api_key: Union[str, Callable[[], str]]) -> Any:
-    """
-    Cache-key component for an API key that may be a rotating-key provider.
-
-    A callable provider is keyed on its identity rather than any token value,
-    so rotating tokens never create new cache entries and tokens are never
-    retained in cache keys. The id() cannot be recycled while the entry
-    lives, because the cached client holds a strong reference to the
-    provider (directly for sync clients, via the async wrapper's closure
-    for async clients).
-    """
-    if callable(api_key):
-        return ("api_key_provider", id(api_key))
-    return api_key
-
-
-def _get_cached_client(cache_key: str) -> Optional[Any]:
-    """Get cached client and refresh its last-used timestamp.
-
-    Must be called while holding ``_client_cache_lock``.
-    """
-    entry = _client_cache.get(cache_key)
-    if entry is None:
-        return None
-
-    client, _ = entry
-    _client_cache[cache_key] = (client, time.monotonic())
-    return client
-
-
-def _store_client(cache_key: str, client: Any) -> None:
-    """Store a client in the cache with the current timestamp.
-
-    Must be called while holding ``_client_cache_lock``.
-    """
-    _client_cache[cache_key] = (client, time.monotonic())
-    _all_clients.add(client)
-
-
-def get_openai_client(
-    api_key: Union[str, Callable[[], str]],
-    base_url: Optional[str] = None,
-    organization: Optional[str] = None,
-    timeout: Union[float, Timeout] = 120.0,
-    default_headers: Optional[Dict[str, str]] = None,
-    http_client: Optional[Any] = None,
-    http_client_config: Optional[Dict[str, Any]] = None,
-) -> OpenAI:
-    """
-    Get or create a singleton OpenAI client with the given configuration.
-
-    Args:
-        api_key: OpenAI API key, or a callable returning a fresh key
-            (for short-lived rotating credentials); a callable is resolved
-            per-request by the OpenAI client and is excluded from the
-            cache key (the cache is keyed on the provider's identity)
-        base_url: Optional base URL for API
-        organization: Optional organization ID
-        timeout: Request timeout
-        default_headers: Optional default headers
-        http_client: Optional httpx.Client instance
-        http_client_config: Optional config dict for creating httpx.Client
-
-    Returns:
-        OpenAI client instance
-    """
-    if isinstance(timeout, (int, float)):
-        timeout = Timeout(timeout)
-
-    # If http_client is provided directly, don't cache (complex object)
-    if http_client is not None:
-        client = OpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            organization=organization,
-            timeout=timeout,
-            default_headers=default_headers,
-            http_client=http_client,
-        )
-        _all_clients.add(client)
-        return client
-
-    cache_key = _get_cache_key(
-        "openai",
-        api_key=_api_key_cache_component(api_key),
-        base_url=base_url,
-        organization=organization,
-        timeout=timeout,
-        default_headers=default_headers,
-        http_client_config=http_client_config,  # Include config in cache key
-    )
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(OpenAI, cached_client)
-
-        created_http_client = None
-        if http_client_config is not None:
-            try:
-                from httpx import Client
-            except ImportError:
-                raise ValueError(
-                    "httpx is required to use http_client_config. "
-                    "Install it with: pip install httpx"
-                )
-            created_http_client = Client(**http_client_config)
-
-        client = OpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            organization=organization,
-            timeout=timeout,
-            default_headers=default_headers,
-            http_client=created_http_client,  # Use the client created from config
-        )
-
-        _store_client(cache_key, client)
-    return client
-
-
-def get_async_openai_client(
-    api_key: Union[str, Callable[[], str]],
-    base_url: Optional[str] = None,
-    organization: Optional[str] = None,
-    timeout: Union[float, Timeout] = 120.0,
-    default_headers: Optional[Dict[str, str]] = None,
-    http_client: Optional[Any] = None,
-    http_client_config: Optional[Dict[str, Any]] = None,
-) -> AsyncOpenAI:
-    """
-    Get or create a singleton AsyncOpenAI client with the given configuration.
-
-    Args:
-        api_key: OpenAI API key, or a callable returning a fresh key
-            (for short-lived rotating credentials); a callable is resolved
-            per-request by the OpenAI client and is excluded from the
-            cache key (the cache is keyed on the provider's identity)
-        base_url: Optional base URL for API
-        organization: Optional organization ID
-        timeout: Request timeout
-        default_headers: Optional default headers
-        http_client: Optional httpx.AsyncClient instance
-        http_client_config: Optional config dict for creating httpx.AsyncClient
-
-    Returns:
-        AsyncOpenAI client instance
-    """
-    if isinstance(timeout, (int, float)):
-        timeout = Timeout(timeout)
-
-    api_key_arg: Union[str, Callable[[], Awaitable[str]]]
-    if callable(api_key):
-        # AsyncOpenAI awaits its api_key callable, so wrap the sync provider
-        api_key_arg = wrap_api_key_provider_async(api_key)
-    else:
-        api_key_arg = api_key
-
-    # If http_client is provided directly, don't cache (complex object)
-    if http_client is not None:
-        client = AsyncOpenAI(
-            api_key=api_key_arg,
-            base_url=base_url,
-            organization=organization,
-            timeout=timeout,
-            default_headers=default_headers,
-            http_client=http_client,
-        )
-        _all_clients.add(client)
-        return client
-
-    cache_key = _get_cache_key(
-        "async_openai",
-        api_key=_api_key_cache_component(api_key),
-        base_url=base_url,
-        organization=organization,
-        timeout=timeout,
-        default_headers=default_headers,
-        http_client_config=http_client_config,  # Include config in cache key
-    )
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(AsyncOpenAI, cached_client)
-
-        created_http_client = None
-        if http_client_config is not None:
-            try:
-                from httpx import AsyncClient
-            except ImportError:
-                raise ValueError(
-                    "httpx is required to use http_client_config. "
-                    "Install it with: pip install httpx"
-                )
-            created_http_client = AsyncClient(**http_client_config)
-
-        client = AsyncOpenAI(
-            api_key=api_key_arg,
-            base_url=base_url,
-            organization=organization,
-            timeout=timeout,
-            default_headers=default_headers,
-            http_client=created_http_client,  # Use the client created from config
-        )
-
-        _store_client(cache_key, client)
-    return client
-
-
-def get_groq_client(api_key: str) -> Groq:
-    """
-    Get or create a singleton Groq client with the given configuration.
-
-    Args:
-        api_key: Groq API key
-
-    Returns:
-        Groq client instance
-    """
-    cache_key = _get_cache_key("groq", api_key=api_key)
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(Groq, cached_client)
-
-        client = Groq(api_key=api_key)
-        _store_client(cache_key, client)
-    return client
-
-
-def get_async_groq_client(api_key: str) -> AsyncGroq:
-    """
-    Get or create a singleton AsyncGroq client with the given configuration.
-
-    Args:
-        api_key: Groq API key
-
-    Returns:
-        AsyncGroq client instance
-    """
-    cache_key = _get_cache_key("async_groq", api_key=api_key)
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(AsyncGroq, cached_client)
-
-        client = AsyncGroq(api_key=api_key)
-        _store_client(cache_key, client)
-    return client
-
-
-def get_cerebras_client(api_key: str) -> Cerebras:
-    """
-    Get or create a singleton Cerebras client with the given configuration.
-
-    Args:
-        api_key: Cerebras API key
-
-    Returns:
-        Cerebras client instance
-    """
-    cache_key = _get_cache_key("cerebras", api_key=api_key)
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(Cerebras, cached_client)
-
-        client = Cerebras(api_key=api_key)
-        _store_client(cache_key, client)
-    return client
-
-
-def get_async_cerebras_client(api_key: str) -> AsyncCerebras:
-    """
-    Get or create a singleton AsyncCerebras client with the given configuration.
-
-    Args:
-        api_key: Cerebras API key
-
-    Returns:
-        AsyncCerebras client instance
-    """
-    cache_key = _get_cache_key("async_cerebras", api_key=api_key)
-
-    with _client_cache_lock:
-        cached_client = _get_cached_client(cache_key)
-        if cached_client is not None:
-            return cast(AsyncCerebras, cached_client)
-
-        client = AsyncCerebras(api_key=api_key)
-        _store_client(cache_key, client)
-    return client
-
-
-def prune_cache(max_age_seconds: float) -> int:
-    """
-    Remove cache entries whose last-used time exceeds *max_age_seconds*.
-
-    Evicted clients are **not** closed here because they may still be serving
-    in-flight requests.  Cleanup is handled by the ``atexit`` handler and the
-    garbage collector.
-
-    Args:
-        max_age_seconds: Maximum age (in seconds) for cache entries to keep.
-            Entries older than this value are removed.
-
-    Returns:
-        Number of cache entries removed.
-    """
-    if max_age_seconds < 0:
-        raise ValueError("max_age_seconds must be non-negative")
-
-    now = time.monotonic()
-
-    with _client_cache_lock:
-        stale_keys = [
-            key
-            for key, (_, last_used_at) in _client_cache.items()
-            if now - last_used_at > max_age_seconds
-        ]
-
-        for key in stale_keys:
-            _client_cache.pop(key)
-
-    # Don't close evicted clients here — they may still be serving in-flight
-    # requests. The atexit handler and GC will clean them up.
-
-    return len(stale_keys)
-
-
-def _cleanup_clients() -> None:
-    """
-    Cleanup function to close all cached clients on exit.
-    Called automatically via atexit.
-    """
-    for client in list(_all_clients):
-        if hasattr(client, "close") and callable(client.close):
-            try:
-                # Check if close is a coroutine function (async)
-                if inspect.iscoroutinefunction(client.close):
-                    # For async clients, we can't await in atexit
-                    # They will be cleaned up by the OS
-                    pass
-                else:
-                    # Sync clients can be closed directly
-                    client.close()
-            except Exception:
-                pass  # Ignore errors during cleanup
-
-
-# Register cleanup function to run on exit
-atexit.register(_cleanup_clients)
-
-
-# For testing purposes
-def _clear_cache() -> None:
-    """Clear the client cache. Only for testing."""
-    with _client_cache_lock:
-        _client_cache.clear()
-</file>
-
-<file path="SECURITY.md">
-# Security Policy
-
-## Threat model — please read this before reporting
-
-Langroid is a framework for building applications in which an LLM generates
-code and queries that are then executed. Several **optional** agents exist for
-exactly that purpose:
-
-- `TableChatAgent`, `LanceDocChatAgent`, and `VectorStore.compute_from_docs`
-  evaluate LLM-generated **pandas expressions** with `eval()`.
-- `SQLChatAgent` executes LLM-generated **SQL** against a database you supply.
-- `Neo4jChatAgent`, `ArangoChatAgent`, and `CSVGraphAgent` execute
-  LLM-generated **Cypher / AQL** against a graph database you supply.
-
-Executing model-generated code against your own data *is the feature*. An LLM
-is not a trust boundary: if any untrusted text reaches the model's context, you
-must assume the model can be induced to emit any query or expression the
-grammar allows. Langroid cannot prevent this, and does not claim to.
-
-### What is, and is not, a security boundary
-
-The following are **best-effort hardening, not security boundaries**:
-
-- `sanitize_command()` / `CommandValidator` / `safe_eval_globals()` in
-  `langroid/utils/pandas_utils.py`
-- `_DANGEROUS_SQL_PATTERNS` and the `sqlglot` AST checks in `SQLChatAgent`
-- `validate_cypher_query()` / `validate_aql_query()` in the graph agents
-
-They exist to stop an *unlucky* LLM, not a *determined attacker*. The pandas
-path uses explicit allowlists for AST nodes, methods, operators, variables, and
-builtins. The SQL, Cypher, and AQL paths use denylists over full query grammars
-that span multiple dialects, quoting and escaping forms, and function families.
-Such denylists cannot be made complete. We patch clear gaps opportunistically,
-but we do not treat a newly found way around them as a vulnerability in
-Langroid.
-
-The **actual** security boundaries for a Langroid deployment are:
-
-- the privileges of the database credential you hand the agent;
-- the OS user, container, or VM the process runs in;
-- filesystem permissions and network egress rules.
-
-### Deploying these agents safely
-
-If you expose any of the code- or query-executing agents to untrusted input:
-
-- **Give the agent a least-privilege database role.** For `SQLChatAgent`, a
-  read-only, non-superuser role with `GRANT SELECT` on only the intended
-  tables. In PostgreSQL, server-side file reads and writes normally require a
-  superuser, membership in `pg_read_server_files` or
-  `pg_write_server_files`, or a direct grant on a privileged function.
-  `COPY ... PROGRAM` instead requires superuser access or membership in the
-  distinct `pg_execute_server_program` role. Server-side `lo_import` and
-  `lo_export` default to superuser-only use, but an administrator can grant
-  access to those functions directly. Ordinary password-authenticated
-  `dblink` connections do not require any of those roles. Do not install
-  unneeded extensions, and revoke access to dangerous extensions and
-  functions, including `dblink`, in addition to granting only the intended
-  table privileges. Review any site-specific functions and grants as well.
-- **Run the process in a container or VM** with no credentials, secrets, or
-  data you are unwilling to expose to the LLM.
-- **Treat `allow_dangerous_operations=True` and `full_eval=True` as
-  "I am providing my own sandbox."** The first permits dangerous database
-  operations. The second disables pandas AST validation while retaining the
-  restricted globals from `safe_eval_globals()`. Both are documented as
-  trusted-environment-only.
-
-## Reporting a vulnerability
-
-Report privately — **not** via GitHub Issues, Discussions, or any other public
-forum:
-
-1. Go to
-   **[Security Advisories](https://github.com/langroid/langroid/security/advisories)**.
-2. Click **"Report a vulnerability"**.
-3. Include a proof of concept that works against a **default configuration**.
-
-We aim to acknowledge in-scope reports within 7 days.
-
-### In scope
-
-- Vulnerabilities in core framework code: tool dispatch and the agent/tool
-  trust boundary, message routing, sender verification.
-- Parsing and deserialization flaws (XXE, unsafe deserialization, decompression
-  bombs) in the document and message parsers.
-- Path traversal in the file tools (`ReadFileTool`, `WriteFileTool`,
-  `ListDirTool`) and in repository / folder ingestion.
-- Credential or secret leakage in a default configuration that does not depend
-  on any of the specific exclusions below. The out-of-scope rules take
-  precedence over this category.
-- **A code path that skips a documented safety gate entirely** — that is, a
-  *missing call* to a validator, not a *bypass* of one.
-- **A statement the `allowed_statement_types` allowlist misclassifies.** The
-  allowlist is a different kind of control from the denylists above: it decides
-  what a statement *does* over a closed set of statement kinds, so a query that
-  performs a write the allowlist did not authorize — for example by nesting it
-  where the classifier does not look — is a bounded, fixable defect and is in
-  scope.
-- Vulnerable dependencies with a demonstrated impact on Langroid.
-
-### Out of scope
-
-The following will be closed without a fix, an advisory, or a CVE request:
-
-- New bypasses of the SQL, Cypher, or AQL denylists: previously unlisted
-  functions, alternate quoting or escaping forms (backticks, Unicode escapes,
-  schema qualification), or dialect-specific syntax. See "What is, and is not,
-  a security boundary" above.
-- Sandbox escapes from the pandas `eval()` path when `full_eval=True`,
-  including object-graph traversal via dunder attributes. `full_eval=True`
-  disables the AST validator by design.
-- Anything requiring `allow_dangerous_operations=True`.
-- "The LLM can be prompt-injected into generating a harmful query." This is the
-  documented threat model, not a defect.
-- Reports that assume the agent was given a superuser or otherwise
-  over-privileged database credential.
-- Theoretical reports with no working proof of concept against a default
-  configuration.
-
-Reports that chain off a previous advisory as an "incomplete fix" are judged
-against this same scope: if the original issue was a missing gate we will fix
-it, and if it was a denylist gap it is out of scope.
-
-## Supported versions
-
-Security fixes ship in the latest release. Please upgrade to the current
-version of `langroid` rather than requesting backports.
-</file>
-
-<file path="langroid/agent/chat_agent.py">
-import copy
-import inspect
-import json
-import logging
-import textwrap
-from contextlib import ExitStack
-from inspect import isclass
-from typing import (
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Self,
-    Set,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
-
-import openai
-from pydantic import BaseModel, ValidationError
-from pydantic.fields import ModelPrivateAttr
-from rich import print
-from rich.console import Console
-from rich.markup import escape
-
-from langroid.agent.base import (
-    Agent,
-    AgentConfig,
-    SearchForTools,
-    async_noop_fn,
-    noop_fn,
-)
-from langroid.agent.chat_document import ChatDocument
-from langroid.agent.tool_message import (
-    ToolMessage,
-    format_schema_for_strict,
-)
-from langroid.agent.xml_tool_message import XMLToolMessage
-from langroid.language_models.base import (
-    LLMFunctionCall,
-    LLMFunctionSpec,
-    LLMMessage,
-    LLMResponse,
-    OpenAIJsonSchemaSpec,
-    OpenAIToolSpec,
-    Role,
-    StreamingIfAllowed,
-    ToolChoiceTypes,
-)
-from langroid.language_models.openai_gpt import OpenAIGPT
-from langroid.mytypes import Entity, NonToolAction
-from langroid.utils.configuration import settings
-from langroid.utils.object_registry import ObjectRegistry
-from langroid.utils.output import status
-from langroid.utils.pydantic_utils import PydanticWrapper, get_pydantic_wrapper
-from langroid.utils.types import is_callable
-
-console = Console()
-
-logger = logging.getLogger(__name__)
-
-
-def _is_identified_result(message: LLMMessage) -> bool:
-    """Whether a TOOL/FUNCTION result has its identifier and no call payload.
-
-    Such results must survive even with empty content so their calls can be
-    marked complete (issue #1063).
-    """
-    has_identifier = (
-        message.role == Role.TOOL and bool((message.tool_call_id or "").strip())
-    ) or (message.role == Role.FUNCTION and bool((message.name or "").strip()))
-    return has_identifier and message.function_call is None and not message.tool_calls
-
-
-def _llm_message_has_payload(message: LLMMessage) -> bool:
-    """Whether a message has the fields required for a valid history entry."""
-    return (
-        (message.content or "").strip() != ""
-        or message.function_call is not None
-        or bool(message.tool_calls)
-        or _is_identified_result(message)
-    )
-
-
-class ChatAgentConfig(AgentConfig):
-    """
-    Configuration for ChatAgent
-
-    Attributes:
-        system_message: system message to include in message sequence
-             (typically defines role and task of agent).
-             Used only if `task` is not specified in the constructor.
-        user_message: user message to include in message sequence.
-             Used only if `task` is not specified in the constructor.
-        use_tools: whether to use our own ToolMessages mechanism
-        handle_llm_no_tool (Any): desired agent_response when
-            LLM generates non-tool msg.
-        use_functions_api: whether to use functions/tools native to the LLM API
-                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
-        use_tools_api: When `use_functions_api` is True, if this is also True,
-            the OpenAI tool-call API is used, rather than the older/deprecated
-            function-call API. However the tool-call API has some tricky aspects,
-            hence we set this to False by default.
-        strict_recovery: whether to enable strict schema recovery when there
-            is a tool-generation error.
-        enable_orchestration_tool_handling: whether to enable handling of orchestration
-            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
-        output_format: When supported by the LLM (certain OpenAI LLMs
-            and local LLMs served by providers such as vLLM), ensures
-            that the output is a JSON matching the corresponding
-            schema via grammar-based decoding
-        handle_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for handling".
-        use_output_format: When `output_format` is a `ToolMessage` T,
-            controls whether T is "enabled for use" (by LLM) and
-            instructions on using T are added to the system message.
-        instructions_output_format: Controls whether we generate instructions for
-            `output_format` in the system message.
-        use_tools_on_output_format: Controls whether to automatically switch
-            to the Langroid-native tools mechanism when `output_format` is set.
-            Note that LLMs may generate tool calls which do not belong to
-            `output_format` even when strict JSON mode is enabled, so this should be
-            enabled when such tool calls are not desired.
-        output_format_include_defaults: Whether to include fields with default arguments
-            in the output schema
-        full_citations: Whether to show source reference citation + content for each
-            citation, or just the main reference citation.
-        search_for_tools_everywhere: Whether to search for tools everywhere,
-            or only in specific LLM response elements based on use_tools /
-            use_functions_api / use_tools_api config settings.
-        recognize_recipient_in_content: Whether to parse LLM response text content
-            for recipient routing patterns, specifically:
-            - ``TO[<recipient>]:<content>`` addressing format, and
-            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
-            When False, only structured routing via function_call/tool_call
-            ``recipient`` fields is recognized. Default is True.
-            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
-            which controls Task-level signals like DONE, PASS, and SEND_TO.
-            To fully disable all text-based routing, set both to False.
-        context_overflow_strategy: Strategy for handling context overflow when
-            message history exceeds model context length. Options:
-            - "truncate": Truncate content of early messages (preserves all messages
-              but with shortened content). This maintains the message sequence.
-            - "drop_turns": Drop complete conversation turns (USER + all responses
-              until next USER). More aggressive but cleaner for voice agents.
-            Default is "truncate" for backward compatibility.
-    """
-
-    system_message: str = "You are a helpful assistant."
-    user_message: Optional[str] = None
-    handle_llm_no_tool: Any = None
-    use_tools: bool = True
-    use_functions_api: bool = False
-    use_tools_api: bool = True
-    strict_recovery: bool = True
-    enable_orchestration_tool_handling: bool = True
-    output_format: Optional[type] = None
-    handle_output_format: bool = True
-    use_output_format: bool = True
-    instructions_output_format: bool = True
-    output_format_include_defaults: bool = True
-    use_tools_on_output_format: bool = True
-    full_citations: bool = True  # show source + content for each citation?
-    search_for_tools_everywhere: bool = True
-    recognize_recipient_in_content: bool = True
-    context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
-
-    def _set_fn_or_tools(self) -> None:
-        """
-        Enable Langroid Tool or OpenAI-like fn-calling,
-        depending on config settings.
-        """
-        if not self.use_functions_api or not self.use_tools:
-            return
-        if self.use_functions_api and self.use_tools:
-            logger.debug(
-                """
-                You have enabled both `use_tools` and `use_functions_api`.
-                Setting `use_functions_api` to False.
-                """
-            )
-            self.use_tools = True
-            self.use_functions_api = False
-
-
-class ChatAgent(Agent):
-    """
-    Chat Agent interacting with external env
-    (could be human, or external tools).
-    The agent (the LLM actually) is provided with an optional "Task Spec",
-    which is a sequence of `LLMMessage`s. These are used to initialize
-    the `task_messages` of the agent.
-    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
-    The `Agent` class mainly exists to hold various common methods and attributes.
-    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
-    `llm_response` method uses "chat mode" API (i.e. one that takes a
-    message sequence rather than a single message),
-    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
-    that takes a single message).
-    """
-
-    def __init__(
-        self,
-        config: ChatAgentConfig = ChatAgentConfig(),
-        task: Optional[List[LLMMessage]] = None,
-    ):
-        """
-        Chat-mode agent initialized with task spec as the initial message sequence
-        Args:
-            config: settings for the agent
-
-        """
-        super().__init__(config)
-        self.config: ChatAgentConfig = config
-        self.config._set_fn_or_tools()
-        self.message_history: List[LLMMessage] = []
-        self.init_state()
-        # An agent's "task" is defined by a system msg and an optional user msg;
-        # These are "priming" messages that kick off the agent's conversation.
-        self.system_message: str = self.config.system_message
-        self.user_message: str | None = self.config.user_message
-
-        if task is not None:
-            # if task contains a system msg, we override the config system msg
-            if len(task) > 0 and task[0].role == Role.SYSTEM:
-                self.system_message = task[0].content or ""
-            # if task contains a user msg, we override the config user msg
-            if len(task) > 1 and task[1].role == Role.USER:
-                self.user_message = task[1].content
-
-        # system-level instructions for using tools/functions:
-        # We maintain these as tools/functions are enabled/disabled,
-        # and whenever an LLM response is sought, these are used to
-        # recreate the system message (via `_create_system_and_tools_message`)
-        # each time, so it reflects the current set of enabled tools/functions.
-        # (a) these are general instructions on using certain tools/functions,
-        #   if they are specified in a ToolMessage class as a classmethod `instructions`
-        self.system_tool_instructions: str = ""
-        # (b) these are only for the builtin in Langroid TOOLS mechanism:
-        self.system_tool_format_instructions: str = ""
-
-        self.llm_functions_map: Dict[str, LLMFunctionSpec] = {}
-        self.llm_functions_handled: Set[str] = set()
-        self.llm_functions_usable: Set[str] = set()
-        self.llm_function_force: Optional[Dict[str, str]] = None
-
-        self.output_format: Optional[type[ToolMessage | BaseModel]] = None
-
-        self.saved_requests_and_tool_setings = self._requests_and_tool_settings()
-        # This variable is not None and equals a `ToolMessage` T, if and only if:
-        # (a) T has been set as the output_format of this agent, AND
-        # (b) T has been "enabled for use" ONLY for enforcing this output format, AND
-        # (c) T has NOT been explicitly "enabled for use" by this Agent.
-        self.enabled_use_output_format: Optional[type[ToolMessage]] = None
-        # As above but deals with "enabled for handling" instead of "enabled for use".
-        self.enabled_handling_output_format: Optional[type[ToolMessage]] = None
-        if config.output_format is not None:
-            self.set_output_format(config.output_format)
-        # instructions specifically related to enforcing `output_format`
-        self.output_format_instructions = ""
-
-        # controls whether to disable strict schemas for this agent if
-        # strict mode causes exception
-        self.disable_strict = False
-        # Tracks whether any strict tool is enabled; used to determine whether to set
-        # `self.disable_strict` on an exception
-        self.any_strict = False
-        # Tracks the set of tools on which we force-disable strict decoding
-        self.disable_strict_tools_set: set[str] = set()
-
-        # search for tools according to the agent configuration
-        if not config.search_for_tools_everywhere:
-            if config.use_functions_api:
-                if config.use_tools_api:
-                    self.search_for_tools = {SearchForTools.TOOLS.value}
-                else:
-                    self.search_for_tools = {SearchForTools.FUNCTIONS.value}
-            else:
-                self.search_for_tools = {SearchForTools.CONTENT.value}
-
-        if self.config.enable_orchestration_tool_handling:
-            # Only enable HANDLING by `agent_response`, NOT LLM generation of these.
-            # This is useful where tool-handlers or agent_response generate these
-            # tools, and need to be handled.
-            # We don't want enable orch tool GENERATION by default, since that
-            # might clutter-up the LLM system message unnecessarily.
-            from langroid.agent.tools.orchestration import (
-                AgentDoneTool,
-                AgentSendTool,
-                DonePassTool,
-                DoneTool,
-                ForwardTool,
-                PassTool,
-                ResultTool,
-                SendTool,
-            )
-
-            self.enable_message(ForwardTool, use=False, handle=True)
-            self.enable_message(DoneTool, use=False, handle=True)
-            self.enable_message(AgentDoneTool, use=False, handle=True)
-            self.enable_message(PassTool, use=False, handle=True)
-            self.enable_message(DonePassTool, use=False, handle=True)
-            self.enable_message(SendTool, use=False, handle=True)
-            self.enable_message(AgentSendTool, use=False, handle=True)
-            self.enable_message(ResultTool, use=False, handle=True)
-
-    def init_state(self) -> None:
-        """
-        Initialize the state of the agent. Just conversation state here,
-        but subclasses can override this to initialize other state.
-        """
-        super().init_state()
-        self.clear_history(0)
-        self.clear_dialog()
-
-    @staticmethod
-    def from_id(id: str) -> "ChatAgent":
-        """
-        Get an agent from its ID
-        Args:
-            agent_id (str): ID of the agent
-        Returns:
-            ChatAgent: The agent with the given ID
-        """
-        return cast(ChatAgent, Agent.from_id(id))
-
-    def clone(self, i: int = 0) -> "ChatAgent":
-        """Create i'th clone of this agent, ensuring tool use/handling is cloned.
-        Important: We assume all member variables are in the __init__ method here
-        and in the Agent class.
-        TODO: We are attempting to clone an agent after its state has been
-        changed in possibly many ways. Below is an imperfect solution. Caution advised.
-        Revisit later.
-        """
-        agent_cls = type(self)
-        # Use model_copy to preserve Pydantic subclass types (like MockLMConfig)
-        # instead of deepcopy which loses subclass information
-        config_copy = self.config.model_copy(deep=True)
-        config_copy.name = f"{config_copy.name}-{i}"
-        new_agent = agent_cls(config_copy)
-        new_agent.system_tool_instructions = self.system_tool_instructions
-        new_agent.system_tool_format_instructions = self.system_tool_format_instructions
-        new_agent.llm_tools_map = self.llm_tools_map
-        new_agent.llm_tools_known = self.llm_tools_known
-        new_agent.llm_tools_handled = self.llm_tools_handled
-        new_agent.llm_tools_usable = self.llm_tools_usable
-        new_agent.llm_functions_map = self.llm_functions_map
-        new_agent.llm_functions_handled = self.llm_functions_handled
-        new_agent.llm_functions_usable = self.llm_functions_usable
-        new_agent.llm_function_force = self.llm_function_force
-        # Ensure each clone gets its own vecdb client when supported.
-        new_agent.vecdb = None if self.vecdb is None else self.vecdb.clone()
-        self._clone_extra_state(new_agent)
-        new_agent.id = ObjectRegistry.new_id()
-        if self.config.add_to_registry:
-            ObjectRegistry.register_object(new_agent)
-        return new_agent
-
-    def _clone_extra_state(self, new_agent: "ChatAgent") -> None:
-        """Hook for subclasses to copy additional state into clones."""
-
-    def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool:
-        """Should we enable strict mode for a given tool?"""
-        if isinstance(tool, str):
-            tool_class = self.llm_tools_map[tool]
-        else:
-            tool_class = tool
-        name = tool_class.default_value("request")
-        if name in self.disable_strict_tools_set or self.disable_strict:
-            return False
-        strict: Optional[bool] = tool_class.default_value("strict")
-        if strict is None:
-            strict = self._strict_tools_available()
-
-        return strict
-
-    def _fn_call_available(self) -> bool:
-        """Does this agent's LLM support function calling?"""
-        return self.llm is not None and self.llm.supports_functions_or_tools()
-
-    def _strict_tools_available(self) -> bool:
-        """Does this agent's LLM support strict tools?"""
-        return (
-            not self.disable_strict
-            and self.llm is not None
-            and isinstance(self.llm, OpenAIGPT)
-            and self.llm.config.parallel_tool_calls is False
-            and self.llm.supports_strict_tools
-        )
-
-    def _json_schema_available(self) -> bool:
-        """Does this agent's LLM support strict JSON schema output format?"""
-        return (
-            not self.disable_strict
-            and self.llm is not None
-            and isinstance(self.llm, OpenAIGPT)
-            and self.llm.supports_json_schema
-        )
-
-    def set_system_message(self, msg: str) -> None:
-        self.system_message = msg
-        if len(self.message_history) > 0:
-            # if there is message history, update the system message in it
-            self.message_history[0].content = msg
-
-    def set_user_message(self, msg: str) -> None:
-        self.user_message = msg
-
-    @property
-    def task_messages(self) -> List[LLMMessage]:
-        """
-        The task messages are the initial messages that define the task
-        of the agent. There will be at least a system message plus possibly a user msg.
-        Returns:
-            List[LLMMessage]: the task messages
-        """
-        msgs = [self._create_system_and_tools_message()]
-        if self.user_message:
-            msgs.append(LLMMessage(role=Role.USER, content=self.user_message))
-        return msgs
-
-    def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None:
-        id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
-        if msg.role == Role.TOOL:
-            # dropping tool result, so ADD the corresponding tool-call back
-            # to the list of pending calls!
-            id = msg.tool_call_id
-            if id in self.oai_tool_id2call:
-                self.oai_tool_calls.append(self.oai_tool_id2call[id])
-        elif msg.tool_calls is not None:
-            # dropping a msg with tool-calls, so DROP these from pending list
-            # as well as from id -> call map
-            for tool_call in msg.tool_calls:
-                if tool_call.id in id2idx:
-                    self.oai_tool_calls.pop(id2idx[tool_call.id])
-                if tool_call.id in self.oai_tool_id2call:
-                    del self.oai_tool_id2call[tool_call.id]
-
-    def clear_history(self, start: int = -2, end: int = -1) -> None:
-        """
-        Clear the message history, deleting  messages from index `start`,
-        up to index `end`.
-
-        Args:
-            start (int): index of first message to delete; default = -2
-                    (i.e. delete last 2 messages, typically these
-                    are the last user and assistant messages)
-            end (int): index of last message to delete; Default = -1
-                    (i.e. delete all messages up to the last one)
-        """
-        n = len(self.message_history)
-        if start < 0:
-            start = max(0, n + start)
-        end_ = n if end == -1 else end + 1
-        dropped = self.message_history[start:end_]
-        # consider the dropped msgs in REVERSE order, so we are
-        # carefully updating self.oai_tool_calls
-        for msg in reversed(dropped):
-            self._drop_msg_update_tool_calls(msg)
-            # clear out the chat document from the ObjectRegistry
-            ChatDocument.delete_id(msg.chat_document_id)
-        del self.message_history[start:end_]
-
-    def update_history(self, message: str, response: str) -> None:
-        """
-        Update the message history with the latest user message and LLM response.
-        Args:
-            message (str): user message
-            response: (str): LLM response
-        """
-        self.message_history.extend(
-            [
-                LLMMessage(role=Role.USER, content=message),
-                LLMMessage(role=Role.ASSISTANT, content=response),
-            ]
-        )
-
-    def tool_format_rules(self) -> str:
-        """
-        Specification of tool formatting rules
-        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
-        based on the currently enabled usable `ToolMessage`s
-
-        Returns:
-            str: formatting rules
-        """
-        # ONLY Usable tools (i.e. LLM-generation allowed),
-        usable_tool_classes: List[Type[ToolMessage]] = [
-            t
-            for t in list(self.llm_tools_map.values())
-            if t.default_value("request") in self.llm_tools_usable
-        ]
-
-        if len(usable_tool_classes) == 0:
-            return ""
-        format_instructions = "\n\n".join(
-            [
-                msg_cls.format_instructions(tool=self.config.use_tools)
-                for msg_cls in usable_tool_classes
-            ]
-        )
-        # if any of the enabled classes has json_group_instructions, then use that,
-        # else fall back to ToolMessage.json_group_instructions
-        for msg_cls in usable_tool_classes:
-            if hasattr(msg_cls, "json_group_instructions") and callable(
-                getattr(msg_cls, "json_group_instructions")
-            ):
-                return msg_cls.group_format_instructions().format(
-                    format_instructions=format_instructions
-                )
-        return ToolMessage.group_format_instructions().format(
-            format_instructions=format_instructions
-        )
-
-    def tool_instructions(self) -> str:
-        """
-        Instructions for tools or function-calls, for enabled and usable Tools.
-        These are inserted into system prompt regardless of whether we are using
-        our own ToolMessage mechanism or the LLM's function-call mechanism.
-
-        Returns:
-            str: concatenation of instructions for all usable tools
-        """
-        enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
-        if len(enabled_classes) == 0:
-            return ""
-        instructions = []
-        for msg_cls in enabled_classes:
-            if msg_cls.default_value("request") in self.llm_tools_usable:
-                class_instructions = ""
-                if hasattr(msg_cls, "instructions") and inspect.ismethod(
-                    msg_cls.instructions
-                ):
-                    class_instructions = msg_cls.instructions()
-                if (
-                    self.config.use_tools
-                    and hasattr(msg_cls, "langroid_tools_instructions")
-                    and inspect.ismethod(msg_cls.langroid_tools_instructions)
-                ):
-                    class_instructions += msg_cls.langroid_tools_instructions()
-                # example will be shown in tool_format_rules() when using TOOLs,
-                # so we don't need to show it here.
-                example = "" if self.config.use_tools else (msg_cls.usage_examples())
-                if example != "":
-                    example = "EXAMPLES:\n" + example
-                guidance = (
-                    ""
-                    if class_instructions == ""
-                    else ("GUIDANCE: " + class_instructions)
-                )
-                if guidance == "" and example == "":
-                    continue
-                instructions.append(
-                    textwrap.dedent(
-                        f"""
-                        TOOL: {msg_cls.default_value("request")}:
-                        {guidance}
-                        {example}
-                        """.lstrip()
-                    )
-                )
-        if len(instructions) == 0:
-            return ""
-        instructions_str = "\n\n".join(instructions)
-        return textwrap.dedent(
-            f"""
-            === GUIDELINES ON SOME TOOLS/FUNCTIONS USAGE ===
-            {instructions_str}
-            """.lstrip()
-        )
-
-    def augment_system_message(self, message: str) -> None:
-        """
-        Augment the system message with the given message.
-        Args:
-            message (str): system message
-        """
-        self.system_message += "\n\n" + message
-
-    def last_message_with_role(self, role: Role) -> LLMMessage | None:
-        """from `message_history`, return the last message with role `role`"""
-        n_role_msgs = len([m for m in self.message_history if m.role == role])
-        if n_role_msgs == 0:
-            return None
-        idx = self.nth_message_idx_with_role(role, n_role_msgs)
-        return self.message_history[idx]
-
-    def last_message_idx_with_role(self, role: Role) -> int:
-        """Index of last message in message_history, with specified role.
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-        indices_with_role = [
-            i for i, m in enumerate(self.message_history) if m.role == role
-        ]
-        if len(indices_with_role) == 0:
-            return -1
-        return indices_with_role[-1]
-
-    def nth_message_idx_with_role(self, role: Role, n: int) -> int:
-        """Index of `n`th message in message_history, with specified role.
-        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
-        Return -1 if not found. Index = 0 is the first message in the history.
-        """
-        indices_with_role = [
-            i for i, m in enumerate(self.message_history) if m.role == role
-        ]
-
-        if len(indices_with_role) < n:
-            return -1
-        return indices_with_role[n - 1]
-
-    def update_last_message(self, message: str, role: str = Role.USER) -> None:
-        """
-        Update the last message that has role `role` in the message history.
-        Useful when we want to replace a long user prompt, that may contain context
-        documents plus a question, with just the question.
-        Args:
-            message (str): new message to replace with
-            role (str): role of message to replace
-        """
-        if len(self.message_history) == 0:
-            return
-        # find last message in self.message_history with role `role`
-        for i in range(len(self.message_history) - 1, -1, -1):
-            if self.message_history[i].role == role:
-                self.message_history[i].content = message
-                break
-
-    def delete_last_message(self, role: str = Role.USER) -> None:
-        """
-        Delete the last message that has role `role` from the message history.
-        Args:
-            role (str): role of message to delete
-        """
-        if len(self.message_history) == 0:
-            return
-        # find last message in self.message_history with role `role`
-        for i in range(len(self.message_history) - 1, -1, -1):
-            if self.message_history[i].role == role:
-                self.message_history.pop(i)
-                break
-
-    def _create_system_and_tools_message(self) -> LLMMessage:
-        """
-        (Re-)Create the system message for the LLM of the agent,
-        taking into account any tool instructions that have been added
-        after the agent was initialized.
-
-        The system message will consist of:
-        (a) the system message from the `task` arg in constructor, if any,
-            otherwise the default system message from the config
-        (b) the system tool instructions, if any
-        (c) the system json tool instructions, if any
-
-        Returns:
-            LLMMessage object
-        """
-        content = self.system_message
-        if self.system_tool_instructions != "":
-            content += "\n\n" + self.system_tool_instructions
-        if self.system_tool_format_instructions != "":
-            content += "\n\n" + self.system_tool_format_instructions
-        if self.output_format_instructions != "":
-            content += "\n\n" + self.output_format_instructions
-
-        # remove leading and trailing newlines and other whitespace
-        return LLMMessage(role=Role.SYSTEM, content=content.strip())
-
-    def handle_message_fallback(self, msg: str | ChatDocument) -> Any:
-        """
-        Fallback method for the "no-tools" scenario, i.e., the current `msg`
-        (presumably emitted by the LLM) does not have any tool that the agent
-        can handle.
-        NOTE: The `msg` may contain tools but either (a) the agent is not
-        enabled to handle them, or (b) there's an explicit `recipient` field
-        in the tool that doesn't match the agent's name.
-
-        Uses the self.config.non_tool_routing to determine the action to take.
-
-        This method can be overridden by subclasses, e.g.,
-        to create a "reminder" message when a tool is expected but the LLM "forgot"
-        to generate one.
-
-        Args:
-            msg (str | ChatDocument): The input msg to handle
-        Returns:
-            Any: The result of the handler method
-        """
-        if (
-            isinstance(msg, str)
-            or msg.metadata.sender != Entity.LLM
-            or self.config.handle_llm_no_tool is None
-            or self.has_only_unhandled_tools(msg)
-        ):
-            return None
-        # we ONLY use the `handle_llm_no_tool` config option when
-        # the msg is from LLM and does not contain ANY tools at all.
-        from langroid.agent.tools.orchestration import AgentDoneTool, ForwardTool
-
-        no_tool_option = self.config.handle_llm_no_tool
-        if no_tool_option in list(NonToolAction):
-            # in case the `no_tool_option` is one of the special NonToolAction vals
-            match self.config.handle_llm_no_tool:
-                case NonToolAction.FORWARD_USER:
-                    return ForwardTool(agent="User")
-                case NonToolAction.DONE:
-                    return AgentDoneTool(content=msg.content, tools=msg.tool_messages)
-        elif is_callable(no_tool_option):
-            return no_tool_option(msg)
-        # Otherwise just return `no_tool_option` as is:
-        # This can be any string, such as a specific nudge/reminder to the LLM,
-        # or even something like ResultTool etc.
-        return no_tool_option
-
-    def unhandled_tools(self) -> set[str]:
-        """The set of tools that are known but not handled.
-        Useful in task flow: an agent can refuse to accept an incoming msg
-        when it only has unhandled tools.
-        """
-        return self.llm_tools_known - self.llm_tools_handled
-
-    def enable_message(
-        self,
-        message_class: Optional[Type[ToolMessage] | List[Type[ToolMessage]]],
-        use: bool = True,
-        handle: bool = True,
-        force: bool = False,
-        require_recipient: bool = False,
-        include_defaults: bool = True,
-    ) -> None:
-        """
-        Add the tool (message class) to the agent, and enable either
-        - tool USE (i.e. the LLM can generate JSON to use this tool),
-        - tool HANDLING (i.e. the agent can handle JSON from this tool),
-
-        Args:
-            message_class: The ToolMessage class OR List of such classes to enable,
-                for USE, or HANDLING, or both.
-                If this is a list of ToolMessage classes, then the remain args are
-                applied to all classes.
-                Optional; if None, then apply the enabling to all tools in the
-                agent's toolset that have been enabled so far.
-            use: IF True, allow the agent (LLM) to use this tool (or all tools),
-                else disallow
-            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
-                tool (or all tools)
-            force: whether to FORCE the agent (LLM) to USE the specific
-                 tool represented by `message_class`.
-                 `force` is ignored if `message_class` is None.
-            require_recipient: whether to require that recipient be specified
-                when using the tool message (only applies if `use` is True).
-            include_defaults: whether to include fields that have default values,
-                in the "properties" section of the JSON format instructions.
-                (Normally the OpenAI completion API ignores these fields,
-                but the Assistant fn-calling seems to pay attn to these,
-                and if we don't want this, we should set this to False.)
-        """
-        if message_class is not None and isinstance(message_class, list):
-            for mc in message_class:
-                self.enable_message(
-                    mc,
-                    use=use,
-                    handle=handle,
-                    force=force,
-                    require_recipient=require_recipient,
-                    include_defaults=include_defaults,
-                )
-            return None
-
-        # Validate that use/handle are booleans, not accidentally passed tool classes
-        if isclass(use) or isclass(handle):
-            param = "use" if isclass(use) else "handle"
-            raise TypeError(
-                textwrap.dedent(
-                    f"""
-                    Invalid arguments to enable_message().
-                    It appears you passed multiple ToolMessage classes as separate
-                    arguments instead of as a list.
-
-                    Correct usage:
-                        agent.enable_message([Tool1, Tool2, Tool3])
-
-                    Incorrect usage:
-                        agent.enable_message(Tool1, Tool2, Tool3)
-
-                    The '{param}' parameter must be a boolean, not a class.
-                    """
-                )
-            )
-
-        if require_recipient and message_class is not None:
-            message_class = message_class.require_recipient()
-        if isinstance(message_class, XMLToolMessage):
-            # XMLToolMessage is not compatible with OpenAI's Tools/functions API,
-            # so we disable use of functions API, enable langroid-native Tools,
-            # which are prompt-based.
-            self.config.use_functions_api = False
-            self.config.use_tools = True
-        super().enable_message_handling(message_class)  # enables handling only
-        tools = self._get_tool_list(message_class)
-        if message_class is not None:
-            request = message_class.default_value("request")
-            if request == "":
-                raise ValueError(
-                    f"""
-                    ToolMessage class {message_class} must have a non-empty
-                    'request' field if it is to be enabled as a tool.
-                    """
-                )
-            llm_function = message_class.llm_function_schema(defaults=include_defaults)
-            self.llm_functions_map[request] = llm_function
-            if force:
-                self.llm_function_force = dict(name=request)
-            else:
-                self.llm_function_force = None
-
-        for t in tools:
-            self.llm_tools_known.add(t)
-
-            if handle:
-                self.llm_tools_handled.add(t)
-                self.llm_functions_handled.add(t)
-
-                if (
-                    self.enabled_handling_output_format is not None
-                    and self.enabled_handling_output_format.name() == t
-                ):
-                    # `t` was designated as "enabled for handling" ONLY for
-                    # output_format enforcement, but we are explicitly ]
-                    # enabling it for handling here, so we set the variable to None.
-                    self.enabled_handling_output_format = None
-            else:
-                self.llm_tools_handled.discard(t)
-                self.llm_functions_handled.discard(t)
-
-            if use:
-                tool_class = self.llm_tools_map[t]
-                allow_llm_use = tool_class._allow_llm_use
-                if isinstance(allow_llm_use, ModelPrivateAttr):
-                    allow_llm_use = allow_llm_use.default
-                if allow_llm_use:
-                    self.llm_tools_usable.add(t)
-                    self.llm_functions_usable.add(t)
-                else:
-                    logger.warning(
-                        f"""
-                        ToolMessage class {tool_class} does not allow LLM use,
-                        because `_allow_llm_use=False` either in the Tool or a
-                        parent class of this tool;
-                        so not enabling LLM use for this tool!
-                        If you intended an LLM to use this tool,
-                        set `_allow_llm_use=True` when you define the tool.
-                        """
-                    )
-                if (
-                    self.enabled_use_output_format is not None
-                    and self.enabled_use_output_format.default_value("request") == t
-                ):
-                    # `t` was designated as "enabled for use" ONLY for output_format
-                    # enforcement, but we are explicitly enabling it for use here,
-                    # so we set the variable to None.
-                    self.enabled_use_output_format = None
-            else:
-                self.llm_tools_usable.discard(t)
-                self.llm_functions_usable.discard(t)
-
-        self._update_tool_instructions()
-
-    def _update_tool_instructions(self) -> None:
-        # Set tool instructions and JSON format instructions,
-        # in case Tools have been enabled/disabled.
-        if self.config.use_tools:
-            self.system_tool_format_instructions = self.tool_format_rules()
-        self.system_tool_instructions = self.tool_instructions()
-
-    def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]:
-        """
-        Returns the current set of enabled requests for inference and tools configs.
-        Used for restoring setings overriden by `set_output_format`.
-        """
-        return (
-            self.enabled_requests_for_inference,
-            self.config.use_functions_api,
-            self.config.use_tools,
-        )
-
-    @property
-    def all_llm_tools_known(self) -> set[str]:
-        """All known tools; we include `output_format` if it is a `ToolMessage`."""
-        known = self.llm_tools_known
-
-        if self.output_format is not None and issubclass(
-            self.output_format, ToolMessage
-        ):
-            return known.union({self.output_format.default_value("request")})
-
-        return known
-
-    def set_output_format(
-        self,
-        output_type: Optional[type],
-        force_tools: Optional[bool] = None,
-        use: Optional[bool] = None,
-        handle: Optional[bool] = None,
-        instructions: Optional[bool] = None,
-        is_copy: bool = False,
-    ) -> None:
-        """
-        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
-        switches to the native Langroid tools mechanism to ensure that no tool
-        calls not of `output_type` are generated. By default, `force_tools`
-        follows the `use_tools_on_output_format` parameter in the config.
-
-        If `output_type` is None, restores to the state prior to setting
-        `output_format`.
-
-        If `use`, we enable use of `output_type` when it is a subclass
-        of `ToolMesage`. Note that this primarily controls instruction
-        generation: the model will always generate `output_type` regardless
-        of whether `use` is set. Defaults to the `use_output_format`
-        parameter in the config. Similarly, handling of `output_type` is
-        controlled by `handle`, which defaults to the
-        `handle_output_format` parameter in the config.
-
-        `instructions` controls whether we generate instructions specifying
-        the output format schema. Defaults to the `instructions_output_format`
-        parameter in the config.
-
-        `is_copy` is set when called via `__getitem__`. In that case, we must
-        copy certain fields to ensure that we do not overwrite the main agent's
-        setings.
-        """
-        # Disable usage of an output format which was not specifically enabled
-        # by `enable_message`
-        if self.enabled_use_output_format is not None:
-            self.disable_message_use(self.enabled_use_output_format)
-            self.enabled_use_output_format = None
-
-        # Disable handling of an output format which did not specifically have
-        # handling enabled via `enable_message`
-        if self.enabled_handling_output_format is not None:
-            self.disable_message_handling(self.enabled_handling_output_format)
-            self.enabled_handling_output_format = None
-
-        # Reset any previous instructions
-        self.output_format_instructions = ""
-
-        if output_type is None:
-            self.output_format = None
-            (
-                requests_for_inference,
-                use_functions_api,
-                use_tools,
-            ) = self.saved_requests_and_tool_setings
-            self.config = self.config.model_copy()
-            self.enabled_requests_for_inference = requests_for_inference
-            self.config.use_functions_api = use_functions_api
-            self.config.use_tools = use_tools
-        else:
-            if force_tools is None:
-                force_tools = self.config.use_tools_on_output_format
-
-            if not any(
-                (isclass(output_type) and issubclass(output_type, t))
-                for t in [ToolMessage, BaseModel]
-            ):
-                output_type = get_pydantic_wrapper(output_type)
-
-            if self.output_format is None and force_tools:
-                self.saved_requests_and_tool_setings = (
-                    self._requests_and_tool_settings()
-                )
-
-            self.output_format = output_type
-            if issubclass(output_type, ToolMessage):
-                name = output_type.default_value("request")
-                if use is None:
-                    use = self.config.use_output_format
-
-                if handle is None:
-                    handle = self.config.handle_output_format
-
-                if use or handle:
-                    is_usable = name in self.llm_tools_usable.union(
-                        self.llm_functions_usable
-                    )
-                    is_handled = name in self.llm_tools_handled.union(
-                        self.llm_functions_handled
-                    )
-
-                    if is_copy:
-                        if use:
-                            # We must copy `llm_tools_usable` so the base agent
-                            # is unmodified
-                            self.llm_tools_usable = self.llm_tools_usable.copy()
-                            self.llm_functions_usable = self.llm_functions_usable.copy()
-                        if handle:
-                            # If handling the tool, do the same for `llm_tools_handled`
-                            self.llm_tools_handled = self.llm_tools_handled.copy()
-                            self.llm_functions_handled = (
-                                self.llm_functions_handled.copy()
-                            )
-                    # Enable `output_type`
-                    self.enable_message(
-                        output_type,
-                        # Do not override existing settings
-                        use=use or is_usable,
-                        handle=handle or is_handled,
-                    )
-
-                    # If the `output_type` ToilMessage was not already enabled for
-                    # use, this means we are ONLY enabling it for use specifically
-                    # for enforcing this output format, so we set the
-                    # `enabled_use_output_forma  to this output_type, to
-                    # record that it should be disabled when `output_format` is changed
-                    if not is_usable:
-                        self.enabled_use_output_format = output_type
-
-                    # (same reasoning as for use-enabling)
-                    if not is_handled:
-                        self.enabled_handling_output_format = output_type
-
-                generated_tool_instructions = name in self.llm_tools_usable.union(
-                    self.llm_functions_usable
-                )
-            else:
-                generated_tool_instructions = False
-
-            if instructions is None:
-                instructions = self.config.instructions_output_format
-            if issubclass(output_type, BaseModel) and instructions:
-                if generated_tool_instructions:
-                    # Already generated tool instructions as part of "enabling for use",
-                    # so only need to generate a reminder to use this tool.
-                    name = cast(ToolMessage, output_type).default_value("request")
-                    self.output_format_instructions = textwrap.dedent(
-                        f"""
-                        === OUTPUT FORMAT INSTRUCTIONS ===
-
-                        Please provide output using the `{name}` tool/function.
-                        """
-                    )
-                else:
-                    if issubclass(output_type, ToolMessage):
-                        output_format_schema = output_type.llm_function_schema(
-                            request=True,
-                            defaults=self.config.output_format_include_defaults,
-                        ).parameters
-                    else:
-                        output_format_schema = output_type.model_json_schema()
-
-                    format_schema_for_strict(output_format_schema)
-
-                    self.output_format_instructions = textwrap.dedent(
-                        f"""
-                        === OUTPUT FORMAT INSTRUCTIONS ===
-                        Please provide output as JSON with the following schema:
-
-                        {output_format_schema}
-                        """
-                    )
-
-            if force_tools:
-                if issubclass(output_type, ToolMessage):
-                    self.enabled_requests_for_inference = {
-                        output_type.default_value("request")
-                    }
-                if self.config.use_functions_api:
-                    self.config = self.config.model_copy()
-                    self.config.use_functions_api = False
-                    self.config.use_tools = True
-
-    def __getitem__(self, output_type: type) -> Self:
-        """
-        Returns a (shallow) copy of `self` with a forced output type.
-        """
-        clone = copy.copy(self)
-        clone.set_output_format(output_type, is_copy=True)
-        return clone
-
-    def disable_message_handling(
-        self,
-        message_class: Optional[Type[ToolMessage]] = None,
-    ) -> None:
-        """
-        Disable this agent from RESPONDING to a `message_class` (Tool). If
-            `message_class` is None, then disable this agent from responding to ALL.
-        Args:
-            message_class: The ToolMessage class to disable; Optional.
-        """
-        super().disable_message_handling(message_class)
-        for t in self._get_tool_list(message_class):
-            self.llm_tools_handled.discard(t)
-            self.llm_functions_handled.discard(t)
-
-    def disable_message_use(
-        self,
-        message_class: Optional[Type[ToolMessage]],
-    ) -> None:
-        """
-        Disable this agent from USING a message class (Tool).
-        If `message_class` is None, then disable this agent from USING ALL tools.
-        Args:
-            message_class: The ToolMessage class to disable.
-                If None, disable all.
-        """
-        for t in self._get_tool_list(message_class):
-            self.llm_tools_usable.discard(t)
-            self.llm_functions_usable.discard(t)
-
-        self._update_tool_instructions()
-
-    def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None:
-        """
-        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
-        Args:
-            message_class: The only ToolMessage class to allow
-        """
-        request = message_class.model_fields["request"].default
-        to_remove = [r for r in self.llm_tools_usable if r != request]
-        for r in to_remove:
-            self.llm_tools_usable.discard(r)
-            self.llm_functions_usable.discard(r)
-        self._update_tool_instructions()
-
-    def _load_output_format(self, message: ChatDocument) -> None:
-        """
-        If set, attempts to parse a value of type `self.output_format` from the message
-        contents or any tool/function call and assigns it to `content_any`.
-        """
-        if self.output_format is not None:
-            any_succeeded = False
-            attempts: list[str | LLMFunctionCall] = [
-                message.content,
-            ]
-
-            if message.function_call is not None:
-                attempts.append(message.function_call)
-
-            if message.oai_tool_calls is not None:
-                attempts.extend(
-                    [
-                        c.function
-                        for c in message.oai_tool_calls
-                        if c.function is not None
-                    ]
-                )
-
-            for attempt in attempts:
-                try:
-                    if isinstance(attempt, str):
-                        content = json.loads(attempt)
-                    else:
-                        if not (
-                            issubclass(self.output_format, ToolMessage)
-                            and attempt.name
-                            == self.output_format.default_value("request")
-                        ):
-                            continue
-
-                        content = attempt.arguments
-
-                    content_any = self.output_format.model_validate(content)
-
-                    if issubclass(self.output_format, PydanticWrapper):
-                        message.content_any = content_any.value  # type: ignore
-                    else:
-                        message.content_any = content_any
-                    any_succeeded = True
-                    break
-                except (ValidationError, json.JSONDecodeError):
-                    continue
-
-            if not any_succeeded:
-                self.disable_strict = True
-                logging.warning(
-                    """
-                    Validation error occured with strict output format enabled.
-                    Disabling strict mode.
-                    """
-                )
-
-    def get_tool_messages(
-        self,
-        msg: str | ChatDocument | None,
-        all_tools: bool = False,
-    ) -> List[ToolMessage]:
-        """
-        Extracts messages and tracks whether any errors occurred. If strict mode
-        was enabled, disables it for the tool, else triggers strict recovery.
-        """
-        self.tool_error = False
-        most_recent_sent_by_llm = (
-            len(self.message_history) > 0
-            and self.message_history[-1].role == Role.ASSISTANT
-        )
-        was_llm = most_recent_sent_by_llm or (
-            isinstance(msg, ChatDocument) and msg.metadata.sender == Entity.LLM
-        )
-        try:
-            tools = super().get_tool_messages(msg, all_tools)
-        except ValidationError as ve:
-            # Check if tool class was attached to the exception
-            if hasattr(ve, "tool_class") and ve.tool_class:
-                tool_class = ve.tool_class  # type: ignore
-                if issubclass(tool_class, ToolMessage):
-                    was_strict = (
-                        self.config.use_functions_api
-                        and self.config.use_tools_api
-                        and self._strict_mode_for_tool(tool_class)
-                    )
-                    # If the result of strict output for a tool using the
-                    # OpenAI tools API fails to parse, we infer that the
-                    # schema edits necessary for compatibility prevented
-                    # adherence to the underlying `ToolMessage` schema and
-                    # disable strict output for the tool
-                    if was_strict:
-                        name = tool_class.default_value("request")
-                        self.disable_strict_tools_set.add(name)
-                        logging.warning(
-                            f"""
-                            Validation error occured with strict tool format.
-                            Disabling strict mode for the {name} tool.
-                            """
-                        )
-                    else:
-                        # We will trigger the strict recovery mechanism to force
-                        # the LLM to correct its output, allowing us to parse
-                        if isinstance(msg, ChatDocument):
-                            self.tool_error = msg.metadata.sender == Entity.LLM
-                        else:
-                            self.tool_error = most_recent_sent_by_llm
-
-            if was_llm:
-                raise ve
-            else:
-                self.tool_error = False
-                return []
-
-        if not was_llm:
-            self.tool_error = False
-
-        return tools
-
-    def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None:
-        """
-        Returns a `ToolMessage` which wraps all enabled tools, excluding those
-        where strict recovery is disabled. Used in strict recovery.
-        """
-        possible_tools = tuple(
-            self.llm_tools_map[t]
-            for t in self.llm_tools_usable
-            if t not in self.disable_strict_tools_set
-        )
-        if len(possible_tools) == 0:
-            return None
-        any_tool_type = Union.__getitem__(possible_tools)  # type ignore
-
-        maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
-
-        class AnyTool(ToolMessage):
-            purpose: str = "To call a tool/function."
-            request: str = "tool_or_function"
-            tool: maybe_optional_type  # type: ignore
-
-            def response(self, agent: ChatAgent) -> None | str | ChatDocument:
-                # One-time use
-                agent.set_output_format(None)
-
-                if self.tool is None:
-                    return None
-
-                # As the ToolMessage schema accepts invalid
-                # `tool.request` values, reparse with the
-                # corresponding tool
-                request = self.tool.request
-                if request not in agent.llm_tools_map:
-                    return None
-                tool = agent.llm_tools_map[request].model_validate_json(
-                    self.tool.to_json()
-                )
-
-                return agent.handle_tool_message(tool)
-
-            async def response_async(
-                self, agent: ChatAgent
-            ) -> None | str | ChatDocument:
-                # One-time use
-                agent.set_output_format(None)
-
-                if self.tool is None:
-                    return None
-
-                # As the ToolMessage schema accepts invalid
-                # `tool.request` values, reparse with the
-                # corresponding tool
-                request = self.tool.request
-                if request not in agent.llm_tools_map:
-                    return None
-                tool = agent.llm_tools_map[request].model_validate_json(
-                    self.tool.to_json()
-                )
-
-                return await agent.handle_tool_message_async(tool)
-
-        return AnyTool
-
-    def _strict_recovery_instructions(
-        self,
-        tool_type: Optional[type[ToolMessage]] = None,
-        optional: bool = True,
-    ) -> str:
-        """Returns instructions for strict recovery."""
-        optional_instructions = (
-            (
-                "\n"
-                + """
-        If you did NOT intend to do so, `tool` should be null.
-        """
-            )
-            if optional
-            else ""
-        )
-        response_prefix = "If you intended to make such a call, r" if optional else "R"
-        instruction_prefix = "If you do so, b" if optional else "B"
-
-        schema_instructions = (
-            f"""
-        The schema for `tool_or_function` is as follows:
-        {tool_type.llm_function_schema(defaults=True, request=True).parameters}
-        """
-            if tool_type
-            else ""
-        )
-
-        return textwrap.dedent(
-            f"""
-        Your previous attempt to make a tool/function call appears to have failed.
-        {response_prefix}espond with your desired tool/function. Do so with the
-        `tool_or_function` tool/function where `tool` is set to your intended call.
-        {schema_instructions}
-
-        {instruction_prefix}e sure that your corrected call matches your intention
-        in your previous request. For any field with a default value which
-        you did not intend to override in your previous attempt, be sure
-        to set that field to its default value. {optional_instructions}
-        """
-        )
-
-    def truncate_message(
-        self,
-        idx: int,
-        tokens: int = 5,
-        warning: str = "...[Contents truncated!]",
-        inplace: bool = True,
-    ) -> LLMMessage:
-        """
-        Truncate message at idx in msg history to `tokens` tokens.
-
-        If inplace is True, the message is truncated in place, else
-        it LEAVES the original message INTACT and returns a new message
-        """
-        if inplace:
-            llm_msg = self.message_history[idx]
-        else:
-            llm_msg = copy.deepcopy(self.message_history[idx])
-        if llm_msg.content is None or (
-            llm_msg.content == "" and _is_identified_result(llm_msg)
-        ):
-            return llm_msg
-        orig_content = llm_msg.content
-        new_content = (
-            self.parser.truncate_tokens(orig_content, tokens)
-            if self.parser is not None
-            else orig_content[: tokens * 4]  # approx truncation
-        )
-        llm_msg.content = new_content + "\n" + warning
-        return llm_msg
-
-    def _reduce_raw_tool_results(self, message: ChatDocument) -> None:
-        """
-        If message is the result of a ToolMessage that had
-        a `_max_retained_tokens` set to a non-None value, then we replace contents
-        with a placeholder message.
-        """
-        parent_message: ChatDocument | None = message.parent
-        tools = [] if parent_message is None else parent_message.tool_messages
-        truncate_tools = []
-        for t in tools:
-            max_retained_tokens = t._max_retained_tokens
-            if isinstance(max_retained_tokens, ModelPrivateAttr):
-                max_retained_tokens = max_retained_tokens.default
-            if max_retained_tokens is not None:
-                truncate_tools.append(t)
-        limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
-        if limiting_tool is not None:
-            max_retained_tokens = limiting_tool._max_retained_tokens
-            if isinstance(max_retained_tokens, ModelPrivateAttr):
-                max_retained_tokens = max_retained_tokens.default
-            if max_retained_tokens is not None:
-                tool_name = limiting_tool.default_value("request")
-                max_tokens: int = max_retained_tokens
-                truncation_warning = f"""
-                    The result of the {tool_name} tool were too large,
-                    and has been truncated to {max_tokens} tokens.
-                    To obtain the full result, the tool needs to be re-used.
-                """
-                self.truncate_message(
-                    message.metadata.msg_idx, max_tokens, truncation_warning
-                )
-
-    def llm_response(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> Optional[ChatDocument]:
-        """
-        Respond to a single user message, appended to the message history,
-        in "chat" mode
-        Args:
-            message (str|ChatDocument): message or ChatDocument object to respond to.
-                If None, use the self.task_messages
-        Returns:
-            LLM response as a ChatDocument object
-        """
-        if self.llm is None:
-            return None
-
-        # If enabled and a tool error occurred, we recover by generating the tool in
-        # strict json mode
-        if (
-            self.tool_error
-            and self.output_format is None
-            and self._json_schema_available()
-            and self.config.strict_recovery
-        ):
-            self.tool_error = False
-            AnyTool = self._get_any_tool_message()
-            if AnyTool is None:
-                return None
-            self.set_output_format(
-                AnyTool,
-                force_tools=True,
-                use=True,
-                handle=True,
-                instructions=True,
-            )
-            recovery_message = self._strict_recovery_instructions(AnyTool)
-            augmented_message = message
-            if augmented_message is None:
-                augmented_message = recovery_message
-            elif isinstance(augmented_message, str):
-                augmented_message = augmented_message + recovery_message
-            else:
-                augmented_message.content = augmented_message.content + recovery_message
-
-            # only use the augmented message for this one response...
-            result = self.llm_response(augmented_message)
-            # ... restore the original user message so that the AnyTool recover
-            # instructions don't persist in the message history
-            # (this can cause the LLM to use the AnyTool directly as a tool)
-            if message is None:
-                self.delete_last_message(role=Role.USER)
-            else:
-                msg = message if isinstance(message, str) else message.content
-                self.update_last_message(msg, role=Role.USER)
-            return result
-
-        hist, output_len = self._prep_llm_messages(message)
-        if len(hist) == 0:
-            return None
-        tool_choice = (
-            "auto"
-            if isinstance(message, str)
-            else (message.oai_tool_choice if message is not None else "auto")
-        )
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
-            try:
-                response = self.llm_response_messages(hist, output_len, tool_choice)
-            except openai.BadRequestError as e:
-                if self.any_strict:
-                    self.disable_strict = True
-                    self.set_output_format(None)
-                    logging.warning(
-                        f"""
-                        OpenAI BadRequestError raised with strict mode enabled.
-                        Message: {e.message}
-                        Disabling strict mode and retrying.
-                        """
-                    )
-                    return self.llm_response(message)
-                else:
-                    raise e
-        self.message_history.extend(ChatDocument.to_LLMMessage(response))
-        response.metadata.msg_idx = len(self.message_history) - 1
-        response.metadata.agent_id = self.id
-        if isinstance(message, ChatDocument):
-            self._reduce_raw_tool_results(message)
-        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
-        response.metadata.tool_ids = (
-            []
-            if isinstance(message, str)
-            else message.metadata.tool_ids if message is not None else []
-        )
-
-        return response
-
-    async def llm_response_async(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> Optional[ChatDocument]:
-        """
-        Async version of `llm_response`. See there for details.
-        """
-        if self.llm is None:
-            return None
-
-        # If enabled and a tool error occurred, we recover by generating the tool in
-        # strict json mode
-        if (
-            self.tool_error
-            and self.output_format is None
-            and self._json_schema_available()
-            and self.config.strict_recovery
-        ):
-            self.tool_error = False
-            AnyTool = self._get_any_tool_message()
-            self.set_output_format(
-                AnyTool,
-                force_tools=True,
-                use=True,
-                handle=True,
-                instructions=True,
-            )
-            recovery_message = self._strict_recovery_instructions(AnyTool)
-            augmented_message = message
-            if augmented_message is None:
-                augmented_message = recovery_message
-            elif isinstance(augmented_message, str):
-                augmented_message = augmented_message + recovery_message
-            else:
-                augmented_message.content = augmented_message.content + recovery_message
-
-            # only use the augmented message for this one response...
-            result = self.llm_response(augmented_message)
-            # ... restore the original user message so that the AnyTool recover
-            # instructions don't persist in the message history
-            # (this can cause the LLM to use the AnyTool directly as a tool)
-            if message is None:
-                self.delete_last_message(role=Role.USER)
-            else:
-                msg = message if isinstance(message, str) else message.content
-                self.update_last_message(msg, role=Role.USER)
-            return result
-
-        hist, output_len = self._prep_llm_messages(message)
-        if len(hist) == 0:
-            return None
-        tool_choice = (
-            "auto"
-            if isinstance(message, str)
-            else (message.oai_tool_choice if message is not None else "auto")
-        )
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
-            try:
-                response = await self.llm_response_messages_async(
-                    hist, output_len, tool_choice
-                )
-            except openai.BadRequestError as e:
-                if self.any_strict:
-                    self.disable_strict = True
-                    self.set_output_format(None)
-                    logging.warning(
-                        f"""
-                        OpenAI BadRequestError raised with strict mode enabled.
-                        Message: {e.message}
-                        Disabling strict mode and retrying.
-                        """
-                    )
-                    return await self.llm_response_async(message)
-                else:
-                    raise e
-        self.message_history.extend(ChatDocument.to_LLMMessage(response))
-        response.metadata.msg_idx = len(self.message_history) - 1
-        response.metadata.agent_id = self.id
-        if isinstance(message, ChatDocument):
-            self._reduce_raw_tool_results(message)
-        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
-        response.metadata.tool_ids = (
-            []
-            if isinstance(message, str)
-            else message.metadata.tool_ids if message is not None else []
-        )
-
-        return response
-
-    def init_message_history(self) -> None:
-        """
-        Initialize the message history with the system message and user message
-        """
-        self.message_history = [self._create_system_and_tools_message()]
-        if self.user_message:
-            self.message_history.append(
-                LLMMessage(role=Role.USER, content=self.user_message)
-            )
-
-    def _prep_llm_messages(
-        self,
-        message: Optional[str | ChatDocument] = None,
-        truncate: bool = True,
-    ) -> Tuple[List[LLMMessage], int]:
-        """
-        Prepare messages to be sent to self.llm_response_messages,
-            which is the main method that calls the LLM API to get a response.
-            If desired output tokens + message history exceeds the model context length,
-            then first the max output tokens is reduced to fit, and if that is not
-            possible, older messages may be truncated to accommodate at least
-            self.config.llm.min_output_tokens of output.
-
-        Returns:
-            Tuple[List[LLMMessage], int]: (messages, output_len)
-                messages = Full list of messages to send
-                output_len = max expected number of tokens in response
-        """
-
-        if (
-            not self.llm_can_respond(message)
-            or self.config.llm is None
-            or self.llm is None
-        ):
-            return [], 0
-
-        if message is None and len(self.message_history) > 0:
-            # this means agent has been used to get LLM response already,
-            # and so the last message is an "assistant" response.
-            # We delete this last assistant response and re-generate it.
-            self.clear_history(-1)
-            logger.warning(
-                "Re-generating the last assistant response since message is None"
-            )
-
-        if len(self.message_history) == 0:
-            # initial messages have not yet been loaded, so load them
-            self.init_message_history()
-
-            # for debugging, show the initial message history
-            if settings.debug:
-                print(
-                    f"""
-                [grey37]LLM Initial Msg History:
-                {escape(self.message_history_str())}
-                [/grey37]
-                """
-                )
-        else:
-            assert self.message_history[0].role == Role.SYSTEM
-            # update the system message with the latest tool instructions
-            self.message_history[0] = self._create_system_and_tools_message()
-
-        if message is not None:
-            if (
-                isinstance(message, str)
-                or message.id() != self.message_history[-1].chat_document_id
-            ):
-                # either the message is a str, or it is a fresh ChatDocument
-                # different from the last message in the history
-                llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
-                llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
-                # Canonicalize retained whitespace-only results before token counting.
-                for llm_msg in llm_msgs:
-                    if (
-                        _is_identified_result(llm_msg)
-                        and llm_msg.content is not None
-                        and llm_msg.content.strip() == ""
-                    ):
-                        llm_msg.content = ""
-                if len(llm_msgs) == 0:
-                    return [], 0
-                # process tools if any
-                done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
-                self.oai_tool_calls = [
-                    t for t in self.oai_tool_calls if t.id not in done_tools
-                ]
-                self.message_history.extend(llm_msgs)
-
-        hist = self.message_history
-        output_len = self.config.llm.model_max_output_tokens
-        if (
-            truncate
-            and output_len > self.llm.chat_context_length() - self.chat_num_tokens(hist)
-        ):
-            CHAT_HISTORY_BUFFER = 300
-            # chat + output > max context length,
-            # so first try to shorten requested output len to fit;
-            # use an extra margin of CHAT_HISTORY_BUFFER tokens
-            # in case our calcs are off (and to allow for some extra tokens)
-            output_len = (
-                self.llm.chat_context_length()
-                - self.chat_num_tokens(hist)
-                - CHAT_HISTORY_BUFFER
-            )
-            if output_len > self.config.llm.min_output_tokens:
-                logger.debug(
-                    f"""
-                    Chat Model context length is {self.llm.chat_context_length()},
-                    but the current message history is {self.chat_num_tokens(hist)}
-                    tokens long, which does not allow
-                    {self.config.llm.model_max_output_tokens} output tokens.
-                    Therefore we reduced `max_output_tokens` to {output_len} tokens,
-                    so they can fit within the model's context length
-                    """
-                )
-            else:
-                # unacceptably small output len, so compress early parts of
-                # conversation history based on the configured strategy
-                strategy = self.config.context_overflow_strategy
-
-                if strategy == "truncate":
-                    # Truncate content of individual messages while preserving
-                    # the message sequence (important for LLM APIs that require
-                    # alternating USER/ASSISTANT messages)
-                    msg_idx_to_compress = 1  # don't touch system msg
-                    # we will try compressing msg indices up to but not including
-                    # last user msg
-                    last_msg_idx_to_compress = (
-                        self.last_message_idx_with_role(
-                            role=Role.USER,
-                        )
-                        - 1
-                    )
-                    n_truncated = 0
-                    while (
-                        self.chat_num_tokens(hist)
-                        > self.llm.chat_context_length()
-                        - self.config.llm.min_output_tokens
-                        - CHAT_HISTORY_BUFFER
-                    ):
-                        if msg_idx_to_compress > last_msg_idx_to_compress:
-                            # We want to preserve the first message (typically
-                            # system msg) and last message (user msg).
-                            raise ValueError(
-                                """
-                            The (message history + max_output_tokens) is longer than the
-                            max chat context length of this model, and we have tried
-                            reducing the requested max output tokens, as well as
-                            truncating early parts of the message history, to
-                            accommodate the model context length, but we have run out
-                            of msgs to truncate.
-
-                            HINT: In the `llm` field of your `ChatAgentConfig` object,
-                            which is of type `LLMConfig/OpenAIGPTConfig`, try
-                            - increasing `chat_context_length`
-                                (if accurate for the model), or
-                            - decreasing `max_output_tokens`
-                            """
-                            )
-                        n_truncated += 1
-                        # compress the msg at idx `msg_idx_to_compress`
-                        hist[msg_idx_to_compress] = self.truncate_message(
-                            msg_idx_to_compress,
-                            tokens=30,
-                            warning="... [Contents truncated!]",
-                        )
-                        msg_idx_to_compress += 1
-
-                    output_len = min(
-                        self.config.llm.model_max_output_tokens,
-                        self.llm.chat_context_length()
-                        - self.chat_num_tokens(hist)
-                        - CHAT_HISTORY_BUFFER,
-                    )
-                    if output_len < self.config.llm.min_output_tokens:
-                        raise ValueError(
-                            f"""
-                            Tried to shorten prompt history for chat mode
-                            but even after truncating all messages except system msg
-                            and last (user) msg, the history token len
-                            {self.chat_num_tokens(hist)} is too long to accommodate
-                            the desired minimum output tokens
-                            {self.config.llm.min_output_tokens} within the
-                            model's context length {self.llm.chat_context_length()}.
-                            Please try shortening the system msg or user prompts,
-                            or adjust `config.llm.min_output_tokens` to be smaller.
-                            """
-                        )
-                    else:
-                        # we MUST have truncated at least one msg
-                        msg_tokens = self.chat_num_tokens()
-                        logger.warning(
-                            f"""
-                        Chat Model context length is {self.llm.chat_context_length()}
-                        tokens, but the current message history is {msg_tokens} tokens
-                        long, which does not allow
-                        {self.config.llm.model_max_output_tokens} output tokens.
-                        Therefore we truncated the first {n_truncated} messages
-                        in the conversation history so that history token
-                        length is reduced to {self.chat_num_tokens(hist)}, and
-                        we use `max_output_tokens = {output_len}`,
-                        so they can fit within the model's context length
-                        of {self.llm.chat_context_length()} tokens.
-                        """
-                        )
-
-                else:  # strategy == "drop_turns"
-                    # Drop complete conversation turns. A complete turn is defined
-                    # as a USER message followed by all messages until the next
-                    # USER message. This is more aggressive but cleaner for voice
-                    # agents with limited context.
-                    n_dropped_turns = 0
-                    while (
-                        self.chat_num_tokens(hist)
-                        > self.llm.chat_context_length()
-                        - self.config.llm.min_output_tokens
-                        - CHAT_HISTORY_BUFFER
-                    ):
-                        # Find the last USER message index
-                        last_user_idx = self.last_message_idx_with_role(role=Role.USER)
-                        if last_user_idx == -1:
-                            break
-
-                        # Find the first complete turn to drop (skip system message)
-                        first_user_idx = -1
-                        for i in range(1, last_user_idx):
-                            if hist[i].role == Role.USER:
-                                first_user_idx = i
-                                break
-                        if first_user_idx == -1:
-                            break
-
-                        # Find the end of this turn: last message before next USER
-                        next_user_idx = -1
-                        for i in range(first_user_idx + 1, last_user_idx + 1):
-                            if hist[i].role == Role.USER:
-                                next_user_idx = i
-                                break
-                        if next_user_idx == -1:
-                            break
-
-                        # Drop the turn
-                        self.clear_history(first_user_idx, next_user_idx - 1)
-                        n_dropped_turns += 1
-
-                    output_len = min(
-                        self.config.llm.model_max_output_tokens,
-                        self.llm.chat_context_length()
-                        - self.chat_num_tokens(hist)
-                        - CHAT_HISTORY_BUFFER,
-                    )
-                    if output_len < self.config.llm.min_output_tokens:
-                        raise ValueError(
-                            f"""
-                            Tried to shorten prompt history for chat mode
-                            but even after dropping complete turns except the system
-                            msg and last turn, the history token len
-                            {self.chat_num_tokens(hist)} is too long to accommodate
-                            the desired minimum output tokens
-                            {self.config.llm.min_output_tokens} within the
-                            model's context length {self.llm.chat_context_length()}.
-                            Please try shortening the system msg or user prompts,
-                            or adjust `config.llm.min_output_tokens` to be smaller.
-                            """
-                        )
-                    else:
-                        # we MUST have dropped at least one turn
-                        msg_tokens = self.chat_num_tokens()
-                        logger.warning(
-                            f"""
-                        Chat Model context length is {self.llm.chat_context_length()}
-                        tokens, but the current message history is {msg_tokens} tokens
-                        long, which does not allow
-                        {self.config.llm.model_max_output_tokens} output tokens.
-                        Therefore we dropped the first {n_dropped_turns} complete
-                        turn(s) from the conversation history so that history token
-                        length is reduced to {self.chat_num_tokens(hist)}, and
-                        we use `max_output_tokens = {output_len}`,
-                        so they can fit within the model's context length
-                        of {self.llm.chat_context_length()} tokens.
-                        """
-                        )
-
-        if isinstance(message, ChatDocument):
-            # record the position of the corresponding LLMMessage in
-            # the message_history
-            message.metadata.msg_idx = len(hist) - 1
-            message.metadata.agent_id = self.id
-        return hist, output_len
-
-    def _function_args(
-        self,
-    ) -> Tuple[
-        Optional[List[LLMFunctionSpec]],
-        str | Dict[str, str],
-        Optional[List[OpenAIToolSpec]],
-        Optional[Dict[str, Dict[str, str] | str]],
-        Optional[OpenAIJsonSchemaSpec],
-    ]:
-        """
-        Get function/tool spec/output format arguments for
-        OpenAI-compatible LLM API call
-        """
-        functions: Optional[List[LLMFunctionSpec]] = None
-        fun_call: str | Dict[str, str] = "none"
-        tools: Optional[List[OpenAIToolSpec]] = None
-        force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
-        self.any_strict = False
-        if self.config.use_functions_api and len(self.llm_functions_usable) > 0:
-            if not self.config.use_tools_api:
-                functions = [
-                    self.llm_functions_map[f] for f in self.llm_functions_usable
-                ]
-                fun_call = (
-                    "auto"
-                    if self.llm_function_force is None
-                    else self.llm_function_force
-                )
-            else:
-
-                def to_maybe_strict_spec(function: str) -> OpenAIToolSpec:
-                    spec = self.llm_functions_map[function]
-                    strict = self._strict_mode_for_tool(function)
-                    if strict:
-                        self.any_strict = True
-                        strict_spec = copy.deepcopy(spec)
-                        format_schema_for_strict(strict_spec.parameters)
-                    else:
-                        strict_spec = spec
-
-                    return OpenAIToolSpec(
-                        type="function",
-                        strict=strict,
-                        function=strict_spec,
-                    )
-
-                tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
-                force_tool = (
-                    None
-                    if self.llm_function_force is None
-                    else {
-                        "type": "function",
-                        "function": {"name": self.llm_function_force["name"]},
-                    }
-                )
-        output_format = None
-        if self.output_format is not None and self._json_schema_available():
-            self.any_strict = True
-            if issubclass(self.output_format, ToolMessage) and not issubclass(
-                self.output_format, XMLToolMessage
-            ):
-                spec = self.output_format.llm_function_schema(
-                    request=True,
-                    defaults=self.config.output_format_include_defaults,
-                )
-                format_schema_for_strict(spec.parameters)
-
-                output_format = OpenAIJsonSchemaSpec(
-                    # We always require that outputs strictly match the schema
-                    strict=True,
-                    function=spec,
-                )
-            elif issubclass(self.output_format, BaseModel):
-                param_spec = self.output_format.model_json_schema()
-                format_schema_for_strict(param_spec)
-
-                output_format = OpenAIJsonSchemaSpec(
-                    # We always require that outputs strictly match the schema
-                    strict=True,
-                    function=LLMFunctionSpec(
-                        name="json_output",
-                        description="Strict Json output format.",
-                        parameters=param_spec,
-                    ),
-                )
-
-        return functions, fun_call, tools, force_tool, output_format
-
-    def llm_response_messages(
-        self,
-        messages: List[LLMMessage],
-        output_len: Optional[int] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-    ) -> ChatDocument:
-        """
-        Respond to a series of messages, e.g. with OpenAI ChatCompletion
-        Args:
-            messages: seq of messages (with role, content fields) sent to LLM
-            output_len: max number of tokens expected in response.
-                    If None, use the LLM's default model_max_output_tokens.
-        Returns:
-            Document (i.e. with fields "content", "metadata")
-        """
-        assert self.config.llm is not None and self.llm is not None
-        output_len = output_len or self.config.llm.model_max_output_tokens
-        streamer = noop_fn
-        if self.llm.get_stream():
-            streamer = self.callbacks.start_llm_stream()
-        self.llm.config.streamer = streamer
-        with ExitStack() as stack:  # for conditionally using rich spinner
-            if not self.llm.get_stream() and not settings.quiet:
-                # show rich spinner only if not streaming!
-                # (Why? b/c the intent of showing a spinner is to "show progress",
-                # and we don't need to do that when streaming, since
-                # streaming output already shows progress.)
-                cm = status(
-                    "LLM responding to messages...",
-                    log_if_quiet=False,
-                )
-                stack.enter_context(cm)
-            if self.llm.get_stream() and not settings.quiet:
-                console.print(f"[green]{self.indent}", end="")
-            functions, fun_call, tools, force_tool, output_format = (
-                self._function_args()
-            )
-            assert self.llm is not None
-            response = self.llm.chat(
-                messages,
-                output_len,
-                tools=tools,
-                tool_choice=force_tool or tool_choice,
-                functions=functions,
-                function_call=fun_call,
-                response_format=output_format,
-            )
-        if self.llm.get_stream():
-            # Create temp ChatDocument for tool check, then clean up to avoid
-            # polluting ObjectRegistry (see PR #939 discussion)
-            temp_doc = ChatDocument.from_LLMResponse(
-                response,
-                displayed=True,
-                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-            )
-            self._call_callback_with_reasoning(
-                "finish_llm_stream",
-                reasoning=response.reasoning,
-                content=response.message or "",
-                tools_content=response.tools_content(),
-                is_tool=self.has_tool_message_attempt(temp_doc),
-            )
-            ObjectRegistry.remove(temp_doc.id())
-        self.llm.config.streamer = noop_fn
-        if response.cached:
-            self.callbacks.cancel_llm_stream()
-        self._render_llm_response(response)
-        self.update_token_usage(
-            response,  # .usage attrib is updated!
-            messages,
-            self.llm.get_stream(),
-            chat=True,
-            print_response_stats=self.config.show_stats and not settings.quiet,
-        )
-        chat_doc = ChatDocument.from_LLMResponse(
-            response,
-            displayed=True,
-            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-        )
-        self.oai_tool_calls = response.oai_tool_calls or []
-        self.oai_tool_id2call.update(
-            {t.id: t for t in self.oai_tool_calls if t.id is not None}
-        )
-
-        # If using strict output format, parse the output JSON
-        self._load_output_format(chat_doc)
-
-        return chat_doc
-
-    async def llm_response_messages_async(
-        self,
-        messages: List[LLMMessage],
-        output_len: Optional[int] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-    ) -> ChatDocument:
-        """
-        Async version of `llm_response_messages`. See there for details.
-        """
-        assert self.config.llm is not None and self.llm is not None
-        output_len = output_len or self.config.llm.model_max_output_tokens
-        functions, fun_call, tools, force_tool, output_format = self._function_args()
-        assert self.llm is not None
-
-        streamer_async = async_noop_fn
-        if self.llm.get_stream():
-            streamer_async = await self.callbacks.start_llm_stream_async()
-        self.llm.config.streamer_async = streamer_async
-
-        response = await self.llm.achat(
-            messages,
-            output_len,
-            tools=tools,
-            tool_choice=force_tool or tool_choice,
-            functions=functions,
-            function_call=fun_call,
-            response_format=output_format,
-        )
-        if self.llm.get_stream():
-            # Create temp ChatDocument for tool check, then clean up to avoid
-            # polluting ObjectRegistry (see PR #939 discussion)
-            temp_doc = ChatDocument.from_LLMResponse(
-                response,
-                displayed=True,
-                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-            )
-            self._call_callback_with_reasoning(
-                "finish_llm_stream",
-                reasoning=response.reasoning,
-                content=response.message or "",
-                tools_content=response.tools_content(),
-                is_tool=self.has_tool_message_attempt(temp_doc),
-            )
-            ObjectRegistry.remove(temp_doc.id())
-        self.llm.config.streamer_async = async_noop_fn
-        if response.cached:
-            self.callbacks.cancel_llm_stream()
-        self._render_llm_response(response)
-        self.update_token_usage(
-            response,  # .usage attrib is updated!
-            messages,
-            self.llm.get_stream(),
-            chat=True,
-            print_response_stats=self.config.show_stats and not settings.quiet,
-        )
-        chat_doc = ChatDocument.from_LLMResponse(
-            response,
-            displayed=True,
-            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-        )
-        self.oai_tool_calls = response.oai_tool_calls or []
-        self.oai_tool_id2call.update(
-            {t.id: t for t in self.oai_tool_calls if t.id is not None}
-        )
-
-        # If using strict output format, parse the output JSON
-        self._load_output_format(chat_doc)
-
-        return chat_doc
-
-    def _call_callback_with_reasoning(
-        self,
-        callback_name: str,
-        reasoning: str,
-        **kwargs: Any,
-    ) -> None:
-        """
-        Call a callback method, only passing 'reasoning' if it accepts it.
-
-        This provides backward compatibility for custom callbacks that don't
-        have the 'reasoning' parameter in their signature.
-
-        Args:
-            callback_name: Name of the callback method (e.g., 'show_llm_response')
-            reasoning: The reasoning content to pass if supported
-            **kwargs: Other arguments to pass to the callback
-        """
-        callback = getattr(self.callbacks, callback_name, None)
-        if callback is None:
-            return
-
-        # Check if callback accepts 'reasoning' param or **kwargs
-        try:
-            sig = inspect.signature(callback)
-            params = sig.parameters
-            accepts_reasoning = "reasoning" in params or any(
-                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-            )
-        except (ValueError, TypeError):
-            # If we can't inspect the signature, assume it doesn't accept reasoning
-            accepts_reasoning = False
-
-        if accepts_reasoning:
-            callback(reasoning=reasoning, **kwargs)
-        else:
-            callback(**kwargs)
-
-    def _render_llm_response(
-        self, response: ChatDocument | LLMResponse, citation_only: bool = False
-    ) -> None:
-        is_cached = (
-            response.cached
-            if isinstance(response, LLMResponse)
-            else response.metadata.cached
-        )
-        if self.llm is None:
-            return
-        if not citation_only and (not self.llm.get_stream() or is_cached):
-            # We would have already displayed the msg "live" ONLY if
-            # streaming was enabled, AND we did not find a cached response.
-            # If we are here, it means the response has not yet been displayed.
-            cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
-            # Track whether we created a temp ChatDocument for cleanup
-            is_temp_doc = isinstance(response, LLMResponse)
-            chat_doc = (
-                response
-                if isinstance(response, ChatDocument)
-                else ChatDocument.from_LLMResponse(
-                    response,
-                    displayed=True,
-                    recognize_recipient_in_content=self.config.recognize_recipient_in_content,
-                )
-            )
-            # TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
-            if not settings.quiet:
-                print(cached + "[green]" + escape(str(response)))
-            if isinstance(response, LLMResponse):
-                content = response.message or ""
-                tools_content = response.tools_content()
-            else:
-                content = response.content
-                tools_content = ""
-            reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
-            self._call_callback_with_reasoning(
-                "show_llm_response",
-                reasoning=reasoning,
-                content=content,
-                tools_content=tools_content,
-                is_tool=self.has_tool_message_attempt(chat_doc),
-                cached=is_cached,
-            )
-            # Clean up temp ChatDocument to avoid polluting ObjectRegistry
-            if is_temp_doc:
-                ObjectRegistry.remove(chat_doc.id())
-        if isinstance(response, LLMResponse):
-            # we are in the context immediately after an LLM responded,
-            # we won't have citations yet, so we're done
-            return
-        if response.metadata.has_citation:
-            citation = (
-                response.metadata.source_content
-                if self.config.full_citations
-                else response.metadata.source
-            )
-            if not settings.quiet:
-                print("[grey37]SOURCES:\n" + escape(citation) + "[/grey37]")
-            self._call_callback_with_reasoning(
-                "show_llm_response",
-                reasoning="",  # Citations don't have reasoning
-                content=str(citation),
-                tools_content="",
-                is_tool=False,
-                cached=False,
-                language="text",
-            )
-
-    def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument:
-        """
-        Get LLM response to `prompt` (which presumably includes the `message`
-        somewhere, along with possible large "context" passages),
-        but only include `message` as the USER message, and not the
-        full `prompt`, in the message history.
-        Args:
-            message: the original, relatively short, user request or query
-            prompt: the full prompt potentially containing `message` plus context
-
-        Returns:
-            Document object containing the response.
-        """
-        # we explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
-        self.update_last_message(message, role=Role.USER)
-        return answer_doc
-
-    async def _llm_response_temp_context_async(
-        self, message: str, prompt: str
-    ) -> ChatDocument:
-        """
-        Async version of `_llm_response_temp_context`. See there for details.
-        """
-        # we explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            answer_doc = cast(
-                ChatDocument,
-                await ChatAgent.llm_response_async(self, prompt),
-            )
-        self.update_last_message(message, role=Role.USER)
-        return answer_doc
-
-    def llm_response_forget(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> ChatDocument:
-        """
-        LLM Response to single message, and restore message_history.
-        In effect a "one-off" message & response that leaves agent
-        message history state intact.
-
-        Args:
-            message (str|ChatDocument): message to respond to.
-
-        Returns:
-            A Document object with the response.
-
-        """
-        # explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        n_msgs = len(self.message_history)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            response = cast(ChatDocument, ChatAgent.llm_response(self, message))
-        # If there is a response, then we will have two additional
-        # messages in the message history, i.e. the user message and the
-        # assistant response. We want to (carefully) remove these two messages.
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-
-        # If using strict output format, parse the output JSON
-        self._load_output_format(response)
-
-        return response
-
-    async def llm_response_forget_async(
-        self, message: Optional[str | ChatDocument] = None
-    ) -> ChatDocument:
-        """
-        Async version of `llm_response_forget`. See there for details.
-        """
-        # explicitly call THIS class's respond method,
-        # not a derived class's (or else there would be infinite recursion!)
-        n_msgs = len(self.message_history)
-        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
-            response = cast(
-                ChatDocument, await ChatAgent.llm_response_async(self, message)
-            )
-        # If there is a response, then we will have two additional
-        # messages in the message history, i.e. the user message and the
-        # assistant response. We want to (carefully) remove these two messages.
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-
-        if len(self.message_history) > n_msgs:
-            msg = self.message_history.pop()
-            self._drop_msg_update_tool_calls(msg)
-        return response
-
-    def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int:
-        """
-        Total number of tokens in the message history so far.
-
-        Args:
-            messages: if provided, compute the number of tokens in this list of
-                messages, rather than the current message history.
-        Returns:
-            int: number of tokens in message history
-        """
-        if self.parser is None:
-            raise ValueError(
-                "ChatAgent.parser is None. "
-                "You must set ChatAgent.parser "
-                "before calling chat_num_tokens()."
-            )
-        hist = messages if messages is not None else self.message_history
-        return sum([self._message_num_tokens(m) for m in hist])
-
-    def _message_num_tokens(self, message: LLMMessage) -> int:
-        """Count tokens for a message, including serialized user attachments."""
-        if self.parser is None:
-            raise ValueError(
-                "ChatAgent.parser is None. "
-                "You must set ChatAgent.parser "
-                "before calling _message_num_tokens()."
-            )
-
-        return self.parser.num_tokens(
-            message.content or ""
-        ) + self._attachment_num_tokens(message)
-
-    def _attachment_num_tokens(self, message: LLMMessage) -> int:
-        """
-        Estimate attachment contribution using the serialized payload
-        that is sent in the API request for user messages.
-        """
-        if self.parser is None or message.role != Role.USER or len(message.files) == 0:
-            return 0
-
-        model = self._chat_model_name_for_attachments()
-        return sum(
-            self.parser.num_tokens(
-                json.dumps(
-                    attachment.to_dict(model),
-                    separators=(",", ":"),
-                    sort_keys=True,
-                )
-            )
-            for attachment in message.files
-        )
-
-    def _chat_model_name_for_attachments(self) -> str:
-        """Return the model name used for attachment serialization."""
-        if self.llm is None:
-            return self.config.llm.chat_model if self.config.llm is not None else ""
-
-        return cast(
-            str,
-            getattr(
-                self.llm,
-                "chat_model_orig",
-                getattr(
-                    getattr(self.llm, "config", None),
-                    "chat_model",
-                    self.config.llm.chat_model if self.config.llm is not None else "",
-                ),
-            ),
-        )
-
-    def message_history_str(self, i: Optional[int] = None) -> str:
-        """
-        Return a string representation of the message history
-        Args:
-            i: if provided, return only the i-th message when i is postive,
-                or last k messages when i = -k.
-        Returns:
-        """
-        if i is None:
-            return "\n".join([str(m) for m in self.message_history])
-        elif i > 0:
-            return str(self.message_history[i])
-        else:
-            return "\n".join([str(m) for m in self.message_history[i:]])
-
-    def __del__(self) -> None:
-        """
-        Cleanup method called when the ChatAgent is garbage collected.
-        Note: We don't close LLM clients here because they may be shared
-        across multiple agents when client caching is enabled.
-        The clients are managed centrally and cleaned up via atexit hooks.
-        """
-        # Previously we closed clients here, but this caused issues when
-        # multiple agents shared the same cached client instance.
-        # Clients are now managed centrally in langroid.language_models.client_cache
-        pass
-</file>
-
-<file path="langroid/language_models/base.py">
-import json
-import logging
-from abc import ABC, abstractmethod
-from datetime import datetime, timezone
-from enum import Enum
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
-
-from pydantic import BaseModel, Field
-from pydantic_settings import BaseSettings
-
-from langroid.cachedb.base import CacheDBConfig
-from langroid.cachedb.redis_cachedb import RedisCacheConfig
-from langroid.language_models.model_info import ModelInfo, get_model_info
-from langroid.parsing.agent_chats import parse_message
-from langroid.parsing.file_attachment import FileAttachment
-from langroid.parsing.parse_json import parse_imperfect_json, top_level_json_field
-from langroid.prompts.dialog import collate_chat_history
-from langroid.utils.configuration import settings
-from langroid.utils.output.printing import show_if_debug
-
-logger = logging.getLogger(__name__)
-
-
-def noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
-    pass
-
-
-async def async_noop_fn(*args: List[Any], **kwargs: Dict[str, Any]) -> None:
-    pass
-
-
-FunctionCallTypes = Literal["none", "auto"]
-ToolChoiceTypes = Literal["none", "auto", "required"]
-ToolTypes = Literal["function"]
-
-DEFAULT_CONTEXT_LENGTH = 16_000
-
-
-class StreamEventType(Enum):
-    TEXT = 1
-    FUNC_NAME = 2
-    FUNC_ARGS = 3
-    TOOL_NAME = 4
-    TOOL_ARGS = 5
-    REASONING = 6
-
-
-class RetryParams(BaseSettings):
-    max_retries: int = 5
-    initial_delay: float = 1.0
-    exponential_base: float = 1.3
-    jitter: bool = True
-
-
-class LLMConfig(BaseSettings):
-    """
-    Common configuration for all language models.
-    """
-
-    type: str = "openai"
-    streamer: Optional[Callable[[Any], None]] = noop_fn
-    streamer_async: Optional[Callable[..., Awaitable[None]]] = async_noop_fn
-    api_base: str | None = None
-    formatter: None | str = None
-    # specify None if you want to use the full max output tokens of the model
-    max_output_tokens: int | None = 8192
-    timeout: int = 20  # timeout for API requests
-    chat_model: str = ""
-    completion_model: str = ""
-    temperature: float = 0.0
-    chat_context_length: int | None = None
-    async_stream_quiet: bool = False  # suppress streaming output in async mode?
-    completion_context_length: int | None = None
-    # if input length + max_output_tokens > context length of model,
-    # we will try shortening requested output
-    min_output_tokens: int = 64
-    use_completion_for_chat: bool = False  # use completion model for chat?
-    # use chat model for completion? For OpenAI models, this MUST be set to True!
-    use_chat_for_completion: bool = True
-    stream: bool = True  # stream output from API?
-    # TODO: we could have a `stream_reasoning` flag here to control whether to show
-    # reasoning output from reasoning models
-    cache_config: None | CacheDBConfig = RedisCacheConfig()
-    thought_delimiters: Tuple[str, str] = ("<think>", "</think>")
-    retry_params: RetryParams = RetryParams()
-
-    @property
-    def model_max_output_tokens(self) -> int:
-        if self.max_output_tokens:
-            return self.max_output_tokens
-        # Build fallback names by progressively stripping provider prefixes
-        # (e.g. "minimax/MiniMax-M2.7" → ["MiniMax-M2.7"]) so that the lookup
-        # succeeds even before OpenAIGPT.__init__ strips the prefix.
-        parts = self.chat_model.split("/")
-        fallbacks = ["/".join(parts[i:]) for i in range(1, len(parts))]
-        return get_model_info(self.chat_model, fallbacks).max_output_tokens
-
-
-class LLMFunctionCall(BaseModel):
-    """
-    Structure of LLM response indicating it "wants" to call a function.
-    Modeled after OpenAI spec for `function_call` field in ChatCompletion API.
-    """
-
-    name: str  # name of function to call
-    arguments: Optional[Dict[str, Any]] = None
-
-    @staticmethod
-    def from_dict(message: Dict[str, Any]) -> "LLMFunctionCall":
-        """
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-        fun_call = LLMFunctionCall(name=message["name"])
-        fun_args_str = message["arguments"]
-        # sometimes may be malformed with invalid indents,
-        # so we try to be safe by removing newlines.
-        if fun_args_str is not None:
-            fun_args_str = fun_args_str.replace("\n", "").strip()
-            dict_or_list = parse_imperfect_json(fun_args_str)
-
-            if not isinstance(dict_or_list, dict):
-                raise ValueError(
-                    f"""
-                        Invalid function args: {fun_args_str}
-                        parsed as {dict_or_list},
-                        which is not a valid dict.
-                        """
-                )
-            fun_args = dict_or_list
-        else:
-            fun_args = None
-        fun_call.arguments = fun_args
-
-        return fun_call
-
-    def __str__(self) -> str:
-        return "FUNC: " + json.dumps(self.model_dump(), indent=2)
-
-
-class LLMFunctionSpec(BaseModel):
-    """
-    Description of a function available for the LLM to use.
-    To be used when calling the LLM `chat()` method with the `functions` parameter.
-    Modeled after OpenAI spec for `functions` fields in ChatCompletion API.
-    """
-
-    name: str
-    description: str
-    parameters: Dict[str, Any]
-
-
-class OpenAIToolCall(BaseModel):
-    """
-    Represents a single tool call in a list of tool calls generated by OpenAI LLM API.
-    See https://platform.openai.com/docs/api-reference/chat/create
-
-    Attributes:
-        id: The id of the tool call.
-        type: The type of the tool call;
-            only "function" is currently possible (7/26/24).
-        function: The function call.
-    """
-
-    id: str | None = None
-    type: ToolTypes = "function"
-    function: LLMFunctionCall | None = None
-    extra_content: Dict[str, Any] | None = None
-
-    @staticmethod
-    def from_dict(message: Dict[str, Any]) -> "OpenAIToolCall":
-        """
-        Initialize from dictionary.
-        Args:
-            d: dictionary containing fields to initialize
-        """
-        id = message["id"]
-        type = message["type"]
-        function = LLMFunctionCall.from_dict(message["function"])
-        extra_content = message.get("extra_content")
-        return OpenAIToolCall(
-            id=id, type=type, function=function, extra_content=extra_content
-        )
-
-    def __str__(self) -> str:
-        if self.function is None:
-            return ""
-        return "OAI-TOOL: " + json.dumps(self.function.model_dump(), indent=2)
-
-
-class OpenAIToolSpec(BaseModel):
-    type: ToolTypes
-    strict: Optional[bool] = None
-    function: LLMFunctionSpec
-
-
-class OpenAIJsonSchemaSpec(BaseModel):
-    strict: Optional[bool] = None
-    function: LLMFunctionSpec
-
-    def to_dict(self) -> Dict[str, Any]:
-        json_schema: Dict[str, Any] = {
-            "name": self.function.name,
-            "description": self.function.description,
-            "schema": self.function.parameters,
-        }
-        if self.strict is not None:
-            json_schema["strict"] = self.strict
-
-        return {
-            "type": "json_schema",
-            "json_schema": json_schema,
-        }
-
-
-class LLMTokenUsage(BaseModel):
-    """
-    Usage of tokens by an LLM.
-    """
-
-    prompt_tokens: int = 0
-    cached_tokens: int = 0
-    completion_tokens: int = 0
-    cost: float = 0.0
-    calls: int = 0  # how many API calls - not used as of 2025-04-04
-
-    def reset(self) -> None:
-        self.prompt_tokens = 0
-        self.cached_tokens = 0
-        self.completion_tokens = 0
-        self.cost = 0.0
-        self.calls = 0
-
-    def __str__(self) -> str:
-        return (
-            f"Tokens = "
-            f"(prompt {self.prompt_tokens}, cached {self.cached_tokens}, "
-            f"completion {self.completion_tokens}), "
-            f"Cost={self.cost}, Calls={self.calls}"
-        )
-
-    @property
-    def total_tokens(self) -> int:
-        return self.prompt_tokens + self.completion_tokens
-
-
-class Role(str, Enum):
-    """
-    Possible roles for a message in a chat.
-    """
-
-    USER = "user"
-    SYSTEM = "system"
-    ASSISTANT = "assistant"
-    FUNCTION = "function"
-    TOOL = "tool"
-
-
-class LLMMessage(BaseModel):
-    """
-    Class representing an entry in the msg-history sent to the LLM API.
-    It could be one of these:
-    - a user message
-    - an LLM ("Assistant") response
-    - a fn-call or tool-call-list from an OpenAI-compatible LLM API response
-    - a result or results from executing a fn or tool-call(s)
-    """
-
-    role: Role
-    name: Optional[str] = None
-    tool_call_id: Optional[str] = None  # which OpenAI LLM tool this is a response to
-    tool_id: str = ""  # used by OpenAIAssistant
-    # None means "no content" (the model returned only a tool/function call).
-    # This is distinct from "" and is dropped from the API payload by api_dict;
-    # see api_dict for how a fully-empty message is handled per-API.
-    content: Optional[str] = None
-    files: List[FileAttachment] = []
-    function_call: Optional[LLMFunctionCall] = None
-    tool_calls: Optional[List[OpenAIToolCall]] = None
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    # link to corresponding chat document, for provenance/rewind purposes
-    chat_document_id: str = ""
-
-    def api_dict(self, model: str, has_system_role: bool = True) -> Dict[str, Any]:
-        """
-        Convert to dictionary for API request, keeping ONLY
-        the fields that are expected in an API call!
-        E.g., DROP the tool_id, since it is only for use in the Assistant API,
-            not the completion API.
-
-        Args:
-            has_system_role: whether the message has a system role (if not,
-                set to "user" role)
-        Returns:
-            dict: dictionary representation of LLM message
-        """
-        d = self.model_dump()
-        files: List[FileAttachment] = d.pop("files")
-        if len(files) > 0 and self.role == Role.USER:
-            # In there are files, then content is an array of
-            # different content-parts
-            d["content"] = [
-                dict(
-                    type="text",
-                    text=self.content or "",
-                )
-            ] + [f.to_dict(model) for f in self.files]
-
-        # if there is a key k = "role" with value "system", change to "user"
-        # in case has_system_role is False
-        if not has_system_role and "role" in d and d["role"] == "system":
-            d["role"] = "user"
-            if d.get("content"):
-                d["content"] = "[ADDITIONAL SYSTEM MESSAGE:]\n\n" + d["content"]
-        # drop None values since API doesn't accept them (this omits `content`
-        # entirely when it is None, i.e. "no content")
-        dict_no_none = {k: v for k, v in d.items() if v is not None}
-        if "name" in dict_no_none and dict_no_none["name"] == "":
-            # OpenAI API does not like empty name
-            del dict_no_none["name"]
-        if "function_call" in dict_no_none:
-            # arguments must be a string
-            if "arguments" in dict_no_none["function_call"]:
-                dict_no_none["function_call"]["arguments"] = json.dumps(
-                    dict_no_none["function_call"]["arguments"]
-                )
-        if dict_no_none.get("tool_calls"):
-            # convert tool calls to API format
-            for tc in dict_no_none["tool_calls"]:
-                if "arguments" in tc["function"]:
-                    # arguments must be a string
-                    if tc["function"]["arguments"] is None:
-                        tc["function"]["arguments"] = "{}"
-                    else:
-                        tc["function"]["arguments"] = json.dumps(
-                            tc["function"]["arguments"]
-                        )
-                if "extra_content" in tc and tc["extra_content"] is None:
-                    del tc["extra_content"]
-        else:
-            # An empty tool-call list is not a call and conveys no useful API
-            # information. Omitting it also lets the empty-message fallback
-            # below produce a valid message.
-            dict_no_none.pop("tool_calls", None)
-        # A message with empty content (None was dropped above, or "") AND no
-        # tool/function call would be an entirely empty message, which some APIs
-        # (e.g. Gemini) reject; fall back to a single space in that case only.
-        # When there IS a tool/function call, empty content is fine (and Gemini
-        # 3.x in fact REQUIRES it — it rejects an assistant turn that carries
-        # both a call and non-empty text content).
-        has_call = bool(dict_no_none.get("tool_calls")) or (
-            dict_no_none.get("function_call") is not None
-        )
-        if not has_call and not dict_no_none.get("content"):
-            dict_no_none["content"] = " "
-        # IMPORTANT! drop fields that are not expected in API call
-        dict_no_none.pop("tool_id", None)
-        dict_no_none.pop("timestamp", None)
-        dict_no_none.pop("chat_document_id", None)
-        return dict_no_none
-
-    def __str__(self) -> str:
-        if self.function_call is not None:
-            content = "FUNC: " + json.dumps(self.function_call)
-        else:
-            content = self.content or ""
-        name_str = f" ({self.name})" if self.name else ""
-        return f"{self.role} {name_str}: {content}"
-
-
-class LLMResponse(BaseModel):
-    """
-    Class representing response from LLM.
-    """
-
-    # None means the model returned NO content (e.g. only a tool/function
-    # call), which is distinct from an empty string "". Preserving this
-    # distinction lets the message be faithfully reproduced downstream
-    # (see ChatDocument.content_is_none and LLMMessage.content).
-    message: Optional[str] = None
-    reasoning: str = ""  # optional reasoning text from reasoning models
-    # Original message text including inline thought signatures (e.g.
-    # <thinking>...</thinking>). Only set when reasoning was extracted
-    # from the message text via get_reasoning_final(); NOT set when
-    # reasoning comes from a separate API field (e.g. reasoning_content),
-    # since in that case the message text never contained thought tags.
-    message_with_reasoning: Optional[str] = None
-    # TODO tool_id needs to generalize to multi-tool calls
-    tool_id: str = ""  # used by OpenAIAssistant
-    oai_tool_calls: Optional[List[OpenAIToolCall]] = None
-    function_call: Optional[LLMFunctionCall] = None
-    usage: Optional[LLMTokenUsage] = None
-    cached: bool = False
-
-    def __str__(self) -> str:
-        if self.function_call is not None:
-            return str(self.function_call)
-        elif self.oai_tool_calls:
-            return "\n".join(str(tc) for tc in self.oai_tool_calls)
-        else:
-            return self.message or ""
-
-    def tools_content(self) -> str:
-        if self.function_call is not None:
-            return str(self.function_call)
-        elif self.oai_tool_calls:
-            return "\n".join(str(tc) for tc in self.oai_tool_calls)
-        else:
-            return ""
-
-    def to_LLMMessage(self) -> LLMMessage:
-        """Convert LLM response to an LLMMessage, to be included in the
-        message-list sent to the API.
-        This is currently NOT used in any significant way in the library, and is only
-        provided as a utility to construct a message list for the API when directly
-        working with an LLM object.
-
-        In a `ChatAgent`, an LLM response is first converted to a ChatDocument,
-        which is in turn converted to an LLMMessage via `ChatDocument.to_LLMMessage()`
-        See `ChatAgent._prep_llm_messages()` and `ChatAgent.llm_response_messages`
-        """
-        return LLMMessage(
-            role=Role.ASSISTANT,
-            content=self.message,
-            name=None if self.function_call is None else self.function_call.name,
-            function_call=self.function_call,
-            tool_calls=self.oai_tool_calls,
-        )
-
-    def get_recipient_and_message(
-        self,
-        recognize_recipient_in_content: bool = True,
-    ) -> Tuple[str, str]:
-        """
-        If `message` or `function_call` of an LLM response contains an explicit
-        recipient name, return this recipient name and `message` stripped
-        of the recipient name if specified.
-
-        Two cases:
-        (a) `message` contains addressing string ``TO[<name>]:<content>``, or
-        (b) `message` is empty and function_call/tool_call with explicit `recipient`
-
-        Args:
-            recognize_recipient_in_content (bool): When True (default), parses
-                message text for ``TO[<recipient>]:<content>`` patterns and
-                top-level JSON ``{"recipient": "..."}`` fields. When False,
-                only function_call/tool_call ``recipient`` fields are checked.
-
-        Returns:
-            (str): name of recipient, which may be empty string if no recipient
-            (str): content of message
-
-        """
-
-        if self.function_call is not None:
-            # in this case we ignore message, since all information is in function_call
-            msg = ""
-            args = self.function_call.arguments
-            recipient = ""
-            if isinstance(args, dict):
-                recipient = args.get("recipient", "")
-            return recipient, msg
-        else:
-            msg = self.message or ""
-            if self.oai_tool_calls is not None:
-                # get the first tool that has a recipient field, if any
-                for tc in self.oai_tool_calls:
-                    if tc.function is not None and tc.function.arguments is not None:
-                        recipient = tc.function.arguments.get(
-                            "recipient"
-                        )  # type: ignore
-                        if recipient is not None and recipient != "":
-                            return recipient, ""
-
-        if not recognize_recipient_in_content:
-            return "", msg
-
-        # It's not a function or tool call, so continue looking to see
-        # if a recipient is specified in the message.
-
-        # First check if message contains "TO: <recipient> <content>"
-        recipient_name, content = parse_message(msg) if msg is not None else ("", "")
-        # check if there is a top level json that specifies 'recipient',
-        # and retain the entire message as content.
-        if recipient_name == "":
-            recipient_name = top_level_json_field(msg, "recipient") if msg else ""
-            content = msg
-        return recipient_name, content
-
-
-# Define an abstract base class for language models
-class LanguageModel(ABC):
-    """
-    Abstract base class for language models.
-    """
-
-    # usage cost by model, accumulates here
-    usage_cost_dict: Dict[str, LLMTokenUsage] = {}
-
-    def __init__(self, config: LLMConfig = LLMConfig()):
-        self.config = config
-        self.chat_model_orig = config.chat_model
-
-    @staticmethod
-    def create(config: Optional[LLMConfig]) -> Optional["LanguageModel"]:
-        """
-        Create a language model.
-        Args:
-            config: configuration for language model
-        Returns: instance of language model
-        """
-        if type(config) is LLMConfig:
-            raise ValueError(
-                """
-                Cannot create a Language Model object from LLMConfig.
-                Please specify a specific subclass of LLMConfig e.g.,
-                OpenAIGPTConfig. If you are creating a ChatAgent from
-                a ChatAgentConfig, please specify the `llm` field of this config
-                as a specific subclass of LLMConfig, e.g., OpenAIGPTConfig.
-                """
-            )
-        from langroid.language_models.azure_openai import AzureGPT
-        from langroid.language_models.mock_lm import MockLM, MockLMConfig
-        from langroid.language_models.openai_gpt import OpenAIGPT
-
-        if config is None or config.type is None:
-            return None
-
-        if config.type == "mock":
-            return MockLM(cast(MockLMConfig, config))
-
-        openai: Union[Type[AzureGPT], Type[OpenAIGPT]]
-
-        if config.type == "azure":
-            openai = AzureGPT
-        else:
-            openai = OpenAIGPT
-        cls = dict(
-            openai=openai,
-        ).get(config.type, openai)
-        return cls(config)  # type: ignore
-
-    @staticmethod
-    def user_assistant_pairs(lst: List[str]) -> List[Tuple[str, str]]:
-        """
-        Given an even-length sequence of strings, split into a sequence of pairs
-
-        Args:
-            lst (List[str]): sequence of strings
-
-        Returns:
-            List[Tuple[str,str]]: sequence of pairs of strings
-        """
-        evens = lst[::2]
-        odds = lst[1::2]
-        return list(zip(evens, odds))
-
-    @staticmethod
-    def get_chat_history_components(
-        messages: List[LLMMessage],
-    ) -> Tuple[str, List[Tuple[str, str]], str]:
-        """
-        From the chat history, extract system prompt, user-assistant turns, and
-        final user msg.
-
-        Args:
-            messages (List[LLMMessage]): List of messages in the chat history
-
-        Returns:
-            Tuple[str, List[Tuple[str,str]], str]:
-                system prompt, user-assistant turns, final user msg
-
-        """
-        # Handle various degenerate cases
-        messages = [m for m in messages]  # copy
-        DUMMY_SYS_PROMPT = "You are a helpful assistant."
-        DUMMY_USER_PROMPT = "Follow the instructions above."
-        if len(messages) == 0 or messages[0].role != Role.SYSTEM:
-            logger.warning("No system msg, creating dummy system prompt")
-            messages.insert(0, LLMMessage(content=DUMMY_SYS_PROMPT, role=Role.SYSTEM))
-        system_prompt = messages[0].content or ""
-
-        # now we have messages = [Sys,...]
-        if len(messages) == 1:
-            logger.warning(
-                "Got only system message in chat history, creating dummy user prompt"
-            )
-            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, msg, ...]
-
-        if messages[1].role != Role.USER:
-            messages.insert(1, LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, user, ...]
-        if messages[-1].role != Role.USER:
-            logger.warning(
-                "Last message in chat history is not a user message,"
-                " creating dummy user prompt"
-            )
-            messages.append(LLMMessage(content=DUMMY_USER_PROMPT, role=Role.USER))
-
-        # now we have messages = [Sys, user, ..., user]
-        # so we omit the first and last elements and make pairs of user-asst messages
-        conversation = [m.content or "" for m in messages[1:-1]]
-        user_prompt = messages[-1].content or ""
-        pairs = LanguageModel.user_assistant_pairs(conversation)
-        return system_prompt, pairs, user_prompt
-
-    @abstractmethod
-    def set_stream(self, stream: bool) -> bool:
-        """Enable or disable streaming output from API.
-        Return previous value of stream."""
-        pass
-
-    @abstractmethod
-    def get_stream(self) -> bool:
-        """Get streaming status"""
-        pass
-
-    @abstractmethod
-    def generate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        pass
-
-    @abstractmethod
-    async def agenerate(self, prompt: str, max_tokens: int = 200) -> LLMResponse:
-        pass
-
-    @abstractmethod
-    def chat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """
-        Get chat-completion response from LLM.
-
-        Args:
-            messages: message-history to send to the LLM
-            max_tokens: max tokens to generate
-            tools: tools available for the LLM to use in its response
-            tool_choice: tool call mode, one of "none", "auto", "required",
-                or a dict specifying a specific tool.
-            functions: functions available for LLM to call (deprecated)
-            function_call: function calling mode, "auto", "none", or a specific fn
-                    (deprecated)
-        """
-
-        pass
-
-    @abstractmethod
-    async def achat(
-        self,
-        messages: Union[str, List[LLMMessage]],
-        max_tokens: int = 200,
-        tools: Optional[List[OpenAIToolSpec]] = None,
-        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
-        functions: Optional[List[LLMFunctionSpec]] = None,
-        function_call: str | Dict[str, str] = "auto",
-        response_format: Optional[OpenAIJsonSchemaSpec] = None,
-    ) -> LLMResponse:
-        """Async version of `chat`. See `chat` for details."""
-        pass
-
-    def __call__(self, prompt: str, max_tokens: int) -> LLMResponse:
-        return self.generate(prompt, max_tokens)
-
-    @staticmethod
-    def _fallback_model_names(model: str) -> List[str]:
-        parts = model.split("/")
-        fallbacks = []
-        for i in range(1, len(parts)):
-            fallbacks.append("/".join(parts[i:]))
-        return fallbacks
-
-    def info(self) -> ModelInfo:
-        """Info of relevant chat model"""
-        orig_model = (
-            self.config.completion_model
-            if self.config.use_completion_for_chat
-            else self.chat_model_orig
-        )
-        return get_model_info(orig_model, self._fallback_model_names(orig_model))
-
-    def completion_info(self) -> ModelInfo:
-        """Info of relevant completion model"""
-        orig_model = (
-            self.chat_model_orig
-            if self.config.use_chat_for_completion
-            else self.config.completion_model
-        )
-        return get_model_info(orig_model, self._fallback_model_names(orig_model))
-
-    def supports_functions_or_tools(self) -> bool:
-        """
-        Does this Model's API support "native" tool-calling, i.e.
-        can we call the API with arguments that contain a list of available tools,
-        and their schemas?
-        Note that, given the plethora of LLM provider APIs this determination is
-        imperfect at best, and leans towards returning True.
-        When the API calls fails with an error indicating tools are not supported,
-        then users are encouraged to use the Langroid-based prompt-based
-        ToolMessage mechanism, which works with ANY LLM. To enable this,
-        in your ChatAgentConfig, set `use_functions_api=False`, and `use_tools=True`.
-        """
-        return self.info().has_tools
-
-    def chat_context_length(self) -> int:
-        return self.config.chat_context_length or DEFAULT_CONTEXT_LENGTH
-
-    def completion_context_length(self) -> int:
-        return self.config.completion_context_length or DEFAULT_CONTEXT_LENGTH
-
-    def chat_cost(self) -> Tuple[float, float, float]:
-        """
-        Return the cost per 1000 tokens for chat completions.
-
-        Returns:
-            Tuple[float, float, float]: (input_cost, cached_cost, output_cost)
-                per 1000 tokens
-        """
-        return (0.0, 0.0, 0.0)
-
-    def reset_usage_cost(self) -> None:
-        for mdl in [self.config.chat_model, self.config.completion_model]:
-            if mdl is None:
-                return
-            if mdl not in self.usage_cost_dict:
-                self.usage_cost_dict[mdl] = LLMTokenUsage()
-            counter = self.usage_cost_dict[mdl]
-            counter.reset()
-
-    def update_usage_cost(
-        self, chat: bool, prompts: int, completions: int, cost: float
-    ) -> None:
-        """
-        Update usage cost for this LLM.
-        Args:
-            chat (bool): whether to update for chat or completion model
-            prompts (int): number of tokens used for prompts
-            completions (int): number of tokens used for completions
-            cost (float): total token cost in USD
-        """
-        mdl = self.config.chat_model if chat else self.config.completion_model
-        if mdl is None:
-            return
-        if mdl not in self.usage_cost_dict:
-            self.usage_cost_dict[mdl] = LLMTokenUsage()
-        counter = self.usage_cost_dict[mdl]
-        counter.prompt_tokens += prompts
-        counter.completion_tokens += completions
-        counter.cost += cost
-        counter.calls += 1
-
-    @classmethod
-    def usage_cost_summary(cls) -> str:
-        s = ""
-        for model, counter in cls.usage_cost_dict.items():
-            s += f"{model}: {counter}\n"
-        return s
-
-    @classmethod
-    def tot_tokens_cost(cls) -> Tuple[int, float]:
-        """
-        Return total tokens used and total cost across all models.
-        """
-        total_tokens = 0
-        total_cost = 0.0
-        for counter in cls.usage_cost_dict.values():
-            total_tokens += counter.total_tokens
-            total_cost += counter.cost
-        return total_tokens, total_cost
-
-    def get_reasoning_final(self, message: str) -> Tuple[str, str]:
-        """Extract "reasoning" and "final answer" from an LLM response, if the
-        reasoning is found within configured delimiters, like <think>, </think>.
-        E.g.,
-        '<think> Okay, let's see, the user wants... </think> 2 + 3 = 5'
-
-        Args:
-            message (str): message from LLM
-
-        Returns:
-            Tuple[str, str]: reasoning, final answer
-        """
-        start, end = self.config.thought_delimiters
-        if start in message and end in message:
-            parts = message.split(start)
-            if len(parts) > 1:
-                reasoning, final = parts[1].split(end)
-                return reasoning, final
-        return "", message
-
-    def followup_to_standalone(
-        self, chat_history: List[Tuple[str, str]], question: str
-    ) -> str:
-        """
-        Given a chat history and a question, convert it to a standalone question.
-        Args:
-            chat_history: list of tuples of (question, answer)
-            query: follow-up question
-
-        Returns: standalone version of the question
-        """
-        history = collate_chat_history(chat_history)
-
-        prompt = f"""
-        You are an expert at understanding a CHAT HISTORY between an AI Assistant
-        and a User, and you are highly skilled in rephrasing the User's FOLLOW-UP
-        QUESTION/REQUEST as a STANDALONE QUESTION/REQUEST that can be understood
-        WITHOUT the context of the chat history.
-
-        Below is the CHAT HISTORY. When the User asks you to rephrase a
-        FOLLOW-UP QUESTION/REQUEST, your ONLY task is to simply return the
-        question REPHRASED as a STANDALONE QUESTION/REQUEST, without any additional
-        text or context.
-
-        <CHAT_HISTORY>
-        {history}
-        </CHAT_HISTORY>
-        """.strip()
-
-        follow_up_question = f"""
-        Please rephrase this as a stand-alone question or request:
-        <FOLLOW-UP-QUESTION-OR-REQUEST>
-        {question}
-        </FOLLOW-UP-QUESTION-OR-REQUEST>
-        """.strip()
-
-        show_if_debug(prompt, "FOLLOWUP->STANDALONE-PROMPT= ")
-        standalone = (
-            self.chat(
-                messages=[
-                    LLMMessage(role=Role.SYSTEM, content=prompt),
-                    LLMMessage(role=Role.USER, content=follow_up_question),
-                ],
-                max_tokens=1024,
-            ).message
-            or ""
-        )
-        standalone = standalone.strip()
-
-        show_if_debug(prompt, "FOLLOWUP->STANDALONE-RESPONSE= ")
-        return standalone
-
-
-class StreamingIfAllowed:
-    """Context to temporarily enable or disable streaming, if allowed globally via
-    `settings.stream`"""
-
-    def __init__(self, llm: LanguageModel, stream: bool = True):
-        self.llm = llm
-        self.stream = stream
-
-    def __enter__(self) -> None:
-        self.old_stream = self.llm.set_stream(settings.stream and self.stream)
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self.llm.set_stream(self.old_stream)
 </file>
 
 <file path="tests/main/sql_chat/test_sql_chat_security.py">
@@ -121238,6 +120242,3326 @@ class SQLHelperAgent(SQLChatAgent):
         return super().llm_response_forget(instruc_msg)
 </file>
 
+<file path="langroid/agent/chat_agent.py">
+import copy
+import inspect
+import json
+import logging
+import textwrap
+from contextlib import ExitStack
+from inspect import isclass
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Self,
+    Set,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+import openai
+from pydantic import BaseModel, ValidationError
+from pydantic.fields import ModelPrivateAttr
+from rich import print
+from rich.console import Console
+from rich.markup import escape
+
+from langroid.agent.base import (
+    Agent,
+    AgentConfig,
+    SearchForTools,
+    async_noop_fn,
+    noop_fn,
+)
+from langroid.agent.chat_document import ChatDocument
+from langroid.agent.tool_message import (
+    ToolMessage,
+    format_schema_for_strict,
+)
+from langroid.agent.xml_tool_message import XMLToolMessage
+from langroid.language_models.base import (
+    LLMFunctionCall,
+    LLMFunctionSpec,
+    LLMMessage,
+    LLMResponse,
+    OpenAIJsonSchemaSpec,
+    OpenAIToolSpec,
+    Role,
+    StreamingIfAllowed,
+    ToolChoiceTypes,
+)
+from langroid.language_models.openai_gpt import OpenAIGPT
+from langroid.mytypes import Entity, NonToolAction
+from langroid.utils.configuration import settings
+from langroid.utils.object_registry import ObjectRegistry
+from langroid.utils.output import status
+from langroid.utils.pydantic_utils import PydanticWrapper, get_pydantic_wrapper
+from langroid.utils.types import is_callable
+
+console = Console()
+
+logger = logging.getLogger(__name__)
+
+
+def _is_identified_result(message: LLMMessage) -> bool:
+    """Whether a TOOL/FUNCTION result has its identifier and no call payload.
+
+    Such results must survive even with empty content so their calls can be
+    marked complete (issue #1063).
+    """
+    has_identifier = (
+        message.role == Role.TOOL and bool((message.tool_call_id or "").strip())
+    ) or (message.role == Role.FUNCTION and bool((message.name or "").strip()))
+    return has_identifier and message.function_call is None and not message.tool_calls
+
+
+def _llm_message_has_payload(message: LLMMessage) -> bool:
+    """Whether a message has the fields required for a valid history entry."""
+    return (
+        (message.content or "").strip() != ""
+        or message.function_call is not None
+        or bool(message.tool_calls)
+        or _is_identified_result(message)
+    )
+
+
+class ChatAgentConfig(AgentConfig):
+    """
+    Configuration for ChatAgent
+
+    Attributes:
+        system_message: system message to include in message sequence
+             (typically defines role and task of agent).
+             Used only if `task` is not specified in the constructor.
+        user_message: user message to include in message sequence.
+             Used only if `task` is not specified in the constructor.
+        use_tools: whether to use our own ToolMessages mechanism
+        handle_llm_no_tool (Any): desired agent_response when
+            LLM generates non-tool msg.
+        use_functions_api: whether to use functions/tools native to the LLM API
+                (e.g. OpenAI's `function_call` or `tool_call` mechanism)
+        use_tools_api: When `use_functions_api` is True, if this is also True,
+            the OpenAI tool-call API is used, rather than the older/deprecated
+            function-call API. However the tool-call API has some tricky aspects,
+            hence we set this to False by default.
+        strict_recovery: whether to enable strict schema recovery when there
+            is a tool-generation error.
+        enable_orchestration_tool_handling: whether to enable handling of orchestration
+            tools, e.g. ForwardTool, DoneTool, PassTool, etc.
+        output_format: When supported by the LLM (certain OpenAI LLMs
+            and local LLMs served by providers such as vLLM), ensures
+            that the output is a JSON matching the corresponding
+            schema via grammar-based decoding
+        handle_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for handling".
+        use_output_format: When `output_format` is a `ToolMessage` T,
+            controls whether T is "enabled for use" (by LLM) and
+            instructions on using T are added to the system message.
+        instructions_output_format: Controls whether we generate instructions for
+            `output_format` in the system message.
+        use_tools_on_output_format: Controls whether to automatically switch
+            to the Langroid-native tools mechanism when `output_format` is set.
+            Note that LLMs may generate tool calls which do not belong to
+            `output_format` even when strict JSON mode is enabled, so this should be
+            enabled when such tool calls are not desired.
+        output_format_include_defaults: Whether to include fields with default arguments
+            in the output schema
+        full_citations: Whether to show source reference citation + content for each
+            citation, or just the main reference citation.
+        search_for_tools_everywhere: Whether to search for tools everywhere,
+            or only in specific LLM response elements based on use_tools /
+            use_functions_api / use_tools_api config settings.
+        recognize_recipient_in_content: Whether to parse LLM response text content
+            for recipient routing patterns, specifically:
+            - ``TO[<recipient>]:<content>`` addressing format, and
+            - JSON ``{"recipient": "<name>"}`` at the top level of the message.
+            When False, only structured routing via function_call/tool_call
+            ``recipient`` fields is recognized. Default is True.
+            Note: this is distinct from ``TaskConfig.recognize_string_signals``,
+            which controls Task-level signals like DONE, PASS, and SEND_TO.
+            To fully disable all text-based routing, set both to False.
+        context_overflow_strategy: Strategy for handling context overflow when
+            message history exceeds model context length. Options:
+            - "truncate": Truncate content of early messages (preserves all messages
+              but with shortened content). This maintains the message sequence.
+            - "drop_turns": Drop complete conversation turns (USER + all responses
+              until next USER). More aggressive but cleaner for voice agents.
+            Default is "truncate" for backward compatibility.
+    """
+
+    system_message: str = "You are a helpful assistant."
+    user_message: Optional[str] = None
+    handle_llm_no_tool: Any = None
+    use_tools: bool = True
+    use_functions_api: bool = False
+    use_tools_api: bool = True
+    strict_recovery: bool = True
+    enable_orchestration_tool_handling: bool = True
+    output_format: Optional[type] = None
+    handle_output_format: bool = True
+    use_output_format: bool = True
+    instructions_output_format: bool = True
+    output_format_include_defaults: bool = True
+    use_tools_on_output_format: bool = True
+    full_citations: bool = True  # show source + content for each citation?
+    search_for_tools_everywhere: bool = True
+    recognize_recipient_in_content: bool = True
+    context_overflow_strategy: Literal["truncate", "drop_turns"] = "truncate"
+
+    def _set_fn_or_tools(self) -> None:
+        """
+        Enable Langroid Tool or OpenAI-like fn-calling,
+        depending on config settings.
+        """
+        if not self.use_functions_api or not self.use_tools:
+            return
+        if self.use_functions_api and self.use_tools:
+            logger.debug(
+                """
+                You have enabled both `use_tools` and `use_functions_api`.
+                Setting `use_functions_api` to False.
+                """
+            )
+            self.use_tools = True
+            self.use_functions_api = False
+
+
+class ChatAgent(Agent):
+    """
+    Chat Agent interacting with external env
+    (could be human, or external tools).
+    The agent (the LLM actually) is provided with an optional "Task Spec",
+    which is a sequence of `LLMMessage`s. These are used to initialize
+    the `task_messages` of the agent.
+    In most applications we will use a `ChatAgent` rather than a bare `Agent`.
+    The `Agent` class mainly exists to hold various common methods and attributes.
+    One difference between `ChatAgent` and `Agent` is that `ChatAgent`'s
+    `llm_response` method uses "chat mode" API (i.e. one that takes a
+    message sequence rather than a single message),
+    whereas the same method in the `Agent` class uses "completion mode" API (i.e. one
+    that takes a single message).
+    """
+
+    def __init__(
+        self,
+        config: ChatAgentConfig = ChatAgentConfig(),
+        task: Optional[List[LLMMessage]] = None,
+    ):
+        """
+        Chat-mode agent initialized with task spec as the initial message sequence
+        Args:
+            config: settings for the agent
+
+        """
+        super().__init__(config)
+        self.config: ChatAgentConfig = config
+        self.config._set_fn_or_tools()
+        self.message_history: List[LLMMessage] = []
+        self.init_state()
+        # An agent's "task" is defined by a system msg and an optional user msg;
+        # These are "priming" messages that kick off the agent's conversation.
+        self.system_message: str = self.config.system_message
+        self.user_message: str | None = self.config.user_message
+
+        if task is not None:
+            # if task contains a system msg, we override the config system msg
+            if len(task) > 0 and task[0].role == Role.SYSTEM:
+                self.system_message = task[0].content or ""
+            # if task contains a user msg, we override the config user msg
+            if len(task) > 1 and task[1].role == Role.USER:
+                self.user_message = task[1].content
+
+        # system-level instructions for using tools/functions:
+        # We maintain these as tools/functions are enabled/disabled,
+        # and whenever an LLM response is sought, these are used to
+        # recreate the system message (via `_create_system_and_tools_message`)
+        # each time, so it reflects the current set of enabled tools/functions.
+        # (a) these are general instructions on using certain tools/functions,
+        #   if they are specified in a ToolMessage class as a classmethod `instructions`
+        self.system_tool_instructions: str = ""
+        # (b) these are only for the builtin in Langroid TOOLS mechanism:
+        self.system_tool_format_instructions: str = ""
+
+        self.llm_functions_map: Dict[str, LLMFunctionSpec] = {}
+        self.llm_functions_handled: Set[str] = set()
+        self.llm_functions_usable: Set[str] = set()
+        self.llm_function_force: Optional[Dict[str, str]] = None
+
+        self.output_format: Optional[type[ToolMessage | BaseModel]] = None
+
+        self.saved_requests_and_tool_setings = self._requests_and_tool_settings()
+        # This variable is not None and equals a `ToolMessage` T, if and only if:
+        # (a) T has been set as the output_format of this agent, AND
+        # (b) T has been "enabled for use" ONLY for enforcing this output format, AND
+        # (c) T has NOT been explicitly "enabled for use" by this Agent.
+        self.enabled_use_output_format: Optional[type[ToolMessage]] = None
+        # As above but deals with "enabled for handling" instead of "enabled for use".
+        self.enabled_handling_output_format: Optional[type[ToolMessage]] = None
+        if config.output_format is not None:
+            self.set_output_format(config.output_format)
+        # instructions specifically related to enforcing `output_format`
+        self.output_format_instructions = ""
+
+        # controls whether to disable strict schemas for this agent if
+        # strict mode causes exception
+        self.disable_strict = False
+        # Tracks whether any strict tool is enabled; used to determine whether to set
+        # `self.disable_strict` on an exception
+        self.any_strict = False
+        # Tracks the set of tools on which we force-disable strict decoding
+        self.disable_strict_tools_set: set[str] = set()
+
+        # search for tools according to the agent configuration
+        if not config.search_for_tools_everywhere:
+            if config.use_functions_api:
+                if config.use_tools_api:
+                    self.search_for_tools = {SearchForTools.TOOLS.value}
+                else:
+                    self.search_for_tools = {SearchForTools.FUNCTIONS.value}
+            else:
+                self.search_for_tools = {SearchForTools.CONTENT.value}
+
+        if self.config.enable_orchestration_tool_handling:
+            # Only enable HANDLING by `agent_response`, NOT LLM generation of these.
+            # This is useful where tool-handlers or agent_response generate these
+            # tools, and need to be handled.
+            # We don't want enable orch tool GENERATION by default, since that
+            # might clutter-up the LLM system message unnecessarily.
+            from langroid.agent.tools.orchestration import (
+                AgentDoneTool,
+                AgentSendTool,
+                DonePassTool,
+                DoneTool,
+                ForwardTool,
+                PassTool,
+                ResultTool,
+                SendTool,
+            )
+
+            self.enable_message(ForwardTool, use=False, handle=True)
+            self.enable_message(DoneTool, use=False, handle=True)
+            self.enable_message(AgentDoneTool, use=False, handle=True)
+            self.enable_message(PassTool, use=False, handle=True)
+            self.enable_message(DonePassTool, use=False, handle=True)
+            self.enable_message(SendTool, use=False, handle=True)
+            self.enable_message(AgentSendTool, use=False, handle=True)
+            self.enable_message(ResultTool, use=False, handle=True)
+
+    def init_state(self) -> None:
+        """
+        Initialize the state of the agent. Just conversation state here,
+        but subclasses can override this to initialize other state.
+        """
+        super().init_state()
+        self.clear_history(0)
+        self.clear_dialog()
+
+    @staticmethod
+    def from_id(id: str) -> "ChatAgent":
+        """
+        Get an agent from its ID
+        Args:
+            agent_id (str): ID of the agent
+        Returns:
+            ChatAgent: The agent with the given ID
+        """
+        return cast(ChatAgent, Agent.from_id(id))
+
+    def clone(self, i: int = 0) -> "ChatAgent":
+        """Create i'th clone of this agent, ensuring tool use/handling is cloned.
+        Important: We assume all member variables are in the __init__ method here
+        and in the Agent class.
+        TODO: We are attempting to clone an agent after its state has been
+        changed in possibly many ways. Below is an imperfect solution. Caution advised.
+        Revisit later.
+        """
+        from langroid.agent.tool_policy import deepcopy_config_sharing_policy
+
+        agent_cls = type(self)
+        # Deep-copy the config WITHOUT mutating it, sharing the tool_policy
+        # hook by REFERENCE (memo-seeded deepcopy): copying the policy would
+        # fork any state it holds (budgets, approval lists) and can fail
+        # outright on unpicklable callables (e.g. objects holding locks).
+        config_copy = deepcopy_config_sharing_policy(self.config)
+        config_copy.name = f"{config_copy.name}-{i}"
+        new_agent = agent_cls(config_copy)
+        new_agent.system_tool_instructions = self.system_tool_instructions
+        new_agent.system_tool_format_instructions = self.system_tool_format_instructions
+        new_agent.llm_tools_map = self.llm_tools_map
+        new_agent.llm_tools_known = self.llm_tools_known
+        new_agent.llm_tools_handled = self.llm_tools_handled
+        new_agent.llm_tools_usable = self.llm_tools_usable
+        new_agent.llm_functions_map = self.llm_functions_map
+        new_agent.llm_functions_handled = self.llm_functions_handled
+        new_agent.llm_functions_usable = self.llm_functions_usable
+        new_agent.llm_function_force = self.llm_function_force
+        # Ensure each clone gets its own vecdb client when supported.
+        new_agent.vecdb = None if self.vecdb is None else self.vecdb.clone()
+        self._clone_extra_state(new_agent)
+        new_agent.id = ObjectRegistry.new_id()
+        if self.config.add_to_registry:
+            ObjectRegistry.register_object(new_agent)
+        return new_agent
+
+    def _clone_extra_state(self, new_agent: "ChatAgent") -> None:
+        """Hook for subclasses to copy additional state into clones."""
+
+    def _strict_mode_for_tool(self, tool: str | type[ToolMessage]) -> bool:
+        """Should we enable strict mode for a given tool?"""
+        if isinstance(tool, str):
+            tool_class = self.llm_tools_map[tool]
+        else:
+            tool_class = tool
+        name = tool_class.default_value("request")
+        if name in self.disable_strict_tools_set or self.disable_strict:
+            return False
+        strict: Optional[bool] = tool_class.default_value("strict")
+        if strict is None:
+            strict = self._strict_tools_available()
+
+        return strict
+
+    def _fn_call_available(self) -> bool:
+        """Does this agent's LLM support function calling?"""
+        return self.llm is not None and self.llm.supports_functions_or_tools()
+
+    def _strict_tools_available(self) -> bool:
+        """Does this agent's LLM support strict tools?"""
+        return (
+            not self.disable_strict
+            and self.llm is not None
+            and isinstance(self.llm, OpenAIGPT)
+            and self.llm.config.parallel_tool_calls is False
+            and self.llm.supports_strict_tools
+        )
+
+    def _json_schema_available(self) -> bool:
+        """Does this agent's LLM support strict JSON schema output format?"""
+        return (
+            not self.disable_strict
+            and self.llm is not None
+            and isinstance(self.llm, OpenAIGPT)
+            and self.llm.supports_json_schema
+        )
+
+    def set_system_message(self, msg: str) -> None:
+        self.system_message = msg
+        if len(self.message_history) > 0:
+            # if there is message history, update the system message in it
+            self.message_history[0].content = msg
+
+    def set_user_message(self, msg: str) -> None:
+        self.user_message = msg
+
+    @property
+    def task_messages(self) -> List[LLMMessage]:
+        """
+        The task messages are the initial messages that define the task
+        of the agent. There will be at least a system message plus possibly a user msg.
+        Returns:
+            List[LLMMessage]: the task messages
+        """
+        msgs = [self._create_system_and_tools_message()]
+        if self.user_message:
+            msgs.append(LLMMessage(role=Role.USER, content=self.user_message))
+        return msgs
+
+    def _drop_msg_update_tool_calls(self, msg: LLMMessage) -> None:
+        id2idx = {t.id: i for i, t in enumerate(self.oai_tool_calls)}
+        if msg.role == Role.TOOL:
+            # dropping tool result, so ADD the corresponding tool-call back
+            # to the list of pending calls!
+            id = msg.tool_call_id
+            if id in self.oai_tool_id2call:
+                self.oai_tool_calls.append(self.oai_tool_id2call[id])
+        elif msg.tool_calls is not None:
+            # dropping a msg with tool-calls, so DROP these from pending list
+            # as well as from id -> call map
+            for tool_call in msg.tool_calls:
+                if tool_call.id in id2idx:
+                    self.oai_tool_calls.pop(id2idx[tool_call.id])
+                if tool_call.id in self.oai_tool_id2call:
+                    del self.oai_tool_id2call[tool_call.id]
+
+    def clear_history(self, start: int = -2, end: int = -1) -> None:
+        """
+        Clear the message history, deleting  messages from index `start`,
+        up to index `end`.
+
+        Args:
+            start (int): index of first message to delete; default = -2
+                    (i.e. delete last 2 messages, typically these
+                    are the last user and assistant messages)
+            end (int): index of last message to delete; Default = -1
+                    (i.e. delete all messages up to the last one)
+        """
+        n = len(self.message_history)
+        if start < 0:
+            start = max(0, n + start)
+        end_ = n if end == -1 else end + 1
+        dropped = self.message_history[start:end_]
+        # consider the dropped msgs in REVERSE order, so we are
+        # carefully updating self.oai_tool_calls
+        for msg in reversed(dropped):
+            self._drop_msg_update_tool_calls(msg)
+            # clear out the chat document from the ObjectRegistry
+            ChatDocument.delete_id(msg.chat_document_id)
+        del self.message_history[start:end_]
+
+    def update_history(self, message: str, response: str) -> None:
+        """
+        Update the message history with the latest user message and LLM response.
+        Args:
+            message (str): user message
+            response: (str): LLM response
+        """
+        self.message_history.extend(
+            [
+                LLMMessage(role=Role.USER, content=message),
+                LLMMessage(role=Role.ASSISTANT, content=response),
+            ]
+        )
+
+    def tool_format_rules(self) -> str:
+        """
+        Specification of tool formatting rules
+        (typically JSON-based but can be non-JSON, e.g. XMLToolMessage),
+        based on the currently enabled usable `ToolMessage`s
+
+        Returns:
+            str: formatting rules
+        """
+        # ONLY Usable tools (i.e. LLM-generation allowed),
+        usable_tool_classes: List[Type[ToolMessage]] = [
+            t
+            for t in list(self.llm_tools_map.values())
+            if t.default_value("request") in self.llm_tools_usable
+        ]
+
+        if len(usable_tool_classes) == 0:
+            return ""
+        format_instructions = "\n\n".join(
+            [
+                msg_cls.format_instructions(tool=self.config.use_tools)
+                for msg_cls in usable_tool_classes
+            ]
+        )
+        # if any of the enabled classes has json_group_instructions, then use that,
+        # else fall back to ToolMessage.json_group_instructions
+        for msg_cls in usable_tool_classes:
+            if hasattr(msg_cls, "json_group_instructions") and callable(
+                getattr(msg_cls, "json_group_instructions")
+            ):
+                return msg_cls.group_format_instructions().format(
+                    format_instructions=format_instructions
+                )
+        return ToolMessage.group_format_instructions().format(
+            format_instructions=format_instructions
+        )
+
+    def tool_instructions(self) -> str:
+        """
+        Instructions for tools or function-calls, for enabled and usable Tools.
+        These are inserted into system prompt regardless of whether we are using
+        our own ToolMessage mechanism or the LLM's function-call mechanism.
+
+        Returns:
+            str: concatenation of instructions for all usable tools
+        """
+        enabled_classes: List[Type[ToolMessage]] = list(self.llm_tools_map.values())
+        if len(enabled_classes) == 0:
+            return ""
+        instructions = []
+        for msg_cls in enabled_classes:
+            if msg_cls.default_value("request") in self.llm_tools_usable:
+                class_instructions = ""
+                if hasattr(msg_cls, "instructions") and inspect.ismethod(
+                    msg_cls.instructions
+                ):
+                    class_instructions = msg_cls.instructions()
+                if (
+                    self.config.use_tools
+                    and hasattr(msg_cls, "langroid_tools_instructions")
+                    and inspect.ismethod(msg_cls.langroid_tools_instructions)
+                ):
+                    class_instructions += msg_cls.langroid_tools_instructions()
+                # example will be shown in tool_format_rules() when using TOOLs,
+                # so we don't need to show it here.
+                example = "" if self.config.use_tools else (msg_cls.usage_examples())
+                if example != "":
+                    example = "EXAMPLES:\n" + example
+                guidance = (
+                    ""
+                    if class_instructions == ""
+                    else ("GUIDANCE: " + class_instructions)
+                )
+                if guidance == "" and example == "":
+                    continue
+                instructions.append(
+                    textwrap.dedent(
+                        f"""
+                        TOOL: {msg_cls.default_value("request")}:
+                        {guidance}
+                        {example}
+                        """.lstrip()
+                    )
+                )
+        if len(instructions) == 0:
+            return ""
+        instructions_str = "\n\n".join(instructions)
+        return textwrap.dedent(
+            f"""
+            === GUIDELINES ON SOME TOOLS/FUNCTIONS USAGE ===
+            {instructions_str}
+            """.lstrip()
+        )
+
+    def augment_system_message(self, message: str) -> None:
+        """
+        Augment the system message with the given message.
+        Args:
+            message (str): system message
+        """
+        self.system_message += "\n\n" + message
+
+    def last_message_with_role(self, role: Role) -> LLMMessage | None:
+        """from `message_history`, return the last message with role `role`"""
+        n_role_msgs = len([m for m in self.message_history if m.role == role])
+        if n_role_msgs == 0:
+            return None
+        idx = self.nth_message_idx_with_role(role, n_role_msgs)
+        return self.message_history[idx]
+
+    def last_message_idx_with_role(self, role: Role) -> int:
+        """Index of last message in message_history, with specified role.
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+        indices_with_role = [
+            i for i, m in enumerate(self.message_history) if m.role == role
+        ]
+        if len(indices_with_role) == 0:
+            return -1
+        return indices_with_role[-1]
+
+    def nth_message_idx_with_role(self, role: Role, n: int) -> int:
+        """Index of `n`th message in message_history, with specified role.
+        (n is assumed to be 1-based, i.e. 1 is the first message with that role).
+        Return -1 if not found. Index = 0 is the first message in the history.
+        """
+        indices_with_role = [
+            i for i, m in enumerate(self.message_history) if m.role == role
+        ]
+
+        if len(indices_with_role) < n:
+            return -1
+        return indices_with_role[n - 1]
+
+    def update_last_message(self, message: str, role: str = Role.USER) -> None:
+        """
+        Update the last message that has role `role` in the message history.
+        Useful when we want to replace a long user prompt, that may contain context
+        documents plus a question, with just the question.
+        Args:
+            message (str): new message to replace with
+            role (str): role of message to replace
+        """
+        if len(self.message_history) == 0:
+            return
+        # find last message in self.message_history with role `role`
+        for i in range(len(self.message_history) - 1, -1, -1):
+            if self.message_history[i].role == role:
+                self.message_history[i].content = message
+                break
+
+    def delete_last_message(self, role: str = Role.USER) -> None:
+        """
+        Delete the last message that has role `role` from the message history.
+        Args:
+            role (str): role of message to delete
+        """
+        if len(self.message_history) == 0:
+            return
+        # find last message in self.message_history with role `role`
+        for i in range(len(self.message_history) - 1, -1, -1):
+            if self.message_history[i].role == role:
+                self.message_history.pop(i)
+                break
+
+    def _create_system_and_tools_message(self) -> LLMMessage:
+        """
+        (Re-)Create the system message for the LLM of the agent,
+        taking into account any tool instructions that have been added
+        after the agent was initialized.
+
+        The system message will consist of:
+        (a) the system message from the `task` arg in constructor, if any,
+            otherwise the default system message from the config
+        (b) the system tool instructions, if any
+        (c) the system json tool instructions, if any
+
+        Returns:
+            LLMMessage object
+        """
+        content = self.system_message
+        if self.system_tool_instructions != "":
+            content += "\n\n" + self.system_tool_instructions
+        if self.system_tool_format_instructions != "":
+            content += "\n\n" + self.system_tool_format_instructions
+        if self.output_format_instructions != "":
+            content += "\n\n" + self.output_format_instructions
+
+        # remove leading and trailing newlines and other whitespace
+        return LLMMessage(role=Role.SYSTEM, content=content.strip())
+
+    def handle_message_fallback(self, msg: str | ChatDocument) -> Any:
+        """
+        Fallback method for the "no-tools" scenario, i.e., the current `msg`
+        (presumably emitted by the LLM) does not have any tool that the agent
+        can handle.
+        NOTE: The `msg` may contain tools but either (a) the agent is not
+        enabled to handle them, or (b) there's an explicit `recipient` field
+        in the tool that doesn't match the agent's name.
+
+        Uses the self.config.non_tool_routing to determine the action to take.
+
+        This method can be overridden by subclasses, e.g.,
+        to create a "reminder" message when a tool is expected but the LLM "forgot"
+        to generate one.
+
+        Args:
+            msg (str | ChatDocument): The input msg to handle
+        Returns:
+            Any: The result of the handler method
+        """
+        if (
+            isinstance(msg, str)
+            or msg.metadata.sender != Entity.LLM
+            or self.config.handle_llm_no_tool is None
+            or self.has_only_unhandled_tools(msg)
+        ):
+            return None
+        # we ONLY use the `handle_llm_no_tool` config option when
+        # the msg is from LLM and does not contain ANY tools at all.
+        from langroid.agent.tools.orchestration import AgentDoneTool, ForwardTool
+
+        no_tool_option = self.config.handle_llm_no_tool
+        if no_tool_option in list(NonToolAction):
+            # in case the `no_tool_option` is one of the special NonToolAction vals
+            match self.config.handle_llm_no_tool:
+                case NonToolAction.FORWARD_USER:
+                    return ForwardTool(agent="User")
+                case NonToolAction.DONE:
+                    return AgentDoneTool(content=msg.content, tools=msg.tool_messages)
+        elif is_callable(no_tool_option):
+            return no_tool_option(msg)
+        # Otherwise just return `no_tool_option` as is:
+        # This can be any string, such as a specific nudge/reminder to the LLM,
+        # or even something like ResultTool etc.
+        return no_tool_option
+
+    def unhandled_tools(self) -> set[str]:
+        """The set of tools that are known but not handled.
+        Useful in task flow: an agent can refuse to accept an incoming msg
+        when it only has unhandled tools.
+        """
+        return self.llm_tools_known - self.llm_tools_handled
+
+    def enable_message(
+        self,
+        message_class: Optional[Type[ToolMessage] | List[Type[ToolMessage]]],
+        use: bool = True,
+        handle: bool = True,
+        force: bool = False,
+        require_recipient: bool = False,
+        include_defaults: bool = True,
+    ) -> None:
+        """
+        Add the tool (message class) to the agent, and enable either
+        - tool USE (i.e. the LLM can generate JSON to use this tool),
+        - tool HANDLING (i.e. the agent can handle JSON from this tool),
+
+        Args:
+            message_class: The ToolMessage class OR List of such classes to enable,
+                for USE, or HANDLING, or both.
+                If this is a list of ToolMessage classes, then the remain args are
+                applied to all classes.
+                Optional; if None, then apply the enabling to all tools in the
+                agent's toolset that have been enabled so far.
+            use: IF True, allow the agent (LLM) to use this tool (or all tools),
+                else disallow
+            handle: if True, allow the agent (LLM) to handle (i.e. respond to) this
+                tool (or all tools)
+            force: whether to FORCE the agent (LLM) to USE the specific
+                 tool represented by `message_class`.
+                 `force` is ignored if `message_class` is None.
+            require_recipient: whether to require that recipient be specified
+                when using the tool message (only applies if `use` is True).
+            include_defaults: whether to include fields that have default values,
+                in the "properties" section of the JSON format instructions.
+                (Normally the OpenAI completion API ignores these fields,
+                but the Assistant fn-calling seems to pay attn to these,
+                and if we don't want this, we should set this to False.)
+        """
+        if message_class is not None and isinstance(message_class, list):
+            for mc in message_class:
+                self.enable_message(
+                    mc,
+                    use=use,
+                    handle=handle,
+                    force=force,
+                    require_recipient=require_recipient,
+                    include_defaults=include_defaults,
+                )
+            return None
+
+        # Validate that use/handle are booleans, not accidentally passed tool classes
+        if isclass(use) or isclass(handle):
+            param = "use" if isclass(use) else "handle"
+            raise TypeError(
+                textwrap.dedent(
+                    f"""
+                    Invalid arguments to enable_message().
+                    It appears you passed multiple ToolMessage classes as separate
+                    arguments instead of as a list.
+
+                    Correct usage:
+                        agent.enable_message([Tool1, Tool2, Tool3])
+
+                    Incorrect usage:
+                        agent.enable_message(Tool1, Tool2, Tool3)
+
+                    The '{param}' parameter must be a boolean, not a class.
+                    """
+                )
+            )
+
+        if require_recipient and message_class is not None:
+            message_class = message_class.require_recipient()
+        if isinstance(message_class, XMLToolMessage):
+            # XMLToolMessage is not compatible with OpenAI's Tools/functions API,
+            # so we disable use of functions API, enable langroid-native Tools,
+            # which are prompt-based.
+            self.config.use_functions_api = False
+            self.config.use_tools = True
+        super().enable_message_handling(message_class)  # enables handling only
+        tools = self._get_tool_list(message_class)
+        if message_class is not None:
+            request = message_class.default_value("request")
+            if request == "":
+                raise ValueError(
+                    f"""
+                    ToolMessage class {message_class} must have a non-empty
+                    'request' field if it is to be enabled as a tool.
+                    """
+                )
+            llm_function = message_class.llm_function_schema(defaults=include_defaults)
+            self.llm_functions_map[request] = llm_function
+            if force:
+                self.llm_function_force = dict(name=request)
+            else:
+                self.llm_function_force = None
+
+        for t in tools:
+            self.llm_tools_known.add(t)
+
+            if handle:
+                self.llm_tools_handled.add(t)
+                self.llm_functions_handled.add(t)
+
+                if (
+                    self.enabled_handling_output_format is not None
+                    and self.enabled_handling_output_format.name() == t
+                ):
+                    # `t` was designated as "enabled for handling" ONLY for
+                    # output_format enforcement, but we are explicitly ]
+                    # enabling it for handling here, so we set the variable to None.
+                    self.enabled_handling_output_format = None
+            else:
+                self.llm_tools_handled.discard(t)
+                self.llm_functions_handled.discard(t)
+
+            if use:
+                tool_class = self.llm_tools_map[t]
+                allow_llm_use = tool_class._allow_llm_use
+                if isinstance(allow_llm_use, ModelPrivateAttr):
+                    allow_llm_use = allow_llm_use.default
+                if allow_llm_use:
+                    self.llm_tools_usable.add(t)
+                    self.llm_functions_usable.add(t)
+                else:
+                    logger.warning(
+                        f"""
+                        ToolMessage class {tool_class} does not allow LLM use,
+                        because `_allow_llm_use=False` either in the Tool or a
+                        parent class of this tool;
+                        so not enabling LLM use for this tool!
+                        If you intended an LLM to use this tool,
+                        set `_allow_llm_use=True` when you define the tool.
+                        """
+                    )
+                if (
+                    self.enabled_use_output_format is not None
+                    and self.enabled_use_output_format.default_value("request") == t
+                ):
+                    # `t` was designated as "enabled for use" ONLY for output_format
+                    # enforcement, but we are explicitly enabling it for use here,
+                    # so we set the variable to None.
+                    self.enabled_use_output_format = None
+            else:
+                self.llm_tools_usable.discard(t)
+                self.llm_functions_usable.discard(t)
+
+        self._update_tool_instructions()
+
+    def _update_tool_instructions(self) -> None:
+        # Set tool instructions and JSON format instructions,
+        # in case Tools have been enabled/disabled.
+        if self.config.use_tools:
+            self.system_tool_format_instructions = self.tool_format_rules()
+        self.system_tool_instructions = self.tool_instructions()
+
+    def _requests_and_tool_settings(self) -> tuple[Optional[set[str]], bool, bool]:
+        """
+        Returns the current set of enabled requests for inference and tools configs.
+        Used for restoring setings overriden by `set_output_format`.
+        """
+        return (
+            self.enabled_requests_for_inference,
+            self.config.use_functions_api,
+            self.config.use_tools,
+        )
+
+    @property
+    def all_llm_tools_known(self) -> set[str]:
+        """All known tools; we include `output_format` if it is a `ToolMessage`."""
+        known = self.llm_tools_known
+
+        if self.output_format is not None and issubclass(
+            self.output_format, ToolMessage
+        ):
+            return known.union({self.output_format.default_value("request")})
+
+        return known
+
+    def set_output_format(
+        self,
+        output_type: Optional[type],
+        force_tools: Optional[bool] = None,
+        use: Optional[bool] = None,
+        handle: Optional[bool] = None,
+        instructions: Optional[bool] = None,
+        is_copy: bool = False,
+    ) -> None:
+        """
+        Sets `output_format` to `output_type` and, if `force_tools` is enabled,
+        switches to the native Langroid tools mechanism to ensure that no tool
+        calls not of `output_type` are generated. By default, `force_tools`
+        follows the `use_tools_on_output_format` parameter in the config.
+
+        If `output_type` is None, restores to the state prior to setting
+        `output_format`.
+
+        If `use`, we enable use of `output_type` when it is a subclass
+        of `ToolMesage`. Note that this primarily controls instruction
+        generation: the model will always generate `output_type` regardless
+        of whether `use` is set. Defaults to the `use_output_format`
+        parameter in the config. Similarly, handling of `output_type` is
+        controlled by `handle`, which defaults to the
+        `handle_output_format` parameter in the config.
+
+        `instructions` controls whether we generate instructions specifying
+        the output format schema. Defaults to the `instructions_output_format`
+        parameter in the config.
+
+        `is_copy` is set when called via `__getitem__`. In that case, we must
+        copy certain fields to ensure that we do not overwrite the main agent's
+        setings.
+        """
+        # Disable usage of an output format which was not specifically enabled
+        # by `enable_message`
+        if self.enabled_use_output_format is not None:
+            self.disable_message_use(self.enabled_use_output_format)
+            self.enabled_use_output_format = None
+
+        # Disable handling of an output format which did not specifically have
+        # handling enabled via `enable_message`
+        if self.enabled_handling_output_format is not None:
+            self.disable_message_handling(self.enabled_handling_output_format)
+            self.enabled_handling_output_format = None
+
+        # Reset any previous instructions
+        self.output_format_instructions = ""
+
+        if output_type is None:
+            self.output_format = None
+            (
+                requests_for_inference,
+                use_functions_api,
+                use_tools,
+            ) = self.saved_requests_and_tool_setings
+            self.config = self.config.model_copy()
+            self.enabled_requests_for_inference = requests_for_inference
+            self.config.use_functions_api = use_functions_api
+            self.config.use_tools = use_tools
+        else:
+            if force_tools is None:
+                force_tools = self.config.use_tools_on_output_format
+
+            if not any(
+                (isclass(output_type) and issubclass(output_type, t))
+                for t in [ToolMessage, BaseModel]
+            ):
+                output_type = get_pydantic_wrapper(output_type)
+
+            if self.output_format is None and force_tools:
+                self.saved_requests_and_tool_setings = (
+                    self._requests_and_tool_settings()
+                )
+
+            self.output_format = output_type
+            if issubclass(output_type, ToolMessage):
+                name = output_type.default_value("request")
+                if use is None:
+                    use = self.config.use_output_format
+
+                if handle is None:
+                    handle = self.config.handle_output_format
+
+                if use or handle:
+                    is_usable = name in self.llm_tools_usable.union(
+                        self.llm_functions_usable
+                    )
+                    is_handled = name in self.llm_tools_handled.union(
+                        self.llm_functions_handled
+                    )
+
+                    if is_copy:
+                        if use:
+                            # We must copy `llm_tools_usable` so the base agent
+                            # is unmodified
+                            self.llm_tools_usable = self.llm_tools_usable.copy()
+                            self.llm_functions_usable = self.llm_functions_usable.copy()
+                        if handle:
+                            # If handling the tool, do the same for `llm_tools_handled`
+                            self.llm_tools_handled = self.llm_tools_handled.copy()
+                            self.llm_functions_handled = (
+                                self.llm_functions_handled.copy()
+                            )
+                    # Enable `output_type`
+                    self.enable_message(
+                        output_type,
+                        # Do not override existing settings
+                        use=use or is_usable,
+                        handle=handle or is_handled,
+                    )
+
+                    # If the `output_type` ToilMessage was not already enabled for
+                    # use, this means we are ONLY enabling it for use specifically
+                    # for enforcing this output format, so we set the
+                    # `enabled_use_output_forma  to this output_type, to
+                    # record that it should be disabled when `output_format` is changed
+                    if not is_usable:
+                        self.enabled_use_output_format = output_type
+
+                    # (same reasoning as for use-enabling)
+                    if not is_handled:
+                        self.enabled_handling_output_format = output_type
+
+                generated_tool_instructions = name in self.llm_tools_usable.union(
+                    self.llm_functions_usable
+                )
+            else:
+                generated_tool_instructions = False
+
+            if instructions is None:
+                instructions = self.config.instructions_output_format
+            if issubclass(output_type, BaseModel) and instructions:
+                if generated_tool_instructions:
+                    # Already generated tool instructions as part of "enabling for use",
+                    # so only need to generate a reminder to use this tool.
+                    name = cast(ToolMessage, output_type).default_value("request")
+                    self.output_format_instructions = textwrap.dedent(
+                        f"""
+                        === OUTPUT FORMAT INSTRUCTIONS ===
+
+                        Please provide output using the `{name}` tool/function.
+                        """
+                    )
+                else:
+                    if issubclass(output_type, ToolMessage):
+                        output_format_schema = output_type.llm_function_schema(
+                            request=True,
+                            defaults=self.config.output_format_include_defaults,
+                        ).parameters
+                    else:
+                        output_format_schema = output_type.model_json_schema()
+
+                    format_schema_for_strict(output_format_schema)
+
+                    self.output_format_instructions = textwrap.dedent(
+                        f"""
+                        === OUTPUT FORMAT INSTRUCTIONS ===
+                        Please provide output as JSON with the following schema:
+
+                        {output_format_schema}
+                        """
+                    )
+
+            if force_tools:
+                if issubclass(output_type, ToolMessage):
+                    self.enabled_requests_for_inference = {
+                        output_type.default_value("request")
+                    }
+                if self.config.use_functions_api:
+                    self.config = self.config.model_copy()
+                    self.config.use_functions_api = False
+                    self.config.use_tools = True
+
+    def __getitem__(self, output_type: type) -> Self:
+        """
+        Returns a (shallow) copy of `self` with a forced output type.
+        """
+        clone = copy.copy(self)
+        clone.set_output_format(output_type, is_copy=True)
+        return clone
+
+    def disable_message_handling(
+        self,
+        message_class: Optional[Type[ToolMessage]] = None,
+    ) -> None:
+        """
+        Disable this agent from RESPONDING to a `message_class` (Tool). If
+            `message_class` is None, then disable this agent from responding to ALL.
+        Args:
+            message_class: The ToolMessage class to disable; Optional.
+        """
+        super().disable_message_handling(message_class)
+        for t in self._get_tool_list(message_class):
+            self.llm_tools_handled.discard(t)
+            self.llm_functions_handled.discard(t)
+
+    def disable_message_use(
+        self,
+        message_class: Optional[Type[ToolMessage]],
+    ) -> None:
+        """
+        Disable this agent from USING a message class (Tool).
+        If `message_class` is None, then disable this agent from USING ALL tools.
+        Args:
+            message_class: The ToolMessage class to disable.
+                If None, disable all.
+        """
+        for t in self._get_tool_list(message_class):
+            self.llm_tools_usable.discard(t)
+            self.llm_functions_usable.discard(t)
+
+        self._update_tool_instructions()
+
+    def disable_message_use_except(self, message_class: Type[ToolMessage]) -> None:
+        """
+        Disable this agent from USING ALL messages EXCEPT a message class (Tool)
+        Args:
+            message_class: The only ToolMessage class to allow
+        """
+        request = message_class.model_fields["request"].default
+        to_remove = [r for r in self.llm_tools_usable if r != request]
+        for r in to_remove:
+            self.llm_tools_usable.discard(r)
+            self.llm_functions_usable.discard(r)
+        self._update_tool_instructions()
+
+    def _load_output_format(self, message: ChatDocument) -> None:
+        """
+        If set, attempts to parse a value of type `self.output_format` from the message
+        contents or any tool/function call and assigns it to `content_any`.
+        """
+        if self.output_format is not None:
+            any_succeeded = False
+            attempts: list[str | LLMFunctionCall] = [
+                message.content,
+            ]
+
+            if message.function_call is not None:
+                attempts.append(message.function_call)
+
+            if message.oai_tool_calls is not None:
+                attempts.extend(
+                    [
+                        c.function
+                        for c in message.oai_tool_calls
+                        if c.function is not None
+                    ]
+                )
+
+            for attempt in attempts:
+                try:
+                    if isinstance(attempt, str):
+                        content = json.loads(attempt)
+                    else:
+                        if not (
+                            issubclass(self.output_format, ToolMessage)
+                            and attempt.name
+                            == self.output_format.default_value("request")
+                        ):
+                            continue
+
+                        content = attempt.arguments
+
+                    content_any = self.output_format.model_validate(content)
+
+                    if issubclass(self.output_format, PydanticWrapper):
+                        message.content_any = content_any.value  # type: ignore
+                    else:
+                        message.content_any = content_any
+                    any_succeeded = True
+                    break
+                except (ValidationError, json.JSONDecodeError):
+                    continue
+
+            if not any_succeeded:
+                self.disable_strict = True
+                logging.warning(
+                    """
+                    Validation error occured with strict output format enabled.
+                    Disabling strict mode.
+                    """
+                )
+
+    def get_tool_messages(
+        self,
+        msg: str | ChatDocument | None,
+        all_tools: bool = False,
+    ) -> List[ToolMessage]:
+        """
+        Extracts messages and tracks whether any errors occurred. If strict mode
+        was enabled, disables it for the tool, else triggers strict recovery.
+        """
+        self.tool_error = False
+        most_recent_sent_by_llm = (
+            len(self.message_history) > 0
+            and self.message_history[-1].role == Role.ASSISTANT
+        )
+        was_llm = most_recent_sent_by_llm or (
+            isinstance(msg, ChatDocument) and msg.metadata.sender == Entity.LLM
+        )
+        try:
+            tools = super().get_tool_messages(msg, all_tools)
+        except ValidationError as ve:
+            # Check if tool class was attached to the exception
+            if hasattr(ve, "tool_class") and ve.tool_class:
+                tool_class = ve.tool_class  # type: ignore
+                if issubclass(tool_class, ToolMessage):
+                    was_strict = (
+                        self.config.use_functions_api
+                        and self.config.use_tools_api
+                        and self._strict_mode_for_tool(tool_class)
+                    )
+                    # If the result of strict output for a tool using the
+                    # OpenAI tools API fails to parse, we infer that the
+                    # schema edits necessary for compatibility prevented
+                    # adherence to the underlying `ToolMessage` schema and
+                    # disable strict output for the tool
+                    if was_strict:
+                        name = tool_class.default_value("request")
+                        self.disable_strict_tools_set.add(name)
+                        logging.warning(
+                            f"""
+                            Validation error occured with strict tool format.
+                            Disabling strict mode for the {name} tool.
+                            """
+                        )
+                    else:
+                        # We will trigger the strict recovery mechanism to force
+                        # the LLM to correct its output, allowing us to parse
+                        if isinstance(msg, ChatDocument):
+                            self.tool_error = msg.metadata.sender == Entity.LLM
+                        else:
+                            self.tool_error = most_recent_sent_by_llm
+
+            if was_llm:
+                raise ve
+            else:
+                self.tool_error = False
+                return []
+
+        if not was_llm:
+            self.tool_error = False
+
+        return tools
+
+    def _get_any_tool_message(self, optional: bool = True) -> type[ToolMessage] | None:
+        """
+        Returns a `ToolMessage` which wraps all enabled tools, excluding those
+        where strict recovery is disabled. Used in strict recovery.
+        """
+        possible_tools = tuple(
+            self.llm_tools_map[t]
+            for t in self.llm_tools_usable
+            if t not in self.disable_strict_tools_set
+        )
+        if len(possible_tools) == 0:
+            return None
+        any_tool_type = Union.__getitem__(possible_tools)  # type ignore
+
+        maybe_optional_type = Optional[any_tool_type] if optional else any_tool_type
+
+        class AnyTool(ToolMessage):
+            purpose: str = "To call a tool/function."
+            request: str = "tool_or_function"
+            tool: maybe_optional_type  # type: ignore
+
+            def response(
+                self,
+                agent: ChatAgent,
+                chat_doc: Optional[ChatDocument] = None,
+            ) -> None | str | ChatDocument:
+                # One-time use
+                agent.set_output_format(None)
+
+                if self.tool is None:
+                    return None
+
+                # As the ToolMessage schema accepts invalid
+                # `tool.request` values, reparse with the
+                # corresponding tool
+                request = self.tool.request
+                if request not in agent.llm_tools_map:
+                    return None
+                tool = agent.llm_tools_map[request].model_validate_json(
+                    self.tool.to_json()
+                )
+
+                # pass the chat_doc through, so the recovered tool's policy
+                # check sees the same message context a normal dispatch would
+                return agent._handle_tool_message_with_policy(tool, chat_doc=chat_doc)
+
+            async def response_async(
+                self,
+                agent: ChatAgent,
+                chat_doc: Optional[ChatDocument] = None,
+            ) -> None | str | ChatDocument:
+                # One-time use
+                agent.set_output_format(None)
+
+                if self.tool is None:
+                    return None
+
+                # As the ToolMessage schema accepts invalid
+                # `tool.request` values, reparse with the
+                # corresponding tool
+                request = self.tool.request
+                if request not in agent.llm_tools_map:
+                    return None
+                tool = agent.llm_tools_map[request].model_validate_json(
+                    self.tool.to_json()
+                )
+
+                # pass the chat_doc through, so the recovered tool's policy
+                # check sees the same message context a normal dispatch would
+                return await agent._handle_tool_message_with_policy_async(
+                    tool, chat_doc=chat_doc
+                )
+
+        # This wrapper is a parsing shim for strict recovery, NOT a tool
+        # execution, so it is exempt from the `tool_policy` hook -- which
+        # also guarantees `set_output_format(None)` above always runs. The
+        # re-parsed ACTUAL tool is dispatched through the policy-checked
+        # path, so the policy is consulted exactly once per logical call.
+        AnyTool._tool_policy_exempt = True  # type: ignore[attr-defined]
+
+        return AnyTool
+
+    def _strict_recovery_instructions(
+        self,
+        tool_type: Optional[type[ToolMessage]] = None,
+        optional: bool = True,
+    ) -> str:
+        """Returns instructions for strict recovery."""
+        optional_instructions = (
+            (
+                "\n"
+                + """
+        If you did NOT intend to do so, `tool` should be null.
+        """
+            )
+            if optional
+            else ""
+        )
+        response_prefix = "If you intended to make such a call, r" if optional else "R"
+        instruction_prefix = "If you do so, b" if optional else "B"
+
+        schema_instructions = (
+            f"""
+        The schema for `tool_or_function` is as follows:
+        {tool_type.llm_function_schema(defaults=True, request=True).parameters}
+        """
+            if tool_type
+            else ""
+        )
+
+        return textwrap.dedent(
+            f"""
+        Your previous attempt to make a tool/function call appears to have failed.
+        {response_prefix}espond with your desired tool/function. Do so with the
+        `tool_or_function` tool/function where `tool` is set to your intended call.
+        {schema_instructions}
+
+        {instruction_prefix}e sure that your corrected call matches your intention
+        in your previous request. For any field with a default value which
+        you did not intend to override in your previous attempt, be sure
+        to set that field to its default value. {optional_instructions}
+        """
+        )
+
+    def truncate_message(
+        self,
+        idx: int,
+        tokens: int = 5,
+        warning: str = "...[Contents truncated!]",
+        inplace: bool = True,
+    ) -> LLMMessage:
+        """
+        Truncate message at idx in msg history to `tokens` tokens.
+
+        If inplace is True, the message is truncated in place, else
+        it LEAVES the original message INTACT and returns a new message
+        """
+        if inplace:
+            llm_msg = self.message_history[idx]
+        else:
+            llm_msg = copy.deepcopy(self.message_history[idx])
+        if llm_msg.content is None or (
+            llm_msg.content == "" and _is_identified_result(llm_msg)
+        ):
+            return llm_msg
+        orig_content = llm_msg.content
+        new_content = (
+            self.parser.truncate_tokens(orig_content, tokens)
+            if self.parser is not None
+            else orig_content[: tokens * 4]  # approx truncation
+        )
+        llm_msg.content = new_content + "\n" + warning
+        return llm_msg
+
+    def _reduce_raw_tool_results(self, message: ChatDocument) -> None:
+        """
+        If message is the result of a ToolMessage that had
+        a `_max_retained_tokens` set to a non-None value, then we replace contents
+        with a placeholder message.
+        """
+        parent_message: ChatDocument | None = message.parent
+        tools = [] if parent_message is None else parent_message.tool_messages
+        truncate_tools = []
+        for t in tools:
+            max_retained_tokens = t._max_retained_tokens
+            if isinstance(max_retained_tokens, ModelPrivateAttr):
+                max_retained_tokens = max_retained_tokens.default
+            if max_retained_tokens is not None:
+                truncate_tools.append(t)
+        limiting_tool = truncate_tools[0] if len(truncate_tools) > 0 else None
+        if limiting_tool is not None:
+            max_retained_tokens = limiting_tool._max_retained_tokens
+            if isinstance(max_retained_tokens, ModelPrivateAttr):
+                max_retained_tokens = max_retained_tokens.default
+            if max_retained_tokens is not None:
+                tool_name = limiting_tool.default_value("request")
+                max_tokens: int = max_retained_tokens
+                truncation_warning = f"""
+                    The result of the {tool_name} tool were too large,
+                    and has been truncated to {max_tokens} tokens.
+                    To obtain the full result, the tool needs to be re-used.
+                """
+                self.truncate_message(
+                    message.metadata.msg_idx, max_tokens, truncation_warning
+                )
+
+    def llm_response(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> Optional[ChatDocument]:
+        """
+        Respond to a single user message, appended to the message history,
+        in "chat" mode
+        Args:
+            message (str|ChatDocument): message or ChatDocument object to respond to.
+                If None, use the self.task_messages
+        Returns:
+            LLM response as a ChatDocument object
+        """
+        if self.llm is None:
+            return None
+
+        # If enabled and a tool error occurred, we recover by generating the tool in
+        # strict json mode
+        if (
+            self.tool_error
+            and self.output_format is None
+            and self._json_schema_available()
+            and self.config.strict_recovery
+        ):
+            self.tool_error = False
+            AnyTool = self._get_any_tool_message()
+            if AnyTool is None:
+                return None
+            self.set_output_format(
+                AnyTool,
+                force_tools=True,
+                use=True,
+                handle=True,
+                instructions=True,
+            )
+            recovery_message = self._strict_recovery_instructions(AnyTool)
+            augmented_message = message
+            if augmented_message is None:
+                augmented_message = recovery_message
+            elif isinstance(augmented_message, str):
+                augmented_message = augmented_message + recovery_message
+            else:
+                augmented_message.content = augmented_message.content + recovery_message
+
+            # only use the augmented message for this one response...
+            result = self.llm_response(augmented_message)
+            # ... restore the original user message so that the AnyTool recover
+            # instructions don't persist in the message history
+            # (this can cause the LLM to use the AnyTool directly as a tool)
+            if message is None:
+                self.delete_last_message(role=Role.USER)
+            else:
+                msg = message if isinstance(message, str) else message.content
+                self.update_last_message(msg, role=Role.USER)
+            return result
+
+        hist, output_len = self._prep_llm_messages(message)
+        if len(hist) == 0:
+            return None
+        tool_choice = (
+            "auto"
+            if isinstance(message, str)
+            else (message.oai_tool_choice if message is not None else "auto")
+        )
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
+            try:
+                response = self.llm_response_messages(hist, output_len, tool_choice)
+            except openai.BadRequestError as e:
+                if self.any_strict:
+                    self.disable_strict = True
+                    self.set_output_format(None)
+                    logging.warning(
+                        f"""
+                        OpenAI BadRequestError raised with strict mode enabled.
+                        Message: {e.message}
+                        Disabling strict mode and retrying.
+                        """
+                    )
+                    return self.llm_response(message)
+                else:
+                    raise e
+        self.message_history.extend(ChatDocument.to_LLMMessage(response))
+        response.metadata.msg_idx = len(self.message_history) - 1
+        response.metadata.agent_id = self.id
+        if isinstance(message, ChatDocument):
+            self._reduce_raw_tool_results(message)
+        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
+        response.metadata.tool_ids = (
+            []
+            if isinstance(message, str)
+            else message.metadata.tool_ids if message is not None else []
+        )
+
+        return response
+
+    async def llm_response_async(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> Optional[ChatDocument]:
+        """
+        Async version of `llm_response`. See there for details.
+        """
+        if self.llm is None:
+            return None
+
+        # If enabled and a tool error occurred, we recover by generating the tool in
+        # strict json mode
+        if (
+            self.tool_error
+            and self.output_format is None
+            and self._json_schema_available()
+            and self.config.strict_recovery
+        ):
+            self.tool_error = False
+            AnyTool = self._get_any_tool_message()
+            self.set_output_format(
+                AnyTool,
+                force_tools=True,
+                use=True,
+                handle=True,
+                instructions=True,
+            )
+            recovery_message = self._strict_recovery_instructions(AnyTool)
+            augmented_message = message
+            if augmented_message is None:
+                augmented_message = recovery_message
+            elif isinstance(augmented_message, str):
+                augmented_message = augmented_message + recovery_message
+            else:
+                augmented_message.content = augmented_message.content + recovery_message
+
+            # only use the augmented message for this one response...
+            result = self.llm_response(augmented_message)
+            # ... restore the original user message so that the AnyTool recover
+            # instructions don't persist in the message history
+            # (this can cause the LLM to use the AnyTool directly as a tool)
+            if message is None:
+                self.delete_last_message(role=Role.USER)
+            else:
+                msg = message if isinstance(message, str) else message.content
+                self.update_last_message(msg, role=Role.USER)
+            return result
+
+        hist, output_len = self._prep_llm_messages(message)
+        if len(hist) == 0:
+            return None
+        tool_choice = (
+            "auto"
+            if isinstance(message, str)
+            else (message.oai_tool_choice if message is not None else "auto")
+        )
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):
+            try:
+                response = await self.llm_response_messages_async(
+                    hist, output_len, tool_choice
+                )
+            except openai.BadRequestError as e:
+                if self.any_strict:
+                    self.disable_strict = True
+                    self.set_output_format(None)
+                    logging.warning(
+                        f"""
+                        OpenAI BadRequestError raised with strict mode enabled.
+                        Message: {e.message}
+                        Disabling strict mode and retrying.
+                        """
+                    )
+                    return await self.llm_response_async(message)
+                else:
+                    raise e
+        self.message_history.extend(ChatDocument.to_LLMMessage(response))
+        response.metadata.msg_idx = len(self.message_history) - 1
+        response.metadata.agent_id = self.id
+        if isinstance(message, ChatDocument):
+            self._reduce_raw_tool_results(message)
+        # Preserve trail of tool_ids for OpenAI Assistant fn-calls
+        response.metadata.tool_ids = (
+            []
+            if isinstance(message, str)
+            else message.metadata.tool_ids if message is not None else []
+        )
+
+        return response
+
+    def init_message_history(self) -> None:
+        """
+        Initialize the message history with the system message and user message
+        """
+        self.message_history = [self._create_system_and_tools_message()]
+        if self.user_message:
+            self.message_history.append(
+                LLMMessage(role=Role.USER, content=self.user_message)
+            )
+
+    def _prep_llm_messages(
+        self,
+        message: Optional[str | ChatDocument] = None,
+        truncate: bool = True,
+    ) -> Tuple[List[LLMMessage], int]:
+        """
+        Prepare messages to be sent to self.llm_response_messages,
+            which is the main method that calls the LLM API to get a response.
+            If desired output tokens + message history exceeds the model context length,
+            then first the max output tokens is reduced to fit, and if that is not
+            possible, older messages may be truncated to accommodate at least
+            self.config.llm.min_output_tokens of output.
+
+        Returns:
+            Tuple[List[LLMMessage], int]: (messages, output_len)
+                messages = Full list of messages to send
+                output_len = max expected number of tokens in response
+        """
+
+        if (
+            not self.llm_can_respond(message)
+            or self.config.llm is None
+            or self.llm is None
+        ):
+            return [], 0
+
+        if message is None and len(self.message_history) > 0:
+            # this means agent has been used to get LLM response already,
+            # and so the last message is an "assistant" response.
+            # We delete this last assistant response and re-generate it.
+            self.clear_history(-1)
+            logger.warning(
+                "Re-generating the last assistant response since message is None"
+            )
+
+        if len(self.message_history) == 0:
+            # initial messages have not yet been loaded, so load them
+            self.init_message_history()
+
+            # for debugging, show the initial message history
+            if settings.debug:
+                print(
+                    f"""
+                [grey37]LLM Initial Msg History:
+                {escape(self.message_history_str())}
+                [/grey37]
+                """
+                )
+        else:
+            assert self.message_history[0].role == Role.SYSTEM
+            # update the system message with the latest tool instructions
+            self.message_history[0] = self._create_system_and_tools_message()
+
+        if message is not None:
+            if (
+                isinstance(message, str)
+                or message.id() != self.message_history[-1].chat_document_id
+            ):
+                # either the message is a str, or it is a fresh ChatDocument
+                # different from the last message in the history
+                llm_msgs = ChatDocument.to_LLMMessage(message, self.oai_tool_calls)
+                llm_msgs = [m for m in llm_msgs if _llm_message_has_payload(m)]
+                # Canonicalize retained whitespace-only results before token counting.
+                for llm_msg in llm_msgs:
+                    if (
+                        _is_identified_result(llm_msg)
+                        and llm_msg.content is not None
+                        and llm_msg.content.strip() == ""
+                    ):
+                        llm_msg.content = ""
+                if len(llm_msgs) == 0:
+                    return [], 0
+                # process tools if any
+                done_tools = [m.tool_call_id for m in llm_msgs if m.role == Role.TOOL]
+                self.oai_tool_calls = [
+                    t for t in self.oai_tool_calls if t.id not in done_tools
+                ]
+                self.message_history.extend(llm_msgs)
+
+        hist = self.message_history
+        output_len = self.config.llm.model_max_output_tokens
+        if (
+            truncate
+            and output_len > self.llm.chat_context_length() - self.chat_num_tokens(hist)
+        ):
+            CHAT_HISTORY_BUFFER = 300
+            # chat + output > max context length,
+            # so first try to shorten requested output len to fit;
+            # use an extra margin of CHAT_HISTORY_BUFFER tokens
+            # in case our calcs are off (and to allow for some extra tokens)
+            output_len = (
+                self.llm.chat_context_length()
+                - self.chat_num_tokens(hist)
+                - CHAT_HISTORY_BUFFER
+            )
+            if output_len > self.config.llm.min_output_tokens:
+                logger.debug(
+                    f"""
+                    Chat Model context length is {self.llm.chat_context_length()},
+                    but the current message history is {self.chat_num_tokens(hist)}
+                    tokens long, which does not allow
+                    {self.config.llm.model_max_output_tokens} output tokens.
+                    Therefore we reduced `max_output_tokens` to {output_len} tokens,
+                    so they can fit within the model's context length
+                    """
+                )
+            else:
+                # unacceptably small output len, so compress early parts of
+                # conversation history based on the configured strategy
+                strategy = self.config.context_overflow_strategy
+
+                if strategy == "truncate":
+                    # Truncate content of individual messages while preserving
+                    # the message sequence (important for LLM APIs that require
+                    # alternating USER/ASSISTANT messages)
+                    msg_idx_to_compress = 1  # don't touch system msg
+                    # we will try compressing msg indices up to but not including
+                    # last user msg
+                    last_msg_idx_to_compress = (
+                        self.last_message_idx_with_role(
+                            role=Role.USER,
+                        )
+                        - 1
+                    )
+                    n_truncated = 0
+                    while (
+                        self.chat_num_tokens(hist)
+                        > self.llm.chat_context_length()
+                        - self.config.llm.min_output_tokens
+                        - CHAT_HISTORY_BUFFER
+                    ):
+                        if msg_idx_to_compress > last_msg_idx_to_compress:
+                            # We want to preserve the first message (typically
+                            # system msg) and last message (user msg).
+                            raise ValueError(
+                                """
+                            The (message history + max_output_tokens) is longer than the
+                            max chat context length of this model, and we have tried
+                            reducing the requested max output tokens, as well as
+                            truncating early parts of the message history, to
+                            accommodate the model context length, but we have run out
+                            of msgs to truncate.
+
+                            HINT: In the `llm` field of your `ChatAgentConfig` object,
+                            which is of type `LLMConfig/OpenAIGPTConfig`, try
+                            - increasing `chat_context_length`
+                                (if accurate for the model), or
+                            - decreasing `max_output_tokens`
+                            """
+                            )
+                        n_truncated += 1
+                        # compress the msg at idx `msg_idx_to_compress`
+                        hist[msg_idx_to_compress] = self.truncate_message(
+                            msg_idx_to_compress,
+                            tokens=30,
+                            warning="... [Contents truncated!]",
+                        )
+                        msg_idx_to_compress += 1
+
+                    output_len = min(
+                        self.config.llm.model_max_output_tokens,
+                        self.llm.chat_context_length()
+                        - self.chat_num_tokens(hist)
+                        - CHAT_HISTORY_BUFFER,
+                    )
+                    if output_len < self.config.llm.min_output_tokens:
+                        raise ValueError(
+                            f"""
+                            Tried to shorten prompt history for chat mode
+                            but even after truncating all messages except system msg
+                            and last (user) msg, the history token len
+                            {self.chat_num_tokens(hist)} is too long to accommodate
+                            the desired minimum output tokens
+                            {self.config.llm.min_output_tokens} within the
+                            model's context length {self.llm.chat_context_length()}.
+                            Please try shortening the system msg or user prompts,
+                            or adjust `config.llm.min_output_tokens` to be smaller.
+                            """
+                        )
+                    else:
+                        # we MUST have truncated at least one msg
+                        msg_tokens = self.chat_num_tokens()
+                        logger.warning(
+                            f"""
+                        Chat Model context length is {self.llm.chat_context_length()}
+                        tokens, but the current message history is {msg_tokens} tokens
+                        long, which does not allow
+                        {self.config.llm.model_max_output_tokens} output tokens.
+                        Therefore we truncated the first {n_truncated} messages
+                        in the conversation history so that history token
+                        length is reduced to {self.chat_num_tokens(hist)}, and
+                        we use `max_output_tokens = {output_len}`,
+                        so they can fit within the model's context length
+                        of {self.llm.chat_context_length()} tokens.
+                        """
+                        )
+
+                else:  # strategy == "drop_turns"
+                    # Drop complete conversation turns. A complete turn is defined
+                    # as a USER message followed by all messages until the next
+                    # USER message. This is more aggressive but cleaner for voice
+                    # agents with limited context.
+                    n_dropped_turns = 0
+                    while (
+                        self.chat_num_tokens(hist)
+                        > self.llm.chat_context_length()
+                        - self.config.llm.min_output_tokens
+                        - CHAT_HISTORY_BUFFER
+                    ):
+                        # Find the last USER message index
+                        last_user_idx = self.last_message_idx_with_role(role=Role.USER)
+                        if last_user_idx == -1:
+                            break
+
+                        # Find the first complete turn to drop (skip system message)
+                        first_user_idx = -1
+                        for i in range(1, last_user_idx):
+                            if hist[i].role == Role.USER:
+                                first_user_idx = i
+                                break
+                        if first_user_idx == -1:
+                            break
+
+                        # Find the end of this turn: last message before next USER
+                        next_user_idx = -1
+                        for i in range(first_user_idx + 1, last_user_idx + 1):
+                            if hist[i].role == Role.USER:
+                                next_user_idx = i
+                                break
+                        if next_user_idx == -1:
+                            break
+
+                        # Drop the turn
+                        self.clear_history(first_user_idx, next_user_idx - 1)
+                        n_dropped_turns += 1
+
+                    output_len = min(
+                        self.config.llm.model_max_output_tokens,
+                        self.llm.chat_context_length()
+                        - self.chat_num_tokens(hist)
+                        - CHAT_HISTORY_BUFFER,
+                    )
+                    if output_len < self.config.llm.min_output_tokens:
+                        raise ValueError(
+                            f"""
+                            Tried to shorten prompt history for chat mode
+                            but even after dropping complete turns except the system
+                            msg and last turn, the history token len
+                            {self.chat_num_tokens(hist)} is too long to accommodate
+                            the desired minimum output tokens
+                            {self.config.llm.min_output_tokens} within the
+                            model's context length {self.llm.chat_context_length()}.
+                            Please try shortening the system msg or user prompts,
+                            or adjust `config.llm.min_output_tokens` to be smaller.
+                            """
+                        )
+                    else:
+                        # we MUST have dropped at least one turn
+                        msg_tokens = self.chat_num_tokens()
+                        logger.warning(
+                            f"""
+                        Chat Model context length is {self.llm.chat_context_length()}
+                        tokens, but the current message history is {msg_tokens} tokens
+                        long, which does not allow
+                        {self.config.llm.model_max_output_tokens} output tokens.
+                        Therefore we dropped the first {n_dropped_turns} complete
+                        turn(s) from the conversation history so that history token
+                        length is reduced to {self.chat_num_tokens(hist)}, and
+                        we use `max_output_tokens = {output_len}`,
+                        so they can fit within the model's context length
+                        of {self.llm.chat_context_length()} tokens.
+                        """
+                        )
+
+        if isinstance(message, ChatDocument):
+            # record the position of the corresponding LLMMessage in
+            # the message_history
+            message.metadata.msg_idx = len(hist) - 1
+            message.metadata.agent_id = self.id
+        return hist, output_len
+
+    def _function_args(
+        self,
+    ) -> Tuple[
+        Optional[List[LLMFunctionSpec]],
+        str | Dict[str, str],
+        Optional[List[OpenAIToolSpec]],
+        Optional[Dict[str, Dict[str, str] | str]],
+        Optional[OpenAIJsonSchemaSpec],
+    ]:
+        """
+        Get function/tool spec/output format arguments for
+        OpenAI-compatible LLM API call
+        """
+        functions: Optional[List[LLMFunctionSpec]] = None
+        fun_call: str | Dict[str, str] = "none"
+        tools: Optional[List[OpenAIToolSpec]] = None
+        force_tool: Optional[Dict[str, Dict[str, str] | str]] = None
+        self.any_strict = False
+        if self.config.use_functions_api and len(self.llm_functions_usable) > 0:
+            if not self.config.use_tools_api:
+                functions = [
+                    self.llm_functions_map[f] for f in self.llm_functions_usable
+                ]
+                fun_call = (
+                    "auto"
+                    if self.llm_function_force is None
+                    else self.llm_function_force
+                )
+            else:
+
+                def to_maybe_strict_spec(function: str) -> OpenAIToolSpec:
+                    spec = self.llm_functions_map[function]
+                    strict = self._strict_mode_for_tool(function)
+                    if strict:
+                        self.any_strict = True
+                        strict_spec = copy.deepcopy(spec)
+                        format_schema_for_strict(strict_spec.parameters)
+                    else:
+                        strict_spec = spec
+
+                    return OpenAIToolSpec(
+                        type="function",
+                        strict=strict,
+                        function=strict_spec,
+                    )
+
+                tools = [to_maybe_strict_spec(f) for f in self.llm_functions_usable]
+                force_tool = (
+                    None
+                    if self.llm_function_force is None
+                    else {
+                        "type": "function",
+                        "function": {"name": self.llm_function_force["name"]},
+                    }
+                )
+        output_format = None
+        if self.output_format is not None and self._json_schema_available():
+            self.any_strict = True
+            if issubclass(self.output_format, ToolMessage) and not issubclass(
+                self.output_format, XMLToolMessage
+            ):
+                spec = self.output_format.llm_function_schema(
+                    request=True,
+                    defaults=self.config.output_format_include_defaults,
+                )
+                format_schema_for_strict(spec.parameters)
+
+                output_format = OpenAIJsonSchemaSpec(
+                    # We always require that outputs strictly match the schema
+                    strict=True,
+                    function=spec,
+                )
+            elif issubclass(self.output_format, BaseModel):
+                param_spec = self.output_format.model_json_schema()
+                format_schema_for_strict(param_spec)
+
+                output_format = OpenAIJsonSchemaSpec(
+                    # We always require that outputs strictly match the schema
+                    strict=True,
+                    function=LLMFunctionSpec(
+                        name="json_output",
+                        description="Strict Json output format.",
+                        parameters=param_spec,
+                    ),
+                )
+
+        return functions, fun_call, tools, force_tool, output_format
+
+    def llm_response_messages(
+        self,
+        messages: List[LLMMessage],
+        output_len: Optional[int] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+    ) -> ChatDocument:
+        """
+        Respond to a series of messages, e.g. with OpenAI ChatCompletion
+        Args:
+            messages: seq of messages (with role, content fields) sent to LLM
+            output_len: max number of tokens expected in response.
+                    If None, use the LLM's default model_max_output_tokens.
+        Returns:
+            Document (i.e. with fields "content", "metadata")
+        """
+        assert self.config.llm is not None and self.llm is not None
+        output_len = output_len or self.config.llm.model_max_output_tokens
+        streamer = noop_fn
+        if self.llm.get_stream():
+            streamer = self.callbacks.start_llm_stream()
+        self.llm.config.streamer = streamer
+        with ExitStack() as stack:  # for conditionally using rich spinner
+            if not self.llm.get_stream() and not settings.quiet:
+                # show rich spinner only if not streaming!
+                # (Why? b/c the intent of showing a spinner is to "show progress",
+                # and we don't need to do that when streaming, since
+                # streaming output already shows progress.)
+                cm = status(
+                    "LLM responding to messages...",
+                    log_if_quiet=False,
+                )
+                stack.enter_context(cm)
+            if self.llm.get_stream() and not settings.quiet:
+                console.print(f"[green]{self.indent}", end="")
+            functions, fun_call, tools, force_tool, output_format = (
+                self._function_args()
+            )
+            assert self.llm is not None
+            response = self.llm.chat(
+                messages,
+                output_len,
+                tools=tools,
+                tool_choice=force_tool or tool_choice,
+                functions=functions,
+                function_call=fun_call,
+                response_format=output_format,
+            )
+        if self.llm.get_stream():
+            # Create temp ChatDocument for tool check, then clean up to avoid
+            # polluting ObjectRegistry (see PR #939 discussion)
+            temp_doc = ChatDocument.from_LLMResponse(
+                response,
+                displayed=True,
+                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+            )
+            self._call_callback_with_reasoning(
+                "finish_llm_stream",
+                reasoning=response.reasoning,
+                content=response.message or "",
+                tools_content=response.tools_content(),
+                is_tool=self.has_tool_message_attempt(temp_doc),
+            )
+            ObjectRegistry.remove(temp_doc.id())
+        self.llm.config.streamer = noop_fn
+        if response.cached:
+            self.callbacks.cancel_llm_stream()
+        self._render_llm_response(response)
+        self.update_token_usage(
+            response,  # .usage attrib is updated!
+            messages,
+            self.llm.get_stream(),
+            chat=True,
+            print_response_stats=self.config.show_stats and not settings.quiet,
+        )
+        chat_doc = ChatDocument.from_LLMResponse(
+            response,
+            displayed=True,
+            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+        )
+        self.oai_tool_calls = response.oai_tool_calls or []
+        self.oai_tool_id2call.update(
+            {t.id: t for t in self.oai_tool_calls if t.id is not None}
+        )
+
+        # If using strict output format, parse the output JSON
+        self._load_output_format(chat_doc)
+
+        return chat_doc
+
+    async def llm_response_messages_async(
+        self,
+        messages: List[LLMMessage],
+        output_len: Optional[int] = None,
+        tool_choice: ToolChoiceTypes | Dict[str, str | Dict[str, str]] = "auto",
+    ) -> ChatDocument:
+        """
+        Async version of `llm_response_messages`. See there for details.
+        """
+        assert self.config.llm is not None and self.llm is not None
+        output_len = output_len or self.config.llm.model_max_output_tokens
+        functions, fun_call, tools, force_tool, output_format = self._function_args()
+        assert self.llm is not None
+
+        streamer_async = async_noop_fn
+        if self.llm.get_stream():
+            streamer_async = await self.callbacks.start_llm_stream_async()
+        self.llm.config.streamer_async = streamer_async
+
+        response = await self.llm.achat(
+            messages,
+            output_len,
+            tools=tools,
+            tool_choice=force_tool or tool_choice,
+            functions=functions,
+            function_call=fun_call,
+            response_format=output_format,
+        )
+        if self.llm.get_stream():
+            # Create temp ChatDocument for tool check, then clean up to avoid
+            # polluting ObjectRegistry (see PR #939 discussion)
+            temp_doc = ChatDocument.from_LLMResponse(
+                response,
+                displayed=True,
+                recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+            )
+            self._call_callback_with_reasoning(
+                "finish_llm_stream",
+                reasoning=response.reasoning,
+                content=response.message or "",
+                tools_content=response.tools_content(),
+                is_tool=self.has_tool_message_attempt(temp_doc),
+            )
+            ObjectRegistry.remove(temp_doc.id())
+        self.llm.config.streamer_async = async_noop_fn
+        if response.cached:
+            self.callbacks.cancel_llm_stream()
+        self._render_llm_response(response)
+        self.update_token_usage(
+            response,  # .usage attrib is updated!
+            messages,
+            self.llm.get_stream(),
+            chat=True,
+            print_response_stats=self.config.show_stats and not settings.quiet,
+        )
+        chat_doc = ChatDocument.from_LLMResponse(
+            response,
+            displayed=True,
+            recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+        )
+        self.oai_tool_calls = response.oai_tool_calls or []
+        self.oai_tool_id2call.update(
+            {t.id: t for t in self.oai_tool_calls if t.id is not None}
+        )
+
+        # If using strict output format, parse the output JSON
+        self._load_output_format(chat_doc)
+
+        return chat_doc
+
+    def _call_callback_with_reasoning(
+        self,
+        callback_name: str,
+        reasoning: str,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Call a callback method, only passing 'reasoning' if it accepts it.
+
+        This provides backward compatibility for custom callbacks that don't
+        have the 'reasoning' parameter in their signature.
+
+        Args:
+            callback_name: Name of the callback method (e.g., 'show_llm_response')
+            reasoning: The reasoning content to pass if supported
+            **kwargs: Other arguments to pass to the callback
+        """
+        callback = getattr(self.callbacks, callback_name, None)
+        if callback is None:
+            return
+
+        # Check if callback accepts 'reasoning' param or **kwargs
+        try:
+            sig = inspect.signature(callback)
+            params = sig.parameters
+            accepts_reasoning = "reasoning" in params or any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+            )
+        except (ValueError, TypeError):
+            # If we can't inspect the signature, assume it doesn't accept reasoning
+            accepts_reasoning = False
+
+        if accepts_reasoning:
+            callback(reasoning=reasoning, **kwargs)
+        else:
+            callback(**kwargs)
+
+    def _render_llm_response(
+        self, response: ChatDocument | LLMResponse, citation_only: bool = False
+    ) -> None:
+        is_cached = (
+            response.cached
+            if isinstance(response, LLMResponse)
+            else response.metadata.cached
+        )
+        if self.llm is None:
+            return
+        if not citation_only and (not self.llm.get_stream() or is_cached):
+            # We would have already displayed the msg "live" ONLY if
+            # streaming was enabled, AND we did not find a cached response.
+            # If we are here, it means the response has not yet been displayed.
+            cached = f"[red]{self.indent}(cached)[/red]" if is_cached else ""
+            # Track whether we created a temp ChatDocument for cleanup
+            is_temp_doc = isinstance(response, LLMResponse)
+            chat_doc = (
+                response
+                if isinstance(response, ChatDocument)
+                else ChatDocument.from_LLMResponse(
+                    response,
+                    displayed=True,
+                    recognize_recipient_in_content=self.config.recognize_recipient_in_content,
+                )
+            )
+            # TODO: prepend TOOL: or OAI-TOOL: if it's a tool-call
+            if not settings.quiet:
+                print(cached + "[green]" + escape(str(response)))
+            if isinstance(response, LLMResponse):
+                content = response.message or ""
+                tools_content = response.tools_content()
+            else:
+                content = response.content
+                tools_content = ""
+            reasoning = response.reasoning if isinstance(response, LLMResponse) else ""
+            self._call_callback_with_reasoning(
+                "show_llm_response",
+                reasoning=reasoning,
+                content=content,
+                tools_content=tools_content,
+                is_tool=self.has_tool_message_attempt(chat_doc),
+                cached=is_cached,
+            )
+            # Clean up temp ChatDocument to avoid polluting ObjectRegistry
+            if is_temp_doc:
+                ObjectRegistry.remove(chat_doc.id())
+        if isinstance(response, LLMResponse):
+            # we are in the context immediately after an LLM responded,
+            # we won't have citations yet, so we're done
+            return
+        if response.metadata.has_citation:
+            citation = (
+                response.metadata.source_content
+                if self.config.full_citations
+                else response.metadata.source
+            )
+            if not settings.quiet:
+                print("[grey37]SOURCES:\n" + escape(citation) + "[/grey37]")
+            self._call_callback_with_reasoning(
+                "show_llm_response",
+                reasoning="",  # Citations don't have reasoning
+                content=str(citation),
+                tools_content="",
+                is_tool=False,
+                cached=False,
+                language="text",
+            )
+
+    def _llm_response_temp_context(self, message: str, prompt: str) -> ChatDocument:
+        """
+        Get LLM response to `prompt` (which presumably includes the `message`
+        somewhere, along with possible large "context" passages),
+        but only include `message` as the USER message, and not the
+        full `prompt`, in the message history.
+        Args:
+            message: the original, relatively short, user request or query
+            prompt: the full prompt potentially containing `message` plus context
+
+        Returns:
+            Document object containing the response.
+        """
+        # we explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            answer_doc = cast(ChatDocument, ChatAgent.llm_response(self, prompt))
+        self.update_last_message(message, role=Role.USER)
+        return answer_doc
+
+    async def _llm_response_temp_context_async(
+        self, message: str, prompt: str
+    ) -> ChatDocument:
+        """
+        Async version of `_llm_response_temp_context`. See there for details.
+        """
+        # we explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            answer_doc = cast(
+                ChatDocument,
+                await ChatAgent.llm_response_async(self, prompt),
+            )
+        self.update_last_message(message, role=Role.USER)
+        return answer_doc
+
+    def llm_response_forget(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> ChatDocument:
+        """
+        LLM Response to single message, and restore message_history.
+        In effect a "one-off" message & response that leaves agent
+        message history state intact.
+
+        Args:
+            message (str|ChatDocument): message to respond to.
+
+        Returns:
+            A Document object with the response.
+
+        """
+        # explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        n_msgs = len(self.message_history)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            response = cast(ChatDocument, ChatAgent.llm_response(self, message))
+        # If there is a response, then we will have two additional
+        # messages in the message history, i.e. the user message and the
+        # assistant response. We want to (carefully) remove these two messages.
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+
+        # If using strict output format, parse the output JSON
+        self._load_output_format(response)
+
+        return response
+
+    async def llm_response_forget_async(
+        self, message: Optional[str | ChatDocument] = None
+    ) -> ChatDocument:
+        """
+        Async version of `llm_response_forget`. See there for details.
+        """
+        # explicitly call THIS class's respond method,
+        # not a derived class's (or else there would be infinite recursion!)
+        n_msgs = len(self.message_history)
+        with StreamingIfAllowed(self.llm, self.llm.get_stream()):  # type: ignore
+            response = cast(
+                ChatDocument, await ChatAgent.llm_response_async(self, message)
+            )
+        # If there is a response, then we will have two additional
+        # messages in the message history, i.e. the user message and the
+        # assistant response. We want to (carefully) remove these two messages.
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+
+        if len(self.message_history) > n_msgs:
+            msg = self.message_history.pop()
+            self._drop_msg_update_tool_calls(msg)
+        return response
+
+    def chat_num_tokens(self, messages: Optional[List[LLMMessage]] = None) -> int:
+        """
+        Total number of tokens in the message history so far.
+
+        Args:
+            messages: if provided, compute the number of tokens in this list of
+                messages, rather than the current message history.
+        Returns:
+            int: number of tokens in message history
+        """
+        if self.parser is None:
+            raise ValueError(
+                "ChatAgent.parser is None. "
+                "You must set ChatAgent.parser "
+                "before calling chat_num_tokens()."
+            )
+        hist = messages if messages is not None else self.message_history
+        return sum([self._message_num_tokens(m) for m in hist])
+
+    def _message_num_tokens(self, message: LLMMessage) -> int:
+        """Count tokens for a message, including serialized user attachments."""
+        if self.parser is None:
+            raise ValueError(
+                "ChatAgent.parser is None. "
+                "You must set ChatAgent.parser "
+                "before calling _message_num_tokens()."
+            )
+
+        return self.parser.num_tokens(
+            message.content or ""
+        ) + self._attachment_num_tokens(message)
+
+    def _attachment_num_tokens(self, message: LLMMessage) -> int:
+        """
+        Estimate attachment contribution using the serialized payload
+        that is sent in the API request for user messages.
+        """
+        if self.parser is None or message.role != Role.USER or len(message.files) == 0:
+            return 0
+
+        model = self._chat_model_name_for_attachments()
+        return sum(
+            self.parser.num_tokens(
+                json.dumps(
+                    attachment.to_dict(model),
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+            )
+            for attachment in message.files
+        )
+
+    def _chat_model_name_for_attachments(self) -> str:
+        """Return the model name used for attachment serialization."""
+        if self.llm is None:
+            return self.config.llm.chat_model if self.config.llm is not None else ""
+
+        return cast(
+            str,
+            getattr(
+                self.llm,
+                "chat_model_orig",
+                getattr(
+                    getattr(self.llm, "config", None),
+                    "chat_model",
+                    self.config.llm.chat_model if self.config.llm is not None else "",
+                ),
+            ),
+        )
+
+    def message_history_str(self, i: Optional[int] = None) -> str:
+        """
+        Return a string representation of the message history
+        Args:
+            i: if provided, return only the i-th message when i is postive,
+                or last k messages when i = -k.
+        Returns:
+        """
+        if i is None:
+            return "\n".join([str(m) for m in self.message_history])
+        elif i > 0:
+            return str(self.message_history[i])
+        else:
+            return "\n".join([str(m) for m in self.message_history[i:]])
+
+    def __del__(self) -> None:
+        """
+        Cleanup method called when the ChatAgent is garbage collected.
+        Note: We don't close LLM clients here because they may be shared
+        across multiple agents when client caching is enabled.
+        The clients are managed centrally and cleaned up via atexit hooks.
+        """
+        # Previously we closed clients here, but this caused issues when
+        # multiple agents shared the same cached client instance.
+        # Clients are now managed centrally in langroid.language_models.client_cache
+        pass
+</file>
+
+<file path="langroid/language_models/model_info.py">
+import logging
+from enum import Enum
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+class ModelProvider(str, Enum):
+    """Enum for model providers"""
+
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+    DEEPSEEK = "deepseek"
+    GOOGLE = "google"
+    MINIMAX = "minimax"
+    UNKNOWN = "unknown"
+
+
+class ModelName(str, Enum):
+    """Parent class for all model name enums"""
+
+    pass
+
+
+class OpenAIChatModel(ModelName):
+    """Enum for OpenAI Chat models"""
+
+    GPT3_5_TURBO = "gpt-3.5-turbo"
+    GPT4 = "gpt-4o"  # avoid deprecated gpt-4
+    GPT4_TURBO = "gpt-4-turbo"
+    GPT4o = "gpt-4o"
+    GPT4o_MINI = "gpt-4o-mini"
+    O1 = "o1"
+    O1_MINI = "o1-mini"
+    O3_MINI = "o3-mini"
+    O3 = "o3"
+    O4_MINI = "o4-mini"
+    GPT4_1 = "gpt-4.1"
+    GPT4_1_MINI = "gpt-4.1-mini"
+    GPT4_1_NANO = "gpt-4.1-nano"
+    GPT5 = "gpt-5"
+    GPT5_MINI = "gpt-5-mini"
+    GPT5_NANO = "gpt-5-nano"
+    GPT5_PRO = "gpt-5-pro"
+    GPT5_1 = "gpt-5.1"
+    GPT5_1_CODEX = "gpt-5.1-codex"
+    GPT5_1_CODEX_MINI = "gpt-5.1-codex-mini"
+    GPT5_1_CHAT = "gpt-5.1-chat"
+    GPT5_2 = "gpt-5.2"
+    GPT5_2_PRO = "gpt-5.2-pro"
+    GPT5_2_CHAT = "gpt-5.2-chat"
+    GPT_OSS_120b = "gpt-oss-120b"
+    GPT_OSS_20b = "gpt-oss-20b"
+
+
+class OpenAICompletionModel(str, Enum):
+    """Enum for OpenAI Completion models"""
+
+    DAVINCI = "davinci-002"
+    BABBAGE = "babbage-002"
+
+
+class AnthropicModel(ModelName):
+    """Enum for Anthropic models"""
+
+    CLAUDE_3_OPUS = "claude-3-opus-latest"
+    CLAUDE_3_SONNET = "claude-3-sonnet-latest"
+    CLAUDE_3_HAIKU = "claude-3-haiku-latest"
+    CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest"
+    CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest"
+    CLAUDE_4_OPUS = "claude-opus-4"
+    CLAUDE_4_SONNET = "claude-sonnet-4"
+    CLAUDE_4_HAIKU = "claude-haiku-4"
+    CLAUDE_4_5_OPUS = "claude-opus-4-5"
+    CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
+    CLAUDE_4_5_HAIKU = "claude-haiku-4-5"
+
+
+class DeepSeekModel(ModelName):
+    """Enum for DeepSeek models direct from DeepSeek API"""
+
+    DEEPSEEK = "deepseek/deepseek-chat"
+    DEEPSEEK_R1 = "deepseek/deepseek-reasoner"
+    OPENROUTER_DEEPSEEK_R1 = "openrouter/deepseek/deepseek-r1"
+
+
+class GeminiModel(ModelName):
+    """Enum for Gemini models"""
+
+    GEMINI_1_5_FLASH = "gemini-1.5-flash"
+    GEMINI_1_5_FLASH_8B = "gemini-1.5-flash-8b"
+    GEMINI_1_5_PRO = "gemini-1.5-pro"
+    GEMINI_2_FLASH = "gemini-2.0-flash"
+    GEMINI_2_FLASH_LITE = "gemini-2.0-flash-lite"
+    GEMINI_2_FLASH_THINKING = "gemini-2.0-flash-thinking-exp"
+    GEMINI_2_PRO = "gemini-2.0-pro-exp-02-05"
+    GEMINI_2_5_FLASH = "gemini-2.5-flash"
+    GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
+    GEMINI_2_5_PRO = "gemini-2.5-pro"
+    GEMINI_3_FLASH = "gemini-3-flash"
+    GEMINI_3_PRO = "gemini-3-pro"
+
+
+class MiniMaxModel(ModelName):
+    """Enum for MiniMax models"""
+
+    MINIMAX_M2_7 = "MiniMax-M2.7"
+    MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
+    MINIMAX_M2_5 = "MiniMax-M2.5"
+    MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
+    MINIMAX_M2_1 = "MiniMax-M2.1"
+    MINIMAX_M2_1_HIGHSPEED = "MiniMax-M2.1-highspeed"
+    MINIMAX_M2 = "MiniMax-M2"
+
+
+class OpenAI_API_ParamInfo(BaseModel):
+    """
+    Parameters exclusive to some models, when using OpenAI API
+    """
+
+    # model-specific params at top level
+    params: Dict[str, List[str]] = dict(
+        reasoning_effort=[
+            OpenAIChatModel.O3_MINI.value,
+            OpenAIChatModel.O3.value,
+            OpenAIChatModel.O4_MINI.value,
+            OpenAIChatModel.GPT5.value,
+            OpenAIChatModel.GPT5_MINI.value,
+            OpenAIChatModel.GPT5_NANO.value,
+            OpenAIChatModel.GPT5_PRO.value,
+            OpenAIChatModel.GPT5_1.value,
+            OpenAIChatModel.GPT5_1_CODEX.value,
+            OpenAIChatModel.GPT5_1_CODEX_MINI.value,
+            OpenAIChatModel.GPT5_2.value,
+            OpenAIChatModel.GPT5_2_PRO.value,
+            OpenAIChatModel.GPT_OSS_120b.value,
+            OpenAIChatModel.GPT_OSS_20b.value,
+            GeminiModel.GEMINI_2_5_PRO.value,
+            GeminiModel.GEMINI_2_5_FLASH.value,
+            GeminiModel.GEMINI_2_5_FLASH_LITE.value,
+        ],
+    )
+    # model-specific params in extra_body
+    extra_parameters: Dict[str, List[str]] = dict(
+        include_reasoning=[
+            DeepSeekModel.OPENROUTER_DEEPSEEK_R1.value,
+        ]
+    )
+
+
+class ModelInfo(BaseModel):
+    """
+    Consolidated information about LLM, related to capacity, cost and API
+    idiosyncrasies. Reasonable defaults for all params in case there's no
+    specific info available.
+    """
+
+    name: str = "unknown"
+    provider: ModelProvider = ModelProvider.UNKNOWN
+    context_length: int = 16_000
+    max_cot_tokens: int = 0  # max chain of thought (thinking) tokens where applicable
+    max_output_tokens: int = 8192  # Maximum number of output tokens - model dependent
+    input_cost_per_million: float = 0.0  # Cost in USD per million input tokens
+    cached_cost_per_million: float = 0.0  # Cost in USD per million cached tokens
+    output_cost_per_million: float = 0.0  # Cost in USD per million output tokens
+    allows_streaming: bool = True  # Whether model supports streaming output
+    allows_system_message: bool = True  # Whether model supports system messages
+    rename_params: Dict[str, str] = {}  # Rename parameters for OpenAI API
+    unsupported_params: List[str] = []
+    has_structured_output: bool = False  # Does model API support structured output?
+    has_tools: bool = True  # Does model API support tools/function-calling?
+    needs_first_user_message: bool = False  # Does API need first msg to be from user?
+    description: Optional[str] = None
+
+
+GEMINI_CANONICAL_MODEL_NAMES = {model.value for model in GeminiModel}
+DEFAULT_MODEL_INFO = ModelInfo()
+WARNED_UNKNOWN_MODELS: set[tuple[str, ...]] = set()
+
+
+# Model information registry
+MODEL_INFO: Dict[str, ModelInfo] = {
+    # OpenAI Models
+    OpenAICompletionModel.DAVINCI.value: ModelInfo(
+        name=OpenAICompletionModel.DAVINCI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=4096,
+        max_output_tokens=4096,
+        input_cost_per_million=2.0,
+        output_cost_per_million=2.0,
+        description="Davinci-002",
+    ),
+    OpenAICompletionModel.BABBAGE.value: ModelInfo(
+        name=OpenAICompletionModel.BABBAGE.value,
+        provider=ModelProvider.OPENAI,
+        context_length=4096,
+        max_output_tokens=4096,
+        input_cost_per_million=0.40,
+        output_cost_per_million=0.40,
+        description="Babbage-002",
+    ),
+    OpenAIChatModel.GPT3_5_TURBO.value: ModelInfo(
+        name=OpenAIChatModel.GPT3_5_TURBO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=16_385,
+        max_output_tokens=4096,
+        input_cost_per_million=0.50,
+        output_cost_per_million=1.50,
+        description="GPT-3.5 Turbo",
+    ),
+    OpenAIChatModel.GPT4.value: ModelInfo(
+        name=OpenAIChatModel.GPT4.value,
+        provider=ModelProvider.OPENAI,
+        context_length=8192,
+        max_output_tokens=8192,
+        input_cost_per_million=30.0,
+        output_cost_per_million=60.0,
+        description="GPT-4 (8K context)",
+    ),
+    OpenAIChatModel.GPT4_TURBO.value: ModelInfo(
+        name=OpenAIChatModel.GPT4_TURBO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=4096,
+        input_cost_per_million=10.0,
+        output_cost_per_million=30.0,
+        description="GPT-4 Turbo",
+    ),
+    OpenAIChatModel.GPT4_1_NANO.value: ModelInfo(
+        name=OpenAIChatModel.GPT4_1_NANO.value,
+        provider=ModelProvider.OPENAI,
+        has_structured_output=True,
+        context_length=1_047_576,
+        max_output_tokens=32_768,
+        input_cost_per_million=0.10,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=0.40,
+        description="GPT-4.1",
+    ),
+    OpenAIChatModel.GPT4_1_MINI.value: ModelInfo(
+        name=OpenAIChatModel.GPT4_1_MINI.value,
+        provider=ModelProvider.OPENAI,
+        has_structured_output=True,
+        context_length=1_047_576,
+        max_output_tokens=32_768,
+        input_cost_per_million=0.40,
+        cached_cost_per_million=0.10,
+        output_cost_per_million=1.60,
+        description="GPT-4.1 Mini",
+    ),
+    OpenAIChatModel.GPT4_1.value: ModelInfo(
+        name=OpenAIChatModel.GPT4_1.value,
+        provider=ModelProvider.OPENAI,
+        has_structured_output=True,
+        context_length=1_047_576,
+        max_output_tokens=32_768,
+        input_cost_per_million=2.00,
+        cached_cost_per_million=0.50,
+        output_cost_per_million=8.00,
+        description="GPT-4.1",
+    ),
+    OpenAIChatModel.GPT4o.value: ModelInfo(
+        name=OpenAIChatModel.GPT4o.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=2.5,
+        cached_cost_per_million=1.25,
+        output_cost_per_million=10.0,
+        has_structured_output=True,
+        description="GPT-4o (128K context)",
+    ),
+    OpenAIChatModel.GPT4o_MINI.value: ModelInfo(
+        name=OpenAIChatModel.GPT4o_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=0.15,
+        cached_cost_per_million=0.075,
+        output_cost_per_million=0.60,
+        has_structured_output=True,
+        description="GPT-4o Mini",
+    ),
+    OpenAIChatModel.O1.value: ModelInfo(
+        name=OpenAIChatModel.O1.value,
+        provider=ModelProvider.OPENAI,
+        context_length=200_000,
+        max_output_tokens=100_000,
+        input_cost_per_million=15.0,
+        cached_cost_per_million=7.50,
+        output_cost_per_million=60.0,
+        allows_streaming=True,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        has_tools=False,
+        description="O1 Reasoning LM",
+    ),
+    OpenAIChatModel.O3.value: ModelInfo(
+        name=OpenAIChatModel.O3.value,
+        provider=ModelProvider.OPENAI,
+        context_length=200_000,
+        max_output_tokens=100_000,
+        input_cost_per_million=2.0,
+        cached_cost_per_million=0.50,
+        output_cost_per_million=8.0,
+        allows_streaming=True,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        has_tools=False,
+        description="O1 Reasoning LM",
+    ),
+    OpenAIChatModel.O1_MINI.value: ModelInfo(
+        name=OpenAIChatModel.O1_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=65_536,
+        input_cost_per_million=1.1,
+        cached_cost_per_million=0.55,
+        output_cost_per_million=4.4,
+        allows_streaming=False,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature", "stream"],
+        has_tools=False,
+        description="O1 Mini Reasoning LM",
+    ),
+    OpenAIChatModel.O3_MINI.value: ModelInfo(
+        name=OpenAIChatModel.O3_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=200_000,
+        max_output_tokens=100_000,
+        input_cost_per_million=1.1,
+        cached_cost_per_million=0.55,
+        output_cost_per_million=4.4,
+        allows_streaming=False,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature", "stream"],
+        has_tools=False,
+        description="O3 Mini Reasoning LM",
+    ),
+    OpenAIChatModel.O4_MINI.value: ModelInfo(
+        name=OpenAIChatModel.O4_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=200_000,
+        max_output_tokens=100_000,
+        input_cost_per_million=1.10,
+        cached_cost_per_million=0.275,
+        output_cost_per_million=4.40,
+        allows_streaming=False,
+        allows_system_message=False,
+        has_structured_output=True,
+        unsupported_params=["temperature", "stream"],
+        has_tools=False,
+        description="O3 Mini Reasoning LM",
+    ),
+    OpenAIChatModel.GPT5.value: ModelInfo(
+        name=OpenAIChatModel.GPT5.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.125,
+        output_cost_per_million=10.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5",
+    ),
+    OpenAIChatModel.GPT5_MINI.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=0.25,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=2.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5 Mini",
+    ),
+    OpenAIChatModel.GPT5_NANO.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_NANO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=0.05,
+        cached_cost_per_million=0.005,
+        output_cost_per_million=0.40,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5 Nano",
+    ),
+    OpenAIChatModel.GPT5_PRO.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_PRO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=272_000,
+        input_cost_per_million=15.00,
+        cached_cost_per_million=7.50,
+        output_cost_per_million=120.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5 Pro",
+    ),
+    OpenAIChatModel.GPT5_1.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_1.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.13,
+        output_cost_per_million=10.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.1",
+    ),
+    OpenAIChatModel.GPT5_1_CODEX.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_1_CODEX.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.125,
+        output_cost_per_million=10.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.1 Codex",
+    ),
+    OpenAIChatModel.GPT5_1_CODEX_MINI.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_1_CODEX_MINI.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=0.25,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=2.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.1 Codex Mini",
+    ),
+    OpenAIChatModel.GPT5_1_CHAT.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_1_CHAT.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.125,
+        output_cost_per_million=10.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.1 Chat",
+    ),
+    OpenAIChatModel.GPT5_2.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_2.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=128_000,
+        input_cost_per_million=1.75,
+        cached_cost_per_million=0.175,
+        output_cost_per_million=14.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.2",
+    ),
+    OpenAIChatModel.GPT5_2_PRO.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_2_PRO.value,
+        provider=ModelProvider.OPENAI,
+        context_length=400_000,
+        max_output_tokens=272_000,
+        input_cost_per_million=15.00,
+        cached_cost_per_million=7.50,
+        output_cost_per_million=120.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.2 Pro",
+    ),
+    OpenAIChatModel.GPT5_2_CHAT.value: ModelInfo(
+        name=OpenAIChatModel.GPT5_2_CHAT.value,
+        provider=ModelProvider.OPENAI,
+        context_length=128_000,
+        max_output_tokens=16_384,
+        input_cost_per_million=1.75,
+        cached_cost_per_million=0.175,
+        output_cost_per_million=14.00,
+        has_structured_output=True,
+        unsupported_params=["temperature"],
+        description="GPT-5.2 Chat",
+    ),
+    OpenAIChatModel.GPT_OSS_120b.value: ModelInfo(
+        name=OpenAIChatModel.GPT_OSS_120b.value,
+        provider=ModelProvider.OPENAI,
+        context_length=131_072,
+        max_output_tokens=65_535,
+        input_cost_per_million=0.15,
+        cached_cost_per_million=0.075,
+        output_cost_per_million=0.60,
+        has_structured_output=True,
+        description="GPT OSS 120B",
+    ),
+    OpenAIChatModel.GPT_OSS_20b.value: ModelInfo(
+        name=OpenAIChatModel.GPT_OSS_20b.value,
+        provider=ModelProvider.OPENAI,
+        context_length=131_072,
+        max_output_tokens=65_535,
+        input_cost_per_million=0.075,
+        cached_cost_per_million=0.037,
+        output_cost_per_million=0.30,
+        has_structured_output=True,
+        description="GPT OSS 20B",
+    ),
+    # Anthropic Models
+    AnthropicModel.CLAUDE_3_5_SONNET.value: ModelInfo(
+        name=AnthropicModel.CLAUDE_3_5_SONNET.value,
+        provider=ModelProvider.ANTHROPIC,
+        context_length=200_000,
+        max_output_tokens=8192,
+        input_cost_per_million=3.0,
+        cached_cost_per_million=0.30,
+        output_cost_per_million=15.0,
+        description="Claude 3.5 Sonnet",
+    ),
+    AnthropicModel.CLAUDE_3_OPUS.value: ModelInfo(
+        name=AnthropicModel.CLAUDE_3_OPUS.value,
+        provider=ModelProvider.ANTHROPIC,
+        context_length=200_000,
+        max_output_tokens=4096,
+        input_cost_per_million=15.0,
+        cached_cost_per_million=1.50,
+        output_cost_per_million=75.0,
+        description="Claude 3 Opus",
+    ),
+    AnthropicModel.CLAUDE_3_SONNET.value: ModelInfo(
+        name=AnthropicModel.CLAUDE_3_SONNET.value,
+        provider=ModelProvider.ANTHROPIC,
+        context_length=200_000,
+        max_output_tokens=4096,
+        input_cost_per_million=3.0,
+        cached_cost_per_million=0.30,
+        output_cost_per_million=15.0,
+        description="Claude 3 Sonnet",
+    ),
+    AnthropicModel.CLAUDE_3_HAIKU.value: ModelInfo(
+        name=AnthropicModel.CLAUDE_3_HAIKU.value,
+        provider=ModelProvider.ANTHROPIC,
+        context_length=200_000,
+        max_output_tokens=4096,
+        input_cost_per_million=0.25,
+        cached_cost_per_million=0.03,
+        output_cost_per_million=1.25,
+        description="Claude 3 Haiku",
+    ),
+    # DeepSeek Models
+    DeepSeekModel.DEEPSEEK.value: ModelInfo(
+        name=DeepSeekModel.DEEPSEEK.value,
+        provider=ModelProvider.DEEPSEEK,
+        context_length=64_000,
+        max_output_tokens=8_000,
+        input_cost_per_million=0.27,
+        cached_cost_per_million=0.07,
+        output_cost_per_million=1.10,
+        description="DeepSeek Chat",
+    ),
+    DeepSeekModel.DEEPSEEK_R1.value: ModelInfo(
+        name=DeepSeekModel.DEEPSEEK_R1.value,
+        provider=ModelProvider.DEEPSEEK,
+        context_length=64_000,
+        max_output_tokens=8_000,
+        input_cost_per_million=0.55,
+        cached_cost_per_million=0.14,
+        output_cost_per_million=2.19,
+        description="DeepSeek-R1 Reasoning LM",
+    ),
+    # Gemini Models
+    GeminiModel.GEMINI_2_FLASH.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_FLASH.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_056_768,
+        max_output_tokens=8192,
+        input_cost_per_million=0.10,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=0.40,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.0 Flash",
+    ),
+    GeminiModel.GEMINI_2_FLASH_LITE.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_FLASH_LITE.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_056_768,
+        max_output_tokens=8192,
+        input_cost_per_million=0.075,
+        output_cost_per_million=0.30,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.0 Flash Lite",
+    ),
+    GeminiModel.GEMINI_1_5_FLASH.value: ModelInfo(
+        name=GeminiModel.GEMINI_1_5_FLASH.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_056_768,
+        max_output_tokens=8192,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 1.5 Flash",
+    ),
+    GeminiModel.GEMINI_1_5_FLASH_8B.value: ModelInfo(
+        name=GeminiModel.GEMINI_1_5_FLASH_8B.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_000_000,
+        max_output_tokens=8192,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 1.5 Flash 8B",
+    ),
+    GeminiModel.GEMINI_1_5_PRO.value: ModelInfo(
+        name=GeminiModel.GEMINI_1_5_PRO.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=2_000_000,
+        max_output_tokens=8192,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 1.5 Pro",
+    ),
+    GeminiModel.GEMINI_2_PRO.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_PRO.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=2_000_000,
+        max_output_tokens=8192,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2 Pro Exp 02-05",
+    ),
+    GeminiModel.GEMINI_2_FLASH_THINKING.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_FLASH_THINKING.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_000_000,
+        max_output_tokens=64_000,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.0 Flash Thinking",
+    ),
+    # Gemini 2.5 Models
+    GeminiModel.GEMINI_2_5_PRO.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_5_PRO.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_048_576,
+        max_output_tokens=65_536,
+        input_cost_per_million=1.25,
+        cached_cost_per_million=0.31,
+        output_cost_per_million=10.0,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.5 Pro",
+    ),
+    GeminiModel.GEMINI_2_5_FLASH.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_5_FLASH.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_048_576,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.30,
+        cached_cost_per_million=0.075,
+        output_cost_per_million=2.50,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.5 Flash",
+    ),
+    GeminiModel.GEMINI_2_5_FLASH_LITE.value: ModelInfo(
+        name=GeminiModel.GEMINI_2_5_FLASH_LITE.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=65_536,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.10,
+        cached_cost_per_million=0.025,
+        output_cost_per_million=0.40,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 2.5 Flash Lite",
+    ),
+    # Gemini 3 Models
+    GeminiModel.GEMINI_3_PRO.value: ModelInfo(
+        name=GeminiModel.GEMINI_3_PRO.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_000_000,
+        max_output_tokens=64_000,
+        input_cost_per_million=2.00,
+        cached_cost_per_million=0.20,
+        output_cost_per_million=12.00,
+        rename_params={"max_tokens": "max_completion_tokens"},
+        description="Gemini 3 Pro",
+    ),
+    GeminiModel.GEMINI_3_FLASH.value: ModelInfo(
+        name=GeminiModel.GEMINI_3_FLASH.value,
+        provider=ModelProvider.GOOGLE,
+        context_length=1_048_576,
+        max_output_tokens=65_535,
+        input_cost_per_million=0.50,
+        cached_cost_per_million=0.05,
+        output_cost_per_million=3.00,
+        description="Gemini 3 Flash",
+    ),
+    # MiniMax Models
+    MiniMaxModel.MINIMAX_M2_7.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_7.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=131_072,
+        input_cost_per_million=0.30,
+        output_cost_per_million=1.20,
+        has_structured_output=True,
+        description="MiniMax M2.7 (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=131_072,
+        input_cost_per_million=0.15,
+        output_cost_per_million=0.60,
+        has_structured_output=True,
+        description="MiniMax M2.7 Highspeed (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_5.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_5.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.30,
+        output_cost_per_million=1.20,
+        has_structured_output=True,
+        description="MiniMax M2.5 (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.15,
+        output_cost_per_million=0.60,
+        has_structured_output=True,
+        description="MiniMax M2.5 Highspeed (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_1.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_1.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.27,
+        output_cost_per_million=0.95,
+        has_structured_output=True,
+        description="MiniMax M2.1 (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.14,
+        output_cost_per_million=0.48,
+        has_structured_output=True,
+        description="MiniMax M2.1 Highspeed (204K context)",
+    ),
+    MiniMaxModel.MINIMAX_M2.value: ModelInfo(
+        name=MiniMaxModel.MINIMAX_M2.value,
+        provider=ModelProvider.MINIMAX,
+        context_length=204_800,
+        max_output_tokens=65_536,
+        input_cost_per_million=0.27,
+        output_cost_per_million=0.95,
+        has_structured_output=True,
+        description="MiniMax M2 (204K context)",
+    ),
+}
+
+
+def get_model_info(
+    model: str | ModelName,
+    fallback_models: List[str] = [],
+) -> ModelInfo:
+    """Get model information by name or enum value"""
+    # Sequence of models to try, starting with the primary model
+    models_to_try = [model] + fallback_models
+
+    # Find the first model in the sequence that has info defined using next()
+    # on a generator expression that filters out None results from _get_model_info
+    found_info = next(
+        (info for m in models_to_try if (info := _get_model_info(m)) is not None),
+        None,  # Default value if the iterator is exhausted (no valid info found)
+    )
+
+    if found_info is not None:
+        return found_info
+
+    normalized_models = _normalize_model_names(models_to_try)
+    found_info = next(
+        (
+            info
+            for normalized_model in normalized_models
+            if (info := _get_model_info(normalized_model)) is not None
+        ),
+        None,
+    )
+    if found_info is not None:
+        return found_info
+
+    _warn_unknown_model(models_to_try)
+    return ModelInfo()
+
+
+def _get_model_info(model: str | ModelName) -> ModelInfo | None:
+    if isinstance(model, str):
+        return MODEL_INFO.get(model)
+    return MODEL_INFO.get(model.value)
+
+
+def _normalize_model_names(models: List[str | ModelName]) -> List[str]:
+    normalized_models: List[str] = []
+    seen: set[str] = set()
+    for model in models:
+        normalized_model = _normalize_gemini_model_name(_model_name(model))
+        if normalized_model is None or normalized_model in seen:
+            continue
+        seen.add(normalized_model)
+        normalized_models.append(normalized_model)
+    return normalized_models
+
+
+def _normalize_gemini_model_name(model: str) -> str | None:
+    base_model = model.rsplit("/", 1)[-1]
+    if base_model in GEMINI_CANONICAL_MODEL_NAMES:
+        return base_model
+    if not base_model.startswith("gemini-"):
+        return None
+
+    # Try stripping known suffixes to find a canonical name.
+    # Use split (not endswith) for "-preview" so dated variants like
+    # "gemini-2.5-flash-lite-preview-06-17" are handled correctly.
+    for suffix in ("-preview", "-exp", "-experimental", "-latest"):
+        stripped = base_model.split(suffix, maxsplit=1)[0]
+        if stripped != base_model and stripped in GEMINI_CANONICAL_MODEL_NAMES:
+            return stripped
+    return None
+
+
+def _warn_unknown_model(models: List[str | ModelName]) -> None:
+    model_names = tuple(_model_name(model) for model in models)
+    if model_names in WARNED_UNKNOWN_MODELS:
+        return
+
+    WARNED_UNKNOWN_MODELS.add(model_names)
+    logger.warning(
+        "Unknown model info for %s; using fallback defaults "
+        "(context_length=%s, max_output_tokens=%s). "
+        "Context-length checks may be inaccurate. "
+        "Set `chat_context_length` explicitly if needed.",
+        ", ".join(model_names),
+        DEFAULT_MODEL_INFO.context_length,
+        DEFAULT_MODEL_INFO.max_output_tokens,
+    )
+
+
+def _model_name(model: str | ModelName) -> str:
+    if isinstance(model, str):
+        return model
+    return model.value
+</file>
+
 <file path="langroid/agent/base.py">
 import asyncio
 import copy
@@ -121340,6 +123664,17 @@ class AgentConfig(BaseSettings):
     respond_tools_only: bool = False  # respond only to tool messages (not plain text)?
     # allow multiple tool messages in a single response?
     allow_multiple_tools: bool = True
+    # Optional pre-execution tool policy hook, called with the final parsed
+    # ToolMessage just BEFORE its selected handler runs, as
+    # ``tool_policy(tool, agent)`` -- or ``tool_policy(tool, agent, chat_doc=...)``
+    # when the callable has a ``chat_doc`` parameter. May be sync or async.
+    # Return True or None to ALLOW (the handler runs exactly once); return
+    # False or a str reason to REJECT (the handler is NOT run, and the LLM
+    # sees a rejection naming the tool and the reason). The hook cannot modify
+    # the tool. If the hook itself raises, the tool is blocked (fail-closed)
+    # and the rejection deliberately excludes the exception message and tool
+    # arguments. See docs/notes/tool-policy-hook.md.
+    tool_policy: Optional[Callable[..., Any]] = None
     human_prompt: str = (
         "Human (respond or q, x to exit current level, " "or hit enter to continue)"
     )
@@ -123019,7 +125354,7 @@ class Agent(ABC):
         results = self._get_multiple_orch_tool_errs(tools)
         if not results:
             results = [
-                await self.handle_tool_message_async(t, chat_doc=chat_doc)
+                await self._handle_tool_message_with_policy_async(t, chat_doc=chat_doc)
                 for t in tools
             ]
             # if there's a solitary ChatDocument|str result, return it as is
@@ -123087,7 +125422,10 @@ class Agent(ABC):
             results = self._get_multiple_orch_tool_errs(tools)
         if not results:
             chat_doc = msg if isinstance(msg, ChatDocument) else None
-            results = [self.handle_tool_message(t, chat_doc=chat_doc) for t in tools]
+            results = [
+                self._handle_tool_message_with_policy(t, chat_doc=chat_doc)
+                for t in tools
+            ]
             # if there's a solitary ChatDocument|str result, return it as is
             if len(results) == 1 and isinstance(results[0], (str, ChatDocument)):
                 return results[0]
@@ -123265,7 +125603,7 @@ class Agent(ABC):
                 #     msg in chat_doc.tool_messages):
                 #    chat_doc.tool_messages.remove(msg)
                 # if we can handle it, do so
-                result = self.handle_tool_message(msg, chat_doc=chat_doc)
+                result = self._handle_tool_message_with_policy(msg, chat_doc=chat_doc)
                 if result is not None and isinstance(result, ChatDocument):
                     return result
             else:
@@ -123370,6 +125708,88 @@ class Agent(ABC):
             ) + truncate_warning
             return result
 
+    def _handle_tool_message_with_policy(
+        self,
+        tool: ToolMessage,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> None | str | ChatDocument:
+        """Framework entry point for sync tool dispatch, enforcing `tool_policy`.
+
+        Consults the `tool_policy` hook (see `AgentConfig.tool_policy`) and,
+        if the tool is allowed, delegates to `handle_tool_message` -- which a
+        subclass may override -- exactly as before, so the policy gates tool
+        execution even through such overrides.
+
+        When dispatch is NOT overridden and the tool has no handler, the
+        policy is not consulted (nothing can execute). When dispatch IS
+        overridden, the base cannot know what the override will do, so the
+        policy is consulted regardless, even though the override may end up
+        returning None.
+
+        Args:
+            tool: ToolMessage object representing the tool request.
+            chat_doc: Optional ChatDocument object containing the tool request.
+
+        Returns:
+            The dispatch result, or the policy's LLM-visible rejection.
+        """
+        from langroid.agent.tool_policy import (
+            check_tool_policy,
+            dispatch_overridden,
+            handler_exists,
+            policy_exempt,
+        )
+
+        if self.config.tool_policy is not None and not policy_exempt(tool):
+            if not dispatch_overridden(self, use_async=False) and not handler_exists(
+                self, tool, use_async=False
+            ):
+                # base dispatch would execute nothing; don't consult the policy
+                return None
+            rejection = check_tool_policy(self.config.tool_policy, tool, self, chat_doc)
+            if rejection is not None:
+                return rejection
+        return self.handle_tool_message(tool, chat_doc=chat_doc)
+
+    async def _handle_tool_message_with_policy_async(
+        self,
+        tool: ToolMessage,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> None | str | ChatDocument:
+        """Async version of `_handle_tool_message_with_policy`.
+
+        The policy is awaited on the CALLER's event loop (so it can use
+        loop-bound resources), then dispatch proceeds via
+        `handle_tool_message_async` -- which a subclass may override --
+        exactly as before.
+
+        Args:
+            tool: ToolMessage object representing the tool request.
+            chat_doc: Optional ChatDocument object containing the tool request.
+
+        Returns:
+            The dispatch result, or the policy's LLM-visible rejection.
+        """
+        from langroid.agent.tool_policy import (
+            check_tool_policy_async,
+            dispatch_overridden,
+            handler_exists,
+            policy_exempt,
+        )
+
+        if self.config.tool_policy is not None and not policy_exempt(tool):
+            if not dispatch_overridden(self, use_async=True) and not handler_exists(
+                self, tool, use_async=True
+            ):
+                # base dispatch would execute nothing; don't consult the policy
+                return None
+            rejection = await check_tool_policy_async(
+                self.config.tool_policy, tool, self, chat_doc
+            )
+            if rejection is not None:
+                return rejection
+        return await self.handle_tool_message_async(tool, chat_doc=chat_doc)
+
     async def handle_tool_message_async(
         self,
         tool: ToolMessage,
@@ -123412,6 +125832,12 @@ class Agent(ABC):
     ) -> None | str | ChatDocument:
         """
         Respond to a tool request from the LLM, in the form of an ToolMessage object.
+
+        NOTE: framework dispatch reaches this method through
+        `_handle_tool_message_with_policy`, which enforces the optional
+        `tool_policy` hook BEFORE delegating here; direct calls to this
+        method by user code are the caller's own seam and are not gated.
+
         Args:
             tool: ToolMessage object representing the tool request.
             chat_doc: Optional ChatDocument object containing the tool request.
@@ -123610,1060 +126036,6 @@ class Agent(ABC):
         if answer != no_answer:
             return (f"{agent_type} says: " + str(answer)).strip()
         return None
-</file>
-
-<file path="langroid/language_models/model_info.py">
-import logging
-from enum import Enum
-from typing import Dict, List, Optional
-
-from pydantic import BaseModel
-
-logger = logging.getLogger(__name__)
-
-
-class ModelProvider(str, Enum):
-    """Enum for model providers"""
-
-    OPENAI = "openai"
-    ANTHROPIC = "anthropic"
-    DEEPSEEK = "deepseek"
-    GOOGLE = "google"
-    MINIMAX = "minimax"
-    UNKNOWN = "unknown"
-
-
-class ModelName(str, Enum):
-    """Parent class for all model name enums"""
-
-    pass
-
-
-class OpenAIChatModel(ModelName):
-    """Enum for OpenAI Chat models"""
-
-    GPT3_5_TURBO = "gpt-3.5-turbo"
-    GPT4 = "gpt-4o"  # avoid deprecated gpt-4
-    GPT4_TURBO = "gpt-4-turbo"
-    GPT4o = "gpt-4o"
-    GPT4o_MINI = "gpt-4o-mini"
-    O1 = "o1"
-    O1_MINI = "o1-mini"
-    O3_MINI = "o3-mini"
-    O3 = "o3"
-    O4_MINI = "o4-mini"
-    GPT4_1 = "gpt-4.1"
-    GPT4_1_MINI = "gpt-4.1-mini"
-    GPT4_1_NANO = "gpt-4.1-nano"
-    GPT5 = "gpt-5"
-    GPT5_MINI = "gpt-5-mini"
-    GPT5_NANO = "gpt-5-nano"
-    GPT5_PRO = "gpt-5-pro"
-    GPT5_1 = "gpt-5.1"
-    GPT5_1_CODEX = "gpt-5.1-codex"
-    GPT5_1_CODEX_MINI = "gpt-5.1-codex-mini"
-    GPT5_1_CHAT = "gpt-5.1-chat"
-    GPT5_2 = "gpt-5.2"
-    GPT5_2_PRO = "gpt-5.2-pro"
-    GPT5_2_CHAT = "gpt-5.2-chat"
-    GPT_OSS_120b = "gpt-oss-120b"
-    GPT_OSS_20b = "gpt-oss-20b"
-
-
-class OpenAICompletionModel(str, Enum):
-    """Enum for OpenAI Completion models"""
-
-    DAVINCI = "davinci-002"
-    BABBAGE = "babbage-002"
-
-
-class AnthropicModel(ModelName):
-    """Enum for Anthropic models"""
-
-    CLAUDE_3_OPUS = "claude-3-opus-latest"
-    CLAUDE_3_SONNET = "claude-3-sonnet-latest"
-    CLAUDE_3_HAIKU = "claude-3-haiku-latest"
-    CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest"
-    CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest"
-    CLAUDE_4_OPUS = "claude-opus-4"
-    CLAUDE_4_SONNET = "claude-sonnet-4"
-    CLAUDE_4_HAIKU = "claude-haiku-4"
-    CLAUDE_4_5_OPUS = "claude-opus-4-5"
-    CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
-    CLAUDE_4_5_HAIKU = "claude-haiku-4-5"
-
-
-class DeepSeekModel(ModelName):
-    """Enum for DeepSeek models direct from DeepSeek API"""
-
-    DEEPSEEK = "deepseek/deepseek-chat"
-    DEEPSEEK_R1 = "deepseek/deepseek-reasoner"
-    OPENROUTER_DEEPSEEK_R1 = "openrouter/deepseek/deepseek-r1"
-
-
-class GeminiModel(ModelName):
-    """Enum for Gemini models"""
-
-    GEMINI_1_5_FLASH = "gemini-1.5-flash"
-    GEMINI_1_5_FLASH_8B = "gemini-1.5-flash-8b"
-    GEMINI_1_5_PRO = "gemini-1.5-pro"
-    GEMINI_2_FLASH = "gemini-2.0-flash"
-    GEMINI_2_FLASH_LITE = "gemini-2.0-flash-lite"
-    GEMINI_2_FLASH_THINKING = "gemini-2.0-flash-thinking-exp"
-    GEMINI_2_PRO = "gemini-2.0-pro-exp-02-05"
-    GEMINI_2_5_FLASH = "gemini-2.5-flash"
-    GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
-    GEMINI_2_5_PRO = "gemini-2.5-pro"
-    GEMINI_3_FLASH = "gemini-3-flash"
-    GEMINI_3_PRO = "gemini-3-pro"
-
-
-class MiniMaxModel(ModelName):
-    """Enum for MiniMax models"""
-
-    MINIMAX_M2_7 = "MiniMax-M2.7"
-    MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
-    MINIMAX_M2_5 = "MiniMax-M2.5"
-    MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
-    MINIMAX_M2_1 = "MiniMax-M2.1"
-    MINIMAX_M2_1_HIGHSPEED = "MiniMax-M2.1-highspeed"
-    MINIMAX_M2 = "MiniMax-M2"
-
-
-class OpenAI_API_ParamInfo(BaseModel):
-    """
-    Parameters exclusive to some models, when using OpenAI API
-    """
-
-    # model-specific params at top level
-    params: Dict[str, List[str]] = dict(
-        reasoning_effort=[
-            OpenAIChatModel.O3_MINI.value,
-            OpenAIChatModel.O3.value,
-            OpenAIChatModel.O4_MINI.value,
-            OpenAIChatModel.GPT5.value,
-            OpenAIChatModel.GPT5_MINI.value,
-            OpenAIChatModel.GPT5_NANO.value,
-            OpenAIChatModel.GPT5_PRO.value,
-            OpenAIChatModel.GPT5_1.value,
-            OpenAIChatModel.GPT5_1_CODEX.value,
-            OpenAIChatModel.GPT5_1_CODEX_MINI.value,
-            OpenAIChatModel.GPT5_2.value,
-            OpenAIChatModel.GPT5_2_PRO.value,
-            OpenAIChatModel.GPT_OSS_120b.value,
-            OpenAIChatModel.GPT_OSS_20b.value,
-            GeminiModel.GEMINI_2_5_PRO.value,
-            GeminiModel.GEMINI_2_5_FLASH.value,
-            GeminiModel.GEMINI_2_5_FLASH_LITE.value,
-        ],
-    )
-    # model-specific params in extra_body
-    extra_parameters: Dict[str, List[str]] = dict(
-        include_reasoning=[
-            DeepSeekModel.OPENROUTER_DEEPSEEK_R1.value,
-        ]
-    )
-
-
-class ModelInfo(BaseModel):
-    """
-    Consolidated information about LLM, related to capacity, cost and API
-    idiosyncrasies. Reasonable defaults for all params in case there's no
-    specific info available.
-    """
-
-    name: str = "unknown"
-    provider: ModelProvider = ModelProvider.UNKNOWN
-    context_length: int = 16_000
-    max_cot_tokens: int = 0  # max chain of thought (thinking) tokens where applicable
-    max_output_tokens: int = 8192  # Maximum number of output tokens - model dependent
-    input_cost_per_million: float = 0.0  # Cost in USD per million input tokens
-    cached_cost_per_million: float = 0.0  # Cost in USD per million cached tokens
-    output_cost_per_million: float = 0.0  # Cost in USD per million output tokens
-    allows_streaming: bool = True  # Whether model supports streaming output
-    allows_system_message: bool = True  # Whether model supports system messages
-    rename_params: Dict[str, str] = {}  # Rename parameters for OpenAI API
-    unsupported_params: List[str] = []
-    has_structured_output: bool = False  # Does model API support structured output?
-    has_tools: bool = True  # Does model API support tools/function-calling?
-    needs_first_user_message: bool = False  # Does API need first msg to be from user?
-    description: Optional[str] = None
-
-
-GEMINI_CANONICAL_MODEL_NAMES = {model.value for model in GeminiModel}
-DEFAULT_MODEL_INFO = ModelInfo()
-WARNED_UNKNOWN_MODELS: set[tuple[str, ...]] = set()
-
-
-# Model information registry
-MODEL_INFO: Dict[str, ModelInfo] = {
-    # OpenAI Models
-    OpenAICompletionModel.DAVINCI.value: ModelInfo(
-        name=OpenAICompletionModel.DAVINCI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=4096,
-        max_output_tokens=4096,
-        input_cost_per_million=2.0,
-        output_cost_per_million=2.0,
-        description="Davinci-002",
-    ),
-    OpenAICompletionModel.BABBAGE.value: ModelInfo(
-        name=OpenAICompletionModel.BABBAGE.value,
-        provider=ModelProvider.OPENAI,
-        context_length=4096,
-        max_output_tokens=4096,
-        input_cost_per_million=0.40,
-        output_cost_per_million=0.40,
-        description="Babbage-002",
-    ),
-    OpenAIChatModel.GPT3_5_TURBO.value: ModelInfo(
-        name=OpenAIChatModel.GPT3_5_TURBO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=16_385,
-        max_output_tokens=4096,
-        input_cost_per_million=0.50,
-        output_cost_per_million=1.50,
-        description="GPT-3.5 Turbo",
-    ),
-    OpenAIChatModel.GPT4.value: ModelInfo(
-        name=OpenAIChatModel.GPT4.value,
-        provider=ModelProvider.OPENAI,
-        context_length=8192,
-        max_output_tokens=8192,
-        input_cost_per_million=30.0,
-        output_cost_per_million=60.0,
-        description="GPT-4 (8K context)",
-    ),
-    OpenAIChatModel.GPT4_TURBO.value: ModelInfo(
-        name=OpenAIChatModel.GPT4_TURBO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=4096,
-        input_cost_per_million=10.0,
-        output_cost_per_million=30.0,
-        description="GPT-4 Turbo",
-    ),
-    OpenAIChatModel.GPT4_1_NANO.value: ModelInfo(
-        name=OpenAIChatModel.GPT4_1_NANO.value,
-        provider=ModelProvider.OPENAI,
-        has_structured_output=True,
-        context_length=1_047_576,
-        max_output_tokens=32_768,
-        input_cost_per_million=0.10,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=0.40,
-        description="GPT-4.1",
-    ),
-    OpenAIChatModel.GPT4_1_MINI.value: ModelInfo(
-        name=OpenAIChatModel.GPT4_1_MINI.value,
-        provider=ModelProvider.OPENAI,
-        has_structured_output=True,
-        context_length=1_047_576,
-        max_output_tokens=32_768,
-        input_cost_per_million=0.40,
-        cached_cost_per_million=0.10,
-        output_cost_per_million=1.60,
-        description="GPT-4.1 Mini",
-    ),
-    OpenAIChatModel.GPT4_1.value: ModelInfo(
-        name=OpenAIChatModel.GPT4_1.value,
-        provider=ModelProvider.OPENAI,
-        has_structured_output=True,
-        context_length=1_047_576,
-        max_output_tokens=32_768,
-        input_cost_per_million=2.00,
-        cached_cost_per_million=0.50,
-        output_cost_per_million=8.00,
-        description="GPT-4.1",
-    ),
-    OpenAIChatModel.GPT4o.value: ModelInfo(
-        name=OpenAIChatModel.GPT4o.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=16_384,
-        input_cost_per_million=2.5,
-        cached_cost_per_million=1.25,
-        output_cost_per_million=10.0,
-        has_structured_output=True,
-        description="GPT-4o (128K context)",
-    ),
-    OpenAIChatModel.GPT4o_MINI.value: ModelInfo(
-        name=OpenAIChatModel.GPT4o_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=16_384,
-        input_cost_per_million=0.15,
-        cached_cost_per_million=0.075,
-        output_cost_per_million=0.60,
-        has_structured_output=True,
-        description="GPT-4o Mini",
-    ),
-    OpenAIChatModel.O1.value: ModelInfo(
-        name=OpenAIChatModel.O1.value,
-        provider=ModelProvider.OPENAI,
-        context_length=200_000,
-        max_output_tokens=100_000,
-        input_cost_per_million=15.0,
-        cached_cost_per_million=7.50,
-        output_cost_per_million=60.0,
-        allows_streaming=True,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        has_tools=False,
-        description="O1 Reasoning LM",
-    ),
-    OpenAIChatModel.O3.value: ModelInfo(
-        name=OpenAIChatModel.O3.value,
-        provider=ModelProvider.OPENAI,
-        context_length=200_000,
-        max_output_tokens=100_000,
-        input_cost_per_million=2.0,
-        cached_cost_per_million=0.50,
-        output_cost_per_million=8.0,
-        allows_streaming=True,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        has_tools=False,
-        description="O1 Reasoning LM",
-    ),
-    OpenAIChatModel.O1_MINI.value: ModelInfo(
-        name=OpenAIChatModel.O1_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=65_536,
-        input_cost_per_million=1.1,
-        cached_cost_per_million=0.55,
-        output_cost_per_million=4.4,
-        allows_streaming=False,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature", "stream"],
-        has_tools=False,
-        description="O1 Mini Reasoning LM",
-    ),
-    OpenAIChatModel.O3_MINI.value: ModelInfo(
-        name=OpenAIChatModel.O3_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=200_000,
-        max_output_tokens=100_000,
-        input_cost_per_million=1.1,
-        cached_cost_per_million=0.55,
-        output_cost_per_million=4.4,
-        allows_streaming=False,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature", "stream"],
-        has_tools=False,
-        description="O3 Mini Reasoning LM",
-    ),
-    OpenAIChatModel.O4_MINI.value: ModelInfo(
-        name=OpenAIChatModel.O4_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=200_000,
-        max_output_tokens=100_000,
-        input_cost_per_million=1.10,
-        cached_cost_per_million=0.275,
-        output_cost_per_million=4.40,
-        allows_streaming=False,
-        allows_system_message=False,
-        has_structured_output=True,
-        unsupported_params=["temperature", "stream"],
-        has_tools=False,
-        description="O3 Mini Reasoning LM",
-    ),
-    OpenAIChatModel.GPT5.value: ModelInfo(
-        name=OpenAIChatModel.GPT5.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.125,
-        output_cost_per_million=10.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5",
-    ),
-    OpenAIChatModel.GPT5_MINI.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=0.25,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=2.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5 Mini",
-    ),
-    OpenAIChatModel.GPT5_NANO.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_NANO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=0.05,
-        cached_cost_per_million=0.005,
-        output_cost_per_million=0.40,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5 Nano",
-    ),
-    OpenAIChatModel.GPT5_PRO.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_PRO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=272_000,
-        input_cost_per_million=15.00,
-        cached_cost_per_million=7.50,
-        output_cost_per_million=120.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5 Pro",
-    ),
-    OpenAIChatModel.GPT5_1.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_1.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.13,
-        output_cost_per_million=10.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.1",
-    ),
-    OpenAIChatModel.GPT5_1_CODEX.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_1_CODEX.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.125,
-        output_cost_per_million=10.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.1 Codex",
-    ),
-    OpenAIChatModel.GPT5_1_CODEX_MINI.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_1_CODEX_MINI.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=0.25,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=2.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.1 Codex Mini",
-    ),
-    OpenAIChatModel.GPT5_1_CHAT.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_1_CHAT.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=16_384,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.125,
-        output_cost_per_million=10.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.1 Chat",
-    ),
-    OpenAIChatModel.GPT5_2.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_2.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=128_000,
-        input_cost_per_million=1.75,
-        cached_cost_per_million=0.175,
-        output_cost_per_million=14.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.2",
-    ),
-    OpenAIChatModel.GPT5_2_PRO.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_2_PRO.value,
-        provider=ModelProvider.OPENAI,
-        context_length=400_000,
-        max_output_tokens=272_000,
-        input_cost_per_million=15.00,
-        cached_cost_per_million=7.50,
-        output_cost_per_million=120.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.2 Pro",
-    ),
-    OpenAIChatModel.GPT5_2_CHAT.value: ModelInfo(
-        name=OpenAIChatModel.GPT5_2_CHAT.value,
-        provider=ModelProvider.OPENAI,
-        context_length=128_000,
-        max_output_tokens=16_384,
-        input_cost_per_million=1.75,
-        cached_cost_per_million=0.175,
-        output_cost_per_million=14.00,
-        has_structured_output=True,
-        unsupported_params=["temperature"],
-        description="GPT-5.2 Chat",
-    ),
-    OpenAIChatModel.GPT_OSS_120b.value: ModelInfo(
-        name=OpenAIChatModel.GPT_OSS_120b.value,
-        provider=ModelProvider.OPENAI,
-        context_length=131_072,
-        max_output_tokens=65_535,
-        input_cost_per_million=0.15,
-        cached_cost_per_million=0.075,
-        output_cost_per_million=0.60,
-        has_structured_output=True,
-        description="GPT OSS 120B",
-    ),
-    OpenAIChatModel.GPT_OSS_20b.value: ModelInfo(
-        name=OpenAIChatModel.GPT_OSS_20b.value,
-        provider=ModelProvider.OPENAI,
-        context_length=131_072,
-        max_output_tokens=65_535,
-        input_cost_per_million=0.075,
-        cached_cost_per_million=0.037,
-        output_cost_per_million=0.30,
-        has_structured_output=True,
-        description="GPT OSS 20B",
-    ),
-    # Anthropic Models
-    AnthropicModel.CLAUDE_3_5_SONNET.value: ModelInfo(
-        name=AnthropicModel.CLAUDE_3_5_SONNET.value,
-        provider=ModelProvider.ANTHROPIC,
-        context_length=200_000,
-        max_output_tokens=8192,
-        input_cost_per_million=3.0,
-        cached_cost_per_million=0.30,
-        output_cost_per_million=15.0,
-        description="Claude 3.5 Sonnet",
-    ),
-    AnthropicModel.CLAUDE_3_OPUS.value: ModelInfo(
-        name=AnthropicModel.CLAUDE_3_OPUS.value,
-        provider=ModelProvider.ANTHROPIC,
-        context_length=200_000,
-        max_output_tokens=4096,
-        input_cost_per_million=15.0,
-        cached_cost_per_million=1.50,
-        output_cost_per_million=75.0,
-        description="Claude 3 Opus",
-    ),
-    AnthropicModel.CLAUDE_3_SONNET.value: ModelInfo(
-        name=AnthropicModel.CLAUDE_3_SONNET.value,
-        provider=ModelProvider.ANTHROPIC,
-        context_length=200_000,
-        max_output_tokens=4096,
-        input_cost_per_million=3.0,
-        cached_cost_per_million=0.30,
-        output_cost_per_million=15.0,
-        description="Claude 3 Sonnet",
-    ),
-    AnthropicModel.CLAUDE_3_HAIKU.value: ModelInfo(
-        name=AnthropicModel.CLAUDE_3_HAIKU.value,
-        provider=ModelProvider.ANTHROPIC,
-        context_length=200_000,
-        max_output_tokens=4096,
-        input_cost_per_million=0.25,
-        cached_cost_per_million=0.03,
-        output_cost_per_million=1.25,
-        description="Claude 3 Haiku",
-    ),
-    # DeepSeek Models
-    DeepSeekModel.DEEPSEEK.value: ModelInfo(
-        name=DeepSeekModel.DEEPSEEK.value,
-        provider=ModelProvider.DEEPSEEK,
-        context_length=64_000,
-        max_output_tokens=8_000,
-        input_cost_per_million=0.27,
-        cached_cost_per_million=0.07,
-        output_cost_per_million=1.10,
-        description="DeepSeek Chat",
-    ),
-    DeepSeekModel.DEEPSEEK_R1.value: ModelInfo(
-        name=DeepSeekModel.DEEPSEEK_R1.value,
-        provider=ModelProvider.DEEPSEEK,
-        context_length=64_000,
-        max_output_tokens=8_000,
-        input_cost_per_million=0.55,
-        cached_cost_per_million=0.14,
-        output_cost_per_million=2.19,
-        description="DeepSeek-R1 Reasoning LM",
-    ),
-    # Gemini Models
-    GeminiModel.GEMINI_2_FLASH.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_FLASH.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_056_768,
-        max_output_tokens=8192,
-        input_cost_per_million=0.10,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=0.40,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.0 Flash",
-    ),
-    GeminiModel.GEMINI_2_FLASH_LITE.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_FLASH_LITE.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_056_768,
-        max_output_tokens=8192,
-        input_cost_per_million=0.075,
-        output_cost_per_million=0.30,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.0 Flash Lite",
-    ),
-    GeminiModel.GEMINI_1_5_FLASH.value: ModelInfo(
-        name=GeminiModel.GEMINI_1_5_FLASH.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_056_768,
-        max_output_tokens=8192,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 1.5 Flash",
-    ),
-    GeminiModel.GEMINI_1_5_FLASH_8B.value: ModelInfo(
-        name=GeminiModel.GEMINI_1_5_FLASH_8B.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_000_000,
-        max_output_tokens=8192,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 1.5 Flash 8B",
-    ),
-    GeminiModel.GEMINI_1_5_PRO.value: ModelInfo(
-        name=GeminiModel.GEMINI_1_5_PRO.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=2_000_000,
-        max_output_tokens=8192,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 1.5 Pro",
-    ),
-    GeminiModel.GEMINI_2_PRO.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_PRO.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=2_000_000,
-        max_output_tokens=8192,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2 Pro Exp 02-05",
-    ),
-    GeminiModel.GEMINI_2_FLASH_THINKING.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_FLASH_THINKING.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_000_000,
-        max_output_tokens=64_000,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.0 Flash Thinking",
-    ),
-    # Gemini 2.5 Models
-    GeminiModel.GEMINI_2_5_PRO.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_5_PRO.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_048_576,
-        max_output_tokens=65_536,
-        input_cost_per_million=1.25,
-        cached_cost_per_million=0.31,
-        output_cost_per_million=10.0,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.5 Pro",
-    ),
-    GeminiModel.GEMINI_2_5_FLASH.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_5_FLASH.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_048_576,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.30,
-        cached_cost_per_million=0.075,
-        output_cost_per_million=2.50,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.5 Flash",
-    ),
-    GeminiModel.GEMINI_2_5_FLASH_LITE.value: ModelInfo(
-        name=GeminiModel.GEMINI_2_5_FLASH_LITE.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=65_536,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.10,
-        cached_cost_per_million=0.025,
-        output_cost_per_million=0.40,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 2.5 Flash Lite",
-    ),
-    # Gemini 3 Models
-    GeminiModel.GEMINI_3_PRO.value: ModelInfo(
-        name=GeminiModel.GEMINI_3_PRO.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_000_000,
-        max_output_tokens=64_000,
-        input_cost_per_million=2.00,
-        cached_cost_per_million=0.20,
-        output_cost_per_million=12.00,
-        rename_params={"max_tokens": "max_completion_tokens"},
-        description="Gemini 3 Pro",
-    ),
-    GeminiModel.GEMINI_3_FLASH.value: ModelInfo(
-        name=GeminiModel.GEMINI_3_FLASH.value,
-        provider=ModelProvider.GOOGLE,
-        context_length=1_048_576,
-        max_output_tokens=65_535,
-        input_cost_per_million=0.50,
-        cached_cost_per_million=0.05,
-        output_cost_per_million=3.00,
-        description="Gemini 3 Flash",
-    ),
-    # MiniMax Models
-    MiniMaxModel.MINIMAX_M2_7.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_7.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=131_072,
-        input_cost_per_million=0.30,
-        output_cost_per_million=1.20,
-        has_structured_output=True,
-        description="MiniMax M2.7 (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_7_HIGHSPEED.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=131_072,
-        input_cost_per_million=0.15,
-        output_cost_per_million=0.60,
-        has_structured_output=True,
-        description="MiniMax M2.7 Highspeed (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_5.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_5.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.30,
-        output_cost_per_million=1.20,
-        has_structured_output=True,
-        description="MiniMax M2.5 (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_5_HIGHSPEED.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.15,
-        output_cost_per_million=0.60,
-        has_structured_output=True,
-        description="MiniMax M2.5 Highspeed (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_1.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_1.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.27,
-        output_cost_per_million=0.95,
-        has_structured_output=True,
-        description="MiniMax M2.1 (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2_1_HIGHSPEED.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.14,
-        output_cost_per_million=0.48,
-        has_structured_output=True,
-        description="MiniMax M2.1 Highspeed (204K context)",
-    ),
-    MiniMaxModel.MINIMAX_M2.value: ModelInfo(
-        name=MiniMaxModel.MINIMAX_M2.value,
-        provider=ModelProvider.MINIMAX,
-        context_length=204_800,
-        max_output_tokens=65_536,
-        input_cost_per_million=0.27,
-        output_cost_per_million=0.95,
-        has_structured_output=True,
-        description="MiniMax M2 (204K context)",
-    ),
-}
-
-
-def get_model_info(
-    model: str | ModelName,
-    fallback_models: List[str] = [],
-) -> ModelInfo:
-    """Get model information by name or enum value"""
-    # Sequence of models to try, starting with the primary model
-    models_to_try = [model] + fallback_models
-
-    # Find the first model in the sequence that has info defined using next()
-    # on a generator expression that filters out None results from _get_model_info
-    found_info = next(
-        (info for m in models_to_try if (info := _get_model_info(m)) is not None),
-        None,  # Default value if the iterator is exhausted (no valid info found)
-    )
-
-    if found_info is not None:
-        return found_info
-
-    normalized_models = _normalize_model_names(models_to_try)
-    found_info = next(
-        (
-            info
-            for normalized_model in normalized_models
-            if (info := _get_model_info(normalized_model)) is not None
-        ),
-        None,
-    )
-    if found_info is not None:
-        return found_info
-
-    _warn_unknown_model(models_to_try)
-    return ModelInfo()
-
-
-def _get_model_info(model: str | ModelName) -> ModelInfo | None:
-    if isinstance(model, str):
-        return MODEL_INFO.get(model)
-    return MODEL_INFO.get(model.value)
-
-
-def _normalize_model_names(models: List[str | ModelName]) -> List[str]:
-    normalized_models: List[str] = []
-    seen: set[str] = set()
-    for model in models:
-        normalized_model = _normalize_gemini_model_name(_model_name(model))
-        if normalized_model is None or normalized_model in seen:
-            continue
-        seen.add(normalized_model)
-        normalized_models.append(normalized_model)
-    return normalized_models
-
-
-def _normalize_gemini_model_name(model: str) -> str | None:
-    base_model = model.rsplit("/", 1)[-1]
-    if base_model in GEMINI_CANONICAL_MODEL_NAMES:
-        return base_model
-    if not base_model.startswith("gemini-"):
-        return None
-
-    # Try stripping known suffixes to find a canonical name.
-    # Use split (not endswith) for "-preview" so dated variants like
-    # "gemini-2.5-flash-lite-preview-06-17" are handled correctly.
-    for suffix in ("-preview", "-exp", "-experimental", "-latest"):
-        stripped = base_model.split(suffix, maxsplit=1)[0]
-        if stripped != base_model and stripped in GEMINI_CANONICAL_MODEL_NAMES:
-            return stripped
-    return None
-
-
-def _warn_unknown_model(models: List[str | ModelName]) -> None:
-    model_names = tuple(_model_name(model) for model in models)
-    if model_names in WARNED_UNKNOWN_MODELS:
-        return
-
-    WARNED_UNKNOWN_MODELS.add(model_names)
-    logger.warning(
-        "Unknown model info for %s; using fallback defaults "
-        "(context_length=%s, max_output_tokens=%s). "
-        "Context-length checks may be inaccurate. "
-        "Set `chat_context_length` explicitly if needed.",
-        ", ".join(model_names),
-        DEFAULT_MODEL_INFO.context_length,
-        DEFAULT_MODEL_INFO.max_output_tokens,
-    )
-
-
-def _model_name(model: str | ModelName) -> str:
-    if isinstance(model, str):
-        return model
-    return model.value
-</file>
-
-<file path="mkdocs.yml">
-site_name: "langroid"
-repo_name: langroid/langroid
-site_description: "Langroid LLM App Development Framework"
-repo_url: https://github.com/langroid/langroid
-site_url: https://langroid.github.io/langroid
-
-edit_uri: ""
-extra_css:
-  - stylesheets/extra.css
-
-theme:
-  logo: assets/orange-logo-lambda-563.png
-  favicon: assets/orange-logo-lambda-563.png
-  features:
-    - navigation.tabs
-#    - navigation.tracking
-#    - navigation.sections
-#    - navigation.indexes
-    - toc
-    - content.code.copy
-    - content.code.select
-    - content.code.annotate
-  icon:
-      repo: fontawesome/brands/github
-  name: material
-  custom_dir: docs/overrides
-  palette:
-    # Palette toggle for light mode
-    - scheme: default
-      primary: indigo
-      accent: indigo
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
-
-    # Palette toggle for dark mode
-    - scheme: slate
-      primary: indigo
-      accent: indigo
-      toggle:
-        icon: material/brightness-4
-        name: Switch to light mode
-
-plugins:
-  - blog:
-      archive: false
-      blog_toc: true
-      categories: false
-      blog_dir: blog
-
-  - rss:
-      enabled: true
-      match_path: blog/posts/.*
-      image: https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Feed-icon.svg/128px-Feed-icon.svg.png
-      date_from_meta:
-        as_creation: date
-      categories:
-        - categories
-        - tags
-  - search
-  - autorefs
-  #- awesome-pages
-  - gen-files:
-      scripts:
-      - docs/auto_docstring.py
-      #- docs/gen_ref_pages.py
-  - literate-nav:
-      nav_file: SUMMARY.md
-  - mkdocstrings:
-      default_handler: python
-      handlers:
-        python:
-          paths: [.]
-          options:
-            members_order: source
-            separate_signature: false
-            filters: ["!^_"]
-            docstring_options:
-              ignore_init_summary: true
-            merge_init_into_class: true
-  - section-index
-
-watch:
-  - langroid
-
-nav:
-  - Home: index.md
-  - Blog: blog/index.md
-  - Getting Started:
-    - quick-start/index.md
-    - Setup: quick-start/setup.md
-    - LLM interaction: quick-start/llm-interaction.md
-    - Simple Chat Agent: quick-start/chat-agent.md
-    - Task Delegation: quick-start/multi-agent-task-delegation.md
-    - Two Agent Chat: quick-start/two-agent-chat-num.md
-    - Three Agent Chat: quick-start/three-agent-chat-num.md
-    - Agent with Tools/Functions: quick-start/chat-agent-tool.md
-    - Three Agents, with Routing: quick-start/three-agent-chat-num-router.md
-    - Agent with Retrieval: quick-start/chat-agent-docs.md
-  # defer to gen-files + literate-nav
-  - FAQ: FAQ.md
-  - Notes-Updates:
-      - Overview: notes/overview.md
-      - XML-based Tools: notes/xml-tools.md
-      - Async Streaming: notes/async-streaming.md
-      - Knowledge Graphs: notes/knowledge-graphs.md
-      - Gemini LLMs, Embeddings, Vertex AI: notes/gemini.md
-      - LLM-based Pdf Parsing: notes/llm-pdf-parser.md
-      - Large Tool Results: notes/large-tool-results.md
-      - GLHF.chat Support: notes/glhf-chat.md
-      - Structured Output: notes/structured-output.md
-      - Tool Handlers: notes/tool-message-handler.md
-      - Task Termination: notes/task-termination.md
-      - Message Routing: notes/message-routing.md
-      - Llama.cpp Embeddings: notes/llama-cpp-embeddings.md
-      - Azure OpenAI models: notes/azure-openai-models.md
-      - Custom Azure OpenAI client: notes/custom-azure-client.md
-      - Enriching Chunks for Retrieval: notes/enriching-for-retrieval.md
-      - Reasoning Content: notes/reasoning-content.md
-      - None Content in LLM Messages: notes/llm-none-content.md
-      - Weaviate: notes/weaviate.md
-      - Handling LLM Non-Tool Messages: notes/handle-llm-no-tool.md
-      - PGVector: notes/pgvector.md
-      - Pinecone: notes/pinecone.md
-      - Tavily Search Tool: notes/tavily_search.md
-      - Seltz Search Tool: notes/seltz_search.md
-      - Twitter Search via Xquik MCP: notes/twitter-search.md
-      - Marker Pdf Parser: notes/marker-pdf.md
-      - URLLoader : notes/url_loader.md
-      - Crawl4AI Crawler: notes/crawl4ai.md
-      - LangDB AI Gateway: notes/langdb.md
-      - Portkey AI Gateway: notes/portkey.md
-      - Markitdown Parsers: notes/markitdown.md
-      - LiteLLM Proxy: notes/litellm-proxy.md
-      - Chunking: notes/chunking.md
-      - Image, PDF Input: notes/file-input.md
-      - MCP Tools: notes/mcp-tools.md
-      - Code-Injection Protection: notes/code-injection-protection.md
-      - TaskTool: notes/task-tool.md
-      - Local Qdrant VectorDB Cleanup: notes/qdrant-resource-cleanup.md
-      - OpenAI HTTP Client Configuration: notes/openai-http-client.md
-      - OpenAI Client Caching: notes/openai-client-caching.md
-      - Rotating API Keys: notes/rotating-api-keys.md
-      - Cross-Encoder Reranking: notes/cross-encoder.md
-      - Task Logs: notes/html-logger.md
-      - Pydantic v2 Migration: notes/pydantic-v2-migration.md
-      - Batch Processing: notes/batch-processing.md
-
-  - Examples:
-    - Guide: examples/guide.md
-    - Hierarchical Agent Computation: examples/agent-tree.md
-    - Demos:
-      - Audience Targeting: demos/targeting/audience-targeting.md
-  - Tutorials:
-    - Langroid Tour: tutorials/langroid-tour.md
-    - Supported LLMs: tutorials/supported-models.md
-    - Local LLM Setup: tutorials/local-llm-setup.md
-    - Non-OpenAI LLMs: tutorials/non-openai-llms.md
-    - SQLChatAgent: tutorials/postgresql-agent.md
-    - LLM Usage Options: tutorials/llm-usage-options.md
-  - Code/API Docs: reference/
-#  - API Documentation:
-#    - language_models: api/language_models_base.md
-
-
-markdown_extensions:
-  - footnotes
-  - toc:
-      permalink: true
-  - attr_list
-  - md_in_html
-  - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
-  - admonition
-  - pymdownx.details
-  - pymdownx.superfences
-  - pymdownx.highlight:
-      anchor_linenums: true
-      line_spans: __span
-      pygments_lang_class: true
-      use_pygments: true
-  - pymdownx.inlinehilite
-  - pymdownx.snippets
-  - pymdownx.arithmatex:
-      generic: true
-  - markdown.extensions.attr_list:
-extra_javascript:
-  - javascripts/mathjax.js
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 </file>
 
 <file path="tests/main/test_prep_llm_message.py">
@@ -125662,9 +127034,203 @@ def test_prep_drops_empty_result_with_malformed_identifier(
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.16.0
+  rev: v0.16.4
   hooks:
     - id: ruff
+</file>
+
+<file path="mkdocs.yml">
+site_name: "langroid"
+repo_name: langroid/langroid
+site_description: "Langroid LLM App Development Framework"
+repo_url: https://github.com/langroid/langroid
+site_url: https://langroid.github.io/langroid
+
+edit_uri: ""
+extra_css:
+  - stylesheets/extra.css
+
+theme:
+  logo: assets/orange-logo-lambda-563.png
+  favicon: assets/orange-logo-lambda-563.png
+  features:
+    - navigation.tabs
+#    - navigation.tracking
+#    - navigation.sections
+#    - navigation.indexes
+    - toc
+    - content.code.copy
+    - content.code.select
+    - content.code.annotate
+  icon:
+      repo: fontawesome/brands/github
+  name: material
+  custom_dir: docs/overrides
+  palette:
+    # Palette toggle for light mode
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+plugins:
+  - blog:
+      archive: false
+      blog_toc: true
+      categories: false
+      blog_dir: blog
+
+  - rss:
+      enabled: true
+      match_path: blog/posts/.*
+      image: https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Feed-icon.svg/128px-Feed-icon.svg.png
+      date_from_meta:
+        as_creation: date
+      categories:
+        - categories
+        - tags
+  - search
+  - autorefs
+  #- awesome-pages
+  - gen-files:
+      scripts:
+      - docs/auto_docstring.py
+      #- docs/gen_ref_pages.py
+  - literate-nav:
+      nav_file: SUMMARY.md
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [.]
+          options:
+            members_order: source
+            separate_signature: false
+            filters: ["!^_"]
+            docstring_options:
+              ignore_init_summary: true
+            merge_init_into_class: true
+  - section-index
+
+watch:
+  - langroid
+
+nav:
+  - Home: index.md
+  - Blog: blog/index.md
+  - Getting Started:
+    - quick-start/index.md
+    - Setup: quick-start/setup.md
+    - LLM interaction: quick-start/llm-interaction.md
+    - Simple Chat Agent: quick-start/chat-agent.md
+    - Task Delegation: quick-start/multi-agent-task-delegation.md
+    - Two Agent Chat: quick-start/two-agent-chat-num.md
+    - Three Agent Chat: quick-start/three-agent-chat-num.md
+    - Agent with Tools/Functions: quick-start/chat-agent-tool.md
+    - Three Agents, with Routing: quick-start/three-agent-chat-num-router.md
+    - Agent with Retrieval: quick-start/chat-agent-docs.md
+  # defer to gen-files + literate-nav
+  - FAQ: FAQ.md
+  - Notes-Updates:
+      - Overview: notes/overview.md
+      - XML-based Tools: notes/xml-tools.md
+      - Async Streaming: notes/async-streaming.md
+      - Knowledge Graphs: notes/knowledge-graphs.md
+      - Gemini LLMs, Embeddings, Vertex AI: notes/gemini.md
+      - LLM-based Pdf Parsing: notes/llm-pdf-parser.md
+      - Large Tool Results: notes/large-tool-results.md
+      - GLHF.chat Support: notes/glhf-chat.md
+      - Structured Output: notes/structured-output.md
+      - Tool Handlers: notes/tool-message-handler.md
+      - Task Termination: notes/task-termination.md
+      - Message Routing: notes/message-routing.md
+      - Llama.cpp Embeddings: notes/llama-cpp-embeddings.md
+      - Azure OpenAI models: notes/azure-openai-models.md
+      - Custom Azure OpenAI client: notes/custom-azure-client.md
+      - Enriching Chunks for Retrieval: notes/enriching-for-retrieval.md
+      - Reasoning Content: notes/reasoning-content.md
+      - None Content in LLM Messages: notes/llm-none-content.md
+      - Weaviate: notes/weaviate.md
+      - Handling LLM Non-Tool Messages: notes/handle-llm-no-tool.md
+      - Tool Policy Hook: notes/tool-policy-hook.md
+      - PGVector: notes/pgvector.md
+      - Pinecone: notes/pinecone.md
+      - Tavily Search Tool: notes/tavily_search.md
+      - Seltz Search Tool: notes/seltz_search.md
+      - Twitter Search via Xquik MCP: notes/twitter-search.md
+      - Marker Pdf Parser: notes/marker-pdf.md
+      - URLLoader : notes/url_loader.md
+      - Crawl4AI Crawler: notes/crawl4ai.md
+      - LangDB AI Gateway: notes/langdb.md
+      - Portkey AI Gateway: notes/portkey.md
+      - Markitdown Parsers: notes/markitdown.md
+      - LiteLLM Proxy: notes/litellm-proxy.md
+      - Chunking: notes/chunking.md
+      - Image, PDF Input: notes/file-input.md
+      - MCP Tools: notes/mcp-tools.md
+      - Code-Injection Protection: notes/code-injection-protection.md
+      - TaskTool: notes/task-tool.md
+      - Local Qdrant VectorDB Cleanup: notes/qdrant-resource-cleanup.md
+      - OpenAI HTTP Client Configuration: notes/openai-http-client.md
+      - OpenAI Client Caching: notes/openai-client-caching.md
+      - Rotating API Keys: notes/rotating-api-keys.md
+      - Cross-Encoder Reranking: notes/cross-encoder.md
+      - Task Logs: notes/html-logger.md
+      - Pydantic v2 Migration: notes/pydantic-v2-migration.md
+      - Batch Processing: notes/batch-processing.md
+
+  - Examples:
+    - Guide: examples/guide.md
+    - Hierarchical Agent Computation: examples/agent-tree.md
+    - Demos:
+      - Audience Targeting: demos/targeting/audience-targeting.md
+  - Tutorials:
+    - Langroid Tour: tutorials/langroid-tour.md
+    - Supported LLMs: tutorials/supported-models.md
+    - Local LLM Setup: tutorials/local-llm-setup.md
+    - Non-OpenAI LLMs: tutorials/non-openai-llms.md
+    - SQLChatAgent: tutorials/postgresql-agent.md
+    - LLM Usage Options: tutorials/llm-usage-options.md
+  - Code/API Docs: reference/
+#  - API Documentation:
+#    - language_models: api/language_models_base.md
+
+
+markdown_extensions:
+  - footnotes
+  - toc:
+      permalink: true
+  - attr_list
+  - md_in_html
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+      use_pygments: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.arithmatex:
+      generic: true
+  - markdown.extensions.attr_list:
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 </file>
 
 <file path="langroid/language_models/openai_gpt.py">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,7 @@ nav:
       - None Content in LLM Messages: notes/llm-none-content.md
       - Weaviate: notes/weaviate.md
       - Handling LLM Non-Tool Messages: notes/handle-llm-no-tool.md
+      - Tool Policy Hook: notes/tool-policy-hook.md
       - PGVector: notes/pgvector.md
       - Pinecone: notes/pinecone.md
       - Tavily Search Tool: notes/tavily_search.md

--- a/tests/main/test_tool_policy_hook.py
+++ b/tests/main/test_tool_policy_hook.py
@@ -1,0 +1,858 @@
+"""
+Tests for the pre-execution tool policy hook (`AgentConfig.tool_policy`),
+issue #1095.
+
+Contract:
+
+1. No hook configured => tool dispatch behaves exactly as before (sync + async).
+2. Hook allows (returns True or None) => the selected handler runs exactly once.
+3. Hook denies (returns False or a str reason) => the handler runs zero times,
+   and an LLM-visible rejection (tool name + reason) is produced.
+4. The hook receives the final parsed ToolMessage (identity + payload) plus
+   bounded context (the agent, and the chat_doc when available), BEFORE
+   execution.
+5. Hook failure (exception) => fail-closed rejection; raw tool arguments do
+   NOT leak into the rejection message.
+6. Composes with (does not weaken) the USER-origin tool security filter.
+
+The hook must work on both sync and async dispatch paths, with both sync and
+async callables. It cannot mutate what the handler executes, it is consulted
+only when a real handler is selected, and it is shared by reference across
+agent clones.
+"""
+
+import asyncio
+import logging
+import threading
+from collections import OrderedDict
+from typing import Any, List, Optional, Tuple, Type, Union
+
+import pytest
+
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.agent.chat_document import ChatDocument
+from langroid.agent.task import Task
+from langroid.agent.tool_message import ToolMessage
+from langroid.language_models.mock_lm import MockLMConfig
+from langroid.mytypes import Entity
+
+HandleResult = Union[None, str, OrderedDict[str, str], ChatDocument]
+
+
+class SquareTool(ToolMessage):
+    request: str = "square"
+    purpose: str = "To compute the square of a number <x>"
+    x: int
+
+
+class NoHandlerTool(ToolMessage):
+    request: str = "orphan_tool"
+    purpose: str = "A tool with no handler anywhere"
+    y: int
+
+
+class CountingAgent(ChatAgent):
+    """Agent with a sync handler for SquareTool that counts invocations."""
+
+    def __init__(self, config: ChatAgentConfig):
+        super().__init__(config)
+        self.calls: int = 0
+
+    def square(self, msg: SquareTool) -> str:
+        self.calls += 1
+        return f"SQUARE_RESULT: {msg.x ** 2}"
+
+
+class CountingAsyncAgent(CountingAgent):
+    """Agent with a genuine async handler for SquareTool."""
+
+    async def square_async(self, msg: SquareTool) -> str:
+        self.calls += 1
+        return f"SQUARE_RESULT: {msg.x ** 2}"
+
+
+def mk_agent(
+    tool_policy: Any = None,
+    agent_cls: Type[CountingAgent] = CountingAgent,
+) -> CountingAgent:
+    agent = agent_cls(
+        ChatAgentConfig(
+            name="TestAgent",
+            llm=MockLMConfig(response_fn=lambda x: x),
+            tool_policy=tool_policy,
+        )
+    )
+    agent.enable_message(SquareTool)
+    return agent
+
+
+def llm_tool_msg(agent: ChatAgent, x: int = 3) -> ChatDocument:
+    """An LLM-origin ChatDocument containing a SquareTool call."""
+    return agent.create_llm_response(SquareTool(x=x).to_json())
+
+
+def result_content(result: HandleResult) -> str:
+    assert result is not None
+    return result.content if isinstance(result, ChatDocument) else str(result)
+
+
+# -------------------- contract 1: no hook => unchanged --------------------
+
+
+def test_no_policy_sync_dispatch_unchanged() -> None:
+    agent = mk_agent()
+    assert agent.config.tool_policy is None
+    result = agent.handle_message(llm_tool_msg(agent))
+    assert "SQUARE_RESULT: 9" in result_content(result)
+    assert agent.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_no_policy_async_dispatch_unchanged() -> None:
+    agent = mk_agent(agent_cls=CountingAsyncAgent)
+    result = await agent.handle_message_async(llm_tool_msg(agent))
+    assert "SQUARE_RESULT: 9" in result_content(result)
+    assert agent.calls == 1
+
+
+# -------------------- contract 2: allow => handler runs once --------------------
+
+
+@pytest.mark.parametrize("decision", [True, None])
+def test_allow_sync(decision: Optional[bool]) -> None:
+    agent = mk_agent(
+        tool_policy=lambda tool, agent: decision,
+    )
+    result = agent.handle_message(llm_tool_msg(agent, x=5))
+    assert "SQUARE_RESULT: 25" in result_content(result)
+    assert agent.calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", [True, None])
+async def test_allow_async(decision: Optional[bool]) -> None:
+    agent = mk_agent(
+        tool_policy=lambda tool, agent: decision,
+        agent_cls=CountingAsyncAgent,
+    )
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=5))
+    assert "SQUARE_RESULT: 25" in result_content(result)
+    assert agent.calls == 1
+
+
+# ---------------- contract 3: deny => zero runs, LLM-visible rejection ----------
+
+
+def test_deny_with_reason_sync() -> None:
+    agent = mk_agent(tool_policy=lambda tool, agent: "budget exceeded")
+    result = agent.handle_message(llm_tool_msg(agent, x=5))
+    content = result_content(result)
+    assert agent.calls == 0
+    assert "square" in content  # tool name
+    assert "budget exceeded" in content  # policy's reason
+    assert "SQUARE_RESULT" not in content
+
+
+def test_deny_with_false_sync() -> None:
+    agent = mk_agent(tool_policy=lambda tool, agent: False)
+    result = agent.handle_message(llm_tool_msg(agent, x=5))
+    content = result_content(result)
+    assert agent.calls == 0
+    assert "square" in content
+
+
+@pytest.mark.asyncio
+async def test_deny_with_reason_async() -> None:
+    agent = mk_agent(
+        tool_policy=lambda tool, agent: "budget exceeded",
+        agent_cls=CountingAsyncAgent,
+    )
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=5))
+    content = result_content(result)
+    assert agent.calls == 0
+    assert "square" in content
+    assert "budget exceeded" in content
+
+
+def test_deny_unrecognized_decision_fails_closed() -> None:
+    """A decision of an unrecognized type must NOT be treated as allow."""
+    agent = mk_agent(tool_policy=lambda tool, agent: 42)
+    result = agent.handle_message(llm_tool_msg(agent, x=5))
+    content = result_content(result)
+    assert agent.calls == 0
+    assert "square" in content
+
+
+# ------------- contract 4: hook sees parsed tool + bounded context -------------
+
+
+def test_policy_receives_parsed_tool_and_context() -> None:
+    seen: List[Tuple[ToolMessage, ChatAgent, Optional[ChatDocument]]] = []
+
+    def policy(
+        tool: ToolMessage,
+        agent: ChatAgent,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> bool:
+        seen.append((tool, agent, chat_doc))
+        return True
+
+    agent = mk_agent(tool_policy=policy)
+    msg = llm_tool_msg(agent, x=7)
+    agent.handle_message(msg)
+    assert len(seen) == 1
+    tool, seen_agent, chat_doc = seen[0]
+    assert isinstance(tool, SquareTool)
+    assert tool.request == "square"
+    assert tool.x == 7  # final parsed payload
+    assert seen_agent is agent
+    assert chat_doc is not None
+    assert chat_doc.content == msg.content
+    assert agent.calls == 1
+
+
+def test_policy_without_chat_doc_param() -> None:
+    """A 2-arg policy (tool, agent) is supported."""
+    seen: List[SquareTool] = []
+
+    def policy(tool: ToolMessage, agent: ChatAgent) -> bool:
+        assert isinstance(tool, SquareTool)
+        seen.append(tool)
+        return True
+
+    agent = mk_agent(tool_policy=policy)
+    agent.handle_message(llm_tool_msg(agent, x=7))
+    assert len(seen) == 1 and seen[0].x == 7
+    assert agent.calls == 1
+
+
+# ---------- contract 5: hook failure => fail-closed, no argument leak ----------
+
+
+SECRET = "31337"
+
+
+def failing_policy(tool: ToolMessage, agent: ChatAgent) -> bool:
+    # a sloppy policy that embeds tool arguments in its exception
+    assert isinstance(tool, SquareTool)
+    raise ValueError(f"policy blew up on x={tool.x}")
+
+
+def test_policy_exception_fails_closed_sync() -> None:
+    agent = mk_agent(tool_policy=failing_policy)
+    result = agent.handle_message(llm_tool_msg(agent, x=int(SECRET)))
+    content = result_content(result)
+    assert agent.calls == 0  # handler never ran
+    assert "square" in content  # tool name present
+    assert SECRET not in content  # raw tool args must not leak
+    assert "policy blew up" not in content  # nor the exception message
+
+
+@pytest.mark.asyncio
+async def test_policy_exception_fails_closed_async() -> None:
+    agent = mk_agent(
+        tool_policy=failing_policy,
+        agent_cls=CountingAsyncAgent,
+    )
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=int(SECRET)))
+    content = result_content(result)
+    assert agent.calls == 0
+    assert "square" in content
+    assert SECRET not in content
+
+
+# -------------------- sync/async callback x dispatch matrix --------------------
+
+
+@pytest.mark.parametrize("decision", [True, "denied by async policy"])
+def test_async_policy_sync_dispatch(decision: Union[bool, str]) -> None:
+    async def policy(tool: ToolMessage, agent: ChatAgent) -> Union[bool, str]:
+        return decision
+
+    agent = mk_agent(tool_policy=policy)
+    result = agent.handle_message(llm_tool_msg(agent, x=4))
+    content = result_content(result)
+    if decision is True:
+        assert "SQUARE_RESULT: 16" in content
+        assert agent.calls == 1
+    else:
+        assert agent.calls == 0
+        assert "denied by async policy" in content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", [True, "denied by async policy"])
+async def test_async_policy_async_dispatch(decision: Union[bool, str]) -> None:
+    async def policy(tool: ToolMessage, agent: ChatAgent) -> Union[bool, str]:
+        return decision
+
+    agent = mk_agent(tool_policy=policy, agent_cls=CountingAsyncAgent)
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=4))
+    content = result_content(result)
+    if decision is True:
+        assert "SQUARE_RESULT: 16" in content
+        assert agent.calls == 1
+    else:
+        assert agent.calls == 0
+        assert "denied by async policy" in content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", [True, "denied by async policy"])
+async def test_async_policy_async_dispatch_sync_handler(
+    decision: Union[bool, str],
+) -> None:
+    """Async policy + async dispatch falling back to a SYNC handler: the
+    policy must be evaluated correctly on this route too."""
+
+    async def policy(tool: ToolMessage, agent: ChatAgent) -> Union[bool, str]:
+        return decision
+
+    agent = mk_agent(tool_policy=policy)  # sync handler only
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=4))
+    content = result_content(result)
+    if decision is True:
+        assert "SQUARE_RESULT: 16" in content
+        assert agent.calls == 1
+    else:
+        assert agent.calls == 0
+        assert "denied by async policy" in content
+
+
+@pytest.mark.asyncio
+async def test_async_policy_loop_bound_state_async_dispatch_sync_handler() -> None:
+    """On the async-dispatch-to-sync-handler route, an async policy must be
+    awaited on the CALLER's event loop: a policy awaiting a Future created
+    on that loop (a loop-bound resource) must evaluate correctly rather
+    than spuriously failing closed."""
+    loop = asyncio.get_running_loop()
+    fut: "asyncio.Future[bool]" = loop.create_future()
+    loop.call_later(0.01, fut.set_result, True)
+
+    async def policy(tool: ToolMessage, agent: ChatAgent) -> bool:
+        return await fut
+
+    agent = mk_agent(tool_policy=policy)  # sync handler only
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=3))
+    assert "SQUARE_RESULT: 9" in result_content(result)
+    assert agent.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_policy_async_dispatch_sync_handler() -> None:
+    """Async dispatch falling back to a sync handler still runs the
+    policy exactly once."""
+    seen: List[ToolMessage] = []
+
+    def policy(tool: ToolMessage, agent: ChatAgent) -> bool:
+        seen.append(tool)
+        return True
+
+    agent = mk_agent(tool_policy=policy)  # sync handler only
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=3))
+    assert "SQUARE_RESULT: 9" in result_content(result)
+    assert agent.calls == 1
+    assert len(seen) == 1  # policy consulted exactly once
+
+
+# ------------------- the hook cannot mutate what executes -------------------
+
+
+def test_policy_cannot_mutate_tool() -> None:
+    """The hook sees copies of the tool AND the chat_doc: mutations through
+    either must not reach the handler (no argument transformation)."""
+
+    def policy(
+        tool: ToolMessage,
+        agent: ChatAgent,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> bool:
+        assert isinstance(tool, SquareTool)
+        tool.x = 999  # tamper via the tool param
+        assert chat_doc is not None
+        for t in chat_doc.tool_messages:  # tamper via the chat_doc route
+            if isinstance(t, SquareTool):
+                t.x = 999
+        return True
+
+    agent = mk_agent(tool_policy=policy)
+    msg = llm_tool_msg(agent, x=3)
+    result = agent.handle_message(msg)
+    assert "SQUARE_RESULT: 9" in result_content(result)  # 3**2, not 999**2
+    assert agent.calls == 1
+    # the real chat_doc's parsed tool is untouched too
+    assert all(t.x == 3 for t in msg.tool_messages if isinstance(t, SquareTool))
+
+
+# ------------- non-copyable payload => distinct fail-closed rejection -------------
+
+
+class LockCarrierTool(ToolMessage):
+    request: str = "lock_carrier"
+    purpose: str = "A tool whose payload holds a non-copyable object"
+    payload: Any = None
+
+
+class LockCarrierAgent(CountingAgent):
+    def lock_carrier(self, msg: LockCarrierTool) -> str:
+        self.calls += 1
+        return "LOCK_HANDLED"
+
+
+def test_non_copyable_payload_fails_closed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A payload the pre-policy deep copy cannot copy (here: a thread lock)
+    fails CLOSED even under an allow-all policy, with an operator-log
+    diagnostic distinct from 'the policy raised', and an LLM message naming
+    only the tool and exception class."""
+    agent = LockCarrierAgent(
+        ChatAgentConfig(
+            name="TestAgent",
+            llm=MockLMConfig(response_fn=lambda x: x),
+            tool_policy=lambda tool, agent: True,  # allow-all
+        )
+    )
+    agent.enable_message(LockCarrierTool)
+    tool = LockCarrierTool(payload=threading.Lock())
+    msg = agent.create_llm_response(content="calling tool", tool_messages=[tool])
+    with caplog.at_level(logging.ERROR, logger="langroid.agent.tool_policy"):
+        result = agent.handle_message(msg)
+    content = result_content(result)
+    assert agent.calls == 0  # handler never ran
+    assert "lock_carrier" in content
+    assert "could not be copied" in content
+    assert "TypeError" in content  # exception class only...
+    assert "_thread.lock" not in content  # ...no payload repr in LLM message
+    assert "could not be copied for policy evaluation" in caplog.text
+    assert "policy hook raised" not in caplog.text  # distinct diagnostic
+
+
+# --------------- policy consulted only when a handler exists ---------------
+
+
+def test_no_handler_policy_not_called_sync() -> None:
+    seen: List[ToolMessage] = []
+
+    def policy(tool: ToolMessage, agent: ChatAgent) -> bool:
+        seen.append(tool)
+        return True
+
+    agent = mk_agent(tool_policy=policy)
+    agent.enable_message(NoHandlerTool)
+    msg = agent.create_llm_response(NoHandlerTool(y=1).to_json())
+    assert agent.handle_message(msg) is None
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_no_handler_policy_not_called_async() -> None:
+    seen: List[ToolMessage] = []
+
+    def policy(tool: ToolMessage, agent: ChatAgent) -> bool:
+        seen.append(tool)
+        return True
+
+    agent = mk_agent(tool_policy=policy)
+    agent.enable_message(NoHandlerTool)
+    msg = agent.create_llm_response(NoHandlerTool(y=1).to_json())
+    assert await agent.handle_message_async(msg) is None
+    assert seen == []
+
+
+# ---------- policy gates dispatch even through subclass overrides ----------
+
+
+class OverridingAgent(CountingAgent):
+    """Subclass with a GENERIC handle_tool_message override, as user code
+    sometimes does (e.g. to log or wrap every tool execution)."""
+
+    def __init__(self, config: ChatAgentConfig):
+        super().__init__(config)
+        self.override_calls: int = 0
+
+    def handle_tool_message(
+        self,
+        tool: ToolMessage,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> Union[None, str, ChatDocument]:
+        self.override_calls += 1
+        if isinstance(tool, SquareTool):
+            return f"OVERRIDE_RESULT: {tool.x + 1}"
+        return super().handle_tool_message(tool, chat_doc=chat_doc)
+
+
+def test_override_gated_by_policy_sync() -> None:
+    agent = mk_agent(
+        tool_policy=lambda tool, agent: "not allowed",
+        agent_cls=OverridingAgent,
+    )
+    assert isinstance(agent, OverridingAgent)
+    result = agent.handle_message(llm_tool_msg(agent, x=3))
+    assert "blocked by tool policy" in result_content(result)
+    assert agent.override_calls == 0  # override never ran
+    assert agent.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_override_gated_by_policy_async() -> None:
+    agent = mk_agent(
+        tool_policy=lambda tool, agent: "not allowed",
+        agent_cls=OverridingAgent,
+    )
+    assert isinstance(agent, OverridingAgent)
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=3))
+    assert "blocked by tool policy" in result_content(result)
+    assert agent.override_calls == 0
+    assert agent.calls == 0
+
+
+def test_override_allowed_by_policy_sync() -> None:
+    agent = mk_agent(
+        tool_policy=lambda tool, agent: True,
+        agent_cls=OverridingAgent,
+    )
+    assert isinstance(agent, OverridingAgent)
+    result = agent.handle_message(llm_tool_msg(agent, x=3))
+    assert "OVERRIDE_RESULT: 4" in result_content(result)  # override honored
+    assert agent.override_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_override_allowed_by_policy_async() -> None:
+    agent = mk_agent(
+        tool_policy=lambda tool, agent: True,
+        agent_cls=OverridingAgent,
+    )
+    assert isinstance(agent, OverridingAgent)
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=3))
+    assert "OVERRIDE_RESULT: 4" in result_content(result)
+    assert agent.override_calls == 1
+
+
+def test_override_no_policy_unchanged_sync() -> None:
+    agent = mk_agent(agent_cls=OverridingAgent)
+    assert isinstance(agent, OverridingAgent)
+    result = agent.handle_message(llm_tool_msg(agent, x=3))
+    assert "OVERRIDE_RESULT: 4" in result_content(result)
+    assert agent.override_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_override_no_policy_unchanged_async() -> None:
+    agent = mk_agent(agent_cls=OverridingAgent)
+    assert isinstance(agent, OverridingAgent)
+    result = await agent.handle_message_async(llm_tool_msg(agent, x=3))
+    assert "OVERRIDE_RESULT: 4" in result_content(result)
+    assert agent.override_calls == 1
+
+
+# ------------------- policy shared by reference across clones -------------------
+
+
+class BudgetPolicy:
+    """Stateful one-use budget: only the first tool call (across ALL agents
+    sharing this policy object) is allowed."""
+
+    def __init__(self) -> None:
+        self.used: int = 0
+
+    def __call__(self, tool: ToolMessage, agent: ChatAgent) -> bool:
+        self.used += 1
+        return self.used <= 1
+
+
+def test_policy_state_shared_across_clones() -> None:
+    budget = BudgetPolicy()
+    agent = mk_agent(tool_policy=budget)
+    clone = agent.clone(1)
+    assert isinstance(clone, CountingAgent)
+    assert clone.config.tool_policy is budget  # shared by reference
+
+    r1 = agent.handle_message(llm_tool_msg(agent, x=2))
+    assert "SQUARE_RESULT: 4" in result_content(r1)
+    assert agent.calls == 1
+
+    # the clone consults the SAME budget, which is now exhausted
+    r2 = clone.handle_message(llm_tool_msg(clone, x=3))
+    assert "blocked by tool policy" in result_content(r2)
+    assert clone.calls == 0
+    assert budget.used == 2
+
+
+def test_policy_shared_across_task_wrapped_clone() -> None:
+    """Task construction deep-copies the agent's config; the policy must
+    stay shared by reference so budget state is enforced globally."""
+    budget = BudgetPolicy()
+    agent = mk_agent(tool_policy=budget)
+    clone = agent.clone(1)
+    assert isinstance(clone, CountingAgent)
+    Task(clone, interactive=False)  # triggers the config copy in Task.__init__
+    assert clone.config.tool_policy is budget  # still shared, not forked
+
+    r1 = agent.handle_message(llm_tool_msg(agent, x=2))
+    assert "SQUARE_RESULT: 4" in result_content(r1)
+    r2 = clone.handle_message(llm_tool_msg(clone, x=3))
+    assert "blocked by tool policy" in result_content(r2)
+    assert clone.calls == 0
+    assert budget.used == 2
+
+
+_POLICY_SETS: List[Any] = []
+
+
+class SetRecordingConfig(ChatAgentConfig):
+    """Records every post-construction assignment to `tool_policy`."""
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "tool_policy":
+            _POLICY_SETS.append(value)
+        super().__setattr__(name, value)
+
+
+def test_clone_never_mutates_live_policy() -> None:
+    """Structural (not timing) check: clone() must never mutate the live
+    config's tool_policy -- in particular never set it to None mid-copy,
+    which a concurrent dispatch could otherwise observe."""
+    budget = BudgetPolicy()
+    cfg = SetRecordingConfig(
+        name="TestAgent",
+        llm=MockLMConfig(response_fn=lambda x: x),
+        tool_policy=budget,
+    )
+    agent = CountingAgent(cfg)
+    agent.enable_message(SquareTool)
+    _POLICY_SETS.clear()
+    before = agent.config.tool_policy
+    clone = agent.clone(1)
+    assert agent.config.tool_policy is before
+    assert before is budget
+    assert _POLICY_SETS == []  # no code path assigned tool_policy on the live cfg
+    assert clone.config.tool_policy is budget
+
+
+class LockingPolicy:
+    """Policy object holding an unpicklable resource (a thread lock)."""
+
+    def __init__(self) -> None:
+        self.lock: threading.Lock = threading.Lock()
+
+    def __call__(self, tool: ToolMessage, agent: ChatAgent) -> bool:
+        with self.lock:
+            return True
+
+    def __deepcopy__(self, memo: Any) -> "LockingPolicy":
+        raise TypeError("cannot deepcopy LockingPolicy (holds a lock)")
+
+
+def test_clone_with_unpicklable_policy() -> None:
+    policy = LockingPolicy()
+    agent = mk_agent(tool_policy=policy)
+    clone = agent.clone(1)  # must not raise
+    assert clone.config.tool_policy is policy
+    result = clone.handle_message(llm_tool_msg(clone, x=2))
+    assert "SQUARE_RESULT: 4" in result_content(result)
+
+
+# --------- strict-recovery AnyTool shim: exempt; inner tool checked once ---------
+
+
+def _strict_recovery_wrapper(agent: CountingAgent, x: int) -> ToolMessage:
+    """Enable strict recovery's AnyTool on `agent` (as the recovery code
+    does) and return a wrapper instance carrying a SquareTool call."""
+    any_tool_class = agent._get_any_tool_message()
+    assert any_tool_class is not None
+    agent.set_output_format(
+        any_tool_class,
+        force_tools=True,
+        use=True,
+        handle=True,
+        instructions=True,
+    )
+    assert agent.output_format is not None  # strict mode is on
+    # the dynamic AnyTool class defaults `request`/`purpose`, which mypy
+    # cannot see through type[ToolMessage]
+    return any_tool_class(tool=SquareTool(x=x))  # type: ignore[call-arg]
+
+
+def test_strict_recovery_policy_consulted_once() -> None:
+    """The AnyTool wrapper is a parsing shim, not a tool execution: a
+    one-use budget must be consumed only by the INNER re-parsed tool."""
+    budget = BudgetPolicy()
+    agent = mk_agent(tool_policy=budget)
+    wrapper = _strict_recovery_wrapper(agent, x=5)
+    result = agent.handle_message(agent.create_llm_response(wrapper.to_json()))
+    assert "SQUARE_RESULT: 25" in result_content(result)
+    assert agent.calls == 1
+    assert budget.used == 1  # consulted exactly once, on the real tool
+    assert agent.output_format is None  # recovery reset strict mode
+
+
+@pytest.mark.asyncio
+async def test_strict_recovery_policy_consulted_once_async() -> None:
+    budget = BudgetPolicy()
+    agent = mk_agent(tool_policy=budget)
+    wrapper = _strict_recovery_wrapper(agent, x=5)
+    result = await agent.handle_message_async(
+        agent.create_llm_response(wrapper.to_json())
+    )
+    assert "SQUARE_RESULT: 25" in result_content(result)
+    assert agent.calls == 1
+    assert budget.used == 1
+    assert agent.output_format is None
+
+
+def test_strict_recovery_denied_inner_tool() -> None:
+    """A deny-all policy blocks the INNER tool (normal rejection), but the
+    shim itself must still run so strict mode is reset."""
+    agent = mk_agent(tool_policy=lambda tool, agent: "no tools allowed")
+    wrapper = _strict_recovery_wrapper(agent, x=5)
+    result = agent.handle_message(agent.create_llm_response(wrapper.to_json()))
+    content = result_content(result)
+    assert agent.calls == 0
+    assert "blocked by tool policy" in content
+    assert "square" in content
+    assert agent.output_format is None  # set_output_format(None) still ran
+
+
+def _chat_doc_aware_policy(
+    seen_docs: List[Optional[ChatDocument]],
+) -> Any:
+    """A policy whose decision depends on message context: it denies when
+    no chat_doc is provided, allows when the chat_doc is present."""
+
+    def policy(
+        tool: ToolMessage,
+        agent: ChatAgent,
+        chat_doc: Optional[ChatDocument] = None,
+    ) -> Union[bool, str]:
+        seen_docs.append(chat_doc)
+        if chat_doc is None:
+            return "no message context provided"
+        return True
+
+    return policy
+
+
+def test_strict_recovery_policy_receives_chat_doc() -> None:
+    """The recovered inner tool's policy check must see the same chat_doc
+    a normal dispatch would, not None."""
+    seen_docs: List[Optional[ChatDocument]] = []
+    agent = mk_agent(tool_policy=_chat_doc_aware_policy(seen_docs))
+    wrapper = _strict_recovery_wrapper(agent, x=5)
+    msg = agent.create_llm_response(wrapper.to_json())
+    result = agent.handle_message(msg)
+    assert "SQUARE_RESULT: 25" in result_content(result)
+    assert agent.calls == 1
+    # the policy saw the real message context (as a copy), not None
+    assert len(seen_docs) == 1
+    assert seen_docs[0] is not None
+    assert seen_docs[0].content == msg.content
+
+
+@pytest.mark.asyncio
+async def test_strict_recovery_policy_receives_chat_doc_async() -> None:
+    seen_docs: List[Optional[ChatDocument]] = []
+    agent = mk_agent(tool_policy=_chat_doc_aware_policy(seen_docs))
+    wrapper = _strict_recovery_wrapper(agent, x=5)
+    msg = agent.create_llm_response(wrapper.to_json())
+    result = await agent.handle_message_async(msg)
+    assert "SQUARE_RESULT: 25" in result_content(result)
+    assert agent.calls == 1
+    assert len(seen_docs) == 1
+    assert seen_docs[0] is not None
+    assert seen_docs[0].content == msg.content
+
+
+def test_injected_exemption_marker_does_not_bypass_policy() -> None:
+    """ToolMessage allows extra fields, so an LLM could emit
+    `"_tool_policy_exempt": true` inside its tool JSON, planting the marker
+    as an INSTANCE attribute. The exemption must resolve on the CLASS only,
+    so this spoof must not bypass a deny-all policy."""
+    agent = mk_agent(tool_policy=lambda tool, agent: "denied")
+    spoofed_json = (
+        SquareTool(x=3)
+        .to_json()
+        .replace(
+            '"request":',
+            '"_tool_policy_exempt": true, "request":',
+            1,
+        )
+    )
+    msg = agent.create_llm_response(spoofed_json)
+    parsed = agent.try_get_tool_messages(msg, all_tools=True)
+    # the spoofed marker really lands on the parsed instance...
+    assert any(getattr(t, "_tool_policy_exempt", False) is True for t in parsed)
+    result = agent.handle_message(msg)
+    content = result_content(result)
+    assert agent.calls == 0  # handler never ran
+    assert "blocked by tool policy" in content
+
+
+def test_strict_recovery_no_policy_unchanged() -> None:
+    agent = mk_agent()
+    wrapper = _strict_recovery_wrapper(agent, x=5)
+    result = agent.handle_message(agent.create_llm_response(wrapper.to_json()))
+    assert "SQUARE_RESULT: 25" in result_content(result)
+    assert agent.calls == 1
+    assert agent.output_format is None
+
+
+# ---------------- contract 6: composes with USER-origin filter ----------------
+
+
+def test_policy_does_not_weaken_user_origin_filter() -> None:
+    """A handle-only tool arriving as raw USER input must stay vetoed by
+    `_filter_user_origin_tools`; the policy hook never even sees it, and
+    an allow-everything policy cannot resurrect it."""
+    policy_calls: List[ToolMessage] = []
+
+    def policy(tool: ToolMessage, agent: ChatAgent) -> bool:
+        policy_calls.append(tool)
+        return True
+
+    agent = CountingAgent(
+        ChatAgentConfig(
+            name="TestAgent",
+            llm=MockLMConfig(response_fn=lambda x: x),
+            tool_policy=policy,
+        )
+    )
+    # handle-only: LLM cannot use it, so raw USER input must not trigger it
+    agent.enable_message(SquareTool, use=False, handle=True)
+    user_msg = agent.create_user_response(SquareTool(x=3).to_json())
+    assert user_msg.metadata.sender == Entity.USER
+    result = agent.handle_message(user_msg)
+    assert agent.calls == 0
+    assert policy_calls == []
+    assert result is None or "SQUARE_RESULT" not in result_content(result)
+
+
+# ------------------- end-to-end: LLM sees the rejection -------------------
+
+
+def test_rejection_is_seen_by_llm_in_task_loop() -> None:
+    llm_inputs: List[str] = []
+
+    def mock_llm(x: str) -> str:
+        llm_inputs.append(x)
+        if len(llm_inputs) == 1:
+            # the tool argument IS the secret sentinel, so a leak of the
+            # raw argument into the rejection would fail the assertion below
+            return SquareTool(x=int(SECRET)).to_json()
+        return "understood, giving up"
+
+    agent = CountingAgent(
+        ChatAgentConfig(
+            name="TestAgent",
+            llm=MockLMConfig(response_fn=mock_llm),
+            tool_policy=lambda tool, agent: "quota exhausted",
+        )
+    )
+    agent.enable_message(SquareTool)
+    task = Task(agent, interactive=False)
+    task.run("go", turns=4)
+    assert agent.calls == 0
+    # the LLM's second input is the policy rejection
+    assert any("quota exhausted" in s for s in llm_inputs[1:])
+    assert all(SECRET not in s for s in llm_inputs)


### PR DESCRIPTION
Closes #1095.

Adds the smallest generic interception point at the central tool-dispatch boundary, so external policy engines (authorization, approvals, DLP, command policy) can allow or deny tool executions. No product-specific code in core.

## API

`AgentConfig.tool_policy: Optional[Callable[..., Any]] = None` (matches the existing callable-config idiom — `api_key_provider`, `streamer`). Called as `tool_policy(tool, agent)`, or with a `chat_doc=` kwarg when the callable declares it (mirrors the tool-handler convention). Sync or async callables both accepted.

Decision protocol: `True`/`None` = allow; `False` = reject (generic reason); `str` = reject with that reason; any other type = reject (fail-closed).

## Semantics

- No hook configured → behavior unchanged (negligible overhead: one None-check per dispatch).
- Allow → the selected handler runs exactly once.
- Reject → handler runs zero times; a framework-native rejection flows back to the LLM like other tool-handling errors.
- **Fail-closed:** a hook exception, or a tool payload that cannot be copied for evaluation, blocks the tool. The LLM-visible message names only the tool and exception class — never the tool arguments (those go to the operator log).
- The hook receives deep copies of the tool and chat_doc, so it cannot mutate what the handler executes.
- Enforcement lives ABOVE `handle_tool_message(_async)` (restored to their pristine bodies), in wrappers at every framework call site, so it composes with subclass overrides. Async policies are awaited on the caller's loop.
- The policy is shared by reference across `clone()` / `Task` / batch copies (a stateful budget policy stays one budget), via a memo-seeded deepcopy that never mutates the live config.
- The strict-recovery `AnyTool` parsing shim is structurally exempt (class-level marker, immune to LLM-injected instance fields); the recovered real tool is policy-checked exactly once, with the dispatching `chat_doc` threaded through.

## Verification

45 tests in `tests/main/test_tool_policy_hook.py` covering all six acceptance-contract points (sync + async), backward-compat across existing tool/task suites, and composition with the `_filter_user_origin_tools` security filter (vetoed tools never reach the policy). `make check` clean; docs note `docs/notes/tool-policy-hook.md`; runnable `examples/basic/tool-policy-hook.py`; `llms*.txt` regenerated.

## Follow-up (out of scope here)

A cold review noted that core dispatch resolves a tool's `_handler` from an instance attribute (`getattr(tool, "_handler", ...)`), which — given `ToolMessage`'s `extra="allow"` — an LLM could in principle inject. This is **pre-existing behavior in `main`'s `handle_tool_message`**, unrelated to this hook (the policy would in fact gate such a call), and the same instance-vs-class trust question as the `_tainted`/`_tool_policy_exempt` markers. It warrants its own hardening issue against core dispatch rather than riding this PR.