### PR TITLE
deprecate GoogleSearchTool: Google Custom Search JSON API sunset (2027-01-01)

### DIFF
--- a/docs/quick-start/setup.md
+++ b/docs/quick-start/setup.md
@@ -120,7 +120,12 @@ to use specific features (as noted below).
 - **GitHub** Personal Access Token (required for apps that need to analyze git
   repos; token-based API calls are less rate-limited). See this
   [GitHub page](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
-- **Google Custom Search API Credentials:** Only needed to enable an Agent to use the `GoogleSearchTool`.
+- **Google Custom Search API Credentials (DEPRECATED):** Only needed for the
+  `GoogleSearchTool`, which is deprecated: Google's Custom Search JSON API is
+  [closed to new customers and discontinued on January 1, 2027](https://developers.google.com/custom-search/v1/overview).
+  New users should use `TavilySearchTool` (`TAVILY_API_KEY`), `ExaSearchTool`
+  (`EXA_API_KEY`), or the key-free `DuckduckgoSearchTool` instead. The setup
+  below remains for users with existing credentials.
   To use Google Search as an LLM Tool/Plugin/function-call,
   you'll need to set up
   [a Google API key](https://developers.google.com/custom-search/v1/introduction#identify_your_application_to_google_with_api_key),

--- a/langroid/agent/tools/google_search_tool.py
+++ b/langroid/agent/tools/google_search_tool.py
@@ -1,4 +1,11 @@
 """
+DEPRECATED: Google's Custom Search JSON API (which this tool relies on) is
+closed to new customers and will be discontinued on January 1, 2027
+(https://developers.google.com/custom-search/v1/overview). The tool keeps
+working for users with existing credentials until then; new users should
+use `TavilySearchTool`, `ExaSearchTool`, or `DuckduckgoSearchTool` instead.
+Using it emits a `DeprecationWarning`.
+
 A tool to trigger a Google search for a given query, and return the top results with
 their titles, links, summaries. Since the tool is stateless (i.e. does not need
 access to agent state), it can be enabled for any agent, without having to define a

--- a/langroid/parsing/web_search.py
+++ b/langroid/parsing/web_search.py
@@ -7,6 +7,7 @@ environment variables in your `.env` file, as explained in the
 """
 
 import os
+import warnings
 from typing import Dict, List
 
 import requests
@@ -98,7 +99,23 @@ class WebSearchResult:
         }
 
 
+GOOGLE_SEARCH_DEPRECATION = (
+    "GoogleSearchTool / google_search() are deprecated: Google's Custom Search "
+    "JSON API is closed to new customers and will be discontinued on "
+    "January 1, 2027 (https://developers.google.com/custom-search/v1/overview). "
+    "Switch to TavilySearchTool, ExaSearchTool, or DuckduckgoSearchTool."
+)
+
+
 def google_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
+    """Search via Google's Custom Search JSON API.
+
+    .. deprecated::
+        The underlying API is closed to new customers and is discontinued on
+        2027-01-01. Existing credentials keep working until then; use
+        :func:`tavily_search`, :func:`exa_search`, or :func:`duckduckgo_search`.
+    """
+    warnings.warn(GOOGLE_SEARCH_DEPRECATION, DeprecationWarning, stacklevel=2)
     load_dotenv()
     api_key = os.getenv("GOOGLE_API_KEY")
     cse_id = os.getenv("GOOGLE_CSE_ID")

--- a/tests/main/test_google_search_deprecation.py
+++ b/tests/main/test_google_search_deprecation.py
@@ -1,0 +1,61 @@
+"""GoogleSearchTool is deprecated (Google Custom Search JSON API sunset,
+2027-01-01). These tests check the deprecation is surfaced without making
+any live API call.
+"""
+
+import warnings
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langroid.agent.tools.google_search_tool import GoogleSearchTool
+from langroid.parsing import web_search
+from langroid.parsing.web_search import GOOGLE_SEARCH_DEPRECATION, google_search
+
+
+def _fake_service() -> MagicMock:
+    """A stand-in for googleapiclient's customsearch service."""
+    service = MagicMock()
+    service.cse.return_value.list.return_value.execute.return_value = {
+        "items": [{"title": "Example", "link": "https://example.com"}]
+    }
+    return service
+
+
+@pytest.fixture
+def no_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_API_KEY", "dummy")
+    monkeypatch.setenv("GOOGLE_CSE_ID", "dummy")
+
+
+def test_google_search_emits_deprecation_warning(no_network: None) -> None:
+    with (
+        patch.object(web_search, "build", return_value=_fake_service()),
+        patch.object(web_search.WebSearchResult, "get_full_content", return_value=""),
+        pytest.warns(DeprecationWarning, match="discontinued on January 1, 2027"),
+    ):
+        results = google_search("anything", num_results=1)
+    assert len(results) == 1  # still works for existing-credential users
+
+
+def test_google_search_tool_handle_emits_deprecation_warning(
+    no_network: None,
+) -> None:
+    tool = GoogleSearchTool(query="anything", num_results=1)
+    with (
+        patch.object(web_search, "build", return_value=_fake_service()),
+        patch.object(web_search.WebSearchResult, "get_full_content", return_value=""),
+        warnings.catch_warnings(record=True) as caught,
+    ):
+        warnings.simplefilter("always")
+        tool.handle()
+    assert any(
+        issubclass(w.category, DeprecationWarning)
+        and str(w.message) == GOOGLE_SEARCH_DEPRECATION
+        for w in caught
+    )
+
+
+def test_deprecation_message_names_alternatives() -> None:
+    for alt in ("TavilySearchTool", "ExaSearchTool", "DuckduckgoSearchTool"):
+        assert alt in GOOGLE_SEARCH_DEPRECATION


### PR DESCRIPTION
Google's Custom Search JSON API — which `GoogleSearchTool` / `google_search()` rely on — is [closed to new customers and will be discontinued on January 1, 2027](https://developers.google.com/custom-search/v1/overview). New users cannot set the tool up at all today, and existing users lose it at the deadline. Rather than adding yet another SERP-proxy vendor (as proposed in #1128), this deprecates the Google tool and consolidates on the existing AI-native providers.

Changes:
- `google_search()` emits a `DeprecationWarning` citing the sunset and naming `TavilySearchTool` / `ExaSearchTool` / `DuckduckgoSearchTool` as replacements. **The tool keeps working** for users with existing credentials — nothing is removed.
- `GoogleSearchTool` module docstring and `docs/quick-start/setup.md` marked deprecated with the same guidance; setup instructions retained for existing users.
- New hermetic test (`tests/main/test_google_search_deprecation.py`): the warning fires from both the function and the tool's `handle()`, with the Google client and content fetch patched — verified to make **no network calls** via a requests-raising guard.

Refs #1128 (thanks @lucaspmgomess for the diagnosis). black/ruff/mypy clean; codex cold review: no findings.