### PR TITLE
fix(utils): expand '~' before the existence check in read_file

### DIFF
--- a/langroid/utils/system.py
+++ b/langroid/utils/system.py
@@ -274,10 +274,12 @@ def read_file(path: str, line_numbers: bool = False) -> str:
     Raises:
         FileNotFoundError: If the specified file does not exist.
     """
-    # raise an error if the file does not exist
-    if not Path(path).exists():
-        raise FileNotFoundError(f"File not found: {path}")
+    # expand "~" before checking existence, so a "~/..." path is not
+    # spuriously reported as missing
     file = Path(path).expanduser()
+    # raise an error if the file does not exist
+    if not file.exists():
+        raise FileNotFoundError(f"File not found: {path}")
     content = file.read_text()
     if line_numbers:
         lines = content.splitlines()

--- a/tests/main/test_system_utils.py
+++ b/tests/main/test_system_utils.py
@@ -95,6 +95,17 @@ def test_read_file_with_line_numbers(tmp_path):
     assert read_file(str(file_path), line_numbers=True) == expected
 
 
+def test_read_file_tilde_expansion(tmp_path, monkeypatch):
+    # simulate a home directory and read a file via a "~/..." path;
+    # read_file must expand "~" before checking existence (regression
+    # for a FileNotFoundError raised on a path that actually exists).
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))  # Windows
+    content = "Line 1\nLine 2"
+    (tmp_path / "tilde_read_test.txt").write_text(content)
+    assert read_file("~/tilde_read_test.txt") == content
+
+
 def test_diff_files(tmp_path):
     file1 = tmp_path / "file1.txt"
     file2 = tmp_path / "file2.txt"


### PR DESCRIPTION
### Problem

`read_file` (`langroid/utils/system.py`) supports `~` home paths via `expanduser()`, but it checks existence on the **un-expanded** path first:

```python
if not Path(path).exists():
    raise FileNotFoundError(f"File not found: {path}")
file = Path(path).expanduser()
```

So `read_file("~/existing_file")` raises `FileNotFoundError` even when `$HOME/existing_file` exists — `Path("~/...").exists()` is `False`. Reachable through `ReadFileTool`.

### Fix

Expand the path once, then check existence and read from the expanded path.

### Test

Adds `test_read_file_tilde_expansion` (writes a file under a fake `$HOME`, reads it via `~/...`). RED before, GREEN after.
