### PR TITLE
fix(llm): await the backoff sleep in the async retry decorator

### DIFF
--- a/langroid/language_models/utils.py
+++ b/langroid/language_models/utils.py
@@ -171,8 +171,8 @@ def async_retry_with_exponential_backoff(
                     f"""OpenAI API request failed with error{e}. 
                     Retrying in {delay} seconds..."""
                 )
-                # Sleep for the delay
-                time.sleep(delay)
+                # Sleep for the delay, without blocking the event loop
+                await asyncio.sleep(delay)
 
             # Raise exceptions for any errors not specified
             except Exception as e:

--- a/tests/main/test_retry_utils.py
+++ b/tests/main/test_retry_utils.py
@@ -7,6 +7,8 @@ retried with exponential backoff. See the type-based guard in
 `retry_with_exponential_backoff` / `async_retry_with_exponential_backoff`.
 """
 
+import asyncio
+
 import httpx
 import openai
 import pytest
@@ -15,6 +17,10 @@ from langroid.language_models.utils import (
     async_retry_with_exponential_backoff,
     retry_with_exponential_backoff,
 )
+
+# Backoff timing used by the event-loop responsiveness test below.
+_DELAY = 0.2
+_TICK = 0.005
 
 
 def _make_openai_error(exc_cls: type, status: int) -> openai.APIStatusError:
@@ -152,6 +158,46 @@ async def test_async_rate_limit_is_retried():
         await wrapped()
 
     assert calls["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_async_retry_delay_does_not_block_event_loop():
+    """Regression guard: the async backoff must not freeze the event loop.
+
+    The retry tests above use `initial_delay=0.0`, so they never exercise the
+    sleep itself. With a real delay, a blocking `time.sleep` inside the
+    coroutine stalls every other task on the loop for the whole backoff.
+    """
+    ticks = 0
+    running = True
+
+    async def heartbeat() -> None:
+        nonlocal ticks
+        while running:
+            await asyncio.sleep(_TICK)
+            ticks += 1
+
+    async def fn():
+        raise _make_openai_error(openai.RateLimitError, 429)
+
+    # exponential_base=1.0 keeps every backoff at exactly _DELAY seconds.
+    wrapped = async_retry_with_exponential_backoff(
+        fn,
+        max_retries=2,
+        initial_delay=_DELAY,
+        exponential_base=1.0,
+        jitter=False,
+    )
+
+    beat = asyncio.create_task(heartbeat())
+    await asyncio.sleep(0)  # let the heartbeat reach its first await
+    with pytest.raises(Exception, match="Maximum number of retries"):
+        await wrapped()
+    running = False
+    await beat
+
+    # 2 backoffs of _DELAY leave room for ~80 ticks; a blocked loop yields ~0.
+    assert ticks > 20
 
 
 def test_sync_internal_server_error_is_retried() -> None:


### PR DESCRIPTION
### The defect

`langroid/language_models/utils.py:175`, inside the `async def wrapper` of
`async_retry_with_exponential_backoff`:

```python
# Sleep for the delay
time.sleep(delay)
```

The synchronous twin at line 93 is correct. The async copy is a
copy-paste of it that was never converted, so the backoff blocks the
event loop instead of yielding to it. `asyncio` is already imported at
line 2, so the fix is one line.

### Why it matters

This decorator wraps the core async LLM paths — `openai_gpt.py:1447`,
`:2000`, `:2277`. On a 429 (the exact case the decorator exists for) the
delay grows 1.3s, 1.69s, 2.2s…, and during each of those waits nothing
else on the loop runs: concurrent agents, `run_batch_tasks`, and any
co-hosted server all stop. The failure is invisible in a single-request
script and only shows up under the concurrency the async path is for.

### Measured

Three 429s with the default `exponential_base=1.3`, with a 10 ms
heartbeat task running alongside:

| | heartbeat ticks over 5.2s | max stall |
|---|---|---|
| before | 5 | 5.211s |
| after | 496 | 0.026s |

### The test

`tests/main/test_retry_utils.py` already has
`test_async_rate_limit_is_retried`, but it passes `initial_delay=0.0`, so
it never exercises the sleep at all — which is why the bug survived it.
The new sibling runs a heartbeat task across two real 0.2s backoffs and
asserts the loop stays responsive.

Without the fix (`git stash` of the one-line change, test kept):

```
>       assert ticks > 20
E       assert 1 > 20

tests/main/test_retry_utils.py:201: AssertionError
FAILED tests/main/test_retry_utils.py::test_async_retry_delay_does_not_block_event_loop
1 failed, 16 passed in 0.58s
```

With the fix:

```
$ pytest tests/main/test_retry_utils.py -q
17 passed in 0.54s
```

`black --check .`, `ruff check .` and `mypy -p langroid` are all clean
(exit 0).