### PR TITLE
fix(utils): expand '~' in read_file and close the resulting file-tool sandbox escape

### DIFF
--- a/langroid/utils/system.py
+++ b/langroid/utils/system.py
@@ -192,9 +192,10 @@ def safe_resolve_path(base_dir: str | Path, user_path: str | Path) -> Path:
     Resolve ``user_path`` relative to ``base_dir`` and ensure the result stays
     within ``base_dir`` (a path-traversal guard for file tools).
 
-    A ``user_path`` containing ``..`` segments, an absolute path, or a symlink
-    pointing outside ``base_dir`` is rejected. Symlinks are resolved via
-    :meth:`pathlib.Path.resolve`, so symlink-based escapes are caught as well.
+    A ``user_path`` containing ``..`` segments, an absolute path, a ``~`` home
+    reference, or a symlink pointing outside ``base_dir`` is rejected. Symlinks
+    are resolved via :meth:`pathlib.Path.resolve`, so symlink-based escapes are
+    caught as well.
 
     Args:
         base_dir (str|Path): Directory that file operations must stay within.
@@ -207,7 +208,9 @@ def safe_resolve_path(base_dir: str | Path, user_path: str | Path) -> Path:
         ValueError: If the resolved path escapes ``base_dir``.
     """
     base = Path(base_dir).resolve()
-    target = (base / Path(user_path)).resolve()
+    # expand "~" here too, so a "~/..." path is checked as the home path it
+    # actually refers to, rather than as a literal "~" directory under base_dir
+    target = (base / Path(user_path).expanduser()).resolve()
     if target != base and base not in target.parents:
         raise ValueError(
             f"Path '{user_path}' is outside the allowed directory '{base}'"
@@ -274,10 +277,12 @@ def read_file(path: str, line_numbers: bool = False) -> str:
     Raises:
         FileNotFoundError: If the specified file does not exist.
     """
-    # raise an error if the file does not exist
-    if not Path(path).exists():
-        raise FileNotFoundError(f"File not found: {path}")
+    # expand "~" before checking existence, so a "~/..." path is not
+    # spuriously reported as missing
     file = Path(path).expanduser()
+    # raise an error if the file does not exist
+    if not file.exists():
+        raise FileNotFoundError(f"File not found: {path}")
     content = file.read_text()
     if line_numbers:
         lines = content.splitlines()

--- a/langroid/utils/system.py
+++ b/langroid/utils/system.py
@@ -187,6 +187,29 @@ def generate_unique_id() -> str:
     return str(uuid.uuid4())
 
 
+def expand_user_path(path: str | Path) -> Path:
+    """
+    Expand a leading ``~`` in ``path``, falling back to the literal path when
+    the home directory cannot be determined.
+
+    :meth:`pathlib.Path.expanduser` raises ``RuntimeError`` for an unresolvable
+    reference such as ``~nosuchuser/f.txt``. Callers here treat a path they
+    cannot expand as an ordinary (literal) path, so an agent-supplied path can
+    never crash a file tool.
+
+    Args:
+        path (str|Path): The path to expand.
+
+    Returns:
+        Path: The expanded path, or the literal path if expansion failed.
+    """
+    p = Path(path)
+    try:
+        return p.expanduser()
+    except RuntimeError:
+        return p
+
+
 def safe_resolve_path(base_dir: str | Path, user_path: str | Path) -> Path:
     """
     Resolve ``user_path`` relative to ``base_dir`` and ensure the result stays
@@ -210,7 +233,7 @@ def safe_resolve_path(base_dir: str | Path, user_path: str | Path) -> Path:
     base = Path(base_dir).resolve()
     # expand "~" here too, so a "~/..." path is checked as the home path it
     # actually refers to, rather than as a literal "~" directory under base_dir
-    target = (base / Path(user_path).expanduser()).resolve()
+    target = (base / expand_user_path(user_path)).resolve()
     if target != base and base not in target.parents:
         raise ValueError(
             f"Path '{user_path}' is outside the allowed directory '{base}'"
@@ -279,7 +302,7 @@ def read_file(path: str, line_numbers: bool = False) -> str:
     """
     # expand "~" before checking existence, so a "~/..." path is not
     # spuriously reported as missing
-    file = Path(path).expanduser()
+    file = expand_user_path(path)
     # raise an error if the file does not exist
     if not file.exists():
         raise FileNotFoundError(f"File not found: {path}")

--- a/langroid/utils/system.py
+++ b/langroid/utils/system.py
@@ -220,6 +220,13 @@ def safe_resolve_path(base_dir: str | Path, user_path: str | Path) -> Path:
     are resolved via :meth:`pathlib.Path.resolve`, so symlink-based escapes are
     caught as well.
 
+    A ``~`` path is checked under *both* interpretations -- expanded (as
+    :func:`read_file` reads it) and literal (as ``create_file`` and
+    :func:`list_dir` write/list it, since those do not expand) -- and rejected
+    if either one escapes. Callers validate with this function but then operate
+    on the raw path, so validating only one interpretation would leave the other
+    unguarded.
+
     Args:
         base_dir (str|Path): Directory that file operations must stay within.
         user_path (str|Path): User/agent-supplied path (relative or absolute).
