### PR TITLE
Make table chat agent tests deterministic

### DIFF
--- a/tests/main/test_table_chat_agent.py
+++ b/tests/main/test_table_chat_agent.py
@@ -1,5 +1,8 @@
+import json
+from collections.abc import Generator
 from io import StringIO
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -7,6 +10,8 @@ import pytest
 
 from langroid.agent.special.table_chat_agent import TableChatAgent, TableChatAgentConfig
 from langroid.agent.task import Task
+from langroid.language_models.base import LLMFunctionCall, LLMMessage, LLMResponse
+from langroid.language_models.mock_lm import MockLM, MockLMConfig
 from langroid.parsing.table_loader import read_tabular_data
 from langroid.parsing.utils import closest_string
 from langroid.utils.configuration import Settings, set_global
@@ -21,18 +26,18 @@ DATA_STRING = """age,gender,income,state,,,,
 
 
 @pytest.fixture
-def mock_data_frame_blanks():
-    return read_tabular_data(StringIO(DATA_STRING))
+def mock_data_frame_blanks() -> pd.DataFrame:
+    return read_tabular_data(StringIO(DATA_STRING))  # type: ignore[arg-type]
 
 
 @pytest.fixture
-def mock_data_file_blanks(tmpdir):
+def mock_data_file_blanks(tmpdir: Any) -> str:
     file_path = tmpdir.join("mock_data.csv")
     file_path.write(DATA_STRING)
     return str(file_path)
 
 
-def generate_data(size: int) -> str:
+def generate_data(size: int) -> pd.DataFrame:
     # Create a list of states
     states = ["CA", "TX"]
 
@@ -61,11 +66,70 @@ def mock_dataframe() -> pd.DataFrame:
 
 
 @pytest.fixture
-def mock_data_file(tmp_path: Path) -> str:
+def mock_data_file(tmp_path: Path) -> Generator[str, None, None]:
     df = generate_data(100)  # generate data for 1000 rows
     file_path = tmp_path / "mock_data.csv"
     df.to_csv(file_path, index=False)
     yield str(file_path)
+
+
+class _SequenceLLM(MockLM):
+    """Return a deterministic sequence of responses for TableChatAgent tests."""
+
+    def __init__(self, responses: list[LLMResponse]) -> None:
+        super().__init__(MockLMConfig())
+        self.responses = responses
+        self.index = 0
+
+    def chat(
+        self,
+        messages: str | list[LLMMessage],
+        *args: Any,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        del messages, args, kwargs
+        if self.index >= len(self.responses):
+            return self.responses[-1]
+        response = self.responses[self.index]
+        self.index += 1
+        return response
+
+
+def _pandas_eval_response(expression: str, fn_api: bool) -> LLMResponse:
+    """Build the first model response that asks TableChatAgent to eval code."""
+    if fn_api:
+        return LLMResponse(
+            message="",
+            function_call=LLMFunctionCall(
+                name="pandas_eval",
+                arguments={"expression": expression},
+            ),
+        )
+
+    return LLMResponse(
+        message=json.dumps({"request": "pandas_eval", "expression": expression})
+    )
+
+
+def _average_income_expression_and_answer(
+    agent: TableChatAgent,
+) -> tuple[str, float]:
+    """Build the query expression and expected answer for the average-income test."""
+    age_col = closest_string("age", agent.df.columns)
+    state_col = closest_string("state", agent.df.columns)
+    gender_col = closest_string("gender", agent.df.columns)
+    income_col = closest_string("income", agent.df.columns)
+    expression = (
+        f"df[(df[{age_col!r}] < 40) & "
+        f"(df[{state_col!r}] == 'CA') & "
+        f"(df[{gender_col!r}] == 'Male')][{income_col!r}].mean()"
+    )
+    answer = agent.df[
+        (agent.df[age_col] < 40)
+        & (agent.df[state_col] == "CA")
+        & (agent.df[gender_col] == "Male")
+    ][income_col].mean()
+    return expression, answer
 
 
 def _test_table_chat_agent(
@@ -73,7 +137,7 @@ def _test_table_chat_agent(
     tabular_data: pd.DataFrame | str,
 ) -> None:
     """
