### PR TITLE
fix: avoid sharing the default TaskConfig across Task instances

### DIFF
--- a/langroid/agent/task.py
+++ b/langroid/agent/task.py
@@ -226,7 +226,7 @@ class Task:
         default_return_type: Optional[type] = None,
         done_if_no_response: List[Responder] = [],
         done_if_response: List[Responder] = [],
-        config: TaskConfig = TaskConfig(),
+        config: TaskConfig | None = None,
         **kwargs: Any,  # catch-all for any legacy params, for backwards compatibility
     ):
         """
@@ -308,6 +308,7 @@ class Task:
             show_subtask_response=noop_fn,
             set_parent_agent=noop_fn,
         )
+        config = config if config is not None else TaskConfig()
         self.config = config
         # Store parsed done sequences (will be initialized after agent assignment)
         self._parsed_done_sequences: Optional[List[DoneSequence]] = None

--- a/tests/main/test_task.py
+++ b/tests/main/test_task.py
@@ -32,6 +32,21 @@ from langroid.utils.configuration import (
 from langroid.utils.constants import DONE, PASS
 
 
+def test_task_config_identity_contract() -> None:
+    """Default tasks get fresh configs while explicit configs retain identity."""
+    first = Task()
+    second = Task()
+
+    assert first.config is not second.config
+    first.config.recognize_string_signals = False
+    assert second.config.recognize_string_signals
+
+    config = TaskConfig()
+    explicit = Task(config=config)
+    assert explicit.config is config
+    assert isinstance(Task(config=None).config, TaskConfig)
+
+
 def test_task_cost(test_settings: Settings):
     """Test that max_cost, max_tokens are respected by Task.run()"""
 


### PR DESCRIPTION
Fixes #1123

## Summary

`Task.__init__` used a `TaskConfig()` default, so tasks created without an
explicit config shared the same mutable object.

This changes the default to `None` and creates a fresh `TaskConfig` for each
task when no config is supplied. Explicitly supplied configs are still used as
is, preserving existing explicit sharing and `Task.clone()` behavior.

The regression test covers default-config isolation, mutation isolation,
explicit-config identity, and `config=None`.

## Tests

- Targeted pytest: `tests/main/test_task.py -k "task_config_identity_contract or task_restart"` (3 passed)
- `black --check langroid/agent/task.py tests/main/test_task.py`
- `ruff check langroid/agent/task.py tests/main/test_task.py`
- `mypy langroid/agent/task.py`