### PR TITLE
fix(parsing): tolerate and log malformed segment specs in parse_number_range_list

### DIFF
--- a/langroid/parsing/utils.py
+++ b/langroid/parsing/utils.py
@@ -216,6 +216,11 @@ def parse_number_range_list(specs: str) -> List[int]:
         specs (str): A string containing segment numbers and/or ranges
                      (e.g., "3,5,7-10").
 
+    Weak LLMs sometimes emit messy specs (a trailing comma, an empty entry, a
+    lone hyphen, or a malformed range like "1-" or "1-2-3"). Such fragments are
+    skipped -- and logged at WARNING -- rather than raised on, so the
+    well-formed part of the spec is still honored.
+
     Returns:
         List[int]: List of segment numbers.
 
@@ -224,16 +229,34 @@ def parse_number_range_list(specs: str) -> List[int]:
         [3, 5, 7, 8, 9, 10]
     """
     spec_indices = set()  # type: ignore
-    for part in specs.split(","):
+    skipped: List[str] = []
+    for original in specs.split(","):
         # some weak LLMs may generate <#1#> instead of 1, so extract just the digits
         # or the "-"
-        part = "".join(char for char in part if char.isdigit() or char == "-")
+        part = "".join(char for char in original if char.isdigit() or char == "-")
+        if part == "" or part == "-":
+            # no digits at all, e.g. from a trailing comma or a lone hyphen
+            if original.strip() != "":
+                skipped.append(original)
+            continue
         if "-" in part:
-            start, end = map(int, part.split("-"))
-            spec_indices.update(range(start, end + 1))
+            endpoints = part.split("-")
+            # a well-formed range has exactly two integer endpoints
+            if len(endpoints) != 2 or endpoints[0] == "" or endpoints[1] == "":
+                skipped.append(original)
+                continue
+            spec_indices.update(range(int(endpoints[0]), int(endpoints[1]) + 1))
         else:
             spec_indices.add(int(part))
 
+    if skipped:
+        logger.warning(
+            "parse_number_range_list: skipped malformed segment spec(s) %s "
+            "in %r; returning only the well-formed segments %s",
+            skipped,
+            specs,
+            sorted(spec_indices),
+        )
     return sorted(list(spec_indices))
 
 

--- a/langroid/parsing/utils.py
+++ b/langroid/parsing/utils.py
@@ -212,10 +212,15 @@ def parse_number_range_list(specs: str) -> List[int]:
     """
     Parse a specs string like "3,5,7-10" into a list of integers.
 
-    Weak LLMs sometimes emit messy specs (a trailing comma, an empty entry, a
-    lone hyphen, or a malformed range like "1-" or "1-2-3"). Such fragments are
-    skipped -- and logged at WARNING -- rather than raised on, so the
-    well-formed part of the spec is still honored.
+    Weak LLMs sometimes emit messy specs. Rather than raising, such fragments
+    are skipped so the well-formed part of the spec is still honored:
+
+    - A fragment with no digits at all (a trailing comma, an empty entry, a
+      lone hyphen) refers to no segment, so nothing is lost and it is skipped
+      quietly.
+    - A fragment that does contain digits but is not a valid spec (``"1-"``,
+      ``"-5"``, ``"1-2-3"``) drops a segment reference the model meant to make,
+      so it is skipped *and* logged at WARNING.
 
     Args:
         specs (str): A string containing segment numbers and/or ranges
@@ -235,9 +240,8 @@ def parse_number_range_list(specs: str) -> List[int]:
         # or the "-"
         part = "".join(char for char in original if char.isdigit() or char == "-")
         if part == "" or part == "-":
-            # no digits at all, e.g. from a trailing comma or a lone hyphen
-            if original.strip() != "":
-                skipped.append(original)
+            # no digits at all, e.g. from a trailing comma or a lone hyphen:
+            # this refers to no segment, so nothing is lost -- skip quietly
             continue
         if "-" in part:
             endpoints = part.split("-")

--- a/langroid/parsing/utils.py
+++ b/langroid/parsing/utils.py
@@ -239,9 +239,10 @@ def parse_number_range_list(specs: str) -> List[int]:
         # some weak LLMs may generate <#1#> instead of 1, so extract just the digits
         # or the "-"
         part = "".join(char for char in original if char.isdigit() or char == "-")
