### PR TITLE
fix: preserve commas in done-sequence patterns

### DIFF
--- a/langroid/agent/done_sequence_parser.py
+++ b/langroid/agent/done_sequence_parser.py
@@ -66,8 +66,22 @@ def _parse_string_pattern(
     """
     events = []
 
-    # Split by comma and strip whitespace
-    parts = [p.strip() for p in pattern.split(",")]
+    # Commas inside bracket parameters are part of the tool name or regex.
+    parts = []
+    current: List[str] = []
+    bracket_depth = 0
+    for char in pattern:
+        if char == "[":
+            bracket_depth += 1
+        elif char == "]" and bracket_depth > 0:
+            bracket_depth -= 1
+
+        if char == "," and bracket_depth == 0:
+            parts.append("".join(current).strip())
+            current = []
+        else:
+            current.append(char)
+    parts.append("".join(current).strip())
 
     for part in parts:
         if not part:

--- a/tests/main/test_done_sequence_commas.py
+++ b/tests/main/test_done_sequence_commas.py
@@ -1,0 +1,11 @@
+from langroid.agent.done_sequence_parser import parse_done_sequence
+from langroid.agent.task import EventType
+
+
+def test_content_match_pattern_can_contain_commas() -> None:
+    sequence = parse_done_sequence(r"L, C[done,\s*thanks]")
+
+    assert len(sequence.events) == 2
+    assert sequence.events[0].event_type == EventType.LLM_RESPONSE
+    assert sequence.events[1].event_type == EventType.CONTENT_MATCH
+    assert sequence.events[1].content_pattern == r"done,\s*thanks"


### PR DESCRIPTION
## Summary

Done-sequence patterns are split on every comma, including commas inside `C[regex]` and `T[name]` parameters. This makes valid regex patterns such as `C[done,\s*thanks]` impossible to parse.

Split only on top-level commas while tracking bracket depth.

## Testing

- Added a regression test for a content-match regex containing a comma.
- Verified the changed parser produces two events and preserves the full regex.
- Ruff check, formatting check, and `compileall` on both changed files.