### PR TITLE
fix(parsing): apply the configured URL limits in URLLoader downloads

### DIFF
--- a/langroid/parsing/url_loader.py
+++ b/langroid/parsing/url_loader.py
@@ -12,6 +12,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from langroid.exceptions import LangroidImportError
 from langroid.mytypes import DocMetaData, Document
 from langroid.parsing.document_parser import DocumentParser, ImagePdfParser
+from langroid.parsing.document_url import fetch_configured_url
 from langroid.parsing.parser import Parser, ParsingConfig
 
 if TYPE_CHECKING:
@@ -133,8 +134,15 @@ class BaseCrawler(ABC):
                     return []
 
             else:
+                config = self.parser.config
                 try:
-                    headers = requests.head(url).headers
+                    headers = requests.head(
+                        url,
+                        timeout=(
+                            config.url_connect_timeout,
+                            config.url_read_timeout,
+                        ),
+                    ).headers
                 except Exception as e:
                     logging.warning(f"Error getting headers for {url}: {e}")
                     headers = CaseInsensitiveDict()
@@ -153,15 +161,13 @@ class BaseCrawler(ABC):
 
                 if temp_file_suffix:
                     try:
-                        response = requests.get(url)
+                        content, _ = fetch_configured_url(url, config)
                         with NamedTemporaryFile(
                             delete=False, suffix=temp_file_suffix
                         ) as temp_file:
-                            temp_file.write(response.content)
+                            temp_file.write(content)
                             temp_file_path = temp_file.name
-                        doc_parser = DocumentParser.create(
-                            temp_file_path, self.parser.config
-                        )
+                        doc_parser = DocumentParser.create(temp_file_path, config)
                         docs = doc_parser.get_doc_chunks()
                         os.remove(temp_file_path)
                         return docs

--- a/tests/main/test_url_loader.py
+++ b/tests/main/test_url_loader.py
@@ -1,8 +1,13 @@
+import http.server
 import os
