### PR TITLE
test: make table chat agent tests deterministic (supersedes #1121)

### DIFF
--- a/tests/main/test_table_chat_agent.py
+++ b/tests/main/test_table_chat_agent.py
@@ -1,5 +1,8 @@
+import json
+from collections.abc import Generator
 from io import StringIO
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -7,6 +10,8 @@ import pytest
 
 from langroid.agent.special.table_chat_agent import TableChatAgent, TableChatAgentConfig
 from langroid.agent.task import Task
+from langroid.language_models.base import LLMFunctionCall, LLMMessage, LLMResponse
+from langroid.language_models.mock_lm import MockLM, MockLMConfig
 from langroid.parsing.table_loader import read_tabular_data
 from langroid.parsing.utils import closest_string
 from langroid.utils.configuration import Settings, set_global
@@ -21,18 +26,18 @@ DATA_STRING = """age,gender,income,state,,,,
 
 
 @pytest.fixture
-def mock_data_frame_blanks():
-    return read_tabular_data(StringIO(DATA_STRING))
+def mock_data_frame_blanks() -> pd.DataFrame:
+    return read_tabular_data(StringIO(DATA_STRING))  # type: ignore[arg-type]
 
 
 @pytest.fixture
-def mock_data_file_blanks(tmpdir):
+def mock_data_file_blanks(tmpdir: Any) -> str:
     file_path = tmpdir.join("mock_data.csv")
     file_path.write(DATA_STRING)
     return str(file_path)
 
 
-def generate_data(size: int) -> str:
+def generate_data(size: int) -> pd.DataFrame:
     # Create a list of states
     states = ["CA", "TX"]
 
@@ -61,11 +66,78 @@ def mock_dataframe() -> pd.DataFrame:
 
 
 @pytest.fixture
-def mock_data_file(tmp_path: Path) -> str:
+def mock_data_file(tmp_path: Path) -> Generator[str, None, None]:
     df = generate_data(100)  # generate data for 1000 rows
     file_path = tmp_path / "mock_data.csv"
     df.to_csv(file_path, index=False)
     yield str(file_path)
+
+
+class _SequenceLLM(MockLM):
+    """Return a deterministic sequence of responses for TableChatAgent tests."""
+
+    def __init__(
+        self,
+        responses: list[tuple[tuple[str, ...], tuple[str, ...], LLMResponse]],
+    ) -> None:
+        super().__init__(MockLMConfig())
+        self.responses = responses
+        self.index = 0
+
+    def chat(
+        self,
+        messages: str | list[LLMMessage],
+        *args: Any,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        del args, kwargs
+        assert isinstance(messages, list)
+        assert self.index < len(self.responses), "unexpected extra model call"
+        expected, forbidden, response = self.responses[self.index]
+        self.index += 1
+        last_message = messages[-1].content or ""
+        for text in expected:
+            assert text in last_message
+        for text in forbidden:
+            assert text not in last_message
+        return response
+
+
+def _pandas_eval_response(expression: str, fn_api: bool) -> LLMResponse:
+    """Build the first model response that asks TableChatAgent to eval code."""
+    if fn_api:
+        return LLMResponse(
+            message="",
+            function_call=LLMFunctionCall(
+                name="pandas_eval",
+                arguments={"expression": expression},
+            ),
+        )
+
+    return LLMResponse(
+        message=json.dumps({"request": "pandas_eval", "expression": expression})
+    )
+
+
+def _average_income_expression_and_answer(
+    agent: TableChatAgent,
+) -> tuple[str, float]:
+    """Build the query expression and expected answer for the average-income test."""
+    age_col = closest_string("age", agent.df.columns)
+    state_col = closest_string("state", agent.df.columns)
+    gender_col = closest_string("gender", agent.df.columns)
+    income_col = closest_string("income", agent.df.columns)
+    expression = (
+        f"df[(df[{age_col!r}] < 40) & "
+        f"(df[{state_col!r}] == 'CA') & "
+        f"(df[{gender_col!r}] == 'Male')][{income_col!r}].mean()"
+    )
+    answer = agent.df[
+        (agent.df[age_col] < 40)
+        & (agent.df[state_col] == "CA")
+        & (agent.df[gender_col] == "Male")
+    ][income_col].mean()
+    return expression, answer
 
 
 def _test_table_chat_agent(
@@ -73,7 +145,7 @@ def _test_table_chat_agent(
     tabular_data: pd.DataFrame | str,
 ) -> None:
     """
-    Test the TableChatAgent with a file as data source
+    Test the TableChatAgent with a deterministic model-driven data query.
     """
     agent = TableChatAgent(
         config=TableChatAgentConfig(
@@ -83,41 +155,39 @@ def _test_table_chat_agent(
             full_eval=True,  # Allow full evaluation in tests
         )
     )
+    expression, answer = _average_income_expression_and_answer(agent)
+    agent.llm = _SequenceLLM(
+        [
+            (
+                ("average income",),
+                (),
+                _pandas_eval_response(expression, fn_api),
+            ),
+            (
+                (str(answer),),
+                ("ERROR",),
+                LLMResponse(message=f"DONE The average income is {answer}"),
+            ),
+        ]
+    )
 
     task = Task(
         agent,
         name="TableChatAgent",
         interactive=False,
     )
+    result = task.run("What is the average income of men under 40 in CA?", turns=6)
 
-    # run until LLM says DONE and shows answer,
-    # at which point the task loop ends.
-    for _ in range(3):
-        # try 3 times to get non-empty result
-        result = task.run("What is the average income of men under 40 in CA?", turns=6)
-        if result.content:
-            break
-    age_col = closest_string("age", agent.df.columns)
-    state_col = closest_string("state", agent.df.columns)
-    gender_col = closest_string("gender", agent.df.columns)
-    income_col = closest_string("income", agent.df.columns)
-    answer = agent.df[
-        (agent.df[age_col] < 40)
-        & (agent.df[state_col] == "CA")
-        & (agent.df[gender_col] == "Male")
-    ][income_col].mean()
-
-    # TODO - there are intermittent failures here; address this, see issue #288
-    assert (
-        result.content == ""
-        or "TOOL" in result.content
-        or result.function_call is not None
-        or contains_approx_float(result.content, answer)
-    )
+    assert result is not None
+    assert contains_approx_float(result.content, answer)
 
 
 @pytest.mark.parametrize("fn_api", [True, False])
-def test_table_chat_agent_dataframe(test_settings: Settings, fn_api, mock_dataframe):
+def test_table_chat_agent_dataframe(
+    test_settings: Settings,
+    fn_api: bool,
+    mock_dataframe: pd.DataFrame,
+) -> None:
     set_global(test_settings)
     _test_table_chat_agent(
         fn_api=fn_api,
@@ -126,7 +196,11 @@ def test_table_chat_agent_dataframe(test_settings: Settings, fn_api, mock_datafr
 
 
 @pytest.mark.parametrize("fn_api", [True, False])
-def test_table_chat_agent_file(test_settings: Settings, fn_api, mock_data_file):
+def test_table_chat_agent_file(
+    test_settings: Settings,
+    fn_api: bool,
+    mock_data_file: str,
+) -> None:
     set_global(test_settings)
     _test_table_chat_agent(
         fn_api=fn_api,
@@ -136,8 +210,10 @@ def test_table_chat_agent_file(test_settings: Settings, fn_api, mock_data_file):
 
 @pytest.mark.parametrize("fn_api", [True, False])
 def test_table_chat_agent_dataframe_blanks(
-    test_settings: Settings, fn_api, mock_data_frame_blanks
-):
+    test_settings: Settings,
+    fn_api: bool,
+    mock_data_frame_blanks: pd.DataFrame,
+) -> None:
     set_global(test_settings)
     _test_table_chat_agent(
         fn_api=fn_api,
@@ -147,8 +223,10 @@ def test_table_chat_agent_dataframe_blanks(
 
 @pytest.mark.parametrize("fn_api", [True, False])
 def test_table_chat_agent_file_blanks(
-    test_settings: Settings, fn_api, mock_data_file_blanks
-):
+    test_settings: Settings,
+    fn_api: bool,
+    mock_data_file_blanks: str,
+) -> None:
     set_global(test_settings)
     _test_table_chat_agent(
         fn_api=fn_api,
@@ -180,6 +258,40 @@ def test_table_chat_agent_assignment_self_correction(test_settings: Settings) ->
             full_eval=False,  # Keep security restrictions to test self-correction
         )
     )
+    agent.llm = _SequenceLLM(
+        [
+            (
+                ("asterisk",),
+                (),
+                _pandas_eval_response(
+                    "df['airline'] = df['airline'].str.replace('*', '', regex=False)",
+                    fn_api=False,
+                ),
+            ),
+            (
+                ("ERROR", "SyntaxError"),
+                (),
+                _pandas_eval_response(
+                    "df.assign(airline=df['airline'].str.replace('*', ''))",
+                    fn_api=False,
+                ),
+            ),
+            (
+                ("United", "Delta", "American", "Southwest"),
+                ("*", "ERROR"),
+                LLMResponse(
+                    message=(
+                        "DONE Removed the asterisks and cleaned data.\n"
+                        "airline  price destination\n"
+                        "United   100 NYC\n"
+                        "Delta    150 LAX\n"
+                        "American 120 CHI\n"
+                        "Southwest 80 DEN"
+                    )
+                ),
+            ),
+        ]
+    )
 
     task = Task(
         agent,
@@ -194,6 +306,7 @@ def test_table_chat_agent_assignment_self_correction(test_settings: Settings) ->
     )
 
     # Check that the result indicates success
+    assert result is not None
     assert "United*" not in result.content
     assert "Delta*" not in result.content
     # The agent successfully cleaned the data (it says so in the message)
@@ -216,6 +329,24 @@ def test_table_chat_agent_url(test_settings: Settings, fn_api: bool) -> None:
             full_eval=True,  # Allow full evaluation in tests
         )
     )
+    answer = agent.df[agent.df["cotton"] < 500]["poultry"].mean()
+    agent.llm = _SequenceLLM(
+        [
+            (
+                ("average poultry",),
+                (),
+                _pandas_eval_response(
+                    "df[df['cotton'] < 500]['poultry'].mean()",
+                    fn_api=fn_api,
+                ),
+            ),
+            (
+                (str(answer),),
+                ("ERROR",),
+                LLMResponse(message=f"DONE The average poultry export is {answer}"),
+            ),
+        ]
+    )
 
     task = Task(
         agent,
@@ -234,7 +365,5 @@ def test_table_chat_agent_url(test_settings: Settings, fn_api: bool) -> None:
         turns=5,
     )
 
-    df = agent.df
-    # directly get the answer
-    answer = df[df["cotton"] < 500]["poultry"].mean()
+    assert result is not None
     assert contains_approx_float(result.content, answer)

--- a/tests/main/test_table_chat_agent.py
+++ b/tests/main/test_table_chat_agent.py
@@ -15,6 +15,7 @@ from langroid.language_models.base import (
     LLMMessage,
     LLMResponse,
     OpenAIToolCall,
+    Role,
 )
 from langroid.language_models.mock_lm import MockLM, MockLMConfig
 from langroid.parsing.table_loader import read_tabular_data
@@ -99,13 +100,35 @@ class _SequenceLLM(MockLM):
         assert isinstance(messages, list)
         assert self.index < len(self.responses), "unexpected extra model call"
         expected, forbidden, response = self.responses[self.index]
+        previous = self.responses[self.index - 1][2] if self.index > 0 else None
         self.index += 1
+        self._assert_tool_result_shape(messages[-1], previous)
         last_message = messages[-1].content or ""
         for text in expected:
             assert text in last_message
         for text in forbidden:
             assert text not in last_message
         return response
+
+    @staticmethod
+    def _assert_tool_result_shape(
+        message: LLMMessage,
+        previous: LLMResponse | None,
+    ) -> None:
+        """Check the tool result is fed back in the shape the API requires.
+
+        Content assertions alone would still pass if the result came back
+        with the wrong role or an absent/mismatched `tool_call_id`, which a
+        real OpenAI request would reject.
+        """
+        if previous is None:
+            return
+        if previous.oai_tool_calls:
+            assert message.role == Role.TOOL
+            assert message.tool_call_id == previous.oai_tool_calls[0].id
+        elif previous.function_call is not None:
+            assert message.role == Role.FUNCTION
+            assert message.name == previous.function_call.name
 
     def assert_fully_consumed(self) -> None:
         """Fail if the agent stopped before using every scripted response.

--- a/tests/main/test_table_chat_agent.py
+++ b/tests/main/test_table_chat_agent.py
@@ -10,7 +10,12 @@ import pytest
 
 from langroid.agent.special.table_chat_agent import TableChatAgent, TableChatAgentConfig
 from langroid.agent.task import Task
-from langroid.language_models.base import LLMFunctionCall, LLMMessage, LLMResponse
+from langroid.language_models.base import (
+    LLMFunctionCall,
+    LLMMessage,
+    LLMResponse,
+    OpenAIToolCall,
+)
 from langroid.language_models.mock_lm import MockLM, MockLMConfig
 from langroid.parsing.table_loader import read_tabular_data
 from langroid.parsing.utils import closest_string
@@ -102,17 +107,43 @@ class _SequenceLLM(MockLM):
             assert text not in last_message
         return response
 
+    def assert_fully_consumed(self) -> None:
+        """Fail if the agent stopped before using every scripted response.
 
-def _pandas_eval_response(expression: str, fn_api: bool) -> LLMResponse:
-    """Build the first model response that asks TableChatAgent to eval code."""
-    if fn_api:
-        return LLMResponse(
-            message="",
-            function_call=LLMFunctionCall(
-                name="pandas_eval",
-                arguments={"expression": expression},
-            ),
+        Without this, a task that terminates early still passes the final
+        content assertions, so the later scripted turns (and their
+        expected/forbidden checks) would never run.
+        """
+        assert self.index == len(self.responses), (
+            f"only {self.index} of {len(self.responses)} scripted model "
+            "responses were consumed"
         )
+
+
+def _pandas_eval_response(agent: TableChatAgent, expression: str) -> LLMResponse:
+    """Build the model response that asks `agent` to eval `expression`.
+
+    The response *shape* is derived from the agent's own config so the test
+    always exercises the code path the agent is actually configured for:
+    OpenAI tool-calls, legacy function-calls, or a Langroid tool message.
+    """
+    if agent.config.use_functions_api:
+        function_call = LLMFunctionCall(
+            name="pandas_eval",
+            arguments={"expression": expression},
+        )
+        if agent.config.use_tools_api:
+            return LLMResponse(
+                message="",
+                oai_tool_calls=[
+                    OpenAIToolCall(
+                        id="call_pandas_eval",
+                        type="function",
+                        function=function_call,
+                    )
+                ],
+            )
+        return LLMResponse(message="", function_call=function_call)
 
     return LLMResponse(
         message=json.dumps({"request": "pandas_eval", "expression": expression})
@@ -156,12 +187,12 @@ def _test_table_chat_agent(
         )
     )
     expression, answer = _average_income_expression_and_answer(agent)
-    agent.llm = _SequenceLLM(
+    llm = _SequenceLLM(
         [
             (
                 ("average income",),
                 (),
-                _pandas_eval_response(expression, fn_api),
+                _pandas_eval_response(agent, expression),
             ),
             (
                 (str(answer),),
@@ -170,6 +201,7 @@ def _test_table_chat_agent(
             ),
         ]
     )
+    agent.llm = llm
 
     task = Task(
         agent,
@@ -180,6 +212,7 @@ def _test_table_chat_agent(
 
     assert result is not None
     assert contains_approx_float(result.content, answer)
+    llm.assert_fully_consumed()
 
 
 @pytest.mark.parametrize("fn_api", [True, False])
@@ -258,22 +291,22 @@ def test_table_chat_agent_assignment_self_correction(test_settings: Settings) ->
             full_eval=False,  # Keep security restrictions to test self-correction
         )
     )
-    agent.llm = _SequenceLLM(
+    llm = _SequenceLLM(
         [
             (
                 ("asterisk",),
                 (),
                 _pandas_eval_response(
+                    agent,
                     "df['airline'] = df['airline'].str.replace('*', '', regex=False)",
-                    fn_api=False,
                 ),
             ),
             (
                 ("ERROR", "SyntaxError"),
                 (),
                 _pandas_eval_response(
+                    agent,
                     "df.assign(airline=df['airline'].str.replace('*', ''))",
-                    fn_api=False,
                 ),
             ),
             (
@@ -292,6 +325,7 @@ def test_table_chat_agent_assignment_self_correction(test_settings: Settings) ->
             ),
         ]
     )
+    agent.llm = llm
 
     task = Task(
         agent,
@@ -311,6 +345,7 @@ def test_table_chat_agent_assignment_self_correction(test_settings: Settings) ->
     assert "Delta*" not in result.content
     # The agent successfully cleaned the data (it says so in the message)
     assert "removed" in result.content.lower() and "cleaned" in result.content.lower()
+    llm.assert_fully_consumed()
 
 
 @pytest.mark.parametrize("fn_api", [True, False])
@@ -330,14 +365,14 @@ def test_table_chat_agent_url(test_settings: Settings, fn_api: bool) -> None:
         )
     )
     answer = agent.df[agent.df["cotton"] < 500]["poultry"].mean()
-    agent.llm = _SequenceLLM(
+    llm = _SequenceLLM(
         [
             (
                 ("average poultry",),
                 (),
                 _pandas_eval_response(
+                    agent,
                     "df[df['cotton'] < 500]['poultry'].mean()",
-                    fn_api=fn_api,
                 ),
             ),
             (
@@ -347,6 +382,7 @@ def test_table_chat_agent_url(test_settings: Settings, fn_api: bool) -> None:
             ),
         ]
     )
+    agent.llm = llm
 
     task = Task(
         agent,
@@ -367,3 +403,4 @@ def test_table_chat_agent_url(test_settings: Settings, fn_api: bool) -> None:
 
     assert result is not None
     assert contains_approx_float(result.content, answer)
+    llm.assert_fully_consumed()


### PR DESCRIPTION
Takes over #1121 by @SiluPanda — the core idea (replace the live-model dependency in `tests/main/test_table_chat_agent.py` with a scripted `MockLM` subclass, and tighten the previously permissive assertions; closes #288) is sound and is preserved as the base commit here, crediting the original author. Verification of the original: 11 passed in ~6s (no live calls), a mutation probe (forcing `pandas_eval` to return a wrong value) fails all 11 — the new assertions are load-bearing.

Adversarial review found two real coverage gaps in #1121 as submitted, both independently verified and fixed in the follow-up commits:

1. **`fn_api=True` did not exercise the path it claims.** `use_tools_api` defaults to `True`, so the real wire format is `oai_tool_calls`; the scripted response used the legacy `function_call` shape, so OpenAI tool-call parsing, call ids, and tool-result routing became untested — a coverage *reduction* vs the live-model version. Fixed: the script now emits the configured shape, and the test asserts the tool result is fed back with the API-required role and id.
2. **Nothing asserted the scripted sequence was fully consumed** — early termination after `pandas_eval` still passed via `contains_approx_float`, silently skipping the second turn's checks. Fixed: the test asserts full script consumption.

All checks green: pytest (file), black/ruff/mypy on changed files, codex cold-diff review clean.