-    Test the TableChatAgent with a file as data source
+    Test the TableChatAgent with a deterministic model-driven data query.
     """
     agent = TableChatAgent(
         config=TableChatAgentConfig(
@@ -83,41 +147,31 @@ def _test_table_chat_agent(
             full_eval=True,  # Allow full evaluation in tests
         )
     )
+    expression, answer = _average_income_expression_and_answer(agent)
+    agent.llm = _SequenceLLM(
+        [
+            _pandas_eval_response(expression, fn_api),
+            LLMResponse(message=f"DONE The average income is {answer}"),
+        ]
+    )
 
     task = Task(
         agent,
         name="TableChatAgent",
         interactive=False,
     )
+    result = task.run("What is the average income of men under 40 in CA?", turns=6)
 
-    # run until LLM says DONE and shows answer,
-    # at which point the task loop ends.
-    for _ in range(3):
-        # try 3 times to get non-empty result
-        result = task.run("What is the average income of men under 40 in CA?", turns=6)
-        if result.content:
-            break
-    age_col = closest_string("age", agent.df.columns)
-    state_col = closest_string("state", agent.df.columns)
-    gender_col = closest_string("gender", agent.df.columns)
-    income_col = closest_string("income", agent.df.columns)
-    answer = agent.df[
-        (agent.df[age_col] < 40)
-        & (agent.df[state_col] == "CA")
-        & (agent.df[gender_col] == "Male")
-    ][income_col].mean()
-
-    # TODO - there are intermittent failures here; address this, see issue #288
-    assert (
-        result.content == ""
-        or "TOOL" in result.content
-        or result.function_call is not None
-        or contains_approx_float(result.content, answer)
-    )
+    assert result is not None
+    assert contains_approx_float(result.content, answer)
 
 
 @pytest.mark.parametrize("fn_api", [True, False])
-def test_table_chat_agent_dataframe(test_settings: Settings, fn_api, mock_dataframe):
+def test_table_chat_agent_dataframe(
+    test_settings: Settings,
+    fn_api: bool,
+    mock_dataframe: pd.DataFrame,
+) -> None:
     set_global(test_settings)
     _test_table_chat_agent(
         fn_api=fn_api,
@@ -126,7 +180,11 @@ def test_table_chat_agent_dataframe(test_settings: Settings, fn_api, mock_datafr
 
 
 @pytest.mark.parametrize("fn_api", [True, False])
-def test_table_chat_agent_file(test_settings: Settings, fn_api, mock_data_file):
+def test_table_chat_agent_file(
+    test_settings: Settings,
+    fn_api: bool,
+    mock_data_file: str,
+) -> None:
     set_global(test_settings)
     _test_table_chat_agent(
         fn_api=fn_api,
@@ -136,8 +194,10 @@ def test_table_chat_agent_file(test_settings: Settings, fn_api, mock_data_file):
 
 @pytest.mark.parametrize("fn_api", [True, False])
 def test_table_chat_agent_dataframe_blanks(
-    test_settings: Settings, fn_api, mock_data_frame_blanks
-):
+    test_settings: Settings,
+    fn_api: bool,
+    mock_data_frame_blanks: pd.DataFrame,
+) -> None:
     set_global(test_settings)
     _test_table_chat_agent(
         fn_api=fn_api,
@@ -147,8 +207,10 @@ def test_table_chat_agent_dataframe_blanks(
 
 @pytest.mark.parametrize("fn_api", [True, False])
 def test_table_chat_agent_file_blanks(
-    test_settings: Settings, fn_api, mock_data_file_blanks
-):
+    test_settings: Settings,
+    fn_api: bool,
+    mock_data_file_blanks: str,
+) -> None:
     set_global(test_settings)
     _test_table_chat_agent(
         fn_api=fn_api,
@@ -180,6 +242,28 @@ def test_table_chat_agent_assignment_self_correction(test_settings: Settings) ->
             full_eval=False,  # Keep security restrictions to test self-correction
         )
     )
+    agent.llm = _SequenceLLM(
+        [
+            _pandas_eval_response(
+                "df['airline'] = df['airline'].str.replace('*', '', regex=False)",
+                fn_api=False,
+            ),
+            _pandas_eval_response(
+                "df.assign(airline=df['airline'].str.replace('*', ''))",
+                fn_api=False,
+            ),
+            LLMResponse(
+                message=(
+                    "DONE Removed the asterisks and cleaned data.\n"
+                    "airline  price destination\n"
+                    "United   100 NYC\n"
+                    "Delta    150 LAX\n"
+                    "American 120 CHI\n"
+                    "Southwest 80 DEN"
+                )
+            ),
+        ]
+    )
 
     task = Task(
         agent,
@@ -194,6 +278,7 @@ def test_table_chat_agent_assignment_self_correction(test_settings: Settings) ->
     )
 
     # Check that the result indicates success
+    assert result is not None
     assert "United*" not in result.content
     assert "Delta*" not in result.content
     # The agent successfully cleaned the data (it says so in the message)
@@ -216,6 +301,16 @@ def test_table_chat_agent_url(test_settings: Settings, fn_api: bool) -> None:
             full_eval=True,  # Allow full evaluation in tests
         )
     )
+    answer = agent.df[agent.df["cotton"] < 500]["poultry"].mean()
+    agent.llm = _SequenceLLM(
+        [
+            _pandas_eval_response(
+                "df[df['cotton'] < 500]['poultry'].mean()",
+                fn_api=fn_api,
+            ),
+            LLMResponse(message=f"DONE The average poultry export is {answer}"),
+        ]
+    )
 
     task = Task(
         agent,
@@ -234,7 +329,5 @@ def test_table_chat_agent_url(test_settings: Settings, fn_api: bool) -> None:
         turns=5,
     )
 
-    df = agent.df
-    # directly get the answer
-    answer = df[df["cotton"] < 500]["poultry"].mean()
+    assert result is not None
     assert contains_approx_float(result.content, answer)

--- a/tests/main/test_table_chat_agent.py
+++ b/tests/main/test_table_chat_agent.py
@@ -76,7 +76,10 @@ def mock_data_file(tmp_path: Path) -> Generator[str, None, None]:
 class _SequenceLLM(MockLM):
     """Return a deterministic sequence of responses for TableChatAgent tests."""
 
-    def __init__(self, responses: list[LLMResponse]) -> None:
+    def __init__(
+        self,
+        responses: list[tuple[tuple[str, ...], tuple[str, ...], LLMResponse]],
+    ) -> None:
         super().__init__(MockLMConfig())
         self.responses = responses
         self.index = 0
@@ -87,11 +90,16 @@ class _SequenceLLM(MockLM):
         *args: Any,
         **kwargs: Any,
     ) -> LLMResponse:
-        del messages, args, kwargs
-        if self.index >= len(self.responses):
-            return self.responses[-1]
-        response = self.responses[self.index]
+        del args, kwargs
+        assert isinstance(messages, list)
+        assert self.index < len(self.responses), "unexpected extra model call"
+        expected, forbidden, response = self.responses[self.index]
         self.index += 1
+        last_message = messages[-1].content or ""
+        for text in expected:
+            assert text in last_message
+        for text in forbidden:
+            assert text not in last_message
         return response
 
 
@@ -150,8 +158,16 @@ def _test_table_chat_agent(
     expression, answer = _average_income_expression_and_answer(agent)
     agent.llm = _SequenceLLM(
         [
-            _pandas_eval_response(expression, fn_api),
-            LLMResponse(message=f"DONE The average income is {answer}"),
+            (
+                ("average income",),
+                (),
+                _pandas_eval_response(expression, fn_api),
+            ),
+            (
+                (str(answer),),
+                ("ERROR",),
+                LLMResponse(message=f"DONE The average income is {answer}"),
+            ),
         ]
     )
 
@@ -244,23 +260,35 @@ def test_table_chat_agent_assignment_self_correction(test_settings: Settings) ->
     )
     agent.llm = _SequenceLLM(
         [
-            _pandas_eval_response(
-                "df['airline'] = df['airline'].str.replace('*', '', regex=False)",
-                fn_api=False,
+            (
+                ("asterisk",),
+                (),
+                _pandas_eval_response(
+                    "df['airline'] = df['airline'].str.replace('*', '', regex=False)",
+                    fn_api=False,
+                ),
             ),
-            _pandas_eval_response(
-                "df.assign(airline=df['airline'].str.replace('*', ''))",
-                fn_api=False,
+            (
+                ("ERROR", "SyntaxError"),
+                (),
+                _pandas_eval_response(
+                    "df.assign(airline=df['airline'].str.replace('*', ''))",
+                    fn_api=False,
+                ),
             ),
-            LLMResponse(
-                message=(
-                    "DONE Removed the asterisks and cleaned data.\n"
-                    "airline  price destination\n"
-                    "United   100 NYC\n"
-                    "Delta    150 LAX\n"
-                    "American 120 CHI\n"
-                    "Southwest 80 DEN"
-                )
+            (
+                ("United", "Delta", "American", "Southwest"),
+                ("*", "ERROR"),
+                LLMResponse(
+                    message=(
+                        "DONE Removed the asterisks and cleaned data.\n"
+                        "airline  price destination\n"
+                        "United   100 NYC\n"
+                        "Delta    150 LAX\n"
+                        "American 120 CHI\n"
+                        "Southwest 80 DEN"
+                    )
+                ),
             ),
         ]
     )
@@ -304,11 +332,19 @@ def test_table_chat_agent_url(test_settings: Settings, fn_api: bool) -> None:
     answer = agent.df[agent.df["cotton"] < 500]["poultry"].mean()
     agent.llm = _SequenceLLM(
         [
-            _pandas_eval_response(
-                "df[df['cotton'] < 500]['poultry'].mean()",
-                fn_api=fn_api,
+            (
+                ("average poultry",),
+                (),
+                _pandas_eval_response(
+                    "df[df['cotton'] < 500]['poultry'].mean()",
+                    fn_api=fn_api,
+                ),
             ),
-            LLMResponse(message=f"DONE The average poultry export is {answer}"),
+            (
+                (str(answer),),
+                ("ERROR",),
+                LLMResponse(message=f"DONE The average poultry export is {answer}"),
+            ),
         ]
     )
 


### PR DESCRIPTION
## Summary

Replace the live-model dependency in `test_table_chat_agent.py` with a deterministic `MockLM` response sequence.

The table-chat tests previously retried a live model and then accepted empty, tool-only, or unfinished function-call results, so they could either fail intermittently or pass without verifying the computed answer. The updated tests now:

- exercise both native function-call and Langroid tool-message paths with scripted `pandas_eval` requests;
- require the final response to contain the computed result;
- deterministically exercise assignment rejection followed by the documented `df.assign(...)` self-correction;
- keep the URL-backed table test deterministic after loading its fixture data; and
- add complete annotations for this test module's fixtures and helpers.

## Validation

- `.venv/bin/pytest -xvs tests/main/test_table_chat_agent.py` — 11 passed
- `.venv/bin/black --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy -p langroid`
- `.venv/bin/mypy tests/main/test_table_chat_agent.py`
- `.venv/bin/pre-commit run --all-files`

Closes #288

AI assistance: This change was implemented with OpenAI Codex and independently reviewed and validated before submission.
