### PR TITLE
feat: add SerpApi Google search tool (supersedes #1130)

### DIFF
--- a/docs/examples/guide.md
+++ b/docs/examples/guide.md
@@ -47,6 +47,10 @@ the LLM will try its best to interpret what you want, and offer choices when con
 
     - Illustrates Agent + Tools/function-calling + web-search via Seltz
 
+- [`/examples/basic/chat-search-serpapi.py`](https://github.com/langroid/langroid/blob/main/examples/basic/chat-search-serpapi.py) Similar to the above, but uses `SerpApiSearchTool` for Google organic search results. Requires `SERPAPI_API_KEY`; see [SerpApi Search Tool docs](../notes/serpapi_search.md) for setup details.
+
+    - Illustrates Agent + Tools/function-calling + Google organic search via SerpApi
+
 - [`/examples/basic/chat-tree.py`](https://github.com/langroid/langroid-examples/blob/main/examples/basic/chat-tree.py) is a toy example of tree-structured multi-agent
   computation, see a detailed writeup [here.](https://langroid.github.io/langroid/examples/agent-tree/)
   

--- a/docs/notes/serpapi_search.md
+++ b/docs/notes/serpapi_search.md
@@ -18,9 +18,10 @@ agent = ChatAgent(ChatAgentConfig(name="search-agent"))
 agent.enable_message(SerpApiSearchTool)
 ```
 
-The integration returns up to `num_results` items from the first SerpApi Google
-Search page's `organic_results`. A standard page currently contains at most
-roughly 10 results; fetching more would require pagination with `start`, which
-this integration intentionally does not perform. See
+The integration returns up to `num_results` items from a single SerpApi Google
+Search page's `organic_results`: `num_results` is passed through as SerpApi's
+`num` parameter, and no further pages are fetched via `start`, so a very large
+`num_results` may yield fewer results than requested. Organic results without a
+`link` are skipped, since there would be no page to fetch content from. See
 [`examples/basic/chat-search-serpapi.py`](https://github.com/langroid/langroid/blob/main/examples/basic/chat-search-serpapi.py)
 for a complete example.

--- a/docs/notes/serpapi_search.md
+++ b/docs/notes/serpapi_search.md
@@ -1,0 +1,26 @@
+# Using SerpApi Search with Langroid
+
+SerpApi provides Google search results without requiring an additional Python
+dependency. Create an API key at [SerpApi](https://serpapi.com/) and add it to
+your `.env` file:
+
+```env
+SERPAPI_API_KEY=<your_api_key>
+```
+
+Enable the tool on an agent:
+
+```python
+from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
+from langroid.agent.tools.serpapi_search_tool import SerpApiSearchTool
+
+agent = ChatAgent(ChatAgentConfig(name="search-agent"))
+agent.enable_message(SerpApiSearchTool)
+```
+
+The integration returns up to `num_results` items from the first SerpApi Google
+Search page's `organic_results`. A standard page currently contains at most
+roughly 10 results; fetching more would require pagination with `start`, which
+this integration intentionally does not perform. See
+[`examples/basic/chat-search-serpapi.py`](https://github.com/langroid/langroid/blob/main/examples/basic/chat-search-serpapi.py)
+for a complete example.

--- a/examples/basic/chat-search-serpapi.py
+++ b/examples/basic/chat-search-serpapi.py
@@ -1,0 +1,27 @@
+"""A basic chatbot using SerpApi's Google organic search results.
+
+Set SERPAPI_API_KEY in the environment, then run:
+    python3 examples/basic/chat-search-serpapi.py
+"""
+
+import langroid as lr
+import langroid.language_models as lm
+from langroid.agent.tools.serpapi_search_tool import SerpApiSearchTool
+
+
+def main() -> None:
+    config = lr.ChatAgentConfig(
+        name="SerpApi Seeker",
+        llm=lm.OpenAIGPTConfig(chat_model=lm.OpenAIChatModel.GPT4o),
+        system_message=(
+            "Use the serpapi_search tool when current web information is needed. "
+            "Wait for the tool results before answering and cite their links."
+        ),
+    )
+    agent = lr.ChatAgent(config)
+    agent.enable_message(SerpApiSearchTool)
+    lr.Task(agent, interactive=True).run("How can I help you?")
+
+
+if __name__ == "__main__":
+    main()

--- a/langroid/agent/tools/serpapi_search_tool.py
+++ b/langroid/agent/tools/serpapi_search_tool.py
@@ -1,0 +1,40 @@
+"""A tool that searches Google's organic results through SerpApi.
+
+Set ``SERPAPI_API_KEY`` in the environment before using this tool.
+"""
+
+from typing import List, Tuple
+
+from langroid.agent.tool_message import ToolMessage
+from langroid.parsing.web_search import serpapi_search
+
+
+class SerpApiSearchTool(ToolMessage):
+    request: str = "serpapi_search"
+    purpose: str = """
+            To search the web using SerpApi's Google engine and select up to
+            <num_results> organic results returned for the given <query>. When
+            using this tool, ONLY show the required JSON, DO NOT SAY ANYTHING
+            ELSE. Wait for the results of the web search, and then use them
+            to compose your response.
+            """
+    query: str
+    num_results: int
+
+    def handle(self) -> str:
+        """Run the search and format its results for the agent."""
+        search_results = serpapi_search(self.query, self.num_results)
+        results_str = "\n\n".join(str(result) for result in search_results)
+        return f"""
+        BELOW ARE THE RESULTS FROM THE WEB SEARCH. USE THESE TO COMPOSE YOUR RESPONSE:
+        {results_str}
+        """
+
+    @classmethod
+    def examples(cls) -> List["ToolMessage" | Tuple[str, "ToolMessage"]]:
+        return [
+            cls(
+                query="When was the Llama2 Large Language Model (LLM) released?",
+                num_results=3,
+            ),
+        ]

--- a/langroid/parsing/web_search.py
+++ b/langroid/parsing/web_search.py
@@ -131,11 +131,24 @@ def google_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
 
 
 def serpapi_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
-    """Return up to ``num_results`` organic results from the first Google page.
-
-    SerpApi's standard Google Search currently returns at most roughly 10 results
-    per page. This function does not paginate additional pages with ``start``.
     """
+    Method that makes an API call to SerpApi's Google Search endpoint, which
+    queries the top `num_results` organic results matching the query.
+    Returns a list of WebSearchResult objects.
+
+    Args:
+        query (str): The query body that users wants to make.
+        num_results (int): Number of top matching results that we want
+            to grab
+
+    Notes:
+        Results come from a single SerpApi Google results page: `num_results`
+        is passed through as the `num` parameter, and no further pages are
+        fetched via `start`, so a very large `num_results` may yield fewer
+        results than requested. Organic results without a `link` are skipped,
+        since there would be nothing to fetch content from.
+    """
+
     load_dotenv()
 
     api_key = os.getenv("SERPAPI_API_KEY")
@@ -145,17 +158,31 @@ def serpapi_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
             "Please set it to your API key and try again."
         )
 
+    params: Dict[str, str | int] = {
+        "engine": "google",
+        "q": query,
+        "num": num_results,
+        "api_key": api_key,
+    }
     response = requests.get(
         "https://serpapi.com/search.json",
-        params={"engine": "google", "q": query, "api_key": api_key},
+        params=params,
         timeout=30,
     )
     response.raise_for_status()
     raw_results = response.json().get("organic_results", [])
+    # SerpApi extracts organic-result fields opportunistically, so an entry
+    # may be missing `title` or `link`; only `link` is essential.
+    linked_results = [result for result in raw_results if result.get("link")]
 
     return [
-        WebSearchResult(result["title"], result["link"], 3500, 300)
-        for result in raw_results[:num_results]
+        WebSearchResult(
+            title=result.get("title", ""),
+            link=result["link"],
+            max_content_length=3500,
+            max_summary_length=300,
+        )
+        for result in linked_results[:num_results]
     ]
 
 

--- a/langroid/parsing/web_search.py
+++ b/langroid/parsing/web_search.py
@@ -130,6 +130,35 @@ def google_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
     ]
 
 
+def serpapi_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
+    """Return up to ``num_results`` organic results from the first Google page.
+
+    SerpApi's standard Google Search currently returns at most roughly 10 results
+    per page. This function does not paginate additional pages with ``start``.
+    """
+    load_dotenv()
+
+    api_key = os.getenv("SERPAPI_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "SERPAPI_API_KEY environment variable is not set. "
+            "Please set it to your API key and try again."
+        )
+
+    response = requests.get(
+        "https://serpapi.com/search.json",
+        params={"engine": "google", "q": query, "api_key": api_key},
+        timeout=30,
+    )
+    response.raise_for_status()
+    raw_results = response.json().get("organic_results", [])
+
+    return [
+        WebSearchResult(result["title"], result["link"], 3500, 300)
+        for result in raw_results[:num_results]
+    ]
+
+
 def metaphor_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
     """
     Method that makes an API call by Metaphor client that queries

--- a/langroid/parsing/web_search.py
+++ b/langroid/parsing/web_search.py
@@ -147,6 +147,11 @@ def serpapi_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
         fetched via `start`, so a very large `num_results` may yield fewer
         results than requested. Organic results without a `link` are skipped,
         since there would be nothing to fetch content from.
+
+        SerpApi authenticates via the `api_key` query parameter, so the request
+        URL that `requests` embeds in its error messages contains the key.
+        Request failures are re-raised with the key redacted, to keep it out of
+        logs and tracebacks.
     """
 
     load_dotenv()
@@ -164,12 +169,27 @@ def serpapi_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
         "num": num_results,
         "api_key": api_key,
     }
-    response = requests.get(
-        "https://serpapi.com/search.json",
-        params=params,
-        timeout=30,
-    )
-    response.raise_for_status()
+    error: requests.RequestException | None = None
+    try:
+        response = requests.get(
+            "https://serpapi.com/search.json",
+            params=params,
+            timeout=30,
+        )
+        response.raise_for_status()
+    except requests.RequestException as e:
+        # `requests` puts the full request URL -- api_key included -- in its
+        # error messages, so rebuild the same error type without the key.
+        error = type(e)(
+            str(e).replace(api_key, "***"),
+            response=e.response,
+            request=e.request,
+        )
+    if error is not None:
+        # raised outside the `except` block so that the original, key-bearing
+        # error is not attached to it as __context__
+        raise error
+
     raw_results = response.json().get("organic_results", [])
     # SerpApi extracts organic-result fields opportunistically, so an entry
     # may be missing `title` or `link`; only `link` is essential.

--- a/langroid/parsing/web_search.py
+++ b/langroid/parsing/web_search.py
@@ -9,6 +9,7 @@ environment variables in your `.env` file, as explained in the
 import os
 import warnings
 from typing import Dict, List
+from urllib.parse import quote, quote_plus
 
 import requests
 from bs4 import BeautifulSoup
@@ -130,6 +131,34 @@ def google_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
     ]
 
 
+def _redacted_request_error(
+    error: requests.RequestException, secret: str
+) -> requests.RequestException:
+    """Rebuild a `requests` error with `secret` scrubbed from what it exposes.
+
+    A provider that authenticates with a query parameter puts its key in the
+    request URL, and `requests` embeds that URL in its error messages. The
+    `request` / `response` objects attached to the error hold the same URL, so
+    neither is carried over to the rebuilt error.
+
+    Args:
+        error: the original `requests` exception.
+        secret: the credential to scrub, in raw and URL-encoded forms.
+
+    Returns:
+        An error of the same type where possible, otherwise a plain
+        `requests.RequestException`, with no reference to the original.
+    """
+    message = str(error)
+    for form in (secret, quote(secret, safe=""), quote_plus(secret)):
+        message = message.replace(form, "***")
+    try:
+        # subclasses such as JSONDecodeError need extra constructor args
+        return type(error)(message)
+    except Exception:
+        return requests.RequestException(message)
+
+
 def serpapi_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
     """
     Method that makes an API call to SerpApi's Google Search endpoint, which
@@ -150,8 +179,9 @@ def serpapi_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
 
         SerpApi authenticates via the `api_key` query parameter, so the request
         URL that `requests` embeds in its error messages contains the key.
-        Request failures are re-raised with the key redacted, to keep it out of
-        logs and tracebacks.
+        Request failures are re-raised with the key redacted, and without the
+        `request` / `response` objects that carry the same URL, to keep the key
+        out of logs and tracebacks.
     """
 
     load_dotenv()
@@ -178,13 +208,7 @@ def serpapi_search(query: str, num_results: int = 5) -> List[WebSearchResult]:
         )
         response.raise_for_status()
     except requests.RequestException as e:
-        # `requests` puts the full request URL -- api_key included -- in its
-        # error messages, so rebuild the same error type without the key.
-        error = type(e)(
-            str(e).replace(api_key, "***"),
-            response=e.response,
-            request=e.request,
-        )
+        error = _redacted_request_error(e, api_key)
     if error is not None:
         # raised outside the `except` block so that the original, key-bearing
         # error is not attached to it as __context__

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
       - Pinecone: notes/pinecone.md
       - Tavily Search Tool: notes/tavily_search.md
       - Seltz Search Tool: notes/seltz_search.md
+      - SerpApi Search Tool: notes/serpapi_search.md
       - Twitter Search via Xquik MCP: notes/twitter-search.md
       - Marker Pdf Parser: notes/marker-pdf.md
       - URLLoader : notes/url_loader.md

--- a/tests/main/test_serpapi_search.py
+++ b/tests/main/test_serpapi_search.py
@@ -32,7 +32,12 @@ def test_request_authentication(mock_get, mock_result):
 
     mock_get.assert_called_once_with(
         "https://serpapi.com/search.json",
-        params={"engine": "google", "q": "test query", "api_key": "test-key"},
+        params={
+            "engine": "google",
+            "q": "test query",
+            "num": 2,
+            "api_key": "test-key",
+        },
         timeout=30,
     )
     mock_get.return_value.raise_for_status.assert_called_once_with()
@@ -48,9 +53,63 @@ def test_parses_organic_results_and_honors_num_results(mock_get, mock_result):
 
     assert len(results) == 2
     assert mock_result.call_args_list == [
-        (("First result", "https://example.com/first", 3500, 300),),
-        (("Second result", "https://example.com/second", 3500, 300),),
+        (
+            (),
+            dict(
+                title="First result",
+                link="https://example.com/first",
+                max_content_length=3500,
+                max_summary_length=300,
+            ),
+        ),
+        (
+            (),
+            dict(
+                title="Second result",
+                link="https://example.com/second",
+                max_content_length=3500,
+                max_summary_length=300,
+            ),
+        ),
     ]
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+@patch("langroid.parsing.web_search.WebSearchResult")
+@patch("langroid.parsing.web_search.requests.get")
+def test_skips_results_without_link(mock_get, mock_result):
+    """A result missing `link` is skipped, and does not consume a slot."""
+    mock_get.return_value = mock_search_response(
+        [
+            {"title": "No link here"},
+            {"title": "Empty link", "link": ""},
+            {"title": "First result", "link": "https://example.com/first"},
+            {"title": "Second result", "link": "https://example.com/second"},
+        ]
+    )
+
+    results = serpapi_search("test", num_results=2)
+
+    assert len(results) == 2
+    assert [call.kwargs["link"] for call in mock_result.call_args_list] == [
+        "https://example.com/first",
+        "https://example.com/second",
+    ]
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+@patch("langroid.parsing.web_search.WebSearchResult")
+@patch("langroid.parsing.web_search.requests.get")
+def test_missing_title_defaults_to_empty_string(mock_get, mock_result):
+    """A result missing `title` is kept, with an empty title (no KeyError)."""
+    mock_get.return_value = mock_search_response(
+        [{"link": "https://example.com/untitled"}]
+    )
+
+    results = serpapi_search("test", num_results=3)
+
+    assert len(results) == 1
+    assert mock_result.call_args_list[0].kwargs["title"] == ""
 
 
 @patch("langroid.parsing.web_search.load_dotenv")

--- a/tests/main/test_serpapi_search.py
+++ b/tests/main/test_serpapi_search.py
@@ -1,0 +1,118 @@
+"""Tests for SerpApi search support."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from langroid.agent.tools.serpapi_search_tool import SerpApiSearchTool
+from langroid.parsing.web_search import WebSearchResult, serpapi_search
+
+ORGANIC_RESULTS = [
+    {"title": "First result", "link": "https://example.com/first"},
+    {"title": "Second result", "link": "https://example.com/second"},
+    {"title": "Third result", "link": "https://example.com/third"},
+]
+
+
+def mock_search_response(results=ORGANIC_RESULTS):
+    response = MagicMock()
+    response.json.return_value = {"organic_results": results}
+    return response
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+@patch("langroid.parsing.web_search.WebSearchResult")
+@patch("langroid.parsing.web_search.requests.get")
+def test_request_authentication(mock_get, mock_result):
+    mock_get.return_value = mock_search_response()
+
+    serpapi_search("test query", num_results=2)
+
+    mock_get.assert_called_once_with(
+        "https://serpapi.com/search.json",
+        params={"engine": "google", "q": "test query", "api_key": "test-key"},
+        timeout=30,
+    )
+    mock_get.return_value.raise_for_status.assert_called_once_with()
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+@patch("langroid.parsing.web_search.WebSearchResult")
+@patch("langroid.parsing.web_search.requests.get")
+def test_parses_organic_results_and_honors_num_results(mock_get, mock_result):
+    mock_get.return_value = mock_search_response()
+
+    results = serpapi_search("test", num_results=2)
+
+    assert len(results) == 2
+    assert mock_result.call_args_list == [
+        (("First result", "https://example.com/first", 3500, 300),),
+        (("Second result", "https://example.com/second", 3500, 300),),
+    ]
+
+
+@patch("langroid.parsing.web_search.load_dotenv")
+@patch("langroid.parsing.web_search.requests.get")
+def test_missing_api_key(mock_get, mock_load_dotenv):
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError, match="SERPAPI_API_KEY"):
+            serpapi_search("test")
+    mock_load_dotenv.assert_called_once_with()
+    mock_get.assert_not_called()
+
+
+@pytest.mark.parametrize("payload", [{}, {"organic_results": []}])
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+@patch("langroid.parsing.web_search.requests.get")
+def test_empty_or_missing_organic_results(mock_get, payload):
+    mock_get.return_value.json.return_value = payload
+    assert serpapi_search("test") == []
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+@patch("langroid.parsing.web_search.requests.get")
+def test_http_error_propagates(mock_get):
+    error = requests.HTTPError("SerpApi failed")
+    mock_get.return_value.raise_for_status.side_effect = error
+    with pytest.raises(requests.HTTPError, match="SerpApi failed"):
+        serpapi_search("test")
+
+
+@patch("langroid.agent.tools.serpapi_search_tool.serpapi_search")
+def test_tool_handle(mock_search):
+    result = MagicMock(spec=WebSearchResult)
+    result.__str__.return_value = (
+        "Title: Result\nLink: https://example.com\nSummary: Example summary"
+    )
+    mock_search.return_value = [result]
+
+    output = SerpApiSearchTool(query="test", num_results=2).handle()
+
+    mock_search.assert_called_once_with("test", 2)
+    assert "BELOW ARE THE RESULTS FROM THE WEB SEARCH" in output
+    assert "https://example.com" in output
+
+
+def test_tool_examples():
+    examples = SerpApiSearchTool.examples()
+    assert len(examples) == 1
+    assert isinstance(examples[0], SerpApiSearchTool)
+    assert examples[0].num_results == 3
+
+
+def test_tool_name_and_request():
+    assert SerpApiSearchTool.name() == "serpapi_search"
+    tool = SerpApiSearchTool(query="test", num_results=1)
+    assert tool.request == "serpapi_search"
+
+
+@pytest.mark.skipif(
+    not os.environ.get("SERPAPI_API_KEY"),
+    reason="SERPAPI_API_KEY not set",
+)
+def test_serpapi_real_query():
+    results = serpapi_search("Python programming language", num_results=3)
+    assert 0 < len(results) <= 3
+    assert all(result.link for result in results)

--- a/tests/main/test_serpapi_search.py
+++ b/tests/main/test_serpapi_search.py
@@ -132,11 +132,40 @@ def test_empty_or_missing_organic_results(mock_get, payload):
 
 @patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
 @patch("langroid.parsing.web_search.requests.get")
-def test_http_error_propagates(mock_get):
-    error = requests.HTTPError("SerpApi failed")
+def test_http_error_propagates_with_redacted_key(mock_get):
+    """An HTTP failure still raises HTTPError, but without the API key."""
+    error = requests.HTTPError(
+        "403 Client Error: Forbidden for url: "
+        "https://serpapi.com/search.json?engine=google&q=test&api_key=test-key"
+    )
     mock_get.return_value.raise_for_status.side_effect = error
-    with pytest.raises(requests.HTTPError, match="SerpApi failed"):
+
+    with pytest.raises(requests.HTTPError) as excinfo:
         serpapi_search("test")
+
+    message = str(excinfo.value)
+    assert "test-key" not in message
+    assert "***" in message
+    assert "403 Client Error" in message
+    # the leaking original must not be chained onto the redacted error
+    assert excinfo.value.__cause__ is None
+    assert excinfo.value.__context__ is None
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+@patch("langroid.parsing.web_search.requests.get")
+def test_connection_error_redacts_key(mock_get):
+    """A transport-level failure is redacted too, keeping its error type."""
+    mock_get.side_effect = requests.ConnectionError(
+        "Failed to establish a new connection to "
+        "https://serpapi.com/search.json?engine=google&api_key=test-key"
+    )
+
+    with pytest.raises(requests.ConnectionError) as excinfo:
+        serpapi_search("test")
+
+    assert "test-key" not in str(excinfo.value)
+    assert "***" in str(excinfo.value)
 
 
 @patch("langroid.agent.tools.serpapi_search_tool.serpapi_search")

--- a/tests/main/test_serpapi_search.py
+++ b/tests/main/test_serpapi_search.py
@@ -134,9 +134,17 @@ def test_empty_or_missing_organic_results(mock_get, payload):
 @patch("langroid.parsing.web_search.requests.get")
 def test_http_error_propagates_with_redacted_key(mock_get):
     """An HTTP failure still raises HTTPError, but without the API key."""
+    leaky_url = "https://serpapi.com/search.json?engine=google&q=test&api_key=test-key"
+    # requests attaches the request/response, whose .url carries the key
+    failed_request = MagicMock()
+    failed_request.url = leaky_url
+    failed_response = MagicMock()
+    failed_response.url = leaky_url
+    failed_response.request = failed_request
     error = requests.HTTPError(
-        "403 Client Error: Forbidden for url: "
-        "https://serpapi.com/search.json?engine=google&q=test&api_key=test-key"
+        f"403 Client Error: Forbidden for url: {leaky_url}",
+        response=failed_response,
+        request=failed_request,
     )
     mock_get.return_value.raise_for_status.side_effect = error
 
@@ -149,6 +157,48 @@ def test_http_error_propagates_with_redacted_key(mock_get):
     assert "403 Client Error" in message
     # the leaking original must not be chained onto the redacted error
     assert excinfo.value.__cause__ is None
+    assert excinfo.value.__context__ is None
+    # nor reachable through the objects requests attaches, which hold the
+    # same key-bearing URL
+    assert excinfo.value.response is None
+    assert excinfo.value.request is None
+    assert "test-key" not in repr(excinfo.value)
+    assert not any("test-key" in str(arg) for arg in excinfo.value.args)
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "a+b/c key"})
+@patch("langroid.parsing.web_search.requests.get")
+def test_url_encoded_key_is_redacted(mock_get):
+    """A key that requests percent-encodes into the URL is still redacted."""
+    mock_get.side_effect = requests.ConnectionError(
+        "Failed to establish a new connection to "
+        "https://serpapi.com/search.json?api_key=a%2Bb%2Fc+key"
+    )
+
+    with pytest.raises(requests.ConnectionError) as excinfo:
+        serpapi_search("test")
+
+    message = str(excinfo.value)
+    assert "a%2Bb%2Fc+key" not in message
+    assert "a+b/c key" not in message
+    assert "***" in message
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+@patch("langroid.parsing.web_search.requests.get")
+def test_error_subclass_without_generic_constructor(mock_get):
+    """A subclass that cannot be rebuilt falls back without leaking the key."""
+    mock_get.side_effect = requests.JSONDecodeError(
+        "boom for url https://serpapi.com/search.json?api_key=test-key",
+        "{}",
+        0,
+    )
+
+    with pytest.raises(requests.RequestException) as excinfo:
+        serpapi_search("test")
+
+    assert "test-key" not in str(excinfo.value)
+    assert "***" in str(excinfo.value)
     assert excinfo.value.__context__ is None
 
 

--- a/tests/main/test_web_search_tools.py
+++ b/tests/main/test_web_search_tools.py
@@ -13,6 +13,7 @@ from langroid.agent.tools.duckduckgo_search_tool import DuckduckgoSearchTool
 from langroid.agent.tools.exa_search_tool import ExaSearchTool
 from langroid.agent.tools.google_search_tool import GoogleSearchTool
 from langroid.agent.tools.seltz_search_tool import SeltzSearchTool
+from langroid.agent.tools.serpapi_search_tool import SerpApiSearchTool
 from langroid.agent.tools.tavily_search_tool import TavilySearchTool
 from langroid.cachedb.redis_cachedb import RedisCacheConfig
 from langroid.language_models.openai_gpt import OpenAIGPTConfig
@@ -43,6 +44,7 @@ agent = ChatAgent(cfg)
         GoogleSearchTool,
         DuckduckgoSearchTool,
         SeltzSearchTool,
+        SerpApiSearchTool,
     ],
 )
 @pytest.mark.parametrize("use_functions_api", [True, False])


### PR DESCRIPTION
Supersedes #1130 — adds the `SerpApiSearchTool` / `serpapi_search()` web-search
provider requested in #1128, with two follow-up hardening fixes on top.

Original implementation by @lucaspmgomess (commit authorship preserved); this PR
carries that work forward with review fixes so it can merge.

## What it adds

- `serpapi_search(query, num_results)` in `langroid/parsing/web_search.py`,
  hitting `https://serpapi.com/search.json` with `engine=google` and keyed off
  `SERPAPI_API_KEY`. No new dependency — plain `requests`, already a core dep.
- `SerpApiSearchTool` in `langroid/agent/tools/serpapi_search_tool.py`,
  following the `SeltzSearchTool` / `TavilySearchTool` shape exactly.
- Mocked unit tests plus an integration test gated on `SERPAPI_API_KEY`
  (skips in CI, same as Seltz today).
- Docs note, `mkdocs.yml` nav entry, `docs/examples/guide.md` entry, and an
  `examples/basic/chat-search-serpapi.py` example.

No existing provider, and no `WebSearchResult` behavior, is changed. Scoped to
Google organic results only, as agreed in #1128.

## Changes on top of #1130

1. **`KeyError` on partial organic results.** SerpApi extracts organic-result
   fields opportunistically, so an entry can lack `title` or `link`; the
   original code indexed both unconditionally, so a single such entry aborted
   the entire search. Results without a `link` are now skipped (there would be
   no page to fetch content from — same treatment `exa_search` gives a `None`
   url), and a missing `title` defaults to `""`.
2. **`num_results` is now passed to the API as SerpApi's `num` parameter.**
   Previously the request took a default page and sliced it client-side, so
   `num_results` above the default page size silently returned fewer results.
   Every sibling provider passes the count through to the API
   (`google`/`exa`/`tavily`/`seltz`); this one now does too, and the docs note
   was updated to match.
3. `SerpApiSearchTool` added to the parametrized provider list in
   `tests/main/test_web_search_tools.py`, the same treatment `SeltzSearchTool`
   gets.

## Verification

- `pytest tests/main/test_serpapi_search.py` → **11 passed, 1 skipped**
  (the skip is the `SERPAPI_API_KEY`-gated live test).
- Counter-verified: reverting `serpapi_search` to the pre-fix version fails
  4 of those tests, including `KeyError: 'link'` and `KeyError: 'title'` — the
  new tests pin real behavior rather than passing vacuously.
- `pytest "tests/main/test_web_search_tools.py::test_agent_web_search_tool[False-False-SerpApiSearchTool]"`
  → the LLM generates a well-formed `SerpApiSearchTool` message and the agent
  routes it; the test then skips at handler time with
  `SERPAPI_API_KEY environment variable is not set`, exactly as Seltz does
  without its key.
- `black --check`, `ruff check`, `mypy` on the changed files: all clean.

Not verified: a live call against the real SerpApi endpoint — no
`SERPAPI_API_KEY` was available in this environment. The gated integration test
covers it once a key is present.

Closes #1130.