@@ -231,14 +238,14 @@ def safe_resolve_path(base_dir: str | Path, user_path: str | Path) -> Path:
         ValueError: If the resolved path escapes ``base_dir``.
     """
     base = Path(base_dir).resolve()
-    # expand "~" here too, so a "~/..." path is checked as the home path it
-    # actually refers to, rather than as a literal "~" directory under base_dir
-    target = (base / expand_user_path(user_path)).resolve()
-    if target != base and base not in target.parents:
-        raise ValueError(
-            f"Path '{user_path}' is outside the allowed directory '{base}'"
-        )
-    return target
+    expanded = (base / expand_user_path(user_path)).resolve()
+    literal = (base / Path(user_path)).resolve()
+    for target in (expanded, literal):
+        if target != base and base not in target.parents:
+            raise ValueError(
+                f"Path '{user_path}' is outside the allowed directory '{base}'"
+            )
+    return expanded
 
 
 def create_file(

--- a/tests/main/test_file_tools.py
+++ b/tests/main/test_file_tools.py
@@ -357,6 +357,21 @@ def test_read_file_tool_symlink_escape_blocked(sandbox_with_secret):
     assert _ESCAPE_MARKER in result
 
 
+def test_read_file_tool_tilde_escape_blocked(sandbox_with_secret, monkeypatch):
+    # "~/..." must be checked as the home path it refers to, not as a literal
+    # "~" directory under the sandbox -- otherwise read_file's expanduser()
+    # reads it from the real home dir after the guard has already passed.
+    sandbox, secret = sandbox_with_secret
+    monkeypatch.setenv("HOME", str(secret.parent))
+    monkeypatch.setenv("USERPROFILE", str(secret.parent))  # Windows
+    tool = ReadFileTool.create(get_curr_dir=lambda: sandbox)(
+        file_path=f"~/{secret.name}"
+    )
+    result = tool.handle()
+    assert "LANGROID_TOOL_ESCAPE_SECRET" not in result
+    assert _ESCAPE_MARKER in result
+
+
 def test_write_file_tool_parent_traversal_blocked(temp_dir):
     sandbox = temp_dir / "sandbox"
     sandbox.mkdir()

--- a/tests/main/test_file_tools.py
+++ b/tests/main/test_file_tools.py
@@ -372,6 +372,19 @@ def test_read_file_tool_tilde_escape_blocked(sandbox_with_secret, monkeypatch):
     assert _ESCAPE_MARKER in result
 
 
+def test_read_file_tool_unresolvable_tilde_user_no_crash(sandbox_with_secret):
+    # "~nosuchuser/..." cannot be expanded (Path.expanduser raises
+    # RuntimeError for it); the tool must return its normal error string
+    # rather than propagating RuntimeError out of the handler.
+    sandbox, _ = sandbox_with_secret
+    tool = ReadFileTool.create(get_curr_dir=lambda: sandbox)(
+        file_path="~nosuchuser12345/f.txt"
+    )
+    result = tool.handle()
+    assert "LANGROID_TOOL_ESCAPE_SECRET" not in result
+    assert "File not found" in result
+
+
 def test_write_file_tool_parent_traversal_blocked(temp_dir):
     sandbox = temp_dir / "sandbox"
     sandbox.mkdir()

--- a/tests/main/test_system_utils.py
+++ b/tests/main/test_system_utils.py
@@ -150,6 +150,27 @@ def test_safe_resolve_path_unresolvable_tilde_user(tmp_path):
     assert base in resolved.parents
 
 
+def test_safe_resolve_path_rejects_literal_tilde_symlink_escape(tmp_path, monkeypatch):
+    # The tools validate with safe_resolve_path but then operate on the RAW
+    # path: create_file/list_dir do not expand "~". So when base_dir is the
+    # home dir, "~/x" expands to an in-base path while the literal "base/~/x"
+    # can follow a "~" symlink out of the sandbox. Both readings must be
+    # checked.
+    home = tmp_path / "home"
+    home.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("SECRET")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))  # Windows
+    try:
+        (home / "~").symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+    with pytest.raises(ValueError, match="outside the allowed directory"):
+        safe_resolve_path(home, "~/secret.txt")
+
+
 def test_safe_resolve_path_allows_path_within_base(tmp_path):
     base = tmp_path / "sandbox"
     (base / "sub").mkdir(parents=True)

--- a/tests/main/test_system_utils.py
+++ b/tests/main/test_system_utils.py
@@ -2,7 +2,12 @@ from pathlib import Path
 
 import pytest
 
-from langroid.utils.system import create_file, diff_files, read_file
+from langroid.utils.system import (
+    create_file,
+    diff_files,
+    read_file,
+    safe_resolve_path,
+)
 
 
 @pytest.fixture
@@ -93,6 +98,45 @@ def test_read_file_with_line_numbers(tmp_path):
     file_path.write_text(content)
     expected = "1: Line 1\n2: Line 2\n3: Line 3"
     assert read_file(str(file_path), line_numbers=True) == expected
+
+
+def test_read_file_tilde_expansion(tmp_path, monkeypatch):
+    # simulate a home directory and read a file via a "~/..." path;
+    # read_file must expand "~" before checking existence (regression
+    # for a FileNotFoundError raised on a path that actually exists).
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))  # Windows
+    content = "Line 1\nLine 2"
+    (tmp_path / "tilde_read_test.txt").write_text(content)
+    assert read_file("~/tilde_read_test.txt") == content
+
+
+def test_read_file_missing_tilde_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))  # Windows
+    with pytest.raises(FileNotFoundError):
+        read_file("~/no_such_file.txt")
+
+
+def test_safe_resolve_path_rejects_tilde(tmp_path, monkeypatch):
+    # "~" must not be treated as a literal directory name under base_dir:
+    # read_file expands it, so the guard has to expand it too.
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "secret.txt").write_text("SECRET")
+    base = tmp_path / "sandbox"
+    base.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))  # Windows
+    with pytest.raises(ValueError, match="outside the allowed directory"):
+        safe_resolve_path(base, "~/secret.txt")
+
+
+def test_safe_resolve_path_allows_path_within_base(tmp_path):
+    base = tmp_path / "sandbox"
+    (base / "sub").mkdir(parents=True)
+    (base / "sub" / "ok.txt").write_text("ok")
+    assert safe_resolve_path(base, "sub/ok.txt") == (base / "sub" / "ok.txt").resolve()
 
 
 def test_diff_files(tmp_path):

--- a/tests/main/test_system_utils.py
+++ b/tests/main/test_system_utils.py
@@ -132,6 +132,24 @@ def test_safe_resolve_path_rejects_tilde(tmp_path, monkeypatch):
         safe_resolve_path(base, "~/secret.txt")
 
 
+def test_read_file_unresolvable_tilde_user(tmp_path, monkeypatch):
+    # "~nosuchuser/..." cannot be expanded; Path.expanduser() raises
+    # RuntimeError for it. read_file must still report it as missing, as it
+    # documents, rather than propagating RuntimeError.
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        read_file("~nosuchuser12345/f.txt")
+
+
+def test_safe_resolve_path_unresolvable_tilde_user(tmp_path):
+    # an unexpandable "~user" path is treated literally, so it stays inside
+    # base_dir and must not raise RuntimeError out of the guard.
+    base = tmp_path / "sandbox"
+    base.mkdir()
+    resolved = safe_resolve_path(base, "~nosuchuser12345/f.txt")
+    assert base in resolved.parents
+
+
 def test_safe_resolve_path_allows_path_within_base(tmp_path):
     base = tmp_path / "sandbox"
     (base / "sub").mkdir(parents=True)


### PR DESCRIPTION
Supersedes #1118 — thanks @pacocartones for finding this and for the original
fix, which this PR builds on.

### Problem

`read_file` (`langroid/utils/system.py`) supports `~` home paths via
`expanduser()`, but checked existence on the **un-expanded** path first:

```python
if not Path(path).exists():
    raise FileNotFoundError(f"File not found: {path}")
file = Path(path).expanduser()
```

So `read_file("~/existing_file")` raised `FileNotFoundError` even when
`$HOME/existing_file` exists. Reachable through `ReadFileTool`.

### Why the one-line fix alone is not safe

`ReadFileTool` gates on `safe_resolve_path(dir, self.file_path)`, which
resolved `"~/secret.txt"` as a **literal `~` directory** under `curr_dir` — so
the guard passes, and an expanding `read_file` then reads the real home
directory. Expanding only in `read_file` turns a blocked read into a working
sandbox escape (`~/.ssh/id_rsa` and friends). Reproduced against a fake
`$HOME`:

```
----- before this PR, with only read_file expanding -----
safe_resolve_path ALLOWED -> /tmp/escape/base/~/secret.txt
read_file result: 'SECRET-HOME-FILE\n'
```

### Fix

1. `read_file` expands once, then checks and reads the expanded path.
2. `safe_resolve_path` expands `~` too, so a `~/...` path is checked as the
   home path it actually refers to and is rejected as outside the allowed
   directory.
3. `Path.expanduser()` raises `RuntimeError` for an unexpandable reference such
   as `~nosuchuser/f.txt`, and the file tools catch only `ValueError` — so
   agent-supplied input could crash a handler, and `read_file` would raise
   `RuntimeError` where it documents `FileNotFoundError`. The new
   `expand_user_path()` falls back to the literal path; such a path then stays
   inside the sandbox and is simply reported as missing.

### Tests

- Tilde read succeeds; a missing tilde path still raises `FileNotFoundError`.
- `safe_resolve_path` rejects `~/...` and still allows in-base paths.
- `ReadFileTool` tilde escape is blocked — a companion to the existing
  GHSA-fg23-3346-88f5 traversal tests.
- Unexpandable `~user` paths do not raise `RuntimeError` out of `read_file`,
  `safe_resolve_path`, or the `ReadFileTool` handler.

Each new test was counter-verified RED with its corresponding source fix
reverted, and all 33 tests in `test_system_utils.py` + `test_file_tools.py`
pass on this branch. `black --check`, `ruff check`, and `mypy` on the changed
source are clean.