+import threading
+import time
+from typing import Any, Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from langroid.parsing.parser import ParsingConfig
 from langroid.parsing.url_loader import (
     Crawl4aiConfig,
     ExaCrawlerConfig,
@@ -95,3 +100,105 @@ def test_crawl4ai_integration():
     assert len(docs) >= 1
     assert len(docs[0].content) > 0
     assert "Example Domain" in docs[0].content or "example" in docs[0].content.lower()
+
+
+# ---------------------------------------------------------------------------
+# Bounded fetching: URLLoader must apply the ParsingConfig URL limits when it
+# downloads a document whose type is only known from its Content-Type header.
+# ---------------------------------------------------------------------------
+
+_STALL = 0.5  # server-side stall, longer than the timeout under test
+_OVERSIZED_CHUNK = 64 * 1024
+_OVERSIZED_BODY = 8 * 1024 * 1024
+
+
+class _CrawlHandler(http.server.BaseHTTPRequestHandler):
+    """Serves the transport edge cases the bounded-fetch tests need.
+
+    Every path is extensionless, so `_is_document_url` is False and the
+    crawler takes the HEAD-then-GET branch under test.
+    """
+
+    served_bytes = 0
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+    def _send_pdf_headers(self) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "application/pdf")
+        self.end_headers()
+
+    def do_HEAD(self) -> None:
+        if self.path == "/stalled-head":
+            time.sleep(_STALL)  # slow loris: the headers never arrive
+            return
+        self._send_pdf_headers()
+
+    def do_GET(self) -> None:
+        if self.path == "/stalled-body":
+            self._send_pdf_headers()
+            time.sleep(_STALL)  # stalls after the headers
+            return
+        # /oversized: a body far larger than url_max_size, with no
+        # Content-Length, so only streaming can bound it.
+        self._send_pdf_headers()
+        chunk = b"%PDF-1.4" + b"0" * (_OVERSIZED_CHUNK - 8)
+        for _ in range(_OVERSIZED_BODY // _OVERSIZED_CHUNK):
+            try:
+                self.wfile.write(chunk)
+                self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                return
+            type(self).served_bytes += len(chunk)
+
+
+@pytest.fixture
+def crawl_server_url() -> Iterator[str]:
+    """Run the handler above on a local HTTP port; yield the base URL."""
+    _CrawlHandler.served_bytes = 0
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _CrawlHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+@pytest.mark.parametrize("path", ["stalled-head", "stalled-body"])
+def test_url_loader_document_fetch_honors_timeouts(
+    crawl_server_url: str, path: str
+) -> None:
+    """A stalled server must not hang the crawler.
+
+    Regression test: `_process_document` called `requests.head` and
+    `requests.get` with no timeout, so either half of the download blocked
+    forever, even though `ParsingConfig` already carries the limits and
+    `parsing/document_url.py` already applies them.
+    """
+    loader = URLLoader(
+        urls=[],
+        parsing_config=ParsingConfig(url_connect_timeout=0.01, url_read_timeout=0.01),
+    )
+    start = time.monotonic()
+
+    assert loader.crawler._process_document(f"{crawl_server_url}/{path}") == []
+
+    assert time.monotonic() - start < _STALL / 2
+
+
+def test_url_loader_document_fetch_honors_max_size(crawl_server_url: str) -> None:
+    """An unbounded response body must not be buffered whole into memory.
+
+    Regression test: `_process_document` read `requests.get(url).content`,
+    ignoring the `url_max_size` its own `ParsingConfig` defines.
+    """
+    loader = URLLoader(urls=[], parsing_config=ParsingConfig(url_max_size=16))
+
+    assert loader.crawler._process_document(f"{crawl_server_url}/oversized") == []
+
+    # Streaming aborts within a chunk or two; only an unbounded read drains
+    # the whole body.
+    assert _CrawlHandler.served_bytes < _OVERSIZED_BODY // 2


### PR DESCRIPTION
### The defect

`BaseCrawler._process_document` in `langroid/parsing/url_loader.py`
downloads documents with:

```python
headers = requests.head(url).headers          # :137  - no timeout
...
response = requests.get(url)                  # :156  - no timeout
temp_file.write(response.content)             # :160  - whole body in RAM
```

No timeout on either call, and the full body buffered unbounded.

### Why it matters

`ParsingConfig` already defines `url_connect_timeout=10.0`,
`url_read_timeout=30.0` and `url_max_size=10MB`
(`parsing/parser.py:117-119`), and `parsing/document_url.py` already has a
hardened `fetch_url_bytes` / `fetch_configured_url` that applies all three
by streaming — used by `document_parser.py:386` and `:443`.
`_process_document` passes `self.parser.config` two lines below the
offending `requests.get`: the configuration is literally in scope and
simply not applied.

This is the RAG crawling path for user- or LLM-supplied URLs. The branch
is reached whenever the URL has no `.pdf`/`.docx`/`.doc` extension and the
type comes from the `Content-Type` header — i.e. exactly the
`?download=…`-style URLs least under the caller's control. Extension-bearing
URLs take the already-hardened `DocumentParser.create` path, so the two
halves of the same feature currently behave differently.

### Measured

Local server, `ParsingConfig(url_connect_timeout=3, url_read_timeout=3, url_max_size=10MB)`:

| | `URLLoader._process_document` | `fetch_configured_url` (repo's own helper) |
|---|---|---|
| slow loris, stalls on HEAD | still hanging at 10s | n/a |
| slow loris, stalls after GET headers | still hanging at 10s | aborts in 3.01s |
| 200 MB body vs a 10 MB cap | 209.7 MB buffered, RSS +405 MB | `ValueError` in 0.03s |

After the change, all three abort at the configured limit (3.00s / 3.01s / immediately).

### The fix

Route the GET through the repo's own `fetch_configured_url`, and pass the
same configured timeouts to the HEAD probe. No new configuration, no new
dependency.

### The tests

`tests/main/test_url_loader.py` gains three hermetic tests over a local
`ThreadingHTTPServer`, in the style of the URL tests in
`tests/main/test_md_html_parser.py` (which already covers the equivalent
`DocumentParser` cases at `test_url_read_timeout_stops_stalled_response`
and `test_url_streaming_rejects_oversized_response`).

Without the fix (`git stash` of the source change, tests kept):

```
FFF                                                                      [100%]
=================================== FAILURES ===================================
tests/main/test_url_loader.py:189: assert (189490.219540483 - 189489.717252294) < (0.5 / 2)
tests/main/test_url_loader.py:189: assert (189491.244783834 - 189490.727693616) < (0.5 / 2)
tests/main/test_url_loader.py:204: assert 8388608 < (8388608 // 2)
=========================== short test summary info ============================
FAILED tests/main/test_url_loader.py::test_url_loader_document_fetch_honors_timeouts[stalled-head]
FAILED tests/main/test_url_loader.py::test_url_loader_document_fetch_honors_timeouts[stalled-body]
FAILED tests/main/test_url_loader.py::test_url_loader_document_fetch_honors_max_size
3 failed, 5 deselected in 2.58s
```

With the fix:

```
$ pytest tests/main/test_url_loader.py -q -k honors
3 passed, 5 deselected in 1.57s

$ pytest tests/main/test_md_html_parser.py -q
79 passed in 0.91s
```

`black --check .`, `ruff check .` and `mypy -p langroid` are all clean
(exit 0). The two `crawl4ai` tests in the same file fail identically on
an unmodified `main` in my environment (the `crawl-4-ai` extra is not
installed); nothing else in the file is affected.