### PR TITLE
test: skip OpenAI Assistants API tests (API sunset 2026-08-26)

### DIFF
--- a/tests/main/test_openai_assistant.py
+++ b/tests/main/test_openai_assistant.py
@@ -18,6 +18,7 @@ from langroid.language_models import LLMMessage, OpenAIGPTConfig, Role
 from langroid.mytypes import Entity
 from langroid.utils.configuration import Settings, set_global
 from langroid.utils.constants import NO_ANSWER
+from tests.utils import assistants_api_sunset
 
 
 class NabroskyTool(ToolMessage):
@@ -83,6 +84,7 @@ def test_openai_assistant_normalizes_none_thread_message(
     assert added_messages == [("", Role.USER)]
 
 
+@assistants_api_sunset
 def test_openai_assistant(test_settings: Settings):
     set_global(test_settings)
     cfg = OpenAIAssistantConfig()
@@ -115,6 +117,7 @@ def test_openai_assistant(test_settings: Settings):
     assert "Beijing" in answer.content
 
 
+@assistants_api_sunset
 def test_openai_assistant_cache(test_settings: Settings):
     set_global(test_settings)
     cfg = OpenAIAssistantConfig(
@@ -160,6 +163,7 @@ def test_openai_assistant_cache(test_settings: Settings):
     assert response.metadata.cached
 
 
+@assistants_api_sunset
 @pytest.mark.xfail(
     reason="Flaky due to non-deterministic LLM tool-use behavior",
     run=True,
@@ -210,6 +214,7 @@ def test_openai_assistant_fn_tool(test_settings: Settings, fn_api: bool):
         assert "25" in result.content
 
 
+@assistants_api_sunset
 @pytest.mark.xfail(
     reason="Flaky/Soon-To-be-deprecated API, may fail",
     run=True,
@@ -262,6 +267,7 @@ def test_openai_assistant_fn_2_level(test_settings: Settings, fn_api: bool):
         assert "25" in result.content
 
 
+@assistants_api_sunset
 @pytest.mark.parametrize("fn_api", [True, False])
 def test_openai_assistant_recipient_tool(test_settings: Settings, fn_api: bool):
     """Test that special case of fn-calling: RecipientTool works,
@@ -348,6 +354,7 @@ def test_openai_assistant_retrieval(test_settings: Settings):
     assert "Lomita" in response.content
 
 
+@assistants_api_sunset
 @pytest.mark.xfail(
     reason="May fail due to unknown flakiness",
     run=True,
@@ -390,6 +397,7 @@ def test_openai_asst_code_interpreter(test_settings: Settings):
     assert str(len(text.split())) in response.content
 
 
+@assistants_api_sunset
 def test_openai_assistant_multi(test_settings: Settings):
     """
     Test task delegation with OpenAIAssistant

--- a/tests/main/test_openai_assistant_async.py
+++ b/tests/main/test_openai_assistant_async.py
@@ -11,6 +11,7 @@ from langroid.agent.tool_message import ToolMessage
 from langroid.mytypes import Entity
 from langroid.utils.configuration import Settings, set_global
 from langroid.utils.constants import NO_ANSWER
+from tests.utils import assistants_api_sunset
 
 
 class NabroskyTool(ToolMessage):
@@ -22,6 +23,7 @@ class NabroskyTool(ToolMessage):
         return str(self.num**2)
 
 
+@assistants_api_sunset
 @pytest.mark.asyncio
 async def test_openai_assistant_async(test_settings: Settings):
     set_global(test_settings)
@@ -54,6 +56,7 @@ async def test_openai_assistant_async(test_settings: Settings):
     assert "Beijing" in answer.content
 
 
+@assistants_api_sunset
 @pytest.mark.asyncio
 @pytest.mark.xfail(reason="Flaky: LLM may not always call the function")
 @pytest.mark.parametrize("fn_api", [True, False])
@@ -132,6 +135,7 @@ def test_openai_asst_batch(test_settings: Settings):
         assert any(str(e) in a.content.lower() for a in answers)
 
 
+@assistants_api_sunset
 def test_openai_asst_task_batch(test_settings: Settings):
     set_global(test_settings)
     cfg = OpenAIAssistantConfig()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,16 @@
+import pytest
+
+# The OpenAI Assistants API beta was sunset on 2026-08-26, and every endpoint
+# (including `POST /assistants`) now returns a bare 404, so any test that talks
+# to the live API can never pass. Skip such tests until Langroid's
+# `OpenAIAssistant` is migrated to the Responses API.
+# See https://developers.openai.com/api/docs/assistants/migration
+assistants_api_sunset = pytest.mark.skip(
+    reason="OpenAI Assistants API was sunset on 2026-08-26 and returns 404; "
+    "pending migration to the Responses API"
+)
+
+
 def contains_approx_float(s: str, x: int | float, k: int = 0) -> bool:
     """
     Check if a string contains a float that is approximately equal to x.


### PR DESCRIPTION
## Why main is red

OpenAI [sunset the Assistants API beta on 2026-08-26](https://community.openai.com/t/assistants-api-beta-deprecation-august-26-2026-sunset/1354666). Every endpoint is gone; `POST /assistants` now returns a bare `404` with an empty body, so every test that drives `OpenAIAssistant` against the live API fails unconditionally.

This is **not** a regression from any recent merge. The identical 7 failures appear on three consecutive commits by different authors:

| Pytest run on `main` | Date | Result |
|---|---|---|
| `93574c0` | Aug 23 | ✅ success |
| `30bef33` | Aug 29 | ❌ same 7 assistant 404s |
| `b410076` | Aug 30 | ❌ same 7 assistant 404s |
| `3c84fc0` | Aug 31 | ❌ same 7 assistant 404s |

The last green run is Aug 23, and the sunset date falls in the Aug 23 → Aug 29 gap. All seven die at the same line — `self.client.beta.assistants.create(...)`.

The failing tests, all of which gated CI via the third (`--nc`) retry pass:

```
tests/main/test_openai_assistant.py::test_openai_assistant
tests/main/test_openai_assistant.py::test_openai_assistant_cache
tests/main/test_openai_assistant.py::test_openai_assistant_recipient_tool[True]
tests/main/test_openai_assistant.py::test_openai_assistant_recipient_tool[False]
tests/main/test_openai_assistant.py::test_openai_assistant_multi
tests/main/test_openai_assistant_async.py::test_openai_assistant_async
tests/main/test_openai_assistant_async.py::test_openai_asst_task_batch
```

## What this PR does

Adds a shared `assistants_api_sunset` skip marker in `tests/utils.py` and applies it to every test that talks to the live Assistants API.

- The two pure-unit tests in `test_openai_assistant.py` (`test_openai_assistant_normalizes_none_tool_output`, `test_openai_assistant_normalizes_none_thread_message`) are **untouched** — they build the agent via `object.__new__` and never call out, so they still provide real coverage.
- Four tests that already carry an `xfail` for flakiness (`test_openai_assistant_fn_tool`, `test_openai_assistant_fn_2_level`, `test_openai_asst_code_interpreter`, `test_openai_assistant_fn_tool_async`) also get the skip. They would not fail the build, but they'd still spend network round-trips reaching a guaranteed 404.
- The marker sits at the top of each decorator stack, so it wins over the existing `xfail`/`parametrize` markers.
- Two pre-existing `@pytest.mark.skip`s (for earlier Assistants API churn) are left as they are.

Net diff is 25 added lines across 3 files; no production code changes.

## Scope

This PR only unblocks CI. Deprecating `OpenAIAssistant` itself and documenting the migration path to the Responses API is a follow-up PR.

## Verification

- `make check` — black, ruff, and mypy all clean (134 source files).
- Confirmed via a scratch probe that the shared marker resolves through `tests.utils` and that `skip` takes precedence over a stacked `xfail` + `parametrize`.
- Verified by AST inspection that the marker landed on exactly the intended functions and on no others.
- The assistant tests themselves could not be executed here: this sandbox's network policy blocks `openaipublic.blob.core.windows.net`, so `tiktoken` cannot fetch its BPE file and the module import fails before collection. CI will confirm.

---
_Generated by [Claude Code](https://claude.ai/code/session_014gUNxiciXhoXToJnoTp1Pr)_