-        if part == "" or part == "-":
-            # no digits at all, e.g. from a trailing comma or a lone hyphen:
-            # this refers to no segment, so nothing is lost -- skip quietly
+        if not any(char.isdigit() for char in part):
+            # no digits at all, e.g. from a trailing comma or one or more
+            # stray hyphens: this refers to no segment, so nothing is lost
+            # -- skip quietly
             continue
         if "-" in part:
             endpoints = part.split("-")

--- a/langroid/parsing/utils.py
+++ b/langroid/parsing/utils.py
@@ -212,14 +212,14 @@ def parse_number_range_list(specs: str) -> List[int]:
     """
     Parse a specs string like "3,5,7-10" into a list of integers.
 
-    Args:
-        specs (str): A string containing segment numbers and/or ranges
-                     (e.g., "3,5,7-10").
-
     Weak LLMs sometimes emit messy specs (a trailing comma, an empty entry, a
     lone hyphen, or a malformed range like "1-" or "1-2-3"). Such fragments are
     skipped -- and logged at WARNING -- rather than raised on, so the
     well-formed part of the spec is still honored.
+
+    Args:
+        specs (str): A string containing segment numbers and/or ranges
+                     (e.g., "3,5,7-10").
 
     Returns:
         List[int]: List of segment numbers.

--- a/tests/main/test_relevance_extractor.py
+++ b/tests/main/test_relevance_extractor.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from typing import List
 
 import nltk
@@ -237,6 +238,81 @@ def test_relevance_extractor_batch(
     expected_sentences = [s.strip() for s in expected_sentences]
     extracted_sentences = [s.strip() for s in extracted_sentences]
     assert set(extracted_sentences) == set(expected_sentences)
+
+
+@pytest.mark.parametrize(
+    "specs, expected",
+    [
+        # well-formed inputs (existing behavior must be preserved)
+        ("3,5,7-10", [3, 5, 7, 8, 9, 10]),
+        ("2-4,7,12-13", [2, 3, 4, 7, 12, 13]),
+        # weak LLMs may wrap numbers as <#1#>, or use spaces
+        ("<#1#>,<#2#>", [1, 2]),
+        (" 1 , 2 ", [1, 2]),
+        # messy fragments that must NOT crash: trailing comma, empty
+        # entries, or a lone hyphen (regression for a ValueError crash)
+        ("1,2,3,", [1, 2, 3]),
+        ("1,,2", [1, 2]),
+        ("1,-,2", [1, 2]),
+        ("", []),
+        (",", []),
+        # malformed ranges are skipped rather than crashing
+        ("1-2-3,5", [5]),
+        ("1-,4", [4]),
+        ("-5,4", [4]),
+        ("1-2-3", []),
+    ],
+)
+def test_parse_number_range_list(specs, expected):
+    assert parse_number_range_list(specs) == expected
+
+
+@pytest.fixture
+def root_log_messages():
+    """Collect root-logger messages via a plain handler.
+
+    CI runs tests/main with `-p no:logging`, which disables pytest's
+    `caplog` fixture, so capture with a temporary `logging.Handler` (as in
+    `tests/main/test_url_loader.py`).
+    """
+    messages = []
+
+    class Collector(logging.Handler):
+        def emit(self, record):
+            messages.append(record.getMessage())
+
+    root = logging.getLogger()
+    handler = Collector(level=logging.WARNING)
+    root.addHandler(handler)
+    try:
+        yield messages
+    finally:
+        root.removeHandler(handler)
+
+
+@pytest.mark.parametrize(
+    "specs, skipped",
+    [
+        ("1-2-3,5", "1-2-3"),
+        ("1-,4", "1-"),
+        ("-5,4", "-5"),
+        ("1,-,2", "-"),
+    ],
+)
+def test_parse_number_range_list_warns_on_skip(specs, skipped, root_log_messages):
+    # skipping must be observable: a malformed fragment is dropped, but the
+    # loss is logged rather than silent.
+    parse_number_range_list(specs)
+    warnings = [m for m in root_log_messages if "skipped malformed segment spec" in m]
+    assert warnings, f"no skip warning logged for {specs!r}"
+    assert any(skipped in m for m in warnings)
+
+
+def test_parse_number_range_list_no_warning_when_clean(root_log_messages):
+    assert parse_number_range_list("3,5,7-10") == [3, 5, 7, 8, 9, 10]
+    assert not [
+        m for m in root_log_messages if "skipped malformed segment spec" in m
+    ], "well-formed spec must not warn"
 
 
 @pytest.mark.parametrize(

--- a/tests/main/test_relevance_extractor.py
+++ b/tests/main/test_relevance_extractor.py
@@ -254,6 +254,8 @@ def test_relevance_extractor_batch(
         ("1,2,3,", [1, 2, 3]),
         ("1,,2", [1, 2]),
         ("1,-,2", [1, 2]),
+        ("1,--,2", [1, 2]),
+        ("1,-foo-,2", [1, 2]),
         ("", []),
         (",", []),
         # malformed ranges are skipped rather than crashing
@@ -320,6 +322,10 @@ def test_parse_number_range_list_warns_on_dropped_segment(
         "1,-,2",
         "",
         ",",
+        # several stray hyphens still carry no segment reference
+        "1,--,2",
+        "1,-foo-,2",
+        "--",
     ],
 )
 def test_parse_number_range_list_no_warning_when_nothing_lost(specs, root_log_messages):

--- a/tests/main/test_relevance_extractor.py
+++ b/tests/main/test_relevance_extractor.py
@@ -296,23 +296,37 @@ def root_log_messages():
         ("1-2-3,5", "1-2-3"),
         ("1-,4", "1-"),
         ("-5,4", "-5"),
-        ("1,-,2", "-"),
     ],
 )
-def test_parse_number_range_list_warns_on_skip(specs, skipped, root_log_messages):
-    # skipping must be observable: a malformed fragment is dropped, but the
-    # loss is logged rather than silent.
+def test_parse_number_range_list_warns_on_dropped_segment(
+    specs, skipped, root_log_messages
+):
+    # a fragment that carried digits but was malformed drops a segment the
+    # model meant to name, so the loss must be logged rather than silent.
     parse_number_range_list(specs)
     warnings = [m for m in root_log_messages if "skipped malformed segment spec" in m]
     assert warnings, f"no skip warning logged for {specs!r}"
     assert any(skipped in m for m in warnings)
 
 
-def test_parse_number_range_list_no_warning_when_clean(root_log_messages):
-    assert parse_number_range_list("3,5,7-10") == [3, 5, 7, 8, 9, 10]
+@pytest.mark.parametrize(
+    "specs",
+    [
+        # well-formed: nothing skipped at all
+        "3,5,7-10",
+        # digit-less fragments refer to no segment, so nothing is lost
+        "1,2,3,",
+        "1,,2",
+        "1,-,2",
+        "",
+        ",",
+    ],
+)
+def test_parse_number_range_list_no_warning_when_nothing_lost(specs, root_log_messages):
+    parse_number_range_list(specs)
     assert not [
         m for m in root_log_messages if "skipped malformed segment spec" in m
-    ], "well-formed spec must not warn"
+    ], f"{specs!r} loses no segment, so it must not warn"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Supersedes #1117 — thanks @pacocartones for finding this and for the original
fix, which this PR builds on.

### Problem

`parse_number_range_list` (`langroid/parsing/utils.py`) is documented to
tolerate weak-LLM output, but it raised `ValueError` on common messy input:

- a trailing comma: `"1,2,3,"` → `int("")`
- an empty entry: `"1,,2"`
- a lone hyphen or a malformed range: `"-"`, `"1-"`, `"-5"`, `"1-2-3"`

Its only production caller, `extract_numbered_segments` via
`RelevanceExtractorAgent.extract_segments`, wraps the call in
`except Exception: return DONE + NO_ANSWER`, so the crash was swallowed and
**every** segment the model had identified was silently discarded in the
DocChat RAG relevance path.

### Fix

Skip digit-less fragments and malformed ranges instead of raising, so the
well-formed part of the spec is still honored — and log the skipped fragments
at `WARNING`, so the partial result is not silent. (The previous behavior
dropped everything with no log at all.) A malformed range such as `"1-2-3"` is
deliberately **not** guessed at.

Well-formed input is unchanged: a differential run over 10,129 generated
well-formed specs found 0 differences from `main`.

### Tests

- 13 parse cases: every well-formed case preserved, every messy case tolerated.
- Warning-emitted / not-emitted cases.

The log assertions use a plain `logging.Handler` rather than `caplog`, since
CI runs `tests/main` with `-p no:logging` (see #1115).

Verified RED against `main` (13 failures) and GREEN on this branch (18 passed),
each run with an in-process source assertion so the import could not silently
resolve to the wrong tree. `black --check`, `ruff check`, and `mypy` on the
changed source are clean.
