### PR TITLE
build: token-safe 'make publish' and non-interactive 'make release'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,3 +309,38 @@ is an ongoing PR, just push to github again and the PR will be updated.
 
 It is strongly recommended to use the `gh` command-line utility when working with git.
 Read more [here](docs/development/github-cli.md).
+
+## Releasing (maintainers)
+
+A release consists of a version bump + GitHub release, followed by a
+PyPI upload. Both steps run non-interactively:
+
+```bash
+make all-patch   # or all-minor / all-major
+make publish
+```
+
+- `make all-patch` bumps the version (via commitizen), pushes `main`
+  and the new tag, creates the GitHub release with auto-generated
+  notes (`gh release create ... --generate-notes`), and builds the
+  wheel + sdist into `dist/`. Release notes can be refined afterwards
+  with `gh release edit <version> --notes-file <file>`.
+- `make publish` uploads `dist/` to PyPI. It reads `PYPI_TOKEN` from
+  the `.env` file in the repository's primary checkout at runtime, so
+  the token never appears on a command line or in any output. Add a
+  line like this to `.env` (which is gitignored):
+
+  ```bash
+  PYPI_TOKEN=pypi-...
+  ```
+
+  The target fails with a clear error if `dist/` is missing either
+  distribution, if the `.env` file is absent, or if `PYPI_TOKEN` is
+  not defined in it. Any `PYPI_TOKEN` already exported in the
+  environment is deliberately ignored; the `.env` file is the single
+  source of truth.
+- Verify the upload independently, e.g.:
+
+  ```bash
+  curl -s https://pypi.org/pypi/langroid/json | jq -r .info.version
+  ```

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@
 
 SHELL := /bin/bash
 
+# Primary checkout's .env (works from any worktree); holds PYPI_TOKEN
+# for `make publish`.
+GIT_PRIMARY_WORKTREE := $(realpath $(shell git rev-parse \
+	--path-format=absolute --git-common-dir)/..)
+PYPI_ENV_FILE ?= $(GIT_PRIMARY_WORKTREE)/.env
+
 .PHONY: setup update
 
 setup: ## Setup the git pre-commit hooks
@@ -134,7 +140,26 @@ clean:
 
 .PHONY: release
 release:
-	@VERSION=$$(cz version -p | cut -d' ' -f2) && gh release create $${VERSION} dist/*
+	@VERSION=$$(cz version -p | cut -d' ' -f2) && \
+		gh release create $${VERSION} dist/* --generate-notes
+
+.PHONY: publish
+publish:
+	@if ! ls dist/*.whl >/dev/null 2>&1 || ! ls dist/*.tar.gz >/dev/null 2>&1; then \
+		echo "Error: dist/ must contain both wheel and source distributions" >&2; \
+		exit 1; \
+	fi
+	@if [ ! -f "$(PYPI_ENV_FILE)" ]; then \
+		echo "Error: PyPI environment file not found: $(PYPI_ENV_FILE)" >&2; \
+		exit 1; \
+	fi
+	@uv run --no-sync --env-file "$(PYPI_ENV_FILE)" -- sh -eu -c '\
+		set +x; \
+		if [ -z "$${PYPI_TOKEN:-}" ]; then \
+			echo "Error: PYPI_TOKEN is not defined in $(PYPI_ENV_FILE)" >&2; \
+			exit 1; \
+		fi; \
+		UV_PUBLISH_TOKEN="$$PYPI_TOKEN" uv publish'
 
 .PHONY: bump-rc
 bump-rc:
@@ -260,7 +285,3 @@ pre-release-alpha-patch: bump-alpha-patch clean build pre-release-push pre-relea
 
 .PHONY: pre-release-alpha-minor
 pre-release-alpha-minor: bump-alpha-minor clean build pre-release-push pre-release-release
-
-.PHONY: publish
-publish:
-	uv publish

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,8 @@ publish:
 		echo "Error: PyPI environment file not found: $(PYPI_ENV_FILE)" >&2; \
 		exit 1; \
 	fi
-	@uv run --no-sync --env-file "$(PYPI_ENV_FILE)" -- sh -eu -c '\
+	@env -u PYPI_TOKEN -u UV_NO_ENV_FILE \
+		uv run --no-sync --env-file "$(PYPI_ENV_FILE)" -- sh -eu -c '\
 		set +x; \
 		if [ -z "$${PYPI_TOKEN:-}" ]; then \
 			echo "Error: PYPI_TOKEN is not defined in $(PYPI_ENV_FILE)" >&2; \

--- a/uv.lock
+++ b/uv.lock
@@ -3737,7 +3737,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2
 
 [[package]]
 name = "langroid"
-version = "0.67.2"
+version = "0.67.3"
 source = { editable = "." }
 dependencies = [
     { name = "adb-cloud-connector" },


### PR DESCRIPTION
Enables agent-driven releases end-to-end:

- **`make publish`**: loads `PYPI_TOKEN` from the primary checkout's `.env` at runtime via `uv run --env-file`, passing it to `uv publish` as `UV_PUBLISH_TOKEN` — the token never appears on a command line, in make output, or in any file an agent composes. Guards: both wheel + sdist must exist in `dist/`, the env file must exist, and the token must be defined — each failing closed with a clear error. `set +x` guards against inherited xtrace leaking the token. Replaces the previous bare `uv publish` target. (Pattern ported from claude-code-tools.)
- **`make release`**: adds `--generate-notes` to `gh release create` so it runs non-interactively (no notes dialog); notes can be refined afterwards with `gh release edit`.
- `uv.lock`: syncs recorded langroid version to 0.67.3.

Verified: all three guard paths fail closed; the happy path authenticated against PyPI (duplicate-file rejection on the already-published 0.67.3 confirms the token flow works).