### PR TITLE
Add SerpApi Google search tool

### DIFF
--- a/docs/examples/guide.md
+++ b/docs/examples/guide.md
@@ -47,7 +47,7 @@ the LLM will try its best to interpret what you want, and offer choices when con
 
     - Illustrates Agent + Tools/function-calling + web-search via Seltz
 
-- [`/examples/basic/chat-search-serpapi.py`](https://github.com/langroid/langroid/blob/main/examples/basic/chat-search-serpapi.py) Similar to the above, but uses `SerpApiSearchTool` for Google organic search results.
+- [`/examples/basic/chat-search-serpapi.py`](https://github.com/langroid/langroid/blob/main/examples/basic/chat-search-serpapi.py) Similar to the above, but uses `SerpApiSearchTool` for Google organic search results. Requires `SERPAPI_API_KEY`; see [SerpApi Search Tool docs](../notes/serpapi_search.md) for setup details.
 
     - Illustrates Agent + Tools/function-calling + Google organic search via SerpApi
 

--- a/docs/examples/guide.md
+++ b/docs/examples/guide.md
@@ -47,6 +47,10 @@ the LLM will try its best to interpret what you want, and offer choices when con
 
     - Illustrates Agent + Tools/function-calling + web-search via Seltz
 
+- [`/examples/basic/chat-search-serpapi.py`](https://github.com/langroid/langroid/blob/main/examples/basic/chat-search-serpapi.py) Similar to the above, but uses `SerpApiSearchTool` for Google organic search results.
+
+    - Illustrates Agent + Tools/function-calling + Google organic search via SerpApi
+
 - [`/examples/basic/chat-tree.py`](https://github.com/langroid/langroid-examples/blob/main/examples/basic/chat-tree.py) is a toy example of tree-structured multi-agent
   computation, see a detailed writeup [here.](https://langroid.github.io/langroid/examples/agent-tree/)
   

--- a/docs/notes/serpapi_search.md
+++ b/docs/notes/serpapi_search.md
@@ -1,0 +1,24 @@
+# Using SerpApi Search with Langroid
+
+SerpApi provides Google search results without requiring an additional Python
+dependency. Create an API key at [SerpApi](https://serpapi.com/) and add it to
+your `.env` file:
+
+```env
+SERPAPI_API_KEY=<your_api_key>
+```
+
+Enable the tool on an agent:
+
+```python
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.agent.tools.serpapi_search_tool import SerpApiSearchTool
+
+agent = ChatAgent(ChatAgentConfig(name="search-agent"))
+agent.enable_message(SerpApiSearchTool)
+```
+
+The integration uses SerpApi's Google engine and returns up to `num_results`
+items from the request's `organic_results`. See
+[`examples/basic/chat-search-serpapi.py`](https://github.com/langroid/langroid/blob/main/examples/basic/chat-search-serpapi.py)
+for a complete example.

--- a/docs/notes/serpapi_search.md
+++ b/docs/notes/serpapi_search.md
@@ -18,7 +18,9 @@ agent = ChatAgent(ChatAgentConfig(name="search-agent"))
 agent.enable_message(SerpApiSearchTool)
 ```
 
-The integration uses SerpApi's Google engine and returns up to `num_results`
-items from the request's `organic_results`. See
+The integration returns up to `num_results` items from the first SerpApi Google
+Search page's `organic_results`. A standard page currently contains at most
+roughly 10 results; fetching more would require pagination with `start`, which
+this integration intentionally does not perform. See
 [`examples/basic/chat-search-serpapi.py`](https://github.com/langroid/langroid/blob/main/examples/basic/chat-search-serpapi.py)
 for a complete example.

--- a/examples/basic/chat-search-serpapi.py
+++ b/examples/basic/chat-search-serpapi.py
@@ -1,0 +1,27 @@
+"""A basic chatbot using SerpApi's Google organic search results.
+
+Set SERPAPI_API_KEY in the environment, then run:
+    python3 examples/basic/chat-search-serpapi.py
+"""
+
+import langroid as lr
+import langroid.language_models as lm
+from langroid.agent.tools.serpapi_search_tool import SerpApiSearchTool
+
+
+def main() -> None:
+    config = lr.ChatAgentConfig(
+        name="SerpApi Seeker",
+        llm=lm.OpenAIGPTConfig(chat_model=lm.OpenAIChatModel.GPT4o),
+        system_message=(
+            "Use the serpapi_search tool when current web information is needed. "
+            "Wait for the tool results before answering and cite their links."
+        ),
+    )
+    agent = lr.ChatAgent(config)
+    agent.enable_message(SerpApiSearchTool)
+    lr.Task(agent, interactive=True).run("How can I help you?")
+
+
+if __name__ == "__main__":
+    main()

--- a/langroid/agent/tools/serpapi_search_tool.py
+++ b/langroid/agent/tools/serpapi_search_tool.py
@@ -1,0 +1,40 @@
+"""A tool that searches Google's organic results through SerpApi.
+
+Set ``SERPAPI_API_KEY`` in the environment before using this tool.
+"""
+
+from typing import List, Tuple
+
+from langroid.agent.tool_message import ToolMessage
+from langroid.parsing.web_search import serpapi_search
+
+
+class SerpApiSearchTool(ToolMessage):
+    request: str = "serpapi_search"
+    purpose: str = """
+            To search the web using SerpApi's Google engine and select up to
+            <num_results> organic results returned for the given <query>. When
+            using this tool, ONLY show the required JSON, DO NOT SAY ANYTHING
+            ELSE. Wait for the results of the web search, and then use them
+            to compose your response.
+            """
+    query: str
+    num_results: int
+
+    def handle(self) -> str:
+        """Run the search and format its results for the agent."""
+        search_results = serpapi_search(self.query, self.num_results)
+        results_str = "\n\n".join(str(result) for result in search_results)
+        return f"""
+        BELOW ARE THE RESULTS FROM THE WEB SEARCH. USE THESE TO COMPOSE YOUR RESPONSE:
+        {results_str}
+        """
+
+    @classmethod
+    def examples(cls) -> List["ToolMessage" | Tuple[str, "ToolMessage"]]:
+        return [
+            cls(
+                query="When was the Llama2 Large Language Model (LLM) released?",
+                num_results=3,
+            ),
+        ]

--- a/langroid/parsing/web_search.py
+++ b/langroid/parsing/web_search.py
@@ -130,6 +130,31 @@ def google_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
     ]
 
 
+def serpapi_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
+    """Return up to ``num_results`` organic results from a SerpApi Google search."""
+    load_dotenv()
+
+    api_key = os.getenv("SERPAPI_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "SERPAPI_API_KEY environment variable is not set. "
+            "Please set it to your API key and try again."
+        )
+
+    response = requests.get(
+        "https://serpapi.com/search.json",
+        params={"engine": "google", "q": query, "api_key": api_key},
+        timeout=30,
+    )
+    response.raise_for_status()
+    raw_results = response.json().get("organic_results", [])
+
+    return [
+        WebSearchResult(result["title"], result["link"], 3500, 300)
+        for result in raw_results[:num_results]
+    ]
+
+
 def metaphor_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
     """
     Method that makes an API call by Metaphor client that queries

--- a/langroid/parsing/web_search.py
+++ b/langroid/parsing/web_search.py
@@ -131,7 +131,11 @@ def google_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
 
 
 def serpapi_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
-    """Return up to ``num_results`` organic results from a SerpApi Google search."""
+    """Return up to ``num_results`` organic results from the first Google page.
+
+    SerpApi's standard Google Search currently returns at most roughly 10 results
+    per page. This function does not paginate additional pages with ``start``.
+    """
     load_dotenv()
 
     api_key = os.getenv("SERPAPI_API_KEY")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
       - Pinecone: notes/pinecone.md
       - Tavily Search Tool: notes/tavily_search.md
       - Seltz Search Tool: notes/seltz_search.md
+      - SerpApi Search Tool: notes/serpapi_search.md
       - Twitter Search via Xquik MCP: notes/twitter-search.md
       - Marker Pdf Parser: notes/marker-pdf.md
       - URLLoader : notes/url_loader.md

--- a/tests/main/test_serpapi_search.py
+++ b/tests/main/test_serpapi_search.py
@@ -1,0 +1,118 @@
+"""Tests for SerpApi search support."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from langroid.agent.tools.serpapi_search_tool import SerpApiSearchTool
+from langroid.parsing.web_search import WebSearchResult, serpapi_search
+
+ORGANIC_RESULTS = [
+    {"title": "First result", "link": "https://example.com/first"},
+    {"title": "Second result", "link": "https://example.com/second"},
+    {"title": "Third result", "link": "https://example.com/third"},
+]
+
+
+def mock_search_response(results=ORGANIC_RESULTS):
+    response = MagicMock()
+    response.json.return_value = {"organic_results": results}
+    return response
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+@patch("langroid.parsing.web_search.WebSearchResult")
+@patch("langroid.parsing.web_search.requests.get")
+def test_request_authentication(mock_get, mock_result):
+    mock_get.return_value = mock_search_response()
+
+    serpapi_search("test query", num_results=2)
+
+    mock_get.assert_called_once_with(
+        "https://serpapi.com/search.json",
+        params={"engine": "google", "q": "test query", "api_key": "test-key"},
+        timeout=30,
+    )
+    mock_get.return_value.raise_for_status.assert_called_once_with()
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+@patch("langroid.parsing.web_search.WebSearchResult")
+@patch("langroid.parsing.web_search.requests.get")
+def test_parses_organic_results_and_honors_num_results(mock_get, mock_result):
+    mock_get.return_value = mock_search_response()
+
+    results = serpapi_search("test", num_results=2)
+
+    assert len(results) == 2
+    assert mock_result.call_args_list == [
+        (("First result", "https://example.com/first", 3500, 300),),
+        (("Second result", "https://example.com/second", 3500, 300),),
+    ]
+
+
+@patch("langroid.parsing.web_search.load_dotenv")
+@patch("langroid.parsing.web_search.requests.get")
+def test_missing_api_key(mock_get, mock_load_dotenv):
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError, match="SERPAPI_API_KEY"):
+            serpapi_search("test")
+    mock_load_dotenv.assert_called_once_with()
+    mock_get.assert_not_called()
+
+
+@pytest.mark.parametrize("payload", [{}, {"organic_results": []}])
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+@patch("langroid.parsing.web_search.requests.get")
+def test_empty_or_missing_organic_results(mock_get, payload):
+    mock_get.return_value.json.return_value = payload
+    assert serpapi_search("test") == []
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+@patch("langroid.parsing.web_search.requests.get")
+def test_http_error_propagates(mock_get):
+    error = requests.HTTPError("SerpApi failed")
+    mock_get.return_value.raise_for_status.side_effect = error
+    with pytest.raises(requests.HTTPError, match="SerpApi failed"):
+        serpapi_search("test")
+
+
+@patch("langroid.agent.tools.serpapi_search_tool.serpapi_search")
+def test_tool_handle(mock_search):
+    result = MagicMock(spec=WebSearchResult)
+    result.__str__.return_value = (
+        "Title: Result\nLink: https://example.com\nSummary: Example summary"
+    )
+    mock_search.return_value = [result]
+
+    output = SerpApiSearchTool(query="test", num_results=2).handle()
+
+    mock_search.assert_called_once_with("test", 2)
+    assert "BELOW ARE THE RESULTS FROM THE WEB SEARCH" in output
+    assert "https://example.com" in output
+
+
+def test_tool_examples():
+    examples = SerpApiSearchTool.examples()
+    assert len(examples) == 1
+    assert isinstance(examples[0], SerpApiSearchTool)
+    assert examples[0].num_results == 3
+
+
+def test_tool_name_and_request():
+    assert SerpApiSearchTool.name() == "serpapi_search"
+    tool = SerpApiSearchTool(query="test", num_results=1)
+    assert tool.request == "serpapi_search"
+
+
+@pytest.mark.skipif(
+    not os.environ.get("SERPAPI_API_KEY"),
+    reason="SERPAPI_API_KEY not set",
+)
+def test_serpapi_real_query():
+    results = serpapi_search("Python programming language", num_results=3)
+    assert 0 < len(results) <= 3
+    assert all(result.link for result in results)


### PR DESCRIPTION
## Summary

Adds `SerpApiSearchTool` as an optional web-search provider for Google organic search results, following the existing Langroid search-tool pattern.

This follows the maintainer discussion in #1128, where SerpApi was preferred over SearchApi because of its broader adoption and existing ecosystem usage.

## Changes

* add `serpapi_search(query, num_results)` using the existing `requests` dependency
* add `SerpApiSearchTool`
* use `SERPAPI_API_KEY`
* scope results to Google `organic_results`
* add fully mocked unit tests
* add an optional live integration test gated by `SERPAPI_API_KEY`
* add documentation and a basic example
* add the documentation/example to the existing project indexes

No new required dependency is introduced, and no existing search provider or `WebSearchResult` behavior is changed.

## Testing

* `tests/main/test_serpapi_search.py`: 9 passed, 1 skipped
* existing Google deprecation + Seltz tests: 9 passed, 2 skipped
* Ruff: passed
* Black: passed
* `git diff --check`: passed

The skipped tests are API-key-gated integration tests.

Related to #1128.