### PR TITLE
fix(parsing): actionable error messages when URL fetch limits trip

### DIFF
--- a/langroid/parsing/document_url.py
+++ b/langroid/parsing/document_url.py
@@ -77,7 +77,9 @@ def fetch_url_bytes(
                 declared_size = None
             if declared_size is not None and declared_size > max_size:
                 raise ValueError(
-                    f"URL document exceeds maximum size of {max_size} bytes"
+                    f"URL document exceeds maximum size of {max_size} bytes; "
+                    "increase ParsingConfig.url_max_size to allow larger "
+                    "documents"
                 )
 
         limit = sample_size if sample_size is not None else max_size
@@ -91,7 +93,9 @@ def fetch_url_bytes(
                 return bytes(body[:sample_size]), response.headers
             if len(body) > max_size:
                 raise ValueError(
-                    f"URL document exceeds maximum size of {max_size} bytes"
+                    f"URL document exceeds maximum size of {max_size} bytes; "
+                    "increase ParsingConfig.url_max_size to allow larger "
+                    "documents"
                 )
         return bytes(body), response.headers
 

--- a/langroid/parsing/url_loader.py
+++ b/langroid/parsing/url_loader.py
@@ -33,6 +33,29 @@ load_dotenv()
 logging.getLogger("url_loader").setLevel(logging.WARNING)
 
 
+def _limit_hint(e: Exception, config: ParsingConfig) -> str:
+    """Actionable suffix for a URL-fetch error caused by the configured limits.
+
+    Returns an empty string for errors unrelated to the limits.
+    """
+    import requests
+    from urllib3.exceptions import TimeoutError as Urllib3TimeoutError
+
+    timed_out = isinstance(e, requests.exceptions.Timeout) or (
+        # requests wraps read-timeouts during streamed body reads in
+        # ConnectionError, not Timeout
+        isinstance(e, requests.exceptions.ConnectionError)
+        and any(isinstance(arg, Urllib3TimeoutError) for arg in e.args)
+    )
+    if timed_out:
+        return (
+            "; if the server is just slow, increase "
+            f"ParsingConfig.url_connect_timeout (now {config.url_connect_timeout}s)"
+            f" / url_read_timeout (now {config.url_read_timeout}s)"
+        )
+    return ""
+
+
 # Base crawler config and specific configurations
 class BaseCrawlerConfig(BaseSettings):
     """Base configuration for web crawlers."""
@@ -130,7 +153,8 @@ class BaseCrawler(ABC):
                         new_chunks = img_parser.get_doc_chunks()
                     return new_chunks
                 except Exception as e:
-                    logging.error(f"Error parsing {url}: {e}")
+                    hint = _limit_hint(e, self.parser.config)
+                    logging.error(f"Error parsing {url}: {e}{hint}")
                     return []
 
             else:
@@ -144,7 +168,8 @@ class BaseCrawler(ABC):
                         ),
                     ).headers
                 except Exception as e:
-                    logging.warning(f"Error getting headers for {url}: {e}")
+                    hint = _limit_hint(e, config)
+                    logging.warning(f"Error getting headers for {url}: {e}{hint}")
                     headers = CaseInsensitiveDict()
 
                 content_type = headers.get("Content-Type", "").lower()
@@ -172,7 +197,8 @@ class BaseCrawler(ABC):
                         os.remove(temp_file_path)
                         return docs
                     except Exception as e:
-                        logging.error(f"Error downloading/parsing {url}: {e}")
+                        hint = _limit_hint(e, config)
+                        logging.error(f"Error downloading/parsing {url}: {e}{hint}")
                         return []
         return []
 

--- a/tests/main/test_url_loader.py
+++ b/tests/main/test_url_loader.py
@@ -169,7 +169,7 @@ def crawl_server_url() -> Iterator[str]:
 
 @pytest.mark.parametrize("path", ["stalled-head", "stalled-body"])
 def test_url_loader_document_fetch_honors_timeouts(
-    crawl_server_url: str, path: str
+    crawl_server_url: str, path: str, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A stalled server must not hang the crawler.
 
@@ -187,9 +187,13 @@ def test_url_loader_document_fetch_honors_timeouts(
     assert loader.crawler._process_document(f"{crawl_server_url}/{path}") == []
 
     assert time.monotonic() - start < _STALL / 2
+    # The timeout must be reported with a pointer to the config knobs.
+    assert "url_read_timeout" in caplog.text
 
 
-def test_url_loader_document_fetch_honors_max_size(crawl_server_url: str) -> None:
+def test_url_loader_document_fetch_honors_max_size(
+    crawl_server_url: str, caplog: pytest.LogCaptureFixture
+) -> None:
     """An unbounded response body must not be buffered whole into memory.
 
     Regression test: `_process_document` read `requests.get(url).content`,
@@ -202,3 +206,5 @@ def test_url_loader_document_fetch_honors_max_size(crawl_server_url: str) -> Non
     # Streaming aborts within a chunk or two; only an unbounded read drains
     # the whole body.
     assert _CrawlHandler.served_bytes < _OVERSIZED_BODY // 2
+    # The size rejection must tell the user which config field to raise.
+    assert "url_max_size" in caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -3737,7 +3737,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2
 
 [[package]]
 name = "langroid"
-version = "0.65.16"
+version = "0.67.2"
 source = { editable = "." }
 dependencies = [
     { name = "adb-cloud-connector" },


### PR DESCRIPTION
Follow-up to #1113 (and prompted by it): when a URL download fails because of the configured `ParsingConfig` limits, the logged error now tells the user which config field to adjust, instead of a bare exception string.

- Size rejections in `fetch_url_bytes` now read: `URL document exceeds maximum size of N bytes; increase ParsingConfig.url_max_size to allow larger documents`.
- Timeouts in `URLLoader._process_document` (HEAD probe, direct document URLs, and header-sniffed downloads) get a suffix naming `ParsingConfig.url_connect_timeout` / `url_read_timeout` with their current values. This includes read-timeouts during streamed body reads, which `requests` wraps in `ConnectionError` — detected by checking for a wrapped urllib3 `TimeoutError`, so genuine connection failures (DNS, refused, SSL) don't get misleading timeout advice.
- The hermetic tests from #1113 now also assert the hints appear in the logs.
- `uv.lock`: syncs the recorded langroid version (stale `0.65.16`) to `0.67.2`.

Tests: `pytest tests/main/test_url_loader.py -k honors` (3 passed), `tests/main/test_md_html_parser.py` (79 passed); black/ruff/mypy clean on changed files.